### PR TITLE
Remove stray quotation mark from courseware-error text.

### DIFF
--- a/lms/templates/courseware/courseware-error.html
+++ b/lms/templates/courseware/courseware-error.html
@@ -20,7 +20,7 @@
     </h1>
     <p>
       ${_("We're sorry, this module is temporarily unavailable. Our staff is working to fix "
-      "it as soon as possible. Please email us at {tech_support_email}' to report any problems or downtime.").format(
+      "it as soon as possible. Please email us at {tech_support_email} to report any problems or downtime.").format(
       tech_support_email=u'<a href=\"mailto:{0}\">{0}</a>'.format(settings.TECH_SUPPORT_EMAIL)
       )}
     </p>


### PR DESCRIPTION
**Description**: This PR removes a stray single quotation mark (`'`) from the `courseware-error.html` template.
**Partner information**: 3rd party-hosted open edX instance
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-946

**Screenshot before**

![screen shot 2015-11-11 at 09 13 17](https://cloud.githubusercontent.com/assets/32585/11086820/1c6802a0-8855-11e5-9e0f-fc055e688876.png)

**Screenshot after**

![screen shot 2015-11-11 at 09 13 33](https://cloud.githubusercontent.com/assets/32585/11086821/222b1772-8855-11e5-9b01-23b3f88fa9ef.png)
