### PR TITLE
Add IntegrityError handling back in as test expects.

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -1112,13 +1112,9 @@ class VerificationCheckpoint(models.Model):
         Returns:
             VerificationCheckpoint object if exists otherwise None
         """
-        try:
-            with transaction.atomic():
-                checkpoint, __ = cls.objects.get_or_create(course_id=course_id, checkpoint_location=checkpoint_location)
-                return checkpoint
-        except IntegrityError:
-            # Record already exists - just return it.
-            return cls.objects.get(course_id=course_id, checkpoint_location=checkpoint_location)
+        with transaction.atomic():
+            checkpoint, __ = cls.objects.get_or_create(course_id=course_id, checkpoint_location=checkpoint_location)
+            return checkpoint
 
 
 class VerificationStatus(models.Model):

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -1109,6 +1109,9 @@ class VerificationCheckpoint(models.Model):
             course_id (CourseKey): CourseKey
             checkpoint_location (str): Verification checkpoint location
 
+        Raises:
+            IntegrityError if create fails due to concurrent create.
+
         Returns:
             VerificationCheckpoint object if exists otherwise None
         """

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -1112,8 +1112,13 @@ class VerificationCheckpoint(models.Model):
         Returns:
             VerificationCheckpoint object if exists otherwise None
         """
-        checkpoint, __ = cls.objects.get_or_create(course_id=course_id, checkpoint_location=checkpoint_location)
-        return checkpoint
+        try:
+            with transaction.atomic():
+                checkpoint, __ = cls.objects.get_or_create(course_id=course_id, checkpoint_location=checkpoint_location)
+                return checkpoint
+        except IntegrityError:
+            # Record already exists - just return it.
+            return cls.objects.get(course_id=course_id, checkpoint_location=checkpoint_location)
 
 
 class VerificationStatus(models.Model):


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-3692

@symbolist had taken out the IntegrityError handling in this code. But the failing test indicates that a recovery of sorts is expected in this case. So get the record and return it upon IntegrityError.

@symbolist Please review - transaction-related.

@macdiesel @nedbat @alawibaba @muzaffaryousaf @muhammad-ammar Please review.
