### PR TITLE
Use the correct original gender field in the rollback test.

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -720,4 +720,4 @@ class TestAccountAPITransactions(TransactionTestCase):
         response = self.client.get(self.url)
         data = response.data
         self.assertEqual(old_email, data["email"])
-        self.assertEqual(u"o", data["gender"])
+        self.assertEqual(u"m", data["gender"])


### PR DESCRIPTION
(I skipped writing a ticket for this one.)

@macdiesel This line got changed in this commit: https://github.com/edx/edx-platform/commit/bc8e4980da21dc83a33a897982867402e89fe84a

But the test was actually correct - just didn't rollback properly. After @symbolist 's transaction PR, it now correctly rolls back.

@nedbat @muhammad-ammar @muzaffaryousaf @alawibaba Please review.
