### PR TITLE
asadiqbal08/SOL-1388

### DIFF
--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -35,7 +35,7 @@ var CourseDetails = Backbone.Model.extend({
         if (newattrs.start_date === null) {
             errors.start_date = gettext("The course must have an assigned start date.");
         }
-        if (this.hasChanged("start_date") && this.get("has_cert_config") === false){
+        if (this.get("has_cert_config") === false){
             errors.start_date = gettext("The course must have at least one active certificate configuration before it can be started.");
         }
         if (newattrs.start_date && newattrs.end_date && newattrs.start_date >= newattrs.end_date) {

--- a/cms/static/js/spec/views/settings/main_spec.js
+++ b/cms/static/js/spec/views/settings/main_spec.js
@@ -32,7 +32,7 @@ define([
                 entrance_exam_minimum_score_pct: '50',
                 license: null,
                 language: '',
-                has_cert_config: false
+                has_cert_config: null
             },
             mockSettingsPage = readFixtures('mock/mock-settings-page.underscore');
 
@@ -73,10 +73,32 @@ define([
         });
 
         it('Changing course start date without active certificate configuration should result in error', function () {
+            this.model.set({'has_cert_config': false});
             this.view.$el.find('#course-start-date')
                 .val('10/06/2014')
                 .trigger('change');
-            expect(this.view.$el.find('span.message-error').text()).toContain("course must have at least one active certificate configuration");
+            expect(this.view.$el.find('span.message-error').text()).toContain("course must have at least one " +
+                "active certificate configuration");
+        });
+
+         it('Changing course end date without active certificate configuration should result in error', function () {
+            this.model.set({'has_cert_config': false});
+            this.view.$el.find('#course-end-date')
+                .val('10/06/2015')
+                .trigger('change');
+            expect(this.view.$el.find('span.message-error').text()).toContain("course must have at least one " +
+                "active certificate configuration");
+
+        });
+
+        it('Changing course start date with active certificate configuration should not result in error', function () {
+            this.model.set({'has_cert_config': true});
+            this.view.$el.find('#course-start-date')
+                .val('10/06/2014')
+                .trigger('change');
+            expect(this.view.$el.find('span.message-error').text()).not.toContain("course must have at least one " +
+                "active certificate configuration");
+
         });
 
         it('Selecting a course in pre-requisite drop down should save it as part of course details', function () {


### PR DESCRIPTION
###### [Course admin should not be allow to save start date until at least web certificate is active](https://openedx.atlassian.net/browse/SOL-1388)

When course admin enter course start date, an error message appear "The course must have at least one active certificate configuration" and save button is disabled but when user enter course end date or enter information in any other field on schedule and detail page , save button becomes enable and course start date is saved on pressing of save button.

@ziafazal please review it.
@mattdrayer 
