### PR TITLE
Fixes for chrome automation:

### DIFF
--- a/common/test/acceptance/pages/studio/settings_certificates.py
+++ b/common/test/acceptance/pages/studio/settings_certificates.py
@@ -488,7 +488,6 @@ class Signatory(object):
         """
         self.wait_for_signature_image_upload_button()
         self.find_css('.action-upload-signature').first.click()
-        self.find_css('.action-upload-signature').first.click()
         self.wait_for_signature_image_upload_prompt()
 
         asset_file_path = self.file_path(image_filename)

--- a/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
@@ -2,6 +2,7 @@
 Acceptance tests for Studio's Setting pages
 """
 import re
+import uuid
 from .base_studio_test import StudioCourseTest
 from ...pages.studio.settings_certificates import CertificatesPage
 from ...pages.studio.settings_advanced import AdvancedSettingsPage
@@ -60,7 +61,7 @@ class CertificatesTest(StudioCourseTest):
             certificate.signatories[idx].name = signatory['name']
             certificate.signatories[idx].title = signatory['title']
             certificate.signatories[idx].organization = signatory['organization']
-            certificate.signatories[idx].upload_signature_image('Signature-{}.png'.format(idx))
+            certificate.signatories[idx].upload_signature_image('Signature-{}.png'.format(uuid.uuid4().hex[:4]))
 
             added_signatories += 1
             if len(signatories) > added_signatories:


### PR DESCRIPTION
- We do not need to click the upload button twice (typo?)
- Using a non-unique name for the upload image is causing GridFS indexing errors when
  run too closely together (which happens with Chrome's speed)
