### PR TITLE
fix html escaped that shouldn't be for Content Experiment

### DIFF
--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -9,9 +9,8 @@ else:
 </%def>
 <%!
 from contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
-from django.utils.translation import ugettext as _
 from openedx.core.lib.js_utils import escape_json_dumps
-from markupsafe import Markup as HTML, escape as HTML_ESCAPE
+from util.markup import HTML, ugettext as _
 %>
 <%block name="title">${xblock.display_name_with_default} ${xblock_type_display_name(xblock) | h}</%block>
 <%block name="bodyclass">is-signedin course container view-container</%block>
@@ -111,10 +110,16 @@ from markupsafe import Markup as HTML, escape as HTML_ESCAPE
                 % if xblock.category == 'split_test':
                     <div class="bit">
                         <h3 class="title-3">${_("Adding components")}</h3>
-                        <p>${_(HTML_ESCAPE("Select a component type under {em_start}Add New Component{em_end}. Then select a template.")).format(em_start=HTML('<strong>'), em_end=HTML("</strong>"))}</p>
+                        <p>${_("Select a component type under {strong_start}Add New Component{strong_end}. Then select a template.").format(
+                                    strong_start=HTML('<strong>'),
+                                    strong_end=HTML("</strong>"),
+                            )}</p>
                         <p>${_("The new component is added at the bottom of the page or group. You can then edit and move the component.")}</p>
                         <h3 class="title-3">${_("Editing components")}</h3>
-                        <p>${_(HTML_ESCAPE("Click the {em_start}Edit{em_end} icon in a component to edit its content.")).format(em_start=HTML('<strong>'), em_end=HTML("</strong>"))}</p>
+                        <p>${_("Click the {strong_start}Edit{strong_end} icon in a component to edit its content.").format(
+                                    strong_start=HTML('<strong>'),
+                                    strong_end=HTML("</strong>"),
+                            )}</p>
                         <h3 class="title-3">${_("Reorganizing components")}</h3>
                         <p>${_("Drag components to new locations within this component.")}</p>
                         <p>${_("For content experiments, you can drag components to other groups.")}</p>

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -11,6 +11,7 @@ else:
 from contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
 from django.utils.translation import ugettext as _
 from openedx.core.lib.js_utils import escape_json_dumps
+from markupsafe import Markup as HTML, escape as HTML_ESCAPE
 %>
 <%block name="title">${xblock.display_name_with_default} ${xblock_type_display_name(xblock) | h}</%block>
 <%block name="bodyclass">is-signedin course container view-container</%block>
@@ -110,10 +111,10 @@ from openedx.core.lib.js_utils import escape_json_dumps
                 % if xblock.category == 'split_test':
                     <div class="bit">
                         <h3 class="title-3">${_("Adding components")}</h3>
-                        <p>${_("Select a component type under {em_start}Add New Component{em_end}. Then select a template.").format(em_start='<strong>', em_end="</strong>") | h}</p>
+                        <p>${_(HTML_ESCAPE("Select a component type under {em_start}Add New Component{em_end}. Then select a template.")).format(em_start=HTML('<strong>'), em_end=HTML("</strong>"))}</p>
                         <p>${_("The new component is added at the bottom of the page or group. You can then edit and move the component.")}</p>
                         <h3 class="title-3">${_("Editing components")}</h3>
-                        <p>${_("Click the {em_start}Edit{em_end} icon in a component to edit its content.").format(em_start='<strong>', em_end="</strong>") | h}</p>
+                        <p>${_(HTML_ESCAPE("Click the {em_start}Edit{em_end} icon in a component to edit its content.")).format(em_start=HTML('<strong>'), em_end=HTML("</strong>"))}</p>
                         <h3 class="title-3">${_("Reorganizing components")}</h3>
                         <p>${_("Drag components to new locations within this component.")}</p>
                         <p>${_("For content experiments, you can drag components to other groups.")}</p>


### PR DESCRIPTION
[TNL-3822](https://openedx.atlassian.net/browse/TNL-3822)

**Background:**
There is some code in Studio container.html that is escaping real html and the html (e.g. strong tag is appearing on the screen).

**Solution:**
I have added markupsafe.escape for escaping the html. To protect it against XSS and used markupsafe.Markup for using strong in escaped string.

Before
![problem-picture](https://cloud.githubusercontent.com/assets/7721119/11536091/c4db2220-9938-11e5-9d90-334390a33182.png)

After 
![done-picture](https://cloud.githubusercontent.com/assets/7721119/11536071/b1ec44aa-9938-11e5-8735-08f0f3d368d8.png)

If someone tries XSS.
![against-xss](https://cloud.githubusercontent.com/assets/7721119/11536105/d99037f0-9938-11e5-87da-c6dbda37851c.png)
