### PR TITLE
SOL-1314: Add Cert link to Support dashboard

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -71,7 +71,7 @@ def get_certificates_for_user(username):
             # In the future, we can update this to construct a URL to the webview certificate
             # for courses that have this feature enabled.
             "download_url": (
-                cert.download_url
+                cert.download_url or get_certificate_url(cert.user.id, cert.course_id)
                 if cert.status == CertificateStatuses.downloadable
                 else None
             ),


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR, it contains changes for [SOL-1314](https://openedx.atlassian.net/browse/SOL-1314).

**Description of [SOL-1314](https://openedx.atlassian.net/browse/SOL-1314):**
As a Support team, I need to be able to view any user's web cert and copy the web cert link.
**Acceptance Criteria**
1. Add the generated web certificate link to the Support team Certificate Dashboard in the "Download URL" column:
courses.edx.org/support/certificates
Support should be able to click the link to view the certificate and copy the url.

cc: @mattdrayer 
