### PR TITLE
Do not install xblock-utils in editable mode

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -89,7 +89,7 @@ git+https://github.com/edx/edx-val.git@0.0.8#egg=edxval==0.0.8
 -e git+https://github.com/edx/edx-search.git@release-2015-11-17#egg=edx-search==0.1.1
 -e git+https://github.com/edx/edx-milestones.git@release-2015-11-17#egg=edx-milestones==0.1.5
 git+https://github.com/edx/edx-lint.git@v0.3.2#egg=edx_lint==0.3.2
--e git+https://github.com/edx/xblock-utils.git@v1.0.0#egg=xblock-utils==v1.0.0
+git+https://github.com/edx/xblock-utils.git@v1.0.0#egg=xblock-utils==v1.0.0
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 -e git+https://github.com/edx/edx-user-state-client.git@30c0ad4b9f57f8d48d6943eb585ec8a9205f4469#egg=edx-user-state-client


### PR DESCRIPTION
This fixes an issue with a prior version of xblock-utils being installed when installing requirements. This caused a warning in the console when starting up lms/cms:

```
2015-11-30 16:52:26,857 WARNING 5601 [xblock.plugin] plugin.py:147 - Unable to load XBlock 'lti_consumer'
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/plugin.py", line 144, in load_classes
    yield (class_.name, cls._load_class_entry_point(class_))
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/plugin.py", line 73, in _load_class_entry_point
    class_ = entry_point.load()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2354, in load
    self.require(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2371, in require
    items = working_set.resolve(reqs, env, installer)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 844, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
VersionConflict: (xblock-utils 0.1a0 (/edx/app/edxapp/venvs/edxapp/src/xblock-utils), Requirement.parse('xblock-utils==v1.0.0'))
```
