### PR TITLE
More-correct data migrations

### DIFF
--- a/common/djangoapps/dark_lang/migrations/0002_data__enable_on_install.py
+++ b/common/djangoapps/dark_lang/migrations/0002_data__enable_on_install.py
@@ -11,11 +11,12 @@ def create_dark_lang_config(apps, schema_editor):
     Enable DarkLang by default when it is installed, to prevent accidental
     release of testing languages.
     """
-    dark_lang_model = apps.get_model("dark_lang", "DarkLangConfig")
+    DarkLangConfig = apps.get_model("dark_lang", "DarkLangConfig")
     db_alias = schema_editor.connection.alias
 
-    if not dark_lang_model.objects.using(db_alias).exists():
-        dark_lang_model.objects.using(db_alias).create(enabled=True)
+    objects = DarkLangConfig.objects.using(db_alias)
+    if not objects.exists():
+        objects.create(enabled=True)
 
 def remove_dark_lang_config(apps, schema_editor):
     """Write your backwards methods here."""

--- a/common/djangoapps/util/migrations/0002_data__default_rate_limit_config.py
+++ b/common/djangoapps/util/migrations/0002_data__default_rate_limit_config.py
@@ -8,9 +8,12 @@ from django.db import migrations, models
 
 def forwards(apps, schema_editor):
     """Ensure that rate limiting is enabled by default. """
-    rate_limit_configuration_model = apps.get_model("util", "RateLimitConfiguration")
+    RateLimitConfiguration = apps.get_model("util", "RateLimitConfiguration")
     db_alias = schema_editor.connection.alias
-    rate_limit_configuration_model.objects.using(db_alias).get_or_create(enabled=True)
+    objects = RateLimitConfiguration.objects.using(db_alias)
+    if not objects.exists():
+        objects.create(enabled=True)
+
 
 class Migration(migrations.Migration):
 

--- a/lms/djangoapps/certificates/migrations/0003_data__default_modes.py
+++ b/lms/djangoapps/certificates/migrations/0003_data__default_modes.py
@@ -9,11 +9,13 @@ from django.core.files import File
 
 def forwards(apps, schema_editor):
     """Add default modes"""
-    badge_image_configuration_model = apps.get_model("certificates", "BadgeImageConfiguration")
+    BadgeImageConfiguration = apps.get_model("certificates", "BadgeImageConfiguration")
+    db_alias = schema_editor.connection.alias
 
-    for mode in ['honor', 'verified', 'professional']:
-        conf, created = badge_image_configuration_model.objects.get_or_create(mode=mode)
-        if created:
+    objects = BadgeImageConfiguration.objects.using(db_alias)
+    if not objects.exists():
+        for mode in ['honor', 'verified', 'professional']:
+            conf = objects.create(mode=mode)
             file_name = '{0}{1}'.format(mode, '.png')
             conf.icon.save(
                 'badges/{}'.format(file_name),


### PR DESCRIPTION
We need to be sure the migrations will work even in the presence of data
from the future.  get_or_create is a problem, because if the data
already exists, there could be more than one record, even if this
migration only creates one.
