### PR TITLE
Fix CCX grades csv file download

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -247,4 +247,5 @@ George Schneeloch <gschneel@mit.edu>
 Dustin Gadal <Dustin.Gadal@gmail.com>
 Robert Raposa <rraposa@edx.org>
 Giovanni Di Milia <gdimilia@mit.edu>
+Peter Wilkins <pwilkins@mit.edu>
 Justin Abrahms <abrahms@mit.edu>

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -733,6 +733,12 @@ class TestCCXGrades(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+        # Are the grades downloaded as an attachment?
+        self.assertEqual(
+            response['content-disposition'],
+            'attachment'
+        )
+
         headers, row = (
             row.strip().split(',') for row in
             response.content.strip().split('\n')

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -615,4 +615,7 @@ def ccx_grades_csv(request, course, ccx=None):
         for row in rows:
             writer.writerow(row)
 
-        return HttpResponse(buf.getvalue(), content_type='text/plain')
+        response = HttpResponse(buf.getvalue(), content_type='text/csv')
+        response['Content-Disposition'] = 'attachment'
+
+        return response


### PR DESCRIPTION
**Background:** In the CCX dashboard, the `Student Admin` tab has a `Download student
grades` action. This action should download a CSV file containing grades, but it doesn't.  Instead, it currently displays the CSV content in the browser instead of putting the content in a CSV formatted attachment. 

This is the `Download student grades` action in the `Student Admin` tab of the CCX dashboard.

![screen shot 2015-10-20 at 11 08 03 am](https://cloud.githubusercontent.com/assets/145821/10612388/9a3874aa-771e-11e5-9e28-afe2807cf645.png)

**Studio Updates:** None.

**LMS Updates:** This fix sets the `content-type` and `content-disposition` request headers so that a CSV file download occurs.

This the current result of clicking the `Download student grades` action:

![screen shot 2015-10-20 at 11 08 46 am](https://cloud.githubusercontent.com/assets/145821/10612458/e638a6cc-771e-11e5-9994-c764d5b9d8e8.png)

This is the result after this fix:

![screen shot 2015-10-20 at 11 31 34 am](https://cloud.githubusercontent.com/assets/145821/10612473/f8edf98e-771e-11e5-82db-5f96f4511430.png)

@pdpinch 
