### PR TITLE
Ahsan/ecom 2678 reverse rename courseware course info tabs

### DIFF
--- a/cms/djangoapps/contentstore/features/pages.py
+++ b/cms/djangoapps/contentstore/features/pages.py
@@ -98,25 +98,25 @@ def _verify_page_names(first, second):
 
 @step(u'the built-in pages are in the default order$')
 def built_in_pages_in_default_order(step):
-    expected_pages = ['Courseware', 'Course Info', 'Wiki', 'Progress']
+    expected_pages = ['Home', 'Course', 'Wiki', 'Progress']
     see_pages_in_expected_order(expected_pages)
 
 
 @step(u'the built-in pages are switched$')
 def built_in_pages_switched(step):
-    expected_pages = ['Courseware', 'Course Info', 'Progress', 'Wiki']
+    expected_pages = ['Home', 'Course', 'Progress', 'Wiki']
     see_pages_in_expected_order(expected_pages)
 
 
 @step(u'the pages are in the default order$')
 def pages_in_default_order(step):
-    expected_pages = ['Courseware', 'Course Info', 'Wiki', 'Progress', 'First', 'Empty']
+    expected_pages = ['Home', 'Course', 'Wiki', 'Progress', 'First', 'Empty']
     see_pages_in_expected_order(expected_pages)
 
 
 @step(u'the pages are switched$$')
 def pages_are_switched(step):
-    expected_pages = ['Courseware', 'Course Info', 'Progress', 'First', 'Empty', 'Wiki']
+    expected_pages = ['Home', 'Course', 'Progress', 'First', 'Empty', 'Wiki']
     see_pages_in_expected_order(expected_pages)
 
 

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -1054,8 +1054,8 @@ class CourseMetadataEditingTest(CourseTestCase):
             self.assertNotIn("notes", course.advanced_modules)
 
     @ddt.data(
-        [{'type': 'courseware'}, {'type': 'course_info'}, {'type': 'wiki', 'is_hidden': True}],
-        [{'type': 'courseware', 'name': 'Courses'}, {'type': 'course_info', 'name': 'Info'}],
+        [{'type': 'course_info'}, {'type': 'courseware'}, {'type': 'wiki', 'is_hidden': True}],
+        [{'type': 'course_info', 'name': 'Home'}, {'type': 'courseware', 'name': 'Course'}],
     )
     def test_course_tab_configurations(self, tab_list):
         self.course.tabs = tab_list

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -620,9 +620,9 @@ class CourseFields(object):
         ],
     )
     info_sidebar_name = String(
-        display_name=_("Course Info Sidebar Name"),
+        display_name=_("Course Home Sidebar Name"),
         help=_(
-            "Enter the heading that you want students to see above your course handouts on the Course Info page. "
+            "Enter the heading that you want students to see above your course handouts on the Course Home page. "
             "Your course handouts appear in the right panel of the page."
         ),
         scope=Scope.settings, default='Course Handouts')

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -305,8 +305,8 @@ class CourseTabList(List):
         """
 
         course.tabs.extend([
-            CourseTab.load('courseware'),
-            CourseTab.load('course_info')
+            CourseTab.load('course_info'),
+            CourseTab.load('courseware')
         ])
 
         # Presence of syllabus tab is indicated by a course attribute
@@ -390,6 +390,19 @@ class CourseTabList(List):
                     yield tab
 
     @classmethod
+    def upgrade_tabs(cls, tabs):
+        """
+        Reverse and Rename Courseware to Course and Course Info to Home Tabs.
+        """
+        if tabs and len(tabs) > 1:
+            if tabs[0].get('type') == 'courseware' and tabs[1].get('type') == 'course_info':
+                tabs[0], tabs[1] = tabs[1], tabs[0]
+                tabs[0]['name'] = _('Home')
+                tabs[1]['name'] = _('Course')
+
+        return tabs
+
+    @classmethod
     def validate_tabs(cls, tabs):
         """
         Check that the tabs set for the specified course is valid.  If it
@@ -406,13 +419,13 @@ class CourseTabList(List):
         if len(tabs) < 2:
             raise InvalidTabsException("Expected at least two tabs.  tabs: '{0}'".format(tabs))
 
-        if tabs[0].get('type') != 'courseware':
+        if tabs[0].get('type') != 'course_info':
             raise InvalidTabsException(
-                "Expected first tab to have type 'courseware'.  tabs: '{0}'".format(tabs))
+                "Expected first tab to have type 'course_info'.  tabs: '{0}'".format(tabs))
 
-        if tabs[1].get('type') != 'course_info':
+        if tabs[1].get('type') != 'courseware':
             raise InvalidTabsException(
-                "Expected second tab to have type 'course_info'.  tabs: '{0}'".format(tabs))
+                "Expected second tab to have type 'courseware'.  tabs: '{0}'".format(tabs))
 
         # the following tabs should appear only once
         # TODO: don't import openedx capabilities from common
@@ -455,6 +468,7 @@ class CourseTabList(List):
         """
         Overrides the from_json method to de-serialize the CourseTab objects from a json-like representation.
         """
+        self.upgrade_tabs(values)
         self.validate_tabs(values)
         tabs = []
         for tab_dict in values:

--- a/common/test/acceptance/pages/lms/tab_nav.py
+++ b/common/test/acceptance/pages/lms/tab_nav.py
@@ -21,7 +21,7 @@ class TabNavPage(PageObject):
         Navigate to the tab `tab_name`.
         """
 
-        if tab_name not in ['Courseware', 'Course Info', 'Discussion', 'Wiki', 'Progress']:
+        if tab_name not in ['Course', 'Home', 'Discussion', 'Wiki', 'Progress']:
             self.warning("'{0}' is not a valid tab name".format(tab_name))
 
         # The only identifier for individual tabs is the link href

--- a/common/test/acceptance/tests/lms/test_certificate_web_view.py
+++ b/common/test/acceptance/tests/lms/test_certificate_web_view.py
@@ -206,7 +206,7 @@ class CertificateProgressPageTest(UniqueCourseTest):
         Problems were added in the setUp
         """
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
 
         # Navigate to Test Subsection in Test Section Section
         self.course_nav.go_to_section('Test Section', 'Test Subsection')

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -592,7 +592,7 @@ class HighLevelTabTest(UniqueCourseTest):
 
         # Navigate to the course info page from the progress page
         self.progress_page.visit()
-        self.tab_nav.go_to_tab('Course Info')
+        self.tab_nav.go_to_tab('Home')
 
         # Expect just one update
         self.assertEqual(self.course_info_page.num_updates, 1)
@@ -650,13 +650,13 @@ class HighLevelTabTest(UniqueCourseTest):
 
     def test_courseware_nav(self):
         """
-        Navigate to a particular unit in the courseware.
+        Navigate to a particular unit in the course.
         """
-        # Navigate to the courseware page from the info page
+        # Navigate to the course page from the info page
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
 
-        # Check that the courseware navigation appears correctly
+        # Check that the course navigation appears correctly
         EXPECTED_SECTIONS = {
             'Test Section': ['Test Subsection'],
             'Test Section 2': ['Test Subsection 2', 'Test Subsection 3']
@@ -723,7 +723,7 @@ class PDFTextBooksTabTest(UniqueCourseTest):
 @attr('shard_1')
 class VideoTest(UniqueCourseTest):
     """
-    Navigate to a video in the courseware and play it.
+    Navigate to a video in the course and play it.
     """
     def setUp(self):
         """
@@ -755,12 +755,12 @@ class VideoTest(UniqueCourseTest):
     @skip("BLD-563: Video Player Stuck on Pause")
     def test_video_player(self):
         """
-        Play a video in the courseware.
+        Play a video in the course.
         """
 
         # Navigate to a video
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
 
         # The video should start off paused
         # Since the video hasn't loaded yet, it's elapsed time is 0
@@ -916,7 +916,7 @@ class TooltipTest(UniqueCourseTest):
         Verify that tooltips are displayed when you hover over the sequence nav bar.
         """
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
 
         self.assertTrue(self.courseware_page.tooltips_displayed())
 
@@ -1065,7 +1065,7 @@ class ProblemExecutionTest(UniqueCourseTest):
     def test_python_execution_in_problem(self):
         # Navigate to the problem page
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
         self.course_nav.go_to_section('Test Section', 'Test Subsection')
 
         problem_page = ProblemPage(self.browser)
@@ -1115,14 +1115,14 @@ class EntranceExamTest(UniqueCourseTest):
 
     def test_entrance_exam_section(self):
         """
-         Scenario: Any course that is enabled for an entrance exam, should have entrance exam chapter at courseware
+         Scenario: Any course that is enabled for an entrance exam, should have entrance exam chapter at course
          page.
-            Given that I am on the courseware page
-            When I view the courseware that has an entrance exam
+            Given that I am on the course page
+            When I view the course that has an entrance exam
             Then there should be an "Entrance Exam" chapter.'
         """
         entrance_exam_link_selector = '.accordion .course-navigation .chapter .group-heading'
-        # visit courseware page and make sure there is not entrance exam chapter.
+        # visit course page and make sure there is not entrance exam chapter.
         self.courseware_page.visit()
         self.courseware_page.wait_for_page()
         self.assertFalse(element_has_text(

--- a/common/test/acceptance/tests/lms/test_lms_acid_xblock.py
+++ b/common/test/acceptance/tests/lms/test_lms_acid_xblock.py
@@ -75,7 +75,7 @@ class XBlockAcidNoChildTest(XBlockAcidBase):
         """
 
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
 
         acid_block = AcidView(self.browser, '.xblock-student_view[data-block-type=acid]')
         self.validate_acid_block_view(acid_block)
@@ -119,7 +119,7 @@ class XBlockAcidChildTest(XBlockAcidBase):
         """
 
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
 
         acid_parent_block = AcidView(self.browser, '.xblock-student_view[data-block-type=acid_parent]')
         self.validate_acid_parent_block_view(acid_parent_block)
@@ -159,7 +159,7 @@ class XBlockAcidAsideTest(XBlockAcidBase):
         """
 
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
 
         acid_aside = AcidView(self.browser, '.xblock_asides-v1-student_view[data-block-type=acid_aside]')
         self.validate_acid_aside_view(acid_aside)

--- a/common/test/acceptance/tests/test_ora.py
+++ b/common/test/acceptance/tests/test_ora.py
@@ -111,7 +111,7 @@ class OpenResponseTest(UniqueCourseTest):
         # Log in and navigate to the essay problems
         self.auth_page.visit()
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
 
     def submit_essay(self, expected_assessment_type, expected_prompt):
         """
@@ -352,7 +352,7 @@ class PeerAssessmentTest(OpenResponseTest):
 
         # Need to reload the page to update the peer grading module
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
         self.course_nav.go_to_section('Test Section', 'Test Subsection')
 
         # Select the problem to calibrate

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -132,7 +132,7 @@ class VideoBaseTest(UniqueCourseTest):
         self.auth_page.visit()
         self.user_info = self.auth_page.user_info
         self.course_info_page.visit()
-        self.tab_nav.go_to_tab('Courseware')
+        self.tab_nav.go_to_tab('Course')
 
     def _navigate_to_courseware_video_and_render(self):
         """ Wait for the video player to render """

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -103,8 +103,8 @@ class WikiRedirectTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         """
         Ensure that the response has the course navigator.
         """
-        self.assertContains(resp, "Course Info")
-        self.assertContains(resp, "courseware")
+        self.assertContains(resp, "Home")
+        self.assertContains(resp, "Course")
 
     @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
     def test_course_navigator(self):

--- a/lms/djangoapps/courseware/features/navigation.feature
+++ b/lms/djangoapps/courseware/features/navigation.feature
@@ -24,5 +24,5 @@ Feature: LMS.Navigate Course
        Given I am viewing a course with multiple sections
        When I navigate to a section
         And I see the content of the section
-        And I return to the courseware
+        And I return to the course
         Then I see that I was most recently in the subsection

--- a/lms/djangoapps/courseware/features/navigation.py
+++ b/lms/djangoapps/courseware/features/navigation.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
 
 from lettuce import world, step
 from common import course_location
@@ -127,11 +128,12 @@ def then_i_see_the_content_of_the_sequence_item(step):
     wait_for_problem('PROBLEM 6')
 
 
-@step(u'I return to the courseware')
-def and_i_return_to_the_courseware(step):
+@step(u'I return to the course')
+def and_i_return_to_the_course(step):
     world.visit('/')
     world.click_link("View Course")
-    world.click_link("Courseware")
+    course = 'a[href*="/courseware"]'
+    world.css_click(course)
 
 
 @step(u'I see that I was most recently in the subsection')

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -28,7 +28,7 @@ class CoursewareTab(EnrolledTab):
     The main courseware view.
     """
     type = 'courseware'
-    title = ugettext_noop('Courseware')
+    title = ugettext_noop('Course')
     priority = 10
     view_name = 'courseware'
     is_movable = False
@@ -40,7 +40,7 @@ class CourseInfoTab(CourseTab):
     The course info view.
     """
     type = 'course_info'
-    title = ugettext_noop('Course Info')
+    title = ugettext_noop('Home')
     priority = 20
     view_name = 'info'
     tab_id = 'info'

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -97,7 +97,7 @@ class AboutTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, EventTrackingT
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("You are enrolled in this course", resp.content)
-        self.assertIn("View Courseware", resp.content)
+        self.assertIn("View Course", resp.content)
 
     @override_settings(COURSE_ABOUT_VISIBILITY_PERMISSION="see_about_page")
     def test_visible_about_page_settings(self):
@@ -473,7 +473,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("You are enrolled in this course", resp.content)
-        self.assertIn("View Courseware", resp.content)
+        self.assertIn("View Course", resp.content)
         self.assertNotIn("Add buyme to Cart <span>($10 USD)</span>", resp.content)
 
     def test_closed_enrollment(self):

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -484,9 +484,10 @@ class TabListTestCase(TabTestCase):
             [{'type': CoursewareTab.type}],
             # missing course_info
             [{'type': CoursewareTab.type}, {'type': 'discussion', 'name': 'fake_name'}],
+            [{'type': 'unknown_type'}],
             # incorrect order
-            [{'type': CourseInfoTab.type, 'name': 'fake_name'}, {'type': CoursewareTab.type}],
-            [{'type': 'unknown_type'}]
+            [{'type': 'discussion', 'name': 'fake_name'},
+             {'type': CourseInfoTab.type, 'name': 'fake_name'}, {'type': CoursewareTab.type}],
         ]
 
         # tab types that should appear only once

--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -37,7 +37,7 @@ class LmsBlockMixin(XBlockMixin):
         scope=Scope.settings,
     )
     chrome = String(
-        display_name=_("Courseware Chrome"),
+        display_name=_("Course Chrome"),
         help=_("Enter the chrome, or navigation tools, to use for the XBlock in the LMS. Valid values are: \n"
                "\"chromeless\" -- to not use tabs or the accordion; \n"
                "\"tabs\" -- to use tabs only; \n"
@@ -48,7 +48,7 @@ class LmsBlockMixin(XBlockMixin):
     )
     default_tab = String(
         display_name=_("Default Tab"),
-        help=_("Enter the tab that is selected in the XBlock. If not set, the Courseware tab is selected."),
+        help=_("Enter the tab that is selected in the XBlock. If not set, the Course tab is selected."),
         scope=Scope.settings,
         default=None,
     )

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -138,7 +138,7 @@ from edxmako.shortcuts import marketing_link
           <span class="register disabled">${_("You are enrolled in this course")}</span>
 
           %if show_courseware_link:
-            <strong>${_("View Courseware")}</strong>
+            <strong>${_("View Course")}</strong>
             </a>
           %endif
 


### PR DESCRIPTION
ECOM-2678
@zubair-arbi @awais786 @tasawernawaz @afeef 
- Rename `Courseware` tab to `Course` and `Course Info` tab to `Home`.
- Reverse the order of the `Course` and `Home` tabs.
- All this implemented for new as well existing courses.
- Update the failing tests due to the changes.

**Old Branch**: https://github.com/edx/edx-platform/pull/10575
**Sandbox**: https://ahsan-ul-haq.sandbox.edx.org

Rebased old branch onto the self paced feature branch `feature/self-paced`.

@peter-fogg @cpennington @renzo @andy-armstrong please review. 
FYI: @edx/ecommerce 
