### PR TITLE
Deprecate end_of_course_survey_url until it can be removed.

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -280,7 +280,8 @@ class CourseFields(object):
     end_of_course_survey_url = String(
         display_name=_("Course Survey URL"),
         help=_("Enter the URL for the end-of-course survey. If your course does not have a survey, enter null."),
-        scope=Scope.settings
+        scope=Scope.settings,
+        deprecated=True  # We wish to remove this entirely, TNL-3399
     )
     discussion_blackouts = List(
         display_name=_("Discussion Blackout Dates"),

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -184,7 +184,6 @@ class AdvancedSettingsPage(CoursePage):
             'no_grade',
             'display_coursenumber',
             'display_organization',
-            'end_of_course_survey_url',
             'catalog_visibility',
             'chrome',
             'days_early_for_beta',


### PR DESCRIPTION
## [TNL-3399](https://openedx.atlassian.net/browse/TNL-3399)

Mark "Course Survey URL" as deprecated in Studio Advanced Settings.
### Sandbox
- [x] http://studio-survey.sandbox.edx.org/
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @andy-armstrong 
- [x] Product review: @explorerleslie 
### Post-review
- [ ] Squash commits
