### PR TITLE
SOL-1433:remove audit course mode

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -354,9 +354,11 @@ def certificates_list_handler(request, course_key_string):
                 handler_name='certificates.certificate_activation_handler',
                 course_key=course_key
             )
-            course_modes = [mode.slug for mode in CourseMode.modes_for_course(
-                course_id=course.id, include_expired=True
-            )]
+            course_modes = [
+                mode.slug for mode in CourseMode.modes_for_course(
+                    course_id=course.id, include_expired=True
+                ) if mode.slug != 'audit'
+            ]
             certificate_web_view_url = get_lms_link_for_certificate_web_view(
                 user_id=request.user.id,
                 course_key=course_key,

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -22,6 +22,7 @@ from xmodule.exceptions import NotFoundError
 from student.models import CourseEnrollment
 from student.roles import CourseInstructorRole, CourseStaffRole
 from student.tests.factories import UserFactory
+from course_modes.tests.factories import CourseModeFactory
 from contentstore.views.certificates import CertificateManager
 from django.test.utils import override_settings
 from contentstore.utils import get_lms_link_for_certificate_web_view
@@ -325,6 +326,19 @@ class CertificatesListHandlerTestCase(EventTestMixin, CourseTestCase, Certificat
         )
         self.assertEqual(response.status_code, 403)
         self.assertIn("error", response.content)
+
+    def test_audit_course_mode_is_skipped(self):
+        """
+        Tests audit course mode is skipped when rendering certificates page.
+        """
+        CourseModeFactory.create(course_id=self.course.id)
+        CourseModeFactory.create(course_id=self.course.id, mode_slug='verified')
+        response = self.client.get_html(
+            self._url(),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'verified')
+        self.assertNotContains(response, 'audit')
 
     def test_assign_unique_identifier_to_certificates(self):
         """

--- a/cms/static/js/certificates/spec/views/certificate_preview_spec.js
+++ b/cms/static/js/certificates/spec/views/certificate_preview_spec.js
@@ -49,7 +49,7 @@ function(_, $, Course, CertificatePreview, TemplateHelpers, ViewHelpers, AjaxHel
             appendSetFixtures('<div class="preview-certificate nav-actions"></div>');
             this.view = new CertificatePreview({
                 el: $('.preview-certificate'),
-                course_modes: ['test1', 'test2', 'test3', 'audit'],
+                course_modes: ['test1', 'test2', 'test3'],
                 certificate_web_view_url: '/users/1/courses/orgX/009/2016?preview=test1',
                 certificate_activation_handler_url: '/certificates/activation/'+ window.course.id,
                 is_active: true
@@ -58,11 +58,6 @@ function(_, $, Course, CertificatePreview, TemplateHelpers, ViewHelpers, AjaxHel
         });
 
         describe('Certificate preview', function() {
-
-            it('course mode "audit" should not be render in preview list', function () {
-                expect(this.view.course_modes.indexOf('audit') < 0).toBe(true);
-            });
-
             it('course mode event should call when user choose a new mode', function () {
                 spyOn(this.view, 'courseModeChanged');
                 this.view.delegateEvents();

--- a/cms/static/js/certificates/views/certificate_preview.js
+++ b/cms/static/js/certificates/views/certificate_preview.js
@@ -27,8 +27,6 @@ function(_, gettext, BaseView, ViewUtils, NotificationView) {
         },
 
         render: function () {
-            // removing the course mode 'audit' from the preview list.
-            this.course_modes = _.without(this.course_modes, 'audit');
             this.$el.html(this.template({
                 course_modes: this.course_modes,
                 certificate_web_view_url: this.certificate_web_view_url,


### PR DESCRIPTION
This PR address issue reported in SOL-1433.  We were stripping `audit` at front-end(JS) instead of backend(python) and as a result of it was generating wrong preview link if course has `audit` mode set.
@asadiqbal08 please review.
@mattdrayer FYI.
