### PR TITLE
Fix login redirect when user is logged out while answering a question…

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -10,6 +10,7 @@ from ..helpers import UniqueCourseTest
 from ...pages.studio.auto_auth import AutoAuthPage
 from ...pages.lms.courseware import CoursewarePage
 from ...pages.lms.problem import ProblemPage
+from ...pages.lms.login_and_register import CombinedLoginAndRegisterPage
 from ...fixtures.course import CourseFixture, XBlockFixtureDesc
 from ..helpers import EventsTestMixin
 
@@ -20,6 +21,7 @@ class ProblemsTest(UniqueCourseTest):
     """
     USERNAME = "joe_student"
     EMAIL = "joe@example.com"
+    PASSWORD = "keep it secret; keep it safe."
 
     def setUp(self):
         super(ProblemsTest, self).setUp()
@@ -42,8 +44,14 @@ class ProblemsTest(UniqueCourseTest):
         ).install()
 
         # Auto-auth register for the course.
-        AutoAuthPage(self.browser, username=self.USERNAME, email=self.EMAIL,
-                     course_id=self.course_id, staff=False).visit()
+        AutoAuthPage(
+            self.browser,
+            username=self.USERNAME,
+            email=self.EMAIL,
+            password=self.PASSWORD,
+            course_id=self.course_id,
+            staff=False
+        ).visit()
 
     def get_problem(self):
         """ Subclasses should override this to complete the fixture """
@@ -321,3 +329,88 @@ class ProblemPartialCredit(ProblemsTest):
         problem_page.click_check()
         problem_page.wait_for_status_icon()
         self.assertTrue(problem_page.simpleprob_is_partially_correct())
+
+
+class LogoutDuringAnswering(ProblemsTest):
+    """
+    Tests for the scenario where a user is logged out (their session expires
+    or is revoked) just before they click "check" on a problem.
+    """
+    def get_problem(self):
+        """
+        Create a problem.
+        """
+        xml = dedent("""
+            <problem>
+                <p>The answer is 1</p>
+                <numericalresponse answer="1">
+                    <formulaequationinput label="where are the songs of spring?" />
+                    <responseparam type="tolerance" default="0.01" />
+                </numericalresponse>
+            </problem>
+        """)
+        return XBlockFixtureDesc('problem', 'TEST PROBLEM', data=xml)
+
+    def log_user_out(self):
+        """
+        Log the user out by deleting their session cookie.
+        """
+        self.browser.delete_cookie('sessionid')
+
+    def test_logout_after_click_redirect(self):
+        """
+        1) User goes to a problem page.
+        2) User fills out an answer to the problem.
+        3) User is logged out because their session id is invalidated or removed.
+        4) User clicks "check", and sees a confirmation modal asking them to
+           re-authenticate, since they've just been logged out.
+        5) User clicks "ok".
+        6) User is redirected to the login page.
+        7) User logs in.
+        8) User is redirected back to the problem page they started out on.
+        9) User is able to submit an answer
+        """
+        self.courseware_page.visit()
+        problem_page = ProblemPage(self.browser)
+        self.assertEqual(problem_page.problem_name, 'TEST PROBLEM')
+        problem_page.fill_answer_numerical('1')
+
+        self.log_user_out()
+        with problem_page.handle_alert(confirm=True):
+            problem_page.click_check()
+
+        login_page = CombinedLoginAndRegisterPage(self.browser)
+        login_page.wait_for_page()
+
+        login_page.login(self.EMAIL, self.PASSWORD)
+
+        problem_page = ProblemPage(self.browser)
+        problem_page.wait_for_page()
+        self.assertEqual(problem_page.problem_name, 'TEST PROBLEM')
+
+        # now we should be able to
+        problem_page.fill_answer_numerical('1')
+        problem_page.click_check()
+        problem_page.wait_for_ajax()
+        self.assertTrue(problem_page.simpleprob_is_correct())
+
+    def test_logout_after_click_no_redirect(self):
+        """
+        1) User goes to a problem page.
+        2) User fills out an answer to the problem.
+        3) User is logged out because their session id is invalidated or removed.
+        4) User clicks "check", and sees a confirmation modal asking them to
+           re-authenticate, since they've just been logged out.
+        5) User clicks "cancel".
+        6) User is not redirected to the login page.
+        """
+        self.courseware_page.visit()
+        problem_page = ProblemPage(self.browser)
+        self.assertEqual(problem_page.problem_name, 'TEST PROBLEM')
+        problem_page.fill_answer_numerical('1')
+        self.log_user_out()
+        with problem_page.handle_alert(confirm=False):
+            problem_page.click_check()
+
+        self.assertTrue(problem_page.is_browser_on_page())
+        self.assertEqual(problem_page.problem_name, 'TEST PROBLEM')

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -393,7 +393,6 @@ class LogoutDuringAnswering(ProblemsTest):
         # now we should be able to
         problem_page.fill_answer_numerical('1')
         problem_page.click_check()
-        problem_page.wait_for_ajax()
         self.assertTrue(problem_page.simpleprob_is_correct())
 
     @flaky(max_runs=15, min_passes=15)

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -386,17 +386,15 @@ class LogoutDuringAnswering(ProblemsTest):
 
         login_page.login(self.EMAIL, self.PASSWORD)
 
-        problem_page = ProblemPage(self.browser)
         problem_page.wait_for_page()
         self.assertEqual(problem_page.problem_name, 'TEST PROBLEM')
 
-        # now we should be able to
         problem_page.fill_answer_numerical('1')
         problem_page.click_check()
         self.assertTrue(problem_page.simpleprob_is_correct())
 
     @flaky(max_runs=15, min_passes=15)
-    def test_logout_after_click_no_redirect(self):
+    def test_logout_cancel_no_redirect(self):
         """
         1) User goes to a problem page.
         2) User fills out an answer to the problem.

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -5,6 +5,7 @@ Bok choy acceptance tests for problems in the LMS
 See also old lettuce tests in lms/djangoapps/courseware/features/problems.feature
 """
 from textwrap import dedent
+from flaky import flaky
 
 from ..helpers import UniqueCourseTest
 from ...pages.studio.auto_auth import AutoAuthPage
@@ -357,6 +358,7 @@ class LogoutDuringAnswering(ProblemsTest):
         """
         self.browser.delete_cookie('sessionid')
 
+    @flaky(max_runs=15, min_passes=15)
     def test_logout_after_click_redirect(self):
         """
         1) User goes to a problem page.
@@ -394,6 +396,7 @@ class LogoutDuringAnswering(ProblemsTest):
         problem_page.wait_for_ajax()
         self.assertTrue(problem_page.simpleprob_is_correct())
 
+    @flaky(max_runs=15, min_passes=15)
     def test_logout_after_click_no_redirect(self):
         """
         1) User goes to a problem page.

--- a/lms/static/js/ajax-error.js
+++ b/lms/static/js/ajax-error.js
@@ -8,8 +8,8 @@ $(document).ajaxError(function (event, jXHR) {
         );
 
         if (window.confirm(message)) {
-            var currentLocation = window.location.href;
-            window.location.href = '/login?next=' + currentLocation;
+            var currentLocation = window.location.pathname;
+            window.location.href = '/login?next=' + encodeURIComponent(currentLocation);
         };
     }
 });


### PR DESCRIPTION
… (TNL-3789)

Fix for [TNL-3789](https://openedx.atlassian.net/browse/TNL-3789).

This addresses an issue for split courses (only in chrome actually — while the acceptance tests don't run in chrome by default, I verified locally that this test fails without the fix in chrome) where if:
1) You're logged in and answering questions
2) You're logged out b/c your session is invalidated or deleted
3) You click "check"
4) You are redirected to the login page
5) You log in
We expect that you are then redirected to the page you were originally on. There's a bug where instead some url escaping doesn't happen correctly and you get a 404.

Reviewers:
- [x] @nasthagiri 
- [x] @cahrens  

Optional:
- [ ] @mushtaqak 

@feanil FYI
