### PR TITLE
Suggest the devops group alias, rather than individual names

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -2,7 +2,7 @@
 #
 # If you open a pull request that adds a new dependency, you should notify:
 #   * @mollydb - to check licensing
-#   * One of @e0d, @jarv, or @feanil - to check system requirements
+#   * @edx/devops - to check system requirements
 
 numpy==1.6.2
 networkx==1.7

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -2,8 +2,7 @@
 #
 # If you open a pull request that adds a new dependency, you should notify:
 #   * @mollydb to check licensing
-#   * One of @e0d, @feanil, @fredsmith, @maxrothman, or @jibsheet
-#     to check system requirements
+#   * @edx/devops to check system requirements
 #
 # A correct GitHub reference looks like this:
 #

--- a/requirements/edx/post.txt
+++ b/requirements/edx/post.txt
@@ -2,7 +2,7 @@
 #
 # If you open a pull request that adds a new dependency, you should notify:
 #   * @mollydb - to check licensing
-#   * support@edx.org - to check system requirements
+#   * @edx/devops - to check system requirements
 
 # This needs to be installed *after* lxml, which is in base.txt.
 # python-saml pulls in lxml as a dependency, and due to a bug in setuptools,

--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -2,8 +2,7 @@
 #
 # If you open a pull request that adds a new dependency, you should notify:
 #   * @mollydb to check licensing
-#   * One of @e0d, @feanil, @fredsmith, @maxrothman, or @jibsheet
-#     to check system requirements
+#   * @edx/devops to check system requirements
 
 # Use a modern setuptools instead of distribute
 setuptools==18.0.1


### PR DESCRIPTION
Before, we had out of date or incomplete lists of people who can review requirement changes.
