### PR TITLE
Teams Discussion Post Style Fixes

### DIFF
--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -2,7 +2,7 @@
 // ====================
 // NOTE: thread = (post + (responses and comments))
 
-// Table of Contents 
+// Table of Contents
 // * +general thread layout
 // * +thread - wrapper styling
 // * +thread - elements - shared styles
@@ -25,7 +25,7 @@ body.discussion, .discussion-module {
 
     .post-header-content {
       display: inline-block;
-      width: flex-grid(9,12); 
+      width: flex-grid(9,12);
     }
 
     .post-header-actions {
@@ -88,14 +88,14 @@ body.discussion {
 
   .discussion-post, .discussion-response, .discussion-comment {
     @include clearfix();
-    
+
     // thread - images
     .author-image {
       @include margin-right($baseline/2);
       display: inline-block;
-      vertical-align: top; 
+      vertical-align: top;
 
-      // STATE: No profile image 
+      // STATE: No profile image
       &:empty {
         display: none;
       }
@@ -146,7 +146,10 @@ body.discussion {
 }
 
 // +post - individual element styling
-body.discussion .discussion-post, body.discussion .discussion-article {
+body.discussion .discussion-post,
+body.discussion .discussion-article,
+body.view-in-course .discussion-post,
+body.view-in-course .discussion-article {
   // NOTE: discussion-article is used for inline discussion modules.
   @include clearfix();
 


### PR DESCRIPTION
This PR allows discussion post styles to be used in the teams space for discussion posts there, and specifically addresses the "This post is visible to..." metadata styling bug in TNL-3575.

Attn: @cahrens @explorerleslie 
