### PR TITLE
Updates the example locations to split format

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -54,7 +54,7 @@
 
   ## Translators: A location (string of text) follows this sentence.
   <p>${_("You must provide the complete location of the problem. In the Staff Debug viewer, the location looks like this:")}<br/>
-  <code>i4x://edX/Open_DemoX/problem/78c98390884243b89f6023745231c525</code></p>
+  <code>block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378</code></p>
 
   <p>
   ${_("Next, select an action to perform for the given user and problem:")}
@@ -141,7 +141,7 @@
     </label>
     ## Translators: A location (string of text) follows this sentence.
     <p id="problem-select-all-help">${_("You must provide the complete location of the problem. In the Staff Debug viewer, the location looks like this:")}<br/>
-    <code>i4x://edX/Open_DemoX/problem/78c98390884243b89f6023745231c525</code></p>
+    <code>block-v1:edX+DemoX+2015+type@problem+block@618c5933b8b544e4a4cc103d3e508378</code></p>
     <p>
       ${_("Then select an action")}:
       <input type="button" class="molly-guard" name="reset-attempts-all" value="${_("Reset ALL students' attempts")}" data-endpoint="${ section_data['reset_student_attempts_url'] }">


### PR DESCRIPTION
## [DOC-2329](https://openedx.atlassian.net/browse/DOC-2329)

Per @JAAkana ’s request, update the old style example of locations on the Instructor Dashboards to split format.
### Reviewers
- [x] Subject matter expert: @JAAkana 
- [x] Subject matter expert: @doctoryes 
- [x] Doc team review (sanity check): @srpearce 
- [x] Product review: @explorerleslie 
### Post-review
- [x] Squash commits
