### PR TITLE
Don't render unconfigured marketing links in CMS footer.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -257,3 +257,4 @@ Muhammad Rehan <muhammadrehan69@gmail.com>
 Shawn Milochik <shawn@milochik.com>
 Afeef Janjua <janjua.afeef@gmail.com>
 Jacek Bzdak <jbzdak@gmail.com>
+Dan Powell <dan@abakas.com>

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -11,16 +11,22 @@ from django.core.urlresolvers import reverse
         <p>&copy; ${settings.COPYRIGHT_YEAR} <a data-rel="edx.org" href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
       </div>
 
-      <nav class="nav-peripheral">
-        <ol>
-          <li class="nav-item nav-peripheral-tos">
-            <a data-rel="edx.org" href="${marketing_link('TOS')}">${_("Terms of Service")}</a>
-          </li>
-          <li class="nav-item nav-peripheral-pp">
-            <a data-rel="edx.org" href="${marketing_link('PRIVACY')}">${_("Privacy Policy")}</a>
-          </li>
-        </ol>
-      </nav>
+      % if is_any_marketing_link_set(['TOS', 'PRIVACY']):
+        <nav class="nav-peripheral">
+          <ol>
+            % if is_marketing_link_set('TOS'):
+              <li class="nav-item nav-peripheral-tos">
+                <a data-rel="edx.org" href="${marketing_link('TOS')}">${_("Terms of Service")}</a>
+              </li>
+            % endif
+            % if is_marketing_link_set('PRIVACY'):
+              <li class="nav-item nav-peripheral-pp">
+                <a data-rel="edx.org" href="${marketing_link('PRIVACY')}">${_("Privacy Policy")}</a>
+              </li>
+            % endif
+          </ol>
+        </nav>
+      % endif
     </div>
 
     <div class="footer-content-secondary" aria-label="{_('Legal')}">

--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -57,6 +57,30 @@ def marketing_link(name):
         return '#'
 
 
+def is_any_marketing_link_set(names):
+    """
+    Returns a boolean if any given named marketing links are configured.
+    """
+
+    return any(is_marketing_link_set(name) for name in names)
+
+
+def is_marketing_link_set(name):
+    """
+    Returns a boolean if a given named marketing link is configured.
+    """
+
+    enable_mktg_site = microsite.get_value(
+        'ENABLE_MKTG_SITE',
+        settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+    )
+
+    if enable_mktg_site:
+        return name in settings.MKTG_URLS
+    else:
+        return name in settings.MKTG_URL_LINK_MAP
+
+
 def marketing_link_context_processor(request):
     """
     A django context processor to give templates access to marketing URLs
@@ -112,6 +136,8 @@ def render_to_string(template_name, dictionary, context=None, namespace='main'):
     context_instance['settings'] = settings
     context_instance['EDX_ROOT_URL'] = settings.EDX_ROOT_URL
     context_instance['marketing_link'] = marketing_link
+    context_instance['is_any_marketing_link_set'] = is_any_marketing_link_set
+    context_instance['is_marketing_link_set'] = is_marketing_link_set
 
     # In various testing contexts, there might not be a current request context.
     request_context = get_template_request_context()

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -14,6 +14,8 @@ from edxmako.middleware import get_template_request_context
 from edxmako import add_lookup, LOOKUP
 from edxmako.shortcuts import (
     marketing_link,
+    is_marketing_link_set,
+    is_any_marketing_link_set,
     render_to_string,
     open_source_footer_context_processor
 )
@@ -40,6 +42,32 @@ class ShortcutsTests(UrlResetMixin, TestCase):
             expected_link = reverse('login')
             link = marketing_link('ABOUT')
             self.assertEquals(link, expected_link)
+
+    @override_settings(MKTG_URLS={'ROOT': 'dummy-root', 'ABOUT': '/about-us'})
+    @override_settings(MKTG_URL_LINK_MAP={'ABOUT': 'login'})
+    def test_is_marketing_link_set(self):
+        # test marketing site on
+        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
+            self.assertTrue(is_marketing_link_set('ABOUT'))
+            self.assertFalse(is_marketing_link_set('NOT_CONFIGURED'))
+        # test marketing site off
+        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
+            self.assertTrue(is_marketing_link_set('ABOUT'))
+            self.assertFalse(is_marketing_link_set('NOT_CONFIGURED'))
+
+    @override_settings(MKTG_URLS={'ROOT': 'dummy-root', 'ABOUT': '/about-us'})
+    @override_settings(MKTG_URL_LINK_MAP={'ABOUT': 'login'})
+    def test_is_any_marketing_link_set(self):
+        # test marketing site on
+        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
+            self.assertTrue(is_any_marketing_link_set(['ABOUT']))
+            self.assertTrue(is_any_marketing_link_set(['ABOUT', 'NOT_CONFIGURED']))
+            self.assertFalse(is_any_marketing_link_set(['NOT_CONFIGURED']))
+        # test marketing site off
+        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
+            self.assertTrue(is_any_marketing_link_set(['ABOUT']))
+            self.assertTrue(is_any_marketing_link_set(['ABOUT', 'NOT_CONFIGURED']))
+            self.assertFalse(is_any_marketing_link_set(['NOT_CONFIGURED']))
 
     @ddt.data((True, None), (False, None))
     @ddt.unpack


### PR DESCRIPTION
If the Terms of Service or Privacy marketing links aren't configured, don't render the navigation links to them in the Studio footer.

I'm not sure if view template conditional logic like this is typically tested, but if so let me know and I'm happy to add coverage.
