### PR TITLE
Convert country to unicode before sending to segment

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1632,7 +1632,7 @@ def create_account_with_params(request, params):
                 'education': profile.level_of_education_display,
                 'address': profile.mailing_address,
                 'gender': profile.gender_display,
-                'country': profile.country,
+                'country': unicode(profile.country),
             }
         ]
 


### PR DESCRIPTION
[ECOM-2646](https://openedx.atlassian.net/browse/ECOM-2646)

Without this explicit conversion the country field is sent as `null`.
