### PR TITLE
Removed read-only fields from enrollment admin

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -138,12 +138,6 @@ class CourseEnrollmentAdmin(admin.ModelAdmin):
     list_filter = ('mode', 'is_active',)
     search_fields = ('course_id', 'mode', 'user__username',)
 
-    def get_readonly_fields(self, request, obj=None):
-        # The course_id, mode, and user fields should not be editable for an existing enrollment.
-        if obj:
-            return self.readonly_fields + ('course_id', 'mode', 'user',)
-        return self.readonly_fields
-
     class Meta(object):
         model = CourseEnrollment
 


### PR DESCRIPTION
The read-only protection is more hassle than it's worth when testing locally and on stage. It's a solution to a problem we don't actually have, so I have reverted the changes.
