### PR TITLE
Cohort Membership fixes TNL-3806

### DIFF
--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -206,12 +206,14 @@ def get_cohort(user, course_key, assign=True, use_cached=False):
                 assignment_type=CourseCohort.RANDOM
             ).course_user_group
 
+        # This block will transactionally commit the membership and the corresponding update to cohort.users
         with transaction.atomic:
-            membership = CohortMembership.objects.get_or_create(
+            membership, created = CohortMembership.objects.get_or_create(
                 course_user_group=cohort,
                 user__id=user.id
             )
-            membership.save()
+            if created:
+                membership.save()
 
         return request_cache.data.setdefault(cache_key, cohort)
 

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -207,7 +207,7 @@ def get_cohort(user, course_key, assign=True, use_cached=False):
             ).course_user_group
 
         # This block will transactionally commit the membership and the corresponding update to cohort.users
-        with transaction.atomic:
+        with transaction.atomic():
             membership, created = CohortMembership.objects.get_or_create(
                 course_user_group=cohort,
                 user__id=user.id

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -181,7 +181,7 @@ def get_cohort(user, course_key, assign=True, use_cached=False):
         return request_cache.data.setdefault(cache_key, None)
 
     # If course is cohorted, check if the user already has a cohort.
-    if not assign: # Check assign first, so as to use django's get_or_create() below if able
+    if not assign:  # Check assign first, so as to use django's get_or_create() below if able
         try:
             cohort = CohortMembership.objects.get(
                 course_id=course_key,

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -185,7 +185,7 @@ def get_cohort(user, course_key, assign=True, use_cached=False):
         try:
             cohort = CohortMembership.objects.get(
                 course_id=course_key,
-                user__id=user.id,
+                user=user,
             )
             return request_cache.data.setdefault(cache_key, cohort)
         except CourseUserGroup.DoesNotExist:
@@ -210,7 +210,7 @@ def get_cohort(user, course_key, assign=True, use_cached=False):
         with transaction.atomic():
             membership, created = CohortMembership.objects.get_or_create(
                 course_user_group=cohort,
-                user__id=user.id
+                user=user
             )
             if created:
                 membership.save()

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -147,6 +147,7 @@ class CohortMembership(models.Model):
         instance.course_user_group.users.remove(instance.user)
         instance.course_user_group.save()
 
+
 class CourseUserGroupPartitionGroup(models.Model):
     """
     Create User Partition Info.

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -9,6 +9,8 @@ import logging
 from django.contrib.auth.models import User
 from django.db import models, transaction, IntegrityError
 from django.core.exceptions import ValidationError
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
 from xmodule_django.models import CourseKeyField
 
 log = logging.getLogger(__name__)
@@ -142,6 +144,10 @@ class CohortMembership(models.Model):
         if not success:
             raise IntegrityError("Unable to save membership after {} tries, aborting.".format(max_retries))
 
+    @receiver(pre_delete)
+    def remove_user_from_cohort(sender, instance, **kwargs):
+        instance.course_user_group.users.remove(instance.user)
+        instance.course_user_group.save()
 
 class CourseUserGroupPartitionGroup(models.Model):
     """

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -150,6 +150,7 @@ def remove_user_from_cohort(sender, instance, **kwargs):
     instance.course_user_group.users.remove(instance.user)
     instance.course_user_group.save()
 
+
 class CourseUserGroupPartitionGroup(models.Model):
     """
     Create User Partition Info.

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -2,6 +2,7 @@
 Django models related to course groups functionality.
 """
 
+import time
 import json
 import logging
 
@@ -132,6 +133,7 @@ class CohortMembership(models.Model):
                 self.course_user_group.users.add(self.user)
                 self.course_user_group.save()
 
+                time.sleep(10)
                 super(CohortMembership, saved_membership).save(update_fields=['course_user_group'])
 
             success = True

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -2,7 +2,6 @@
 Django models related to course groups functionality.
 """
 
-import time
 import json
 import logging
 
@@ -135,7 +134,6 @@ class CohortMembership(models.Model):
                 self.course_user_group.users.add(self.user)
                 self.course_user_group.save()
 
-                time.sleep(10)
                 super(CohortMembership, saved_membership).save(update_fields=['course_user_group'])
 
             success = True

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -142,11 +142,13 @@ class CohortMembership(models.Model):
         if not success:
             raise IntegrityError("Unable to save membership after {} tries, aborting.".format(max_retries))
 
-    @receiver(pre_delete)
-    def remove_user_from_cohort(sender, instance, **kwargs):
-        instance.course_user_group.users.remove(instance.user)
-        instance.course_user_group.save()
 
+# Ensures CohortMemberships remove underlying course_user_group data on delete
+# Needs to exist outside class definition in order to use 'sender=CohortMembership'
+@receiver(pre_delete, sender=CohortMembership)
+def remove_user_from_cohort(sender, instance, **kwargs):
+    instance.course_user_group.users.remove(instance.user)
+    instance.course_user_group.save()
 
 class CourseUserGroupPartitionGroup(models.Model):
     """

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -397,13 +397,14 @@ def remove_user_from_cohort(request, course_key_string, cohort_id):
 
         # This atomic() wrapper ensures that the CohortMembership and course_user_group models are updated atomically.
         # This will be commited to the database immediately.
-        with transaction.atomic(): # This is to ensure pre-delete handling is done atomically
+        with transaction.atomic():  # This is to ensure pre-delete handling is done atomically
             membership.delete()
 
         return json_http_response({'success': True})
     except CohortMembership.DoesNotExist:
         return json_http_response({'success': False,
                                    'msg': "User '{0}' was not present in cohort '{1}'".format(username, cohort_id)})
+
 
 def debug_cohort_mgmt(request, course_key_string):
     """

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -394,8 +394,12 @@ def remove_user_from_cohort(request, course_key_string, cohort_id):
 
     try:
         membership = CohortMembership.objects.get(user=user, course_id=course_group.course_id)
+
+        # This atomic() wrapper ensures that the CohortMembership and course_user_group models are updated atomically.
+        # This will be commited to the database immediately.
         with transaction.atomic(): # This is to ensure pre-delete handling is done atomically
             membership.delete()
+
         return json_http_response({'success': True})
     except CohortMembership.DoesNotExist:
         return json_http_response({'success': False,

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -12,6 +12,7 @@ from django.views.decorators.http import require_http_methods
 from util.json_request import expect_json, JsonResponse
 from django.contrib.auth.decorators import login_required
 from django.utils.translation import ugettext
+from django.db import transaction
 
 import logging
 import re
@@ -384,16 +385,21 @@ def remove_user_from_cohort(request, course_key_string, cohort_id):
         return json_http_response({'success': False,
                                    'msg': 'No username specified'})
 
-    cohort = cohorts.get_cohort_by_id(course_key, cohort_id)
     try:
         user = User.objects.get(username=username)
-        cohort.users.remove(user)
-        return json_http_response({'success': True})
     except User.DoesNotExist:
         log.debug('no user')
         return json_http_response({'success': False,
                                    'msg': "No user '{0}'".format(username)})
 
+    try:
+        membership = CohortMembership.objects.get(user=user, course_id=course_group.course_id)
+        with transaction.atomic(): # This is to ensure pre-delete handling is done atomically
+            membership.delete()
+        return json_http_response({'success': True})
+    except CohortMembership.DoesNotExist:
+        return json_http_response({'success': False,
+                                   'msg': "User '{0}' was not present in cohort '{1}'".format(username, cohort_id)})
 
 def debug_cohort_mgmt(request, course_key_string):
     """


### PR DESCRIPTION
## [TNL-3806](https://openedx.atlassian.net/browse/TNL-3806)

Fixing issue with course_user_group table getting out-of-sync with CohortMembership model. The exact details of how this was occurring/why this fixes it are included on the commit message for  https://github.com/edx/edx-platform/commit/7f8d2f95cd07347a9b2e541ca9d6ae3c72456e87 (copied below)
### Sandbox

Working on this. Since the issue isn't trivial to reproduce normally, I'll be building 2 sandboxes with the `sleep()` calls in place. One without the fix, to confirm the issue is reproducible, and one with the fix, to confirm the issue is properly fixed. All calls to `sleep()` will be removed before submitting.
### Testing

Test plan outlined above with sandboxes. Manual testing is the only way I know how to be able to verify this, as it relies on `ATMOIC_REQUESTS` and race conditions. If anyone feels strongly about adding unit tests and wants to help figure out how we can make that happen, I'm all ears. Otherwise, I'm prepared to chalk this up as a one-time manual test related to changing default transaction handling as part of the 1.8 upgrade.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @dianakhuang 
- [ ] Code review: @robrap 
- [x] UI/UX/Accessibility (nothing user-facing in this PR)
### Devops assistance

I had mentioned this to @maxrothman and @jibsheet last week, so FYI guys.
### Post-review
- [ ] Squash commits
