### PR TITLE
Use a custom config for eventtracking.django to resolve name conflict…

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1852,7 +1852,7 @@ INSTALLED_APPS = (
     'static_template_view',
     'staticbook',
     'track',
-    'eventtracking.django',
+    'eventtracking.django.apps.EventTrackingConfig',
     'util',
     'certificates',
     'dashboard',


### PR DESCRIPTION
… with lettuce.django.
