### PR TITLE
Fixing discussions edit widget's width.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -254,3 +254,4 @@ Arbab Nazar <arbab@edx.org>
 Douglas Hall <dhall@edx.org>
 Awais Jibran <awaisdar001@gmail.com>
 Muhammad Rehan <muhammadrehan69@gmail.com>
+Ahmed Jazzar <ajazzar@qrf.org>

--- a/lms/static/sass/discussion/views/_create-edit-post.scss
+++ b/lms/static/sass/discussion/views/_create-edit-post.scss
@@ -6,7 +6,7 @@
 .edit-post-form {
   @include clearfix();
   box-sizing: border-box;
-  margin: 0;
+  margin: 0 auto;
   border-radius: 3px;
   padding: ($baseline);
   max-width: 1180px;


### PR DESCRIPTION
Fixing the **overflow in Markdown widget** that occurs when the user is _editing_ his response in discussions forums.

![editing response](https://cloud.githubusercontent.com/assets/11036472/10937280/7730b7be-82fa-11e5-9149-94847e119fe8.png)
