### PR TITLE
Extract translatable strings from edx.utils.validate.js.

### DIFF
--- a/common/static/common/js/utils/edx.utils.validate.js
+++ b/common/static/common/js/utils/edx.utils.validate.js
@@ -24,12 +24,13 @@
             var _fn = {
                 validate: {
 
+                   template: _.template( '<li><%= content %></li>' ),
+
                     msg: {
-                        email: '<li><%- gettext("The email address you\'ve provided isn\'t formatted correctly.") %></li>',
-                        min: '<li><%- _.sprintf( gettext("%(field)s must have at least %(count)d characters."), context ) %></li>',
-                        max: '<li><%- _.sprintf( gettext("%(field)s can only contain up to %(count)d characters."), context ) %></li>',
-                        required: '<li><%- _.sprintf( gettext("Please enter your %(field)s."), context ) %></li>',
-                        custom: '<li><%= content %></li>'
+                        email: gettext("The email address you've provided isn't formatted correctly."),
+                        min: gettext("%(field)s must have at least %(count)d characters."),
+                        max: gettext("%(field)s can only contain up to %(count)d characters."),
+                        required: gettext("Please enter your %(field)s.")
                     },
 
                     field: function( el ) {
@@ -131,9 +132,9 @@
 
                     getMessage: function( $el, tests ) {
                         var txt = [],
-                            tpl,
                             label,
-                            obj,
+                            context,
+                            content,
                             customMsg;
 
                         _.each( tests, function( value, key ) {
@@ -143,30 +144,20 @@
 
                                 // If the field has a custom error msg attached, use it
                                 if ( customMsg ) {
-                                    tpl = _fn.validate.msg.custom;
-
-                                    obj = {
-                                        content: customMsg
-                                    };
+                                    content = customMsg;
                                 } else {
-                                    tpl = _fn.validate.msg[key];
-
-                                    obj = {
-                                        // We pass the context object to the template so that
-                                        // we can perform variable interpolation using sprintf
-                                        context: {
-                                            field: label
-                                        }
-                                    };
+                                    context = {field: label};
 
                                     if ( key === 'min' ) {
-                                        obj.context.count = parseInt( $el.attr('minlength'), 10 );
+                                        context.count = parseInt( $el.attr('minlength'), 10 );
                                     } else if ( key === 'max' ) {
-                                        obj.context.count = parseInt( $el.attr('maxlength'), 10 );
+                                        context.count = parseInt( $el.attr('maxlength'), 10 );
                                     }
+
+                                    content = _.sprintf( _fn.validate.msg[key], context );
                                 }
 
-                                txt.push( _.template( tpl, obj ) );
+                                txt.push( _fn.validate.template( {content: content} ) );
                             }
                         });
 


### PR DESCRIPTION
## Background

The JavaScript validation utility functions from `edx.utils.validate.js` file that are used on the combined login registration page include some translatable strings that weren't getting extracted by the i18n tools because they were defined inside underscore template strings. This PR pulls the translatable strings out of underscore templates to make sure `xgettext` detects the strings at extraction time.

The following error messages are missing translations because the `"Please enter your %(field)s."` translation string was not getting extracted by i18n tools and are not in transifex:

![validationtranslations](https://cloud.githubusercontent.com/assets/32585/10659356/70f3ed90-789f-11e5-9804-40adf3b58d73.jpg)
## How to test
### Before

Run `paver i18n_dummy` without this change. Inspect `conf/locale/eo/LC_MESSAGES/*.po` files. Note that the `.po` files **do not contain** the following strings:
- `"The email address you've provided isn't formatted correctly."`
- `"%(field)s must have at least %(count)d characters."`
- `"%(field)s can only contain up to %(count)d characters."`
- `"Please enter your %(field)s."`
### After

Checkout changes from this PR. Run `paver i18n_dummy` again. The above strings should be present in the generated `*.po` files.
## Info

**Partner Information**: not an edX partner - 3rd party-hosted open edX instance
**Jira ticket**: https://openedx.atlassian.net/browse/OSPR-895
**Sandbox URL**: http://pr10287.sandbox.opencraft.com/

---

**Settings**

``` yaml
EDXAPP_LANGUAGE_CODE: fr
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```
