### PR TITLE
LMS: Fixing contrast issues in the forums

### DIFF
--- a/lms/static/sass/discussion/elements/_navigation.scss
+++ b/lms/static/sass/discussion/elements/_navigation.scss
@@ -172,11 +172,19 @@
 }
 
 .forum-nav-thread {
-  border-bottom: 1px solid $gray-l3;
-  background-color: $gray-l5;
+  border-bottom: 1px solid $gray-l4;
+  background-color: $gray-l6;
 
   &.is-unread {
-    background-color: $white;
+
+    .forum-nav-thread-comments-count {
+      background-color: $blue-d1;
+      color: $white;
+
+      &:after {
+        border-right-color: $blue-d1;
+      }
+    }
   }
 }
 
@@ -184,8 +192,23 @@
   display: block;
   padding: ($baseline/4) ($baseline/2);
 
-  &.is-active, &:hover, &:focus {
+  &.is-active,
+  &:hover,
+  &:focus {
     background-color: $forum-color-active-thread;
+  }
+
+  &.is-active {
+    color: $base-font-color;
+
+    .forum-nav-thread-comments-count {
+      background-color: $gray-l4;
+      color: $base-font-color;
+
+      &:after {
+        border-right-color: $gray-l4;
+      }
+    }
   }
 }
 
@@ -263,7 +286,7 @@
   border-radius: 2px;
   padding: ($baseline/10) ($baseline/5);
   min-width: 2em; // Fit most comment counts but allow expansion if necessary
-  background-color: $gray-l3;
+  background-color: $gray-l4;
 
   // Speech bubble tail
   &:after {
@@ -276,24 +299,7 @@
     height: 0;
     border-style: solid;
     @include border-width(0, ($baseline/4), ($baseline/4), 0);
-    @include border-color(transparent, $gray-l3, transparent, transparent);
-  }
-
-  &.is-unread {
-    background-color: $white;
-
-    &:after {
-      border-right-color: $white
-    }
-  }
-}
-
-.forum-nav-thread.is-unread .forum-nav-thread-comments-count {
-  background-color: $blue;
-  color: $white;
-
-  &:after {
-    border-right-color: $blue;
+    @include border-color(transparent, $gray-l4, transparent, transparent);
   }
 }
 
@@ -312,7 +318,8 @@
   @extend %forum-nav-load-more-content;
   color: $link-color;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     color: $link-color;
     background-color: $forum-color-active-thread;
   }

--- a/lms/static/sass/discussion/utilities/_shame.scss
+++ b/lms/static/sass/discussion/utilities/_shame.scss
@@ -164,9 +164,4 @@ li[class*=forum-nav-thread-label-] {
   .wrapper-post-header .post-title {
     margin-bottom: 0 !important; // overrides "#seq_content h1" styling
   }
-
-  .posted-details {
-    font-size: 12px !important;
-    color: #919191 !important;
-  }
 }

--- a/lms/static/sass/discussion/utilities/_variables.scss
+++ b/lms/static/sass/discussion/utilities/_variables.scss
@@ -2,7 +2,7 @@
 // ====================
 
 // color variables
-$forum-color-active-thread: tint($blue, 85%);
+$forum-color-active-thread: $white;
 $forum-color-pinned: $pink;
 $forum-color-reported: $pink;
 $forum-color-closed: $black;

--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -32,6 +32,10 @@ body.discussion, .discussion-module {
       @include float(right);
       width: flex-grid(3,12);
     }
+
+    .posted-details {
+      color: $gray-d1;
+    }
   }
 
   // response layout
@@ -127,7 +131,7 @@ body.discussion {
     .posted-details {
       @extend %t-copy-sub2;
       margin-top: ($baseline/5);
-      color: $gray-l1;
+      color: $gray-d1;
 
       .username {
         @extend %t-strong;


### PR DESCRIPTION
This work addresses contrast issues in the forums for [AC-21](https://openedx.atlassian.net/browse/AC-21).
## Background

The forums have a few contrast issues, specifically the:
- light blue behind the active topic in the topic navigation list
- unreader/new comments notification flag
- post meta information
## Solution

By changing Sass values, I was able to provide enough contrast for automated tests to pass. I did have to alter the overall look of the forum navigation though, by changing the light blue selected topic to white. However this more closely matches the course navigation used throughout the LMS.

<img width="367" alt="screen shot 2015-12-09 at 3 39 42 pm" src="https://cloud.githubusercontent.com/assets/2112024/11698107/1cec28cc-9e8b-11e5-9123-2a08314d9818.png">
### States

Topic list
- Default (light gray background, blue link text)
- Hover (white background, pink link text)
- Active (white background, base text color)

Comment icon
- Unread (blue with white text)
  - Hover/Active (same)
- Read (gray with black text)
  - Hover/Active (same)
## Sandbox

https://clrux-ac-21.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/cba3e4cd91d0466b9ac50926e495b76f/threads/565dd91d9ee40d2a40000005

(Login with verified)
## Reviewers
- [x] @frrrances (UI/Sass)
- [x] @explorerleslie (TNL)
- [x] @catong or @lamagnifica (Documentation)

cc @cptvitamin 
