### PR TITLE
Remove the @method_decorator-wrapped non_atomic_request decorators.

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -38,7 +38,12 @@ class ChooseModeView(View):
 
     """
 
+    @method_decorator(transaction.non_atomic_requests)
+    def dispatch(self, *args, **kwargs):
+        return super(ChooseModeView, self).dispatch(*args, **kwargs)
+
     @method_decorator(login_required)
+    @method_decorator(transaction.atomic)
     def get(self, request, course_id, error=None):
         """Displays the course mode choice page.
 
@@ -136,7 +141,6 @@ class ChooseModeView(View):
 
         return render_to_response("course_modes/choose.html", context)
 
-    @method_decorator(transaction.non_atomic_requests)
     @method_decorator(login_required)
     @method_decorator(outer_atomic(read_committed=True))
     def post(self, request, course_id):

--- a/common/djangoapps/util/db.py
+++ b/common/djangoapps/util/db.py
@@ -157,9 +157,11 @@ class OuterAtomic(transaction.Atomic):
 
         connection = transaction.get_connection(self.using)
 
-        # TestCase setup nests tests in two atomics. But there shouldn't be any other.
-        # The outermost atomic starts a transaction and so does not have a savepoint, therefore the "- 1".
-        if self.ALLOW_NESTED and (len(connection.savepoint_ids) - (self.atomic_for_testcase_calls - 1)) > 0:
+        # TestCase setup nests tests in two atomics - one for the test class and one for the individual test.
+        # The outermost atomic starts a transaction - so does not have a savepoint.
+        # The inner atomic starts a savepoint around the test.
+        # So, for tests only, there should be exactly one savepoint_id and two atomic_for_testcase_calls.
+        if self.ALLOW_NESTED and (self.atomic_for_testcase_calls - len(connection.savepoint_ids)) < 1:
             raise transaction.TransactionManagementError('Cannot be inside an atomic block.')
 
         # Otherwise, this shouldn't be nested in any atomic block.

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -822,6 +822,9 @@ class SubmitPhotosView(View):
     """
 
     @method_decorator(transaction.non_atomic_requests)
+    def dispatch(self, *args, **kwargs):
+        return super(SubmitPhotosView, self).dispatch(*args, **kwargs)
+
     @method_decorator(login_required)
     @method_decorator(outer_atomic(read_committed=True))
     def post(self, request):


### PR DESCRIPTION
Instead, create a dispatch() method for each class-based view and wrap that method in a transaction.non_atomic_request decorator. 
Reword comments in outer_atomic test situation description.
