### PR TITLE
Lighten course tab font weight.

### DIFF
--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -35,7 +35,7 @@
       a {
         @include padding(($baseline/2), ($baseline*0.75), 13px, ($baseline*0.75));
         @extend %t-title7;
-        @extend %t-strong;
+        @extend %t-regular;
         border-bottom: 3px solid transparent;
         color: $gray-d1;
         display: block;


### PR DESCRIPTION
@marcotuts 
<img width="687" alt="lookin-good" src="https://cloud.githubusercontent.com/assets/1819831/11277079/dfb59c5a-8eb2-11e5-9b72-fe941fb59c90.png">
