### PR TITLE
set path explicitly for storing cookie

### DIFF
--- a/cms/static/js/views/import.js
+++ b/cms/static/js/views/import.js
@@ -98,7 +98,7 @@ define(
                 file: file,
                 date: moment().valueOf(),
                 completed: completed || false
-            }));
+            }), {path: window.location.pathname});
         };
 
         /**

--- a/common/test/acceptance/tests/studio/base_studio_test.py
+++ b/common/test/acceptance/tests/studio/base_studio_test.py
@@ -20,6 +20,12 @@ class StudioCourseTest(UniqueCourseTest):
         Install a course with no content using a fixture.
         """
         super(StudioCourseTest, self).setUp()
+        self.install_course_fixture(is_staff)
+
+    def install_course_fixture(self, is_staff=False):
+        """
+        Install a course fixture
+        """
         self.course_fixture = CourseFixture(
             self.course_info['org'],
             self.course_info['number'],

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -364,6 +364,34 @@ class TestCourseImport(ImportTestMixin, StudioCourseTest):
         """
         self.assertEqual(self.import_page.header_text, 'Course Import')
 
+    def test_multiple_course_import_message(self):
+        """
+        Given that I visit an empty course before import
+        When I visit the import page
+        And I upload a course with file name 2015.lzdwNM.tar.gz
+        Then timestamp is visible after course is updated successfully
+        And then I create a new course
+        When I visit the import page of this new course
+        Then timestamp is not visible
+        """
+        self.import_page.visit()
+        self.import_page.upload_tarball(self.tarball_name)
+        self.import_page.wait_for_upload()
+        self.assertTrue(self.import_page.is_timestamp_visible())
+
+        # Create a new course and visit the import page
+        self.course_info = {
+            'org': 'test_org_2',
+            'number': self.unique_id + '_2',
+            'run': 'test_run_2',
+            'display_name': 'Test Course 2' + self.unique_id
+        }
+        self.install_course_fixture()
+        self.import_page = self.import_page_class(*self.page_args())
+        self.import_page.visit()
+        # As this is new course which is never import so timestamp should not present
+        self.assertFalse(self.import_page.is_timestamp_visible())
+
 
 @attr('shard_4')
 class TestLibraryImport(ImportTestMixin, StudioLibraryTest):


### PR DESCRIPTION
[TNL-2622](https://openedx.atlassian.net/browse/TNL-2622)

**Problem**:
The jquery cookie plugin stored the cookie with default path up-to last forward slash of url for example
1) Mongo Course Url:  `/import/edX/edX_01/2015_edX`
2) Split Course Url: `/import/course-v1:edX+edX_01+2015_edX`
So the for mongo the stored path of cookie will be `/import/edX/edX_01/`(fine) and for the split courses the url will be same for all that will be `/import/` so when ever we goto un-imported split course it will show that it is already imported if at least one of the split course is imported.

**Solution**:

We can set the `path` explicitly for cookie using jquery plugin  [here](https://github.com/carhartl/jquery-cookie#path) so in this way the `path` will store with full url and while reading the cookie it will pick up the correct cookie .This will help to prevent the above problem but what about already stored cookies on client machines ? so as we already saving the file url [here](https://github.com/edx/edx-platform/blob/062e979e0ed14161d0f882091a06e032ca76bb3e/cms/static/js/views/import.js#L307) which contains the url of course and solution for this problem the idea is to get fetch all the cookies of domain and then filtered the cookies which have the course url in file url.
