### PR TITLE
Make xblock-activetable available on edx.org.

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -28,5 +28,6 @@
 # Peer instruction xblock - prototype (from UBC; not for use on edx.org yet)
 ubcpi-xblock==0.4.4
 
-# Vector Drawing XBlock (Davidson)
+# Vector Drawing and ActiveTable XBlocks (Davidson)
 -e git+https://github.com/open-craft/xblock-vectordraw.git@ded76fc8f6c99ba4949ed57a7bf62a1f12e44683#egg=xblock-vectordraw
+-e git+https://github.com/open-craft/xblock-activetable.git@1786a2c8fc06ca3ecfac1972464048982bd486ff#egg=xblock-activetable


### PR DESCRIPTION
This XBlock has been reviewed in open-craft/xblock-activetable#1.
