### PR TITLE
Fix `withData` and `withConfiguration` helpers.

### DIFF
--- a/common/static/common/js/spec_helpers/spec_helpers.js
+++ b/common/static/common/js/spec_helpers/spec_helpers.js
@@ -13,9 +13,11 @@ define([], function () {
     var withData = function (data, func) {
         for (var name in data) {
             if (data.hasOwnProperty(name)) {
-                it(name, function () {
-                    func.apply(this, data[name]);
-                });
+                (function (name) {
+                    it(name, function () {
+                        func.apply(this, data[name]);
+                    });
+                })(name);
             }
         }
     };
@@ -31,12 +33,14 @@ define([], function () {
     var withConfiguration = function (config, setup, test) {
         for (var name in config) {
             if (config.hasOwnProperty(name)) {
-                describe(name, function () {
-                    beforeEach(function () {
-                        setup.apply(this, config[name]);
+                (function (name) {
+                    describe(name, function () {
+                        beforeEach(function () {
+                            setup.apply(this, config[name]);
+                        });
+                        test();
                     });
-                    test();
-                });
+                })(name);
             }
         }
     };

--- a/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
@@ -171,10 +171,11 @@ define([
                 ]
             }, function (url, expectedEvent) {
                 var teamsTabView = createTeamsTabView(this, {
-                        userInfo: TeamSpecHelpers.createMockUserInfo({staff: true})
-                    });
+                    userInfo: TeamSpecHelpers.createMockUserInfo({staff: true})
+                });
+                teamsTabView.teamsCollection = TeamSpecHelpers.createMockTeams();
                 teamsTabView.router.navigate(url, {trigger: true});
-                if (AjaxHelpers.currentRequest(requests)) {
+                if (requests.length > requests.currentIndex) {
                     AjaxHelpers.respondWithJson(requests, {});
                 }
                 expect(Logger.log).toHaveBeenCalledWith('edx.team.page_viewed', expectedEvent);


### PR DESCRIPTION
@dan-f @andy-armstrong, this is a port of a fix I made in https://github.com/edx/edx-ui-toolkit/pull/2. @dan-f pointed out that closing over the iteration variable of a loop can lead to bugs, and it did! See the commit message for the full details.

This did in fact uncover some bugs in https://github.com/edx/edx-platform, though fortunately they were limited to testing.
