### PR TITLE
Added connector setting in course

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -402,6 +402,15 @@ class CourseFields(object):
         default=False,
         scope=Scope.settings
     )
+    ccx_connector = String(
+        # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content.
+        display_name=_("CCX Connector URL"),
+        # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content.
+        help=_(
+            "URL for CCX Connector application for managing creation of CCXs. (optional)"
+        ),
+        scope=Scope.settings
+    )
     allow_anonymous = Boolean(
         display_name=_("Allow Anonymous Discussion Posts"),
         help=_("Enter true or false. If true, students can create discussion posts that are anonymous to all users."),


### PR DESCRIPTION
> As an initial implementation, this can be done as an advanced setting on the course (similar to enable_ccx). The key should be ccx_connector and the name should be "CCX Connector URL" The help text should be "URL for CCX Connector application for managing creation of CCXs. (optional)"

Issue https://github.com/mitocw/edx-platform/issues/118
@pdpinch 

![screen shot 2015-10-27 at 6 20 00 pm](https://cloud.githubusercontent.com/assets/10431250/10759170/a6eefbc4-7cd7-11e5-8c61-a3d50712f40c.png)
