### PR TITLE
Marking flaky test

### DIFF
--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -588,6 +588,7 @@ class YouTubeVideoTest(VideoBaseTest):
         self.go_to_sequential_position(1)
         execute_video_steps(tab1_video_names)
 
+    @flaky  # TODO: fix this, ticket TNL-3725
     def test_video_component_stores_speed_correctly_for_multiple_videos(self):
         """
         Scenario: Video component stores speed correctly when each video is in separate sequential


### PR DESCRIPTION
common.test.acceptance.tests.video.test_video_module.YouTubeVideoTest.test_video_component_stores_speed_correctly_for_multiple_videos
is flaky, see https://openedx.atlassian.net/browse/TNL-3725 for details.

Failures from this morning:
- https://build.testeng.edx.org/job/edx-platform-bok-choy-master/1506/testReport/
- https://build.testeng.edx.org/job/edx-platform-bok-choy-master/1508/testReport/
- https://build.testeng.edx.org/view/edx-platform-pr-tests/job/edx-platform-bok-choy-pr/7763/testReport/
- https://build.testeng.edx.org/view/edx-platform-pr-tests/job/edx-platform-bok-choy-pr/7760/testReport/
