### PR TITLE
Release/due times no longer round to half hours.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -259,3 +259,4 @@ Afeef Janjua <janjua.afeef@gmail.com>
 Jacek Bzdak <jbzdak@gmail.com>
 Jillian Vogel <pomegranited@gmail.com>
 Dan Powell <dan@abakas.com>
+Mariana Araújo <simbelm.ne@gmail.com>

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -194,7 +194,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             this.$('input.date').datepicker({'dateFormat': 'm/d/yy'});
             this.$('input.time').timepicker({
                 'timeFormat' : 'H:i',
-                'forceRoundTime': true
+                'forceRoundTime': false
             });
             if (this.model.get(this.fieldName)) {
                 DateUtils.setDate(

--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -763,8 +763,20 @@ class CourseOutlineModal(object):
     def has_release_date(self):
         return self.find_css("#start_date").present
 
+    def has_release_time(self):
+        """
+        Check if the input box for the release time exists in the subsection's settings window
+        """
+        return self.find_css("#start_time").present
+
     def has_due_date(self):
         return self.find_css("#due_date").present
+
+    def has_due_time(self):
+        """
+        Check if the input box for the due time exists in the subsection's settings window
+        """
+        return self.find_css("#due_time").present
 
     def has_policy(self):
         return self.find_css("#grading_type").present
@@ -790,6 +802,15 @@ class CourseOutlineModal(object):
             "{} is updated in modal.".format(property_name)
         ).fulfill()
 
+    def set_time(self, input_selector, time):
+        """
+        Set `time` value to input pointed by `input_selector`
+        Not using the time picker to make sure it's not being rounded up
+        """
+
+        self.page.q(css=input_selector).fill(time)
+        self.page.q(css=input_selector).results[0].send_keys(Keys.ENTER)
+
     @property
     def release_date(self):
         return self.find_css("#start_date").first.attrs('value')[0]
@@ -802,6 +823,20 @@ class CourseOutlineModal(object):
         self.set_date('release_date', "#start_date", date)
 
     @property
+    def release_time(self):
+        """
+        Returns the current value of the release time. Default is u'00:00'
+        """
+        return self.find_css("#start_time").first.attrs('value')[0]
+
+    @release_time.setter
+    def release_time(self, time):
+        """
+        Time is "HH:MM" string.
+        """
+        self.set_time("#start_time", time)
+
+    @property
     def due_date(self):
         return self.find_css("#due_date").first.attrs('value')[0]
 
@@ -811,6 +846,20 @@ class CourseOutlineModal(object):
         Date is "mm/dd/yyyy" string.
         """
         self.set_date('due_date', "#due_date", date)
+
+    @property
+    def due_time(self):
+        """
+        Returns the current value of the release time. Default is u''
+        """
+        return self.find_css("#due_time").first.attrs('value')[0]
+
+    @due_time.setter
+    def due_time(self, time):
+        """
+        Time is "HH:MM" string.
+        """
+        self.set_time("#due_time", time)
 
     @property
     def policy(self):

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -372,22 +372,30 @@ class EditingSectionsTest(CourseOutlineTest):
 
         # Verify fields
         self.assertTrue(modal.has_release_date())
+        self.assertTrue(modal.has_release_time())
         self.assertTrue(modal.has_due_date())
+        self.assertTrue(modal.has_due_time())
         self.assertTrue(modal.has_policy())
 
         # Verify initial values
         self.assertEqual(modal.release_date, u'1/1/1970')
+        self.assertEqual(modal.release_time, u'00:00')
         self.assertEqual(modal.due_date, u'')
+        self.assertEqual(modal.due_time, u'')
         self.assertEqual(modal.policy, u'Not Graded')
 
         # Set new values
         modal.release_date = '3/12/1972'
+        modal.release_time = '04:01'
         modal.due_date = '7/21/2014'
+        modal.due_time = '23:39'
         modal.policy = 'Lab'
 
         modal.save()
         self.assertIn(u'Released: Mar 12, 1972', subsection.release_date)
+        self.assertIn(u'04:01', subsection.release_date)
         self.assertIn(u'Due: Jul 21, 2014', subsection.due_date)
+        self.assertIn(u'23:39', subsection.due_date)
         self.assertIn(u'Lab', subsection.policy)
 
     def test_can_edit_section(self):


### PR DESCRIPTION
Patch for issue [TNL-3772 - Due dates can only be set to the hour or half past](https://openedx.atlassian.net/browse/TNL-3772), assigned to me by @antoviaque . It is covered by the OpenCraft contributor agreement.

Since both due and release dates are meant to allow any minute, I set ['forceRoundTime'](https://github.com/simbs/edx-platform/commit/869550784d977a0a5e607dbaedec7fab5c2e4738#diff-fecac9c1a5c871b71bafab46e808b363) in BaseDateEditor to false. I set it explicitly even though the default in the [timepicker lib is false](https://github.com/edx/edx-platform/blob/062e979e0ed14161d0f882091a06e032ca76bb3e/common/static/js/vendor/timepicker/jquery.timepicker.js#L32), in case the default should change.

I also updated the bok choy acceptance test as requested. I added checks in [test_can_edit_subsection](https://github.com/simbs/edx-platform/commit/869550784d977a0a5e607dbaedec7fab5c2e4738#diff-d8eb01091f6f5be72153b83284b8776e) for the release time and due time, in the same manner the dates were being tested. The final assertions for date and time are separate to make it easier to know which field failed. I ran the updated test before and after the bug fix, and it fails and passes respectively.
[overview.py](https://github.com/simbs/edx-platform/commit/869550784d977a0a5e607dbaedec7fab5c2e4738#diff-0922791d5011c835dedd3e237454bad0) was updated with the necessary extra supporting methods/properties.
