### PR TITLE
WIP wiki support for microsite templates

### DIFF
--- a/common/djangoapps/microsite_configuration/templatetags/microsite.py
+++ b/common/djangoapps/microsite_configuration/templatetags/microsite.py
@@ -63,3 +63,14 @@ def microsite_css_overrides_file():
         return "<link href='{}' rel='stylesheet' type='text/css'>".format(static(file_path))
     else:
         return ""
+
+
+@register.filter
+def microsite_template_path(template_name):
+    """
+    Django template filter to apply template overriding to microsites.
+    The django_templates loader does not support the leading slash, therefore
+    it is stripped before returning.
+    """
+    template_name = microsite.get_template_path(template_name)
+    return template_name[1:] if template_name[0] == '/' else template_name

--- a/common/djangoapps/microsite_configuration/tests/test_microsites.py
+++ b/common/djangoapps/microsite_configuration/tests/test_microsites.py
@@ -32,3 +32,10 @@ class MicroSiteTests(TestCase):
         expected = u'my | less specific | Page | edX'
         title = microsite.page_title_breadcrumbs_tag(None, *crumbs)
         self.assertEqual(expected, title)
+
+    def test_microsite_template_path(self):
+        """
+        When an unexistent path is passed to the filter, it should return the same path
+        """
+        path = microsite.microsite_template_path('footer.html')
+        self.assertEqual("footer.html", path)

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -31,6 +31,9 @@ def run():
     if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
         enable_third_party_auth()
 
+    if settings.FEATURES.get('USE_MICROSITES', False):
+        enable_microsites_pre_startup()
+
     django.setup()
 
     autostartup()
@@ -116,6 +119,18 @@ def enable_stanford_theme():
     settings.LOCALE_PATHS = (theme_root / 'conf/locale',) + settings.LOCALE_PATHS
 
 
+def enable_microsites_pre_startup():
+    """
+    The TEMPLATE_ENGINE directory to search for microsite templates
+    in non-mako templates must be loaded before the django startup
+    """
+    microsites_root = settings.MICROSITE_ROOT_DIR
+    microsite_config_dict = settings.MICROSITE_CONFIGURATION
+
+    if microsite_config_dict:
+        settings.DEFAULT_TEMPLATE_ENGINE['DIRS'].append(microsites_root)
+
+
 def enable_microsites():
     """
     Enable the use of microsites, which are websites that allow
@@ -151,7 +166,6 @@ def enable_microsites():
 
     # if we have any valid microsites defined, let's wire in the Mako and STATIC_FILES search paths
     if microsite_config_dict:
-        settings.DEFAULT_TEMPLATE_ENGINE['DIRS'].append(microsites_root)
         edxmako.paths.add_lookup('main', microsites_root)
 
         settings.STATICFILES_DIRS.insert(0, microsites_root)

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -19,7 +19,7 @@
   {% block headextra %}{% endblock %}
   {% render_block "css" %}
 
-  {% optional_include "head-extra.html" %}
+  {% optional_include "head-extra.html"|microsite_template_path %}
 
   <meta name="path_prefix" content="{{EDX_ROOT_URL}}">
 </head>
@@ -28,14 +28,14 @@
   <div class="window-wrap" dir="${static.dir_rtl()}">
     <a class="nav-skip" href="{% block nav_skip %}#content{% endblock %}">{% trans "Skip to main content" %}</a>
     {% with course=request.course %}
-      {% include "header.html" %}
+      {% include "header.html"|microsite_template_path %}
     {% endwith %}
     <div class="content-wrapper" id="content">
       {% block body %}{% endblock %}
       {% block bodyextra %}{% endblock %}
     </div>
     {% with course=request.course %}
-      {% include "footer.html" %}
+      {% include "footer.html"|microsite_template_path %}
     {% endwith %}
 
   </div>


### PR DESCRIPTION
This PR would allow the templates being rendered with the django_template engine, most notably the wiki, to support the templates override used for microsites. Specially the header and footer templates.

The way this PR addresses this issue is by creating a template tag that wrapps the microsite.get_template_path function used for finding the templates. Then it uses this  templatetag inside the main_django.html template. 
