### PR TITLE
Use 0.1.4 of i18n-tools so Django 1.8 will work. PLAT-919

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -45,7 +45,7 @@ git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 -e git+https://github.com/edx/edx-submissions.git@0.1.2#egg=edx-submissions==0.1.2
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
-git+https://github.com/edx/i18n-tools.git@v0.1.3#egg=i18n-tools==v0.1.3
+git+https://github.com/edx/i18n-tools.git@v0.1.4#egg=i18n-tools==v0.1.4
 git+https://github.com/edx/edx-oauth2-provider.git@0.5.8#egg=edx-oauth2-provider==0.5.8
 git+https://github.com/edx/edx-val.git@0.0.8#egg=edxval==0.0.8
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock


### PR DESCRIPTION
@sarina Looks like @clintonb updated i18n-tools a while ago, and we needed to use the new version for Django 1.8 compatibility.  Sorry we didn't care of it before the merge!
