### PR TITLE
Use upstream nose instead of a fork.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -134,6 +134,7 @@ freezegun==0.1.11
 mock-django==0.6.9
 mock==1.0.1
 moto==0.3.1
+nose==1.3.7
 nose-exclude
 nose-ignore-docstring
 nosexcover==1.0.7

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -33,9 +33,6 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 # Used for testing
 -e git+https://github.com/gabrielfalcao/lettuce.git@b18b8fb711eb7a178c58574716032ad8de525912#egg=lettuce=1.8-support
 
-# nose fork needed for multiprocess support
-git+https://github.com/edx/nose.git@99c2aff0ff51bf228bfa5482e97e612c97a23245#egg=nose==1.3.7.1
-
 # Our libraries:
 -e git+https://github.com/edx/XBlock.git@a20c70f2e3df1cb716b9c7a25fecf57020543b7f#egg=XBlock
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail


### PR DESCRIPTION
The multiprocessing issues we had seen previously do not appear
when we use our combination of plugin settings for multiprocessing.
This makes it unnecessary to use a fork.

@jzoldak @efischer19 @clytwynec 

Example of this is captured in [this build](https://build.testeng.edx.org/view/All/job/edx-platform-bok-choy-custom/47/). There, if you drill in, you will see that nose (our fork) is explicitly uninstalled, so we are sure to use the official nose release in the job. We are no longer seeing the multiprocess logging error I had been seeing when developing for multiprocessing locally. This is likely because we have retooled our paver commands to use specific plugins + settings for multiprocessing (namely, simpler verbosity + xunitmp).
