### PR TITLE
Add pagination support to course catalog API

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -9,7 +9,6 @@ from rest_framework.exceptions import NotFound, PermissionDenied
 from lms.djangoapps.courseware.courses import get_courses, get_course_with_access
 
 from .permissions import can_view_courses_for_username
-from .serializers import CourseSerializer
 
 
 def get_effective_user(requesting_user, target_username):
@@ -41,14 +40,14 @@ def course_detail(request, username, course_key):
         course_key (CourseKey): Identifies the course of interest
 
     Return value:
-        CourseSerializer object representing the requested course
+        `CourseDescriptor` object representing the requested course
     """
     user = get_effective_user(request.user, username)
     try:
         course = get_course_with_access(user, 'see_exists', course_key)
     except Http404:
         raise NotFound()
-    return CourseSerializer(course, context={'request': request}).data
+    return course
 
 
 def list_courses(request, username):
@@ -69,8 +68,8 @@ def list_courses(request, username):
 
 
     Return value:
-        A CourseSerializer object representing the collection of courses.
+        List of `CourseDescriptor` objects representing the collection of courses.
     """
     user = get_effective_user(request.user, username)
     courses = get_courses(user)
-    return CourseSerializer(courses, context={'request': request}, many=True).data
+    return courses

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -42,7 +42,7 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     Serializer for Course objects
     """
 
-    course_id = serializers.CharField(source='id', read_only=True)  # pylint: disable=invalid-name
+    course_id = serializers.CharField(source='id', read_only=True)
     name = serializers.CharField(source='display_name_with_default')
     number = serializers.CharField(source='display_number_with_default')
     org = serializers.CharField(source='display_org_with_default')
@@ -88,7 +88,8 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
         """
         Get the representation for SerializerMethodField `blocks_url`
         """
-        return '?'.join([
+        base_url = '?'.join([
             reverse('blocks_in_course'),
             urllib.urlencode({'course_id': course.id}),
         ])
+        return self.context['request'].build_absolute_uri(base_url)

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -1,0 +1,67 @@
+"""
+Test data created by CourseSerializer
+"""
+
+from datetime import datetime
+
+from rest_framework.test import APIRequestFactory
+from rest_framework.request import Request
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.course_module import DEFAULT_START_DATE
+
+from ..serializers import CourseSerializer
+from .mixins import CourseApiFactoryMixin
+
+
+class TestCourseSerializerFields(CourseApiFactoryMixin, ModuleStoreTestCase):
+    """
+    Test variations of start_date field responses
+    """
+
+    def setUp(self):
+        super(TestCourseSerializerFields, self).setUp()
+        self.staff_user = self.create_user('staff', is_staff=True)
+        self.honor_user = self.create_user('honor', is_staff=False)
+        self.request_factory = APIRequestFactory()
+
+    def _get_request(self, user=None):
+        """
+        Build a Request object for the specified user
+        """
+        if user is None:
+            user = self.honor_user
+        request = Request(self.request_factory.get('/'))
+        request.user = user
+        return request
+
+    def test_advertised_start(self):
+        course = self.create_course(
+            course=u'custom',
+            start=datetime(2015, 3, 15),
+            advertised_start=u'The Ides of March'
+        )
+        result = CourseSerializer(course, context={'request': self._get_request()}).data
+        self.assertEqual(result['course_id'], u'edX/custom/2012_Fall')
+        self.assertEqual(result['start_type'], u'string')
+        self.assertEqual(result['start_display'], u'The Ides of March')
+
+    def test_empty_start(self):
+        course = self.create_course(start=DEFAULT_START_DATE, course=u'custom')
+        result = CourseSerializer(course, context={'request': self._get_request()}).data
+        self.assertEqual(result['course_id'], u'edX/custom/2012_Fall')
+        self.assertEqual(result['start_type'], u'empty')
+        self.assertIsNone(result['start_display'])
+
+    def test_description(self):
+        course = self.create_course()
+        result = CourseSerializer(course, context={'request': self._get_request()}).data
+        self.assertEqual(result['description'], u'A course about toys.')
+
+    def test_blocks_url(self):
+        course = self.create_course()
+        result = CourseSerializer(course, context={'request': self._get_request()}).data
+        self.assertEqual(
+            result['blocks_url'],
+            u'http://testserver/api/courses/v1/blocks/?course_id=edX%2Ftoy%2F2012_Fall'
+        )

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -4,7 +4,6 @@ Tests for Blocks Views
 
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory
-from rest_framework.exceptions import NotFound
 
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
@@ -121,7 +120,7 @@ class CourseDetailViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase
         self.verify_response(params={'username': self.honor_user.username})
 
     def test_as_anonymous_user(self):
-        self.verify_response(expected_status_code=401)
+        self.verify_response(expected_status_code=200)
 
     def test_hidden_course_as_honor(self):
         self.setup_user(self.honor_user)
@@ -142,5 +141,5 @@ class CourseDetailViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase
         request = request_factory.get('/')
         request.query_params = {}
         request.user = self.staff_user
-        with self.assertRaises(NotFound):
-            CourseDetailView().get(request, 'a:b:c')
+        response = CourseDetailView().dispatch(request, course_key_string='a:b:c')
+        self.assertEqual(404, response.status_code)

--- a/openedx/core/lib/api/paginators.py
+++ b/openedx/core/lib/api/paginators.py
@@ -29,6 +29,38 @@ class DefaultPagination(pagination.PageNumberPagination):
         })
 
 
+class NamespacedPageNumberPagination(pagination.PageNumberPagination):
+    """
+    Pagination scheme that returns results with pagination metadata
+    embedded in a "pagination" attribute.  Can be used with data
+    that comes as a list of items, or as a dict with a "results"
+    attribute that contains a list of items.
+    """
+
+    page_size_query_param = "page_size"
+
+    def get_paginated_response(self, data):
+        """
+        Annotate the response with pagination information
+        """
+        metadata = {
+            'next': self.get_next_link(),
+            'previous': self.get_previous_link(),
+            'count': self.page.paginator.count,
+            'num_pages': self.page.paginator.num_pages,
+        }
+        if isinstance(data, dict):
+            if 'results' not in data:
+                raise TypeError(u'Malformed result dict')
+            data['pagination'] = metadata
+        else:
+            data = {
+                'results': data,
+                'pagination': metadata,
+            }
+        return Response(data)
+
+
 def paginate_search_results(object_class, search_results, page_size, page):
     """
     Takes edx-search results and returns a Page object populated

--- a/openedx/core/lib/api/tests/test_paginators.py
+++ b/openedx/core/lib/api/tests/test_paginators.py
@@ -1,10 +1,15 @@
 """ Tests paginator methods """
+
+from collections import namedtuple
+
 import ddt
 from mock import Mock, MagicMock
 from unittest import TestCase
 from django.http import Http404
+from django.test import RequestFactory
+from rest_framework import serializers
 
-from openedx.core.lib.api.paginators import paginate_search_results
+from openedx.core.lib.api.paginators import NamespacedPageNumberPagination, paginate_search_results
 
 
 @ddt.ddt
@@ -116,6 +121,50 @@ class PaginateSearchResultsTestCase(TestCase):
         """
         with self.assertRaises(Http404):
             paginate_search_results(self.mock_model, self.search_results, self.default_size, page_num)
+
+
+class NamespacedPaginationTestCase(TestCase):
+    """
+    Test behavior of `NamespacedPageNumberPagination`
+    """
+
+    TestUser = namedtuple('TestUser', ['username', 'email'])
+
+    class TestUserSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+        """
+        Simple serializer to paginate results from
+        """
+        username = serializers.CharField()
+        email = serializers.CharField()
+
+    expected_data = {
+        'results': [
+            {'username': 'user_5', 'email': 'user_5@example.com'},
+            {'username': 'user_6', 'email': 'user_6@example.com'},
+            {'username': 'user_7', 'email': 'user_7@example.com'},
+            {'username': 'user_8', 'email': 'user_8@example.com'},
+            {'username': 'user_9', 'email': 'user_9@example.com'},
+        ],
+        'pagination': {
+            'next': 'http://testserver/endpoint?page=3&page_size=5',
+            'previous': 'http://testserver/endpoint?page_size=5',
+            'count': 25,
+            'num_pages': 5,
+        }
+    }
+
+    def setUp(self):
+        super(NamespacedPaginationTestCase, self).setUp()
+        self.paginator = NamespacedPageNumberPagination()
+        self.users = [self.TestUser('user_{}'.format(idx), 'user_{}@example.com'.format(idx)) for idx in xrange(25)]
+        self.request_factory = RequestFactory()
+
+    def test_basic_pagination(self):
+        request = self.request_factory.get('/endpoint', data={'page': 2, 'page_size': 5})
+        request.query_params = {'page': 2, 'page_size': 5}
+        paged_users = self.paginator.paginate_queryset(self.users, request)
+        results = self.TestUserSerializer(paged_users, many=True).data
+        self.assertEqual(self.expected_data, self.paginator.get_paginated_response(results).data)
 
 
 def build_mock_object(obj_id):


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-1724

Modified API level code to return native business objects.  Keeping serialization logic at the view level lets us take better advantage of DRF idioms.

This includes both the addition of pagination support, and a trial run of a paginator that namespaces the pagination information, as described here: https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=47481813

Please review: @nasthagiri @jimabramson 

FYI @aleffert 
