### PR TITLE
Remove escaping html from dashboard link

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -112,7 +112,7 @@ from django.utils.http import urlquote_plus
                         ${_("{a_start}Go to your dashboard{a_end} to purchase course credit.").format(
 		             a_start=u"<a href={url}>".format(url=reverse('dashboard')),
 			     a_end="</a>"
-		      ) | h}
+		      )}
                     </span>
                 %elif credit_course_requirements['eligibility_status'] == 'partial_eligible':
                     <span>${_("{student_name}, you have not yet met the requirements for credit.").format(student_name=student.profile.name) | h}</span>


### PR DESCRIPTION
ECOM-2554
Un-escape HTML dashboard link on progress page.

Please review this @edx/ecommerce 

<img width="1057" alt="screen shot 2015-10-20 at 6 59 12 pm" src="https://cloud.githubusercontent.com/assets/4245618/10609377/d8a7a83a-775c-11e5-9ec8-b639b52f8e52.png">
