### PR TITLE
asadiqbal08/SOL-1416  Certs: Remove Restriction on Date Setting

### DIFF
--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -35,9 +35,6 @@ var CourseDetails = Backbone.Model.extend({
         if (newattrs.start_date === null) {
             errors.start_date = gettext("The course must have an assigned start date.");
         }
-        if (this.hasChanged("start_date") && this.get("has_cert_config") === false){
-            errors.start_date = gettext("The course must have at least one active certificate configuration before it can be started.");
-        }
         if (newattrs.start_date && newattrs.end_date && newattrs.start_date >= newattrs.end_date) {
             errors.end_date = gettext("The course end date must be later than the course start date.");
         }

--- a/cms/static/js/spec/views/settings/main_spec.js
+++ b/cms/static/js/spec/views/settings/main_spec.js
@@ -72,13 +72,6 @@ define([
             );
         });
 
-        it('Changing course start date without active certificate configuration should result in error', function () {
-            this.view.$el.find('#course-start-date')
-                .val('10/06/2014')
-                .trigger('change');
-            expect(this.view.$el.find('span.message-error').text()).toContain("course must have at least one active certificate configuration");
-        });
-
         it('Selecting a course in pre-requisite drop down should save it as part of course details', function () {
             var pre_requisite_courses = ['test/CSS101/2012_T1'];
             var requests = AjaxHelpers.requests(this),


### PR DESCRIPTION
[SOL-1416 Certs: Remove Restriction on Date Setting](https://openedx.atlassian.net/browse/SOL-1416)

Allow Course Teams/PMs (staff and global staff) to set the Start date of a course with Web Certs enabled. (remove restriction). 
@ziafazal please review it. 
@mattdrayer 
