### PR TITLE
Add signatory limit help text

### DIFF
--- a/cms/static/sass/views/_certificates.scss
+++ b/cms/static/sass/views/_certificates.scss
@@ -33,17 +33,30 @@
       @extend %no-content;
     }
 
-    .wrapper-certificate {
+    .wrapper-certificates {
 
       .title {
         @extend %t-title4;
         @extend %t-strong;
-        margin-bottom: ($baseline/2);
       }
 
       .copy {
         @extend %t-copy-sub1;
       }
+
+      .instructions {
+        @extend %t-copy-sub1;
+        margin-bottom: $baseline;
+      }
+    }
+
+    .certificate-settings {
+      margin-bottom: $baseline;
+    }
+
+    .actual-course-title {
+      @extend %t-strong;
+      margin-bottom: $baseline;
     }
   }
 
@@ -205,6 +218,10 @@
 
       .wrapper-form {
         padding: $baseline ($baseline*1.5);
+
+        label {
+          @extend %t-strong;
+        }
       }
 
       .action-add-signatory {

--- a/cms/templates/js/certificate-details.underscore
+++ b/cms/templates/js/certificate-details.underscore
@@ -13,42 +13,48 @@
         </li>
      <% } %>
      <% if (showDetails) { %>
-         <header>
-           <span class="title"><%= gettext("Certificate Details") %></span>
-         </header>
-         <div class='certificate-info-section'>
-             <div class='course-title-section pull-left'>
-                <div class="actual-course-title">
-                        <span class="certificate-label"><b><%= gettext('Course Title') %>: </b> </span>
-                        <span class="certificate-value"><%= course.get('name') %></span>
-                </div>
-                <% if (course_title) { %>
-                    <div class="course-title-override">
-                        <span class="certificate-label"><b><%= gettext('Course Title Override') %>: </b></span>
-                        <span class="certificate-value"><%= course_title %></span>
-                    </div>
-                <% } %>
-             </div>
+         <section class="certificate-settings course-details">
+             <header>
+               <h2 class="title title-2"><%= gettext("Certificate Details") %></h2>
+             </header>
+             <div class='certificate-info-section'>
+                 <div class='course-title-section pull-left'>
+                    <p class="actual-course-title">
+                            <span class="certificate-label"><%= gettext('Course Title') %>: </span>
+                            <span class="certificate-value"><%= course.get('name') %></span>
+                    </p>
+                    <% if (course_title) { %>
+                        <p class="course-title-override">
+                            <span class="certificate-label"><b><%= gettext('Course Title Override') %>: </b></span>
+                            <span class="certificate-value"><%= course_title %></span>
+                        </p>
+                    <% } %>
+                 </div>
 
-            <div class='course-number-section pull-left'>
-                <div class="actual-course-number">
-                        <span class="certificate-label"><b><%= gettext('Course Number') %>: </b> </span>
-                        <span class="certificate-value"><%= course.get('num') %></span>
-                </div>
+                <div class='course-number-section pull-left'>
+                    <p class="actual-course-number">
+                            <span class="certificate-label"><b><%= gettext('Course Number') %>: </b> </span>
+                            <span class="certificate-value"><%= course.get('num') %></span>
+                    </p>
 
-                <% if (course.get('display_course_number')) { %>
-                    <div class="course-number-override">
-                        <span class="certificate-label"><b><%= gettext('Course Number Override') %>: </b></span>
-                        <span class="certificate-value"><%= course.get('display_course_number') %></span>
-                    </div>
-                <% } %>
+                    <% if (course.get('display_course_number')) { %>
+                        <p class="course-number-override">
+                            <span class="certificate-label"><b><%= gettext('Course Number Override') %>: </b></span>
+                            <span class="certificate-value"><%= course.get('display_course_number') %></span>
+                        </p>
+                    <% } %>
+                </div>
             </div>
-        </div>
+        </section>
 
-         <header style='margin-top: 30px;'>
-           <span class="title"><%= gettext("Certificate Signatories") %></span>
-         </header>
-         <div class="signatory-details-list"></div>
+
+        <section class="certificate-settings signatories">
+             <header>
+               <h2 class="title title-2"><%= gettext("Certificate Signatories") %></h2>
+             </header>
+             <p class="instructions">It is strongly recommended that you include four or fewer signatories. If you include additional signatories, preview the certificate in Print View to ensure the certificate will print correctly on one page.</p>
+             <div class="signatory-details-list"></div>
+        </section>
     <% } %>
    </ol>
 

--- a/cms/templates/js/certificate-editor.underscore
+++ b/cms/templates/js/certificate-editor.underscore
@@ -19,8 +19,11 @@
                 <textarea id="certificate-description-<%= uniqueId %>" class="certificate-description-input text input-text" name="certificate-description" placeholder="<%= gettext("Description of the certificate") %>" aria-describedby="certificate-description-<%=uniqueId %>-tip"><%= description %></textarea>
                 <span id="certificate-description-<%= uniqueId %>-tip" class="tip tip-stacked"><%= gettext("Description of the certificate") %></span>
             </div>
-            <div class="field text actual-course-title">
-                <label class="actual-course-title"><b><%= gettext("Course Title") %></b></label>
+            <header>
+              <h2 class="title title-2"><%= gettext("Certificate Details") %></h2>
+            </header>
+            <div class="actual-course-title">
+                <span class="actual-course-title"><%= gettext("Course Title") %>: </span>
                 <span class="actual-title"><%= course.get('name') %></span>
             </div>
             <div class="input-wrap field text add-certificate-course-title">
@@ -30,8 +33,9 @@
             </div>
         </fieldset>
          <header>
-            <span class="title"><%= gettext("Certificate Signatories") %></legend>
+            <h2 class="title title-2"><%= gettext("Certificate Signatories") %></h2>
          </header>
+         <p class="instructions">It is strongly recommended that you include four or fewer signatories. If you include additional signatories, preview the certificate in Print View to ensure the certificate will print correctly on one page.</p>
         <div class="signatory-edit-list"> </div>
         <span>
            <button class="action action-add-signatory" type="button"><%= gettext("Add Additional Signatory") %></button>


### PR DESCRIPTION
This PR adds signatory limit help text to the Certificates page and adds some visual and semantic cleanup (though more would be nice). 

Below are screenshots of the before and after edit and view of the Certificates page in Studio.

BEFORE:
![screen shot 2015-12-02 at 10 14 20 am](https://cloud.githubusercontent.com/assets/4327102/11534597/7946854e-98dd-11e5-9625-a4d560447a76.png)

![screen shot 2015-12-02 at 10 14 09 am](https://cloud.githubusercontent.com/assets/4327102/11534603/7c5871de-98dd-11e5-9c22-4bd68627ba77.png)

AFTER:
![screen shot 2015-11-30 at 1 40 29 pm](https://cloud.githubusercontent.com/assets/4327102/11534567/5c13d774-98dd-11e5-94dc-8aed392c7e62.png)

![screen shot 2015-11-30 at 1 55 48 pm](https://cloud.githubusercontent.com/assets/4327102/11534572/60718f78-98dd-11e5-9c3b-075a974f337e.png)

REVIEW:
- [x] @talbs 
- [x] @mattdrayer 

NOTE: The test failure is a known flaky test and is unrelated.
