### PR TITLE
Bug fix: Added test cases and updated course info view with exception handling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -253,3 +253,4 @@ Justin Abrahms <abrahms@mit.edu>
 Arbab Nazar <arbab@edx.org>
 Douglas Hall <dhall@edx.org>
 Awais Jibran <awaisdar001@gmail.com>
+Muhammad Rehan <muhammadrehan69@gmail.com>


### PR DESCRIPTION
TNL-3643

**Background:** While on course updates web page of cms if we manually change URL 
in address bar to some invalid URL, the response will be 500 internal server 
error instead of user facing 404 Error.

**Fix:** I wrote test cases for this to ensure the failure, started debuging to track it. 
The bug was due to the uncatched exceptions in handler view of course updates. 
I just did exception handling and further little tweaks to fix it. Now, It
is working like a charm.

Any kind of suggestions are always welcome.

Thank you,
M. Rehan
