### PR TITLE
Hide Xblock due dates in studio for self-paced courses.

### DIFF
--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -165,7 +165,7 @@ if (is_proctored_exam) {
                         <span class="sr status-grading-label"> <%= gettext('Graded as:') %> </span>
                         <i class="icon fa fa-check"></i>
                         <span class="status-grading-value"> <%= gradingType %> </span>
-                        <% if (xblockInfo.get('due_date')) { %>
+                        <% if (xblockInfo.get('due_date') && !course.get('self_paced')) { %>
                             <span class="status-grading-date"> <%= gettext('Due:') %> <%= xblockInfo.get('due_date') %> </span>
                         <% } %>
                     </p>


### PR DESCRIPTION
Dates could show up in self-paced courses if a due date was set on a subsection of an instructor-led course which was subsequently set to self-paced. I should have caught this in #10404, but failed to do so. I've double-checked to verify that dates won't sneak through anywhere else in the Studio UI, and field overrides take care of the issue everywhere in the LMS. @bderusha @clintonb 
