### PR TITLE
Removed user_id parameter from grade event

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -497,7 +497,7 @@ def get_module_system_for_user(user, student_data,  # TODO  # pylint: disable=to
         """
         Manages the workflow for recording and updating of student module grade state
         """
-        user_id = event.get('user_id', user.id)
+        user_id = user.id
 
         grade = event.get('value')
         max_grade = event.get('max_value')

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1633,8 +1633,8 @@ class TestXmoduleRuntimeEvent(TestSubmittingProblems):
         super(TestXmoduleRuntimeEvent, self).setUp()
         self.homework = self.add_graded_section_to_course('homework')
         self.problem = self.add_dropdown_to_section(self.homework.location, 'p1', 1)
-        self.grade_dict = {'value': 0.18, 'max_value': 32, 'user_id': self.student_user.id}
-        self.delete_dict = {'value': None, 'max_value': None, 'user_id': self.student_user.id}
+        self.grade_dict = {'value': 0.18, 'max_value': 32}
+        self.delete_dict = {'value': None, 'max_value': None}
 
     def get_module_for_user(self, user):
         """Helper function to get useful module at self.location in self.course_id for user"""


### PR DESCRIPTION
**Description:** Implementing grade event improvements from [this discussion thread](https://github.com/edx/edx-platform/pull/8775/files#r45460367). Before #8775, `set_grade` handler asserted on `user_id` being the same as current logged in user ID, resulting in assertion error if grade event was sent for other user. In #8775, set_grade was simplified and moved out of `FieldDataCache`, and the assertion was removed as well. This could potentially lead to incorrect behavior, as other parts of `handle_grade_event` still assumed the grade was sent for the current user. This PR aims to reduce this risk.
**JIRA Ticket:** [OSPR-973](https://openedx.atlassian.net/browse/OSPR-973)
**Sandbox:** [LMS](http://pr10704.sandbox.opencraft.com/), [Studio](http://studio.pr10704.sandbox.opencraft.com/)
**Testing instructions:** None - no user facing parts and no XBlocks/XModules that send grades to other users (as far as I know)
