### PR TITLE
Fixed start time for courses on LMS dashboard.

### DIFF
--- a/common/djangoapps/util/date_utils.py
+++ b/common/djangoapps/util/date_utils.py
@@ -98,7 +98,7 @@ DEFAULT_SHORT_DATE_FORMAT = "%b %d, %Y"
 DEFAULT_LONG_DATE_FORMAT = "%A, %B %d, %Y"
 DEFAULT_TIME_FORMAT = "%I:%M:%S %p"
 DEFAULT_DATE_TIME_FORMAT = "%b %d, %Y at %H:%M"
-DEFAULT_DAY_AND_TIME_FORMAT = "%A at %-I%P"
+DEFAULT_DAY_AND_TIME_FORMAT = "%A at %-I:%M%P"
 
 
 def strftime_localized(dtime, format):      # pylint: disable=redefined-builtin

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -378,7 +378,7 @@
       .course-info {
         display: block;
         @include float(left);
-        width: flex-grid(4);
+        width: flex-grid(4.1);
         padding: 0;
         margin-top: ($baseline/2);
 


### PR DESCRIPTION
[TNL-3738](https://openedx.atlassian.net/browse/TNL-3738)

On LMS dashboard start time for courses wasn't showing minutes if course starting date is less than 5 days. Fixed the `DEFAULT_DAY_AND_TIME_FORMAT` format.
## Reproduction Steps
1. Set a course start date within next 5 days.
2. Set start time to `14:30`.
3. Enroll into course and check on your LMS dashboard.
