### PR TITLE
Fix: correcting play/skip icon for bumper

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_play_skip_control_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_play_skip_control_spec.js
@@ -25,12 +25,6 @@
             expect($('.video_control.play')).toExist();
         });
 
-        it('add ARIA attributes to play control', function () {
-            expect($('.video_control.play')).toHaveAttrs({
-                'aria-disabled': 'false'
-            });
-        });
-
         it('can update state on play', function () {
             state.el.trigger('play');
             expect($('.video_control.play')).not.toExist();

--- a/common/lib/xmodule/xmodule/js/spec/video/video_skip_control_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_skip_control_spec.js
@@ -30,13 +30,6 @@
             expect($('.skip-control')).toExist();
         });
 
-        it('add ARIA attributes to play control', function () {
-            state.el.trigger('play');
-            expect($('.skip-control')).toHaveAttrs({
-                'aria-disabled': 'false'
-            });
-        });
-
         it('can skip the video on click', function () {
             spyOn(state.bumperState.videoBumper, 'skipAndDoNotShowAgain');
             state.el.trigger('play');

--- a/common/lib/xmodule/xmodule/js/src/video/09_play_skip_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_play_skip_control.js
@@ -25,9 +25,9 @@ define('video/09_play_skip_control.js', [], function() {
 
     PlaySkipControl.prototype = {
         template: [
-            '<button class="control video_control play play-skip-control" aria-disabled="false">',
+            '<button class="control video_control play play-skip-control">',
                 '<span class="icon-fallback-img">',
-                    '<span class="icon icon-play" aria-hidden="true"></span>',
+                    '<span class="icon fa fa-play" aria-hidden="true"></span>',
                     '<span class="text control-text">',
                         gettext('Play'),
                     '</span>',
@@ -79,8 +79,8 @@ define('video/09_play_skip_control.js', [], function() {
                 .removeClass('play')
                 .addClass('skip')
                 .find('.icon')
-                    .removeClass('icon-play')
-                    .addClass('icon-step-forward')
+                    .removeClass('fa-play')
+                    .addClass('fa-step-forward')
                 .find('.control-text')
                     .text(gettext('Skip'));
             // Disable possibility to pause the video.


### PR DESCRIPTION
Changes the icon prefixes from `icon-` to `fa-` so they appear correctly on the video bumper.

@frrrances would you review this for me? It's a hotfix for the current release so somewhat time-sensitive.
