### PR TITLE
Disable the pip version check message for uninstalls

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -199,17 +199,17 @@ def uninstall_python_packages():
 
         # Uninstall South
         if any(line.startswith("South") for line in frozen):
-            sh("pip uninstall -y South")
+            sh("pip uninstall --disable-pip-version-check -y South")
             uninstalled = True
 
         # Uninstall edx-val
         if any("edxval" in line for line in frozen):
-            sh("pip uninstall -y edxval")
+            sh("pip uninstall --disable-pip-version-check -y edxval")
             uninstalled = True
 
         # Uninstall django-storages
         if any("django-storages==" in line for line in frozen):
-            sh("pip uninstall -y django-storages")
+            sh("pip uninstall --disable-pip-version-check -y django-storages")
             uninstalled = True
 
         if not uninstalled:


### PR DESCRIPTION
@nedbat @benpatterson 
Similar to #9655.

For quieting these messages from the current output:

```
pip freeze
pip uninstall -y South
You are using pip version 6.0.8, however version 7.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Uninstalling South-1.0.1:
  Successfully uninstalled South-1.0.1
pip uninstall -y edxval
You are using pip version 6.0.8, however version 7.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Uninstalling edxval-0.0.5:
  Successfully uninstalled edxval-0.0.5
pip uninstall -y django-storages
You are using pip version 6.0.8, however version 7.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Uninstalling django-storages-1.1.5:
  Successfully uninstalled django-storages-1.1.5
```
