### PR TITLE
log exception in the logs to debug issue on production or sandbox environments

### DIFF
--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -84,6 +84,7 @@ def handle_500(template_path, context=None):
                     # In debug mode let django process the 500 errors and display debug info for the developer
                     raise
                 else:
+                    log.exception("Error in django view.")
                     return render_to_response(template_path, context)
         return inner
     return decorator


### PR DESCRIPTION
@mattdrayer @saleem-latif I have modified the decorator which allows custom template rendering in case of 500 error. It'll now add the error stack trace to logs on production and sandbox environments which would allow us tracking the cause of error and fix it.
