### PR TITLE
Adnan/chrome fix showsrandom xblocks from configured

### DIFF
--- a/common/test/acceptance/pages/studio/library.py
+++ b/common/test/acceptance/pages/studio/library.py
@@ -9,6 +9,7 @@ from .component_editor import ComponentEditorView
 from .container import XBlockWrapper
 from ...pages.studio.users import UsersPageMixin
 from ...pages.studio.pagination import PaginatedMixin
+from selenium.webdriver.common.keys import Keys
 
 from ..common.utils import confirm_prompt, wait_for_notification
 
@@ -168,7 +169,8 @@ class StudioLibraryContentEditor(ComponentEditorView):
         Sets value of children count input
         """
         count_text = self.get_setting_element(self.COUNT_LABEL)
-        count_text.clear()
+        count_text.send_keys(Keys.CONTROL, "a")
+        count_text.send_keys(Keys.BACK_SPACE)
         count_text.send_keys(count)
         EmptyPromise(lambda: self.count == count, "count is updated in modal.").fulfill()
 

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -158,7 +158,7 @@ class LibraryContentTest(LibraryContentTestBase):
             XBlockFixtureDesc("html", "Html3", data='html3'),
         )
 
-    @ddt.data(1, 2, 3)
+    @ddt.data(2, 3, 4)
     def test_shows_random_xblocks_from_configured(self, count):
         """
         Scenario: Ensures that library content shows {count} random xblocks from library in LMS

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -156,9 +156,10 @@ class LibraryContentTest(LibraryContentTestBase):
             XBlockFixtureDesc("html", "Html1", data='html1'),
             XBlockFixtureDesc("html", "Html2", data='html2'),
             XBlockFixtureDesc("html", "Html3", data='html3'),
+
         )
 
-    @ddt.data(2, 3, 4)
+    @ddt.data(2, 2, 3)
     def test_shows_random_xblocks_from_configured(self, count):
         """
         Scenario: Ensures that library content shows {count} random xblocks from library in LMS


### PR DESCRIPTION
Google chrome don't consider if we remove the value and then input same value e.g If 1 is the default value and I remove the 1 and then input 1 again, it don't consider change and "Publish" button don't visible.

I have figured out that above issue and changed the test data different from the default values so that GC can consider it value is changed.
