### PR TITLE
adjust timed exam button styles in timer bar and content

### DIFF
--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -92,24 +92,6 @@ html.video-fullscreen {
       display: inline;
     }
   }
-
-  // ----------------------------
-  // Primary button style definition used by proctored/timed exams
-  // ----------------------------
-  .btn-pl-primary {
-    @extend %btn-pl-primary-base;
-
-    background-image: none;
-    box-shadow: none;
-    text-shadow: none;
-
-    // overrides for the timer bar because it is
-    // a bit more narrow
-    &.exam-button-turn-in-exam {
-      @extend %t-action4;
-      padding: ($baseline / 5) $baseline;
-    }
-  }
 }
 
 // TO-DO should this be content wrapper?
@@ -161,13 +143,13 @@ div.course-wrapper {
         @include text-align(left);
         @extend %t-copy-base;
         width: 100%;
+
         &:hover {
           background-color: transparent;
+          color: $link-hover;
         }
       }
-      button.gated-sequence > a {
-        color: #147ABA;
-      }
+
       span.proctored-exam-code {
         margin-top: 5px;
         font-size: 1.3em;
@@ -190,6 +172,25 @@ div.course-wrapper {
       .proctored-exam-select-code {
         margin-left: 30px;
       }
+
+      .exam-action-button {
+        @extend %t-weight4;
+        margin-right: $baseline;
+        background-image: none;
+        box-shadow: none;
+        text-shadow: none;
+
+        &.btn-pl-primary {
+          @extend %btn-pl-primary-base;
+          border: 0;
+
+          &:hover,
+          &:focus {
+            border: 0;
+          }
+        }
+      }
+
       background-color: #F2F4F5;
       padding: 30px;
       font-size: 16px;

--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -91,6 +91,18 @@
         b {
           color: $white;
         }
+
+        .exam-button-turn-in-exam {
+          background-color: transparent;
+          border: 1px solid $white;
+          color: $white;
+
+          &:hover {
+            border: 1px solid $white;
+            background-color: $white;
+            color: $action-primary-bg;
+          }
+        }
       }
     }
     &.warning {
@@ -101,7 +113,20 @@
       color: $white;
     }
     .exam-button-turn-in-exam {
+      @extend %btn-pl-primary-base;
+      @extend %t-action3;
+      @extend %t-weight4;
       margin-right: $baseline;
+      border: 0;
+      background-image: none;
+      padding: ($baseline/5) ($baseline*.75);
+      box-shadow: none;
+      text-shadow: none;
+
+      &:hover,
+      &:focus {
+        border: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adjusts the styles for the timed exam buttons in both the timer bar and content area so they look like this: 

Default:
<img width="1346" alt="screen shot 2015-10-29 at 10 57 07 pm" src="https://cloud.githubusercontent.com/assets/4327102/10837507/a46cf0c6-7e90-11e5-8e66-f59883d5e38f.png">

Low time:
<img width="1340" alt="screen shot 2015-10-29 at 10 57 50 pm" src="https://cloud.githubusercontent.com/assets/4327102/10837508/a9620ea4-7e90-11e5-920b-e181090394e5.png">

Hover:
<img width="307" alt="screen shot 2015-10-29 at 10 58 01 pm" src="https://cloud.githubusercontent.com/assets/4327102/10837511/b0745e0e-7e90-11e5-865b-ef73ae391071.png">

Content:
<img width="849" alt="screen shot 2015-10-29 at 10 58 14 pm" src="https://cloud.githubusercontent.com/assets/4327102/10837513/b4efb64a-7e90-11e5-856f-cb05a84cc4db.png">

Note: I did not address any other sass cleanup.

@chrisndodge Can you review?
