### PR TITLE
Fixed test cc and test arr license that were failing on Chrome

### DIFF
--- a/common/test/acceptance/tests/video/test_video_license.py
+++ b/common/test/acceptance/tests/video/test_video_license.py
@@ -76,7 +76,7 @@ class VideoLicenseTest(StudioCourseTest):
         container_page = unit.go_to()
         container_page.edit()
         video = [xb for xb in container_page.xblocks if xb.name == "Test Video"][0]
-        video.edit().open_advanced_tab()
+        video.open_advanced_tab()
         video.set_license('all-rights-reserved')
         video.save_settings()
         container_page.publish_action.click()
@@ -106,7 +106,7 @@ class VideoLicenseTest(StudioCourseTest):
         container_page = unit.go_to()
         container_page.edit()
         video = [xb for xb in container_page.xblocks if xb.name == "Test Video"][0]
-        video.edit().open_advanced_tab()
+        video.open_advanced_tab()
         video.set_license('creative-commons')
         video.save_settings()
         container_page.publish_action.click()


### PR DESCRIPTION
@benpatterson @jzoldak @singingwolfboy 
Please review. 
edit() function was being called twice. Removed one from both the tests: 
https://build.testeng.edx.org/view/All/job/edx-platform-bok-choy-custom/61/testReport/common.test.acceptance.tests.video.test_video_license/VideoLicenseTest/test_arr_license/
https://build.testeng.edx.org/view/All/job/edx-platform-bok-choy-custom/61/testReport/common.test.acceptance.tests.video.test_video_license/VideoLicenseTest/test_cc_license/
