### PR TITLE
Revert disable check button on save

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -538,19 +538,6 @@ describe 'Problem', ->
       runs ->
         expect(window.SR.readElts).toHaveBeenCalled()
 
-    it 'disables check button while posting', ->
-      runs ->
-        spyOn($, 'postWithPrefix').andCallFake (url, answers, callback) -> callback(success: 'OK')
-        spyOn @problem, 'enableCheckButton'
-        @problem.save()
-        expect(@problem.enableCheckButton).toHaveBeenCalledWith false
-      waitsFor (->
-        return jQuery.active == 0
-      ), "jQuery requests finished", 1000
-
-      runs ->
-        expect(@problem.enableCheckButton).toHaveBeenCalledWith true
-
   describe 'refreshMath', ->
     beforeEach ->
       @problem = new Problem($('.xblock-student_view'))

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -412,13 +412,11 @@ class @Problem
       @save_internal()
 
   save_internal: =>
-    @enableCheckButton false
     Logger.log 'problem_save', @answers
     $.postWithPrefix "#{@url}/problem_save", @answers, (response) =>
       saveMessage = response.msg
       @gentle_alert saveMessage
       @updateProgress response
-      @enableCheckButton true
 
   refreshMath: (event, element) =>
     element = event.target unless element


### PR DESCRIPTION
@cahrens 
@sarina 
This PR reverts #10488 . That PR introduced a visual bug where the check button's text switched from "check" to "checking" while it was disabled: https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/js/src/capa/display.coffee#L688

The reason I'm reverting this instead of fixing it is that it looks like there could be a potential race condition with any of these buttons. Really, whenever we click one of these buttons, all of the buttons should be disabled until after the ajax call goes through.

I'm going to add this information to the original ticket: https://openedx.atlassian.net/browse/TNL-3477.

@stvstnfrd , @caesar2164 , FYIs. Thank you for raising the original issue; heads up that there's a visual bug in the original fix.

@jcdyer 
