### PR TITLE
Bump problem builder XBlock version to include PR 80

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -2,7 +2,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
--e git+https://github.com/open-craft/problem-builder.git@1cb40ca523502ca2a8a2abe5aef4d1b6735cb5c7#egg=xblock-problem-builder
+-e git+https://github.com/open-craft/problem-builder.git@90b2ecd8e948f34162e558b22f60e90287385f32#egg=xblock-problem-builder
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
This bumps the version of the Problem Builder XBlock deployed on edx.org to include a small fix to ensure that problem builder grades always appear on the progress page: https://github.com/open-craft/problem-builder/pull/80
