### PR TITLE
Fix gettext guidance violation

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/combinedopenended/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/combinedopenended/display.coffee
@@ -325,7 +325,7 @@ class @CombinedOpenEnded
         @submit_button.hide()
         @queueing()
         @grader_status = @$(@grader_status_sel)
-        @grader_status.html("<span class='grading'>" + gettext "Your response has been submitted. Please check back later for your grade." + "</span>")
+        @grader_status.html("<span class='grading'>" + (gettext "Your response has been submitted. Please check back later for your grade.") + "</span>")
       else if @child_type == "selfassessment"
         @setup_score_selection()
     else if @child_state == 'post_assessment'

--- a/lms/static/js/student_account/views/account_settings_fields.js
+++ b/lms/static/js/student_account/views/account_settings_fields.js
@@ -11,8 +11,8 @@
             successMessage: function() {
                 return this.indicators.success + interpolate_text(
                     gettext(
-                        'We\'ve sent a confirmation message to {new_email_address}. ' +
-                        'Click the link in the message to update your email address.'
+                        /* jshint maxlen: false */
+                        'We\'ve sent a confirmation message to {new_email_address}. Click the link in the message to update your email address.'
                     ),
                     {'new_email_address': this.fieldValue()}
                 );
@@ -79,8 +79,8 @@
             successMessage: function () {
                 return this.indicators.success + interpolate_text(
                     gettext(
-                        'We\'ve sent a message to {email_address}. ' +
-                        'Click the link in the message to reset your password.'
+                        /* jshint maxlen: false */
+                        'We\'ve sent a message to {email_address}. Click the link in the message to reset your password.'
                     ),
                     {'email_address': this.model.get(this.options.emailAttribute)}
                 );


### PR DESCRIPTION
1. No string concatenation should be used in the gettext function.
2. Some extra parentheses should be used in coffee script, to avoid the following situation: in coffee script, the call `gettext "text to be extracted" + "text should not be extracted"` will be translated into `gettext("text to be extracted" + "text should not be extracted")` rather than `gettext("text to be extracted") + "text should not be extracted"`.
