### PR TITLE
Update `cert_info` docstring with correct return type.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -194,7 +194,7 @@ def cert_info(user, course_overview, course_mode):
         course_mode (str): The enrollment mode (honor, verified, audit, etc.)
 
     Returns:
-        dict: A dictionary with keys:
+        dict: Empty dict if certificates are disabled or hidden, or a dictionary with keys:
             'status': one of 'generating', 'ready', 'notpassing', 'processing', 'restricted'
             'show_download_url': bool
             'download_url': url, only present if show_download_url is True


### PR DESCRIPTION
@edx/ecommerce I noticed yesterday that the documentation was out-of-date for the `cert_info` function; hopefully this will help prevent similar bugs in the future.
