### PR TITLE
Reserve ecommerce worker username

### DIFF
--- a/lms/djangoapps/commerce/migrations/0001_add_ecommerce_service_user.py
+++ b/lms/djangoapps/commerce/migrations/0001_add_ecommerce_service_user.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.db import models
+from south.db import db
+from south.utils import datetime_utils as datetime
+from south.v2 import DataMigration
+
+
+class Migration(DataMigration):
+    username = settings.ECOMMERCE_SERVICE_WORKER_USERNAME
+    email = username + '@fake.email'
+
+    def forwards(self, orm):
+        """Add the service user."""
+        user = User.objects.create(username=self.username, email=self.email)
+        user.set_unusable_password()
+        user.save()
+
+    def backwards(self, orm):
+        """Remove the service user."""
+        User.objects.get(username=self.username, email=self.email).delete()
+
+    models = {}
+    complete_apps = ['commerce']
+    symmetrical = True

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2578,6 +2578,7 @@ ECOMMERCE_PUBLIC_URL_ROOT = None
 ECOMMERCE_API_URL = None
 ECOMMERCE_API_SIGNING_KEY = None
 ECOMMERCE_API_TIMEOUT = 5
+ECOMMERCE_SERVICE_WORKER_USERNAME = 'ecommerce_worker'
 
 # Reverification checkpoint name pattern
 CHECKPOINT_PATTERN = r'(?P<checkpoint_name>[^/]+)'


### PR DESCRIPTION
Django's user model allows email addresses to be blank. However, edx-platform includes a migration requiring that email addresses be unique. Someone in our production environment already had a blank email address, so this migration was failing earlier.

Follow up to #9961, resolving [this error](https://gist.github.com/feanil/b74993e987b7ed7c2a7b). The commit introduced by #9961 will be reverted by this week's release. This PR will re-introduce the migration with fixes applied. @edx/ecommerce @feanil 
