### PR TITLE
Added photo_id_key while AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING is True

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -647,6 +647,9 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         # verification functionality. If you do want to work on it, you have to
         # explicitly enable these in your private settings.
         if settings.FEATURES.get('AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING'):
+            # fake photo id key is set only for initial verification
+            self.photo_id_key = 'fake-photo-id-key'
+            self.save()
             return
 
         aes_key = random_aes_key()


### PR DESCRIPTION
`photo_id_key` is required so dummy value is added when `AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING` flag is `True`.

ECOM-2547

@awais786 @afeef @zubair-arbi @ahsan-ul-haq 
