### PR TITLE
Remove duplicate verbosity args for acceptance tests.

### DIFF
--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -133,11 +133,11 @@ END
         ;;
 
     "lms-acceptance")
-        paver test_acceptance -s lms --extra_args="-v 3"
+        paver test_acceptance -s lms
         ;;
 
     "cms-acceptance")
-        paver test_acceptance -s cms --extra_args="-v 3"
+        paver test_acceptance -s cms
         ;;
 
     "bok-choy")


### PR DESCRIPTION
Verbosity level is already specified here:
https://github.com/edx/edx-platform/blob/django-upgrade/1.8/pavelib/acceptance_test.py#L39

Specifying both `--verbosity` and `-v` results in the following error:

```
optparse.OptionConflictError: option -v/--verbosity: conflicting option string(s): -v, --verbosity
```
