### PR TITLE
Made CCX schedule configuration sync with studio (Date time management).

### DIFF
--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -52,6 +52,7 @@ from ccx_keys.locator import CCXLocator
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import get_override_for_ccx, override_field_for_ccx
 from lms.djangoapps.ccx.tests.factories import CcxFactory
+from lms.djangoapps.ccx.views import get_date
 
 
 def intercept_renderer(path, context):
@@ -290,6 +291,21 @@ class TestCoachDashboard(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         role = CourseCcxCoachRole(course_key)
         self.assertTrue(role.has_user(self.coach))
 
+    def test_get_date(self):
+        """
+        Assert that get_date returns valid date.
+        """
+        ccx = self.make_ccx()
+        for section in self.course.get_children():
+            self.assertEqual(get_date(ccx, section, 'start'), self.mooc_start)
+            self.assertEqual(get_date(ccx, section, 'due'), None)
+            for subsection in section.get_children():
+                self.assertEqual(get_date(ccx, subsection, 'start'), self.mooc_start)
+                self.assertEqual(get_date(ccx, subsection, 'due'), self.mooc_due)
+                for unit in subsection.get_children():
+                    self.assertEqual(get_date(ccx, unit, 'start', parent_node=subsection), self.mooc_start)
+                    self.assertEqual(get_date(ccx, unit, 'due', parent_node=subsection), self.mooc_due)
+
     @SharedModuleStoreTestCase.modifies_courseware
     @patch('ccx.views.render_to_response', intercept_renderer)
     @patch('ccx.views.TODAY')
@@ -341,15 +357,24 @@ class TestCoachDashboard(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)})
         response = self.client.get(url)
         schedule = json.loads(response.mako_context['schedule'])  # pylint: disable=no-member
+
         self.assertEqual(len(schedule), 2)
         self.assertEqual(schedule[0]['hidden'], False)
-        self.assertEqual(schedule[0]['start'], None)
-        self.assertEqual(schedule[0]['children'][0]['start'], None)
-        self.assertEqual(schedule[0]['due'], None)
-        self.assertEqual(schedule[0]['children'][0]['due'], None)
+        # If a coach does not override dates, then dates will be imported from master course.
         self.assertEqual(
-            schedule[0]['children'][0]['children'][0]['due'], None
+            schedule[0]['start'],
+            self.chapters[0].start.strftime('%Y-%m-%d %H:%M')
         )
+        self.assertEqual(
+            schedule[0]['children'][0]['start'],
+            self.sequentials[0].start.strftime('%Y-%m-%d %H:%M')
+        )
+
+        if self.sequentials[0].due:
+            expected_due = self.sequentials[0].due.strftime('%Y-%m-%d %H:%M')
+        else:
+            expected_due = None
+        self.assertEqual(schedule[0]['children'][0]['due'], expected_due)
 
         url = reverse(
             'save_ccx',
@@ -392,7 +417,7 @@ class TestCoachDashboard(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         # scheduled chapter
         ccx = CustomCourseForEdX.objects.get()
         course_start = get_override_for_ccx(ccx, self.course, 'start')
-        self.assertEqual(str(course_start)[:-9], u'2014-11-20 00:00')
+        self.assertEqual(str(course_start)[:-9], self.chapters[0].start.strftime('%Y-%m-%d %H:%M'))
 
         # Make sure grading policy adjusted
         policy = get_override_for_ccx(ccx, self.course, 'grading_policy',

--- a/lms/static/sass/course/ccx_coach/_dashboard.scss
+++ b/lms/static/sass/course/ccx_coach/_dashboard.scss
@@ -18,6 +18,11 @@ table.ccx-schedule {
     th, td {
         padding: 10px;
     }
+    td.no-link {
+        font-size: 13px;
+        text-shadow: 0 1px 0 #fcfbfb;
+        text-decoration: none;
+    }
     .sequential .unit {
         padding-left: 25px;
     }
@@ -40,6 +45,7 @@ table.ccx-schedule {
     margin-left: 20px;
 }
 
+
 .ccx-sidebar-panel {
     border: 1px solid #cbcbcb;
     padding: 15px;
@@ -48,8 +54,46 @@ table.ccx-schedule {
 
 form.ccx-form {
     line-height: 1.5;
+    // inspiration was taken from https://github.com/edx/ux-pattern-library
     select {
+        @include font-size(16);
+        background: #fcfcfc;
+        border: 1px solid #e9e8e8;
+        box-sizing: padding-box;
+        color: #282c2e;
+        display: inline-block;
+        font-size: ($baseline*.9.5);
+        height: 40px;
+        line-height: 20px;
+        padding: 10px;
+        transition: all 125ms ease-in-out 0s;
         width: 100%;
+        &:disabled {
+            border-color: #cfd8dc;
+            background: #e7ecee;
+            cursor: not-allowed;
+        }
+    }
+    input {
+        @include font-size(15);
+        background: #FCFCFC none repeat scroll 0% 0%;
+        border: 1px solid #E7E6E6;
+        box-sizing: border-box;
+        color: #34383A;
+        display: inline-block;
+        line-height: normal;
+        transition: all 0.125s ease-in-out 0s;
+        padding: 5px 10px 5px 10px;
+        &:focus {
+            border-color: #0ea6ec;
+            color: #282c2e;
+            outline: 0;
+        }
+        &:disabled {
+            border-color: #cfd8dc;
+            background: #e7ecee;
+            cursor: not-allowed;
+        }
     }
     .field {
         margin: 5px 0 5px 0;
@@ -72,6 +116,10 @@ button.ccx-button-link {
     }
     &:hover {
         color: brown;
+        background: none;
+    }
+    &:focus {
+        background: none;
     }
 }
 

--- a/lms/templates/ccx/schedule.html
+++ b/lms/templates/ccx/schedule.html
@@ -39,14 +39,14 @@
     <header>
       <h2 id="ccx_schedule_set_date_heading"></h2>
     </header>
-    <form>
+    <form class="ccx-form">
       <div class="field datepair">
         ## Translators: This explains to people using a screen reader how to interpret the format of YYYY-MM-DD
         <label class="sr form-label" for="ccx_dialog_date">${_('Date format four digit year dash two digit month dash two digit day')}</label>
-        <input placeholder="Date" class="date" type="text" name="date" id="ccx_dialog_date" size="11" />
+        <input placeholder="${_('Date')}" class="date" type="text" name="date" id="ccx_dialog_date" size="11" />
         ## Translators: This explains to people using a screen reader how to interpret the format of HH:MM
         <label class="sr form-label" for="ccx_dialog_time">${_('Time format two digit hours colon two digit minutes')}</label>
-        <input placeholder="Time" class="time" type="text" name="time" id="ccx_dialog_time" size="6" />
+        <input placeholder="${_('Time')}" class="time" type="text" name="time" id="ccx_dialog_time" size="6" />
       </div>
       <div class="field">
         <button type="submit" class="btn btn-primary">${_('Set date')}</button>
@@ -63,7 +63,7 @@
       <p id="message_save" class="text-helper">${_("You have unsaved changes.")}</p>
       <div class="field">
         <br/>
-        <button id="save-changes" aria-describedby="message_save">${_("Save changes")}</button>
+        <button id="save-changes" aria-describedby="message_save" class="ccx-schedule-save-changes">${_("Save changes")}</button>
       </div>
     </form>
   </div>
@@ -87,31 +87,35 @@
         <label for="ccx_vertical" class="form-label"><b>${_('Unit')}</b></label>
         <select name="vertical" id="ccx_vertical"></select>
       </div>
-      <div class="field datepair">
-        <label for="ccx_start_date" class="form-label">
-            <b>${_('Start Date')}</b>
-            <span class="sr">
-              ## Translators: This explains to people using a screen reader how to interpret the format of YYYY-MM-DD
-              &nbsp;${_('format four digit year dash two digit month dash two digit day')}
-            </span>
-        </label>
-        <input placeholder="yyyy-mm-dd" type="text" class="date" name="start_date" id="ccx_start_date" />
-        ## Translators: This explains to people using a screen reader how to interpret the format of HH:MM
-        <label for="ccx_start_time" class="sr form-label">${_('Start time format two digit hours colon two digit minutes')}</label>
-        <input placeholder="time" type="text" class="time" name="start_time" id="ccx_start_time"/>
-      </div>
-      <div class="field datepair">
-        <label for="ccx_due_date" class="form-label">
-            <b>${_('Due Date')}</b> ${_('(Optional)')}
-            <span class="sr">
+      <div class="ccx_start_date_time_fields">
+        <div class="field datepair">
+          <label for="ccx_start_date" class="form-label">
+              <b>${_('Start Date')}</b>
+              <span class="sr">
                 ## Translators: This explains to people using a screen reader how to interpret the format of YYYY-MM-DD
                 &nbsp;${_('format four digit year dash two digit month dash two digit day')}
-            </span>
-        </label>
-        <input placeholder="yyyy-mm-dd" type="text" class="date" name="due_date" id="ccx_due_date"/>
-        ## Translators: This explains to people using a screen reader how to interpret the format of HH:MM
-        <label for="ccx_due_time" class="sr form-label">${_('Due Time format two digit hours colon two digit minutes')}</label>
-        <input placeholder="time" type="text" class="time" name="due_time" id="ccx_due_time"/>
+              </span>
+          </label>
+          <input placeholder="${_('yyyy-mm-dd')}" type="text" class="date" name="start_date" id="ccx_start_date" />
+          ## Translators: This explains to people using a screen reader how to interpret the format of HH:MM
+          <label for="ccx_start_time" class="sr form-label">${_('Start time format two digit hours colon two digit minutes')}</label>
+          <input placeholder="${_('time')}" type="text" class="time" name="start_time" id="ccx_start_time"/>
+        </div>
+      </div>
+      <div class="ccx_due_date_time_fields">
+        <div class="field datepair">
+          <label for="ccx_due_date" class="form-label">
+              <b>${_('Due Date')}</b> ${_('(Optional)')}
+              <span class="sr">
+                  ## Translators: This explains to people using a screen reader how to interpret the format of YYYY-MM-DD
+                  &nbsp;${_('format four digit year dash two digit month dash two digit day')}
+              </span>
+          </label>
+          <input placeholder="${_('yyyy-mm-dd')}" type="text" class="date" name="due_date" id="ccx_due_date"/>
+          ## Translators: This explains to people using a screen reader how to interpret the format of HH:MM
+          <label for="ccx_due_time" class="sr form-label">${_('Due Time format two digit hours colon two digit minutes')}</label>
+          <input placeholder="${_('time')}" type="text" class="time" name="due_time" id="ccx_due_time"/>
+        </div>
       </div>
       <div class="field">
         <br/>

--- a/lms/templates/ccx/schedule.underscore
+++ b/lms/templates/ccx/schedule.underscore
@@ -24,9 +24,13 @@
           <td class="unit">
             <button class="toggle-collapse ccx-button-link" aria-expanded="false">
               <i class="fa fa-caret-right"></i>
-              <span class="sr"><%- gettext('toggle chapter') %>&nbsp;<%= chapter.display_name %></span>
+              <span class="sr">
+                <%- interpolate(gettext('toggle chapter %(displayName)s'),
+                  {displayName: chapter.display_name}, true) %>
+              </span>
             </button>
-            <span class="sr"><%- gettext('Section') %>&nbsp;</span><%= chapter.display_name %>
+            <span class="sr">
+              <%- gettext('Section') %>&nbsp;</span><%= chapter.display_name %>
           </td>
           <td class="date start-date">
             <button class="ccx-button-link">
@@ -34,13 +38,11 @@
               <span class="sr"><%- gettext('Click to change') %></span>
             </button>
           </td>
-          <td class="date due-date">
-            <button class="ccx-button-link">
-              <%= chapter.due %>
-              <span class="sr"><%- gettext('Click to change') %></span>
-            </button>
+          <td class="date due-date no-link">
+            <%- gettext('N/A') %>
           </td>
-          <td><button class="remove-unit ccx-button-link" aria-label="Remove chapter <%= chapter.display_name %>">
+          <td><button class="remove-unit ccx-button-link" aria-label="<%- interpolate(
+                gettext('Remove chapter %(chapterDisplayName)s'), {chapterDisplayName: chapter.display_name}, true) %>">
             <i class="fa fa-remove" aria-hidden="true"></i> <%- gettext('remove') %>
           </button></td>
         </tr>
@@ -50,7 +52,10 @@
             <td class="unit">
               <button class="toggle-collapse ccx-button-link" aria-expanded="false">
                  <i class="fa fa-caret-right"></i>
-                 <span class="sr"><%- gettext('toggle subsection') %>&nbsp;<%= child.display_name %></span>
+                 <span class="sr">
+                     <%- interpolate(gettext('toggle subsection %(displayName)s'),
+                      {displayName: child.display_name}, true) %>
+                 </span>
               </button>
               <span class="sr"><%- gettext('Subsection') %>&nbsp;</span><%= child.display_name %>
             </td>
@@ -66,32 +71,45 @@
                 <span class="sr"><%- gettext('Click to change') %></span>
               </button>
             </td>
-            <td><button class="remove-unit ccx-button-link" aria-label="Remove subsection <%= child.display_name %>">
+            <td><button class="remove-unit ccx-button-link" aria-label="<%- interpolate(
+                gettext('Remove subsection %(subsectionDisplayName)s'), {subsectionDisplayName: child.display_name}, true) %>">
               <i class="fa fa-remove" aria-hidden="true"></i> <%- gettext('remove') %>
             </button></td>
           </tr>
           <% _.each(child.children, function(subchild) { %>
-            <tr class="vertical" data-dapth="3"
+            <tr class="vertical" data-depth="3"
                 data-location="<%= chapter.location %> <%= child.location %> <%= subchild.location %>">
               <td class="unit">&nbsp;
                  <span class="sr"><%- gettext('Unit') %>&nbsp;</span>
                  <%= subchild.display_name %>
               </td>
-              <td class="date start-date">
-                <button class="ccx-button-link">
+              <td class="date start-date no-link">
+                <% if (subchild.start) { %>
                   <%= subchild.start %>
-                  <span class="sr"><%- gettext('Click to change') %></span>
-                </button>
+                <% } else { %>
+                  <%
+                  // Translators: Unit's aka vertical start date is set to Unscheduled when user has not set start date on corresponding subsection aka sequential.
+                  %>
+                  <%- gettext('Unscheduled') %>
+                <% } %>
               </td>
-              <td class="date due-date">
-                <button class="ccx-button-link">
+              <td class="date due-date no-link">
+                <% if (subchild.due) { %>
                   <%= subchild.due %>
-                  <span class="sr"><%- gettext('Click to change') %></span>
+                <% } else { %>
+                  <%
+                  // Translators: Unit's aka vertical due date is set to Unscheduled when user has not set due date on corresponding subsection aka sequential.
+                  %>
+                  <%- gettext('Unscheduled') %>
+                <% } %>
+              </td>
+              <td>
+                <button class="remove-unit ccx-button-link" aria-label="<%- interpolate(
+                    gettext('Remove unit %(unitName)s'), {unitName: subchild.display_name}, true) %>">
+                  <i class="fa fa-remove" aria-hidden="true"></i> <%- gettext('remove') %>
                 </button>
               </td>
-              <td><button class="remove-unit ccx-button-link" aria-label="Remove unit <%= subchild.display_name %>">
-                <i class="fa fa-remove" aria-hidden="true"></i> <%- gettext('remove') %>
-              </button></td>
+          </tr>
           <% }); %>
         <% }); %>
       <% }); %>


### PR DESCRIPTION
### What is done in this PR

**Studio Updates:** None.

**LMS Updates:** 
#### Fixed UI style
- Fixed UI style according to http://ux.edx.org/elements/forms/

@talbs!
#### SCHEDULE A UNIT (form on the right)
- Showing disabled start and due date if user has not selected chapter from dropdown.
- If coach has not overriden dates then I am using start and due date of master course if they exist.
- Showing only start date fields enable for a section/chapter.
- Showing start and due date fields enable for a subsection/sequential.
- Showing disabled start and due date fields for a unit/vertical.
#### Schedule Tree
- Coach can change start date of a **chapter**.
- A **chapter** does not have due date node on schedule tree. There is **N/A** in due date node.
- Coach can change both start and due date of subsection. Afterword all units of that subsection will be updated.
- **Unit** inherits start and due dates of its subsection.
- Showing **unscheduled** on **units** that don't have dates.
- Fixed  i18n issue

@pdpinch @giocalitri @pwilkins 

PR https://github.com/mitocw/edx-platform/pull/99
Fixed https://github.com/mitocw/edx-platform/issues/51
Fixed https://github.com/mitocw/edx-platform/issues/56
Fixed https://github.com/mitocw/edx-platform/issues/79
Fixed https://github.com/mitocw/edx-platform/issues/80
Fixes https://github.com/mitocw/edx-platform/issues/86

![screen shot 2015-10-26 at 3 47 30 pm](https://cloud.githubusercontent.com/assets/10431250/10727237/13271652-7bfa-11e5-86d7-691c6bcb38cf.png)
![screen shot 2015-10-26 at 3 47 40 pm](https://cloud.githubusercontent.com/assets/10431250/10727238/132fd36e-7bfa-11e5-8e09-cbe47e3bb9b9.png)
![screen shot 2015-10-26 at 3 47 45 pm](https://cloud.githubusercontent.com/assets/10431250/10727239/135fafda-7bfa-11e5-8c52-6909988f8cb3.png)
![screen shot 2015-10-26 at 3 47 58 pm](https://cloud.githubusercontent.com/assets/10431250/10727243/1ae215f4-7bfa-11e5-8fea-05eef274a734.png)
![screen shot 2015-10-26 at 3 48 08 pm](https://cloud.githubusercontent.com/assets/10431250/10727244/1b18de90-7bfa-11e5-9d90-95e2c0d6321c.png)
