### PR TITLE
Moving south DataMigration to Django 1.8 migration.

### DIFF
--- a/common/djangoapps/dark_lang/migrations/0002_auto_20151106_0718.py
+++ b/common/djangoapps/dark_lang/migrations/0002_auto_20151106_0718.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def create_dark_lang_config(apps, schema_editor):
+    """
+    Enable DarkLang by default when it is installed, to prevent accidental
+    release of testing languages.
+    """
+    dark_lang_model = apps.get_model("dark_lang", "DarkLangConfig")
+    db_alias = schema_editor.connection.alias
+
+    dark_lang_model.objects.using(db_alias).get_or_create(enabled=True)
+
+def remove_dark_lang_config(apps, schema_editor):
+    """Write your backwards methods here."""
+    raise RuntimeError("Cannot reverse this migration.")
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dark_lang', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_dark_lang_config, remove_dark_lang_config),
+    ]

--- a/common/djangoapps/embargo/migrations/0002_auto_20151106_0650.py
+++ b/common/djangoapps/embargo/migrations/0002_auto_20151106_0650.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django_countries import countries
+
+
+def create_embargo_countries(apps, schema_editor):
+    """Populate the available countries with all 2-character ISO country codes. """
+    country_model = apps.get_model("embargo", "Country")
+    db_alias = schema_editor.connection.alias
+    for country_code, __ in list(countries):
+        country_model.objects.using(db_alias).get_or_create(country=country_code)
+
+def remove_embargo_countries(apps, schema_editor):
+    """Clear all available countries. """
+    country_model = apps.get_model("embargo", "Country")
+    db_alias = schema_editor.connection.alias
+    country_model.objects.using(db_alias).all().delete()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('embargo', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_embargo_countries, remove_embargo_countries),
+    ]
+

--- a/lms/djangoapps/certificates/migrations/0003_auto_20151106_0743.py
+++ b/lms/djangoapps/certificates/migrations/0003_auto_20151106_0743.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+import json
+
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    """
+    Bootstraps the HTML view template with some default configuration parameters
+    """
+    config = {
+        "default": {
+            "accomplishment_class_append": "accomplishment-certificate",
+            "platform_name": "Your Platform Name Here",
+            "company_about_url": "http://www.example.com/about-us",
+            "company_privacy_url": "http://www.example.com/privacy-policy",
+            "company_tos_url": "http://www.example.com/terms-service",
+            "company_verified_certificate_url": "http://www.example.com/verified-certificate",
+            "logo_src": "/static/certificates/images/logo.png",
+            "logo_url": "http://www.example.com"
+        },
+        "honor": {
+            "certificate_type": "Honor Code",
+            "certificate_title": "Certificate of Achievement",
+        },
+        "verified": {
+            "certificate_type": "Verified",
+            "certificate_title": "Verified Certificate of Achievement",
+        }
+    }
+    certificate_html_view_configuration_model = apps.get_model("certificates", "CertificateHtmlViewConfiguration")
+    db_alias = schema_editor.connection.alias
+
+    certificate_html_view_configuration_model.objects.using(db_alias).create(
+        configuration=json.dumps(config),
+        enabled=False,
+    )
+
+def backwards(apps, schema_editor):
+    """
+    Rolling back to zero-state, so remove all currently-defined configurations
+    """
+    certificate_html_view_configuration_model = apps.get_model("certificates", "CertificateHtmlViewConfiguration")
+    db_alias = schema_editor.connection.alias
+
+    certificate_html_view_configuration_model.objects.using(db_alias).all().delete()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('certificates', '0002_auto_20151022_1336'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards)
+    ]


### PR DESCRIPTION
This convert following data migrations:
- [dark_lang_config](https://github.com/edx/edx-platform/blob/062e979e0ed14161d0f882091a06e032ca76bb3e/common/djangoapps/dark_lang/migrations/0002_enable_on_install.py)
- [embargo_country](https://github.com/edx/edx-platform/blob/062e979e0ed14161d0f882091a06e032ca76bb3e/common/djangoapps/embargo/migrations/0003_add_countries.py)
- [CertificateHtmlViewConfiguration](https://github.com/edx/edx-platform/blob/69c47e09511c0fda4762dc959a6a3025dc96f272/lms/djangoapps/certificates/migrations/0020_certificatehtmlviewconfiguration_data.py)
