### PR TITLE
remove reset style for button outlines in firefox

### DIFF
--- a/lms/static/sass/base/_reset.scss
+++ b/lms/static/sass/base/_reset.scss
@@ -50,6 +50,7 @@ input[type="checkbox"], input[type="radio"] { box-sizing: border-box; padding: 0
 input[type="search"] { -webkit-appearance: textfield; -moz-box-sizing: content-box; -webkit-box-sizing: content-box; box-sizing: content-box; }
 input[type="search"]::-webkit-search-decoration, input[type="search"]::-webkit-search-cancel-button { -webkit-appearance: none; }
 button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
+button:-moz-focusring { outline: 1px dotted black; }
 textarea { overflow: auto; vertical-align: top; resize: vertical; }
 input:valid, textarea:valid {  }
 


### PR DESCRIPTION
## Overview

There is a reset style still in the LMS to override focus outlines for buttons in Firefox.  Other browsers all use the default outline, while Firefox has no default focus indicator for buttons in the LMS.

There are several cases where should change links to buttons because it is semantically more correct. We've found that in doing so, we end up with no focus indicator in Firefox in places where one previously worked and should continue to work.   This change will make it so that by default, the browser will apply its focus indicator to buttons in the LMS, and we can override it in special cases rather than removing it all together and only applying it back in some cases.
## Sandbox

https://clytwynec.sandbox.edx.org
## Reviews

This will need both UX and Accessibility reviews.
- [x] @frrrances or @talbs 
- [x] @cptvitamin or @clrux 
## In Progress

I'm currently going through the LMS in the above sandbox to check for buttons that this may have unintentionally applied new styles to.  So far, I've found that most things that look like buttons are actually links, so no new styles have been applied to them.
