### PR TITLE
Include default for display_coursenumber field.

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -792,7 +792,8 @@ class CourseFields(object):
             "number that you entered when you created the course. To use the course number that you entered when "
             "you created the course, enter null."
         ),
-        scope=Scope.settings
+        scope=Scope.settings,
+        default=""
     )
 
     max_student_enrollments_allowed = Integer(


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-3676

Since we no longer monkey-patch ugettext/gettext, the defaulting works differently. This field was defaulting to `None` instead of `""`.

@nedbat @macdiesel @alawibaba @muzaffaryousaf @symbolist @muhammad-ammar Please review.
