### PR TITLE
Manually set transaction to rollback upon error.

### DIFF
--- a/openedx/core/djangoapps/user_api/preferences/views.py
+++ b/openedx/core/djangoapps/user_api/preferences/views.py
@@ -128,6 +128,10 @@ class PreferencesView(APIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
         except PreferenceUpdateError as error:
+            # This exception is caught here in order to send an error response.
+            # However, an update failure on any preference is expected to rollback
+            # the entire transaction. So set the transaction to rollback manually.
+            transaction.set_rollback(True)
             return Response(
                 {
                     "developer_message": error.developer_message,


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-3690

The failing test expects all user preference updates to be rolled back if any one fails. However, it also catches all the exceptions that would trigger a rollback. So trigger the rollback manually.

@symbolist Please review - transaction-related.

@macdiesel @nedbat @alawibaba @muzaffaryousaf @muhammad-ammar Please review.
