### PR TITLE
Monkey-patch python_social_auth mixin.

### DIFF
--- a/common/djangoapps/monkey_patch/third_party_auth.py
+++ b/common/djangoapps/monkey_patch/third_party_auth.py
@@ -1,0 +1,26 @@
+"""
+Monkey patch implementation for a python_social_auth Django ORM method that is not Django 1.8-compatible.
+Remove once the module fully supports Django 1.8!
+"""
+
+from django.db import transaction
+from social.storage.django_orm import DjangoUserMixin
+
+
+def patch():
+    """
+    Monkey-patch the DjangoUserMixin class.
+    """
+    def create_social_auth_wrapper(wrapped_func):
+        wrapped_func = wrapped_func.__func__
+        def _w(*args, **kwargs):
+            # The entire reason for this monkey-patch is to wrap the create_social_auth call
+            # in an atomic transaction. The call can sometime raise an IntegrityError, which is
+            # caught and dealt with by python_social_auth - but not inside of an atomic transaction.
+            # In Django 1.8, unless the exception is raised in an atomic transaction, the transaction
+            # becomes unusable after the IntegrityError exception is raised.
+            with transaction.atomic():
+                return wrapped_func(*args, **kwargs)
+        return classmethod(_w)
+
+    DjangoUserMixin.create_social_auth = create_social_auth_wrapper(DjangoUserMixin.create_social_auth)

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -14,6 +14,7 @@ from openedx.core.lib.django_startup import autostartup
 import edxmako
 import logging
 import analytics
+from monkey_patch import third_party_auth
 
 
 log = logging.getLogger(__name__)
@@ -23,6 +24,8 @@ def run():
     """
     Executed during django startup
     """
+    third_party_auth.patch()
+
     # To override the settings before executing the autostartup() for python-social-auth
     if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
         enable_third_party_auth()

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -66,7 +66,11 @@ pyparsing==2.0.1
 python-memcached==1.48
 python-openid==2.2.5
 python-dateutil==2.1
+
+# This module gets monkey-patched in third_party_auth.py to fix a Django 1.8 incompatibility.
+# When this dependency gets upgraded, the monkey patch should be removed, if possible.
 python-social-auth==0.2.12
+
 pytz==2015.2
 pysrt==0.4.7
 PyYAML==3.10


### PR DESCRIPTION
Fix a Django 1.8-incompatible method in order to make it compatible.

https://openedx.atlassian.net/browse/TNL-3604

This PR replaces PR #10273 .

@symbolist Has already approved - another thumb here, Usman?

@macdiesel @alawibaba @muzaffaryousaf @muhammad-ammar @nedbat Need a review from one of you.
