### PR TITLE
Using edx-django-oauth2-provider from PyPI

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -195,22 +195,12 @@ def uninstall_python_packages():
     # to really really get rid of it.
     for _ in range(3):
         uninstalled = False
-        frozen = sh("pip freeze", capture=True).splitlines()
+        frozen = sh("pip freeze", capture=True)
 
-        # Uninstall South
-        if any(line.startswith("South") for line in frozen):
-            sh("pip uninstall --disable-pip-version-check -y South")
-            uninstalled = True
-
-        # Uninstall edx-val
-        if any("edxval" in line for line in frozen):
-            sh("pip uninstall --disable-pip-version-check -y edxval")
-            uninstalled = True
-
-        # Uninstall django-storages
-        if any("django-storages==" in line for line in frozen):
-            sh("pip uninstall --disable-pip-version-check -y django-storages")
-            uninstalled = True
+        for package in ("South", "edxval", "django-storages", "django-oauth2-provider"):
+            if "{}==".format(package) in frozen:
+                sh("pip uninstall --disable-pip-version-check -y {}".format(package))
+                uninstalled = True
 
         if not uninstalled:
             break

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -32,6 +32,7 @@ django-method-override==0.1.0
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
 django==1.8.5
+edx-oauth2-provider==0.5.9
 edx-rest-api-client==1.2.1
 elasticsearch==0.4.5
 facebook-sdk==0.4.0
@@ -59,7 +60,6 @@ polib==1.0.3
 pycrypto>=2.6
 pygments==2.0.1
 pygraphviz==1.1
-PyJWT==1.0.1
 pymongo==2.9.1
 pyparsing==2.0.1
 python-memcached==1.48

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -46,7 +46,6 @@
 # Third-party:
 -e git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline
 git+https://github.com/edx/django-wiki.git@v0.0.5#egg=django-wiki==0.0.5
--e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-6a#egg=django-oauth2-provider==0.2.7-fork-edx-6
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 -e git+https://github.com/edx/django-rest-framework-oauth.git@f0b503fda8c254a38f97fef802ded4f5fe367f7a#egg=djangorestframework-oauth==1.0.1
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
@@ -82,7 +81,6 @@ git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.1.4#egg=i18n-tools==v0.1.4
-git+https://github.com/edx/edx-oauth2-provider.git@0.5.8#egg=edx-oauth2-provider==0.5.8
 git+https://github.com/edx/edx-val.git@0.0.8#egg=edxval==0.0.8
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock


### PR DESCRIPTION
- Uninstalling old package
- Using package from PyPI

Related to https://github.com/edx/django-oauth2-provider/pull/21.
