### PR TITLE
Enroll the coach in the CCX on creation

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -47,7 +47,6 @@ from instructor.enrollment import (
     unenroll_email,
     get_email_params,
 )
-
 from .models import CustomCourseForEdX
 from .overrides import (
     get_override_for_ccx,
@@ -55,7 +54,6 @@ from .overrides import (
     clear_ccx_field_info_from_ccx_map,
     bulk_delete_ccx_override_fields,
 )
-
 
 log = logging.getLogger(__name__)
 TODAY = datetime.datetime.today  # for patching in tests
@@ -183,7 +181,19 @@ def create_ccx(request, course, ccx=None):
                 override_field_for_ccx(ccx, vertical, hidden, True)
 
     ccx_id = CCXLocator.from_course_locator(course.id, ccx.id)  # pylint: disable=no-member
+
     url = reverse('ccx_coach_dashboard', kwargs={'course_id': ccx_id})
+
+    # Enroll the coach in the course
+    email_params = get_email_params(course, auto_enroll=True, course_key=ccx_id, display_name=ccx.display_name)
+    enroll_email(
+        course_id=ccx_id,
+        student_email=request.user.email,
+        auto_enroll=True,
+        email_students=True,
+        email_params=email_params,
+    )
+
     return redirect(url)
 
 


### PR DESCRIPTION
**Problem**
When a CCX coach first accesses the course, and clicks CCX Coach link on the dashboard, she is invited to give her CCX course a name, and doing so creates the CCX course. 

Two things that _should_ happen at that point don't, namely:
- The coach is not enrolled in the CCX course;
- The coach is not granted staff access to the course. **EDIT**: _the scope of this PR has narrowed, and now no longer includes a solution for this problem_.

**Solution**
This PR fixes those issues at the time that the CCX course is created, by enrolling the coach in the course. ~~and granting that coach staff access to the course.~~

**How to test**

Assuming that CCX is enabled:
1. While logged out, register as a new user.
2. As a logged-in instructor:
   - Visit the membership view in the LMS
   - Add the new user created in the first step as a CCX coach.
3. As the logged-in new user: 
   - Refresh your dashboard.
   - Visit the CCX coach tab
   - Give your CCX course a name and click create.
   - Note that the new user is present in the list of enrolled users.~~, and has staff access to the course (ie, can access the grading, student admin and scheduling views within the course dashboard).~~

Fixes https://github.com/mitocw/edx-platform/issues/36
