### PR TITLE
Pin xblock-sdk.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -35,6 +35,7 @@ git+https://github.com/edx/lettuce.git@django1.8/upgrade#egg=lettuce==1.8
 
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@django1.8-upgrade#egg=XBlock
+git+https://github.com/edx/xblock-sdk.git@ned/upgrade-django-18#egg=xblock-sdk==1.0
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@django1.8-upgrade#egg=event-tracking


### PR DESCRIPTION
Some requirement is pulling in `xblock-sdk`. Just pinning to the version which supports the latest Django. Get rids of the warning of type:

```
2015-10-27 07:39:35,347 WARNING 9681 [xblock.plugin] plugin.py:147 - Unable to load XBlock 'view_counter_demo'
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/plugin.py", line 144, in load_classes
    yield (class_.name, cls._load_class_entry_point(class_))
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/plugin.py", line 73, in _load_class_entry_point
    class_ = entry_point.load()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2354, in load
    self.require(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2371, in require
    items = working_set.resolve(reqs, env, installer)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 844, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
VersionConflict: (Django 1.8.4 (/edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages), Requirement.parse('Django<1.5,>=1.4'))
```
