### PR TITLE
Fix underscore extraction error

### DIFF
--- a/common/static/common/templates/discussion/thread-response.underscore
+++ b/common/static/common/templates/discussion/thread-response.underscore
@@ -1,11 +1,7 @@
 <div class="discussion-response"></div>
 <a href="#" class="action-show-comments">
     <%
-    var fmts = ngettext(
-        "Show Comment (%(num_comments)s)",
-        "Show Comments (%(num_comments)s)",
-        comments.length
-    );
+    var fmts = ngettext("Show Comment (%(num_comments)s)", "Show Comments (%(num_comments)s)", comments.length);
     print(interpolate(fmts, {num_comments: comments.length}, true));
     %>
     <i class="icon fa fa-caret-down"></i>


### PR DESCRIPTION
The underscore extraction library has two bugs (limitations):
1. It requires strings and function names (one of `gettext`, `ngettext` and `interpolate`) to be in the same line for proper extraction.
   For example, in the following line, the string "text extracted" is correctly extracted:
   `gettext("text extracted")`
   However, in the following line, the string "text can't be extracted" can not be extracted:
   `gettext("text can't be extracted")`
2. It always extract the first argument of `gettext` and `interpolate`, and the first two arguments of `ngettext`, regardless of whether it is a string literal (that should be extracted) or it is a varible name (that should not be extracted).
   For example, in the following line, the varible name `fmt` is mistakenly extracted:
   `interpolate(fmt, params, true)`

Now the two bugs affects edx-platform in the following ways:
1. Some strings are not extracted, as they are not in the same line with the function name.
2. Some varible names are  mistakenly extracted, as they are in the same line with the function name.

To solve such problems, some rules should be applied:
1. String literals should always be in the same line with the function name (one of `gettext`, `ngettext` and `interpolate`), even if it will produce a very long line. Fail to do so will cause the string not be extracted or only partially extracted.
2. Varible names must not be in the same line with the function name (one of `gettext`, `ngettext` and `interpolate`), even if it is a very simple case like `gettext(message)`. Fail to do so will cause the varible name be mistakenly extracted.

This PR fixes the existing problem in underscore files. And I've also submitted a note for this in the developer's documentation (https://github.com/edx/edx-documentation/pull/654).

For now, only the strings not be extracted are touched. Another case will be handled by updating the underlying library.
