### PR TITLE
New Relic transaction naming now ignores suffix most of the time.

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -1037,7 +1037,7 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course
         # New Relic. The suffix is necessary for XModule handlers because the
         # "handler" in those cases is always just "xmodule_handler".
         nr_tx_name = "{}.{}".format(instance.__class__.__name__, handler)
-        nr_tx_name += "/{}".format(suffix) if suffix else ""
+        nr_tx_name += "/{}".format(suffix) if (suffix and handler == "xmodule_handler") else ""
         newrelic.agent.set_transaction_name(nr_tx_name, group="Python/XBlock/Handler")
 
         tracking_context_name = 'module_callback_handler'


### PR DESCRIPTION
@e0d: As requested.
@efischer19: May I get this into the release? It's a tiny change, not user facing. We got flagged by New Relic for it.

---

Changes to New Relic transaction naming for XBlocks

The only time it should include the suffix is when the handler is
explicity "xmodule_handler", meaning it's an old-style handler
that routes everything. For example, Capa uses one handler for
all its AJAX requests, and only differentiates actions based on
suffix ("get", "problem_check", etc.).

What prompted this change is that LTIDescriptor defines a handler
"lti_2_0_result_rest_handler" which encodes user-specific
information into the suffix. This is a perfectly valid thing to
do, but it blows out the number of named transactions in our
metrics.
