### PR TITLE
Django 1.8 disallows access to args[]

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/force_publish.py
+++ b/cms/djangoapps/contentstore/management/commands/force_publish.py
@@ -17,39 +17,37 @@ class Command(BaseCommand):
     help = '''
     Force publish a course. Takes two arguments:
     <course_id>: the course id of the course you want to publish forcefully
-    commit: do the force publish
+    --commit: do the force publish
 
-    If you do not specify 'commit', the command will print out what changes would be made.
+    If you do not specify '--commit', the command will print out what changes would be made.
     '''
+
+    def add_arguments(self, parser):
+        parser.add_argument('course_key', help="ID of the Course to force publish")
+        parser.add_argument('--commit', action='store_true', help="Pull updated metadata from external IDPs")
 
     def handle(self, *args, **options):
         """Execute the command"""
-        if len(args) not in {1, 2}:
-            raise CommandError("force_publish requires 1 or more argument: <course_id> |commit|")
 
         try:
-            course_key = CourseKey.from_string(args[0])
+            course_key = CourseKey.from_string(options['course_key'])
         except InvalidKeyError:
             raise CommandError("Invalid course key.")
 
         if not modulestore().get_course(course_key):
             raise CommandError("Course not found.")
 
-        commit = False
-        if len(args) == 2:
-            commit = args[1] == 'commit'
-
         # for now only support on split mongo
         owning_store = modulestore()._get_modulestore_for_courselike(course_key)  # pylint: disable=protected-access
         if hasattr(owning_store, 'force_publish_course'):
-            versions = get_course_versions(args[0])
+            versions = get_course_versions(options['course_key'])
             print "Course versions : {0}".format(versions)
 
-            if commit:
+            if options['commit']:
                 if query_yes_no("Are you sure to publish the {0} course forcefully?".format(course_key), default="no"):
                     # publish course forcefully
                     updated_versions = owning_store.force_publish_course(
-                        course_key, ModuleStoreEnum.UserID.mgmt_command, commit
+                        course_key, ModuleStoreEnum.UserID.mgmt_command, options['commit']
                     )
                     if updated_versions:
                         # if publish and draft were different

--- a/cms/djangoapps/contentstore/management/commands/tests/test_force_publish.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_force_publish.py
@@ -2,7 +2,7 @@
 Tests for the force_publish management command
 """
 import mock
-from django.core.management.base import CommandError
+from django.core.management import call_command, CommandError
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -27,7 +27,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
         """
         errstring = "force_publish requires 1 or more argument: <course_id> |commit"
         with self.assertRaisesRegexp(CommandError, errstring):
-            self.command.handle()
+            call_command()
 
     def test_invalid_course_key(self):
         """
@@ -35,7 +35,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
         """
         errstring = "Invalid course key."
         with self.assertRaisesRegexp(CommandError, errstring):
-            self.command.handle('TestX/TS01')
+            call_command('TestX/TS01')
 
     def test_too_many_arguments(self):
         """
@@ -43,7 +43,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
         """
         errstring = "force_publish requires 1 or more argument: <course_id> |commit"
         with self.assertRaisesRegexp(CommandError, errstring):
-            self.command.handle(unicode(self.course.id), 'commit', 'invalid-arg')
+            call_command(unicode(self.course.id), '--commit', 'invalid-arg')
 
     def test_course_key_not_found(self):
         """
@@ -51,7 +51,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
         """
         errstring = "Course not found."
         with self.assertRaisesRegexp(CommandError, errstring):
-            self.command.handle(unicode('course-v1:org+course+run'))
+            call_command(unicode('course-v1:org+course+run'))
 
     def test_force_publish_non_split(self):
         """
@@ -60,7 +60,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
         course = CourseFactory.create(default_store=ModuleStoreEnum.Type.mongo)
         errstring = 'The owning modulestore does not support this command.'
         with self.assertRaisesRegexp(CommandError, errstring):
-            self.command.handle(unicode(course.id))
+            call_command(unicode(course.id))
 
     @SharedModuleStoreTestCase.modifies_courseware
     def test_force_publish(self):
@@ -91,7 +91,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
             patched_yes_no.return_value = True
 
             # force publish course
-            self.command.handle(unicode(self.course.id), 'commit')
+            call_command(unicode(self.course.id), '--commit')
 
             # verify that course has no changes
             self.assertFalse(self.store.has_changes(self.store.get_item(self.course.location)))

--- a/cms/djangoapps/contentstore/management/commands/tests/test_force_publish.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_force_publish.py
@@ -27,7 +27,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
         """
         errstring = "force_publish requires 1 or more argument: <course_id> |commit"
         with self.assertRaisesRegexp(CommandError, errstring):
-            call_command()
+            call_command('force_publish')
 
     def test_invalid_course_key(self):
         """
@@ -35,7 +35,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
         """
         errstring = "Invalid course key."
         with self.assertRaisesRegexp(CommandError, errstring):
-            call_command('TestX/TS01')
+            call_command('force_publish', 'TestX/TS01')
 
     def test_too_many_arguments(self):
         """
@@ -43,7 +43,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
         """
         errstring = "force_publish requires 1 or more argument: <course_id> |commit"
         with self.assertRaisesRegexp(CommandError, errstring):
-            call_command(unicode(self.course.id), '--commit', 'invalid-arg')
+            call_command('force_publish', unicode(self.course.id), '--commit', 'invalid-arg')
 
     def test_course_key_not_found(self):
         """
@@ -51,7 +51,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
         """
         errstring = "Course not found."
         with self.assertRaisesRegexp(CommandError, errstring):
-            call_command(unicode('course-v1:org+course+run'))
+            call_command('force_publish', unicode('course-v1:org+course+run'))
 
     def test_force_publish_non_split(self):
         """
@@ -60,7 +60,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
         course = CourseFactory.create(default_store=ModuleStoreEnum.Type.mongo)
         errstring = 'The owning modulestore does not support this command.'
         with self.assertRaisesRegexp(CommandError, errstring):
-            call_command(unicode(course.id))
+            call_command('force_publish', unicode(course.id))
 
     @SharedModuleStoreTestCase.modifies_courseware
     def test_force_publish(self):
@@ -91,7 +91,7 @@ class TestForcePublish(SharedModuleStoreTestCase):
             patched_yes_no.return_value = True
 
             # force publish course
-            call_command(unicode(self.course.id), '--commit')
+            call_command('force_publish', unicode(self.course.id), '--commit')
 
             # verify that course has no changes
             self.assertFalse(self.store.has_changes(self.store.get_item(self.course.location)))


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/
You need to declare and do proper argument parsing.  --commit is also
more natural than a bare 'commit' on the end of a command.
