### PR TITLE
do orphan deletion in a bulk operation (SUST-21)

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -693,12 +693,13 @@ def _delete_orphans(course_usage_key, user_id, commit=False):
     items = store.get_orphans(course_usage_key)
     branch = course_usage_key.branch
     if commit:
-        for itemloc in items:
-            revision = ModuleStoreEnum.RevisionOption.all
-            # specify branches when deleting orphans
-            if branch == ModuleStoreEnum.BranchName.published:
-                revision = ModuleStoreEnum.RevisionOption.published_only
-            store.delete_item(itemloc, user_id, revision=revision)
+        with store.bulk_operations(course_usage_key):
+            for itemloc in items:
+                revision = ModuleStoreEnum.RevisionOption.all
+                # specify branches when deleting orphans
+                if branch == ModuleStoreEnum.BranchName.published:
+                    revision = ModuleStoreEnum.RevisionOption.published_only
+                store.delete_item(itemloc, user_id, revision=revision)
     return [unicode(item) for item in items]
 
 


### PR DESCRIPTION
Right now, when you delete orphans, each orphan is deleted in a separate mongo call. This wraps the orphan deletion in a bulk_operations context manager.

See [SUST-21](https://openedx.atlassian.net/browse/SUST-21) for more info.

Reviewers:
- [x] @awaisdar001 
- [x] @doctoryes 

@maxrothman , FYI
