### PR TITLE
Disable wiki notifications

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1887,7 +1887,10 @@ INSTALLED_APPS = (
     'sekizai',
     #'wiki.plugins.attachments',
     'wiki.plugins.links',
-    'wiki.plugins.notifications',
+    # Notifications were enabled, but only 11 people used it in three years. It
+    # got tangled up during the Django 1.8 migration, so we are disabling it.
+    # See TNL-3783 for details.
+    #'wiki.plugins.notifications',
     'course_wiki.plugins.markdownedx',
 
     # Foldit integration


### PR DESCRIPTION
This is an expedient fix to a problem with migrations during the Django
1.8 upgrade.
