### PR TITLE
LMS: darkening footer copyright text for WCAG

### DIFF
--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -58,12 +58,14 @@ html.video-fullscreen {
 
 .content-wrapper {
 
-  .course-license, .xblock-license {
+  .course-license,
+  .xblock-license {
     @include text-align(right);
     @extend %t-title7;
     display: block;
     width: auto;
     padding: ($baseline/4) 0;
+    color: $gray-d1;
 
     span {
       color: inherit;


### PR DESCRIPTION
This small update darkens the footer text "Copyright, All Rights Reserved" to satisfy WCAG AA requirements. It relates to [AC-255](https://openedx.atlassian.net/browse/AC-255).
## Befores and Afters
### Before

<img width="176" alt="screen shot 2015-12-02 at 11 35 15 am" src="https://cloud.githubusercontent.com/assets/2112024/11537552/852d7382-98eb-11e5-972d-0c13567a2eee.png">
### After

<img width="176" alt="screen shot 2015-12-02 at 11 52 02 am" src="https://cloud.githubusercontent.com/assets/2112024/11537559/8aeea2a0-98eb-11e5-9338-69eef5a9bdc4.png">
## Reviewers
- [x] @frrrances (Sass/UI)
