### PR TITLE
Added validations for start and due date in Schedule tab inside CCX coach dashboard

### DIFF
--- a/lms/static/js/spec/ccx/schedule_spec.js
+++ b/lms/static/js/spec/ccx/schedule_spec.js
@@ -124,7 +124,7 @@ define(['common/js/spec_helpers/ajax_helpers', 'js/ccx/schedule'],
                 val = "i4x://edX/DemoX/sequential/edx_introduction";
                 view.sequential_select.val(val);
                 view.sequential_select.change();
-                val = "i4x://edX/DemoX/vertical/vertical_0270f6de40fc",
+                val = "i4x://edX/DemoX/vertical/vertical_0270f6de40fc";
                 view.vertical_select.val(val);
                 view.vertical_select.change();
                 expect(view.vertical_select.val()).toEqual(val);
@@ -141,9 +141,51 @@ define(['common/js/spec_helpers/ajax_helpers', 'js/ccx/schedule'],
                 view.vertical_select.val(val);
                 view.vertical_select.change();
                 var unit = view.find_unit(view.schedule, 'i4x://edX/DemoX/chapter/d8a6192ade314473a78242dfeedfbf5b');
+                view.set_datetime('start', '2015-12-12 10:00');
+                view.set_datetime('due', '2015-12-12 10:30');
                 expect(unit.hidden).toBe(true);
                 $('#add-unit-button').click();
                 expect(unit.hidden).toBe(false);
+            });
+
+            it("add unit when start date is greater the due date", function() {
+                var val = 'i4x://edX/DemoX/chapter/d8a6192ade314473a78242dfeedfbf5b';
+                view.chapter_select.val(val);
+                view.chapter_select.change();
+                val = "i4x://edX/DemoX/sequential/edx_introduction";
+                view.sequential_select.val(val);
+                view.sequential_select.change();
+                val = "i4x://edX/DemoX/vertical/vertical_0270f6de40fc";
+                view.vertical_select.val(val);
+                view.vertical_select.change();
+                var unit = view.find_unit(view.schedule, 'i4x://edX/DemoX/chapter/d8a6192ade314473a78242dfeedfbf5b');
+                // start date is before due date
+                view.set_datetime('start', '2015-11-13 10:45');
+                view.set_datetime('due', '2015-11-12 10:00');
+                expect(unit.hidden).toBe(true);
+                $('#add-unit-button').click();
+                // Assert unit is not added to schedule
+                expect(unit.hidden).toBe(true);
+            });
+
+            it("add unit when start date is missing", function() {
+                var val = 'i4x://edX/DemoX/chapter/d8a6192ade314473a78242dfeedfbf5b';
+                view.chapter_select.val(val);
+                view.chapter_select.change();
+                val = "i4x://edX/DemoX/sequential/edx_introduction";
+                view.sequential_select.val(val);
+                view.sequential_select.change();
+                val = "i4x://edX/DemoX/vertical/vertical_0270f6de40fc";
+                view.vertical_select.val(val);
+                view.vertical_select.change();
+                var unit = view.find_unit(view.schedule, 'i4x://edX/DemoX/chapter/d8a6192ade314473a78242dfeedfbf5b');
+                // start date is missing
+                view.set_datetime('start', null);
+                view.set_datetime('due', '2015-12-12 10:00');
+                expect(unit.hidden).toBe(true);
+                $('#add-unit-button').click();
+                // Assert unit is not added to schedule
+                expect(unit.hidden).toBe(true);
             });
 
             it("gets a datetime string from date and time fields", function() {

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -316,7 +316,7 @@
             },
             'js/ccx/schedule': {
                 exports: 'js/ccx/schedule',
-                deps: ['jquery', 'underscore', 'backbone', 'gettext']
+                deps: ['jquery', 'underscore', 'backbone', 'gettext', 'moment']
             },
 
             // Backbone classes loaded explicitly until they are converted to use RequireJS


### PR DESCRIPTION
### Background

From issue https://github.com/mitocw/edx-platform/issues/79 and https://github.com/mitocw/edx-platform/issues/39
### What is done in this PR

**Studio Updates:** None.

**LMS Updates:** 
- Showing error message incase user do not specify a time with date in `add unit form` inside ccx coach schedule tab.
- Showing error message in case start date is greater the due date i.e added date validation in `add unit form` inside ccx coach schedule tab.

@pdpinch @giocalitri  @pwilkins
MIT PR https://github.com/mitocw/edx-platform/pull/97

![screen shot 2015-10-07 at 3 09 16 pm](https://cloud.githubusercontent.com/assets/10431250/10334719/73721222-6d05-11e5-909e-e8e212e4d9d0.png)

![screen shot 2015-10-07 at 4 36 45 pm](https://cloud.githubusercontent.com/assets/10431250/10336689/09af3aea-6d14-11e5-8fe1-9235c570a959.png)
