### PR TITLE
No need for docstrings on "class Meta"

### DIFF
--- a/common/djangoapps/config_models/models.py
+++ b/common/djangoapps/config_models/models.py
@@ -67,7 +67,7 @@ class ConfigurationModel(models.Model):
             should be cached
     """
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         abstract = True
         ordering = ("-change_date", )
 

--- a/common/djangoapps/course_modes/admin.py
+++ b/common/djangoapps/course_modes/admin.py
@@ -31,7 +31,7 @@ from verify_student import models as verification_models  # pylint: disable=impo
 
 class CourseModeForm(forms.ModelForm):
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseMode
 
     COURSE_MODE_SLUG_CHOICES = (

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -110,7 +110,6 @@ class CourseMode(models.Model):
     UPSELL_TO_VERIFIED_MODES = [HONOR]
 
     class Meta(object):
-        """ meta attributes of this model """
         unique_together = ('course_id', 'mode_slug', 'currency')
 
     def clean(self):

--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -57,7 +57,7 @@ class Role(models.Model):
     users = models.ManyToManyField(User, related_name="roles")
     course_id = CourseKeyField(max_length=255, blank=True, db_index=True)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         # use existing table that was originally created from django_comment_client app
         db_table = 'django_comment_client_role'
 
@@ -99,7 +99,7 @@ class Permission(models.Model):
     name = models.CharField(max_length=30, null=False, blank=False, primary_key=True)
     roles = models.ManyToManyField(Role, related_name="permissions")
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         # use existing table that was originally created from django_comment_client app
         db_table = 'django_comment_client_permission'
 

--- a/common/djangoapps/embargo/forms.py
+++ b/common/djangoapps/embargo/forms.py
@@ -25,7 +25,7 @@ class RestrictedCourseForm(forms.ModelForm):
     error message instead.
 
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = RestrictedCourse
 
     def clean_course_key(self):
@@ -58,7 +58,7 @@ class RestrictedCourseForm(forms.ModelForm):
 class IPFilterForm(forms.ModelForm):
     """Form validating entry of IP addresses"""
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = IPFilter
 
     def _is_valid_ip(self, address):

--- a/common/djangoapps/embargo/models.py
+++ b/common/djangoapps/embargo/models.py
@@ -646,7 +646,7 @@ class CourseAccessRuleHistory(models.Model):
             else:
                 CourseAccessRuleHistory.save_snapshot(restricted_course)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         get_latest_by = 'timestamp'
 
 

--- a/common/djangoapps/enrollment/serializers.py
+++ b/common/djangoapps/enrollment/serializers.py
@@ -76,7 +76,7 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
         """Retrieves the username from the associated model."""
         return model.username
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseEnrollment
         fields = ('created', 'mode', 'is_active', 'course_details', 'user')
         lookup_field = 'username'

--- a/common/djangoapps/external_auth/models.py
+++ b/common/djangoapps/external_auth/models.py
@@ -14,8 +14,9 @@ from django.contrib.auth.models import User
 
 
 class ExternalAuthMap(models.Model):
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('external_id', 'external_domain'), )
+
     external_id = models.CharField(max_length=255, db_index=True)
     external_domain = models.CharField(max_length=255, db_index=True)
     external_credentials = models.TextField(blank=True)  # JSON dictionary

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -17,7 +17,7 @@ from student.roles import REGISTERED_ACCESS_ROLES
 class CourseAccessRoleForm(forms.ModelForm):
     """Form for adding new Course Access Roles view the Django Admin Panel."""
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseAccessRole
 
     email = forms.EmailField(required=True)
@@ -125,7 +125,7 @@ class CourseAccessRoleAdmin(admin.ModelAdmin):
 class LinkedInAddToProfileConfigurationAdmin(admin.ModelAdmin):
     """Admin interface for the LinkedIn Add to Profile configuration. """
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = LinkedInAddToProfileConfiguration
 
     # Exclude deprecated fields
@@ -144,7 +144,7 @@ class CourseEnrollmentAdmin(admin.ModelAdmin):
             return self.readonly_fields + ('course_id', 'mode', 'user',)
         return self.readonly_fields
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseEnrollment
 
 
@@ -159,7 +159,7 @@ class UserProfileAdmin(admin.ModelAdmin):
             return self.readonly_fields + ('user',)
         return self.readonly_fields
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = UserProfile
 
 

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -216,7 +216,7 @@ class UserProfile(models.Model):
     # cache key format e.g user.<user_id>.profile.country = 'SG'
     PROFILE_COUNTRY_CACHE_KEY = u"user.{user_id}.profile.country"
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         db_table = "auth_userprofile"
 
     # CRITICAL TODO/SECURITY
@@ -487,7 +487,8 @@ class Registration(models.Model):
         registration profile is created when the user creates an
         account, but that account is inactive. Once the user clicks
         on the activation key, it becomes active. '''
-    class Meta(object):  # pylint: disable=missing-docstring
+
+    class Meta(object):
         db_table = "auth_registration"
 
     user = models.ForeignKey(User, unique=True)
@@ -903,7 +904,7 @@ class CourseEnrollment(models.Model):
     # cache key format e.g enrollment.<username>.<course_key>.mode = 'honor'
     COURSE_ENROLLMENT_CACHE_KEY = u"enrollment.{}.{}.mode"
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('user', 'course_id'),)
         ordering = ('user', 'course_id')
 
@@ -1516,7 +1517,7 @@ class CourseEnrollmentAllowed(models.Model):
 
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('email', 'course_id'),)
 
     def __unicode__(self):
@@ -1553,7 +1554,7 @@ class CourseAccessRole(models.Model):
     course_id = CourseKeyField(max_length=255, db_index=True, blank=True)
     role = models.CharField(max_length=64, db_index=True)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = ('user', 'org', 'course_id', 'role')
 
     @property
@@ -1882,9 +1883,6 @@ class EntranceExamConfiguration(models.Model):
     skip_entrance_exam = models.BooleanField(default=True)
 
     class Meta(object):
-        """
-        Meta class to make user and course_id unique in the table
-        """
         unique_together = (('user', 'course_id'), )
 
     def __unicode__(self):
@@ -1944,7 +1942,7 @@ class LanguageProficiency(models.Model):
     /edx-platform/openedx/core/djangoapps/user_api/accounts/views.py or its associated api method
     (update_account_settings) so that the events are emitted.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('code', 'user_profile'),)
 
     user_profile = models.ForeignKey(UserProfile, db_index=True, related_name='language_proficiencies')

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -104,7 +104,7 @@ class ProviderConfig(ConfigurationModel):
 
     # "enabled" field is inherited from ConfigurationModel
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         abstract = True
 
     @property
@@ -203,7 +203,7 @@ class OAuth2ProviderConfig(ProviderConfig):
     )
     other_settings = models.TextField(blank=True, help_text="Optional JSON object with advanced settings, if any.")
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         verbose_name = "Provider Configuration (OAuth)"
         verbose_name_plural = verbose_name
 
@@ -282,7 +282,7 @@ class SAMLProviderConfig(ProviderConfig):
         super(SAMLProviderConfig, self).clean()
         self.other_settings = clean_json(self.other_settings, dict)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         verbose_name = "Provider Configuration (SAML IdP)"
         verbose_name_plural = "Provider Configuration (SAML IdPs)"
 
@@ -373,7 +373,7 @@ class SAMLConfiguration(ConfigurationModel):
         ),
     )
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         verbose_name = "SAML Configuration"
         verbose_name_plural = verbose_name
 
@@ -439,7 +439,7 @@ class SAMLProviderData(models.Model):
     sso_url = models.URLField(verbose_name="SSO URL")
     public_key = models.TextField()
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         verbose_name = "SAML Provider Data"
         verbose_name_plural = verbose_name
         ordering = ('-fetched_at', )
@@ -551,6 +551,6 @@ class LTIProviderConfig(ProviderConfig):
             return self.lti_consumer_secret
         return getattr(settings, 'SOCIAL_AUTH_LTI_CONSUMER_SECRETS', {}).get(self.lti_consumer_key, '')
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         verbose_name = "Provider Configuration (LTI)"
         verbose_name_plural = verbose_name

--- a/common/djangoapps/track/backends/django.py
+++ b/common/djangoapps/track/backends/django.py
@@ -46,7 +46,7 @@ class TrackingLog(models.Model):
     time = models.DateTimeField('event time')
     host = models.CharField(max_length=64, blank=True)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         app_label = 'track'
         db_table = 'track_trackinglog'
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -74,7 +74,7 @@ class XModuleFactory(Factory):
     # We have to give a model for Factory.
     # However, the class that we create is actually determined by the category
     # specified in the factory
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = Dummy
 
     @lazy_attribute

--- a/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
+++ b/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
@@ -104,7 +104,7 @@ class ModuleSystemFactory(Factory):
     performed by :func:`xmodule.tests.get_test_system`, so
     arguments for that function are valid factory attributes.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = ModuleSystem
 
     @classmethod
@@ -120,7 +120,7 @@ class DescriptorSystemFactory(Factory):
     performed by :func:`xmodule.tests.get_test_descriptor_system`, so
     arguments for that function are valid factory attributes.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = DescriptorSystem
 
     @classmethod

--- a/common/lib/xmodule/xmodule/tests/xml/factories.py
+++ b/common/lib/xmodule/xmodule/tests/xml/factories.py
@@ -64,7 +64,7 @@ class XmlImportFactory(Factory):
     Factory for generating XmlImportData's, which can hold all the data needed
     to run an XModule XML import
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = XmlImportData
 
     filesystem = MemoryFS()

--- a/common/test/acceptance/fixtures/discussion.py
+++ b/common/test/acceptance/fixtures/discussion.py
@@ -12,8 +12,9 @@ from . import COMMENTS_STUB_URL
 
 
 class ContentFactory(factory.Factory):
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = dict
+
     id = None
     user_id = "1234"
     username = "dummy-username"
@@ -64,8 +65,9 @@ class Response(Comment):
 
 
 class SearchResult(factory.Factory):
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = dict
+
     discussion_data = []
     annotated_content_info = {}
     num_pages = 1

--- a/common/test/acceptance/fixtures/edxnotes.py
+++ b/common/test/acceptance/fixtures/edxnotes.py
@@ -10,8 +10,9 @@ from . import EDXNOTES_STUB_URL
 
 
 class Range(factory.Factory):
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = dict
+
     start = "/div[1]/p[1]"
     end = "/div[1]/p[1]"
     startOffset = 0
@@ -19,8 +20,9 @@ class Range(factory.Factory):
 
 
 class Note(factory.Factory):
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = dict
+
     user = "dummy-user"
     usage_id = "dummy-usage-id"
     course_id = "dummy-course-id"

--- a/lms/djangoapps/bulk_email/forms.py
+++ b/lms/djangoapps/bulk_email/forms.py
@@ -22,7 +22,7 @@ class CourseEmailTemplateForm(forms.ModelForm):
 
     name = forms.CharField(required=False)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseEmailTemplate
         fields = ('html_template', 'plain_template', 'name')
 
@@ -76,7 +76,7 @@ class CourseEmailTemplateForm(forms.ModelForm):
 class CourseAuthorizationAdminForm(forms.ModelForm):
     """Input form for email enabling, allowing us to verify data."""
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseAuthorization
 
     def clean_course_id(self):

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -44,7 +44,7 @@ class Email(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         abstract = True
 
 
@@ -144,7 +144,7 @@ class Optout(models.Model):
     user = models.ForeignKey(User, db_index=True, null=True)
     course_id = CourseKeyField(max_length=255, db_index=True)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = ('user', 'course_id')
 
 

--- a/lms/djangoapps/ccx/models.py
+++ b/lms/djangoapps/ccx/models.py
@@ -103,7 +103,7 @@ class CcxFieldOverride(models.Model):
     location = LocationKeyField(max_length=255, db_index=True)
     field = models.CharField(max_length=255)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('ccx', 'location', 'field'),)
 
     value = models.TextField(default='null')

--- a/lms/djangoapps/ccx/tests/factories.py
+++ b/lms/djangoapps/ccx/tests/factories.py
@@ -8,8 +8,9 @@ from ccx.models import CustomCourseForEdX  # pylint: disable=import-error
 
 
 class CcxFactory(DjangoModelFactory):  # pylint: disable=missing-docstring
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CustomCourseForEdX
+
     display_name = "Test CCX"
     id = None  # pylint: disable=redefined-builtin, invalid-name
     coach = SubFactory(UserFactory)

--- a/lms/djangoapps/certificates/admin.py
+++ b/lms/djangoapps/certificates/admin.py
@@ -28,7 +28,6 @@ class CertificateTemplateForm(forms.ModelForm):
         )
 
     class Meta(object):
-        """ Meta definitions for CertificateTemplateForm  """
         model = CertificateTemplate
 
 

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -136,7 +136,7 @@ class GeneratedCertificate(models.Model):
         auto_now=True, default=datetime.now)
     error_reason = models.CharField(max_length=512, blank=True, default='')
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('user', 'course_id'),)
 
     @classmethod
@@ -252,7 +252,7 @@ class ExampleCertificateSet(TimeStampedModel):
     """
     course_key = CourseKeyField(max_length=255, db_index=True)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         get_latest_by = 'created'
 
     @classmethod
@@ -509,7 +509,7 @@ class CertificateGenerationCourseSetting(TimeStampedModel):
     course_key = CourseKeyField(max_length=255, db_index=True)
     enabled = models.BooleanField(default=False)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         get_latest_by = 'created'
 
     @classmethod
@@ -625,9 +625,6 @@ class BadgeAssertion(models.Model):
         return self.data['json']['id']
 
     class Meta(object):
-        """
-        Meta information for Django's construction of the model.
-        """
         unique_together = (('course_id', 'user', 'mode'),)
 
 
@@ -736,7 +733,7 @@ class CertificateTemplate(TimeStampedModel):
     def __unicode__(self):
         return u'%s' % (self.name, )
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         get_latest_by = 'created'
         unique_together = (('organization_id', 'course_key', 'mode'),)
 
@@ -788,7 +785,7 @@ class CertificateTemplateAsset(TimeStampedModel):
     def __unicode__(self):
         return u'%s' % (self.asset.url, )  # pylint: disable=no-member
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         get_latest_by = 'created'
 
 

--- a/lms/djangoapps/commerce/api/v1/serializers.py
+++ b/lms/djangoapps/commerce/api/v1/serializers.py
@@ -31,7 +31,7 @@ class CourseModeSerializer(serializers.ModelSerializer):
         except AttributeError:
             return None
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseMode
         fields = ('name', 'currency', 'price', 'sku', 'expires')
 

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -101,7 +101,7 @@ class StudentModule(CallStackMixin, models.Model):
 
     course_id = CourseKeyField(max_length=255, db_index=True)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('student', 'module_state_key', 'course_id'),)
 
     # Internal state of the object
@@ -160,7 +160,7 @@ class StudentModuleHistory(CallStackMixin, models.Model):
     objects = CallStackManager()
     HISTORY_SAVING_TYPES = {'problem'}
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         get_latest_by = "created"
 
     student_module = models.ForeignKey(StudentModule, db_index=True)
@@ -195,7 +195,7 @@ class XBlockFieldBase(models.Model):
     """
     objects = ChunkingManager()
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         abstract = True
 
     # The name of the field
@@ -222,7 +222,7 @@ class XModuleUserStateSummaryField(XBlockFieldBase):
     """
     Stores data set in the Scope.user_state_summary scope by an xmodule field
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('usage_id', 'field_name'),)
 
     # The definition id for the module
@@ -233,7 +233,7 @@ class XModuleStudentPrefsField(XBlockFieldBase):
     """
     Stores data set in the Scope.preferences scope by an xmodule field
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('student', 'module_type', 'field_name'),)
 
     # The type of the module for these preferences
@@ -246,8 +246,9 @@ class XModuleStudentInfoField(XBlockFieldBase):
     """
     Stores data set in the Scope.preferences scope by an xmodule field
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('student', 'field_name'),)
+
     student = models.ForeignKey(User, db_index=True)
 
 
@@ -263,7 +264,7 @@ class OfflineComputedGrade(models.Model):
 
     gradeset = models.TextField(null=True, blank=True)		# grades, stored as JSON
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('user', 'course_id'), )
 
     def __unicode__(self):
@@ -275,7 +276,7 @@ class OfflineComputedGradeLog(models.Model):
     Log of when offline grades are computed.
     Use this to be able to show instructor when the last computed grades were done.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         ordering = ["-created"]
         get_latest_by = "created"
 
@@ -298,7 +299,7 @@ class StudentFieldOverride(TimeStampedModel):
     location = LocationKeyField(max_length=255, db_index=True)
     student = models.ForeignKey(User, db_index=True)
 
-    class Meta(object):   # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('course_id', 'field', 'location', 'student'),)
 
     field = models.CharField(max_length=255)

--- a/lms/djangoapps/django_comment_client/tests/factories.py
+++ b/lms/djangoapps/django_comment_client/tests/factories.py
@@ -3,13 +3,15 @@ from django_comment_common.models import Role, Permission
 
 
 class RoleFactory(DjangoModelFactory):
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = Role
+
     name = 'Student'
     course_id = 'edX/toy/2012_Fall'
 
 
 class PermissionFactory(DjangoModelFactory):
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = Permission
+
     name = 'create_comment'

--- a/lms/djangoapps/foldit/models.py
+++ b/lms/djangoapps/foldit/models.py
@@ -83,7 +83,7 @@ class PuzzleComplete(models.Model):
     e.g. PuzzleID 1234, set 1, subset 3.  (Sets and subsets correspond to levels
     in the intro puzzles)
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         # there should only be one puzzle complete entry for any particular
         # puzzle for any user
         unique_together = ('user', 'puzzle_id', 'puzzle_set', 'puzzle_subset')

--- a/lms/djangoapps/instructor_task/tests/factories.py
+++ b/lms/djangoapps/instructor_task/tests/factories.py
@@ -9,7 +9,7 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 
 class InstructorTaskFactory(DjangoModelFactory):
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = InstructorTask
 
     task_type = 'rescore_problem'

--- a/lms/djangoapps/licenses/tests.py
+++ b/lms/djangoapps/licenses/tests.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 class CourseSoftwareFactory(DjangoModelFactory):
     '''Factory for generating CourseSoftware objects in database'''
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseSoftware
 
     name = SOFTWARE_1
@@ -48,7 +48,7 @@ class UserLicenseFactory(DjangoModelFactory):
     By default, the user assigned is null, indicating that the
     serial number has not yet been assigned.
     '''
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = UserLicense
 
     user = None

--- a/lms/djangoapps/lti_provider/models.py
+++ b/lms/djangoapps/lti_provider/models.py
@@ -117,9 +117,6 @@ class GradedAssignment(models.Model):
     version_number = models.IntegerField(default=0)
 
     class Meta(object):
-        """
-        Uniqueness constraints.
-        """
         unique_together = ('outcome_service', 'lis_result_sourcedid')
 
 
@@ -135,7 +132,4 @@ class LtiUser(models.Model):
     edx_user = models.ForeignKey(User, unique=True)
 
     class Meta(object):
-        """
-        Uniqueness constraints.
-        """
         unique_together = ('lti_consumer', 'lti_user_id')

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -97,7 +97,7 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
         else:
             return {}
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseEnrollment
         fields = ('created', 'mode', 'is_active', 'course', 'certificate')
         lookup_field = 'username'
@@ -113,7 +113,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         lookup_field='username'
     )
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = User
         fields = ('id', 'username', 'email', 'name', 'course_enrollments')
         lookup_field = 'username'

--- a/lms/djangoapps/notifier_api/serializers.py
+++ b/lms/djangoapps/notifier_api/serializers.py
@@ -63,7 +63,7 @@ class NotifierUserSerializer(serializers.ModelSerializer):
                     pass
         return ret
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = User
         fields = ("id", "email", "name", "preferences", "course_info")
         read_only_fields = ("id", "email")

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -1164,7 +1164,7 @@ class InvoiceHistory(models.Model):
         elif hasattr(instance, 'invoice'):
             InvoiceHistory.save_invoice_snapshot(instance.invoice)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         get_latest_by = "timestamp"
 
 

--- a/lms/djangoapps/survey/admin.py
+++ b/lms/djangoapps/survey/admin.py
@@ -10,7 +10,7 @@ from survey.models import SurveyForm
 class SurveyFormAdminForm(forms.ModelForm):
     """Form providing validation of SurveyForm content."""
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = SurveyForm
         fields = ('name', 'form')
 

--- a/lms/djangoapps/teams/models.py
+++ b/lms/djangoapps/teams/models.py
@@ -154,7 +154,6 @@ class CourseTeamMembership(models.Model):
     """This model represents the membership of a single user in a single team."""
 
     class Meta(object):
-        """Stores meta information for the model."""
         unique_together = (('user', 'team'),)
 
     user = models.ForeignKey(User)

--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -62,7 +62,6 @@ class UserMembershipSerializer(serializers.ModelSerializer):
     )
 
     class Meta(object):
-        """Defines meta information for the ModelSerializer."""
         model = CourseTeamMembership
         fields = ("user", "date_joined", "last_activity_at")
         read_only_fields = ("date_joined", "last_activity_at")
@@ -75,7 +74,6 @@ class CourseTeamSerializer(serializers.ModelSerializer):
     country = CountryField()
 
     class Meta(object):
-        """Defines meta information for the ModelSerializer."""
         model = CourseTeam
         fields = (
             "id",
@@ -99,7 +97,6 @@ class CourseTeamCreationSerializer(serializers.ModelSerializer):
     country = CountryField(required=False)
 
     class Meta(object):
-        """Defines meta information for the ModelSerializer."""
         model = CourseTeam
         fields = (
             "name",
@@ -161,7 +158,6 @@ class MembershipSerializer(serializers.ModelSerializer):
     )
 
     class Meta(object):
-        """Defines meta information for the ModelSerializer."""
         model = CourseTeamMembership
         fields = ("user", "team", "date_joined", "last_activity_at")
         read_only_fields = ("date_joined", "last_activity_at")
@@ -209,7 +205,7 @@ class BulkTeamCountTopicSerializer(BaseTopicSerializer):  # pylint: disable=abst
     Serializes a set of topics, adding the team_count field to each topic as a bulk operation.
     Requires that `context` is provided with a valid course_id in order to filter teams within the course.
     """
-    class Meta:  # pylint: disable=missing-docstring,old-style-class
+    class Meta(object):
         list_serializer_class = BulkTeamCountTopicListSerializer
 
 

--- a/lms/djangoapps/teams/tests/factories.py
+++ b/lms/djangoapps/teams/tests/factories.py
@@ -18,7 +18,7 @@ class CourseTeamFactory(DjangoModelFactory):
 
     Note that team_id is not auto-generated from name when using the factory.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseTeam
         django_get_or_create = ('team_id',)
 
@@ -31,8 +31,9 @@ class CourseTeamFactory(DjangoModelFactory):
 
 class CourseTeamMembershipFactory(DjangoModelFactory):
     """Factory for CourseTeamMemberships."""
-    class Meta(object):    # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseTeamMembership
+
     last_activity_at = LAST_ACTIVITY_AT
 
     @classmethod

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -188,7 +188,7 @@ class PhotoVerification(StatusModel):
     # capturing it so that we can later query for the common problems.
     error_code = models.CharField(blank=True, max_length=50)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         abstract = True
         ordering = ['-created_at']
 
@@ -1043,7 +1043,7 @@ class VerificationCheckpoint(models.Model):
     checkpoint_location = models.CharField(max_length=255)
     photo_verification = models.ManyToManyField(SoftwareSecurePhotoVerification)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = ('course_id', 'checkpoint_location')
 
     def __unicode__(self):
@@ -1152,7 +1152,7 @@ class VerificationStatus(models.Model):
     response = models.TextField(null=True, blank=True)
     error = models.TextField(null=True, blank=True)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         get_latest_by = "timestamp"
         verbose_name = "Verification Status"
         verbose_name_plural = "Verification Statuses"
@@ -1329,7 +1329,7 @@ class SkippedReverification(models.Model):
     checkpoint = models.ForeignKey(VerificationCheckpoint, related_name="skipped_checkpoint")
     created_at = models.DateTimeField(auto_now_add=True)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('user', 'course_id'),)
 
     @classmethod

--- a/lms/djangoapps/verify_student/tests/factories.py
+++ b/lms/djangoapps/verify_student/tests/factories.py
@@ -10,7 +10,7 @@ class SoftwareSecurePhotoVerificationFactory(DjangoModelFactory):
     """
     Factory for SoftwareSecurePhotoVerification
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = SoftwareSecurePhotoVerification
 
     status = 'approved'

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -18,7 +18,7 @@ class CourseUserGroup(models.Model):
     which may be treated specially.  For example, a user can be in at most one cohort per
     course, and cohorts are used to split up the forums by group.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = (('name', 'course_id'), )
 
     name = models.CharField(max_length=255,

--- a/openedx/core/djangoapps/course_groups/tests/helpers.py
+++ b/openedx/core/djangoapps/course_groups/tests/helpers.py
@@ -18,7 +18,7 @@ class CohortFactory(DjangoModelFactory):
     """
     Factory for constructing mock cohorts.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseUserGroup
 
     name = Sequence("cohort{}".format)
@@ -38,7 +38,7 @@ class CourseCohortFactory(DjangoModelFactory):
     """
     Factory for constructing mock course cohort.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseCohort
 
     course_user_group = factory.SubFactory(CohortFactory)
@@ -49,7 +49,7 @@ class CourseCohortSettingsFactory(DjangoModelFactory):
     """
     Factory for constructing mock course cohort settings.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CourseCohortsSettings
 
     is_cohorted = False

--- a/openedx/core/djangoapps/credit/admin.py
+++ b/openedx/core/djangoapps/credit/admin.py
@@ -13,7 +13,7 @@ class CreditCourseAdmin(admin.ModelAdmin):
     list_filter = ('enabled',)
     search_fields = ('course_key',)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CreditCourse
 
 
@@ -23,7 +23,7 @@ class CreditProviderAdmin(admin.ModelAdmin):
     list_filter = ('active',)
     search_fields = ('provider_id', 'display_name')
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CreditProvider
 
 
@@ -32,7 +32,7 @@ class CreditEligibilityAdmin(admin.ModelAdmin):
     list_display = ('course', 'username', 'deadline')
     search_fields = ('username', 'course__course_key')
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CreditEligibility
 
 
@@ -43,7 +43,7 @@ class CreditRequestAdmin(admin.ModelAdmin):
     readonly_fields = ('uuid',)
     search_fields = ('uuid', 'username', 'course__course_key', 'provider__provider_id')
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CreditRequest
 
 

--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -291,9 +291,6 @@ class CreditRequirement(TimeStampedModel):
     active = models.BooleanField(default=True)
 
     class Meta(object):
-        """
-        Model metadata.
-        """
         unique_together = ('namespace', 'name', 'course')
         ordering = ["order"]
 
@@ -428,7 +425,7 @@ class CreditRequirementStatus(TimeStampedModel):
     # Maintain a history of requirement status updates for auditing purposes
     history = HistoricalRecords()
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = ('username', 'requirement')
 
     @classmethod
@@ -515,7 +512,7 @@ class CreditEligibility(TimeStampedModel):
         help_text=ugettext_lazy("Deadline for purchasing and requesting credit.")
     )
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = ('username', 'course')
         verbose_name_plural = "Credit eligibilities"
 
@@ -637,7 +634,7 @@ class CreditRequest(TimeStampedModel):
 
     history = HistoricalRecords()
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         # Enforce the constraint that each user can have exactly one outstanding
         # request to a given provider.  Multiple requests use the same UUID.
         unique_together = ('username', 'course', 'provider')

--- a/openedx/core/djangoapps/credit/serializers.py
+++ b/openedx/core/djangoapps/credit/serializers.py
@@ -29,6 +29,6 @@ class CreditCourseSerializer(serializers.ModelSerializer):
 
     course_key = CourseKeyField()
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = CreditCourse
         exclude = ('id',)

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -24,7 +24,7 @@ class LanguageProficiencySerializer(serializers.ModelSerializer):
     Class that serializes the LanguageProficiency model for account
     information.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = LanguageProficiency
         fields = ("code",)
 
@@ -143,7 +143,7 @@ class AccountUserSerializer(serializers.HyperlinkedModelSerializer, ReadOnlyFiel
     """
     Class that serializes the portion of User model needed for account information.
     """
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = User
         fields = ("username", "email", "date_joined", "is_active")
         read_only_fields = ("username", "email", "date_joined", "is_active")
@@ -158,7 +158,7 @@ class AccountLegacyProfileSerializer(serializers.HyperlinkedModelSerializer, Rea
     requires_parental_consent = serializers.SerializerMethodField()
     language_proficiencies = LanguageProficiencySerializer(many=True, required=False)
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = UserProfile
         fields = (
             "name", "gender", "goals", "year_of_birth", "level_of_education", "country",

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -27,7 +27,7 @@ class UserPreference(models.Model):
     key = models.CharField(max_length=255, db_index=True, validators=[RegexValidator(KEY_REGEX)])
     value = models.TextField()
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = ("user", "key")
 
     @classmethod
@@ -96,7 +96,7 @@ class UserCourseTag(models.Model):
     course_id = CourseKeyField(max_length=255, db_index=True)
     value = models.TextField()
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         unique_together = ("user", "course_id", "key")
 
 
@@ -112,5 +112,4 @@ class UserOrgTag(TimeStampedModel):
     value = models.TextField()
 
     class Meta(object):
-        """ Meta class for defining unique constraints. """
         unique_together = ("user", "org", "key")

--- a/openedx/core/djangoapps/user_api/serializers.py
+++ b/openedx/core/djangoapps/user_api/serializers.py
@@ -28,7 +28,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         """
         return dict([(pref.key, pref.value) for pref in user.preferences.all()])
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = User
         # This list is the minimal set required by the notification service
         fields = ("id", "url", "email", "name", "username", "preferences")
@@ -41,7 +41,7 @@ class UserPreferenceSerializer(serializers.HyperlinkedModelSerializer):
     """
     user = UserSerializer()
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = UserPreference
         depth = 1
 
@@ -52,7 +52,7 @@ class RawUserPreferenceSerializer(serializers.ModelSerializer):
     """
     user = serializers.PrimaryKeyRelatedField(queryset=User.objects.all())
 
-    class Meta(object):  # pylint: disable=missing-docstring
+    class Meta(object):
         model = UserPreference
         depth = 1
 

--- a/openedx/core/lib/api/serializers.py
+++ b/openedx/core/lib/api/serializers.py
@@ -36,8 +36,4 @@ class CollapsedReferenceSerializer(serializers.HyperlinkedModelSerializer):
         self.fields['url'].lookup_url_kwarg = lookup_field
 
     class Meta(object):
-        """Defines meta information for the ModelSerializer.
-
-        model is set dynamically in __init__.
-        """
         fields = ("url",)

--- a/pylintrc
+++ b/pylintrc
@@ -73,7 +73,7 @@ class-attribute-rgx = ([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 inlinevar-rgx = [A-Za-z_][A-Za-z0-9_]*$
 good-names = f,i,j,k,db,ex,Run,_,__
 bad-names = foo,bar,baz,toto,tutu,tata
-no-docstring-rgx = __.*__|test_.+|setUp|tearDown
+no-docstring-rgx = __.*__$|test_.+|setUp$|setUpClass$|tearDown$|tearDownClass$|Meta$
 docstring-min-length = -1
 
 [FORMAT]
@@ -152,4 +152,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 6a610602e4c093047ed189c9a0d4ba796c7d1622
+# 503c3db797ee662a18237a57f00cb1e6e553be34

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -50,7 +50,7 @@ git+https://github.com/edx/edx-oauth2-provider.git@0.5.7#egg=oauth2-provider==0.
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/edx/edx-search.git@release-2015-09-11a#egg=edx-search
 git+https://github.com/edx/edx-milestones.git@release-2015-10-20#egg=edx-milestones==0.1.3
-git+https://github.com/edx/edx-lint.git@v0.2.9#egg=edx_lint==0.2.9
+git+https://github.com/edx/edx-lint.git@v0.3.0#egg=edx_lint==0.3.0
 -e git+https://github.com/edx/xblock-utils.git@213a97a50276d6a2504d8133650b2930ead357a0#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-reverification-block.git@0.0.4#egg=edx-reverification-block==0.0.4


### PR DESCRIPTION
Updated pylintrc to excuse "class Meta" from needing a docstring, then
removed all the needless pylint pragmas and placebo docstrings on them.

Why did I do this now? Because Django 1.8 has required more Meta
definitions, and it annoyed me to have to quiet pylint all over the
place.
