### PR TITLE
Implement 'from_string_or_404' in utils

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -90,6 +90,7 @@ from util.organizations_helpers import (
     organizations_enabled,
 )
 from util.string_utils import _has_non_ascii_characters
+from util.course_key_utils import from_string_or_404
 from xmodule.contentstore.content import StaticContent
 from xmodule.course_module import CourseFields
 from xmodule.course_module import DEFAULT_START_DATE
@@ -868,10 +869,7 @@ def course_info_handler(request, course_key_string):
     GET
         html: return html for editing the course info handouts and updates.
     """
-    try:
-        course_key = CourseKey.from_string(course_key_string)
-    except InvalidKeyError:
-        raise Http404
+    course_key = from_string_or_404(course_key_string)
 
     with modulestore().bulk_operations(course_key):
         course_module = get_course_and_check_access(course_key, request.user)

--- a/common/djangoapps/util/course_key_utils.py
+++ b/common/djangoapps/util/course_key_utils.py
@@ -1,0 +1,30 @@
+"""
+Convenience methods for working with course objects
+"""
+from django.http import Http404
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+
+def from_string_or_404(course_key_string):
+    """
+    Gets CourseKey from the string passed as parameter.
+
+    Parses course key from string(containing course key) or raises 404 if the string's format is invalid.
+
+    Arguments:
+        course_key_string(str): It is string containing the course key
+
+    Returns:
+        CourseKey: A key that uniquely identifies a course
+
+    Raises:
+        HTTP404: A 404 not found exception will be thrown if course_key_string's format is invalid
+
+    """
+    try:
+        course_key = CourseKey.from_string(course_key_string)
+    except InvalidKeyError:
+        raise Http404
+
+    return course_key

--- a/common/djangoapps/util/tests/test_course_key_utils.py
+++ b/common/djangoapps/util/tests/test_course_key_utils.py
@@ -1,0 +1,32 @@
+"""
+Tests for util.course_key_utils
+"""
+from nose.tools import assert_equals, assert_raises  # pylint: disable=no-name-in-module
+from util.course_key_utils import from_string_or_404
+from opaque_keys.edx.keys import CourseKey
+from django.http import Http404
+
+
+def test_from_string_or_404():
+
+    #testing with split style course keys
+    assert_raises(
+        Http404,
+        from_string_or_404,
+        "/some.invalid.key/course-v1:TTT+CS01+2015_T0"
+    )
+    assert_equals(
+        CourseKey.from_string("course-v1:TTT+CS01+2015_T0"),
+        from_string_or_404("course-v1:TTT+CS01+2015_T0")
+    )
+
+    #testing with mongo style course keys
+    assert_raises(
+        Http404,
+        from_string_or_404,
+        "/some.invalid.key/TTT/CS01/2015_T0"
+    )
+    assert_equals(
+        CourseKey.from_string("TTT/CS01/2015_T0"),
+        from_string_or_404("TTT/CS01/2015_T0")
+    )


### PR DESCRIPTION
[SUST-22](https://openedx.atlassian.net/browse/SUST-22)

Implemented 'from_string_or_404' in util app (which is in common djangoapps) that parses course key from string or raises Http404 in case its format is invalid.
