### PR TITLE
Xmodule: syncing link color with LMS

### DIFF
--- a/common/lib/xmodule/xmodule/css/html/display.scss
+++ b/common/lib/xmodule/xmodule/css/html/display.scss
@@ -91,7 +91,7 @@ ul {
 
 a {
   &:link, &:visited, &:hover, &:active, &:focus {
-    color: #1d9dd9;
+    color: $blue;
   }
 }
 


### PR DESCRIPTION
This updates the xmodule link color to match the rest of the LMS. It was too light, failing contrast checks. It pertains to [AC-256](https://openedx.atlassian.net/browse/AC-256).
## Befores and Afters
### Before

<img width="228" alt="screen shot 2015-12-02 at 2 28 18 pm" src="https://cloud.githubusercontent.com/assets/2112024/11541644/427d62de-9901-11e5-821a-093a3c914969.png">
### After

<img width="221" alt="screen shot 2015-12-02 at 2 28 27 pm" src="https://cloud.githubusercontent.com/assets/2112024/11541651/48616d26-9901-11e5-907c-069e3b3537e2.png">
## Reviewers
- [x] @frrrances (Sass/UI)
