### PR TITLE
Capa: removing unnecessary aria and roles from elements

### DIFF
--- a/common/lib/capa/capa/templates/choicegroup.html
+++ b/common/lib/capa/capa/templates/choicegroup.html
@@ -1,5 +1,5 @@
 <form class="choicegroup capa_inputtype" id="inputtype_${id}">
-    <fieldset>
+    <div role="group" aria-describedby="">
         % for choice_id, choice_description in choices:
         <label for="input_${id}_${choice_id}"
             ## If the student has selected this choice...
@@ -37,7 +37,7 @@
         </label>
         % endfor
         <span id="answer_${id}"></span>
-    </fieldset>
+    </div>
     <div class="indicator-container">
         % if input_type == 'checkbox' or not value:
             <span class="status ${status.classname if show_correctness != 'never' else 'unanswered'}" id="status_${id}" aria-describedby="inputtype_${id}" data-tooltip="${status.display_tooltip}">

--- a/common/lib/capa/capa/templates/choicegroup.html
+++ b/common/lib/capa/capa/templates/choicegroup.html
@@ -19,15 +19,12 @@
             % endif
             % endif
             >
-            <input type="${input_type}" name="input_${id}${name_array_suffix}" id="input_${id}_${choice_id}" aria-role="radio" aria-describedby="answer_${id}" value="${choice_id}"
+            <input type="${input_type}" name="input_${id}${name_array_suffix}" id="input_${id}_${choice_id}" aria-describedby="answer_${id}" value="${choice_id}"
             ## If the student selected this choice...
             % if input_type == 'radio' and ( (isinstance(value, basestring) and (choice_id == value))  or  (not isinstance(value, basestring) and choice_id in value) ):
             checked="true"
             % elif input_type != 'radio' and choice_id in value:
             checked="true"
-            % endif
-            % if input_type != 'radio':
-            aria-multiselectable="true"
             % endif
 
             /> ${choice_description}

--- a/common/lib/capa/capa/templates/choicegroup.html
+++ b/common/lib/capa/capa/templates/choicegroup.html
@@ -1,5 +1,5 @@
 <form class="choicegroup capa_inputtype" id="inputtype_${id}">
-    <fieldset role="${input_type}group" aria-label="${label}">
+    <fieldset>
         % for choice_id, choice_description in choices:
         <label for="input_${id}_${choice_id}"
             ## If the student has selected this choice...

--- a/common/lib/capa/capa/templates/choicegroup.html
+++ b/common/lib/capa/capa/templates/choicegroup.html
@@ -1,5 +1,5 @@
 <form class="choicegroup capa_inputtype" id="inputtype_${id}">
-    <div role="group" aria-describedby="">
+    <div role="group" aria-labelledby="problem_label_${id}">
         % for choice_id, choice_description in choices:
         <label for="input_${id}_${choice_id}"
             ## If the student has selected this choice...

--- a/common/lib/capa/capa/templates/choicegroup.html
+++ b/common/lib/capa/capa/templates/choicegroup.html
@@ -1,5 +1,6 @@
 <form class="choicegroup capa_inputtype" id="inputtype_${id}">
-    <div role="group" aria-labelledby="problem_label_${id}">
+    <fieldset>
+        <legend class="sr" aria-labelledby="problem_label_${id}">Instructions: </legend>
         % for choice_id, choice_description in choices:
         <label for="input_${id}_${choice_id}"
             ## If the student has selected this choice...
@@ -37,7 +38,7 @@
         </label>
         % endfor
         <span id="answer_${id}"></span>
-    </div>
+    </fieldset>
     <div class="indicator-container">
         % if input_type == 'checkbox' or not value:
             <span class="status ${status.classname if show_correctness != 'never' else 'unanswered'}" id="status_${id}" aria-describedby="inputtype_${id}" data-tooltip="${status.display_tooltip}">

--- a/common/lib/capa/capa/tests/test_input_templates.py
+++ b/common/lib/capa/capa/tests/test_input_templates.py
@@ -340,7 +340,7 @@ class ChoiceGroupTemplateTest(TemplateTestCase):
 
     def test_label(self):
         xml = self.render_to_xml(self.context)
-        xpath = "//fieldset[@aria-label='%s']" % self.context['label']
+        xpath = "//div[@role='group]"
         self.assert_has_xpath(xml, xpath, self.context)
 
 

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
@@ -529,7 +529,7 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
             .replace(/"/g, '&quot;')
             .replace(/'/g, '&apos;');
 
-          line = '<p class="problem-label" id="' + id + '">' + line.replace(/>>|<</g, '') + '</p>';
+          line = '<p class="problem-label" id="' + id + '" aria-hidden="true">' + line.replace(/>>|<</g, '') + '</p>';
         } else if (line.match(/<\w+response/) && didinput && curlabel == prevlabel) {
           // reset label to prevent gobbling up previous one (if multiple questions)
           curlabel = '';

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
@@ -14,6 +14,9 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
 
   constructor: (element) ->
     @element = element
+    @problem_id_data = $(@element[0].closest('.xmodule_edit')).data('usage-id')
+    @problem_id = @problem_id_data.split('@')[2]
+    window.problem_id = @problem_id
 
     if $(".markdown-box", @element).length != 0
       @markdown_editor = CodeMirror.fromTextArea($(".markdown-box", element)[0], {
@@ -517,6 +520,7 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
       var line, i, curlabel, prevlabel = '';
       var didinput = false;
       for (i = 0; i < split.length; i++) {
+        var id = 'problem_label_' + window.problem_id + '_2_1';
         line = split[i];
         if (match = line.match(/>>(.*)<</)) {
           curlabel = match[1].replace(/&/g, '&amp;')
@@ -524,7 +528,8 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
             .replace(/>/g, '&gt;')
             .replace(/"/g, '&quot;')
             .replace(/'/g, '&apos;');
-          line = line.replace(/>>|<</g, '');
+
+          line = '<p class="problem-label" id="' + id + '">' + line.replace(/>>|<</g, '') + '</p>';
         } else if (line.match(/<\w+response/) && didinput && curlabel == prevlabel) {
           // reset label to prevent gobbling up previous one (if multiple questions)
           curlabel = '';

--- a/common/test/acceptance/tests/lms/test_certificate_web_view.py
+++ b/common/test/acceptance/tests/lms/test_certificate_web_view.py
@@ -218,11 +218,11 @@ class CertificateProgressPageTest(UniqueCourseTest):
         self.course_nav.q(css='select option[value="{}"]'.format('blue')).first.click()
 
         # Select correct radio button for the answer
-        self.course_nav.q(css='fieldset label:nth-child(3) input').nth(0).click()
+        self.course_nav.q(css='div[role="group"] label:nth-child(3) input').nth(0).click()
 
         # Select correct radio buttons for the answer
-        self.course_nav.q(css='fieldset label:nth-child(1) input').nth(1).click()
-        self.course_nav.q(css='fieldset label:nth-child(3) input').nth(1).click()
+        self.course_nav.q(css='div[role="group"] label:nth-child(1) input').nth(1).click()
+        self.course_nav.q(css='div[role="group"] label:nth-child(3) input').nth(1).click()
 
         # Submit the answer
         self.course_nav.q(css='button.check.Check').click()


### PR DESCRIPTION
This edit removes unnecessary `aria` and `roles` from checkbox and radio options within Capa problems. It relates to [AC-251](https://openedx.atlassian.net/browse/AC-251).
## Problem

`input type="checkbox"` is understood and doesn't need `role="checkbox"` or `aria-multiselectable="true"` as these are both inherent properties to checkbox elements. The same is true for `input type="radio"`.

Additionally, I've removed the empty `aria-label` from the `fieldset` as well as the unnecessary role.
## Reviewers
- [ ] @cptvitamin 
