### PR TITLE
fix external_auth ssl tests

### DIFF
--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -195,7 +195,7 @@ def _external_login_or_signup(request,
         if settings.AUTHENTICATION_BACKENDS:
             auth_backend = settings.AUTHENTICATION_BACKENDS[0]
         else:
-            auth_backend = 'django.contrib.auth.backends.ModelBackend'
+            auth_backend = 'ratelimitbackend.backends.RateLimitModelBackend'
         user.backend = auth_backend
         if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
             AUDIT_LOG.info(u'Linked user.id: {0} logged in via Shibboleth'.format(user.id))
@@ -204,7 +204,7 @@ def _external_login_or_signup(request,
     elif uses_certs:
         # Certificates are trusted, so just link the user and log the action
         user = internal_user
-        user.backend = 'django.contrib.auth.backends.ModelBackend'
+        user.backend = 'ratelimitbackend.backends.RateLimitModelBackend'
         if settings.FEATURES['SQUELCH_PII_IN_LOGS']:
             AUDIT_LOG.info(u'Linked user_id {0} logged in via SSL certificate'.format(user.id))
         else:


### PR DESCRIPTION
TNL-3625

These tests are failing because authentication was always failing for user. This happens due to internal change in [get_user](https://github.com/django/django/blob/1.8.4/django/contrib/auth/__init__.py#L172) which is being used by auth middleware to get authenticated user. `backend_path` path is [set](https://github.com/edx/edx-platform/pull/10240/files#diff-753cb010d2261b914993e519a0a31560L198) to `django.contrib.auth.backends.ModelBackend` in `external_auth/views.py` but this backend is not present in `settings.AUTHENTICATION_BACKENDS` due to which `get_user` always return `AnonymousUser` for which authentication will fail always. 

Now we have replaced `django.contrib.auth.backends.ModelBackend` with `ratelimitbackend.backends.RateLimitModelBackend`.  [RateLimitModelBackend](https://github.com/brutasse/django-ratelimit-backend) is based on `ModelBackend` 
