### PR TITLE
Update --commit flag so you don't have to say --commit=commit

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/delete_orphans.py
+++ b/cms/djangoapps/contentstore/management/commands/delete_orphans.py
@@ -11,12 +11,12 @@ class Command(BaseCommand):
     help = '''
     Delete orphans from a MongoDB backed course. Takes two arguments:
     <course_id>: the course id of the course whose orphans you want to delete
-    |commit|: optional argument. If not provided, will not run task.
+    |--commit|: optional argument. If not provided, will dry run delete
     '''
 
     def add_arguments(self, parser):
         parser.add_argument('course_id')
-        parser.add_argument('--commit', action='store')
+        parser.add_argument('--commit', action='store_true', help='Commit to deleting the orphans')
 
     def handle(self, *args, **options):
         try:
@@ -24,20 +24,16 @@ class Command(BaseCommand):
         except InvalidKeyError:
             raise CommandError("Invalid course key.")
 
-        commit = False
         if options['commit']:
-            commit = options['commit'] == 'commit'
-
-        if commit:
             print 'Deleting orphans from the course:'
             deleted_items = _delete_orphans(
-                course_key, ModuleStoreEnum.UserID.mgmt_command, commit
+                course_key, ModuleStoreEnum.UserID.mgmt_command, options['commit']
             )
             print "Success! Deleted the following orphans from the course:"
             print "\n".join(deleted_items)
         else:
             print 'Dry run. The following orphans would have been deleted from the course:'
             deleted_items = _delete_orphans(
-                course_key, ModuleStoreEnum.UserID.mgmt_command, commit
+                course_key, ModuleStoreEnum.UserID.mgmt_command, options['commit']
             )
             print "\n".join(deleted_items)

--- a/cms/djangoapps/contentstore/management/commands/tests/test_delete_orphans.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_delete_orphans.py
@@ -24,7 +24,7 @@ class TestDeleteOrphan(TestOrphanBase):
     @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
     def test_delete_orphans_no_commit(self, default_store):
         """
-        Tests that running the command without a 'commit' argument
+        Tests that running the command without a '--commit' argument
         results in no orphans being deleted
         """
         course = self.create_course_with_orphans(default_store)
@@ -37,12 +37,12 @@ class TestDeleteOrphan(TestOrphanBase):
     @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
     def test_delete_orphans_commit(self, default_store):
         """
-        Tests that running the command WITH the 'commit' argument
+        Tests that running the command WITH the '--commit' argument
         results in the orphans being deleted
         """
         course = self.create_course_with_orphans(default_store)
 
-        call_command('delete_orphans', unicode(course.id), commit='commit')
+        call_command('delete_orphans', unicode(course.id), '--commit')
 
         # make sure this module wasn't deleted
         self.assertTrue(self.store.has_item(course.id.make_usage_key('html', 'multi_parent_html')))
@@ -66,7 +66,7 @@ class TestDeleteOrphan(TestOrphanBase):
 
         # call delete orphans, specifying the published branch
         # of the course
-        call_command('delete_orphans', unicode(published_branch), commit='commit')
+        call_command('delete_orphans', unicode(published_branch), '--commit')
 
         # now all orphans should be deleted
         self.assertOrphanCount(course.id, 0)


### PR DESCRIPTION
With the 1.8 upgrade, we stopped using 'manage.py cms command commit'
and switched to --commit because we no longer directly access args[]
https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/

When this command was updated, it was switched to --commit=commit, but
using store_true allows a much more natural --commit syntax.
