### PR TITLE
Clean up occurrences of SlashSeparatedCourseKey in the django_comment_client app.

### DIFF
--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -13,7 +13,7 @@ from django.core.urlresolvers import reverse
 from request_cache.middleware import RequestCache
 from mock import patch, ANY, Mock
 from nose.tools import assert_true, assert_equal  # pylint: disable=no-name-in-module
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 from lms.lib.comment_client import Thread
 
 from common.test.utils import MockSignalHandlerMixin, disable_signal
@@ -1733,7 +1733,7 @@ class UsersEndpointTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
         self.assertNotIn("users", content)
 
     def test_course_does_not_exist(self):
-        course_id = SlashSeparatedCourseKey.from_deprecated_string("does/not/exist")
+        course_id = CourseKey.from_string("does/not/exist")
         response = self.make_request(course_id=course_id, username="other")
 
         self.assertEqual(response.status_code, 404)

--- a/lms/djangoapps/django_comment_client/management/commands/get_discussion_link.py
+++ b/lms/djangoapps/django_comment_client/management/commands/get_discussion_link.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from courseware.courses import get_course
 
@@ -16,10 +15,7 @@ class Command(BaseCommand):
             raise CommandError("Only one course id may be specifiied")
         course_id = args[0]
 
-        try:
-            course_key = CourseKey.from_string(course_id)
-        except InvalidKeyError:
-            course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+        course_key = CourseKey.from_string(course_id)
 
         course = get_course(course_key)
         if not course:

--- a/lms/djangoapps/django_comment_client/management/commands/seed_permissions_roles.py
+++ b/lms/djangoapps/django_comment_client/management/commands/seed_permissions_roles.py
@@ -3,7 +3,7 @@ Management command to seed default permissions and roles.
 """
 from django.core.management.base import BaseCommand, CommandError
 from django_comment_common.utils import seed_permissions_roles
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 
 
 class Command(BaseCommand):
@@ -15,6 +15,6 @@ class Command(BaseCommand):
             raise CommandError("Please provide a course id")
         if len(args) > 1:
             raise CommandError("Too many arguments")
-        course_id = SlashSeparatedCourseKey.from_deprecated_string(args[0])
+        course_id = CourseKey.from_string(args[0])
 
         seed_permissions_roles(course_id)

--- a/lms/djangoapps/django_comment_client/tests/test_models.py
+++ b/lms/djangoapps/django_comment_client/tests/test_models.py
@@ -3,7 +3,7 @@ Tests for the django comment client integration models
 """
 from django.test.testcases import TestCase
 from nose.plugins.attrib import attr
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_TOY_MODULESTORE
 import django_comment_common.models as models
@@ -23,7 +23,7 @@ class RoleClassTestCase(ModuleStoreTestCase):
         # For course ID, syntax edx/classname/classdate is important
         # because xmodel.course_module.id_to_location looks for a string to split
 
-        self.course_id = SlashSeparatedCourseKey("edX", "toy", "2012_Fall")
+        self.course_id = CourseKey.from_string("edX/toy/2012_Fall")
         self.student_role = models.Role.objects.get_or_create(name="Student",
                                                               course_id=self.course_id)[0]
         self.student_role.add_permission("delete_thread")
@@ -31,7 +31,7 @@ class RoleClassTestCase(ModuleStoreTestCase):
                                                                 course_id=self.course_id)[0]
         self.TA_role = models.Role.objects.get_or_create(name="Community TA",
                                                          course_id=self.course_id)[0]
-        self.course_id_2 = SlashSeparatedCourseKey("edx", "6.002x", "2012_Fall")
+        self.course_id_2 = CourseKey.from_string("edX/6.002x/2012_Fall")
         self.TA_role_2 = models.Role.objects.get_or_create(name="Community TA",
                                                            course_id=self.course_id_2)[0]
 


### PR DESCRIPTION
Use the preferred form `CourseKey.from_string()` instead of `SlashSeparatedCourseKey.from_deprecated_string()` everywhere in this app.

This is a cleanup PR and doesn't change anything.  The first three commits listed are part of #9616.  I based this PR on the topic branch of that commit to avoid otherwise inevitable merge conflicts.
