### PR TITLE
updated query counts for certificate generation.

### DIFF
--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1510,7 +1510,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
 
         current_task = Mock()
         current_task.update_state = Mock()
-        with self.assertNumQueries(149):
+        with self.assertNumQueries(213):
             with patch('instructor_task.tasks_helper._get_current_task') as mock_current_task:
                 mock_current_task.return_value = current_task
                 with patch('capa.xqueue_interface.XQueueInterface.send_to_queue') as mock_queue:


### PR DESCRIPTION
no ticket for this one. fixes this error:
exceptions.AssertionError: 213 queries executed, 149 expected

@doctoryes @nedbat @symbolist @muhammad-ammar @muzaffaryousaf 
