### PR TITLE
Improve page object definition for learner profile page.

### DIFF
--- a/common/test/acceptance/pages/lms/learner_profile.py
+++ b/common/test/acceptance/pages/lms/learner_profile.py
@@ -1,13 +1,13 @@
 """
 Bok-Choy PageObject class for learner profile page.
 """
-from . import BASE_URL
 from bok_choy.page_object import PageObject
-from .fields import FieldsMixin
 from bok_choy.promise import EmptyPromise
-from .instructor_dashboard import InstructorDashboardPage
 from selenium.webdriver import ActionChains
 
+from . import BASE_URL
+from .fields import FieldsMixin
+from .instructor_dashboard import InstructorDashboardPage
 
 PROFILE_VISIBILITY_SELECTOR = '#u-field-select-account_privacy option[value="{}"]'
 FIELD_ICONS = {
@@ -43,7 +43,10 @@ class LearnerProfilePage(FieldsMixin, PageObject):
         """
         Check if browser is showing correct page.
         """
-        return self.q(css='body.view-profile').present
+        return all([
+            self.q(css='body.view-profile').present,
+            not self.q(css='ui-loading-indicator').visible
+        ])
 
     @property
     def privacy(self):


### PR DESCRIPTION
@raeeschachar another improvement to the Learner Profile page object. This allows visiting the page to work under a headless browser. 

In general, I think that using this pattern of checking for the ui-loading-indicator visibility for lms pages will get rid of a lot of test flakiness. 

We just need to confirm when we use it that for the page under test, the front-end code hides div with the ui-loading-indicator class, rather than removing the class from the div. @benpatterson I think you mentioned that it depends on whether the page uses backbone, or requirejs, or something like that?
