### PR TITLE
Fixes TNL-3664 by collapsing actions dropdown after an action item is clicked.

### DIFF
--- a/lms/static/js/dashboard/legacy.js
+++ b/lms/static/js/dashboard/legacy.js
@@ -79,8 +79,8 @@
             return properties;
         }
 
-        function toggleCourseActionsDropdown(event) {
-            var dashboard_index = $(this).data('dashboard-index');
+        function toggleCourseActionsDropdownInternal(element) {
+            var dashboard_index = element.data('dashboard-index');
 
             // Toggle the visibility control for the selected element and set the focus
             var dropdown_selector = 'div#actions-dropdown-' + dashboard_index;
@@ -97,6 +97,10 @@
             var anchor = $(anchor_selector);
             var aria_expanded_state = (anchor.attr('aria-expanded') === 'true');
             anchor.attr('aria-expanded', !aria_expanded_state);
+        }
+
+        function toggleCourseActionsDropdown(event) {
+            toggleCourseActionsDropdownInternal($(this));
 
             // Suppress the actual click event from the browser
             event.preventDefault();
@@ -118,11 +122,13 @@
         });
 
         $(".action-email-settings").click(function(event) {
-            $("#email_settings_course_id").val( $(event.target).data("course-id") );
-            $("#email_settings_course_number").text( $(event.target).data("course-number") );
+            var element = $(event.target);
+            $("#email_settings_course_id").val( element.data("course-id") );
+            $("#email_settings_course_number").text( element.data("course-number") );
             if($(event.target).data("optout") === "False") {
                 $("#receive_emails").prop('checked', true);
             }
+            toggleCourseActionsDropdownInternal(element);
         });
 
         $(".action-unenroll").click(function(event) {
@@ -138,6 +144,7 @@
             }, true));
             $('#refund-info').html( element.data("refund-info") );
             $("#unenroll_course_id").val( element.data("course-id") );
+            toggleCourseActionsDropdownInternal(element);
         });
 
         $('#unenroll_form').on('ajax:complete', function(event, xhr) {


### PR DESCRIPTION
### Fixes [TNL-3644](https://openedx.atlassian.net/browse/TNL-3644): Course settings dropdown doesn't disappear if you close modals
#### Components affected:
- LMS
#### Steps to verify:
1. Go to your student dashboard page in the LMS
2. Click the "gear" icon and select "Unenroll"
3. On the Unenroll modal, exit out of the modal

Note that the settings menu is now collapsed. It stayed open before the fix.
#### Additional discussion

Normally, when we fix a bug, we would like to add a test alongside the fix, to be sure that the bug remains fixed. You will note that I do not include a test with this PR. My rationale is that the code in [legacy.js](https://github.com/edx/edx-platform/blob/69dc51859e57e458e1a64717224343ff90e19298/lms/static/js/dashboard/legacy.js) is not designed to be testable, so I do not see how to test the new behaviour without rewriting major part of [legacy.js](https://github.com/edx/edx-platform/blob/69dc51859e57e458e1a64717224343ff90e19298/lms/static/js/dashboard/legacy.js), [_dashboard_course_listing.html](https://github.com/edx/edx-platform/blob/69dc51859e57e458e1a64717224343ff90e19298/lms/templates/dashboard/_dashboard_course_listing.html), and perhaps introducing a new template file. My concern is that such change introduces much more risk (read: potential bugs and problems) than it actually fixes. Especially when it is done by someone who is completely new to the project such as me.

In comparison, the conservative bugfix is trivial. So I propose it here.
#### Legal

This PR is covered by OpenCraft contributor agreement.

@antoviaque
