### PR TITLE
Add an uninstall step to the Python prereq installation

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -9,7 +9,7 @@ from paver.easy import *
 from .utils.envs import Env
 
 
-PREREQS_MD5_DIR = os.getenv('PREREQ_CACHE_DIR', Env.REPO_ROOT / '.prereqs_cache')
+PREREQS_STATE_DIR = os.getenv('PREREQ_CACHE_DIR', Env.REPO_ROOT / '.prereqs_cache')
 NPM_REGISTRY = "http://registry.npmjs.org/"
 
 # If you make any changes to this list you also need to make
@@ -85,7 +85,7 @@ def prereq_cache(cache_name, paths, install_func):
     """
     # Retrieve the old hash
     cache_filename = cache_name.replace(" ", "_")
-    cache_file_path = os.path.join(PREREQS_MD5_DIR, "{}.sha1".format(cache_filename))
+    cache_file_path = os.path.join(PREREQS_STATE_DIR, "{}.sha1".format(cache_filename))
     old_hash = None
     if os.path.isfile(cache_file_path):
         with open(cache_file_path) as cache_file:
@@ -102,9 +102,9 @@ def prereq_cache(cache_name, paths, install_func):
         # If the code executed within the context fails (throws an exception),
         # then this step won't get executed.
         try:
-            os.makedirs(PREREQS_MD5_DIR)
+            os.makedirs(PREREQS_STATE_DIR)
         except OSError:
-            if not os.path.isdir(PREREQS_MD5_DIR):
+            if not os.path.isdir(PREREQS_STATE_DIR):
                 raise
 
         with open(cache_file_path, "w") as cache_file:
@@ -164,14 +164,83 @@ def install_node_prereqs():
 
 
 @task
+def uninstall_python_packages():
+    """
+    Uninstall Python packages that need explicit uninstallation.
+
+    Some Python packages that we no longer want need to be explicitly
+    uninstalled, notably, South.  Some other packages were once installed in
+    ways that were resistant to being upgraded, like edxval.  Also uninstall
+    them.
+
+    """
+    # So that we don't constantly uninstall things, use a version number of the
+    # uninstallation needs.  Check it, and skip this if we're up to date.
+    expected_version = 1
+    state_file_path = os.path.join(PREREQS_STATE_DIR, "python_uninstall_version.txt")
+    if os.path.isfile(state_file_path):
+        with open(state_file_path) as state_file:
+            version = int(state_file.read())
+        if version == expected_version:
+            return
+
+    # Run pip to find the packages we need to get rid of.  Believe it or not,
+    # edx-val is installed in a way that it is present twice, so we have a loop
+    # to really really get rid of it.
+    for _ in range(3):
+        uninstalled = False
+        frozen = sh("pip freeze", capture=True).splitlines()
+
+        # Uninstall South
+        if any(line.startswith("South") for line in frozen):
+            sh("pip uninstall -y South")
+            uninstalled = True
+
+        # Uninstall edx-val
+        if any("edxval" in line for line in frozen):
+            sh("pip uninstall -y edxval")
+            uninstalled = True
+
+        if not uninstalled:
+            break
+    else:
+        # We tried three times and didn't manage to get rid of the pests.
+        print "Couldn't uninstall unwanted Python packages!"
+        return
+
+    # Write our version.
+    with open(state_file_path, "w") as state_file:
+        state_file.write(str(expected_version))
+
+
+@task
 def install_python_prereqs():
     """
-    Installs Python prerequisites
+    Installs Python prerequisites.
     """
     if no_prereq_install():
         return
 
-    prereq_cache("Python prereqs", PYTHON_REQ_FILES + [sysconfig.get_python_lib()], python_prereqs_installation)
+    # Include all of the requirements files in the fingerprint.
+    files_to_fingerprint = list(PYTHON_REQ_FILES)
+
+    # Also fingerprint the directories where packages get installed:
+    # ("/edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages")
+    files_to_fingerprint.append(sysconfig.get_python_lib())
+
+    # In a virtualenv, "-e installs" get put in a src directory.
+    src_dir = os.path.join(sys.prefix, "src")
+    if os.path.isdir(src_dir):
+        files_to_fingerprint.append(src_dir)
+
+    # Also fingerprint this source file, so that if the logic for installations
+    # changes, we will redo the installation.
+    this_file = __file__
+    if this_file.endswith(".pyc"):
+        this_file = this_file[:-1]      # use the .py file instead of the .pyc
+    files_to_fingerprint.append(this_file)
+
+    prereq_cache("Python prereqs", files_to_fingerprint, python_prereqs_installation)
 
 
 @task
@@ -184,4 +253,5 @@ def install_prereqs():
 
     install_ruby_prereqs()
     install_node_prereqs()
+    uninstall_python_packages()
     install_python_prereqs()


### PR DESCRIPTION
Some packages need to be explicitly uninstalled.  Do this as part of
install_prereqs.  Also, add the venv/src directory and the
pavelib/prereqs.py file to the hash, so that we do a better job
detecting when we need to install prerequisites again.
