### PR TITLE
Remove flaky flag from profile bok choy test

### DIFF
--- a/common/test/acceptance/pages/lms/fields.py
+++ b/common/test/acceptance/pages/lms/fields.py
@@ -179,7 +179,7 @@ class FieldsMixin(object):
 
         query = self.q(css=field_selector)
         query.fill(value)
-        query.results[0].send_keys(u'\ue004')  # Focus Out using TAB
+        query.results[0].send_keys(u'\ue007')  # Press Enter
 
     def get_non_editable_mode_value(self, field_id):
         """

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -3,7 +3,6 @@
 End-to-end tests for Student's Profile Page.
 """
 from contextlib import contextmanager
-from flaky import flaky
 
 from datetime import datetime
 from bok_choy.web_app_test import WebAppTest
@@ -730,7 +729,6 @@ class DifferentUserLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         self.verify_profile_page_is_private(profile_page, is_editable=False)
         self.verify_profile_page_view_event(username, different_user_id, visibility=self.PRIVACY_PRIVATE)
 
-    @flaky  # TODO fix this TNL-3679
     def test_different_user_public_profile(self):
         """
         Scenario: Verify that desired fields are shown when looking at a different user's public profile.


### PR DESCRIPTION
## [TNL-3679](https://openedx.atlassian.net/browse/TNL-3679)

In the failure case, the bio field was not properly edited (despite all appropriate "waits" existing in the code). The language and country fields WERE edited properly (and they are edited before the bio field), so it's not the case that the page itself wasn't ready.

I don't know if switching from TAB'ing out of the field to pressing ENTER will help, but ENTER is what we are doing on other fields.

I have run this 30 times in Jenkins with no failures, so I figured it is worth a try!
### Testing
- [ ] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 

FYI @jzoldak 
