### PR TITLE
Fix for TNL-3429: use display_name, not display_name_with_default.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -254,3 +254,4 @@ Arbab Nazar <arbab@edx.org>
 Douglas Hall <dhall@edx.org>
 Awais Jibran <awaisdar001@gmail.com>
 Muhammad Rehan <muhammadrehan69@gmail.com>
+Andrew Gaylard <a.gaylard@gmail.com>

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -12,7 +12,7 @@ from contentstore.views.helpers import xblock_studio_url, xblock_type_display_na
 from django.utils.translation import ugettext as _
 from openedx.core.lib.js_utils import escape_json_dumps
 %>
-<%block name="title">${xblock.display_name_with_default} ${xblock_type_display_name(xblock) | h}</%block>
+<%block name="title">${xblock.display_name} ${xblock_type_display_name(xblock) | h}</%block>
 <%block name="bodyclass">is-signedin course container view-container</%block>
 
 <%namespace name='static' file='static_content.html'/>
@@ -55,15 +55,15 @@ from openedx.core.lib.js_utils import escape_json_dumps
                     ancestor_url = xblock_studio_url(ancestor)
                     %>
                     % if ancestor_url:
-                        <a href="${ancestor_url | h}" class="navigation-item navigation-link navigation-parent">${ancestor.display_name_with_default | h}</a>
+                        <a href="${ancestor_url | h}" class="navigation-item navigation-link navigation-parent">${ancestor.display_name | h}</a>
                     % else:
-                        <span class="navigation-item navigation-parent">${ancestor.display_name_with_default | h}</span>
+                        <span class="navigation-item navigation-parent">${ancestor.display_name | h}</span>
                     % endif
                 % endfor
             </small>
             <div class="wrapper-xblock-field incontext-editor is-editable"
                  data-field="display_name" data-field-display-name="${_("Display Name")}">
-                <h1 class="page-header-title xblock-field-value incontext-editor-value"><span class="title-value">${xblock.display_name_with_default | h}</span></h1>
+                <h1 class="page-header-title xblock-field-value incontext-editor-value"><span class="title-value">${xblock.display_name | h}</span></h1>
             </div>
         </div>
 


### PR DESCRIPTION
# Fix for TNL-3429: use display_name, not display_name_with_default.
## JIRA ticket

https://openedx.atlassian.net/browse/TNL-3429
## Components affected
- Studio
## Test sequence to reproduce bug TNL-3429 and verify the fix

_Note: In the screenshots, the text "angle brackets" is deliberately highlighted to draw attention to the relevant fields._
1.    Start up Studio as the edxapp user: "paver devstack studio".
2.    Open a browser to Studio: http://127.0.0.1:8001. The home page loads.
3.    Click the "Sign in" button. The sign in page loads.
4.    Sign in as as the "staff@example.com" user.
5.    Click on "edX Demonstration Course". This opens the course outline page.
6.    Scroll to the bottom of the page.
7.    Click "New Section" and create a section named "Section: <angle brackets>".
8.    Click "New Subsection" and create a subsection named "Subsection: <angle brackets>".   Both names are rendered correctly on the course outline page. See course-outline-0.png: ![course-outline-0](https://cloud.githubusercontent.com/assets/6389399/11400323/6478b378-9395-11e5-90cb-6c6c1fa8864c.png)
9.    If necessary, click on the triangle alongside the subsection name to expand the field.
10.    Click "New Unit".  The unit page loads.
- Without the fix, this reproduces bug TNL-3429. See unit-page-0.png: 
  ![unit-page-0](https://cloud.githubusercontent.com/assets/6389399/11400525/7c10c2e0-9396-11e5-84ec-17704672afee.png)
- With the fix, the text is rendered correctly.  See see unit-page-3.png: 
  ![unit-page-3](https://cloud.githubusercontent.com/assets/6389399/11400533/8b3454f8-9396-11e5-86f6-56cdcc1134a5.png)
## Test case

The test case test_course_metadata_utils.py checks for the escaping of the angle brackets, and continues to work (i.e. pass) as before.
## Additional notes

From examining packet traces, the browser sends the new unit/subsection/section name after editing to the server with the < and > characters unescaped, which is correct for JSON. Only the " and \ characters are escaped in the JSON strings when sending the change to the server, as expected. However, when the server sends the JSON **back** to the browser for (re-)rendering, the < and > characters **are** now escaped in the JSON strings.

This doesn't look right; I would expect uniformity in both directions. I'd also expect that HTML-escaping would not be done in the JSON. Also, it doesn't make sense to escape only the < and > characters and not the other HTML-sensitive characters: ; & ' ".

The function which produces this is `display_name_with_default` in `course_metadata_utils.py`. However, some of the JS code in the browser expects the < and > characters to be escaped, while other parts do not, hence this bug, and hence also why it is not sufficient merely to remove the escaping code from this function: it causes other parts of the front-end to mis-render the text.

So the safer fix is to modify the `container.html` template, as it does not affect other front-end functions.  The change is to use `display_name` instead of `display_name_with_default` in the template.  Given that the section, subsection, and unit names cannot be empty (the front-end does not allow it), no default value for these fields is needed anyway.
## Urgency

Not urgent: no course is being held up by this bug.
## Legal

This PR is covered by OpenCraft contributor agreement

@antoviaque
