### PR TITLE
remove unneeded aria-describedby and aria-hidden attrs on studio modal

### DIFF
--- a/cms/templates/js/basic-modal.underscore
+++ b/cms/templates/js/basic-modal.underscore
@@ -1,7 +1,5 @@
 <div class="wrapper wrapper-modal-window wrapper-modal-window-<%= name %>"
-     aria-describedby="modal-window-description"
      aria-labelledby="modal-window-title"
-     aria-hidden=""
      role="dialog">
     <div class="modal-window-overlay"></div>
     <div class="modal-window <%= viewSpecificClasses %> modal-<%= size %> modal-type-<%= type %>" tabindex="-1" aria-labelledby="modal-window-title">

--- a/cms/templates/ux/reference/modal_access-component.html
+++ b/cms/templates/ux/reference/modal_access-component.html
@@ -1,4 +1,4 @@
-<div class="wrapper wrapper-modal-window wrapper-modal-window-edit-xblock" aria-describedby="modal-window-description" aria-labelledby="modal-window-title" aria-hidden="" role="dialog">
+<div class="wrapper wrapper-modal-window wrapper-modal-window-edit-xblock"  aria-labelledby="modal-window-title" role="dialog">
   <div class="modal-window-overlay"></div>
   <div class="modal-window confirm modal-med modal-type-html modal-editor" style="top: 50px; left: 400px;" tabindex="-1" aria-labelledby="modal-window-title">
     <div class="edit-xblock-modal">

--- a/cms/templates/ux/reference/modal_bulkpublish-section.html
+++ b/cms/templates/ux/reference/modal_bulkpublish-section.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 
-<div class="wrapper wrapper-modal-window wrapper-modal-window-bulkpublish-section" aria-describedby="modal-window-description" aria-labelledby="modal-window-title" aria-hidden="" role="dialog">
+<div class="wrapper wrapper-modal-window wrapper-modal-window-bulkpublish-section" aria-labelledby="modal-window-title" role="dialog">
     <div class="modal-window-overlay"></div>
     <div style="top: 5%; left: 30%;" class="modal-window confirm modal-med modal-type-confirm">
         <div class="bulkpublish-section-modal">

--- a/cms/templates/ux/reference/modal_bulkpublish-subsection.html
+++ b/cms/templates/ux/reference/modal_bulkpublish-subsection.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 
-<div class="wrapper wrapper-modal-window wrapper-modal-window-bulkpublish-subsection" aria-describedby="modal-window-description" aria-labelledby="modal-window-title" aria-hidden="" role="dialog">
+<div class="wrapper wrapper-modal-window wrapper-modal-window-bulkpublish-subsection" aria-labelledby="modal-window-title" role="dialog">
     <div class="modal-window-overlay"></div>
     <div style="top: 5%; left: 30%;" class="modal-window confirm modal-med modal-type-confirm">
         <div class="bulkpublish-subsection-modal">

--- a/cms/templates/ux/reference/modal_bulkpublish-unit.html
+++ b/cms/templates/ux/reference/modal_bulkpublish-unit.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 
-<div class="wrapper wrapper-modal-window wrapper-modal-window-bulkpublish-unit" aria-describedby="modal-window-description" aria-labelledby="modal-window-title" aria-hidden="" role="dialog">
+<div class="wrapper wrapper-modal-window wrapper-modal-window-bulkpublish-unit" aria-labelledby="modal-window-title"  role="dialog">
     <div class="modal-window-overlay"></div>
     <div style="top: 5%; left: 30%;" class="modal-window confirm modal-med modal-type-confirm">
         <div class="bulkpublish-unit-modal">


### PR DESCRIPTION
## Overview

Summary found in [AC-239](https://openedx.atlassian.net/browse/AC-239).
- Removed the aria-hidden attr on the `.wrapper-modal-window` elements.
- Remove the aria-describedby attr from the  `.wrapper-modal-window` elements.  I couldn't find any cases in the codebase where this was actually being used.
## Sandbox

https://studio-clytwynec.sandbox.edx.org/
## Reviews

@cptvitamin @clrux  Please review.
