### PR TITLE
SOL-1319: removed  entrance exam dependency on ENABLE_MKTG_SITE

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -67,7 +67,8 @@ from contentstore.tasks import rerun_course
 from contentstore.views.entrance_exam import (
     create_entrance_exam,
     update_entrance_exam,
-    delete_entrance_exam
+    delete_entrance_exam,
+    is_entrance_exams_enabled
 )
 
 from .library import LIBRARIES_ENABLED
@@ -927,7 +928,8 @@ def settings_handler(request, course_key_string):
                 'is_credit_course': False,
                 'show_min_grade_warning': False,
                 'enrollment_end_editable': enrollment_end_editable,
-                'is_prerequisite_courses_enabled': is_prerequisite_courses_enabled()
+                'is_prerequisite_courses_enabled': is_prerequisite_courses_enabled(),
+                'is_entrance_exams_enabled': is_entrance_exams_enabled()
             }
             if is_prerequisite_courses_enabled():
                 courses, in_process_course_actions = get_courses_accessible_to_user(request)

--- a/cms/djangoapps/contentstore/views/entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/entrance_exam.py
@@ -54,6 +54,13 @@ def check_feature_enabled(feature_name):
     return _check_feature_enabled
 
 
+def is_entrance_exams_enabled():
+    """
+    Returns a boolean indicating entrance exam feature is enable or not.
+    """
+    return settings.FEATURES.get('ENTRANCE_EXAMS', False)
+
+
 @login_required
 @ensure_csrf_cookie
 @check_feature_enabled(feature_name='ENTRANCE_EXAMS')

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -361,7 +361,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
               </ol>
             </section>
 
-          % if about_page_editable:
+          % if about_page_editable or is_prerequisite_courses_enabled or is_entrance_exams_enabled:
             <hr class="divide" />
 
             <section class="group-settings requirements">
@@ -371,11 +371,13 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
               </header>
 
               <ol class="list-input">
+                % if about_page_editable:
                 <li class="field text" id="field-course-effort">
                   <label for="course-effort">${_("Hours of Effort per Week")}</label>
                   <input type="text" class="short time" id="course-effort" placeholder="HH:MM" />
                   <span class="tip tip-inline">${_("Time spent on all course work")}</span>
                 </li>
+                % endif
                 % if is_prerequisite_courses_enabled:
                 <li class="field field-select" id="field-pre-requisite-course">
                     <label for="pre-requisite-course">${_("Prerequisite Course")}</label>
@@ -389,7 +391,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
                     <button type="submit" class="sr" name="submit" value="submit">${_("set pre-requisite course")}</button>
                 </li>
                 % endif
-                % if settings.FEATURES.get('ENTRANCE_EXAMS'):
+                % if is_entrance_exams_enabled:
                 <li>
                     <h3 id="heading-entrance-exam">${_("Entrance Exam")}</h3>
                     <div class="show-data">


### PR DESCRIPTION
Entrance exam section on studio had dependancy on `ENABLE_MKTG_SITE` feature it would not display until `ENABLE_MKTG_SITE` is switched off. This PR fixes this behaviour.
@asadiqbal08 Please review.
@mattdrayer FYI.
