### PR TITLE
Use ugettext_noop instead of lambdas assigned to the underscore

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -471,7 +471,7 @@ class ChoiceGroup(InputTypeBase):
 
     @classmethod
     def get_attributes(cls):
-        _ = lambda text: text
+        from django.utils.translation import ugettext_noop as _
         return [Attribute("show_correctness", "always"),
                 Attribute('label', ''),
                 Attribute("submitted_message", _("Answer received."))]
@@ -1707,7 +1707,7 @@ class ChoiceTextGroup(InputTypeBase):
         """
         Returns a list of `Attribute` for this problem type
         """
-        _ = lambda text: text
+        from django.utils.translation import ugettext_noop as _
         return [
             Attribute("show_correctness", "always"),
             Attribute("submitted_message", _("Answer received.")),

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -33,6 +33,7 @@ from sys import float_info
 from collections import namedtuple
 from shapely.geometry import Point, MultiPoint
 
+from django.utils.translation import ugettext_noop as _
 import dogstats_wrapper as dog_stats_api
 
 # specific library imports
@@ -57,10 +58,6 @@ registry = TagRegistry()
 
 CorrectMap = correctmap.CorrectMap  # pylint: disable=invalid-name
 CORRECTMAP_PY = None
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
-
 QUESTION_HINT_CORRECT_STYLE = 'feedback-hint-correct'
 QUESTION_HINT_INCORRECT_STYLE = 'feedback-hint-incorrect'
 QUESTION_HINT_LABEL_STYLE = 'hint-label'

--- a/common/lib/xmodule/xmodule/annotatable_module.py
+++ b/common/lib/xmodule/xmodule/annotatable_module.py
@@ -3,15 +3,14 @@ import logging
 from lxml import etree
 from pkg_resources import resource_string
 
+from django.utils.translation import ugettext_noop as _
+
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xblock.fields import Scope, String
 import textwrap
 
 log = logging.getLogger(__name__)
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class AnnotatableFields(object):

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -27,13 +27,11 @@ from xmodule.exceptions import NotFoundError
 from xblock.fields import Scope, String, Boolean, Dict, Integer, Float
 from .fields import Timedelta, Date
 from django.utils.timezone import UTC
+from django.utils.translation import ugettext_noop as _
 from xmodule.capa_base_constants import RANDOMIZATION, SHOWANSWER
 from django.conf import settings
 
 log = logging.getLogger("edx.courseware")
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 # Generate this many different variants of problems with rerandomize=per_student

--- a/common/lib/xmodule/xmodule/combined_open_ended_module.py
+++ b/common/lib/xmodule/xmodule/combined_open_ended_module.py
@@ -3,6 +3,7 @@ import logging
 from lxml import etree
 from pkg_resources import resource_string
 
+from django.utils.translation import ugettext_noop as _
 from xmodule.raw_module import RawDescriptor
 from .x_module import XModule, module_attr
 from xblock.fields import Integer, Scope, String, List, Float, Boolean
@@ -14,9 +15,6 @@ from .fields import Date, Timedelta
 import textwrap
 
 log = logging.getLogger("edx.courseware")
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 V1_SETTINGS_ATTRIBUTES = [
     "display_name",

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -24,12 +24,10 @@ from xblock.core import XBlock
 from xblock.fields import Scope, List, String, Dict, Boolean, Integer, Float
 from .fields import Date
 from django.utils.timezone import UTC
+from django.utils.translation import ugettext_noop as _
 
 
 log = logging.getLogger(__name__)
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 CATALOG_VISIBILITY_CATALOG_AND_ABOUT = "both"
 CATALOG_VISIBILITY_ABOUT = "about"

--- a/common/lib/xmodule/xmodule/discussion_module.py
+++ b/common/lib/xmodule/xmodule/discussion_module.py
@@ -1,14 +1,13 @@
+import json
 from pkg_resources import resource_string
 
-import json
+from django.utils.translation import ugettext_noop as _
+
 from xblock.core import XBlock
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xmodule.editing_module import MetadataOnlyEditingDescriptor
 from xblock.fields import String, Scope, UNIQUE_ID
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class DiscussionFields(object):

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -9,6 +9,7 @@ from path import Path as path
 from fs.errors import ResourceNotFoundError
 from pkg_resources import resource_string
 
+from django.utils.translation import ugettext_noop as _
 import dogstats_wrapper as dog_stats_api
 from xmodule.util.misc import escape_html_characters
 from xmodule.contentstore.content import StaticContent
@@ -22,9 +23,6 @@ from xblock.core import XBlock
 from xblock.fields import Scope, String, Boolean, List
 
 log = logging.getLogger("edx.courseware")
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class HtmlFields(object):

--- a/common/lib/xmodule/xmodule/imageannotation_module.py
+++ b/common/lib/xmodule/xmodule/imageannotation_module.py
@@ -4,6 +4,7 @@ Module for Image annotations using annotator.
 from lxml import etree
 from pkg_resources import resource_string
 
+from django.utils.translation import ugettext_noop as _
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xblock.core import Scope, String
@@ -12,9 +13,6 @@ from xmodule.annotator_token import retrieve_token
 from xblock.fragment import Fragment
 
 import textwrap
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class AnnotatableFields(object):

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -9,6 +9,8 @@ from capa.responsetypes import registry
 from gettext import ngettext
 from lazy import lazy
 
+from django.utils.translation import ugettext_noop as _
+
 from .mako_module import MakoModuleDescriptor
 from opaque_keys.edx.locator import LibraryLocator
 import random
@@ -21,10 +23,6 @@ from xmodule.x_module import XModule, STUDENT_VIEW
 from xmodule.studio_editable import StudioEditableModule, StudioEditableDescriptor
 from .xml_module import XmlDescriptor
 from pkg_resources import resource_string  # pylint: disable=no-name-in-module
-
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 ANY_CAPA_TYPE_VALUE = 'any'

--- a/common/lib/xmodule/xmodule/library_root_xblock.py
+++ b/common/lib/xmodule/xmodule/library_root_xblock.py
@@ -3,6 +3,8 @@
 """
 import logging
 
+from django.utils.translation import ugettext_noop as _
+
 from xmodule.studio_editable import StudioEditableModule
 
 from xblock.fields import Scope, String, List, Boolean
@@ -10,9 +12,6 @@ from xblock.fragment import Fragment
 from xblock.core import XBlock
 
 log = logging.getLogger(__name__)
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class LibraryRoot(XBlock):

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -66,6 +66,8 @@ from webob import Response
 import mock
 from xml.sax.saxutils import escape
 
+from django.utils.translation import ugettext_noop as _
+
 from xmodule.editing_module import MetadataOnlyEditingDescriptor
 from xmodule.raw_module import EmptyDataRawDescriptor
 from xmodule.x_module import XModule, module_attr
@@ -75,9 +77,6 @@ from xblock.core import String, Scope, List, XBlock
 from xblock.fields import Boolean, Float
 
 log = logging.getLogger(__name__)
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 DOCS_ANCHOR_TAG_OPEN = (
     "<a target='_blank' "

--- a/common/lib/xmodule/xmodule/mixin.py
+++ b/common/lib/xmodule/xmodule/mixin.py
@@ -1,11 +1,9 @@
 """
 Reusable mixins for XBlocks and/or XModules
 """
+from django.utils.translation import ugettext_noop as _
 
 from xblock.fields import Scope, String, XBlockMixin
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class LicenseMixin(XBlockMixin):

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -4,16 +4,15 @@ Support for inheritance of fields down an XBlock hierarchy.
 from __future__ import absolute_import
 
 from datetime import datetime
+
+from django.conf import settings
+from django.utils.translation import ugettext_noop as _
 from pytz import UTC
+
 from xmodule.partitions.partitions import UserPartition
 from xblock.fields import Scope, Boolean, String, Float, XBlockMixin, Dict, Integer, List
 from xblock.runtime import KeyValueStore, KvsFieldData
 from xmodule.fields import Date, Timedelta
-from django.conf import settings
-
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class UserPartitionList(List):

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -1,7 +1,10 @@
 import json
 import logging
 import traceback
+
+from django.utils.translation import ugettext_noop as _
 from lxml import etree
+
 from xmodule.timeinfo import TimeInfo
 from xmodule.capa_module import ComplexEncoder
 from xmodule.progress import Progress
@@ -33,8 +36,6 @@ ACCEPT_FILE_UPLOAD = False
 
 # Contains all reasonable bool and case combinations of True
 TRUE_DICT = ["True", True, "TRUE", "true"]
-
-_ = lambda text: text
 
 HUMAN_TASK_TYPE = {
     # Translators: "Self" is used to denote an openended response that is self-graded

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_rubric.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_rubric.py
@@ -1,4 +1,6 @@
 import logging
+
+from django.utils.translation import ugettext_noop as _
 from lxml import etree
 
 log = logging.getLogger(__name__)
@@ -10,8 +12,6 @@ GRADER_TYPE_IMAGE_DICT = {
     'IN': '/static/images/peer_grading_icon.png',
     'BC': '/static/images/ml_grading_icon.png',
 }
-
-_ = lambda text: text
 
 HUMAN_GRADER_TYPE = {
     # Translators: "Self-Assessment" refers to the self-assessed mode of openended evaluation

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py
@@ -1,18 +1,21 @@
+from datetime import datetime
 import json
 import logging
 import re
+
 import bleach
+from boto.s3.connection import S3Connection
+from boto.s3.key import Key
+from django.utils.translation import ugettext_noop as _
 from html5lib.tokenizer import HTMLTokenizer
+from pytz import UTC
+
 from xmodule.progress import Progress
 import capa.xqueue_interface as xqueue_interface
 from capa.util import *
 from .peer_grading_service import PeerGradingService, MockPeerGradingService
 import controller_query_service
 
-from datetime import datetime
-from pytz import UTC
-from boto.s3.connection import S3Connection
-from boto.s3.key import Key
 
 log = logging.getLogger("edx.courseware")
 
@@ -88,7 +91,6 @@ class OpenEndedChild(object):
     DONE = 'done'
 
     # This is used to tell students where they are at in the module
-    _ = lambda text: text
     HUMAN_NAMES = {
         # Translators: "Not started" communicates to a student that their response
         # has not yet been graded

--- a/common/lib/xmodule/xmodule/peer_grading_module.py
+++ b/common/lib/xmodule/xmodule/peer_grading_module.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime
 
 from django.utils.timezone import UTC
+from django.utils.translation import ugettext_noop as _
 from lxml import etree
 from pkg_resources import resource_string
 
@@ -22,9 +23,6 @@ from xmodule.validation import StudioValidation, StudioValidationMessage
 from open_ended_grading_classes import combined_open_ended_rubric
 
 log = logging.getLogger(__name__)
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 EXTERNAL_GRADER_NO_CONTACT_ERROR = "Failed to contact external graders.  Please notify course staff."

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -6,9 +6,10 @@ xModule implementation of a learning sequence
 
 import json
 import logging
+from lxml import etree
 import warnings
 
-from lxml import etree
+from django.utils.translation import ugettext_noop as _
 
 from xblock.core import XBlock
 from xblock.fields import Integer, Scope, Boolean
@@ -27,9 +28,6 @@ log = logging.getLogger(__name__)
 # HACK: This shouldn't be hard-coded to two types
 # OBSOLETE: This obsoletes 'type'
 class_priority = ['video', 'problem']
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class SequenceFields(object):

--- a/common/lib/xmodule/xmodule/split_test_module.py
+++ b/common/lib/xmodule/xmodule/split_test_module.py
@@ -8,6 +8,8 @@ from webob import Response
 from uuid import uuid4
 from operator import itemgetter
 
+from django.utils.translation import ugettext_noop as _
+
 from xmodule.progress import Progress
 from xmodule.seq_module import SequenceDescriptor
 from xmodule.studio_editable import StudioEditableModule, StudioEditableDescriptor
@@ -22,9 +24,6 @@ from xblock.fields import Scope, Integer, String, ReferenceValueDict
 from xblock.fragment import Fragment
 
 log = logging.getLogger('edx.' + __name__)
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 DEFAULT_GROUP_NAME = _(u'Group ID {group_id}')
 

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -1,16 +1,13 @@
 """
 Implement CourseTab
 """
-
 from abc import ABCMeta
 import logging
 
+from django.utils.translation import ugettext_noop as _
+
 from xblock.fields import List
 from openedx.core.lib.api.plugins import PluginError
-
-# We should only scrape strings for i18n in this file, since the target language is known only when
-# they are rendered in the template.  So ugettext gets called in the template.
-_ = lambda text: text
 
 log = logging.getLogger("edx.courseware")
 

--- a/common/lib/xmodule/xmodule/textannotation_module.py
+++ b/common/lib/xmodule/xmodule/textannotation_module.py
@@ -1,7 +1,8 @@
-''' Text annotation module '''
-
+"""Text annotation module"""
 from lxml import etree
 from pkg_resources import resource_string
+
+from django.utils.translation import ugettext_noop as _
 
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
@@ -10,9 +11,6 @@ from xmodule.annotator_mixin import get_instructions
 from xmodule.annotator_token import retrieve_token
 from xblock.fragment import Fragment
 import textwrap
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class AnnotatableFields(object):

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -24,6 +24,7 @@ from lxml import etree
 from pkg_resources import resource_string
 
 from django.conf import settings
+from django.utils.translation import ugettext_noop as _
 
 from openedx.core.lib.cache_utils import memoize_in_request_cache
 from xblock.core import XBlock
@@ -83,7 +84,6 @@ except ImportError:
     BrandingInfoConfig = None
 
 log = logging.getLogger(__name__)
-_ = lambda text: text
 
 
 @XBlock.wants('settings')

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -3,12 +3,10 @@ XFields for video module.
 """
 import datetime
 
+from django.utils.translation import ugettext_noop as _
+
 from xblock.fields import Scope, String, Float, Boolean, List, Dict, DateTime
-
 from xmodule.fields import RelativeTime
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class VideoFields(object):

--- a/common/lib/xmodule/xmodule/videoannotation_module.py
+++ b/common/lib/xmodule/xmodule/videoannotation_module.py
@@ -4,6 +4,8 @@ Module for Video annotations using annotator.
 from lxml import etree
 from pkg_resources import resource_string
 
+from django.utils.translation import ugettext_noop as _
+
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xblock.core import Scope, String
@@ -12,9 +14,6 @@ from xmodule.annotator_token import retrieve_token
 from xblock.fragment import Fragment
 
 import textwrap
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class AnnotatableFields(object):

--- a/common/lib/xmodule/xmodule/word_cloud_module.py
+++ b/common/lib/xmodule/xmodule/word_cloud_module.py
@@ -8,8 +8,10 @@ If student have answered - words he entered and cloud.
 
 import json
 import logging
-
 from pkg_resources import resource_string
+
+from django.utils.translation import ugettext_noop as _
+
 from xmodule.raw_module import EmptyDataRawDescriptor
 from xmodule.editing_module import MetadataOnlyEditingDescriptor
 from xmodule.x_module import XModule
@@ -17,9 +19,6 @@ from xmodule.x_module import XModule
 from xblock.fields import Scope, Dict, Boolean, List, Integer, String
 
 log = logging.getLogger(__name__)
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 def pretty_bool(value):

--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -1,15 +1,13 @@
 """
 Namespace that defines fields common to all blocks used in the LMS
 """
+from django.utils.translation import ugettext_noop as _
 from lazy import lazy
 
 from xblock.fields import Boolean, Scope, String, XBlockMixin, Dict
 from xblock.validation import ValidationMessage
 from xmodule.modulestore.inheritance import UserPartitionList
 from xmodule.partitions.partitions import NoSuchUserPartitionError, NoSuchUserPartitionGroupError
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class GroupAccessDict(Dict):

--- a/openedx/core/lib/course_tabs.py
+++ b/openedx/core/lib/course_tabs.py
@@ -1,9 +1,9 @@
 """
 Tabs for courseware.
 """
-from openedx.core.lib.api.plugins import PluginManager
+from django.utils.translation import ugettext_noop as _
 
-_ = lambda text: text
+from openedx.core.lib.api.plugins import PluginManager
 
 
 # Stevedore extension point namespaces


### PR DESCRIPTION
Replaces instances of an old hack with the more clear [ugettext_noop](https://docs.djangoproject.com/en/1.8/ref/utils/#django.utils.translation.ugettext_noop).

I spotted this while working on something else and figured I'd take a shot at fixing it. These changes are as of yet untested, but I will verify them using these [i18n coverage testing instructions](http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html#coverage-testing).

@sarina, could you please review this? Who should I ping as a second set of eyes?
