### PR TITLE
Xmodule: darkening gray text for WCAG AA requirements

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -972,7 +972,7 @@ div.problem {
   .detailed-solution {
     > p:first-child {
       @extend %t-strong;
-      color: #aaa;
+      color: $gray;
       text-transform: uppercase;
       font-style: normal;
       font-size: 0.9em;


### PR DESCRIPTION
This work darkens the gray text for Xmodule answer explanations to meet WCAG AA requirements. It pertains to [AC-261](https://openedx.atlassian.net/browse/AC-261).
## Befores and Afters
### Before

<img width="167" alt="screen shot 2015-12-02 at 3 10 14 pm" src="https://cloud.githubusercontent.com/assets/2112024/11542771/fd05a72e-9906-11e5-8f43-dd9deb69aa4e.png">
### After

<img width="144" alt="screen shot 2015-12-02 at 3 10 01 pm" src="https://cloud.githubusercontent.com/assets/2112024/11542778/02b3479e-9907-11e5-9222-f9a2ee1375f2.png">
## Reviewers
- [x] @frrrances (Sass/UI)
