### PR TITLE
Adding gettext to JSHint ignore

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -140,6 +140,7 @@
         "spyOnEvent",
 
         // Miscellaneous globals
-        "JSON"
+        "JSON",
+        "gettext"
     ]
 }

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -12,7 +12,7 @@ set -e
 
 # Violations thresholds for failing the build
 export PYLINT_THRESHOLD=5650
-export JSHINT_THRESHOLD=9390
+export JSHINT_THRESHOLD=9080
 
 doCheckVars() {
     if [ -n "$CIRCLECI" ] ; then


### PR DESCRIPTION
This addition adds in an ignore for `gettext` in JSHint.

@andy-armstrong @clytwynec 
