### PR TITLE
Changes the dropdown button to a span with a role of button

### DIFF
--- a/lms/static/js/my_courses_dropdown.js
+++ b/lms/static/js/my_courses_dropdown.js
@@ -2,8 +2,8 @@ $(document).ready(function () {
   'use strict';
 
   // define variables for code legibility
-  var dropdownMenuToggle = $('button.dropdown');
-  var dropdownMenu = $('ul.dropdown-menu');
+  var dropdownMenuToggle = $('.dropdown');
+  var dropdownMenu = $('.dropdown-menu');
   var menuItems = dropdownMenu.find('a');
 
   // bind menu toggle click for later use
@@ -17,8 +17,8 @@ $(document).ready(function () {
 
   //catch keypresses when focused on dropdownMenuToggle (we only care about spacebar keypresses here)
   dropdownMenuToggle.on('keydown', function(event){
-    // if space key pressed
-    if ( event.which == 32) {
+    // if space or enter key pressed
+    if ( event.which == 32 || event.which == 13) {
       dropdownMenuToggle.click();
       event.preventDefault();
     }
@@ -42,8 +42,8 @@ $(document).ready(function () {
     // var to store next focused item index
     var itemToFocusIndex;
 
-    // if space key pressed
-    if ( event.which == 32) {
+    // if space or enter key pressed
+    if ( event.which == 32 || event.which == 13) {
       dropdownMenuToggle.click();
       event.preventDefault();
     }

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -191,9 +191,9 @@ header.global {
       }
     }
 
-    button.dropdown {
-      font-size: 14px;
-      padding: 0 ($baseline/2);
+    .dropdown {
+      display: inline-block;
+      padding: ($baseline / 5) ($baseline / 2.5);
       color: $base-font-color;
       border: none;
       background: $white;

--- a/lms/templates/navigation-edx.html
+++ b/lms/templates/navigation-edx.html
@@ -83,14 +83,14 @@ site_status_msg = get_site_status_msg(course_id)
         </a>
       </li>
       <li class="primary">
-        <button class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span> &#9662;</button>
-        <ul class="dropdown-menu" aria-label="More Options" role="menu">
+        <span role="button" tabindex="0" class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span> &#9662;</span>
+        <ul class="dropdown-menu" aria-label="More Options">
           <%block name="navigation_dropdown_menu_links" >
             <li><a href="${reverse('dashboard')}">${_("Dashboard")}</a></li>
             <li><a href="${reverse('learner_profile', kwargs={'username': user.username})}">${_("Profile")}</a></li>
             <li><a href="${reverse('account_settings')}">${_("Account")}</a></li>
           </%block>
-          <li><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></li>
+          <li><a href="${reverse('logout')}">${_("Sign Out")}</a></li>
         </ul>
       </li>
     </ul>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -86,14 +86,14 @@ site_status_msg = get_site_status_msg(course_id)
         </a>
       </li>
       <li class="primary">
-        <button class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span><span class="fa fa-sort-desc" aria-hidden="true"></span></button>
-        <ul class="dropdown-menu" aria-label="More Options" role="menu">
+        <span role="button" tabindex="0" class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span><span class="fa fa-sort-desc" aria-hidden="true"></span></span>
+        <ul class="dropdown-menu" aria-label="More Options">
           <%block name="navigation_dropdown_menu_links" >
             <li><a href="${reverse('dashboard')}">${_("Dashboard")}</a></li>
             <li><a href="${reverse('learner_profile', kwargs={'username': user.username})}">${_("Profile")}</a></li>
             <li><a href="${reverse('account_settings')}">${_("Account")}</a></li>
           </%block>
-          <li><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></li>
+          <li><a href="${reverse('logout')}">${_("Sign Out")}</a></li>
         </ul>
       </li>
     </ol>


### PR DESCRIPTION
@clytwynec Here's a quick tweak to your branch which fixes the focus issue. We're using a `span role="button"` instead of a `button`. It reads the same in screenreaders, but receives the outline.

I couldn't find any overwriting styles oddly, but I think we ran into this issue with the course navigation, which is why we used `a role="button"` there instead of the original `button`.
