### PR TITLE
Remove RemovedInDjango19Warning warnings

### DIFF
--- a/common/djangoapps/config_models/admin.py
+++ b/common/djangoapps/config_models/admin.py
@@ -5,14 +5,14 @@ Admin site models for managing :class:`.ConfigurationModel` subclasses
 from django.forms import models
 from django.contrib import admin
 from django.contrib.admin import ListFilter
-from django.core.cache import get_cache, InvalidCacheBackendError
+from django.core.cache import caches, InvalidCacheBackendError
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 
 try:
-    cache = get_cache('configuration')  # pylint: disable=invalid-name
+    cache = caches['configuration']  # pylint: disable=invalid-name
 except InvalidCacheBackendError:
     from django.core.cache import cache
 

--- a/common/djangoapps/config_models/models.py
+++ b/common/djangoapps/config_models/models.py
@@ -3,11 +3,11 @@ Django Model baseclass for database-backed configuration.
 """
 from django.db import connection, models
 from django.contrib.auth.models import User
-from django.core.cache import get_cache, InvalidCacheBackendError
+from django.core.cache import caches, InvalidCacheBackendError
 from django.utils.translation import ugettext_lazy as _
 
 try:
-    cache = get_cache('configuration')  # pylint: disable=invalid-name
+    cache = caches['configuration']  # pylint: disable=invalid-name
 except InvalidCacheBackendError:
     from django.core.cache import cache
 

--- a/common/djangoapps/enrollment/api.py
+++ b/common/djangoapps/enrollment/api.py
@@ -3,7 +3,7 @@ Enrollment API for creating, updating, and deleting enrollments. Also provides a
 course level, such as available course modes.
 
 """
-from django.utils import importlib
+import importlib
 import logging
 from django.conf import settings
 from django.core.cache import cache

--- a/common/djangoapps/external_auth/tests/test_shib.py
+++ b/common/djangoapps/external_auth/tests/test_shib.py
@@ -13,7 +13,7 @@ from django.test.client import RequestFactory, Client as DjangoTestClient
 from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import AnonymousUser, User
-from django.utils.importlib import import_module
+from importlib import import_module
 from edxmako.tests import mako_middleware_process_request
 from external_auth.models import ExternalAuthMap
 from external_auth.views import (

--- a/common/djangoapps/static_replace/management/commands/clear_collectstatic_cache.py
+++ b/common/djangoapps/static_replace/management/commands/clear_collectstatic_cache.py
@@ -3,12 +3,12 @@
 ###
 
 from django.core.management.base import NoArgsCommand
-from django.core.cache import get_cache
+from django.core.cache import caches
 
 
 class Command(NoArgsCommand):
     help = 'Import the specified data directory into the default ModuleStore'
 
     def handle_noargs(self, **options):
-        staticfiles_cache = get_cache('staticfiles')
+        staticfiles_cache = caches['staticfiles']
         staticfiles_cache.clear()

--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -8,7 +8,7 @@ from django.test.client import RequestFactory
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import AnonymousUser
-from django.utils.importlib import import_module
+from importlib import import_module
 from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 

--- a/common/djangoapps/student/tests/test_password_policy.py
+++ b/common/djangoapps/student/tests/test_password_policy.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import AnonymousUser
-from django.utils.importlib import import_module
+from importlib import import_module
 from django.test.utils import override_settings
 from django.conf import settings
 from mock import patch

--- a/common/djangoapps/util/cache.py
+++ b/common/djangoapps/util/cache.py
@@ -17,7 +17,7 @@ from django.core import cache
 from django.utils.translation import get_language
 
 try:
-    cache = cache.get_cache('general')
+    cache = cache.caches['general']
 except Exception:
     cache = cache.cache
 

--- a/common/djangoapps/util/tests/test_memcache.py
+++ b/common/djangoapps/util/tests/test_memcache.py
@@ -3,7 +3,7 @@ Tests for memcache in util app
 """
 
 from django.test import TestCase
-from django.core.cache import get_cache
+from django.core.cache import caches
 from util.memcache import safe_key
 
 
@@ -18,7 +18,7 @@ class MemcacheTest(TestCase):
 
     def setUp(self):
         super(MemcacheTest, self).setUp()
-        self.cache = get_cache('default')
+        self.cache = caches['default']
 
     def test_safe_key(self):
         key = safe_key('test', 'prefix', 'version')

--- a/common/djangoapps/util/url.py
+++ b/common/djangoapps/util/url.py
@@ -5,7 +5,7 @@ Utility functions related to urls.
 import sys
 from django.conf import settings
 from django.core.urlresolvers import set_urlconf
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 def reload_django_url_config():

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -17,7 +17,7 @@ from django.conf import settings
 if not settings.configured:
     settings.configure()
 
-from django.core.cache import get_cache, InvalidCacheBackendError
+from django.core.cache import caches, InvalidCacheBackendError
 import django.dispatch
 import django.utils
 
@@ -152,9 +152,9 @@ def create_modulestore_instance(
         request_cache = None
 
     try:
-        metadata_inheritance_cache = get_cache('mongo_metadata_inheritance')
+        metadata_inheritance_cache = caches['mongo_metadata_inheritance']
     except InvalidCacheBackendError:
-        metadata_inheritance_cache = get_cache('default')
+        metadata_inheritance_cache = caches['default']
 
     if issubclass(class_, MixedModuleStore):
         _options['create_modulestore_instance'] = create_modulestore_instance

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -15,7 +15,7 @@ from time import time
 from pymongo.errors import DuplicateKeyError  # pylint: disable=unused-import
 
 try:
-    from django.core.cache import get_cache, InvalidCacheBackendError
+    from django.core.cache import caches, InvalidCacheBackendError
     DJANGO_AVAILABLE = True
 except ImportError:
     DJANGO_AVAILABLE = False
@@ -30,6 +30,15 @@ from xmodule.modulestore.split_mongo import BlockKey
 
 
 new_contract('BlockData', BlockData)
+
+
+def get_cache(alias):
+    """
+    Return cache for an `alias`
+
+    Note: The primary purpose of this is to mock the cache in test_split_modulestore.py
+    """
+    return caches[alias]
 
 
 def round_power_2(value):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -12,7 +12,7 @@ import uuid
 
 from contracts import contract
 from nose.plugins.attrib import attr
-from django.core.cache import get_cache, InvalidCacheBackendError
+from django.core.cache import caches, InvalidCacheBackendError
 
 from openedx.core.lib import tempdir
 from xblock.fields import Reference, ReferenceList, ReferenceValueDict
@@ -915,7 +915,7 @@ class TestCourseStructureCache(SplitModuleTest):
     def setUp(self):
         # use the default cache, since the `course_structure_cache`
         # is a dummy cache during testing
-        self.cache = get_cache('default')
+        self.cache = caches['default']
 
         # make sure we clear the cache before every test...
         self.cache.clear()

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -11,7 +11,7 @@ from courseware.views import progress  # pylint: disable=import-error
 from courseware.field_overrides import OverrideFieldData
 from datetime import datetime
 from django.conf import settings
-from django.core.cache import get_cache
+from django.core.cache import caches
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from edxmako.middleware import MakoMiddleware  # pylint: disable=import-error
@@ -161,7 +161,7 @@ class FieldOverridePerformanceTestCase(ProceduralCourseTestMixin,
         with self.settings(MODULESTORE_BRANCH='published-only'):
             # Clear all caches before measuring
             for cache in settings.CACHES:
-                get_cache(cache).clear()
+                caches[cache].clear()
 
             # Refill the metadata inheritance cache
             modulestore().get_course(self.course.id, depth=None)

--- a/lms/djangoapps/course_wiki/editors.py
+++ b/lms/djangoapps/course_wiki/editors.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.utils.encoding import force_unicode
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -5,7 +5,7 @@ import json
 import ddt
 
 from django.conf import settings
-from django.core.cache import get_cache
+from django.core.cache import caches
 from django.test.client import Client, RequestFactory
 from django.contrib.auth.models import User
 from django.core.management import call_command
@@ -360,7 +360,7 @@ class ViewsQueryCountTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSet
     def clear_caches(self):
         """Clears caches so that query count numbers are accurate."""
         for cache in settings.CACHES:
-            get_cache(cache).clear()
+            caches[cache].clear()
         RequestCache.clear_request_cache()
 
     def count_queries(func):  # pylint: disable=no-self-argument

--- a/lms/djangoapps/lti_provider/__init__.py
+++ b/lms/djangoapps/lti_provider/__init__.py
@@ -4,6 +4,3 @@ platform. LTI is a standard protocol for connecting educational tools, defined
 by IMS:
     http://www.imsglobal.org/toolsinteroperability2.cfm
 """
-
-# Import the tasks module to ensure that signal handlers are registered.
-import lms.djangoapps.lti_provider.tasks

--- a/lms/djangoapps/lti_provider/startup.py
+++ b/lms/djangoapps/lti_provider/startup.py
@@ -1,0 +1,2 @@
+# Import the tasks module to ensure that signal handlers are registered.
+import lms.djangoapps.lti_provider.tasks

--- a/openedx/core/djangoapps/content/course_overviews/__init__.py
+++ b/openedx/core/djangoapps/content/course_overviews/__init__.py
@@ -23,6 +23,3 @@ a user enrollment dashboard, a course metadata API, or a course marketing
 page.
 """
 
-# importing signals is necessary to activate signal handler, which invalidates
-# the CourseOverview cache every time a course is published
-import openedx.core.djangoapps.content.course_overviews.signals  # pylint: disable=unused-import

--- a/openedx/core/djangoapps/content/course_overviews/startup.py
+++ b/openedx/core/djangoapps/content/course_overviews/startup.py
@@ -1,0 +1,3 @@
+# importing signals is necessary to activate signal handler, which invalidates
+# the CourseOverview cache every time a course is published
+import openedx.core.djangoapps.content.course_overviews.signals  # pylint: disable=unused-import

--- a/openedx/core/djangoapps/content/course_structures/api/v0/tests_api.py
+++ b/openedx/core/djangoapps/content/course_structures/api/v0/tests_api.py
@@ -99,7 +99,7 @@ class CourseStructureApiTests(ModuleStoreTestCase):
         """
         Verify that course_structure returns info for entire course.
         """
-        with mock.patch(self.MOCK_CACHE, cache.get_cache(backend='default')):
+        with mock.patch(self.MOCK_CACHE, cache.caches['default']):
             with self.assertNumQueries(3):
                 structure = course_structure(self.course.id)
 
@@ -110,7 +110,7 @@ class CourseStructureApiTests(ModuleStoreTestCase):
 
         self.assertDictEqual(structure, expected)
 
-        with mock.patch(self.MOCK_CACHE, cache.get_cache(backend='default')):
+        with mock.patch(self.MOCK_CACHE, cache.caches['default']):
             with self.assertNumQueries(2):
                 course_structure(self.course.id)
 
@@ -120,7 +120,7 @@ class CourseStructureApiTests(ModuleStoreTestCase):
         """
         block_types = ['html', 'video']
 
-        with mock.patch(self.MOCK_CACHE, cache.get_cache(backend='default')):
+        with mock.patch(self.MOCK_CACHE, cache.caches['default']):
             with self.assertNumQueries(3):
                 structure = course_structure(self.course.id, block_types=block_types)
 
@@ -131,7 +131,7 @@ class CourseStructureApiTests(ModuleStoreTestCase):
 
         self.assertDictEqual(structure, expected)
 
-        with mock.patch(self.MOCK_CACHE, cache.get_cache(backend='default')):
+        with mock.patch(self.MOCK_CACHE, cache.caches['default']):
             with self.assertNumQueries(2):
                 course_structure(self.course.id, block_types=block_types)
 

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -40,8 +40,8 @@ git+https://github.com/edx/lettuce.git@django1.8/upgrade#egg=lettuce==1.8
 -e git+https://github.com/edx/event-tracking.git@django1.8-upgrade#egg=event-tracking
 git+https://github.com/edx/django-splash.git@ammar/upgrade-to-django1.8#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@ammar/fix-deprecation-warnings#egg=ora2==0.2
--e git+https://github.com/edx/edx-submissions.git@ammar/fix-deprecation-warnings#egg=edx-submissions==0.1.1
+-e git+https://github.com/edx/edx-ora2.git@muzaffar/upgrage-django-1.8#egg=ora2==0.2
+-e git+https://github.com/edx/edx-submissions.git@muzaffar/upgrage-django-1.8#egg=edx-submissions==0.1.1
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.1.3#egg=i18n-tools==v0.1.3

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -40,7 +40,7 @@ git+https://github.com/edx/lettuce.git@django1.8/upgrade#egg=lettuce==1.8
 -e git+https://github.com/edx/event-tracking.git@django1.8-upgrade#egg=event-tracking
 git+https://github.com/edx/django-splash.git@ammar/upgrade-to-django1.8#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@muzaffar/upgrage-django-1.8#egg=ora2==0.2
+-e git+https://github.com/edx/edx-ora2.git@ned/django-upgrade-1.8#egg=ora2==0.2
 -e git+https://github.com/edx/edx-submissions.git@muzaffar/upgrage-django-1.8#egg=edx-submissions==0.1.1
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -18,7 +18,7 @@ git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6
 -e git+https://github.com/eventbrite/zendesk.git@d53fe0e81b623f084e91776bcf6369f8b7b63879#egg=zendesk
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip   
 -e git+https://github.com/jazkarta/edx-jsme.git@c5bfa5d361d6685d8c643838fc0055c25f8b7999#egg=edx-jsme
-git+https://github.com/edx/django-pyfs.git@aefed1e258afc2899af239c3d1216a465ddbddf2#egg=django-pyfs==1.0.1
+git+https://github.com/edx/django-pyfs.git@ammar/fix-deprecation-warnings#egg=django-pyfs==1.0.2
 git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a0c695#egg=django-cas
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 # Master pyfs has a bug working with VPC auth. This is a fix. We should switch
@@ -40,8 +40,8 @@ git+https://github.com/edx/lettuce.git@django1.8/upgrade#egg=lettuce==1.8
 -e git+https://github.com/edx/event-tracking.git@django1.8-upgrade#egg=event-tracking
 git+https://github.com/edx/django-splash.git@ammar/upgrade-to-django1.8#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@3fe9b164bf8dcd51ea89cacc37a00bd72f81fc91#egg=ora2==0.1
--e git+https://github.com/edx/edx-submissions.git@muzaffar/upgrage-django-1.8#egg=edx-submissions
+-e git+https://github.com/edx/edx-ora2.git@ammar/fix-deprecation-warnings#egg=ora2==0.2
+-e git+https://github.com/edx/edx-submissions.git@ammar/fix-deprecation-warnings#egg=edx-submissions==0.1.1
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.1.3#egg=i18n-tools==v0.1.3


### PR DESCRIPTION
TNL-3450

django-wiki hash should be from [https://github.com/edx/django-wiki/pull/12] but due to a migration issue hash is not updated here. will update once that issue is resolved.
