### PR TITLE
Use waits because MathJax rendering is asynchronous.

### DIFF
--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -116,11 +116,19 @@ class DiscussionThreadPage(PageObject, DiscussionPageMixin):
     def is_discussion_body_visible(self):
         return self._is_element_visible(".post-body")
 
-    def is_mathjax_preview_available(self):
-        return self.q(css=".MathJax_Preview").text[0] == ""
+    def verify_mathjax_preview_available(self):
+        """ Checks that MathJax Preview css class is present """
+        self.wait_for(
+            lambda: len(self.q(css=".MathJax_Preview").text) > 0 and self.q(css=".MathJax_Preview").text[0] == "",
+            description="MathJax Preview is rendered"
+        )
 
-    def is_mathjax_rendered(self):
-        return self._is_element_visible(".MathJax")
+    def verify_mathjax_rendered(self):
+        """ Checks that MathJax css class is present """
+        self.wait_for(
+            lambda: self._is_element_visible(".MathJax"),
+            description="MathJax Preview is rendered"
+        )
 
     def is_response_visible(self, comment_id):
         """Returns true if the response is viewable onscreen"""

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -42,21 +42,33 @@ class ProblemPage(PageObject):
         """
         return self.q(css="div.problem div.problem-hint").text[0]
 
-    @property
-    def mathjax_rendered_in_problem(self):
+    def verify_mathjax_rendered_in_problem(self):
         """
         Check that MathJax have been rendered in problem hint
         """
-        mathjax_container = self.q(css="div.problem p .MathJax .math")
-        return mathjax_container.visible and mathjax_container.present
+        def mathjax_present():
+            """ Returns True if MathJax css is present in the problem body """
+            mathjax_container = self.q(css="div.problem p .MathJax .math")
+            return mathjax_container.visible and mathjax_container.present
 
-    @property
-    def mathjax_rendered_in_hint(self):
+        self.wait_for(
+            mathjax_present,
+            description="MathJax rendered in problem body"
+        )
+
+    def verify_mathjax_rendered_in_hint(self):
         """
         Check that MathJax have been rendered in problem hint
         """
-        mathjax_container = self.q(css="div.problem div.problem-hint .MathJax .math")
-        return mathjax_container.visible and mathjax_container.present
+        def mathjax_present():
+            """ Returns True if MathJax css is present in the problem body """
+            mathjax_container = self.q(css="div.problem div.problem-hint .MathJax .math")
+            return mathjax_container.visible and mathjax_container.present
+
+        self.wait_for(
+            mathjax_present,
+            description="MathJax rendered in hint"
+        )
 
     def fill_answer(self, text):
         """

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -6,7 +6,6 @@ import datetime
 from pytz import UTC
 from uuid import uuid4
 from nose.plugins.attrib import attr
-from flaky import flaky
 
 from .helpers import BaseDiscussionTestCase
 from ..helpers import UniqueCourseTest
@@ -218,7 +217,6 @@ class DiscussionTabSingleThreadTest(BaseDiscussionTestCase, DiscussionResponsePa
         self.thread_page = self.create_single_thread_page(thread_id)  # pylint: disable=attribute-defined-outside-init
         self.thread_page.visit()
 
-    @flaky  # TODO fix this, see TNL-2419
     def test_mathjax_rendering(self):
         thread_id = "test_thread_{}".format(uuid4().hex)
 
@@ -233,8 +231,14 @@ class DiscussionTabSingleThreadTest(BaseDiscussionTestCase, DiscussionResponsePa
         thread_fixture.push()
         self.setup_thread_page(thread_id)
         self.assertTrue(self.thread_page.is_discussion_body_visible())
-        self.assertTrue(self.thread_page.is_mathjax_preview_available())
-        self.assertTrue(self.thread_page.is_mathjax_rendered())
+        self.thread_page.wait_for(
+            self.thread_page.is_mathjax_preview_available,
+            description="MathJax Preview is rendered"
+        )
+        self.thread_page.wait_for(
+            self.thread_page.is_mathjax_rendered,
+            description="MathJax is rendered"
+        )
 
     def test_markdown_reference_link(self):
         """

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -231,14 +231,8 @@ class DiscussionTabSingleThreadTest(BaseDiscussionTestCase, DiscussionResponsePa
         thread_fixture.push()
         self.setup_thread_page(thread_id)
         self.assertTrue(self.thread_page.is_discussion_body_visible())
-        self.thread_page.wait_for(
-            self.thread_page.is_mathjax_preview_available,
-            description="MathJax Preview is rendered"
-        )
-        self.thread_page.wait_for(
-            self.thread_page.is_mathjax_rendered,
-            description="MathJax is rendered"
-        )
+        self.thread_page.verify_mathjax_preview_available()
+        self.thread_page.verify_mathjax_rendered()
 
     def test_markdown_reference_link(self):
         """

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -275,28 +275,18 @@ class ProblemWithMathjax(ProblemsTest):
         problem_page = ProblemPage(self.browser)
         self.assertEqual(problem_page.problem_name, "MATHJAX TEST PROBLEM")
 
-        # Verify MathJax has been rendered
-        problem_page.wait_for(
-            lambda: problem_page.mathjax_rendered_in_problem,
-            description="MathJax rendered in body"
-        )
+        problem_page.verify_mathjax_rendered_in_problem()
 
         # The hint button rotates through multiple hints
         problem_page.click_hint()
         self.assertIn("Hint (1 of 2): mathjax should work1", problem_page.hint_text)
-        problem_page.wait_for(
-            lambda: problem_page.mathjax_rendered_in_hint,
-            description="MathJax rendered in hint"
-        )
+        problem_page.verify_mathjax_rendered_in_hint()
 
         # Rotate the hint and check the problem hint
         problem_page.click_hint()
 
         self.assertIn("Hint (2 of 2): mathjax should work2", problem_page.hint_text)
-        problem_page.wait_for(
-            lambda: problem_page.mathjax_rendered_in_hint,
-            description="MathJax rendered in hint"
-        )
+        problem_page.verify_mathjax_rendered_in_hint()
 
 
 class ProblemPartialCredit(ProblemsTest):


### PR DESCRIPTION
## [TNL-2419](https://openedx.atlassian.net/browse/TNL-2419)

I was inspired to fix this because it failed on one of my other PRs (despite the fact that the test was already marked flaky). I did something similar to a different MathJax bok choy test in the upgrade PR-- it appears that 2.5 might be "more asynchronous" vs. 2.4.

Passed 15 runs in Jenkins.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang  

FYI: @benpatterson 
### Post-review
- [x] Squash commits
