### PR TITLE
asadiqbal08/SOL-1312 Certs: Remove limits on Number of Signatories

### DIFF
--- a/cms/static/js/certificates/spec/views/certificate_editor_spec.js
+++ b/cms/static/js/certificates/spec/views/certificate_editor_spec.js
@@ -18,7 +18,6 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
          Notification, AjaxHelpers, TemplateHelpers, ViewHelpers, ValidationHelpers, CustomMatchers) {
     'use strict';
 
-    var MAX_SIGNATORIES = 4;
     var SELECTORS = {
         detailsView: '.certificate-details',
         editView: '.certificate-edit',
@@ -198,12 +197,12 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
                 expect(this.collection.length).toBe(1);
             });
 
-            it('user can only add signatories up to max 4', function() {
-                for(var i = 1; i < MAX_SIGNATORIES ; i++) {
+            it('users can add signatories as many as they want', function() {
+                // currently checking for 10 signatories as a test.
+                for(var i = 1; i <= 10 ; i++) {
                     this.view.$(SELECTORS.addSignatoryButton).click();
                 }
-                expect(this.view.$(SELECTORS.addSignatoryButton)).toHaveClass('disableClick');
-
+                expect(this.view.$(SELECTORS.addSignatoryButton)).not.toHaveClass('disableClick');
             });
 
             it('user can add signatories if not reached the upper limit', function() {
@@ -212,21 +211,6 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
                 expect('click').not.toHaveBeenPreventedOn(SELECTORS.addSignatoryButton);
                 expect(this.view.$(SELECTORS.addSignatoryButton)).not.toHaveClass('disableClick');
             });
-
-            it('user can add signatories when signatory reached the upper limit But after deleting a signatory',
-                function() {
-                    for(var i = 1; i < MAX_SIGNATORIES ; i++) {
-                        this.view.$(SELECTORS.addSignatoryButton).click();
-                    }
-                    expect(this.view.$(SELECTORS.addSignatoryButton)).toHaveClass('disableClick');
-
-                    // now delete anyone of the signatory, Add signatory should be enabled.
-                    var signatory = this.model.get('signatories').at(0);
-                    var text = 'Delete "'+ signatory.get('name') +'" from the list of signatories?';
-                    clickDeleteItem(this, text, SELECTORS.signatoryDeleteButton + ':first');
-                    expect(this.view.$(SELECTORS.addSignatoryButton)).not.toHaveClass('disableClick');
-                }
-            );
 
             it('signatories should save when fields have too many characters per line', function() {
                 this.view.$(SELECTORS.addSignatoryButton).click();

--- a/cms/static/js/certificates/views/certificate_editor.js
+++ b/cms/static/js/certificates/views/certificate_editor.js
@@ -12,7 +12,6 @@ define([ // jshint ignore:line
 function($, _, Backbone, gettext,
          ListItemEditorView, SignatoryModel, SignatoryEditorView) {
     'use strict';
-    var MAX_SIGNATORIES_LIMIT = 4;
     var CertificateEditorView = ListItemEditorView.extend({
         tagName: 'div',
         events: {
@@ -72,7 +71,6 @@ function($, _, Backbone, gettext,
                 });
                 self.$('div.signatory-edit-list').append($(signatory_view.render()));
             });
-            this.disableAddSignatoryButton();
             return this;
         },
 
@@ -80,13 +78,6 @@ function($, _, Backbone, gettext,
             // Append a new signatory to the certificate model's signatories collection
             var signatory = new SignatoryModel({certificate: this.getSaveableModel()}); // jshint ignore:line
             this.render();
-        },
-
-        disableAddSignatoryButton: function() {
-            // Disable the 'Add Signatory' link if the constraint has been met.
-            if(this.$(".signatory-edit-list > div.signatory-edit").length >= MAX_SIGNATORIES_LIMIT) {
-                this.$(".action-add-signatory").addClass("disableClick");
-            }
         },
 
         getTemplateOptions: function() {


### PR DESCRIPTION
As a Course Staff I want to be able to add as many signatories to a Certificate as I want.
This will be on PMs to manage the layout and Print View issues.
@ziafazal can you please look around this PR ? 
@mattdrayer FYI
###### Note: I am removing the code related to signatories limits.
###### However, I suggested to add a `MAX_SIGNATORY_LIMIT` (with default value of 4) configuration under Course Advance Settings (along with Certificate Web/HTML View Enabled) instead of completely removing the code related to signatory limit.
