### PR TITLE
Allow non-public XBlock assets in debug mode

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -711,6 +711,9 @@ INSTALLED_APPS = (
     'south',
     'method_override',
 
+    # Common views
+    'openedx.core.djangoapps.common_views',
+
     # History tables
     'simple_history',
 

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -32,7 +32,7 @@ urlpatterns = patterns(
         'contentstore.views.component_handler', name='component_handler'),
 
     url(r'^xblock/resource/(?P<block_type>[^/]*)/(?P<uri>.*)$',
-        'contentstore.views.xblock.xblock_resource', name='xblock_resource_url'),
+        'openedx.core.djangoapps.common_views.xblock.xblock_resource', name='xblock_resource_url'),
 
     # temporary landing page for a course
     url(r'^edge/(?P<org>[^/]+)/(?P<course>[^/]+)/course/(?P<coursename>[^/]+)$',

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -5,7 +5,6 @@ Module rendering
 import hashlib
 import json
 import logging
-import mimetypes
 
 import static_replace
 
@@ -944,23 +943,6 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
             raise Http404("invalid location")
 
         return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
-
-
-def xblock_resource(request, block_type, uri):  # pylint: disable=unused-argument
-    """
-    Return a package resource for the specified XBlock.
-    """
-    try:
-        xblock_class = XBlock.load_class(block_type, select=settings.XBLOCK_SELECT_FUNCTION)
-        content = xblock_class.open_local_resource(uri)
-    except IOError:
-        log.info('Failed to load xblock resource', exc_info=True)
-        raise Http404
-    except Exception:  # pylint: disable=broad-except
-        log.error('Failed to load xblock resource', exc_info=True)
-        raise Http404
-    mimetype, _ = mimetypes.guess_type(uri)
-    return HttpResponse(content, mimetype=mimetype)
 
 
 def get_module_by_usage_id(request, course_id, usage_id, disable_staff_debug_info=False, course=None):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1794,6 +1794,9 @@ INSTALLED_APPS = (
     'djcelery',
     'south',
 
+    # Common views
+    'openedx.core.djangoapps.common_views',
+
     # History tables
     'simple_history',
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -307,7 +307,7 @@ if settings.COURSEWARE_ENABLED:
         # xblock Resource URL
         url(
             r'xblock/resource/(?P<block_type>[^/]+)/(?P<uri>.*)$',
-            'courseware.module_render.xblock_resource',
+            'openedx.core.djangoapps.common_views.xblock.xblock_resource',
             name='xblock_resource_url',
         ),
 

--- a/openedx/core/djangoapps/common_views/xblock.py
+++ b/openedx/core/djangoapps/common_views/xblock.py
@@ -1,10 +1,11 @@
 """
-Views dedicated to rendering xblocks.
+Common views dedicated to rendering xblocks.
 """
 from __future__ import absolute_import
 
 import logging
 import mimetypes
+import pkg_resources
 
 from xblock.core import XBlock
 
@@ -21,7 +22,13 @@ def xblock_resource(request, block_type, uri):  # pylint: disable=unused-argumen
     """
     try:
         xblock_class = XBlock.load_class(block_type, select=settings.XBLOCK_SELECT_FUNCTION)
-        content = xblock_class.open_local_resource(uri)
+        # Note: in debug mode, return any file rather than going through the XBlock which
+        # will only return public files. This allows unbundled files to be served up
+        # during development.
+        if settings.DEBUG:
+            content = pkg_resources.resource_stream(xblock_class.__module__, uri)
+        else:
+            content = xblock_class.open_local_resource(uri)
     except IOError:
         log.info('Failed to load xblock resource', exc_info=True)
         raise Http404


### PR DESCRIPTION
This change allows XBlocks to use non-public assets when they are in debug mode. This allows developers to iterate on raw source files rather than having to build and use the minified version for every change.

Unfortunately this change was required by https://github.com/edx/edx-ora2/pull/733 which has already merged. This bug was reported as https://github.com/edx/edx-ora2/pull/733.

@cahrens @dianakhuang please review.
