### PR TITLE
fix wiki alertbox style

### DIFF
--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -897,13 +897,14 @@ section.wiki {
   .alert {
     position: relative;
     width: auto;
-    margin: 24px 40px;
+    margin: 24px 0px;
     padding: 8px 12px;
     border: 1px solid #EBE8BF;
     border-radius: 3px;
     background: $yellow;
     color: $black;
     font-size: 0.9em;
+    min-width: inherit;
 
     .close {
       position: absolute;


### PR DESCRIPTION
[TNL-3821](https://openedx.atlassian.net/browse/TNL-3821)

Fixed styling issue of course wiki's alert notification addressed by the ticket above.
@mushtaqak please have a look.

Before: 
<img width="1276" alt="screen shot 2015-12-01 at 4 15 54 pm" src="https://cloud.githubusercontent.com/assets/7848408/11500301/0d781844-984e-11e5-8bd2-aea05d1ea3a9.png">

After: 
<img width="1275" alt="screen shot 2015-12-01 at 5 06 14 pm" src="https://cloud.githubusercontent.com/assets/7848408/11500311/1de0a8d6-984e-11e5-9135-c0171d5062be.png">
