### PR TITLE
time.coffee no longer exists

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1223,7 +1223,7 @@ from openedx.core.lib.rooted_paths import rooted_glob
 courseware_js = (
     [
         'coffee/src/' + pth + '.js'
-        for pth in ['courseware', 'histogram', 'navigation', 'time']
+        for pth in ['courseware', 'histogram', 'navigation']
     ] +
     ['js/' + pth + '.js' for pth in ['ajax-error']] +
     sorted(rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/modules/**/*.js'))


### PR DESCRIPTION
@andy-armstrong can you review this? I noticed a 404 last week and create this PR, and then promptly forgot about it!

When running in devstack (LMS courseware):
GET http://localhost:8000/static/coffee/src/time.js 404 (NOT FOUND)
