### PR TITLE
SOL-1466: Make sure web view renders certs only if downloadable.

### DIFF
--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -215,7 +215,7 @@ class MicrositeCertificatesViewsTests(ModuleStoreTestCase):
             grade="0.95",
             key='the_key',
             distinction=True,
-            status='generated',
+            status='downloadable',
             mode='honor',
             name=self.user.profile.name,
         )

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -38,6 +38,7 @@ from certificates.api import (
 )
 from certificates.models import (
     GeneratedCertificate,
+    CertificateStatuses,
     CertificateHtmlViewConfiguration,
     CertificateSocialNetworks,
     BadgeAssertion
@@ -351,7 +352,8 @@ def _get_user_certificate(request, user, course_key, course, preview_mode=None):
         else:
             user_certificate = GeneratedCertificate.objects.get(
                 user=user,
-                course_id=course_key
+                course_id=course_key,
+                status=CertificateStatuses.downloadable
             )
 
     # If there's no generated certificate data for this user, we need to see if we're in 'preview' mode...


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR, it contains changes for [SOL-1466](https://openedx.atlassian.net/browse/SOL-1466).

**Description od [SOL-1466](https://openedx.atlassian.net/browse/SOL-1466):**

At the moment certs web view only looks for an entry in cert generated table to get cert related info. It should actually check for downloadable state of certs also. That would allow rendering of only those certs which are in downloadable state.

cc: @mattdrayer 
