### PR TITLE
Made coach dashboard available on ccx in addition to master course

### DIFF
--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -286,6 +286,10 @@ class TestCoachDashboard(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         course_enrollments = get_override_for_ccx(ccx, self.course, 'max_student_enrollments_allowed')
         self.assertEqual(course_enrollments, settings.CCX_MAX_STUDENTS_ALLOWED)
 
+        # assert ccx creator has role=ccx_coach
+        role = CourseCcxCoachRole(course_key)
+        self.assertTrue(role.has_user(self.coach))
+
     @SharedModuleStoreTestCase.modifies_courseware
     @patch('ccx.views.render_to_response', intercept_renderer)
     @patch('ccx.views.TODAY')

--- a/lms/djangoapps/instructor/access.py
+++ b/lms/djangoapps/instructor/access.py
@@ -45,25 +45,25 @@ def list_with_level(course, level):
     return ROLES[level](course.id).users_with_role()
 
 
-def allow_access(course, user, level):
+def allow_access(course, user, level, send_email=True):
     """
     Allow user access to course modification.
 
     `level` is one of ['instructor', 'staff', 'beta']
     """
-    _change_access(course, user, level, 'allow')
+    _change_access(course, user, level, 'allow', send_email)
 
 
-def revoke_access(course, user, level):
+def revoke_access(course, user, level, send_email=True):
     """
     Revoke access from user to course modification.
 
     `level` is one of ['instructor', 'staff', 'beta']
     """
-    _change_access(course, user, level, 'revoke')
+    _change_access(course, user, level, 'revoke', send_email)
 
 
-def _change_access(course, user, level, action):
+def _change_access(course, user, level, action, send_email=True):
     """
     Change access of user.
 
@@ -85,7 +85,7 @@ def _change_access(course, user, level, action):
                 course_id=course.id,
                 student_email=user.email,
                 auto_enroll=True,
-                email_students=True,
+                email_students=send_email,
                 email_params=email_params,
             )
         role.add_users(user)


### PR DESCRIPTION
### Background

From issue https://github.com/mitocw/edx-platform/issues/33
### What is done in this PR

**Studio Updates:** None.

**LMS Updates:** 
- Previously ccx coach dashboard was only available on master course. Coach needs to open master course to access coach dashboard
- After this fix coach can access his dashboard from both master course and ccx

@pdpinch @pwilkins @giocalitri 

MIT PR https://github.com/mitocw/edx-platform/pull/143
