### PR TITLE
Where possible, use ugettext_noop instead of lambdas assigned to the underscore

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -471,6 +471,8 @@ class ChoiceGroup(InputTypeBase):
 
     @classmethod
     def get_attributes(cls):
+        # Make '_' a no-op so we can scrape strings. Using lambda instead of
+        #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
         _ = lambda text: text
         return [Attribute("show_correctness", "always"),
                 Attribute('label', ''),
@@ -1707,6 +1709,8 @@ class ChoiceTextGroup(InputTypeBase):
         """
         Returns a list of `Attribute` for this problem type
         """
+        # Make '_' a no-op so we can scrape strings. Using lambda instead of
+        #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
         _ = lambda text: text
         return [
             Attribute("show_correctness", "always"),

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -58,7 +58,8 @@ registry = TagRegistry()
 CorrectMap = correctmap.CorrectMap  # pylint: disable=invalid-name
 CORRECTMAP_PY = None
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 QUESTION_HINT_CORRECT_STYLE = 'feedback-hint-correct'

--- a/common/lib/xmodule/xmodule/annotatable_module.py
+++ b/common/lib/xmodule/xmodule/annotatable_module.py
@@ -10,7 +10,8 @@ import textwrap
 
 log = logging.getLogger(__name__)
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -32,9 +32,9 @@ from django.conf import settings
 
 log = logging.getLogger("edx.courseware")
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
-
 
 # Generate this many different variants of problems with rerandomize=per_student
 NUM_RANDOMIZATION_BINS = 20

--- a/common/lib/xmodule/xmodule/combined_open_ended_module.py
+++ b/common/lib/xmodule/xmodule/combined_open_ended_module.py
@@ -1,3 +1,6 @@
+"""
+ORA1. Deprecated.
+"""
 import logging
 
 from lxml import etree
@@ -15,7 +18,8 @@ import textwrap
 
 log = logging.getLogger("edx.courseware")
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 V1_SETTINGS_ATTRIBUTES = [

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -28,7 +28,8 @@ from django.utils.timezone import UTC
 
 log = logging.getLogger(__name__)
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 CATALOG_VISIBILITY_CATALOG_AND_ABOUT = "both"

--- a/common/lib/xmodule/xmodule/discussion_module.py
+++ b/common/lib/xmodule/xmodule/discussion_module.py
@@ -1,13 +1,17 @@
+"""
+Definition of the Discussion module.
+"""
+import json
 from pkg_resources import resource_string
 
-import json
 from xblock.core import XBlock
 from xmodule.x_module import XModule
 from xmodule.raw_module import RawDescriptor
 from xmodule.editing_module import MetadataOnlyEditingDescriptor
 from xblock.fields import String, Scope, UNIQUE_ID
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -23,7 +23,8 @@ from xblock.fields import Scope, String, Boolean, List
 
 log = logging.getLogger("edx.courseware")
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/imageannotation_module.py
+++ b/common/lib/xmodule/xmodule/imageannotation_module.py
@@ -13,7 +13,8 @@ from xblock.fragment import Fragment
 
 import textwrap
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -22,10 +22,9 @@ from xmodule.studio_editable import StudioEditableModule, StudioEditableDescript
 from .xml_module import XmlDescriptor
 from pkg_resources import resource_string  # pylint: disable=no-name-in-module
 
-
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
-
 
 ANY_CAPA_TYPE_VALUE = 'any'
 

--- a/common/lib/xmodule/xmodule/library_root_xblock.py
+++ b/common/lib/xmodule/xmodule/library_root_xblock.py
@@ -11,7 +11,8 @@ from xblock.core import XBlock
 
 log = logging.getLogger(__name__)
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -76,13 +76,14 @@ from xblock.fields import Boolean, Float
 
 log = logging.getLogger(__name__)
 
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
-
 DOCS_ANCHOR_TAG_OPEN = (
     "<a target='_blank' "
     "href='http://edx.readthedocs.org/projects/ca/en/latest/exercises_tools/lti_component.html'>"
 )
+
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
+_ = lambda text: text
 
 
 class LTIFields(object):

--- a/common/lib/xmodule/xmodule/mixin.py
+++ b/common/lib/xmodule/xmodule/mixin.py
@@ -1,10 +1,10 @@
 """
 Reusable mixins for XBlocks and/or XModules
 """
-
 from xblock.fields import Scope, String, XBlockMixin
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -15,6 +15,7 @@ from ..course_metadata_utils import DEFAULT_START_DATE
 
 
 # Make '_' a no-op so we can scrape strings
+# Using lambda instead of `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_modulev1.py
@@ -1,7 +1,9 @@
 import json
 import logging
 import traceback
+
 from lxml import etree
+
 from xmodule.timeinfo import TimeInfo
 from xmodule.capa_module import ComplexEncoder
 from xmodule.progress import Progress
@@ -34,6 +36,8 @@ ACCEPT_FILE_UPLOAD = False
 # Contains all reasonable bool and case combinations of True
 TRUE_DICT = ["True", True, "TRUE", "true"]
 
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 HUMAN_TASK_TYPE = {

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_rubric.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/combined_open_ended_rubric.py
@@ -1,4 +1,5 @@
 import logging
+
 from lxml import etree
 
 log = logging.getLogger(__name__)
@@ -11,6 +12,8 @@ GRADER_TYPE_IMAGE_DICT = {
     'BC': '/static/images/ml_grading_icon.png',
 }
 
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 HUMAN_GRADER_TYPE = {

--- a/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py
+++ b/common/lib/xmodule/xmodule/open_ended_grading_classes/openendedchild.py
@@ -1,20 +1,29 @@
+"""
+ORA1. Deprecated.
+"""
+from datetime import datetime
 import json
 import logging
 import re
+
 import bleach
+from boto.s3.connection import S3Connection
+from boto.s3.key import Key
 from html5lib.tokenizer import HTMLTokenizer
+from pytz import UTC
+
 from xmodule.progress import Progress
 import capa.xqueue_interface as xqueue_interface
 from capa.util import *
 from .peer_grading_service import PeerGradingService, MockPeerGradingService
 import controller_query_service
 
-from datetime import datetime
-from pytz import UTC
-from boto.s3.connection import S3Connection
-from boto.s3.key import Key
 
 log = logging.getLogger("edx.courseware")
+
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
+_ = lambda text: text
 
 # Set the default number of max attempts.  Should be 1 for production
 # Set higher for debugging/testing
@@ -88,7 +97,6 @@ class OpenEndedChild(object):
     DONE = 'done'
 
     # This is used to tell students where they are at in the module
-    _ = lambda text: text
     HUMAN_NAMES = {
         # Translators: "Not started" communicates to a student that their response
         # has not yet been graded

--- a/common/lib/xmodule/xmodule/peer_grading_module.py
+++ b/common/lib/xmodule/xmodule/peer_grading_module.py
@@ -1,3 +1,6 @@
+"""
+ORA1. Deprecated.
+"""
 import json
 import logging
 
@@ -23,9 +26,9 @@ from open_ended_grading_classes import combined_open_ended_rubric
 
 log = logging.getLogger(__name__)
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
-
 
 EXTERNAL_GRADER_NO_CONTACT_ERROR = "Failed to contact external graders.  Please notify course staff."
 MAX_ALLOWED_FEEDBACK_LENGTH = 5000

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -6,14 +6,13 @@ xModule implementation of a learning sequence
 
 import json
 import logging
+from pkg_resources import resource_string
 import warnings
 
 from lxml import etree
-
 from xblock.core import XBlock
 from xblock.fields import Integer, Scope, Boolean
 from xblock.fragment import Fragment
-from pkg_resources import resource_string
 
 from .exceptions import NotFoundError
 from .fields import Date
@@ -28,7 +27,8 @@ log = logging.getLogger(__name__)
 # OBSOLETE: This obsoletes 'type'
 class_priority = ['video', 'problem']
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/split_test_module.py
+++ b/common/lib/xmodule/xmodule/split_test_module.py
@@ -23,7 +23,8 @@ from xblock.fragment import Fragment
 
 log = logging.getLogger('edx.' + __name__)
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 DEFAULT_GROUP_NAME = _(u'Group ID {group_id}')

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -1,18 +1,17 @@
 """
 Implement CourseTab
 """
-
 from abc import ABCMeta
 import logging
 
 from xblock.fields import List
 from openedx.core.lib.api.plugins import PluginError
 
-# We should only scrape strings for i18n in this file, since the target language is known only when
-# they are rendered in the template.  So ugettext gets called in the template.
-_ = lambda text: text
-
 log = logging.getLogger("edx.courseware")
+
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
+_ = lambda text: text
 
 
 class CourseTab(object):

--- a/common/lib/xmodule/xmodule/textannotation_module.py
+++ b/common/lib/xmodule/xmodule/textannotation_module.py
@@ -1,5 +1,4 @@
-''' Text annotation module '''
-
+"""Text annotation module"""
 from lxml import etree
 from pkg_resources import resource_string
 
@@ -11,7 +10,8 @@ from xmodule.annotator_token import retrieve_token
 from xblock.fragment import Fragment
 import textwrap
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -83,6 +83,9 @@ except ImportError:
     BrandingInfoConfig = None
 
 log = logging.getLogger(__name__)
+
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -4,10 +4,10 @@ XFields for video module.
 import datetime
 
 from xblock.fields import Scope, String, Float, Boolean, List, Dict, DateTime
-
 from xmodule.fields import RelativeTime
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/videoannotation_module.py
+++ b/common/lib/xmodule/xmodule/videoannotation_module.py
@@ -13,7 +13,8 @@ from xblock.fragment import Fragment
 
 import textwrap
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/common/lib/xmodule/xmodule/word_cloud_module.py
+++ b/common/lib/xmodule/xmodule/word_cloud_module.py
@@ -8,8 +8,8 @@ If student have answered - words he entered and cloud.
 
 import json
 import logging
-
 from pkg_resources import resource_string
+
 from xmodule.raw_module import EmptyDataRawDescriptor
 from xmodule.editing_module import MetadataOnlyEditingDescriptor
 from xmodule.x_module import XModule
@@ -18,7 +18,8 @@ from xblock.fields import Scope, Dict, Boolean, List, Integer, String
 
 log = logging.getLogger(__name__)
 
-# Make '_' a no-op so we can scrape strings
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
 

--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -1,15 +1,13 @@
 """
 Namespace that defines fields common to all blocks used in the LMS
 """
+from django.utils.translation import ugettext_noop as _
 from lazy import lazy
 
 from xblock.fields import Boolean, Scope, String, XBlockMixin, Dict
 from xblock.validation import ValidationMessage
 from xmodule.modulestore.inheritance import UserPartitionList
 from xmodule.partitions.partitions import NoSuchUserPartitionError, NoSuchUserPartitionGroupError
-
-# Make '_' a no-op so we can scrape strings
-_ = lambda text: text
 
 
 class GroupAccessDict(Dict):

--- a/openedx/core/lib/course_tabs.py
+++ b/openedx/core/lib/course_tabs.py
@@ -3,8 +3,6 @@ Tabs for courseware.
 """
 from openedx.core.lib.api.plugins import PluginManager
 
-_ = lambda text: text
-
 
 # Stevedore extension point namespaces
 COURSE_TAB_NAMESPACE = 'openedx.course_tab'


### PR DESCRIPTION
Replaces instances of an old hack with the more clear [ugettext_noop](https://docs.djangoproject.com/en/1.8/ref/utils/#django.utils.translation.ugettext_noop).

In places where this is used because Django cannot be imported (such as within xmodule), add comments that clearly indicate why we use the "hack", eg

``` python
# Using lambda instead of `django.utils.translation.ugettext_noop` because
# Django cannot be imported in this file
```
