### PR TITLE
LMS: changing blue to pink, ensuring contrast, for Studio/Staff

### DIFF
--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -301,6 +301,9 @@ $audit-color-lvl2: tint($audit-color-lvl1, 33%);
 // edx-specific: credit
 $credit-color-base: rgb(244,195,0); // accessible with black text
 
+// edx-specific: Studio/Staff actions
+$staff-color: $pink;
+
 
 // ----------------------------
 // #TYPOGRAPHY

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -67,8 +67,6 @@ $gray-d2:   shade($gray,40%) !default;
 $gray-d3:   shade($gray,60%) !default;
 $gray-d4:   shade($gray,80%) !default;
 
-
-$blue: rgb(0, 120, 176);
 $yellow: rgb(255, 252, 221);
 
 $pink: rgb(182,37,103);

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -30,16 +30,16 @@ html.video-fullscreen {
   .instructor-info-action {
     @extend %t-copy-sub2;
     @include float(right);
-    margin-left: ($baseline/2);
+    @include margin-left($baseline/2);
     padding: ($baseline/4) ($baseline/2);
     border-radius: ($baseline/4);
     background-color: $shadow-l2;
     text-align: right;
     text-transform: uppercase;
-    color: $lighter-base-font-color;
+    color: $blue-d1;
 
     &:hover {
-      background-color: $link-hover;
+      background-color: $blue-d1;
       color: $white;
     }
   }

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -36,10 +36,10 @@ html.video-fullscreen {
     background-color: $shadow-l2;
     text-align: right;
     text-transform: uppercase;
-    color: $blue-d1;
+    color: $staff-color;
 
     &:hover {
-      background-color: $blue-d1;
+      background-color: $staff-color;
       color: $white;
     }
   }

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -252,10 +252,10 @@
         background-color: $shadow-l2;
         text-align: right;
         text-transform: uppercase;
-        color: $lighter-base-font-color;
+        color: $blue-d1;
 
         &:hover {
-          background-color: $link-hover;
+          background-color: $blue-d1;
           color: $white;
         }
       }

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -252,10 +252,10 @@
         background-color: $shadow-l2;
         text-align: right;
         text-transform: uppercase;
-        color: $blue-d1;
+        color: $staff-color;
 
         &:hover {
-          background-color: $blue-d1;
+          background-color: $staff-color;
           color: $white;
         }
       }


### PR DESCRIPTION
This work changes the blue in the "View in Studio" and "Staff Debug" buttons to pink (which is what it was previously) to meet or exceed WCAG AA color contrast requirements. It completes work for [AC-253](https://openedx.atlassian.net/browse/AC-253).
## Examples of changes
### Before

<img width="169" alt="screen shot 2015-12-02 at 10 54 20 am" src="https://cloud.githubusercontent.com/assets/2112024/11536202/64aeafa0-98e5-11e5-9e20-bf6e7263aa9f.png">
<img width="164" alt="screen shot 2015-12-02 at 10 54 24 am" src="https://cloud.githubusercontent.com/assets/2112024/11536203/64afc0fc-98e5-11e5-9d5d-bb2e5382062a.png">
<img width="151" alt="screen shot 2015-12-02 at 10 54 30 am" src="https://cloud.githubusercontent.com/assets/2112024/11536204/64aff432-98e5-11e5-9cba-4d23d2ba3edf.png">
<img width="154" alt="screen shot 2015-12-02 at 10 54 33 am" src="https://cloud.githubusercontent.com/assets/2112024/11536205/64b3f6b8-98e5-11e5-84aa-6420dd92edbf.png">
### After

<img width="161" alt="screen shot 2015-12-02 at 12 10 20 pm" src="https://cloud.githubusercontent.com/assets/2112024/11538000/c90c9b58-98ed-11e5-9aea-47880d84b5ed.png">
<img width="163" alt="screen shot 2015-12-02 at 12 10 24 pm" src="https://cloud.githubusercontent.com/assets/2112024/11537999/c90b1be8-98ed-11e5-80f5-02cd58dff391.png">
<img width="144" alt="screen shot 2015-12-02 at 12 10 27 pm" src="https://cloud.githubusercontent.com/assets/2112024/11538001/c9107dfe-98ed-11e5-9627-c9596be4a975.png">
<img width="151" alt="screen shot 2015-12-02 at 12 10 30 pm" src="https://cloud.githubusercontent.com/assets/2112024/11538002/c9144592-98ed-11e5-98e1-65ec312408f7.png">
## Reviewers
- [ ] @frrrances (Sass/UI)
