### PR TITLE
Create distinct terms for gender, education sign up terms

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -241,7 +241,7 @@ class UserProfile(models.Model):
         ('m', ugettext_noop('Male')),
         ('f', ugettext_noop('Female')),
         # Translators: 'Other' refers to the student's gender
-        ('o', ugettext_noop('Other'))
+        ('o', ugettext_noop('Other/Prefer Not to Say'))
     )
     gender = models.CharField(
         blank=True, null=True, max_length=6, db_index=True, choices=GENDER_CHOICES
@@ -260,9 +260,9 @@ class UserProfile(models.Model):
         ('jhs', ugettext_noop("Junior secondary/junior high/middle school")),
         ('el', ugettext_noop("Elementary/primary school")),
         # Translators: 'None' refers to the student's level of education
-        ('none', ugettext_noop("None")),
+        ('none', ugettext_noop("No Formal Education")),
         # Translators: 'Other' refers to the student's level of education
-        ('other', ugettext_noop("Other"))
+        ('other', ugettext_noop("Other Education"))
     )
     level_of_education = models.CharField(
         blank=True, null=True, max_length=6, db_index=True,

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1020,8 +1020,8 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                     {"value": "hs", "name": "Secondary/high school"},
                     {"value": "jhs", "name": "Junior secondary/junior high/middle school"},
                     {"value": "el", "name": "Elementary/primary school"},
-                    {"value": "none", "name": "None"},
-                    {"value": "other", "name": "Other"},
+                    {"value": "none", "name": "No Formal Education"},
+                    {"value": "other", "name": "Other Education"},
                 ],
             }
         )
@@ -1046,8 +1046,8 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                     {"value": "hs", "name": "Secondary/high school TRANSLATED"},
                     {"value": "jhs", "name": "Junior secondary/junior high/middle school TRANSLATED"},
                     {"value": "el", "name": "Elementary/primary school TRANSLATED"},
-                    {"value": "none", "name": "None TRANSLATED"},
-                    {"value": "other", "name": "Other TRANSLATED"},
+                    {"value": "none", "name": "No Formal Education TRANSLATED"},
+                    {"value": "other", "name": "Other Education TRANSLATED"},
                 ],
             }
         )
@@ -1064,7 +1064,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                     {"value": "", "name": "--", "default": True},
                     {"value": "m", "name": "Male"},
                     {"value": "f", "name": "Female"},
-                    {"value": "o", "name": "Other"},
+                    {"value": "o", "name": "Other/Prefer Not to Say"},
                 ],
             }
         )
@@ -1084,7 +1084,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                     {"value": "", "name": "--", "default": True},
                     {"value": "m", "name": "Male TRANSLATED"},
                     {"value": "f", "name": "Female TRANSLATED"},
-                    {"value": "o", "name": "Other TRANSLATED"},
+                    {"value": "o", "name": "Other/Prefer Not to Say TRANSLATED"},
                 ],
             }
         )


### PR DESCRIPTION
On the logistration page, we use the same string ("Other") in two different contexts - to indicate level of education, and to indicate gender. This in turn creates bad translations - for example "non-gendered" in the dropdown for "education".

This PR changes the language so these strings are distinct.

A third problematic string is "None", which we use for level of education but we also use to mean the logical "none" as in "no results" elsewhere in the platform, resulting in translations such as "Results: No education" within the platform.

The values that are stored the the database will stay the same, only the strings will change. Minor changes to documentation will be required.

cc @marcotuts, @srpearce
