### PR TITLE
Overridden start and due dates of problems to control due date of a unit from ccx schedule

### DIFF
--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -156,7 +156,7 @@ class TestCoachDashboard(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         cls.verticals = flatten([
             [
                 ItemFactory.create(
-                    due=due, parent=sequential, graded=True, format='Homework'
+                    start=start, due=due, parent=sequential, graded=True, format='Homework', category=u'vertical'
                 ) for _ in xrange(2)
             ] for sequential in cls.sequentials
         ])
@@ -363,6 +363,9 @@ class TestCoachDashboard(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         unhide(schedule[0])
         schedule[0]['start'] = u'2014-11-20 00:00'
         schedule[0]['children'][0]['due'] = u'2014-12-25 00:00'  # what a jerk!
+        schedule[0]['children'][0]['children'][0]['start'] = u'2014-12-20 00:00'
+        schedule[0]['children'][0]['children'][0]['due'] = u'2014-12-25 00:00'
+
         response = self.client.post(
             url, json.dumps(schedule), content_type='application/json'
         )
@@ -372,6 +375,13 @@ class TestCoachDashboard(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertEqual(schedule[0]['start'], u'2014-11-20 00:00')
         self.assertEqual(
             schedule[0]['children'][0]['due'], u'2014-12-25 00:00'
+        )
+
+        self.assertEqual(
+            schedule[0]['children'][0]['children'][0]['due'], u'2014-12-25 00:00'
+        )
+        self.assertEqual(
+            schedule[0]['children'][0]['children'][0]['start'], u'2014-12-20 00:00'
         )
 
         # Make sure start date set on course, follows start date of earliest

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -258,6 +258,16 @@ def save_ccx(request, course, ccx=None):
                 graded[block.format] = graded.get(block.format, 0) + 1
 
             children = unit.get('children', None)
+            # For a vertical, override start and due dates of all its problems.
+            if unit.get('category', None) == u'vertical':
+                for component in block.get_children():
+                    # override start and due date of problem (Copy dates of vertical into problems)
+                    if start:
+                        override_field_for_ccx(ccx, component, 'start', start)
+
+                    if due:
+                        override_field_for_ccx(ccx, component, 'due', due)
+
             if children:
                 override_fields(block, children, graded, earliest, ccx_ids_to_delete)
         return earliest, ccx_ids_to_delete


### PR DESCRIPTION
### Background

From issue https://github.com/mitocw/edx-platform/issues/100
### What is done in this PR

**Studio Updates:** None.

**LMS Updates:** 
- On saving schedule I am overridding start and due dates of all problems to control due date of a unit from ccx schedule.

@pdpinch @giocalitri  @pwilkins
MIT PR https://github.com/mitocw/edx-platform/pull/116
- CCX schedule with due date past. (In schedule)
  ![screen shot 2015-10-21 at 7 55 20 pm](https://cloud.githubusercontent.com/assets/10431250/10640552/9411723c-782e-11e5-8f19-dd4a3c0ba0d5.png)
- CCX course with due date override. You can see there is no check button. (In courseware)
  ![screen shot 2015-10-21 at 7 55 24 pm](https://cloud.githubusercontent.com/assets/10431250/10640553/9412bcdc-782e-11e5-92b0-e20c95878767.png)
- Master course still has check button because due date is not past yet.
  ![screen shot 2015-10-21 at 7 55 31 pm](https://cloud.githubusercontent.com/assets/10431250/10640554/941392d8-782e-11e5-8ee4-1e05c3a53869.png)
