### PR TITLE
Remove .git URL restriction for git imports

### DIFF
--- a/lms/djangoapps/dashboard/git_import.py
+++ b/lms/djangoapps/dashboard/git_import.py
@@ -144,8 +144,7 @@ def add_repo(repo, rdir_in, branch=None):
     if not os.path.isdir(GIT_REPO_DIR):
         raise GitImportError(GitImportError.NO_DIR)
     # pull from git
-    if not (repo.endswith('.git') or
-            repo.startswith(('http:', 'https:', 'git:', 'file:'))):
+    if not (repo.startswith(('http:', 'https:', 'file:')) or ('@' in repo)):
         raise GitImportError(GitImportError.URL_BAD)
 
     if rdir_in:

--- a/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
+++ b/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
@@ -43,6 +43,7 @@ class TestGitAddCourse(ModuleStoreTestCase):
     """
 
     TEST_REPO = 'https://github.com/mitocw/edx4edx_lite.git'
+    TEST_REPO_WITHOUT_DOT_GIT = 'https://github.com/mitocw/edx4edx_lite'
     TEST_COURSE = 'MITx/edx4edx/edx4edx'
     TEST_BRANCH = 'testing_do_not_delete'
     TEST_BRANCH_COURSE = SlashSeparatedCourseKey('MITx', 'edx4edx_branch', 'edx4edx')
@@ -80,6 +81,10 @@ class TestGitAddCourse(ModuleStoreTestCase):
             os.mkdir(self.GIT_REPO_DIR / 'edx4edx')
 
         call_command('git_add_course', self.TEST_REPO,
+                     self.GIT_REPO_DIR / 'edx4edx_lite')
+
+        # Test command using a URL that doesn't end with '.git'
+        call_command('git_add_course', self.TEST_REPO_WITHOUT_DOT_GIT,
                      self.GIT_REPO_DIR / 'edx4edx_lite')
 
         # Test with all three args (branch)


### PR DESCRIPTION
@pdpinch This removes the "must end with .git" URL restriction for git imports, which isn't a valid restriction, as this isn't something Git uses to check if a URL is valid.
