### PR TITLE
Remove more Django19 warnings

### DIFF
--- a/cms/startup.py
+++ b/cms/startup.py
@@ -9,12 +9,15 @@ settings.INSTALLED_APPS  # pylint: disable=pointless-statement
 
 from openedx.core.lib.django_startup import autostartup
 import django
+from monkey_patch import third_party_auth
 
 
 def run():
     """
     Executed during django startup
     """
+    third_party_auth.patch_cms()
+
     django.setup()
 
     autostartup()

--- a/cms/startup.py
+++ b/cms/startup.py
@@ -16,7 +16,7 @@ def run():
     """
     Executed during django startup
     """
-    third_party_auth.patch_cms()
+    third_party_auth.patch()
 
     django.setup()
 

--- a/common/djangoapps/monkey_patch/third_party_auth.py
+++ b/common/djangoapps/monkey_patch/third_party_auth.py
@@ -10,7 +10,7 @@ from social.apps.django_app.default.models import (
 )
 
 
-def patch_lms():
+def patch():
     """
     Monkey-patch the DjangoUserMixin class.
     """
@@ -30,11 +30,7 @@ def patch_lms():
 
     DjangoUserMixin.create_social_auth = create_social_auth_wrapper(DjangoUserMixin.create_social_auth)
 
-
-def patch_cms():
-    """
-    Monkey-patch some social auth models' Meta class to squelch Django19 warnings.
-    """
+    # Monkey-patch some social auth models' Meta class to squelch Django19 warnings.
     # pylint: disable=protected-access
     UserSocialAuth._meta.app_label = "default"
     Nonce._meta.app_label = "default"

--- a/common/djangoapps/monkey_patch/third_party_auth.py
+++ b/common/djangoapps/monkey_patch/third_party_auth.py
@@ -5,9 +5,11 @@ Remove once the module fully supports Django 1.8!
 
 from django.db import transaction
 from social.storage.django_orm import DjangoUserMixin
+from social.apps.django_app.default.models import (
+    UserSocialAuth, Nonce, Association, Code
+)
 
-
-def patch():
+def patch_lms():
     """
     Monkey-patch the DjangoUserMixin class.
     """
@@ -26,3 +28,12 @@ def patch():
         return classmethod(_create_social_auth)
 
     DjangoUserMixin.create_social_auth = create_social_auth_wrapper(DjangoUserMixin.create_social_auth)
+
+def patch_cms():
+    """
+    Monkey-patch some social auth models' Meta class to squelch Django19 warnings.
+    """
+    UserSocialAuth._meta.app_label = "default"
+    Nonce._meta.app_label = "default"
+    Association._meta.app_label = "default"
+    Code._meta.app_label = "default"

--- a/common/djangoapps/monkey_patch/third_party_auth.py
+++ b/common/djangoapps/monkey_patch/third_party_auth.py
@@ -9,6 +9,7 @@ from social.apps.django_app.default.models import (
     UserSocialAuth, Nonce, Association, Code
 )
 
+
 def patch_lms():
     """
     Monkey-patch the DjangoUserMixin class.
@@ -29,10 +30,12 @@ def patch_lms():
 
     DjangoUserMixin.create_social_auth = create_social_auth_wrapper(DjangoUserMixin.create_social_auth)
 
+
 def patch_cms():
     """
     Monkey-patch some social auth models' Meta class to squelch Django19 warnings.
     """
+    # pylint: disable=protected-access
     UserSocialAuth._meta.app_label = "default"
     Nonce._meta.app_label = "default"
     Association._meta.app_label = "default"

--- a/lms/djangoapps/notes/models.py
+++ b/lms/djangoapps/notes/models.py
@@ -22,6 +22,9 @@ class Note(models.Model):
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)
     updated = models.DateTimeField(auto_now=True, db_index=True)
 
+    class Meta:
+        app_label = 'notes'
+
     def clean(self, json_body):
         """
         Cleans the note object or raises a ValidationError.

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -24,7 +24,7 @@ def run():
     """
     Executed during django startup
     """
-    third_party_auth.patch_lms()
+    third_party_auth.patch()
 
     # To override the settings before executing the autostartup() for python-social-auth
     if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -24,7 +24,7 @@ def run():
     """
     Executed during django startup
     """
-    third_party_auth.patch()
+    third_party_auth.patch_lms()
 
     # To override the settings before executing the autostartup() for python-social-auth
     if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):


### PR DESCRIPTION
Squelch more Django19 warnings.

@nedbat @muhammad-ammar @muzaffaryousaf @macdiesel @symbolist  PTAL - have these warnings been fixed elsewhere? Is a monkey patch too extreme to fix warnings? Don't see another easy way.
