### PR TITLE
Adding * to allowed hosts as a temporary fix to start load testing

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -126,6 +126,8 @@ LMS_BASE = ENV_TOKENS.get('LMS_BASE')
 SITE_NAME = ENV_TOKENS['SITE_NAME']
 
 ALLOWED_HOSTS = [
+    # TODO: bbeggs remove this before prod, temp fix to get load testing running
+    "*",
     ENV_TOKENS.get('CMS_BASE')
 ]
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -172,6 +172,8 @@ for feature, value in ENV_FEATURES.items():
 CMS_BASE = ENV_TOKENS.get('CMS_BASE', 'studio.edx.org')
 
 ALLOWED_HOSTS = [
+    # TODO: bbeggs remove this before prod, temp fix to get load testing running
+    "*",
     ENV_TOKENS.get('LMS_BASE'),
     FEATURES['PREVIEW_LMS_BASE'],
 ]


### PR DESCRIPTION
@doctoryes @feanil @fredsmith @nedbat 

temporary work around to get 1.8 deployed to the load test env.

We are having issues getting the application in to the ELBs in AWs. ELBs use HTTP/1.0 which does not require a host header. When this header is absent in django 1.8 in our current configuration it returns a 400 from the /heartbeat endpoint thus preventing the application from coming online.
