### PR TITLE
Corrected permission class and test

### DIFF
--- a/openedx/core/djangoapps/credit/tests/test_views.py
+++ b/openedx/core/djangoapps/credit/tests/test_views.py
@@ -660,7 +660,18 @@ class CreditEligibilityViewTests(AuthMixin, UserMixin, ReadOnlyMixin, TestCase):
     def test_nonstaff_can_only_view_own_data(self):
         """ Verify that non-staff users can only view their own eligibility data. """
         user = UserFactory(password=self.password)
+        eligibility = CreditEligibilityFactory(username=user.username)
+        url = self.create_url(eligibility)
+
+        # Verify user can view own data
         self.client.logout()
         self.client.login(username=user.username, password=self.password)
-        response = self.client.get(self.path)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # User should not be able to view data for other users.
+        alt_user = UserFactory(password=self.password)
+        alt_eligibility = CreditEligibilityFactory(username=alt_user.username)
+        url = self.create_url(alt_eligibility)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 403)

--- a/openedx/core/lib/api/permissions.py
+++ b/openedx/core/lib/api/permissions.py
@@ -92,4 +92,4 @@ class IsStaffOrOwner(permissions.BasePermission):
 
     def has_permission(self, request, view):
         user = request.user
-        return user.is_staff or (user.username == request.data.get('username'))
+        return user.is_staff or (user.username == request.GET.get('username'))


### PR DESCRIPTION
- The permission now checks the correct request attribute (GET instead of data).
- The Credit API view test has been updated to check for the positive access instead of just denial.
  
  ECOM-3096
