### PR TITLE
Adding lti-users with optional personal data (email, name) to edx gradebooks

### DIFF
--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -5,7 +5,7 @@ Tests for the LTI provider views
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
-from mock import patch, MagicMock
+from mock import patch, MagicMock, ANY
 
 from courseware.testutils import RenderXBlockTestMixin
 from lti_provider import views, models
@@ -13,7 +13,8 @@ from lti_provider.signature_validator import SignatureValidator
 from opaque_keys.edx.locator import CourseLocator, BlockUsageLocator
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-
+from django.contrib.auth.models import User
+from student.models import CourseEnrollment
 
 LTI_DEFAULT_PARAMS = {
     'roles': u'Instructor,urn:lti:instrole:ims/lis/Administrator',
@@ -30,6 +31,9 @@ LTI_DEFAULT_PARAMS = {
 LTI_OPTIONAL_PARAMS = {
     'lis_result_sourcedid': u'result sourcedid',
     'lis_outcome_service_url': u'outcome service URL',
+    'lis_person_contact_email_primary': u'rob.smith@example.com',
+    'lis_person_name_given': u'Rob',
+    'lis_person_name_family': u'Smith',
     'tool_consumer_instance_guid': u'consumer instance guid'
 }
 
@@ -80,13 +84,15 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
     """
     @patch('lti_provider.views.render_courseware')
     @patch('lti_provider.views.authenticate_lti_user')
-    def test_valid_launch(self, _authenticate, render):
+    @patch('lti_provider.views.enroll_user_to_course')
+    def test_valid_launch(self, enroll_mock, _authenticate, render):
         """
         Verifies that the LTI launch succeeds when passed a valid request.
         """
         request = build_launch_request()
         views.lti_launch(request, unicode(COURSE_KEY), unicode(USAGE_KEY))
         render.assert_called_with(request, USAGE_KEY)
+        enroll_mock.assert_called_with(request.user, COURSE_KEY)
 
     @patch('lti_provider.views.render_courseware')
     @patch('lti_provider.views.store_outcome_parameters')
@@ -142,7 +148,6 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
         request = build_launch_request()
         response = views.lti_launch(request, None, None)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.status_code, 403)
 
     @patch('lti_provider.views.render_courseware')
     def test_lti_consumer_record_supplemented_with_guid(self, _render):
@@ -156,6 +161,30 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
         )
         self.assertEqual(consumer.instance_guid, u'consumer instance guid')
 
+    @patch('lti_provider.views.render_courseware')
+    @patch('lti_provider.views.authenticate_lti_user')
+    def test_lti_optional_param_email_is_used(self, _authenticate, _render):
+        request = build_launch_request()
+        if not hasattr(request, 'POST'):
+            request.POST = {}
+        request.POST.update(LTI_OPTIONAL_PARAMS)
+        views.lti_launch(request, unicode(COURSE_KEY), unicode(USAGE_KEY))
+        lti_params = {'email': 'rob.smith@example.com', 'first_name': 'Rob', 'last_name': 'Smith'}
+        _authenticate.assert_called_with(ANY, ANY, ANY, lti_params)
+
+    def test_enroll_user_to_course(self):
+        email = 'rob.smith@example.com'
+        user = User.objects.create_user(
+            username=email,
+            password='password',
+            email=email,
+        )
+        views.enroll_user_to_course(user, COURSE_KEY)
+        self.assertTrue(CourseEnrollment.is_enrolled(user, COURSE_KEY))
+        with self.assertNumQueries(1):
+            #don't enroll 2d time
+            views.enroll_user_to_course(user, COURSE_KEY)
+
 
 class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCase):
     """
@@ -163,6 +192,7 @@ class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCa
     This class overrides the get_response method, which is used by
     the tests defined in RenderXBlockTestMixin.
     """
+
     def get_response(self, url_encoded_params=None):
         """
         Overridable method to get the response from the endpoint that is being tested.

--- a/lms/djangoapps/lti_provider/users.py
+++ b/lms/djangoapps/lti_provider/users.py
@@ -15,8 +15,13 @@ from django.db import IntegrityError, transaction
 from lti_provider.models import LtiUser
 from student.models import UserProfile
 
+USERNAME_DB_FIELD_SIZE = 30
+FIRST_NAME_DB_FIELD_SIZE = 30
+LAST_NAME_DB_FIELD_SIZE = 30
+EMAIL_DB_FIELD_SIZE = 75
 
-def authenticate_lti_user(request, lti_user_id, lti_consumer):
+
+def authenticate_lti_user(request, lti_user_id, lti_consumer, lti_params=None):
     """
     Determine whether the user specified by the LTI launch has an existing
     account. If not, create a new Django User model and associate it with an
@@ -32,7 +37,7 @@ def authenticate_lti_user(request, lti_user_id, lti_consumer):
         )
     except LtiUser.DoesNotExist:
         # This is the first time that the user has been here. Create an account.
-        lti_user = create_lti_user(lti_user_id, lti_consumer)
+        lti_user = create_lti_user(lti_user_id, lti_consumer, lti_params)
 
     if not (request.user.is_authenticated() and
             request.user == lti_user.edx_user):
@@ -41,24 +46,56 @@ def authenticate_lti_user(request, lti_user_id, lti_consumer):
         switch_user(request, lti_user, lti_consumer)
 
 
-def create_lti_user(lti_user_id, lti_consumer):
+def cut_to_max_len(text, max_len):
+    """
+    Cut a passed string to a max length and return it,
+    if the string is less than the max length then it is retured unchanged
+    """
+    if text is None or len(text) < max_len:
+        return text
+    else:
+        return text[:max_len]
+
+
+def create_lti_user(lti_user_id, lti_consumer, lti_params=None):
     """
     Generate a new user on the edX platform with a random username and password,
     and associates that account with the LTI identity.
     """
+    if lti_params is None:
+        lti_params = {}
     edx_password = str(uuid.uuid4())
 
     created = False
     while not created:
         try:
-            edx_user_id = generate_random_edx_username()
-            edx_email = "{}@{}".format(edx_user_id, settings.LTI_USER_EMAIL_DOMAIN)
+            if 'email' in lti_params:
+                edx_email = cut_to_max_len(lti_params['email'], EMAIL_DB_FIELD_SIZE)
+                edx_username = cut_to_max_len(lti_params['email'], USERNAME_DB_FIELD_SIZE)
+                try:
+                    #if this username already exists then use the random username
+                    edx_user = User.objects.get(username=edx_username)
+                    edx_username = generate_random_edx_username()
+                except User.DoesNotExist:
+                    pass
+            else:
+                edx_username = generate_random_edx_username()
+                edx_email = "{}@{}".format(edx_username, settings.LTI_USER_EMAIL_DOMAIN)
+
             with transaction.atomic():
                 edx_user = User.objects.create_user(
-                    username=edx_user_id,
+                    username=edx_username,
                     password=edx_password,
                     email=edx_email,
                 )
+
+                if edx_user is not None:
+                    if 'first_name' in lti_params:
+                        edx_user.first_name = cut_to_max_len(lti_params['first_name'], FIRST_NAME_DB_FIELD_SIZE)
+                    if 'last_name' in lti_params:
+                        edx_user.last_name = cut_to_max_len(lti_params['last_name'], LAST_NAME_DB_FIELD_SIZE)
+                        edx_user.save()
+
                 # A profile is required if PREVENT_CONCURRENT_LOGINS flag is set.
                 # TODO: We could populate user information from the LTI launch here,
                 # but it's not necessary for our current uses.
@@ -104,7 +141,7 @@ def generate_random_edx_username():
     """
     allowable_chars = string.ascii_letters + string.digits
     username = ''
-    for _index in range(30):
+    for _index in range(USERNAME_DB_FIELD_SIZE):
         username = username + random.SystemRandom().choice(allowable_chars)
     return username
 


### PR DESCRIPTION
   **Background:** Grades of users that worked with edX courses in another LMS (Canvas) are not shown in edX gradebooks. The users are not enrolled to these courses automatically.

   **Studio Updates:** None.

   **LMS Updates:** When users work with a edX course in another LMS they are enrolled to the courses automatically and are visible in edX gradebooks. If additional POST parameters ('lis_person_contact_email_primary', 'lis_person_name_given', 'lis_person_name_family') are passed by the other LMS to edX then a user's email is used as a username of a corresponding edX user. Otherwise a random value is used (as before).

   **Manual test instructions:**
1. Setup edX Demo course http://127.0.0.1:8000/courses/course-v1%3AedX%2BDemoX%2BDemo_Course/ as an LTI Provider to Canvas LMS:
   http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/building_course/lti/lti_canvas_example.html
   In the "Edit External Tool" dialog select "Privacy" as "Public", then additional parameters with a user's email and name should be passed to edX LMS.
2. Log in the Canvas LMS and open the edX Demo course, answer some questions correctly.
3. Log in edX LMS as staff@example.com/edx and open the gradebook for the edX Demo course.
   http://127.0.0.1:8000/courses/course-v1:edX+DemoX+Demo_Course/instructor/api/gradebook
   You should see the LTI-user from Canvas with grades, the user's email should be used as a username in edX LMS.
   ![edx](https://cloud.githubusercontent.com/assets/7777978/11216866/92da8ae4-8d5e-11e5-8814-a9401620249b.jpg)
