### PR TITLE
saleem-latif/SOL-1387: Custom 500 error message should only be seen for Preview

### DIFF
--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -56,13 +56,18 @@ def jsonable_server_error(request, template_name='500.html'):
         return server_error(request, template_name=template_name)
 
 
-def handle_500(template_path, context=None):
+def handle_500(template_path, context=None, test_func=None):
     """
     Decorator for view specific 500 error handling.
+    Custom handling will be skipped only if test_func is passed and it returns False
 
-    Usage::
+    Usage:
 
-        @handle_500(template_path='certificates/server-error.html', context={'error-info': 'Internal Server Error'})
+        @handle_500(
+            template_path='certificates/server-error.html',
+            context={'error-info': 'Internal Server Error'},
+            test_func=lambda request: request.GET.get('preview', None)
+        )
         def my_view(request):
             # Any unhandled exception in this view would be handled by the handle_500 decorator
             # ...
@@ -83,9 +88,15 @@ def handle_500(template_path, context=None):
                 if settings.DEBUG:
                     # In debug mode let django process the 500 errors and display debug info for the developer
                     raise
-                else:
+                elif test_func is None or test_func(request):
+                    # Display custom 500 page if either
+                    #   1. test_func is None (meaning nothing to test)
+                    #   2. or test_func(request) returns True
                     log.exception("Error in django view.")
                     return render_to_response(template_path, context)
+                else:
+                    # Do not show custom 500 error when test fails
+                    raise
         return inner
     return decorator
 

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -454,8 +454,12 @@ class CertificatesViewsTests(ModuleStoreTestCase, EventTrackingTestCase):
             user_id=self.user.id,
             course_id=unicode(self.course.id)
         )
-        response = self.client.get(test_url)
+        response = self.client.get(test_url + "?preview=honor")
         self.assertIn("Invalid Certificate Configuration", response.content)
+
+        # Verify that Exception is raised when certificate is not in the preview mode
+        with self.assertRaises(Exception):
+            self.client.get(test_url)
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_certificate_evidence_event_emitted(self):

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -281,7 +281,10 @@ def _update_certificate_context(context, course, user, user_certificate):
     )
 
 
-@handle_500(template_path="certificates/server-error.html")
+@handle_500(
+    template_path="certificates/server-error.html",
+    test_func=lambda request: request.GET.get('preview', None)
+)
 def render_html_view(request, user_id, course_id):
     """
     This public view generates an HTML representation of the specified student's certificate


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR, it contains changes for [SOL-1387](https://openedx.atlassian.net/browse/SOL-1387):

**Description of [SOL-1387](https://openedx.atlassian.net/browse/SOL-1387):**

**Background**
We updated the 500 error message that course teams and PMs see when they attempt to preview a Certificate that has not been set up properly in [SOL-1297](https://openedx.atlassian.net/browse/SOL-1297) This message is great. HOWEVER, we have found that the same updated 500 error message can be seen by students when the certificate is not set up correctly.
**Acceptance Criteria**
The custom 500 error message should only be seen when triggered through the Studio Preview. All other 500 error messages should be the generic copy

cc: @mattdrayer 
