### PR TITLE
Fix old migration code

### DIFF
--- a/common/djangoapps/student/migrations/0035_access_roles.py
+++ b/common/djangoapps/student/migrations/0035_access_roles.py
@@ -35,10 +35,10 @@ class Migration(DataMigration):
         if isinstance(store, MixedModuleStore):
             self.mongostore = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo)
             self.xmlstore = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.xml)
-        elif store.get_modulestore_type() == ModuleStoreEnum.Type.mongo:
+        elif store.get_modulestore_type(None) == ModuleStoreEnum.Type.mongo:
             self.mongostore = store
             self.xmlstore = None
-        elif store.get_modulestore_type() == ModuleStoreEnum.Type.xml:
+        elif store.get_modulestore_type(None) == ModuleStoreEnum.Type.xml:
             self.mongostore = None
             self.xmlstore = store
         else:

--- a/common/djangoapps/student/migrations/0036_access_roles_orgless.py
+++ b/common/djangoapps/student/migrations/0036_access_roles_orgless.py
@@ -29,10 +29,10 @@ class Migration(DataMigration):
         if isinstance(store, MixedModuleStore):
             self.mongostore = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo)
             self.xmlstore = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.xml)
-        elif store.get_modulestore_type() == ModuleStoreEnum.Type.mongo:
+        elif store.get_modulestore_type(None) == ModuleStoreEnum.Type.mongo:
             self.mongostore = store
             self.xmlstore = None
-        elif store.get_modulestore_type() == ModuleStoreEnum.Type.xml:
+        elif store.get_modulestore_type(None) == ModuleStoreEnum.Type.xml:
             self.mongostore = None
             self.xmlstore = store
         else:


### PR DESCRIPTION
The interface of `get_modulestore_type` has changed since this migration code was originally implemented.  This commit updates the old migration code.  
This issue was found when trying to migrate an old test database on my local machine.

@ormsbee @BenjiLee 
