### PR TITLE
Disable Fast Preview for version 2.5.

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -1,3 +1,16 @@
+if (window) {
+    // MathJax Fast Preview was introduced in 2.5. However, it
+    // causes undesirable flashing/font size changes when
+    // MathJax is used for interactive preview (equation editor).
+    // Setting processSectionDelay to 0 (see below) fully eliminates
+    // fast preview, but to reduce confusion, we are also setting
+    // the option as displayed in the context menu to false.
+    // When upgrading to 2.6, check if this variable name changed.
+    window.MathJax = {
+      menuSettings: {CHTMLpreview: false}
+    };
+}
+
 require.config({
     // NOTE: baseUrl has been previously set in cms/static/templates/base.html
     waitSeconds: 60,
@@ -70,7 +83,7 @@ require.config({
         // end of Annotation tool files
 
         // externally hosted files
-        "mathjax": "//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": [
             // youtube URL does not end in ".js". We add "?noext" to the path so
             // that require.js adds the ".js" to the query component of the URL,
@@ -191,6 +204,12 @@ require.config({
                   ]
                 }
               });
+              // In order to eliminate all flashing during interactive
+              // preview, it is necessary to set processSectionDelay to 0
+              // (remove delay between input and output phases). This
+              // effectively disables fast preview, regardless of
+              // the fast preview setting as shown in the context menu.
+              MathJax.Hub.processSectionDelay = 0;
               MathJax.Hub.Configured();
             }
         },

--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -51,7 +51,7 @@ requirejs.config({
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
         "mock-ajax": "xmodule_js/common_static/js/vendor/mock-ajax",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix",

--- a/cms/static/coffee/spec/main_squire.coffee
+++ b/cms/static/coffee/spec/main_squire.coffee
@@ -42,7 +42,7 @@ requirejs.config({
         "domReady": "xmodule_js/common_static/js/vendor/domReady",
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix"

--- a/common/static/js/capa/spec/formula_equation_preview_spec.js
+++ b/common/static/js/capa/spec/formula_equation_preview_spec.js
@@ -235,8 +235,7 @@ describe("Formula Equation Preview", function () {
 
                 // Refresh the MathJax.
                 expect(MathJax.Hub.Queue).toHaveBeenCalledWith(
-                    ['Text', this.jax, 'THE_FORMULA'],
-                    ['Reprocess', this.jax]
+                    ['Text', this.jax, 'THE_FORMULA']
                 );
             });
         });
@@ -302,8 +301,7 @@ describe("Formula Equation Preview", function () {
             runs(function () {
                 // Refresh the MathJax.
                 expect(MathJax.Hub.Queue).toHaveBeenCalledWith(
-                    ['Text', this.jax, '\\text{OOPSIE}'],
-                    ['Reprocess', this.jax]
+                    ['Text', this.jax, '\\text{OOPSIE}']
                 );
                 expect($img.css('visibility')).toEqual('hidden');
             });
@@ -349,17 +347,15 @@ describe("Formula Equation Preview", function () {
 
             this.callbacks[0](this.responses[0]);
             expect(MathJax.Hub.Queue).toHaveBeenCalledWith(
-                ['Text', this.jax, 'THE_FORMULA_0'],
-                ['Reprocess', this.jax]
+                ['Text', this.jax, 'THE_FORMULA_0']
             );
             expect($img.css('visibility')).toEqual('visible');
 
             this.callbacks[1](this.responses[1]);
             expect(MathJax.Hub.Queue).toHaveBeenCalledWith(
-                ['Text', this.jax, 'THE_FORMULA_1'],
-                ['Reprocess', this.jax]
+                ['Text', this.jax, 'THE_FORMULA_1']
             );
-            expect($img.css('visibility')).toEqual('hidden')
+            expect($img.css('visibility')).toEqual('hidden');
         });
 
         it("doesn't display outdated information", function () {
@@ -370,15 +366,14 @@ describe("Formula Equation Preview", function () {
             // Switch the order (1 returns before 0)
             this.callbacks[1](this.responses[1]);
             expect(MathJax.Hub.Queue).toHaveBeenCalledWith(
-                ['Text', this.jax, 'THE_FORMULA_1'],
-                ['Reprocess', this.jax]
+                ['Text', this.jax, 'THE_FORMULA_1']
             );
-            expect($img.css('visibility')).toEqual('hidden')
+            expect($img.css('visibility')).toEqual('hidden');
 
             MathJax.Hub.Queue.reset();
             this.callbacks[0](this.responses[0]);
             expect(MathJax.Hub.Queue).not.toHaveBeenCalled();
-            expect($img.css('visibility')).toEqual('hidden')
+            expect($img.css('visibility')).toEqual('hidden');
         });
 
         it("doesn't show an error if the responses are close together",
@@ -392,8 +387,7 @@ describe("Formula Equation Preview", function () {
 
                this.callbacks[1](this.responses[1]);
                expect(MathJax.Hub.Queue).toHaveBeenCalledWith(
-                   ['Text', this.jax, 'THE_FORMULA_1'],
-                   ['Reprocess', this.jax]
+                   ['Text', this.jax, 'THE_FORMULA_1']
                );
 
                // Make sure that it doesn't indeed show up later

--- a/common/static/js/capa/src/formula_equation_preview.js
+++ b/common/static/js/capa/src/formula_equation_preview.js
@@ -139,8 +139,7 @@ formulaEquationPreview.enable = function () {
                         if (inputData.jax) {
                             // Set the text as the latex code, and then update the MathJax.
                             MathJax.Hub.Queue(
-                                ['Text', inputData.jax, latex],
-                                ['Reprocess', inputData.jax]
+                                ['Text', inputData.jax, latex]
                             );
                         } else if (latex) {
                             console.log("[FormulaEquationInput] Oops no mathjax for ", latex);

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -1,10 +1,27 @@
 ## mako
 ## File:   templates/mathjax_include.html
 ##
-## Advanced mathjax using 2.0-latest CDN for Dynamic Math
-##
-## This enables ASCIIMathJAX, and is used by js_textbox
+## Note that this file is only used by LMS.
+## MathJax configuration for Studio lives in
+## cms/js/require-config.js.
 
+
+<%page args="disable_fast_preview=True"/>
+
+%if disable_fast_preview:
+// Fast Preview was introduced in 2.5. However, it
+// causes undesirable flashing/font size changes when
+// MathJax is used for interactive preview (equation editor).
+// Setting processSectionDelay to 0 (see below) fully eliminates
+// fast preview, but to reduce confusion, we are also setting
+// the option as displayed in the context menu to false.
+// When upgrading to 2.6, check if this variable name changed.
+<script type="text/javascript">
+    window.MathJax = {
+      menuSettings: {CHTMLpreview: false}
+    };
+</script>
+%endif
 
 %if mathjax_mode is not Undefined and mathjax_mode == 'wiki':
 <script type="text/x-mathjax-config">
@@ -30,7 +47,16 @@
 </script>
 %endif
 <script type="text/x-mathjax-config">
-  window.HUB = MathJax.Hub;
+
+  %if disable_fast_preview:
+  // In order to eliminate all flashing during interactive
+  // preview, it is necessary to set processSectionDelay to 0
+  // (remove delay between input and output phases). This
+  // effectively disables fast preview, regardless of
+  // the fast preview setting as shown in the context menu.
+  MathJax.Hub.processSectionDelay = 0;
+  %endif
+
   MathJax.Hub.signal.Interest(function(message) {
     if(message[0] === "End Math") {
         set_mathjax_display_div_settings();
@@ -50,4 +76,4 @@
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -49,7 +49,7 @@
             'jasmine.async': 'xmodule_js/common_static/js/vendor/jasmine.async',
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly.pkgd',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
-            'mathjax': '//cdn.mathjax.org/mathjax/2.4-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured', // jshint ignore:line
+            'mathjax': '//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured', // jshint ignore:line
             'youtube': '//www.youtube.com/player_api?noext',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',
             'coffee/src/instructor_dashboard/student_admin': 'coffee/src/instructor_dashboard/student_admin',

--- a/lms/templates/discussion/_js_body_dependencies.html
+++ b/lms/templates/discussion/_js_body_dependencies.html
@@ -1,1 +1,3 @@
-<%include file="/mathjax_include.html" />
+<%page args="disable_fast_preview=True"/>
+
+<%include file="/mathjax_include.html" args="disable_fast_preview=disable_fast_preview"/>

--- a/lms/templates/discussion/index.html
+++ b/lms/templates/discussion/index.html
@@ -18,7 +18,8 @@ from django.core.urlresolvers import reverse
 </%block>
 
 <%block name="js_extra">
-<%include file="_js_body_dependencies.html" />
+## Enable fast preview to fix discussion MathJax rendering bug when page first loads.
+<%include file="_js_body_dependencies.html" args="disable_fast_preview=False"/>
 <%static:js group='discussion'/>
 </%block>
 


### PR DESCRIPTION
## [TNL-3693](https://openedx.atlassian.net/browse/TNL-3693)

Upgrade from MathJax 2.4 to 2.5 (take 2, after #10223 was backed out of the release). This may introduce performance improvements for users (in particular, rendering speed), and it fixes a CAT-2 bug, TNL-3365.

Fast preview has been disabled within the courseware to address TNL-3693. This approach was recommended in https://github.com/mathjax/MathJax/issues/1030 and https://github.com/mathjax/MathJax/issues/1007. To be as safe as possible, the LMS default is to disable fast preview, which means it will also be disabled for the wiki, teams, and discussion profiles.

However, fast preview is ENABLED within the discussion tab because otherwise TNL-3365, a bug in initial rendering only, sometimes reappears (apparently a race condition, more likely to be hit on sandbox vs. devstack).

For simplicity, fast preview is always disabled in Studio.
### Sandbox
- [x] http://cahrens.sandbox.edx.org. Test the following things--
- Studio equation input: http://studio-cahrens.sandbox.edx.org/container/block-v1:mathjax+mathjax+mathjax+type@vertical+block@6737885effbf48e9b02cf73ab893663f (log in as staff)
- LMS equation input (with an inline component containing MathJax): http://cahrens.sandbox.edx.org/courses/course-v1:mathjax+mathjax+mathjax/courseware/4add5954d71b4fe3b46c9533526b7231/b29120ddd1834140946f98c5104af450/2?activate_block_id=block-v1%3Amathjax%2Bmathjax%2Bmathjax%2Btype%40vertical%2Bblock%406737885effbf48e9b02cf73ab893663f
- LMS MathJax rendering in problem: http://cahrens.sandbox.edx.org/courses/course-v1:mathjax+mathjax+mathjax/courseware/4add5954d71b4fe3b46c9533526b7231/b29120ddd1834140946f98c5104af450/
- discussion forum (TNL-3365): http://cahrens.sandbox.edx.org/courses/course-v1:mathjax+mathjax+mathjax/discussion/forum/course/threads/562fc36e2b594e5bb4000002
- discussion forum repo method 2: http://cahrens.sandbox.edx.org/courses/course-v1:mathjax+mathjax+mathjax/discussion/forum/course/threads/562fc32d2b594ed108000001 then click on a MathJax post on the LHS.
### Testing
- [x] Performance

Sitespeed reports--
2.4 https://build.testeng.edx.org/job/get-sitespeed-report/87/SiteSpeedIO_Report/index.html
2.5 https://build.testeng.edx.org/job/get-sitespeed-report/92/SiteSpeedIO_Report/
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [x] Code review: @robrap
- [x] Product review: @explorerleslie (I'd love it if you manually test!)

FYI @ormsbee @benpatterson @andy-armstrong @mushtaqak 
### Post-review
- [x] Squash commits
