### PR TITLE
Force wrapping for long content like hyperlinks.

### DIFF
--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -102,6 +102,13 @@ div.course-wrapper {
     @extend .content;
     padding: ($baseline*2);
     line-height: 1.6;
+
+    .xblock {
+        overflow-wrap: break-word;
+        word-wrap: break-word;
+        word-break: break-word;
+    }
+
     h1 {
       margin: 0 0 lh();
     }


### PR DESCRIPTION
Content that doesn't fit on the screen was causing the viewport to be
the wrong size on mobile devices resulting. This forces wrapping for
long content instead of letting it force the viewport size.

JIRA: https://openedx.atlassian.net/browse/MA-1236

Before:

![screen shot 2015-10-28 at 2 09 40 pm](https://cloud.githubusercontent.com/assets/114396/10799180/d48ca996-7d81-11e5-9fa6-ff028388cb6f.png)

After:
![screen shot 2015-10-28 at 2 29 18 pm](https://cloud.githubusercontent.com/assets/114396/10799184/d90183fc-7d81-11e5-8a83-52f052066323.png)

![screen shot 2015-10-28 at 2 36 25 pm 1](https://cloud.githubusercontent.com/assets/114396/10799194/e1d59fd6-7d81-11e5-859f-34526bf32fc8.png)
