### PR TITLE
Only showing preloaded updates with date before today

### DIFF
--- a/cms/djangoapps/contentstore/course_info_model.py
+++ b/cms/djangoapps/contentstore/course_info_model.py
@@ -15,6 +15,8 @@ Current db representation:
 import re
 import logging
 
+from dateutil import parser
+
 from django.http import HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 
@@ -165,7 +167,27 @@ def _get_html(course_updates_items):
     Method to create course_updates_html from course_updates items
     """
     list_items = []
-    for update in reversed(course_updates_items):
+    date_items = []
+    no_date_items = []
+
+    #print course_updates_items
+
+    #for a in (course_updates_items):
+    #   print a.get("date")
+
+
+    for item in course_updates_items:
+        try:
+            parser.parse(item.get("date"))
+            date_items.append(item)
+        except ValueError:
+            no_date_items.append(item)
+
+    date_items = sorted(date_items, key=lambda k: parser.parse(k.get("date")), reverse=True)
+
+    course_updates_items_sorted = date_items + no_date_items
+
+    for update in course_updates_items_sorted:
         # filter course update items which have status "deleted".
         if update.get("status") != CourseInfoModule.STATUS_DELETED:
             list_items.append(u"<article><h2>{date}</h2>{content}</article>".format(**update))

--- a/cms/templates/js/course_info_update.underscore
+++ b/cms/templates/js/course_info_update.underscore
@@ -4,7 +4,7 @@
 		<div class="row">
 			<label for="update-date-<%= updateModel.cid %>" class="inline-label">Date:</label>
 			<!-- TODO replace w/ date widget and actual date (problem is that persisted version is "Month day" not an actual date obj -->
-			<input id="update-date-<%= updateModel.cid %>" type="text" class="date" value="<%= updateModel.get('date') %>">
+			<input id="update-date-<%= updateModel.cid %>" type="text" class="date" value="<%= updateModel.get('date') %>" readonly="true">
 		</div>
 		<div class="row">
 			<textarea class="new-update-content text-editor"><%= updateModel.get('content') %></textarea>

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -32,6 +32,21 @@ from lms.djangoapps.courseware.courseware_access_exception import CoursewareAcce
 from student.models import CourseEnrollment
 import branding
 
+# Libraries used for the updates filtered by date and locale date feature. 
+from xml.dom import minidom
+import lxml
+from lxml import etree
+from dateutil import parser
+from django.utils import timezone
+import datetime
+from django.utils.translation import ugettext as _, get_language
+import locale
+from openedx.core.djangoapps.user_api.models import UserPreference
+from lang_pref import LANGUAGE_KEY
+from django.utils.dateformat import format
+from django.utils import formats
+
+
 from opaque_keys.edx.keys import UsageKey
 
 
@@ -298,7 +313,32 @@ def get_course_info_section(request, course, section_key):
     html = ''
     if info_module is not None:
         try:
-            html = info_module.render(STUDENT_VIEW).content
+           # html = info_module.render(STUDENT_VIEW).content
+            html_pre = info_module.render(STUDENT_VIEW).content
+            root = lxml.html.fromstring(html_pre)
+            for article in root.findall('article'):
+                article_date = article.find('h2').text
+                # Updates later than now  are not shown.
+                try:
+                    if parser.parse(article_date) > datetime.datetime.now():
+                        root.remove(article)
+                except ValueError:
+                    pass
+            # Updates are shown with user locale format. Updates without date are not affected.
+            for article in root.findall('article'):
+                for heading in article.iter('h2'):
+                    try:
+                        heading.text = formats.date_format(parser.parse(heading.text))#"SHORT_DATE_FORMAT") 
+                    except ValueError:
+                        heading.text = heading.text
+
+
+            #Finally, the html is created.
+
+            html = lxml.html.tostring(root)
+
+
+
         except Exception:  # pylint: disable=broad-except
             html = render_to_string('courseware/error-message.html', None)
             log.exception(


### PR DESCRIPTION
**Background:**
Currently the updates of the courses are thought to be introduced as the course is being developed. All of them are seen in the course info page as you introduce them in the Studio, independently of the date field. But if we want to run a fully automatised course in regards to updates, that is, with pre-loaded updates with a release date, there is no mechanism now to do it so. This PR orders the updates entries by date in the HTML that is used to back them up, and shows the updates only when the release date is being reached. 

**Studio Updates:**
The datepicker which is used to introduce the data is being blocked to only receive dates, via JS. Then the updates are reordered by date before being saved as HTML. Compatibility with old updates with text instead of a date is kept. 

**LMS Updates:**
The updates that are shown in the LMS info page are the subset of updates whose date is less than current date. Thus, we can preload the updates before the beginning of the course and these updates will be released automatically when their release date is reached. The dates are shown in the format corresponding to the language chosen by the user in the dashboard.

**Testing**

Updates you see in Studio:
![cms_updates](https://cloud.githubusercontent.com/assets/7533324/8675165/a52cd00a-2a42-11e5-8cc4-a47c0202e994.png)

And the updates seen in the LMS:

![lms_updates](https://cloud.githubusercontent.com/assets/7533324/8675176/bbb07f2a-2a42-11e5-968b-28e38fdaae5b.png)
