### PR TITLE
MA-1667: Update Mobile API to support Web Certificates

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -183,7 +183,7 @@ def certificate_downloadable_status(student, course_key):
 
     if current_status['status'] == CertificateStatuses.downloadable:
         response_data['is_downloadable'] = True
-        response_data['download_url'] = current_status['download_url']
+        response_data['download_url'] = get_certificate_url(student.id, course_key)
 
     return response_data
 

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -8,7 +8,7 @@ from django.template import defaultfilters
 
 from courseware.access import has_access
 from student.models import CourseEnrollment, User
-from certificates.models import certificate_status_for_student, CertificateStatuses
+from certificates.api import certificate_downloadable_status
 from xmodule.course_module import DEFAULT_START_DATE
 
 
@@ -89,10 +89,12 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
 
     def get_certificate(self, model):
         """Returns the information about the user's certificate in the course."""
-        certificate_info = certificate_status_for_student(model.user, model.course_id)
-        if certificate_info['status'] == CertificateStatuses.downloadable:
+        certificate_info = certificate_downloadable_status(model.user, model.course_id)
+        if certificate_info['is_downloadable']:
             return {
-                "url": certificate_info['download_url'],
+                'url': self.context['request'].build_absolute_uri(
+                    certificate_info['download_url']
+                ),
             }
         else:
             return {}

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -1,6 +1,7 @@
 """
 Tests for users API
 """
+# pylint: disable=no-member
 import datetime
 import ddt
 from mock import patch
@@ -10,6 +11,7 @@ from django.conf import settings
 from django.utils import timezone
 from django.template import defaultfilters
 
+from certificates.api import generate_user_certificates
 from certificates.models import CertificateStatuses
 from certificates.tests.factories import GeneratedCertificateFactory
 from courseware.access_response import (
@@ -180,7 +182,7 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         certificate_data = response.data[0]['certificate']
         self.assertDictEqual(certificate_data, {})
 
-    def test_certificate(self):
+    def test_pdf_certificate(self):
         self.login_and_enroll()
 
         certificate_url = "http://test_certificate_url"
@@ -195,6 +197,27 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         response = self.api_response()
         certificate_data = response.data[0]['certificate']
         self.assertEquals(certificate_data['url'], certificate_url)
+
+    @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
+    def test_web_certificate(self):
+        self.login_and_enroll()
+
+        self.course.cert_html_view_enabled = True
+        self.store.update_item(self.course, self.user.id)
+
+        with patch('courseware.grades.grade') as mock_grade:
+            mock_grade.return_value = {'grade': 'Pass', 'percent': 0.75}
+            generate_user_certificates(self.user, self.course.id)
+
+        response = self.api_response()
+        certificate_data = response.data[0]['certificate']
+        self.assertRegexpMatches(
+            certificate_data['url'],
+            r'http.*/certificates/user/{user_id}/course/{course_id}'.format(
+                user_id=self.user.id,
+                course_id=self.course.id,
+            )
+        )
 
     def test_no_facebook_url(self):
         self.login_and_enroll()


### PR DESCRIPTION
Update Mobile API's User Enrollment endpoint to support Web certificates in addition to PDF certificates.

@mattdrayer @jcdyer Please review.
