### PR TITLE
Correct the remove icon.

### DIFF
--- a/cms/static/js/views/metadata.js
+++ b/cms/static/js/views/metadata.js
@@ -288,7 +288,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
                 var template = _.template(
                     '<li class="list-settings-item">' +
                         '<input type="text" class="input" value="<%= ele %>">' +
-                        '<a href="#" class="remove-action remove-setting" data-index="<%= index %>"><i class="icon fa fa-remove-sign"></i><span class="sr">Remove</span></a>' +
+                        '<a href="#" class="remove-action remove-setting" data-index="<%= index %>"><i class="icon fa fa-times-circle" aria-hidden="true"></i><span class="sr">Remove</span></a>' +
                     '</li>'
                 );
                 list.append($(template({'ele': ele, 'index': index})));
@@ -455,7 +455,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
                     '<li class="list-settings-item">' +
                         '<input type="text" class="input input-key" value="<%= key %>">' +
                         '<input type="text" class="input input-value" value="<%= value %>">' +
-                        '<a href="#" class="remove-action remove-setting" data-value="<%= value %>"><i class="icon fa fa-remove-sign"></i><span class="sr">Remove</span></a>' +
+                        '<a href="#" class="remove-action remove-setting" data-value="<%= value %>"><i class="icon fa fa-times-circle" aria-hidden="true"></i><span class="sr">Remove</span></a>' +
                     '</li>'
                 );
 


### PR DESCRIPTION
@talbs please review

When consulting #6055 to see what I should change "icon-remove-sign" to in ORA2 for the fa update, I noticed this incorrect class was used in two places.

I made the change and verify that now I see a remove icon:

![image](https://cloud.githubusercontent.com/assets/484484/11189424/030fa6f2-8c5e-11e5-9039-65eafcd9d7b2.png)
