### PR TITLE
Now using outer_atomic()

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -1505,8 +1505,7 @@ def cohort_students_and_upload(_xmodule_instance_args, _entry_id, course_id, tas
                 continue
 
             try:
-                with outer_atomic():
-                    add_user_to_cohort(cohorts_status[cohort_name]['cohort'], username_or_email)
+                add_user_to_cohort(cohorts_status[cohort_name]['cohort'], username_or_email)
                 cohorts_status[cohort_name]['Students Added'] += 1
                 task_progress.succeeded += 1
             except User.DoesNotExist:

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -10,6 +10,8 @@ from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseBadRequest
 from django.views.decorators.http import require_http_methods
 from util.json_request import expect_json, JsonResponse
+from util.db import outer_atomic
+from django.db import transaction
 from django.contrib.auth.decorators import login_required
 from django.utils.translation import ugettext
 
@@ -23,7 +25,7 @@ from edxmako.shortcuts import render_to_response
 
 from . import cohorts
 from lms.djangoapps.django_comment_client.utils import get_discussion_category_map, get_discussion_categories_ids
-from .models import CourseUserGroup, CourseUserGroupPartitionGroup
+from .models import CourseUserGroup, CourseUserGroupPartitionGroup, CohortMembership
 
 log = logging.getLogger(__name__)
 
@@ -299,6 +301,7 @@ def users_in_cohort(request, course_key_string, cohort_id):
                                'users': user_info})
 
 
+@transaction.non_atomic_requests
 @ensure_csrf_cookie
 @require_POST
 def add_users_to_cohort(request, course_key_string, cohort_id):
@@ -363,6 +366,7 @@ def add_users_to_cohort(request, course_key_string, cohort_id):
                                'unknown': unknown})
 
 
+@transaction.non_atomic_requests
 @ensure_csrf_cookie
 @require_POST
 def remove_user_from_cohort(request, course_key_string, cohort_id):
@@ -384,15 +388,25 @@ def remove_user_from_cohort(request, course_key_string, cohort_id):
         return json_http_response({'success': False,
                                    'msg': 'No username specified'})
 
-    cohort = cohorts.get_cohort_by_id(course_key, cohort_id)
     try:
         user = User.objects.get(username=username)
-        cohort.users.remove(user)
-        return json_http_response({'success': True})
     except User.DoesNotExist:
         log.debug('no user')
         return json_http_response({'success': False,
                                    'msg': "No user '{0}'".format(username)})
+
+    try:
+        membership = CohortMembership.objects.get(user=user, course_id=course_key)
+
+        # This outer_atomic() wrapper ensures that the CohortMembership and course_user_group models udate atomically.
+        # This will be commited to the database immediately.
+        with outer_atomic():
+            membership.delete()
+
+        return json_http_response({'success': True})
+    except CohortMembership.DoesNotExist:
+        return json_http_response({'success': False,
+                                   'msg': "User '{0}' was not present in cohort '{1}'".format(username, cohort_id)})
 
 
 def debug_cohort_mgmt(request, course_key_string):


### PR DESCRIPTION
Thanks once again to @doctoryes, now actually ensuring we write to database
when the atomic block exits, by virtue of using outer_atomic. Previously, we
had been writing to a savepoint in the outer transaction, and testing had not
caught the difference until now.

I've verified this fix on my local devstack, after reproducing the error that I found
using sandboxes. I'll get a sandbox up shortly to verify the fix "live" using sleeps.

FYI @robrap @doctoryes 
