### PR TITLE
Upgrade to latest 2.x version of pymongo.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -58,7 +58,7 @@ pycrypto>=2.6
 pygments==2.0.1
 pygraphviz==1.1
 PyJWT==1.0.1
-pymongo==2.8.1
+pymongo==2.9.1
 pyparsing==2.0.1
 python-memcached==1.48
 python-openid==2.2.5


### PR DESCRIPTION
Release Notes: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=10004&version=14795

Mostly backports to prep for moving to 3.0

@edx/devops 
