### PR TITLE
Optionally add max and actual score for assignments to get_student_grade_summary_data output.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -254,3 +254,4 @@ Arbab Nazar <arbab@edx.org>
 Douglas Hall <dhall@edx.org>
 Awais Jibran <awaisdar001@gmail.com>
 Muhammad Rehan <muhammadrehan69@gmail.com>
+Shawn Milochik <shawn@milochik.com>

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -631,17 +631,21 @@ class GradeTable(object):
         self.grades = {}
         self._current_row = {}
 
-    def _add_grade_to_row(self, component, score):
+    def _add_grade_to_row(self, component, score, possible=None):
         """Creates component if needed, and assigns score
 
         Args:
             component (str): Course component being graded
             score (float): Score of student on component
+            possible (float): Max possible score for the component
 
         Returns:
            None
         """
         component_index = self.components.setdefault(component, len(self.components))
+        if possible is not None:
+            # send a tuple instead of a single value
+            score = (score, possible)
         self._current_row[component_index] = score
 
     @contextmanager
@@ -681,7 +685,10 @@ class GradeTable(object):
         return self.components.keys()
 
 
-def get_student_grade_summary_data(request, course, get_grades=True, get_raw_scores=False, use_offline=False):
+def get_student_grade_summary_data(
+        request, course, get_grades=True, get_raw_scores=False,
+        use_offline=False, get_score_max=False
+):
     """
     Return data arrays with student identity and grades for specified course.
 
@@ -697,6 +704,11 @@ def get_student_grade_summary_data(request, course, get_grades=True, get_raw_sco
     data = list (one per student) of lists of data corresponding to the fields
 
     If get_raw_scores=True, then instead of grade summaries, the raw grades for all graded modules are returned.
+
+    If get_score_max is True, two values will be returned for each grade -- the
+    total number of points earned and the total number of points possible. For
+    example, if two points are possible and one is earned, (1, 2) will be
+    returned instead of 0.5 (the default).
     """
     course_key = course.id
     enrolled_students = User.objects.filter(
@@ -723,9 +735,18 @@ def get_student_grade_summary_data(request, course, get_grades=True, get_raw_sco
             log.debug(u'student=%s, gradeset=%s', student, gradeset)
             with gtab.add_row(student.id) as add_grade:
                 if get_raw_scores:
-                    # TODO (ichuang) encode Score as dict instead of as list, so score[0] -> score['earned']
+                    # The following code calls add_grade, which is an alias
+                    # for the add_row method on the GradeTable class. This adds
+                    # a grade for each assignment. Depending on whether
+                    # get_score_max is True, it will return either a single
+                    # value as a float between 0 and 1, or a two-tuple
+                    # containing the earned score and possible score for
+                    # the assignment (see docstring).
                     for score in gradeset['raw_scores']:
-                        add_grade(score.section, getattr(score, 'earned', score[0]))
+                        if get_score_max is True:
+                            add_grade(score.section, score.earned, score.possible)
+                        else:
+                            add_grade(score.section, score.earned)
                 else:
                     for grade_item in gradeset['section_breakdown']:
                         add_grade(grade_item['label'], grade_item['percent'])


### PR DESCRIPTION
**Background** Currently, only a grade between 0 and 1 is sent to the remote gradebook. The remote gradebook should receive both the raw grade (the float between 0 and 1) and the maximum score per assignment.  This change is in response to issue #95 on mitocw/edx-platform. https://github.com/mitocw/edx-platform/issues/95

This patch allows this additional data to be optionally added to the bundle passed to the code which writes the CSV file sent to the remote gradebook. After this patch is merged, additional work will have to be done to consume this new data during the CSV creation.

The remote gradebook feature has been in edX for almost three years.  We believe that MIT is its only consumer.

**Studio Updates** None.

**LMS Updates** From issue #95:
...Course staff want to use edX to weight and scale grades, as presented by the LMS `Progress` tab. 

In a nutshell, we intend to identify a source of the grade data, use that source to modify `get_student_grade_summary_data()` in `legacy.py` which is called by `return_csv()` in the same file.

**Testing** This feature can be run from the Legacy Dashboard for courses that are configured to use the remote gradebook feature.  (The remote gradebook configuration is described here `edx-platform/docs/en_us/internal/remote_gradebook.md`.)

![unnamed](https://cloud.githubusercontent.com/assets/130120/10861429/07d11e16-7f55-11e5-9ade-4e1928035dc0.png)

1 - The `Gradebook Name` is set as an advanced setting in Studio.
2 - The `Export grades for assignment to remote gradebook` executes the remote
    gradebook feature.
3 - For testing, exporting the CSV file exercises the same code as we are
    changing.  It is an easy way to check the results.

Cover letter by @pwilkins 
