### PR TITLE
Increase the test output timeout and quiet the pylint output.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,6 +42,7 @@ test:
     # to understand how multiple containers can be used to
     # run subsets of tests in parallel.
     - ./scripts/all-tests.sh:
+        timeout: 900  # if a command runs this many seconds without output, kill it
         parallel: true
 
   post:

--- a/scripts/circle-ci-tests.sh
+++ b/scripts/circle-ci-tests.sh
@@ -55,9 +55,7 @@ else
             paver run_pep8 > pep8.log || { cat pep8.log; EXIT=1; }
 
             echo "Finding pylint violations and storing in report..."
-            # HACK: we need to print something to the console, otherwise circleci
-            # fails and aborts the job because nothing is displayed for > 10 minutes.
-            paver run_pylint -l $PYLINT_THRESHOLD | tee pylint.log || EXIT=1
+            paver run_pylint -l $PYLINT_THRESHOLD > pylint.log || { cat pylint.log; EXIT=1; }
 
             mkdir -p reports
             echo "Finding jshint violations and storing report..."


### PR DESCRIPTION
@benpatterson 

Tested with this build on CircleCi: https://circleci.com/gh/jzoldak/edx-platform/93
