### PR TITLE
adds an accessible label to the search input and the search button

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -39,9 +39,11 @@ from microsite_configuration import microsite
         % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
           <div class="course-search">
             <form method="get" action="/courses">
-              <input class="search-input" name="search_query" type="text" placeholder="${_("Search for a course")}"></input>
+              <label><span class="sr">${_("Search for a course")}</span>
+                <input class="search-input" name="search_query" type="text" placeholder="${_("Search for a course")}"></input>
+              </label>
               <button class="search-button" type="submit">
-                <i class="icon fa fa-search" aria-hidden="true"></i>
+                <i class="icon fa fa-search" aria-hidden="true"></i><span class="sr">${_("Search")}</span>
               </button>
             </form>
           </div>


### PR DESCRIPTION
This work hopes to resolve [AC-222 ](https://openedx.atlassian.net/browse/AC-222) by adding accessible labels to the search input and the search button on the Open edX homepage.

Before:

![Screen shot of current search field and button](https://cloud.githubusercontent.com/assets/444368/10969682/e850b65e-8397-11e5-8b0b-fc4e73712bd5.png)

After: No visual change

![Screen shot afterwards shows no visual difference](https://cloud.githubusercontent.com/assets/444368/10969533/fc0b3238-8396-11e5-8410-77fe12e3b86e.png)
