### PR TITLE
Xmodule: darkening 'correct' green color for WCAG AA requirements

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -23,8 +23,8 @@
 // ====================
 $annotation-yellow: rgba(255,255,10,0.3);
 $color-copy-tip: rgb(100,100,100);
-$correct: $green-d1;
-$partiallycorrect: $green-d1;
+$correct: $green-d2;
+$partiallycorrect: $green-d2;
 $incorrect: $red;
 
 // +Extends - Capa


### PR DESCRIPTION
This work darkens the "correct" green color to meet WCAG AA requirements. It relates to [AC-263](https://openedx.atlassian.net/browse/AC-263).
## Before and Afters
### Before

<img width="781" alt="screen shot 2015-12-02 at 3 20 01 pm" src="https://cloud.githubusercontent.com/assets/2112024/11543204/53f3e0e4-9909-11e5-84d7-6924ca507a7b.png">
### After

<img width="531" alt="screen shot 2015-12-02 at 3 29 29 pm" src="https://cloud.githubusercontent.com/assets/2112024/11543231/807e37ae-9909-11e5-8dd1-62335440fce7.png">
## Reviewers
- [x] @frrrances (Sass/UI)
