### PR TITLE
Update github.txt

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -58,7 +58,7 @@ git+https://github.com/edx/edx-lint.git@v0.3.2#egg=edx_lint==0.3.2
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 -e git+https://github.com/edx/edx-user-state-client.git@30c0ad4b9f57f8d48d6943eb585ec8a9205f4469#egg=edx-user-state-client
 git+https://github.com/edx/edx-organizations.git@release-2015-11-17-with-django-18#egg=edx-organizations==0.1.8
-git+https://github.com/edx/edx-proctoring.git@0.11.2#egg=edx-proctoring==0.11.2
+git+https://github.com/edx/edx-proctoring.git@0.11.6#egg=edx-proctoring==0.11.6
 
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga


### PR DESCRIPTION
@feanil @robrap 

To support this week's RC cutting. Here are the diffs:

https://github.com/edx/edx-proctoring/compare/0.11.2...0.11.6

I'm a bit confused looking at this compare, as 0.11.2 already contained the Django1.8 upgrade so those migrations and 1.8 code changes shouldn't be different between the two. It could be due to some git history not being aligned (e.g. 0.11.2 was on Django1.8 branch but it was rebased when merged to master).

Can you sign off for inclusion in this week's RC? 
