### PR TITLE
Updated CreditCourse update endpoint

### DIFF
--- a/openedx/core/djangoapps/credit/tests/test_views.py
+++ b/openedx/core/djangoapps/credit/tests/test_views.py
@@ -469,23 +469,47 @@ class CreditCourseViewSetTests(TestCase):
         response = self.client.get(self.path, **headers)
         self.assertEqual(response.status_code, 200)
 
-    def test_create(self):
-        """ Verify the endpoint supports creating new CreditCourse objects. """
-        course_key = CourseKey.from_string('a/b/c')
+    def assert_course_created(self, course_id, response):
+        """ Verify an API request created a new CreditCourse object. """
         enabled = True
         data = {
-            'course_key': unicode(course_key),
+            'course_key': unicode(course_id),
             'enabled': enabled
         }
 
-        response = self.client.post(self.path, data=json.dumps(data), content_type=JSON)
         self.assertEqual(response.status_code, 201)
 
         # Verify the API returns the serialized CreditCourse
         self.assertDictEqual(json.loads(response.content), data)
 
         # Verify the CreditCourse was actually created
+        course_key = CourseKey.from_string(course_id)
         self.assertTrue(CreditCourse.objects.filter(course_key=course_key, enabled=enabled).exists())
+
+    def test_create(self):
+        """ Verify the endpoint supports creating new CreditCourse objects. """
+        course_id = 'a/b/c'
+        enabled = True
+        data = {
+            'course_key': unicode(course_id),
+            'enabled': enabled
+        }
+
+        response = self.client.post(self.path, data=json.dumps(data), content_type=JSON)
+        self.assert_course_created(course_id, response)
+
+    def test_put_as_create(self):
+        """ Verify the update endpoint supports creating a new CreditCourse object. """
+        course_id = 'd/e/f'
+        enabled = True
+        data = {
+            'course_key': unicode(course_id),
+            'enabled': enabled
+        }
+
+        path = reverse('credit:creditcourse-detail', args=[course_id])
+        response = self.client.put(path, data=json.dumps(data), content_type=JSON)
+        self.assert_course_created(course_id, response)
 
     def test_get(self):
         """ Verify the endpoint supports retrieving CreditCourse objects. """

--- a/openedx/core/djangoapps/credit/views.py
+++ b/openedx/core/djangoapps/credit/views.py
@@ -1,8 +1,8 @@
 """
 Views for the credit Django app.
 """
-import json
 import datetime
+import json
 import logging
 
 from django.conf import settings
@@ -21,13 +21,15 @@ import pytz
 from rest_framework import viewsets, mixins, permissions
 from rest_framework.authentication import SessionAuthentication
 from rest_framework_oauth.authentication import OAuth2Authentication
-from util.json_request import JsonResponse
-from util.date_utils import from_timestamp
+
 from openedx.core.djangoapps.credit import api
 from openedx.core.djangoapps.credit.exceptions import CreditApiBadRequest, CreditRequestNotFound
 from openedx.core.djangoapps.credit.models import CreditCourse
 from openedx.core.djangoapps.credit.serializers import CreditCourseSerializer
 from openedx.core.djangoapps.credit.signature import signature, get_shared_secret_key
+from openedx.core.lib.api.mixins import PutAsCreateMixin
+from util.date_utils import from_timestamp
+from util.json_request import JsonResponse
 
 log = logging.getLogger(__name__)
 
@@ -371,7 +373,7 @@ def _validate_timestamp(timestamp_value, provider_id):
         return HttpResponseForbidden(u"Timestamp is too far in the past.")
 
 
-class CreditCourseViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSet):
+class CreditCourseViewSet(PutAsCreateMixin, mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSet):
     """ CreditCourse endpoints. """
 
     lookup_field = 'course_key'


### PR DESCRIPTION
The update (PUT) endpoint now supports creating new CreditCourse objects in addition to updating existing ones. This functionality greatly simplifies the logic needed by consumers (e.g. the Course Administration Tool) to create or update CreditCourse objects.

ECOM-2524
