### PR TITLE
SOL-1389: Cert Exception: Add error states and messages

### DIFF
--- a/lms/static/js/certificates/models/certificate_exception.js
+++ b/lms/static/js/certificates/models/certificate_exception.js
@@ -30,7 +30,8 @@
 
                 validate: function(attrs){
                     if (!_.str.trim(attrs.user_name) && !_.str.trim(attrs.user_email)) {
-                        return gettext('Student username/email is required.');
+                        return gettext('Student username/email field is required and can not be empty. ' +
+                            'Kindly fill in username/email and then press "Add Exception" button.');
                     }
 
                 }

--- a/lms/static/js/certificates/views/certificate_whitelist.js
+++ b/lms/static/js/certificates/views/certificate_whitelist.js
@@ -77,7 +77,9 @@
                             caller_object.showMessage(response.message, 'msg-error');
                         }
                         catch(exception){
-                            caller_object.showMessage("Server Error, Please try again later.", 'msg-error');
+                            caller_object.showMessage(
+                                "Server Error, Please refresh the page and try again.", 'msg-error'
+                            );
                         }
                     };
                 }

--- a/lms/static/js/certificates/views/certificate_whitelist_editor.js
+++ b/lms/static/js/certificates/views/certificate_whitelist_editor.js
@@ -58,7 +58,10 @@
                     });
 
                     if(this.collection.findWhere(model)){
-                        this.showMessage("username/email already in exception list", 'msg-error');
+                        this.showMessage(
+                            "User (username/email=" + (user_name || user_email) + ") already in exception list.",
+                            'msg-error'
+                        );
                     }
                     else if(certificate_exception.isValid()){
                         certificate_exception.save(
@@ -67,7 +70,7 @@
                                 success: this.showSuccess(
                                     this,
                                     true,
-                                    'Students added to Certificate white list successfully'
+                                    'Student added to Certificate white list successfully.'
                                 ),
                                 error: this.showError(this)
                             }
@@ -98,7 +101,11 @@
                         this.showMessage('Exception is being removed from server.', 'msg-success');
                     }
                     else{
-                        this.showMessage('Could not find Certificate Exception in white list.', 'msg-error');
+                        this.showMessage(
+                            'Could not find Certificate Exception in white list. ' +
+                            'Please refresh the page and try again',
+                            'msg-error'
+                        );
                     }
                 },
 
@@ -131,7 +138,9 @@
                             caller.showMessage(response_data.message, 'msg-error');
                         }
                         catch(exception){
-                            caller.showMessage("Server Error, Please try again later.", 'msg-error');
+                            caller.showMessage("" +
+                                "Server Error, Please refresh the page and try again.", 'msg-error'
+                            );
                         }
                     };
                 }

--- a/lms/static/js/spec/instructor_dashboard/certificates_exception_spec.js
+++ b/lms/static/js/spec/instructor_dashboard/certificates_exception_spec.js
@@ -24,7 +24,8 @@ define([
             };
 
             var EXPECTED_ERRORS = {
-                user_name_or_email_required: "Student username/email is required."
+                user_name_or_email_required: 'Student username/email field is required and can not be empty. ' +
+                'Kindly fill in username/email and then press "Add Exception" button.'
             };
 
             beforeEach(function() {
@@ -331,12 +332,14 @@ define([
                 var message_selector='.message',
                     error_class = 'msg-error',
                     success_class = 'msg-success',
-                    success_message = 'Students added to Certificate white list successfully',
-                    requests = AjaxHelpers.requests(this);
+                    success_message = 'Student added to Certificate white list successfully.',
+                    requests = AjaxHelpers.requests(this),
+                    duplicate_user='test_user';
 
                 var error_messages = {
-                    empty_user_name_email: 'Student username/email is required.',
-                    duplicate_user: 'username/email already in exception list'
+                    empty_user_name_email: 'Student username/email field is required and can not be empty. ' +
+                    'Kindly fill in username/email and then press "Add Exception" button.',
+                    duplicate_user: "User (username/email=" + (duplicate_user) + ") already in exception list."
                 };
 
                 // click 'Add Exception' button with empty username/email field
@@ -348,7 +351,7 @@ define([
                 expect(view.$el.find(message_selector).html()).toMatch(error_messages.empty_user_name_email);
 
                 // Add a new Exception to list
-                view.$el.find('#certificate-exception').val("test_user");
+                view.$el.find('#certificate-exception').val(duplicate_user);
                 view.$el.find('#notes').val("test user notes");
                 view.$el.find('#add-exception').click();
 
@@ -357,7 +360,7 @@ define([
                     {
                         id: 3,
                         user_id : 3,
-                        user_name: "test_user",
+                        user_name: duplicate_user,
                         user_email : "test2@test.com",
                         course_id: "edX/test/course",
                         created: "Thursday, October 29, 2015",
@@ -370,13 +373,13 @@ define([
                 expect(view.$el.find(message_selector).html()).toMatch(success_message);
 
                 // Add a duplicate Certificate Exception
-                view.$el.find('#certificate-exception').val("test_user");
+                view.$el.find('#certificate-exception').val(duplicate_user);
                 view.$el.find('#notes').val("test user notes");
                 view.$el.find('#add-exception').click();
 
                 // Verify success message
                 expect(view.$el.find(message_selector)).toHaveClass(error_class);
-                expect(view.$el.find(message_selector).html()).toMatch(error_messages.duplicate_user);
+                expect(view.$el.find(message_selector).html()).toEqual(error_messages.duplicate_user);
             });
 
             it('verifies certificate exception can be deleted by clicking "delete" ', function(){


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR, it contains changes for [SOL-1389](https://openedx.atlassian.net/browse/SOL-1389).

**Description of [SOL-1389](https://openedx.atlassian.net/browse/SOL-1389):**
**Background**
When PM enters username/email and click add exception button, there is no validation that the user exists in edX or is enrolled in the course. The action adds the user to the exception table no matter if user exists in database or not. It should only add user if user exists in database.
**Acceptance Criteria**
1. Only allow users to be added to the Cert Exception table if the user exists in the database. 
2. If the user does not exist in the database, display an error message to the user:
   
   > "We can't find the user you've entered. Make sure the username or email address is correct, then try again."
3. When a PM attempts to add a user to the Exception list from the Instructor Dashboard, the system should validate that the user is enrolled in the course. If not, the system should display this message:
   
   > "The user you have entered is not enrolled in this course. Make sure the username or email address is correct, then try again."

cc: @mattdrayer 
