### PR TITLE
WIP: optimize course structure list

### DIFF
--- a/lms/djangoapps/course_structure_api/v0/serializers.py
+++ b/lms/djangoapps/course_structure_api/v0/serializers.py
@@ -3,29 +3,47 @@
 from django.core.urlresolvers import reverse
 from rest_framework import serializers
 
-from courseware.courses import course_image_url
-
 
 class CourseSerializer(serializers.Serializer):
     """ Serializer for Courses """
-    id = serializers.CharField()  # pylint: disable=invalid-name
-    name = serializers.CharField(source='display_name')
-    category = serializers.CharField()
+    id = serializers.SerializerMethodField()  # pylint: disable=invalid-name
+    name = serializers.SerializerMethodField()
+    category = serializers.SerializerMethodField()
     org = serializers.SerializerMethodField()
     run = serializers.SerializerMethodField()
     course = serializers.SerializerMethodField()
     uri = serializers.SerializerMethodField()
     image_url = serializers.SerializerMethodField()
-    start = serializers.DateTimeField()
-    end = serializers.DateTimeField()
+    start = serializers.SerializerMethodField()
+    end = serializers.SerializerMethodField()
+
+    def get_id(self, course):
+        """ Gets course ID """
+        return unicode(course.id)
 
     def get_org(self, course):
         """ Gets the course org """
         return course.id.org
 
+    def get_category(self, _course):
+        """ Gets course category (always a course) """
+        return 'course'
+
     def get_run(self, course):
         """ Gets the course run """
         return course.id.run
+
+    def get_name(self, course):
+        """ Gets display name """
+        return course.display_name
+
+    def get_start(self, course):
+        """ Gets course start """
+        return course.start
+
+    def get_end(self, course):
+        """ Gets course end """
+        return course.end
 
     def get_course(self, course):
         """ Gets the course """
@@ -38,4 +56,4 @@ class CourseSerializer(serializers.Serializer):
 
     def get_image_url(self, course):
         """ Get the course image URL """
-        return course_image_url(course)
+        return course.course_image_url


### PR DESCRIPTION
The analytics data pipeline is timing out when hitting the course structure course list endpoint ([AN-6142](https://openedx.atlassian.net/browse/AN-6142)).  This is an early PR that uses course overviews instead of the modulestore to populate the course list.

I still need to update the tests.

@brianhw @adampalay @ormsbee @nasthagiri 
