### PR TITLE
Compare all refund dates in UTC

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1377,7 +1377,7 @@ class CourseEnrollment(models.Model):
 
         # If it is after the refundable cutoff date they should not be refunded.
         refund_cutoff_date = self.refund_cutoff_date()
-        if refund_cutoff_date and datetime.now() > refund_cutoff_date:
+        if refund_cutoff_date and datetime.now(UTC) > refund_cutoff_date:
             return False
 
         course_mode = CourseMode.mode_for_course(self.course_id, 'verified')
@@ -1400,7 +1400,7 @@ class CourseEnrollment(models.Model):
             self.course_overview.start.replace(tzinfo=None)
         )
 
-        return refund_window_start_date + EnrollmentRefundConfiguration.current().refund_window
+        return refund_window_start_date.replace(tzinfo=UTC) + EnrollmentRefundConfiguration.current().refund_window
 
     @property
     def username(self):

--- a/common/djangoapps/student/tests/test_refunds.py
+++ b/common/djangoapps/student/tests/test_refunds.py
@@ -113,10 +113,10 @@ class RefundableTest(SharedModuleStoreTestCase):
         self.assertTrue(self.enrollment.refundable())
 
         with patch('student.models.CourseEnrollment.refund_cutoff_date') as cutoff_date:
-            cutoff_date.return_value = datetime.now() - timedelta(days=1)
+            cutoff_date.return_value = datetime.now(pytz.UTC) - timedelta(minutes=5)
             self.assertFalse(self.enrollment.refundable())
 
-            cutoff_date.return_value = datetime.now() + timedelta(days=1)
+            cutoff_date.return_value = datetime.now(pytz.UTC) + timedelta(minutes=5)
             self.assertTrue(self.enrollment.refundable())
 
     @ddt.data(
@@ -132,7 +132,7 @@ class RefundableTest(SharedModuleStoreTestCase):
         """
         Assert that the later date is used with the configurable refund period in calculating the returned cutoff date.
         """
-        now = datetime.now().replace(microsecond=0)
+        now = datetime.now(pytz.UTC).replace(microsecond=0)
         order_date = now + order_date_delta
         course_start = now + course_start_delta
         expected_date = now + expected_date_delta


### PR DESCRIPTION
`datetime.now()` does not return UTC by default.  We are comparing `EST` and `UTC` dates right now making the refund period 5 hours longer than specified. This is not a blocker for release. Since our refund window is 14 days, the 5 hour difference is negligible. But since we have to cut a new AMI tomorrow anyway it would be nice to get this in.

@peter-fogg @clintonb Please review. 

FYI @efischer19 
