### PR TITLE
Raise UnicodeDecodeError exception after logging the exception

### DIFF
--- a/common/djangoapps/track/backends/logger.py
+++ b/common/djangoapps/track/backends/logger.py
@@ -41,6 +41,7 @@ class LoggerBackend(BaseBackend):
                 "UnicodeDecodeError Event_type: %r, Event_source: %r, Page: %r, Referer: %r",
                 event.get('event_type'), event.get('event_source'), event.get('page'), event.get('referer')
             )
+            raise
 
         # TODO: remove trucation of the serialized event, either at a
         # higher level during the emittion of the event, or by


### PR DESCRIPTION
@adampalay mention a very good point about https://github.com/edx/edx-platform/pull/9700 that we should raise `UnicodeDecodeError` exception after logging the required details of exception.

@brianhw , @adampalay Kindly Review !
