### PR TITLE
Delete dead reference to modules.css.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1409,14 +1409,12 @@ PIPELINE_CSS = {
     'style-course': {
         'source_filenames': [
             'css/lms-course.css',
-            'xmodule/modules.css',
         ],
         'output_filename': 'css/lms-course.css',
     },
     'style-course-rtl': {
         'source_filenames': [
             'css/lms-course-rtl.css',
-            'xmodule/modules.css',
         ],
         'output_filename': 'css/lms-course-rtl.css',
     },


### PR DESCRIPTION
PLAT-878

FYI @talbs and @cpennington 

Note I couldn't find any references to descriptors.css. I will spin up a sandbox and add it to this PR when it ready.

Sandbox-- http://xmodule.sandbox.edx.org/
