### PR TITLE
Fix jump_to_id url

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -650,10 +650,14 @@ def get_module_system_for_user(user, student_data,  # TODO  # pylint: disable=to
     # because it is agnostic to course-hierarchy.
     # NOTE: module_id is empty string here. The 'module_id' will get assigned in the replacement
     # function, we just need to specify something to get the reverse() to work.
+    # As the module id is empty string and and jump_to_id url ends with slash so its took
+    # the form of // at end with module_id empty so replacing  // (double slashes)
+    # with / (single slash).
+    jump_to_id_url = reverse('jump_to_id', kwargs={'course_id': course_id.to_deprecated_string(), 'module_id': ''})[:-1]
     block_wrappers.append(partial(
         replace_jump_to_id_urls,
         course_id,
-        reverse('jump_to_id', kwargs={'course_id': course_id.to_deprecated_string(), 'module_id': ''}),
+        jump_to_id_url,
     ))
 
     if settings.FEATURES.get('DISPLAY_DEBUG_INFO_TO_STAFF'):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -6,6 +6,8 @@ import cgi
 from urllib import urlencode
 import ddt
 import json
+import urllib
+
 import unittest
 from datetime import datetime
 from HTMLParser import HTMLParser
@@ -72,16 +74,23 @@ class TestJumpTo(ModuleStoreTestCase):
     def test_jumpto_from_chapter(self):
         location = self.course_key.make_usage_key('chapter', 'Overview')
         jumpto_url = '{0}/{1}/jump_to/{2}'.format('/courses', self.course_key.to_deprecated_string(), location.to_deprecated_string())
-        expected = 'courses/edX/toy/2012_Fall/courseware/Overview/'
+        expected_url = 'courses/edX/toy/2012_Fall/courseware/Overview/'
         response = self.client.get(jumpto_url)
-        self.assertRedirects(response, expected, status_code=302, target_status_code=302)
+        self.assertRedirects(response, expected_url, status_code=302, target_status_code=302)
 
-    @unittest.skip
-    def test_jumpto_id(self):
-        jumpto_url = '{0}/{1}/jump_to_id/{2}'.format('/courses', self.course_key.to_deprecated_string(), 'Overview')
-        expected = 'courses/edX/toy/2012_Fall/courseware/Overview/'
+    def test_jumpto_id_with_slash(self):
+        jumpto_url = '{0}/{1}/jump_to_id/{2}/'.format('/courses', self.course_key.to_deprecated_string(), 'Overview')
+        expected_url = 'courses/edX/toy/2012_Fall/courseware/Overview/'
         response = self.client.get(jumpto_url)
-        self.assertRedirects(response, expected, status_code=302, target_status_code=302)
+        # test the url is redirect with status_code 302
+        self.assertEqual(int(response.status_code), 302)
+        self.assertTrue(expected_url in response['location'])
+
+    def test_jumpto_id_without_slash(self):
+        jumpto_url = '{0}/{1}/jump_to_id/{2}'.format('/courses', self.course_key.to_deprecated_string(), 'Overview')
+        expected_url = jumpto_url + '/'
+        response = self.client.get(jumpto_url)
+        self.assertRedirects(response, expected_url, status_code=301, target_status_code=302)
 
     def test_jumpto_from_section(self):
         course = CourseFactory.create()
@@ -168,9 +177,24 @@ class TestJumpTo(ModuleStoreTestCase):
 
     def test_jumpto_id_invalid_location(self):
         location = Location('edX', 'toy', 'NoSuchPlace', None, None, None)
-        jumpto_url = '{0}/{1}/jump_to_id/{2}'.format('/courses', self.course_key.to_deprecated_string(), location.to_deprecated_string())
+        jumpto_url = '{0}/{1}/jump_to_id/{2}/'.format(
+            '/courses',
+            self.course_key.to_deprecated_string(),
+            location.to_deprecated_string()
+        )
         response = self.client.get(jumpto_url)
         self.assertEqual(response.status_code, 404)
+
+    def test_jumpto_id_invalid_location_without_slash(self):
+        location = Location('edX', 'toy', 'NoSuchPlace', None, None, None)
+        jumpto_url = '{0}/{1}/jump_to_id/{2}'.format(
+            '/courses',
+            self.course_key.to_deprecated_string(),
+            location.to_deprecated_string()
+        )
+        expected_url = urllib.quote(jumpto_url + '/')
+        response = self.client.get(jumpto_url)
+        self.assertRedirects(response, expected_url, status_code=301, target_status_code=404)
 
 
 @attr('shard_1')

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -260,7 +260,7 @@ if settings.COURSEWARE_ENABLED:
             'courseware.views.jump_to', name="jump_to",
         ),
         url(
-            r'^courses/{}/jump_to_id/(?P<module_id>.*)$'.format(settings.COURSE_ID_PATTERN),
+            r'^courses/{}/jump_to_id/(?P<module_id>.*)/$'.format(settings.COURSE_ID_PATTERN),
             'courseware.views.jump_to_id', name="jump_to_id",
         ),
 


### PR DESCRIPTION
[PLAT-73](https://openedx.atlassian.net/browse/PLAT-73)

jump_to_id url returns 404 if it has a trailing slash
