### PR TITLE
Add xblock-vectordraw to requirements.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -67,3 +67,4 @@ git+https://github.com/edx/edx-proctoring.git@0.10.16#egg=edx-proctoring==0.10.1
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 -e git+https://github.com/open-craft/xblock-poll@e7a6c95c300e95c51e42bfd1eba70489c05a6527#egg=xblock-poll
+-e git+https://github.com/open-craft/xblock-vectordraw.git@initial-implementation#egg=xblock-vectordraw


### PR DESCRIPTION
This uses the development branch for now to make it easy to set up and maintain a sandbox.

**JIRA ticket**: [OSPR-935](https://openedx.atlassian.net/browse/OSPR-935)
