### PR TITLE
Management commands should no longer access args[]

### DIFF
--- a/common/djangoapps/third_party_auth/management/commands/saml.py
+++ b/common/djangoapps/third_party_auth/management/commands/saml.py
@@ -12,16 +12,14 @@ class Command(BaseCommand):
     """ manage.py commands to manage SAML/Shibboleth SSO """
     help = '''Configure/maintain/update SAML-based SSO'''
 
-    def handle(self, *args, **options):
-        if len(args) != 1:
-            raise CommandError("saml requires one argument: pull")
+    def add_arguments(self, parser):
+        parser.add_argument('--pull', action='store_true', help="Pull updated metadata from external IDPs")
 
+    def handle(self, *args, **options):
         if not SAMLConfiguration.is_enabled():
             raise CommandError("SAML support is disabled via SAMLConfiguration.")
 
-        subcommand = args[0]
-
-        if subcommand == "pull":
+        if options['pull']:
             log_handler = logging.StreamHandler(self.stdout)
             log_handler.setLevel(logging.DEBUG)
             log = logging.getLogger('third_party_auth.tasks')


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/

Django intercepts the 'pull' argument and says "unrecognized arguments pull"
There were no tests for this command, so it wasn't noticed during the
upgrade testing, only once our integration monitoring noticed.
