### PR TITLE
LMS: Profile - saving on blur rather than change

### DIFF
--- a/common/test/acceptance/pages/lms/fields.py
+++ b/common/test/acceptance/pages/lms/fields.py
@@ -204,11 +204,14 @@ class FieldsMixin(object):
 
         if value is not None:
             select_option_by_text(query, value)
+            query.results[0].send_keys(u'\ue004')  # Focus Out using TAB
 
         if self.mode_for_field(field_id) == 'edit':
             return get_selected_option_text(query)
         else:
             return self.get_non_editable_mode_value(field_id)
+
+        # blur the field to save the value
 
     def link_title_for_link_field(self, field_id):
         """

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -295,7 +295,6 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         """
         username, user_id = self.log_in_as_unique_user()
         profile_page = self.visit_profile_page(username, privacy=self.PRIVACY_PRIVATE)
-        from nose.tools import set_trace; set_trace()
         self.verify_profile_page_is_private(profile_page)
         self.verify_profile_page_view_event(username, user_id, visibility=self.PRIVACY_PRIVATE)
 

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -118,7 +118,6 @@ class LearnerProfileTestMixin(EventsTestMixin):
         """
         Verifies that the correct view event was captured for the profile page.
         """
-
         actual_events = self.wait_for_events(
             event_filter={'event_type': 'edx.user.settings.viewed'}, number_of_matches=1)
         self.assert_events_match(

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -295,6 +295,7 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         """
         username, user_id = self.log_in_as_unique_user()
         profile_page = self.visit_profile_page(username, privacy=self.PRIVACY_PRIVATE)
+        from nose.tools import set_trace; set_trace()
         self.verify_profile_page_is_private(profile_page)
         self.verify_profile_page_view_event(username, user_id, visibility=self.PRIVACY_PRIVATE)
 

--- a/lms/static/js/spec/student_account/account_settings_fields_spec.js
+++ b/lms/static/js/spec/student_account/account_settings_fields_spec.js
@@ -51,7 +51,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                 var view = new AccountSettingsFieldViews.LanguagePreferenceFieldView(fieldData).render();
 
                 var data = {'language': FieldViewsSpecHelpers.SELECT_OPTIONS[2][0]};
-                view.$(selector).val(data[fieldData.valueAttribute]).change();
+                view.$(selector).val(data[fieldData.valueAttribute]);
+                $(view.el).find('.button-save').click();
                 FieldViewsSpecHelpers.expectAjaxRequestWithData(requests, data);
                 AjaxHelpers.respondWithNoContent(requests);
 
@@ -65,7 +66,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                 FieldViewsSpecHelpers.expectMessageContains(view, "Your changes have been saved.");
 
                 data = {'language': FieldViewsSpecHelpers.SELECT_OPTIONS[1][0]};
-                view.$(selector).val(data[fieldData.valueAttribute]).change();
+                view.$(selector).val(data[fieldData.valueAttribute]);
+                $(view.el).find('.button-save').click();
                 FieldViewsSpecHelpers.expectAjaxRequestWithData(requests, data);
                 AjaxHelpers.respondWithNoContent(requests);
 
@@ -98,7 +100,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                 expect(view.modelValue()).toBe(FieldViewsSpecHelpers.SELECT_OPTIONS[0][0]);
 
                 var data = {'language_proficiencies': [{'code': FieldViewsSpecHelpers.SELECT_OPTIONS[1][0]}]};
-                view.$(selector).val(FieldViewsSpecHelpers.SELECT_OPTIONS[1][0]).change();
+                view.$(selector).val(FieldViewsSpecHelpers.SELECT_OPTIONS[1][0]);
+                $(view.el).find('.button-save').click();
                 FieldViewsSpecHelpers.expectAjaxRequestWithData(requests, data);
                 AjaxHelpers.respondWithNoContent(requests);
             });

--- a/lms/static/js/spec/views/fields_helpers.js
+++ b/lms/static/js/spec/views/fields_helpers.js
@@ -179,7 +179,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                 expect(view.fieldValue()).not.toContain(data.validValue);
             }
 
-            view.$(data.valueInputSelector).val(data.validValue).change().blur();
+            view.$(data.valueInputSelector).val(data.validValue).change();
+            $(view.el).find('.button-save').click(); // save the updated values
             // When the value in the field is changed
             expect(view.fieldValue()).toBe(data.validValue);
             expectMessageContains(view, view.indicators.inProgress);
@@ -239,7 +240,7 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
         var verifyTextField = function (view, data, requests) {
             verifyEditableField(view, _.extend({
                     valueSelector: '.u-field-value',
-                    valueInputSelector: '.u-field-value > input'
+                    valueInputSelector: '.u-field-value input'
                 }, data
             ), requests);
         };
@@ -247,7 +248,7 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
         var verifyDropDownField = function (view, data, requests) {
             verifyEditableField(view, _.extend({
                     valueSelector: '.u-field-value',
-                    valueInputSelector: '.u-field-value > select'
+                    valueInputSelector: '.u-field-value select'
                 }, data
             ), requests);
         };

--- a/lms/static/js/spec/views/fields_helpers.js
+++ b/lms/static/js/spec/views/fields_helpers.js
@@ -179,7 +179,7 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                 expect(view.fieldValue()).not.toContain(data.validValue);
             }
 
-            view.$(data.valueInputSelector).val(data.validValue).change();
+            view.$(data.valueInputSelector).val(data.validValue).change().blur();
             // When the value in the field is changed
             expect(view.fieldValue()).toBe(data.validValue);
             expectMessageContains(view, view.indicators.inProgress);

--- a/lms/static/js/spec/views/fields_helpers.js
+++ b/lms/static/js/spec/views/fields_helpers.js
@@ -144,18 +144,19 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
 
             switch (fieldClass) {
                 case FieldViews.TextFieldView:
-                    valueInputSelector = '.u-field-value > input';
+                    valueInputSelector = '.u-field-value input';
                     break;
                 case FieldViews.DropdownFieldView:
-                    valueInputSelector = '.u-field-value > select';
+                    valueInputSelector = '.u-field-value select';
                     _.extend(fieldData, {validValue: SELECT_OPTIONS[0][0]});
                     break;
                 case FieldViews.TextareaFieldView:
-                    valueInputSelector = '.u-field-value > textarea';
+                    valueInputSelector = '.u-field-value textarea';
                     break;
             }
 
-            view.$(valueInputSelector).val(fieldData.validValue).change();
+            view.$(valueInputSelector).val(fieldData.validValue);
+            $(view.el).find('.button-save').click();
             expect(view.fieldValue()).toBe(fieldData.validValue);
             expectMessageContains(view, view.helpMessage);
             AjaxHelpers.expectNoRequests(requests);
@@ -179,8 +180,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                 expect(view.fieldValue()).not.toContain(data.validValue);
             }
 
-            view.$(data.valueInputSelector).val(data.validValue).change();
-            $(view.el).find('.button-save').click(); // save the updated values
+            view.$(data.valueInputSelector).val(data.validValue);
+            $(view.el).find('.button-save').click();
             // When the value in the field is changed
             expect(view.fieldValue()).toBe(data.validValue);
             expectMessageContains(view, view.indicators.inProgress);
@@ -199,7 +200,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                 expectMessageContains(view, view.indicators.success);
             }
 
-            view.$(data.valueInputSelector).val(data.invalidValue1).change();
+            view.$(data.valueInputSelector).val(data.invalidValue1);
+            $(view.el).find('.button-save').click();
             request_data[data.valueAttribute] = data.invalidValue1;
             AjaxHelpers.expectJsonRequest(
                 requests, 'PATCH', url, request_data
@@ -210,7 +212,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
             expectMessageContains(view, view.messages.error);
             expect(view.el).toHaveClass('mode-edit');
 
-            view.$(data.valueInputSelector).val(data.invalidValue2).change();
+            view.$(data.valueInputSelector).val(data.invalidValue2);
+            $(view.el).find('.button-save').click();
             request_data[data.valueAttribute] = data.invalidValue2;
             AjaxHelpers.expectJsonRequest(
                 requests, 'PATCH', url, request_data
@@ -221,7 +224,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
             expectMessageContains(view, data.validationError);
             expect(view.el).toHaveClass('mode-edit');
 
-            view.$(data.valueInputSelector).val('').change();
+            view.$(data.valueInputSelector).val('');
+            $(view.el).find('.button-save').click();
             // When the value in the field is changed
             expect(view.fieldValue()).toBe(data.defaultValue);
             request_data[data.valueAttribute] = data.defaultValue;

--- a/lms/static/js/spec/views/fields_spec.js
+++ b/lms/static/js/spec/views/fields_spec.js
@@ -100,7 +100,6 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
             });
 
             it("correctly renders, updates and persists changes to TextFieldView when editable == always", function() {
-
                 requests = AjaxHelpers.requests(this);
 
                 var fieldData = FieldViewsSpecHelpers.createFieldData(FieldViews.TextFieldView, {
@@ -124,7 +123,6 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
             });
 
             it("correctly renders and updates DropdownFieldView when editable == never", function() {
-
                 requests = AjaxHelpers.requests(this);
 
                 var fieldData = FieldViewsSpecHelpers.createFieldData(FieldViews.DropdownFieldView, {
@@ -163,7 +161,6 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
             });
 
             it("correctly renders, updates and persists changes to DropdownFieldView when editable == always", function() {
-
                 requests = AjaxHelpers.requests(this);
 
                 var fieldData = FieldViewsSpecHelpers.createFieldData(FieldViews.DropdownFieldView, {
@@ -187,7 +184,6 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
             });
 
             it("correctly renders, updates and persists changes to DropdownFieldView when editable == toggle", function() {
-
                 requests = AjaxHelpers.requests(this);
 
                 var fieldData = FieldViewsSpecHelpers.createFieldData(FieldViews.DropdownFieldView, {
@@ -235,7 +231,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                         view.showEditMode(true);
                     }
                     expect(view.$(dropdownSelectClass).length).toBe(1);
-                    view.$(dropdownSelectClass).val(FieldViewsSpecHelpers.SELECT_OPTIONS[0]).change();
+                    view.$(dropdownSelectClass).val(FieldViewsSpecHelpers.SELECT_OPTIONS[0]);
+                    $(view.el).find('.button-save').click();
                     expect(view.fieldValue()).toBe(FieldViewsSpecHelpers.SELECT_OPTIONS[0][0]);
 
                     AjaxHelpers.respondWithNoContent(requests);
@@ -301,7 +298,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
 
                 view.$('.wrapper-u-field').click();
                 expect(view.el).toHaveClass('mode-edit');
-                view.$(valueInputSelector).val(BIO).focusout();
+                view.$(valueInputSelector).val(BIO);
+                $(view.el).find('.button-save').click();
                 expect(view.fieldValue()).toBe(BIO);
                 expect(view.$(textareaLinkClass).length).toBe(0);
                 AjaxHelpers.expectJsonRequest(
@@ -312,7 +310,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                 expect(view.$(textareaLinkClass).length).toBe(1);
 
                 view.$('.wrapper-u-field').click();
-                view.$(valueInputSelector).val('').focusout();
+                view.$(valueInputSelector).val('');
+                $(view.el).find('.button-save').click();
                 AjaxHelpers.respondWithNoContent(requests);
                 expect(view.el).toHaveClass('mode-placeholder');
                 expect(view.fieldValue()).toBe(fieldData.placeholderValue);

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -330,7 +330,6 @@
 
             events: {
                 'click': 'startEditing',
-                'change select': 'finishEditing',
                 'focusout select': 'finishEditing'
             },
 

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -205,6 +205,7 @@
                 this.mode = 'display';
                 if (render) { this.render(); }
                 this.updateDisplayModeClass();
+                this.$el.find('.button-save').hide();
             },
 
             showEditMode: function(render) {
@@ -216,6 +217,7 @@
                 this.$el.removeClass('mode-display');
 
                 this.$el.addClass('mode-edit');
+                this.$el.find('.button-save').show();
             },
 
             startEditing: function () {
@@ -286,13 +288,14 @@
             fieldTemplate: field_text_template,
 
             events: {
-                'change input': 'saveValue'
+                'click': 'saveValue'
             },
 
             initialize: function (options) {
                 this._super(options);
                 _.bindAll(this, 'render', 'fieldValue', 'updateValueInField', 'saveValue');
                 this.listenTo(this.model, "change:" + this.options.valueAttribute, this.updateValueInField);
+                this.listenForSave();
             },
 
             render: function () {
@@ -304,6 +307,10 @@
                 }));
                 this.delegateEvents();
                 return this;
+            },
+
+            listenForSave: function() {
+                this.$el.on('click', '.button-save', this.saveValue);
             },
 
             fieldValue: function () {
@@ -329,8 +336,7 @@
             fieldTemplate: field_dropdown_template,
 
             events: {
-                'click': 'startEditing',
-                'focusout select': 'finishEditing'
+                'click': 'startEditing'
             },
 
             initialize: function (options) {
@@ -338,6 +344,7 @@
                 this._super(options);
 
                 this.listenTo(this.model, "change:" + this.options.valueAttribute, this.updateValueInField);
+                this.listenForSave();
             },
 
             render: function () {
@@ -360,6 +367,10 @@
                     this.showCanEditMessage(this.mode === 'display');
                 }
                 return this;
+            },
+
+            listenForSave: function() {
+                this.$el.on('click', '.button-save', this.saveValue);
             },
 
             modelValueIsSet: function() {
@@ -410,8 +421,6 @@
                 if (this.mode === 'display') {
                     this.updateDisplayModeClass();
                 }
-
-                this.$('.u-field-value select').blur();
             },
 
             saveValue: function () {
@@ -462,7 +471,6 @@
             events: {
                 'click .wrapper-u-field': 'startEditing',
                 'click .u-field-placeholder': 'startEditing',
-                'focusout textarea': 'finishEditing',
                 'change textarea': 'adjustTextareaHeight',
                 'keyup textarea': 'adjustTextareaHeight',
                 'keydown textarea': 'onKeyDown',
@@ -474,6 +482,7 @@
                 _.bindAll(this, 'render', 'onKeyDown', 'adjustTextareaHeight', 'fieldValue', 'saveValue', 'updateView');
                 this._super(options);
                 this.listenTo(this.model, "change:" + this.options.valueAttribute, this.updateView);
+                this.listenForSave();
             },
 
             render: function () {
@@ -498,6 +507,11 @@
                     this.showCanEditMessage(this.mode === 'display');
                 }
                 return this;
+            },
+
+            listenForSave: function() {
+                this.$el.on('click', '.button-save', this.saveValue);
+                this.showDisplayMode(true);
             },
 
             onKeyDown: function (event) {

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -288,7 +288,7 @@
             fieldTemplate: field_text_template,
 
             events: {
-                'click': 'saveValue'
+                // 'click': 'saveValue'
             },
 
             initialize: function (options) {

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -511,7 +511,7 @@
 
             listenForSave: function() {
                 this.$el.on('click', '.button-save', this.saveValue);
-                this.showDisplayMode(true);
+                this.finishEditing();
             },
 
             onKeyDown: function (event) {

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -20,7 +20,7 @@
         var FieldViews = {};
 
         FieldViews.FieldView = Backbone.View.extend({
-                
+
             fieldType: 'generic',
 
             className: function () {
@@ -410,6 +410,8 @@
                 if (this.mode === 'display') {
                     this.updateDisplayModeClass();
                 }
+
+                this.$('.u-field-value select').blur();
             },
 
             saveValue: function () {

--- a/lms/static/sass/shared/_fields.scss
+++ b/lms/static/sass/shared/_fields.scss
@@ -104,6 +104,27 @@
     }
 }
 
+.u-field-save {
+    display: inline-block;
+    width: flex-grid(1, 12);
+
+    .button-save {
+        display: none;
+        vertical-align: top;
+        margin-top: -($baseline / 4);
+    }
+}
+
+.editable-always {
+
+    .u-field-save {
+
+        .button-save {
+            display: block !important;
+        }
+    }
+}
+
 .u-field-message {
     @extend %t-copy-sub1;
     @include padding-left($baseline/2);

--- a/lms/static/sass/shared/_fields.scss
+++ b/lms/static/sass/shared/_fields.scss
@@ -111,7 +111,16 @@
     .button-save {
         display: none;
         vertical-align: top;
-        margin-top: -($baseline / 4);
+    }
+}
+
+.u-field-dropdown {
+
+    .u-field-save {
+
+        .button-save {
+            margin-top: -($baseline / 4);
+        }
     }
 }
 
@@ -121,6 +130,16 @@
 
         .button-save {
             display: block !important;
+        }
+    }
+}
+
+.team-edit-fields {
+
+    .editable-always {
+
+        .u-field-save {
+            display: none;
         }
     }
 }

--- a/lms/templates/fields/field_dropdown.underscore
+++ b/lms/templates/fields/field_dropdown.underscore
@@ -34,6 +34,9 @@
         </button>
     <% } %>
 </span>
+<span class="u-field-save">
+    <button class="button-save"><%- gettext('Update') %></button>
+</span>
 
 <span class="u-field-message" id="u-field-message-<%- id %>">
     <span class="u-field-message-notification" aria-live="polite"></span>

--- a/lms/templates/fields/field_text.underscore
+++ b/lms/templates/fields/field_text.underscore
@@ -4,6 +4,9 @@
 <span class="u-field-value">
     <input id="u-field-input-<%- id %>" aria-describedby="u-field-message-help-<%- id %>" type="text" name="input" value="<%- value %>">
 </span>
+<span class="u-field-save">
+    <button class="button-save"><%- gettext('Update') %></button>
+</span>
 <span class="u-field-message" id="u-field-message-<%- id %>">
     <span class="u-field-message-notification" aria-live="polite"></span>
     <span class="u-field-message-help" id="u-field-message-help-<%- id %>"> <%- message %></span>

--- a/lms/templates/fields/field_textarea.underscore
+++ b/lms/templates/fields/field_textarea.underscore
@@ -31,6 +31,9 @@
             <span class="sr" id="u-field-placeholder-value-<%- id %>"><%- placeholderValue %></span>
         <% } %>
     </div>
+    <span class="u-field-save">
+        <button class="button-save"><%- gettext('Update') %></button>
+    </span>
 
     <div class="u-field-footer">
         <% if (messagePosition === 'footer') { %>


### PR DESCRIPTION
This small change in how the learner profiles saves changes. Previously, it saved the changes whenever an option was selected, however if a user makes an accidental selection the process has to be done again. This is a hindrance to usability. The change I've made removes the on change sniffer so the changes only save on blur.

This work relates to [AC-104](https://openedx.atlassian.net/browse/AC-104).

**Note: since the dropdown, text, and textarea fields are part of a template, this work impacts Teams and the Profile, and may impact other areas.**
## Sandbox

http://clrux-ac-104.sandbox.edx.org
## Reviewers
