### PR TITLE
Fix missing translator comments

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -387,10 +387,10 @@ class CourseFields(object):
         # a role created by a course Instructor to enable a person (the "Coach") to manage the custom course for
         # his students.
         display_name=_("Enable CCX"),
-        # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content. CCX Coach is
-        # a role created by a course Instructor to enable a person (the "Coach") to manage the custom course for
-        # his students.
         help=_(
+            # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content. CCX Coach is
+            # a role created by a course Instructor to enable a person (the "Coach") to manage the custom course for
+            # his students.
             "Allow course instructors to assign CCX Coach roles, and allow coaches to manage Custom Courses on edX."
             " When false, Custom Courses cannot be created, but existing Custom Courses will be preserved."
         ),

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -207,18 +207,14 @@ class LTIFields(object):
     ask_to_send_username = Boolean(
         display_name=_("Request user's username"),
         # Translators: This is used to request the user's username for a third party service.
-        help=_(
-            "Select True to request the user's username."
-        ),
+        help=_("Select True to request the user's username."),
         default=False,
         scope=Scope.settings
     )
     ask_to_send_email = Boolean(
         display_name=_("Request user's email"),
         # Translators: This is used to request the user's email for a third party service.
-        help=_(
-            "Select True to request the user's email address."
-        ),
+        help=_("Select True to request the user's email address."),
         default=False,
         scope=Scope.settings
     )

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -115,9 +115,9 @@ def _footer_copyright():
         else microsite.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
     )
 
-    # Translators: 'EdX', 'edX', and 'Open edX' are trademarks of 'edX Inc.'.
-    # Please do not translate any of these trademarks and company names.
     return _(
+        # Translators: 'EdX', 'edX', and 'Open edX' are trademarks of 'edX Inc.'.
+        # Please do not translate any of these trademarks and company names.
         u"\u00A9 {org_name}.  All rights reserved except where noted.  "
         u"EdX, Open edX and the edX and Open EdX logos are registered trademarks "
         u"or trademarks of edX Inc."

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -73,9 +73,9 @@ class LoginSessionView(APIView):
 
         # Translators: These instructions appear on the login form, immediately
         # below a field meant to hold the user's email address.
-        email_instructions = _(
-            u"The email address you used to register with {platform_name}"
-        ).format(platform_name=settings.PLATFORM_NAME)
+        email_instructions = _("The email address you used to register with {platform_name}").format(
+            platform_name=settings.PLATFORM_NAME
+        )
 
         form_desc.add_field(
             "email",
@@ -267,15 +267,17 @@ class RegistrationView(APIView):
         conflicts = check_account_exists(email=email, username=username)
         if conflicts:
             conflict_messages = {
-                # Translators: This message is shown to users who attempt to create a new
-                # account using an email address associated with an existing account.
                 "email": _(
-                    u"It looks like {email_address} belongs to an existing account. Try again with a different email address."  # pylint: disable=line-too-long
+                    # Translators: This message is shown to users who attempt to create a new
+                    # account using an email address associated with an existing account.
+                    u"It looks like {email_address} belongs to an existing account. "
+                    u"Try again with a different email address."
                 ).format(email_address=email),
-                # Translators: This message is shown to users who attempt to create a new
-                # account using a username associated with an existing account.
                 "username": _(
-                    u"It looks like {username} belongs to an existing account. Try again with a different username."
+                    # Translators: This message is shown to users who attempt to create a new
+                    # account using a username associated with an existing account.
+                    u"It looks like {username} belongs to an existing account. "
+                    u"Try again with a different username."
                 ).format(username=username),
             }
             errors = {
@@ -387,11 +389,11 @@ class RegistrationView(APIView):
         # meant to hold the user's public username.
         username_label = _(u"Public username")
 
-        # Translators: These instructions appear on the registration form, immediately
-        # below a field meant to hold the user's public username.
         username_instructions = _(
+            # Translators: These instructions appear on the registration form, immediately
+            # below a field meant to hold the user's public username.
             u"The name that will identify you in your courses - "
-            "{bold_start}(cannot be changed later){bold_end}"
+            u"{bold_start}(cannot be changed later){bold_end}"
         ).format(bold_start=u'<strong>', bold_end=u'</strong>')
 
         # Translators: This example username is used as a placeholder in
@@ -542,9 +544,9 @@ class RegistrationView(APIView):
         """
         # Translators: This phrase appears above a field on the registration form
         # meant to hold the user's reasons for registering with edX.
-        goals_label = _(
-            u"Tell us why you're interested in {platform_name}"
-        ).format(platform_name=settings.PLATFORM_NAME)
+        goals_label = _(u"Tell us why you're interested in {platform_name}").format(
+            platform_name=settings.PLATFORM_NAME
+        )
 
         form_desc.add_field(
             "goals",
@@ -627,18 +629,14 @@ class RegistrationView(APIView):
 
         # Translators: "Terms of Service" is a legal document users must agree to
         # in order to register a new account.
-        label = _(
-            u"I agree to the {platform_name} {terms_of_service}."
-        ).format(
+        label = _(u"I agree to the {platform_name} {terms_of_service}.").format(
             platform_name=settings.PLATFORM_NAME,
             terms_of_service=terms_link
         )
 
         # Translators: "Terms of Service" is a legal document users must agree to
         # in order to register a new account.
-        error_msg = _(
-            u"You must agree to the {platform_name} {terms_of_service}."
-        ).format(
+        error_msg = _(u"You must agree to the {platform_name} {terms_of_service}.").format(
             platform_name=settings.PLATFORM_NAME,
             terms_of_service=terms_link
         )
@@ -674,18 +672,14 @@ class RegistrationView(APIView):
 
         # Translators: "Terms of service" is a legal document users must agree to
         # in order to register a new account.
-        label = _(
-            u"I agree to the {platform_name} {terms_of_service}."
-        ).format(
+        label = _(u"I agree to the {platform_name} {terms_of_service}.").format(
             platform_name=settings.PLATFORM_NAME,
             terms_of_service=terms_link
         )
 
         # Translators: "Terms of service" is a legal document users must agree to
         # in order to register a new account.
-        error_msg = _(
-            u"You must agree to the {platform_name} {terms_of_service}."
-        ).format(
+        error_msg = _(u"You must agree to the {platform_name} {terms_of_service}.").format(
             platform_name=settings.PLATFORM_NAME,
             terms_of_service=terms_link
         )
@@ -784,9 +778,9 @@ class PasswordResetView(APIView):
 
         # Translators: These instructions appear on the password reset form,
         # immediately below a field meant to hold the user's email address.
-        email_instructions = _(
-            u"The email address you used to register with {platform_name}"
-        ).format(platform_name=settings.PLATFORM_NAME)
+        email_instructions = _(u"The email address you used to register with {platform_name}").format(
+            platform_name=settings.PLATFORM_NAME
+        )
 
         form_desc.add_field(
             "email",


### PR DESCRIPTION
Turns out if the string literal starts on the next line after the translation
function, then the translator comment is lost.  So, either close up short
strings, or add a dummy empty string on the first line to concatenate with the
real string.

Ugh.
