### PR TITLE
Course pacing template changes.

### DIFF
--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -101,17 +101,17 @@ var DetailsView = ValidatingView.extend({
         this.$('#' + this.fieldToSelectorMap['entrance_exam_minimum_score_pct']).val(this.model.get('entrance_exam_minimum_score_pct'));
 
         var selfPacedButton = this.$('#course-pace-self-paced'),
-            instructorLedButton = this.$('#course-pace-instructor-led'),
+            instructorPacedButton = this.$('#course-pace-instructor-paced'),
             paceToggleTip = this.$('#course-pace-toggle-tip');
-        (this.model.get('self_paced') ? selfPacedButton : instructorLedButton).attr('checked', true);
+        (this.model.get('self_paced') ? selfPacedButton : instructorPacedButton).attr('checked', true);
         if (this.model.canTogglePace()) {
             selfPacedButton.removeAttr('disabled');
-            instructorLedButton.removeAttr('disabled');
+            instructorPacedButton.removeAttr('disabled');
             paceToggleTip.text('');
         }
         else {
             selfPacedButton.attr('disabled', true);
-            instructorLedButton.attr('disabled', true);
+            instructorPacedButton.attr('disabled', true);
             paceToggleTip.text(gettext('Course pacing cannot be changed once a course has started.'));
         }
 
@@ -254,7 +254,7 @@ var DetailsView = ValidatingView.extend({
             break;
         case 'course-pace-self-paced':
             // Fallthrough to handle both radio buttons
-        case 'course-pace-instructor-led':
+        case 'course-pace-instructor-paced':
             this.model.set('self_paced', JSON.parse(event.currentTarget.value));
             break;
         default: // Everything else is handled by datepickers and CodeMirror.

--- a/cms/static/sass/views/_outline.scss
+++ b/cms/static/sass/views/_outline.scss
@@ -178,25 +178,37 @@
   .course-status {
     margin-bottom: $baseline;
 
-    .status-release {
+    .status-release,
+    .status-pacing {
       @extend %t-copy-base;
       display: inline-block;
       color: $color-copy-base;
+
+      // STATE: hover
+      &:hover {
+        .status-actions {
+          opacity: 1.0;
+        }
+      }
     }
 
     .status-release-label,
     .status-release-value,
+    .status-pacing-label,
+    .status-pacing-value,
     .status-actions {
       display: inline-block;
       vertical-align: middle;
       margin-bottom: 0;
     }
 
-    .status-release-label {
+    .status-release-label,
+    .status-pacing-label {
       margin-right: ($baseline/4);
     }
 
-    .status-release-value {
+    .status-release-value,
+    .status-pacing-value {
       @extend %t-strong;
     }
 
@@ -205,14 +217,6 @@
       @include transition(opacity $tmg-f1 ease-in-out 0);
       margin-left: ($baseline/4);
       opacity: 0.0;
-    }
-
-    // STATE: hover
-    &:hover {
-
-      .status-actions {
-        opacity: 1.0;
-      }
     }
   }
 

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -1044,7 +1044,7 @@
   .group-settings.pacing {
     .list-input {
       margin-top: $baseline/2;
-      background-color: $gray-l4;
+      background-color: $gray-l6;
       border-radius: 3px;
       padding: ($baseline/2);
     }

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -7,6 +7,7 @@ from util.date_utils import get_default_time_display
 from django.utils.translation import ugettext as _
 from contentstore.utils import reverse_usage_url
 from microsite_configuration import microsite
+from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 %>
 <%block name="title">${_("Course Outline")}</%block>
 <%block name="bodyclass">is-signedin course view-outline</%block>
@@ -161,6 +162,16 @@ from microsite_configuration import microsite
                       </li>
                     </ul>
                 </div>
+                % if SelfPacedConfiguration.current().enabled:
+                    <div class="status-pacing">
+                        <h2 class=status-pacing-label>${_("Course Pacing:")}</h2>
+                        % if context_course.self_paced:
+                            <p class="status-pacing-value">${_("Self-Paced")}</p>
+                        % else:
+                            <p class="status-pacing-value">${_("Instructor-Paced")}</p>
+                        % endif
+                    </div>
+               % endif
             </div>
 
             <div class="wrapper-dnd">

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -425,9 +425,9 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
 
               <ol class="list-input">
                 <li class="field">
-                  <input type="radio" class="field-radio" name="self-paced" id="course-pace-instructor-led" value="false"/>
-                  <label class="course-pace-label" for="course-pace-instructor-led">Instructor-Led</label>
-                  <span class="tip">${_("Instructor-led courses progress at the pace that the course author sets. You can configure release dates for course content and due dates for assignments.")}</span>
+                  <input type="radio" class="field-radio" name="self-paced" id="course-pace-instructor-paced" value="false"/>
+                  <label class="course-pace-label" for="course-pace-instructor-paced">Instructor-Paced</label>
+                  <span class="tip">${_("Instructor-paced courses progress at the pace that the course author sets. You can configure release dates for course content and due dates for assignments.")}</span>
                 </li>
                 <li class="field">
                   <input type="radio" class="field-radio" name="self-paced" id="course-pace-self-paced" value="true"/>

--- a/common/test/acceptance/pages/studio/settings.py
+++ b/common/test/acceptance/pages/studio/settings.py
@@ -151,7 +151,7 @@ class SettingsPage(CoursePage):
     @course_pacing.setter
     def course_pacing(self, pacing):
         """
-        Sets the course to either self-paced or instructor-led by checking
+        Sets the course to either self-paced or instructor-paced by checking
         the appropriate radio button.
         """
         self.wait_for_element_presence(self.checked_pacing_css, 'course pacing controls present')

--- a/common/test/acceptance/tests/studio/test_studio_settings_details.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_details.py
@@ -209,11 +209,11 @@ class CoursePacingTest(StudioSettingsDetailsTest):
         # Set the course start date to tomorrow in order to allow setting pacing
         self.course_fixture.add_course_details({'start_date': datetime.now() + timedelta(days=1)})
 
-    def test_default_instructor_led(self):
+    def test_default_instructor_paced(self):
         """
-        Test that the 'instructor led' button is checked by default.
+        Test that the 'instructor paced' button is checked by default.
         """
-        self.assertEqual(self.settings_detail.course_pacing, 'Instructor-Led')
+        self.assertEqual(self.settings_detail.course_pacing, 'Instructor-Paced')
 
     def test_self_paced(self):
         """

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -126,7 +126,7 @@ class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
 
     def setUp(self):
         super(SelfPacedCourseInfoTestCase, self).setUp()
-        self.instructor_led_course = CourseFactory.create(self_paced=False)
+        self.instructor_paced_course = CourseFactory.create(self_paced=False)
         self.self_paced_course = CourseFactory.create(self_paced=True)
         self.setup_user()
 
@@ -141,8 +141,8 @@ class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
                 resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
 
-    def test_num_queries_instructor_led(self):
-        self.fetch_course_info_with_queries(self.instructor_led_course, 14, 4)
+    def test_num_queries_instructor_paced(self):
+        self.fetch_course_info_with_queries(self.instructor_paced_course, 14, 4)
 
     def test_num_queries_self_paced(self):
         self.fetch_course_info_with_queries(self.self_paced_course, 14, 4)

--- a/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
@@ -42,9 +42,9 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         inject_field_overrides((course, section), course, UserFactory.create())
         return (course, section)
 
-    def test_instructor_led(self):
-        __, il_section = self.setup_course("Instructor Led Course", False)
-        self.assertEqual(self.due_date, il_section.due)
+    def test_instructor_paced(self):
+        __, ip_section = self.setup_course("Instructor Paced Course", False)
+        self.assertEqual(self.due_date, ip_section.due)
 
     def test_self_paced(self):
         __, sp_section = self.setup_course("Self-Paced Course", True)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -822,7 +822,7 @@ class ProgressPageTests(ModuleStoreTestCase):
     )
     @ddt.unpack
     def test_query_counts(self, (sql_calls, mongo_calls, self_paced), self_paced_enabled):
-        """Test that query counts remain the same for self-paced and instructor-led courses."""
+        """Test that query counts remain the same for self-paced and instructor-paced courses."""
         SelfPacedConfiguration(enabled=self_paced_enabled).save()
         self.setup_course(self_paced=self_paced)
         with self.assertNumQueries(sql_calls), check_mongo_calls(mongo_calls):


### PR DESCRIPTION
# [ECOM-2794](https://openedx.atlassian.net/browse/ECOM-2794) and [ECOM-2800](https://openedx.atlassian.net/browse/ECOM-2800)

Adds a label on the course outline page to show course pacing (read-only) and changes "Instructor Led" to "Instructor Paced". Enabled behind the self-paced feature flag.

Also makes a small style change to the course settings page, as noted in [ECOM-2794](https://openedx.atlassian.net/browse/ECOM-2794).

[Sandbox is here.](http://studio-peter-fogg.sandbox.edx.org/course/course-v1:edX+Test101+course)

@clintonb @bderusha 

FYI @marcotuts 
