### PR TITLE
Fix for flaky asset test SOL-1160

### DIFF
--- a/common/test/acceptance/pages/studio/asset_index.py
+++ b/common/test/acceptance/pages/studio/asset_index.py
@@ -38,7 +38,11 @@ class AssetIndexPage(CoursePage):
 
     @wait_for_js
     def is_browser_on_page(self):
-        return self.q(css='body.view-uploads').present
+        return all([
+            self.q(css='body.view-uploads').present,
+            self.q(css='.page-header').present,
+            not self.q(css='div.ui-loading').visible,
+        ])
 
     @wait_for_js
     def type_filter_on_page(self):

--- a/common/test/acceptance/tests/studio/test_studio_asset.py
+++ b/common/test/acceptance/tests/studio/test_studio_asset.py
@@ -1,9 +1,6 @@
 """
 Acceptance tests for Studio related to the asset index page.
 """
-
-from flaky import flaky
-
 from ...pages.studio.asset_index import AssetIndexPage
 
 from .base_studio_test import StudioCourseTest
@@ -37,7 +34,6 @@ class AssetIndexTest(StudioCourseTest):
         """
         self.asset_page.visit()
 
-    @flaky  # TODO fix this, see SOL-1160
     def test_type_filter_exists(self):
         """
         Make sure type filter is on the page.


### PR DESCRIPTION
@raeeschachar @vkaracic This change works for running headless and looks like it fixes SOL-1160. I imagine it will fix the page for running under Chrome also.

Please review. I'll remove the temp commit before merging.
With this change, we can close #9758.

@benpatterson FYI
