### PR TITLE
saleem-latif/SOL-1384: Refactor certificates bok-choy pages to use PageObject

### DIFF
--- a/common/test/acceptance/pages/studio/settings_certificates.py
+++ b/common/test/acceptance/pages/studio/settings_certificates.py
@@ -78,7 +78,7 @@ class CertificatesPage(CoursePage):
         Return list of the certificates for the course.
         """
         css = self.certficate_css + ' .wrapper-collection'
-        return [Certificate(self, self.certficate_css, index) for index in xrange(len(self.q(css=css)))]
+        return [CertificateSectionPage(self, self.certficate_css, index) for index in xrange(len(self.q(css=css)))]
 
     @property
     def no_certificates_message_shown(self):
@@ -171,15 +171,41 @@ class CertificatesPage(CoursePage):
         self.wait_for_ajax()
 
 
-class Certificate(object):
+class CertificateSectionPage(CertificatesPage):
     """
-    Certificate page object wrapper
+    CertificateSectionPage is the certificate section within Certificates page, There might be multiple certificates
+    in a Certificates Page so this section object can be used to used to identify unique certificate and apply
+    operations on it.
     """
 
-    def __init__(self, page, prefix, index):
-        self.page = page
+    def __init__(self, container, prefix, index):
+        """
+        Initialize CertificateSection Page
+
+        :param container: Container Page Object of the certificate section
+        :param prefix: css selector of the container element
+        :param index: index of section in the certificate list on the page
+
+        :return:
+        """
         self.selector = prefix + ' .certificates-list-item-{}'.format(index)
         self.index = index
+
+        super(CertificateSectionPage, self).__init__(container.browser, **container.course_info)
+
+    def is_browser_on_page(self):
+        """
+        Verify that the browser is on the page and it is not still loading.
+        """
+        return self.q(css=".certificates").present
+
+    @property
+    def url(self):
+        """
+        Construct a URL to the page section within the certificate page.
+        """
+        # This is a page section and can not be accessed directly
+        return None
 
     ################
     # Helpers
@@ -195,7 +221,7 @@ class Certificate(object):
         """
         Find elements as defined by css locator.
         """
-        return self.page.q(css=self.get_selector(css=css_selector))
+        return self.q(css=self.get_selector(css=css_selector))
 
     def get_text(self, css):
         """
@@ -280,7 +306,7 @@ class Certificate(object):
         Return list of the signatories for the certificate.
         """
         css = self.selector + ' .signatory-' + self.mode
-        return [Signatory(self, self.selector, self.mode, index) for index in xrange(len(self.page.q(css=css)))]
+        return [SignatorySectionPage(self, self.selector, self.mode, index) for index in xrange(len(self.q(css=css)))]
 
     ################
     # Wait Actions
@@ -312,16 +338,16 @@ class Certificate(object):
         """
         Create a new certificate.
         """
-        disable_animations(self.page)
+        disable_animations(self)
         self.find_css('.action-primary').first.click()
-        self.page.wait_for_ajax()
+        self.wait_for_ajax()
 
     def click_save_certificate_button(self):
         """
         Save certificate.
         """
         self.find_css('.action-primary').first.click()
-        self.page.wait_for_ajax()
+        self.wait_for_ajax()
 
     def click_add_signatory_button(self):
         """
@@ -355,15 +381,42 @@ class Certificate(object):
         self.find_css('.actions .delete.action-icon').first.click()
 
 
-class Signatory(object):
+class SignatorySectionPage(CertificatesPage):
     """
-    Signatory page object wrapper
+    SignatorySectionPage is the signatory section within CertificatesSection, There might be multiple signatories
+    in a certificate section so this section object can be used to used to identify unique section and apply
+    operations on it.
     """
-    def __init__(self, certificate, prefix, mode, index):
-        self.certificate = certificate
+    def __init__(self, container, prefix, mode, index):
+        """
+        Initialize SignatorySection Page
+
+        :param container: Container Section Page Object of the Signatory section
+        :param prefix: css selector of the container element
+        :param index: index of section in the signatory list on the page
+        :param mode: 'details' or 'edit', showing whether signatory is being displayed or edited
+
+        :return:
+        """
         self.prefix = prefix
         self.index = index
         self.mode = mode
+
+        super(SignatorySectionPage, self).__init__(container.browser, **container.course_info)
+
+    def is_browser_on_page(self):
+        """
+        Verify that the browser is on the page and it is not still loading.
+        """
+        return self.q(css=self.prefix + " .signatory-details-list, .signatory-edit-list").present
+
+    @property
+    def url(self):
+        """
+        Construct a URL to the page section within the certificate section page.
+        """
+        # This is a page section and can not be accessed directly
+        return None
 
     ################
     # Helpers
@@ -392,7 +445,7 @@ class Signatory(object):
         """
         Find elements as defined by css locator.
         """
-        return self.certificate.page.q(css=self.get_selector(css=css_selector))
+        return self.q(css=self.get_selector(css=css_selector))
 
     ################
     # Properties
@@ -461,24 +514,24 @@ class Signatory(object):
         self.click_signatory_delete_icon()
         self.wait_for_signatory_delete_prompt()
 
-        self.certificate.page.q(css='#prompt-warning a.button.action-primary').first.click()
-        self.certificate.page.wait_for_ajax()
+        self.q(css='#prompt-warning a.button.action-primary').first.click()
+        self.wait_for_ajax()
 
     def save(self):
         """
         Save signatory.
         """
         # Click on the save button.
-        self.certificate.page.q(css='button.signatory-panel-save').click()
+        self.q(css='button.signatory-panel-save').click()
         self.mode = 'details'
-        self.certificate.page.wait_for_ajax()
+        self.wait_for_ajax()
         self.wait_for_signatory_detail_view()
 
     def close(self):
         """
         Cancel signatory editing.
         """
-        self.certificate.page.q(css='button.signatory-panel-close').click()
+        self.q(css='button.signatory-panel-close').click()
         self.mode = 'details'
         self.wait_for_signatory_detail_view()
 
@@ -491,20 +544,20 @@ class Signatory(object):
         self.wait_for_signature_image_upload_prompt()
 
         asset_file_path = self.file_path(image_filename)
-        self.certificate.page.q(
+        self.q(
             css='.assetupload-modal .upload-dialog input[type="file"]'
         )[0].send_keys(asset_file_path)
 
         EmptyPromise(
-            lambda: not self.certificate.page.q(
+            lambda: not self.q(
                 css='.assetupload-modal a.action-upload.disabled'
             ).present,
             'Upload button is not disabled anymore'
         ).fulfill()
 
-        self.certificate.page.q(css='.assetupload-modal a.action-upload').first.click()
+        self.q(css='.assetupload-modal a.action-upload').first.click()
         EmptyPromise(
-            lambda: not self.certificate.page.q(css='.assetupload-modal .upload-dialog').visible,
+            lambda: not self.q(css='.assetupload-modal .upload-dialog').visible,
             'Upload dialog is removed after uploading image'
         ).fulfill()
 
@@ -518,7 +571,7 @@ class Signatory(object):
         Returns whether or not the delete icon is present.
         """
         EmptyPromise(
-            lambda: self.certificate.page.q(css='.signatory-panel-delete').present,
+            lambda: self.q(css='.signatory-panel-delete').present,
             'Delete icon is displayed'
         ).fulfill()
 
@@ -527,7 +580,7 @@ class Signatory(object):
         Promise to wait until signatory delete prompt is visible
         """
         EmptyPromise(
-            lambda: self.certificate.page.q(css='a.button.action-primary').present,
+            lambda: self.q(css='a.button.action-primary').present,
             'Delete prompt is displayed'
         ).fulfill()
 
@@ -554,7 +607,7 @@ class Signatory(object):
         Promise to wait until signatory image upload prompt is visible
         """
         EmptyPromise(
-            lambda: self.certificate.page.q(css='.assetupload-modal .action-upload').present,
+            lambda: self.q(css='.assetupload-modal .action-upload').present,
             'Signature image upload dialog opened'
         ).fulfill()
 
@@ -563,7 +616,7 @@ class Signatory(object):
         Promise to wait until signatory image upload button is visible
         """
         EmptyPromise(
-            lambda: self.certificate.page.q(css=".action-upload-signature").first.present,
+            lambda: self.q(css=".action-upload-signature").first.present,
             'Signature image upload button available'
         ).fulfill()
 
@@ -573,7 +626,7 @@ class Signatory(object):
         Promise for the signature image to be displayed
         """
         EmptyPromise(
-            lambda: self.certificate.page.q(css=".current-signature-image .signature-image").present,
+            lambda: self.q(css=".current-signature-image .signature-image").present,
             'Signature image available'
         ).fulfill()
 


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR, it contains changes for [SOL-1384](https://openedx.atlassian.net/browse/SOL-1384):

**Description of [SOL-1384](https://openedx.atlassian.net/browse/SOL-1384):**
The pages defined in `common/test/acceptance/pages/studio/settings_certificates.py` include page objects that are declared as python objects. (For example, the **Certificate** class is defined as just an object, but the docstring and the things that are done on it are **PageObject** functions)
This organization makes it difficult to extend and maintain. (It also makes it difficult to troubleshoot if, for example, someone wants to use the Browser object in a testcase that is looping over an Object rather than a **PageObject**).
The Certificate and Signatory objects can be declared as PageObjects that more-easily inherit all the methods, rather than re-declaring them with things like `self.page = page`.

cc: @mattdrayer 
