### PR TITLE
ExternalAuthMap table not being created in CMS. TNL-3508

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -745,6 +745,7 @@ INSTALLED_APPS = (
     # For CMS
     'contentstore',
     'course_creators',
+    'external_auth',
     'student',  # misleading name due to sharing with lms
     'openedx.core.djangoapps.course_groups',  # not used in cms (yet), but tests run
     'xblock_config',


### PR DESCRIPTION
This will fix errors related to externalAuthMap table not being created. In conjunction with this commit: https://github.com/edx/edx-platform/commit/869e1b91f7f3f5aa58fd63c4065b8abda5f9ed0a all tests will now pass in common/djangoapps/external_auth/tests/test_ssl.py

https://openedx.atlassian.net/browse/TNL-3508

@nedbat @muzaffaryousaf @doctoryes @alawibaba @muhammad-ammar @symbolist 
