### PR TITLE
Dependency update: Bumped XBlock version

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -71,7 +71,7 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@xblock-0.4.1#egg=XBlock==0.4.1
+-e git+https://github.com/edx/XBlock.git@xblock-0.4.2#egg=XBlock==0.4.2
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1


### PR DESCRIPTION
**Description:** This PR updates XBlock to latest version available to date. Changes since the last version only include an option to force exporting default values of an XBlock field (see https://github.com/edx/XBlock/pull/326 for details).

**JIRA Task:** [OSPR-970](https://openedx.atlassian.net/browse/OSPR-970)
**Testing instructions:** Smoke test is enough.
