### PR TITLE
ECOM-2602 Initial Verification status should convey all possible states

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -255,3 +255,4 @@ Douglas Hall <dhall@edx.org>
 Awais Jibran <awaisdar001@gmail.com>
 Muhammad Rehan <muhammadrehan69@gmail.com>
 Shawn Milochik <shawn@milochik.com>
+Afeef Janjua <janjua.afeef@gmail.com>

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1870,14 +1870,22 @@ class TestReverifyView(TestCase):
         # Allow the student to reverify
         self._assert_can_reverify()
 
-    def test_reverify_view_cannot_reverify_pending(self):
+    def test_reverify_view_can_reverify_pending(self):
+        """ Test that the user can still re-verify even if the previous photo
+        verification is in pending state.
+
+        A photo verification is considered in pending state when the user has
+        either submitted the photo verification (status in database: 'submitted')
+        or photo verification submission failed (status in database: 'must_retry').
+        """
+
         # User has submitted a verification attempt, but Software Secure has not yet responded
         attempt = SoftwareSecurePhotoVerification.objects.create(user=self.user)
         attempt.mark_ready()
         attempt.submit()
 
-        # Cannot reverify because an attempt has already been submitted.
-        self._assert_cannot_reverify()
+        # Can re-verify because an attempt has already been submitted.
+        self._assert_can_reverify()
 
     def test_reverify_view_cannot_reverify_approved(self):
         # Submitted attempt has been approved

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1350,7 +1350,11 @@ class ReverifyView(View):
         Backbone views used in the initial verification flow.
         """
         status, _ = SoftwareSecurePhotoVerification.user_status(request.user)
-        if status in ["must_reverify", "expired"]:
+
+        # If the verification process is still ongoing i.e. the status for photo
+        # verification is either 'submitted' or 'must_retry' then its marked as
+        # 'pending'
+        if status in ["must_reverify", "expired", "pending"]:
             context = {
                 "user_full_name": request.user.profile.name,
                 "platform_name": settings.PLATFORM_NAME,


### PR DESCRIPTION
[ECOM-2602](https://openedx.atlassian.net/browse/ECOM-2602) - Displays the re-verification page on all statuses except 'approved'
- [x] Allowed the user to open the re-verification page using direct url when verification status is 'pending' (submitted, must_retry)
- [x] Updated the corresponding test case 

cc: @awais786 @ahsan-ul-haq @zubair-arbi @tasawernawaz 
