### PR TITLE
Modify existing Programs migration to account for help_text change

### DIFF
--- a/openedx/core/djangoapps/programs/migrations/0003_auto_20151120_1613.py
+++ b/openedx/core/djangoapps/programs/migrations/0003_auto_20151120_1613.py
@@ -14,12 +14,22 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='programsapiconfig',
             name='authoring_app_css_path',
-            field=models.CharField(max_length=255, verbose_name="Path to authoring app's CSS", blank=True),
+            field=models.CharField(
+                max_length=255,
+                help_text='This value is required in order to enable the Studio authoring interface.',
+                verbose_name="Path to authoring app's CSS",
+                blank=True
+            ),
         ),
         migrations.AddField(
             model_name='programsapiconfig',
             name='authoring_app_js_path',
-            field=models.CharField(max_length=255, verbose_name="Path to authoring app's JS", blank=True),
+            field=models.CharField(
+                max_length=255,
+                help_text='This value is required in order to enable the Studio authoring interface.',
+                verbose_name="Path to authoring app's JS",
+                blank=True
+            ),
         ),
         migrations.AddField(
             model_name='programsapiconfig',


### PR DESCRIPTION
Prevents makemigrations from creating a new migration for the programs app.

@andy-armstrong @macdiesel 
