### PR TITLE
SOL-1333: Add Cert Regenerate UI on Instructor Dash

### DIFF
--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -143,6 +143,10 @@ urlpatterns = patterns(
         'instructor.views.api.start_certificate_generation',
         name='start_certificate_generation'),
 
+    url(r'^start_certificate_regeneration',
+        'instructor.views.api.start_certificate_regeneration',
+        name='start_certificate_regeneration'),
+
     url(r'^create_certificate_exception/(?P<white_list_student>[^/]*)',
         'instructor.views.api.create_certificate_exception',
         name='create_certificate_exception'),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -37,7 +37,7 @@ from student.models import CourseEnrollment
 from shoppingcart.models import Coupon, PaidCourseRegistration, CourseRegCodeItem
 from course_modes.models import CourseMode, CourseModesArchive
 from student.roles import CourseFinanceAdminRole, CourseSalesAdminRole
-from certificates.models import CertificateGenerationConfiguration, CertificateWhitelist
+from certificates.models import CertificateGenerationConfiguration, CertificateWhitelist, GeneratedCertificate
 from certificates import api as certs_api
 from util.date_utils import get_default_time_display
 
@@ -299,6 +299,7 @@ def _section_certificates(course):
         'enabled_for_course': certs_api.cert_generation_enabled(course.id),
         'instructor_generation_enabled': instructor_generation_enabled,
         'html_cert_enabled': html_cert_enabled,
+        'certificate_statuses': GeneratedCertificate.get_unique_statuses(course_key=course.id),
         'urls': {
             'generate_example_certificates': reverse(
                 'generate_example_certificates',
@@ -310,6 +311,10 @@ def _section_certificates(course):
             ),
             'start_certificate_generation': reverse(
                 'start_certificate_generation',
+                kwargs={'course_id': course.id}
+            ),
+            'start_certificate_regeneration': reverse(
+                'start_certificate_regeneration',
                 kwargs={'course_id': course.id}
             ),
             'list_instructor_tasks_url': reverse(

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -512,3 +512,27 @@ def generate_certificates_for_students(request, course_key, students=None):  # p
     task_key = ""
 
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
+
+
+def regenerate_certificates(request, course_key, statuses_to_regenerate, students=None):
+    """
+    Submits a task to regenerate certificates for given students enrolled in the course or
+    all students if argument 'students' is None.
+    Regenerate Certificate only if the status of the existing generated certificate is in 'statuses_to_regenerate'
+    list passed in the arguments.
+
+    Raises AlreadyRunningError if certificates are currently being generated.
+    """
+    if students:
+        task_type = 'regenerate_certificates_certain_student'
+        students = [student.id for student in students]
+        task_input = {'students': students}
+    else:
+        task_type = 'regenerate_certificates_all_student'
+        task_input = {}
+
+    task_input.update({"statuses_to_regenerate": statuses_to_regenerate})
+    task_class = generate_certificates
+    task_key = ""
+
+    return submit_task(request, task_type, task_class, course_key, task_input, task_key)

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -22,6 +22,7 @@ from instructor_task.api import (
     submit_executive_summary_report,
     submit_course_survey_report,
     generate_certificates_for_all_students,
+    regenerate_certificates
 )
 
 from instructor_task.api_helper import AlreadyRunningError
@@ -31,6 +32,7 @@ from instructor_task.tests.test_base import (InstructorTaskTestCase,
                                              InstructorTaskModuleTestCase,
                                              TestReportMixin,
                                              TEST_COURSE_KEY)
+from certificates.models import CertificateStatuses
 
 
 class InstructorTaskReportTest(InstructorTaskTestCase):
@@ -262,4 +264,19 @@ class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCa
             self.create_task_request(self.instructor),
             self.course.id
         )
+        self._test_resubmission(api_call)
+
+    def test_regenerate_certificates(self):
+        """
+        Tests certificates regeneration task submission api
+        """
+        def api_call():
+            """
+            wrapper method for regenerate_certificates
+            """
+            return regenerate_certificates(
+                self.create_task_request(self.instructor),
+                self.course.id,
+                [CertificateStatuses.downloadable, CertificateStatuses.generating]
+            )
         self._test_resubmission(api_call)

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1635,3 +1635,149 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             },
             result
         )
+
+    def test_certificate_regeneration_for_students(self):
+        """
+        Verify that certificates are regenerated for all eligible students enrolled in a course whose generated
+        certificate statuses lies in the list 'statuses_to_regenerate' given in task_input.
+        """
+        # create 10 students
+        students = [self.create_student(username='student_{}'.format(i), email='student_{}@example.com'.format(i))
+                    for i in xrange(1, 11)]
+
+        # mark 2 students to have certificates generated already
+        for student in students[:2]:
+            GeneratedCertificateFactory.create(
+                user=student,
+                course_id=self.course.id,
+                status=CertificateStatuses.downloadable,
+                mode='honor'
+            )
+
+        # mark 3 students to have certificates generated with status 'error'
+        for student in students[2:5]:
+            GeneratedCertificateFactory.create(
+                user=student,
+                course_id=self.course.id,
+                status=CertificateStatuses.error,
+                mode='honor'
+            )
+
+        # mark 6th students to have certificates generated with status 'deleted'
+        for student in students[5:6]:
+            GeneratedCertificateFactory.create(
+                user=student,
+                course_id=self.course.id,
+                status=CertificateStatuses.deleted,
+                mode='honor'
+            )
+
+        # white-list 7 students
+        for student in students[:7]:
+            CertificateWhitelistFactory.create(user=student, course_id=self.course.id, whitelist=True)
+
+        current_task = Mock()
+        current_task.update_state = Mock()
+
+        # Certificates should be regenerated for students having generated certificates with status
+        # 'downloadable' or 'error' which are total of 5 students in this test case
+        task_input = {'statuses_to_regenerate': [CertificateStatuses.downloadable, CertificateStatuses.error]}
+
+        with patch('instructor_task.tasks_helper._get_current_task') as mock_current_task:
+            mock_current_task.return_value = current_task
+            with patch('capa.xqueue_interface.XQueueInterface.send_to_queue') as mock_queue:
+                mock_queue.return_value = (0, "Successfully queued")
+                result = generate_students_certificates(
+                    None, None, self.course.id, task_input, 'certificates generated'
+                )
+
+        self.assertDictContainsSubset(
+            {
+                'action_name': 'certificates generated',
+                'total': 10,
+                'attempted': 5,
+                'succeeded': 5,
+                'failed': 0,
+                'skipped': 5
+            },
+            result
+        )
+
+    def test_certificate_regeneration_with_expected_failures(self):
+        """
+        Verify that certificates are regenerated for all eligible students enrolled in a course whose generated
+        certificate statuses lies in the list 'statuses_to_regenerate' given in task_input.
+        """
+        # create 10 students
+        students = [self.create_student(username='student_{}'.format(i), email='student_{}@example.com'.format(i))
+                    for i in xrange(1, 11)]
+
+        # mark 2 students to have certificates generated already
+        for student in students[:2]:
+            GeneratedCertificateFactory.create(
+                user=student,
+                course_id=self.course.id,
+                status=CertificateStatuses.downloadable,
+                mode='honor'
+            )
+
+        # mark 3 students to have certificates generated with status 'error'
+        for student in students[2:5]:
+            GeneratedCertificateFactory.create(
+                user=student,
+                course_id=self.course.id,
+                status=CertificateStatuses.error,
+                mode='honor'
+            )
+
+        # mark 6th students to have certificates generated with status 'deleted'
+        for student in students[5:6]:
+            GeneratedCertificateFactory.create(
+                user=student,
+                course_id=self.course.id,
+                status=CertificateStatuses.deleted,
+                mode='honor'
+            )
+
+        # mark rest of the 4 students with having generated certificates with status 'generating'
+        # These students are not added in white-list and they have not completed grades so certificate generation
+        # for these students should fail other than the one student that has been added to white-list
+        # so from these students 3 failures and 1 success
+        for student in students[6:]:
+            GeneratedCertificateFactory.create(
+                user=student,
+                course_id=self.course.id,
+                status=CertificateStatuses.generating,
+                mode='honor'
+            )
+
+        # white-list 7 students
+        for student in students[:7]:
+            CertificateWhitelistFactory.create(user=student, course_id=self.course.id, whitelist=True)
+
+        current_task = Mock()
+        current_task.update_state = Mock()
+
+        # Regenerated certificates for students having generated certificates with status
+        # 'deleted' or 'generating'
+        task_input = {'statuses_to_regenerate': [CertificateStatuses.deleted, CertificateStatuses.generating]}
+
+        with patch('instructor_task.tasks_helper._get_current_task') as mock_current_task:
+            mock_current_task.return_value = current_task
+            with patch('capa.xqueue_interface.XQueueInterface.send_to_queue') as mock_queue:
+                mock_queue.return_value = (0, "Successfully queued")
+                result = generate_students_certificates(
+                    None, None, self.course.id, task_input, 'certificates generated'
+                )
+
+        self.assertDictContainsSubset(
+            {
+                'action_name': 'certificates generated',
+                'total': 10,
+                'attempted': 5,
+                'succeeded': 2,
+                'failed': 3,
+                'skipped': 5
+            },
+            result
+        )

--- a/lms/static/js/spec/instructor_dashboard/certificates_spec.js
+++ b/lms/static/js/spec/instructor_dashboard/certificates_spec.js
@@ -1,0 +1,116 @@
+/*global define, onCertificatesReady */
+define([
+        'jquery',
+        'common/js/spec_helpers/ajax_helpers',
+        'js/instructor_dashboard/certificates'
+    ],
+    function($, AjaxHelpers) {
+        'use strict';
+        describe("edx.instructor_dashboard.certificates.regenerate_certificates", function() {
+            var $regenerate_certificates_button = null,
+                $certificate_regeneration_status = null,
+                requests = null;
+            var MESSAGES = {
+                success_message: 'Certificate regeneration task has been started. ' +
+                    'You can view the status of the generation task in the "Pending Tasks" section.',
+                error_message: 'Please select one or more certificate statuses that require certificate regeneration.',
+                server_error_message: "Error while regenerating certificates. Please try again."
+            };
+            var expected = {
+                error_class: 'msg-error',
+                success_class: 'msg-success',
+                url: 'test/url/',
+                postData : [],
+                selected_statuses: ['downloadable', 'error'],
+                body: 'certificate_statuses=downloadable&certificate_statuses=error'
+            };
+
+            var select_options = function(option_values){
+                $.each(option_values, function(index, element){
+                    $("#certificate-statuses option[value=" + element + "]").attr('selected', 'selected');
+                });
+            };
+
+            beforeEach(function() {
+                var fixture = '<section id = "certificates"><h2>Regenerate Certificates</h2>' +
+                    '<form id="certificate-regenerating-form" method="post" action="' + expected.url + '">' +
+                    '   <p id="status-multi-select-tip">Select one or more certificate statuses ' +
+                    '       below using your mouse and ctrl or command key.</p>' +
+                    '   <select class="multi-select" multiple id="certificate-statuses" ' +
+                    '       name="certificate_statuses" aria-describedby="status-multi-select-tip">' +
+                    '       <option value="downloadable">Downloadable (2)</option>' +
+                    '       <option value="error">Error (2)</option>' +
+                    '       <option value="generating">Generating (1)</option>' +
+                    '   </select>' +
+                    '   <label for="certificate-statuses">' +
+                    '       Select certificate statuses that need regeneration and click Regenerate ' +
+                    '       Certificates button.' +
+                    '   </label>' +
+                    '   <input type="button" id="btn-start-regenerating-certificates" value="Regenerate Certificates"' +
+                    '   data-endpoint="' + expected.url + '"/>' +
+                    '</form>' +
+                    '<div class="message certificate-regeneration-status"></div></section>';
+
+                setFixtures(fixture);
+                onCertificatesReady();
+                $regenerate_certificates_button = $("#btn-start-regenerating-certificates");
+                $certificate_regeneration_status = $(".certificate-regeneration-status");
+                requests = AjaxHelpers.requests(this);
+            });
+
+            it("does not regenerate certificates if user cancels operation in confirm popup", function() {
+                spyOn(window, 'confirm').andReturn(false);
+                $regenerate_certificates_button.click();
+                expect(window.confirm).toHaveBeenCalled();
+                AjaxHelpers.expectNoRequests(requests);
+            });
+
+            it("sends regenerate certificates request if user accepts operation in confirm popup", function() {
+                spyOn(window, 'confirm').andReturn(true);
+                $regenerate_certificates_button.click();
+                expect(window.confirm).toHaveBeenCalled();
+                AjaxHelpers.expectRequest(requests, 'POST', expected.url);
+            });
+
+            it("sends regenerate certificates request with selected certificate statuses", function() {
+                spyOn(window, 'confirm').andReturn(true);
+
+                select_options(expected.selected_statuses);
+
+                $regenerate_certificates_button.click();
+                AjaxHelpers.expectRequest(requests, 'POST', expected.url, expected.body);
+            });
+
+            it("displays error message in case of server side error", function() {
+                spyOn(window, 'confirm').andReturn(true);
+                select_options(expected.selected_statuses);
+
+                $regenerate_certificates_button.click();
+                AjaxHelpers.respondWithError(requests, 500, {message: MESSAGES.server_error_message});
+                expect($certificate_regeneration_status).toHaveClass(expected.error_class);
+                expect($certificate_regeneration_status.text()).toEqual(MESSAGES.server_error_message);
+            });
+
+            it("displays error message returned by the server in case of unsuccessful request", function() {
+                spyOn(window, 'confirm').andReturn(true);
+                select_options(expected.selected_statuses);
+
+                $regenerate_certificates_button.click();
+                AjaxHelpers.respondWithError(requests, 400, {message: MESSAGES.error_message});
+                expect($certificate_regeneration_status).toHaveClass(expected.error_class);
+                expect($certificate_regeneration_status.text()).toEqual(MESSAGES.error_message);
+            });
+
+            it("displays success message returned by the server in case of successful request", function() {
+                spyOn(window, 'confirm').andReturn(true);
+                select_options(expected.selected_statuses);
+
+                $regenerate_certificates_button.click();
+                AjaxHelpers.respondWithJson(requests, {message: MESSAGES.success_message, success: true});
+                expect($certificate_regeneration_status).toHaveClass(expected.success_class);
+                expect($certificate_regeneration_status.text()).toEqual(MESSAGES.success_message);
+            });
+
+        });
+    }
+);

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -293,6 +293,10 @@
                 exports: 'coffee/src/instructor_dashboard/student_admin',
                 deps: ['jquery', 'underscore', 'coffee/src/instructor_dashboard/util', 'string_utils']
             },
+            'js/instructor_dashboard/certificates': {
+                exports: 'js/instructor_dashboard/certificates',
+                deps: ['jquery', 'gettext', 'underscore']
+            },
             // LMS class loaded explicitly until they are converted to use RequireJS
             'js/student_account/account': {
                 exports: 'js/student_account/account',
@@ -644,6 +648,7 @@
         'lms/include/js/spec/instructor_dashboard/ecommerce_spec.js',
         'lms/include/js/spec/instructor_dashboard/student_admin_spec.js',
         'lms/include/js/spec/instructor_dashboard/certificates_exception_spec.js',
+        'lms/include/js/spec/instructor_dashboard/certificates_spec.js',
         'lms/include/js/spec/student_account/account_spec.js',
         'lms/include/js/spec/student_account/access_spec.js',
         'lms/include/js/spec/student_account/logistration_factory_spec.js',

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -92,6 +92,20 @@
     }
   }
 
+  .msg-success{
+    border-top: 2px solid $confirm-color;
+    background: tint($confirm-color,95%);
+    color: $confirm-color;
+  }
+
+  .multi-select {
+    min-width: 150px;
+
+    option {
+        padding: ($baseline/5) $baseline ($baseline/10) ($baseline/4);
+    }
+  }
+
   // inline copy
   .copy-confirm {
     color: $confirm-color;
@@ -2125,12 +2139,6 @@ input[name="subject"] {
 }
 
 #certificate-white-list-editor{
-  .msg-success{
-    border-top: 2px solid $confirm-color;
-    background: tint($confirm-color,95%);
-    color: $confirm-color;
-  }
-
   .certificate-exception-inputs{
     .student-username-or-email{
       width: 300px;

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -92,6 +92,25 @@ import json
         %endif
     % endif
 
+    <hr>
+    <p class="start-certificate-regeneration">
+        <h2>${_("Regenerate Certificates")}</h2>
+        <form id="certificate-regenerating-form" method="post" action="${section_data['urls']['start_certificate_regeneration']}">
+            <p id='status-multi-select-tip'>${_('Select one or more certificate statuses below using your mouse and ctrl or command key.')}</p>
+            <select class="multi-select" multiple id="certificate-statuses" name="certificate_statuses" aria-describedby="status-multi-select-tip">
+                %for status in section_data['certificate_statuses']:
+                    <option value="${status['status']}">${status['status'].title() + " ({})".format(status['count'])}</option>
+                %endfor
+            </select>
+            <label for="certificate-statuses">
+                ${_("Select certificate statuses that need regeneration and click Regenerate Certificates button.")}
+            </label>
+
+            <input type="button" id="btn-start-regenerating-certificates" value="${_('Regenerate Certificates')}" data-endpoint="${section_data['urls']['start_certificate_regeneration']}"/>
+        </form>
+        <div class="message certificate-regeneration-status"></div>
+    </div>
+
     <div class="certificate_exception-container">
         <hr>
         <h2> ${_("Certificate Exceptions")} </h2>


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 

Kindly review his PR, it contains changes for [SOL-1333](https://openedx.atlassian.net/browse/SOL-1333), 

**Description of [SOL-1333](https://openedx.atlassian.net/browse/SOL-1333):**
Sometimes PMs need to regenerate certificates for users. Possible scenarios are
- user did not pass when certificates are generated and course team has changed grading
- course team accidentally enabled web certificates on course and generated certificates whereas PDF certificates were required
- there was an error which resulted in failure to generate certificate for some students

**Acceptance Criteria**
We should provide a button on instructor dashboard under certificates tab which would allow PMs to regenerate certificates of all students whose certificate status is one of these
1. downloadable
2. error
3. notpassing

...as well as all students in the course.

cc: @mattdrayer 
