### PR TITLE
Disabled auto enroll in ccx coach's enrollment tab

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -420,7 +420,7 @@ def ccx_invite(request, course, ccx=None):
     action = request.POST.get('enrollment-button')
     identifiers_raw = request.POST.get('student-ids')
     identifiers = _split_input_list(identifiers_raw)
-    auto_enroll = True if 'auto-enroll' in request.POST else False
+    auto_enroll = True
     email_students = True if 'email-students' in request.POST else False
     for identifier in identifiers:
         user = None

--- a/lms/templates/ccx/enrollment.html
+++ b/lms/templates/ccx/enrollment.html
@@ -13,7 +13,7 @@
 
 
   <div class="enroll-option">
-    <input type="checkbox" name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes" aria-describedby="auto-enroll-helper">
+    <input type="checkbox" name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes" aria-describedby="auto-enroll-helper" disabled>
     <label style="display:inline" for="auto-enroll">${_("Auto Enroll")}</label>
     <div class="hint auto-enroll-hint">
       <span class="hint-caret"></span>


### PR DESCRIPTION
HI

In this PR i disabled auto-enroll checkbox in ccx enrollment tab. Now invited students will always be  enrolled. 

The UI implementation is in response to https://github.com/edx/edx-platform/pull/7834#issuecomment-97179306

Issue https://github.com/mitocw/edx-platform/issues/57
Mit PR https://github.com/mitocw/edx-platform/pull/117
##### What is done in this PR

**Studio Updates:** None.

**LMS Updates:** Disable auto enroll checkbox on section `BATCH ENROLLMENT` in enrollment tab, ccx coach dashboard.

fixes https://github.com/mitocw/edx-platform/issues/57
@pdpinch  @pwilkins @giocalitri 

![screen shot 2015-10-26 at 6 33 58 pm](https://cloud.githubusercontent.com/assets/10431250/10730238/915303ea-7c10-11e5-8312-24b55987cefc.png)
