### PR TITLE
Updated receipt page to use order endpoint

### DIFF
--- a/lms/djangoapps/commerce/api/v0/urls.py
+++ b/lms/djangoapps/commerce/api/v0/urls.py
@@ -7,7 +7,7 @@ from commerce.api.v0 import views
 BASKET_URLS = patterns(
     '',
     url(r'^$', views.BasketsView.as_view(), name='create'),
-    url(r'^{}/order/$'.format(r'(?P<basket_id>[\w]+)'), views.BasketOrderView.as_view(), name='retrieve_order'),
+    url(r'^(?P<basket_id>[\w]+)/order/$', views.BasketOrderView.as_view(), name='retrieve_order'),
 )
 
 urlpatterns = patterns(

--- a/lms/djangoapps/commerce/api/v1/urls.py
+++ b/lms/djangoapps/commerce/api/v1/urls.py
@@ -4,15 +4,19 @@ from django.conf.urls import patterns, url, include
 
 from commerce.api.v1 import views
 
-
 COURSE_URLS = patterns(
     '',
     url(r'^$', views.CourseListView.as_view(), name='list'),
     url(r'^{}/$'.format(settings.COURSE_ID_PATTERN), views.CourseRetrieveUpdateView.as_view(), name='retrieve_update'),
 )
 
+ORDER_URLS = patterns(
+    '',
+    url(r'^(?P<number>[-\w]+)/$', views.OrderView.as_view(), name='detail'),
+)
+
 urlpatterns = patterns(
     '',
     url(r'^courses/', include(COURSE_URLS, namespace='courses')),
-
+    url(r'^orders/', include(ORDER_URLS, namespace='orders')),
 )

--- a/lms/djangoapps/commerce/api/v1/views.py
+++ b/lms/djangoapps/commerce/api/v1/views.py
@@ -2,16 +2,20 @@
 import logging
 
 from django.http import Http404
+from edx_rest_api_client import exceptions
 from rest_framework.authentication import SessionAuthentication
-from rest_framework_oauth.authentication import OAuth2Authentication
+from rest_framework.views import APIView
 from rest_framework.generics import RetrieveUpdateAPIView, ListAPIView
 from rest_framework.permissions import IsAuthenticated
+from rest_framework_oauth.authentication import OAuth2Authentication
 
+from commerce import ecommerce_api_client
 from commerce.api.v1.models import Course
 from commerce.api.v1.permissions import ApiKeyOrModelPermission
 from commerce.api.v1.serializers import CourseSerializer
 from course_modes.models import CourseMode
 from openedx.core.lib.api.mixins import PutAsCreateMixin
+from util.json_request import JsonResponse
 
 log = logging.getLogger(__name__)
 
@@ -54,3 +58,18 @@ class CourseRetrieveUpdateView(PutAsCreateMixin, RetrieveUpdateAPIView):
         # There is nothing to pre-save. The default behavior changes the Course.id attribute from
         # a CourseKey to a string, which is not desired.
         pass
+
+
+class OrderView(APIView):
+    """ Retrieve order details. """
+
+    authentication_classes = (SessionAuthentication,)
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, number):  # pylint:disable=unused-argument
+        """ HTTP handler. """
+        try:
+            order = ecommerce_api_client(request.user).orders(number).get()
+            return JsonResponse(order)
+        except exceptions.HttpNotFoundError:
+            return JsonResponse(status=404)

--- a/lms/djangoapps/commerce/tests/mocks.py
+++ b/lms/djangoapps/commerce/tests/mocks.py
@@ -103,3 +103,17 @@ class mock_create_refund(mock_ecommerce_api_endpoint):  # pylint: disable=invali
 
     def get_uri(self):
         return TEST_API_URL + '/refunds/'
+
+
+class mock_order_endpoint(mock_ecommerce_api_endpoint):  # pylint: disable=invalid-name
+    """ Mocks calls to E-Commerce API client basket order method. """
+
+    default_response = {'number': 'EDX-100001'}
+    method = httpretty.GET
+
+    def __init__(self, order_number, **kwargs):
+        super(mock_order_endpoint, self).__init__(**kwargs)
+        self.order_number = order_number
+
+    def get_uri(self):
+        return TEST_API_URL + '/orders/{}/'.format(self.order_number)


### PR DESCRIPTION
The receipt page now retrieves data for orders instead of baskets. Going forward baskets will be deleted after an order has been placed, so there should be no permanent references to baskets. Orders will continue to be persisted permanently.

ECOM-2653
