### PR TITLE
Failing startup if private settings fail to load

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -2,6 +2,8 @@
 Specific overrides to the base prod settings to make development easier.
 """
 
+from os.path import abspath, dirname, join
+
 from .aws import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 # Don't use S3 in devstack, fall back to filesystem
@@ -115,10 +117,8 @@ REQUIRE_DEBUG = DEBUG
 
 ###############################################################################
 # See if the developer has any local overrides.
-try:
-    from .private import *  # pylint: disable=import-error
-except ImportError:
-    pass
+if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+    from .private import *  # pylint: disable=import-error,wildcard-import
 
 #####################################################################
 # Lastly, run any migrations, if needed.

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -1,6 +1,7 @@
 """
 Specific overrides to the base prod settings to make development easier.
 """
+from os.path import abspath, dirname, join
 
 from .aws import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
@@ -219,10 +220,8 @@ CORS_ORIGIN_ALLOW_ALL = True
 
 #####################################################################
 # See if the developer has any local overrides.
-try:
-    from .private import *      # pylint: disable=wildcard-import
-except ImportError:
-    pass
+if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+    from .private import *  # pylint: disable=import-error,wildcard-import
 
 #####################################################################
 # Lastly, run any migrations, if needed.


### PR DESCRIPTION
Squashing private settings import errors leads to wasted developer time when developers expect settings to be in place, and they aren't. This change only loads private settings if the private.py file exists. If there is an error during the import of that file, the application will not start.

ECOM-2653
