### PR TITLE
Clearing the cache on model save

### DIFF
--- a/common/djangoapps/microsite_configuration/backends/database.py
+++ b/common/djangoapps/microsite_configuration/backends/database.py
@@ -15,6 +15,8 @@ from microsite_configuration.models import (
     MicrositeTemplate
 )
 from microsite_configuration.microsite import get_value as microsite_get_value
+from django.dispatch import receiver
+from django.db.models.signals import post_save
 
 
 class DatabaseMicrositeBackend(SettingsFileMicrositeBackend):
@@ -162,3 +164,12 @@ class DatabaseMicrositeTemplateBackend(BaseMicrositeTemplateBackend):
         return Template(
             text=template_text
         )
+
+    @staticmethod
+    @receiver(post_save, sender=MicrositeTemplate)
+    def clear_cache(sender, instance, **kwargs):
+        """
+        Clear the cached template when the model is saved
+        """
+        cache_key = "template_cache." + instance.microsite.key + '.' + instance.template_uri
+        cache.delete(cache_key)

--- a/common/djangoapps/microsite_configuration/backends/database.py
+++ b/common/djangoapps/microsite_configuration/backends/database.py
@@ -167,9 +167,9 @@ class DatabaseMicrositeTemplateBackend(BaseMicrositeTemplateBackend):
 
     @staticmethod
     @receiver(post_save, sender=MicrositeTemplate)
-    def clear_cache(sender, instance, **kwargs):
+    def clear_cache(sender, instance, **kwargs):  # pylint: disable=unused-argument
         """
         Clear the cached template when the model is saved
         """
         cache_key = "template_cache." + instance.microsite.key + '.' + instance.template_uri
-        cache.delete(cache_key)
+        cache.delete(cache_key)  # pylint: disable=maybe-no-member


### PR DESCRIPTION
This PR adds a method on the template backend that clears the cache when the model is saved
