### PR TITLE
Percent-based padding on course-content  

### DIFF
--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -100,7 +100,7 @@ div.course-wrapper {
 
   section.course-content {
     @extend .content;
-    padding: ($baseline*2);
+    padding: ($baseline*2) 3%; // percent allows for smaller padding on mobile
     line-height: 1.6;
     h1 {
       margin: 0 0 lh();


### PR DESCRIPTION
This PR switches course-content to use percent padding on the sides instead of fixed pixel padding to help mobile have less relative padding. Addresses [UX-2985](https://openedx.atlassian.net/browse/UX-2985) and [MA-1619](https://openedx.atlassian.net/browse/MA-1619)

SANDBOX: 
https://frrrances.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/19a30717eff543078a5d94ae9d6c18a5/

REVIEWERS: 
- [x] @aleffert 
- [x] @talbs 
