### PR TITLE
Clytwynec/auto auth redirect

### DIFF
--- a/common/djangoapps/student/tests/test_auto_auth.py
+++ b/common/djangoapps/student/tests/test_auto_auth.py
@@ -194,7 +194,7 @@ class AutoAuthEnabledTestCase(UrlResetMixin, TestCase):
 
         # Check that the redirect was to the course info/outline page
         urls = ('/info', 'course/{}'.format(course_key.to_deprecated_string()))
-        response.url.endswith(urls)  # pylint: disable=no-member
+        self.assertTrue(response.url.endswith(urls))  # pylint: disable=no-member
 
     def test_redirect_to_main(self):
         # Create user and redirect to 'home' (cms) or 'dashboard' (lms)
@@ -206,7 +206,7 @@ class AutoAuthEnabledTestCase(UrlResetMixin, TestCase):
 
         # Check that the redirect was to either /dashboard or /home
         urls = ('/dashboard', '/home')
-        response.url.endswith(urls)  # pylint: disable=no-member
+        self.assertTrue(response.url.endswith(urls))  # pylint: disable=no-member
 
     def _auto_auth(self, params=None, status_code=None, **kwargs):
         """

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -21,7 +21,7 @@ from django.contrib.auth.views import password_reset_confirm
 from django.contrib import messages
 from django.core.context_processors import csrf
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, NoReverseMatch
 from django.core.validators import validate_email, ValidationError
 from django.db import IntegrityError, transaction
 from django.http import (HttpResponse, HttpResponseBadRequest, HttpResponseForbidden,
@@ -1891,12 +1891,28 @@ def auto_auth(request):
     if redirect_when_done:
         # Redirect to course info page if course_id is known
         if course_id:
-            return redirect(reverse('info', kwargs={'course_id': unicode(course_id)}))
-        # Otherwise redirect to dashboard
+            try:
+                # redirect to course info page in LMS
+                redirect_url = reverse(
+                    'info',
+                    kwargs={'course_id': unicode(course_id)}
+                )
+            except NoReverseMatch:
+                # redirect to course outline page in Studio
+                redirect_url = reverse(
+                    'course_handler',
+                    kwargs={'course_key_string': unicode(course_key)}
+                )
         else:
-            return redirect(reverse('dashboard'))
+            try:
+                # redirect to dashboard for LMS
+                redirect_url = reverse('dashboard')
+            except NoReverseMatch:
+                # redirect to home for Studio
+                redirect_url = reverse('home')
 
-    if request.META.get('HTTP_ACCEPT') == 'application/json':
+        return redirect(redirect_url)
+    elif request.META.get('HTTP_ACCEPT') == 'application/json':
         response = JsonResponse({
             'created_status': u"Logged in" if login_when_done else "Created",
             'username': username,

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1799,6 +1799,7 @@ def auto_auth(request):
     * `course_id`: Enroll the student in the course with `course_id`
     * `roles`: Comma-separated list of roles to grant the student in the course with `course_id`
     * `no_login`: Define this to create the user but not login
+    * `redirect`: Set to "true" will redirect to course if course_id is defined, otherwise it will redirect to dashboard
 
     If username, email, or password are not provided, use
     randomly generated credentials.
@@ -1823,6 +1824,7 @@ def auto_auth(request):
     if course_id:
         course_key = CourseLocator.from_string(course_id)
     role_names = [v.strip() for v in request.GET.get('roles', '').split(',') if v.strip()]
+    redirect_when_done = request.GET.get('redirect', None)
     login_when_done = 'no_login' not in request.GET
 
     form = AccountCreationForm(
@@ -1885,7 +1887,15 @@ def auto_auth(request):
     create_comments_service_user(user)
 
     # Provide the user with a valid CSRF token
-    # then return a 200 response
+    # then return a 200 response unless redirect is true
+    if redirect_when_done:
+        # Redirect to course info page if course_id is known
+        if course_id:
+            return redirect(reverse('info', kwargs={'course_id': unicode(course_id)}))
+        # Otherwise redirect to dashboard
+        else:
+            return redirect(reverse('dashboard'))
+
     if request.META.get('HTTP_ACCEPT') == 'application/json':
         response = JsonResponse({
             'created_status': u"Logged in" if login_when_done else "Created",

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1824,7 +1824,7 @@ def auto_auth(request):
     if course_id:
         course_key = CourseLocator.from_string(course_id)
     role_names = [v.strip() for v in request.GET.get('roles', '').split(',') if v.strip()]
-    redirect_when_done = request.GET.get('redirect', None)
+    redirect_when_done = request.GET.get('redirect', '').lower() == 'true'
     login_when_done = 'no_login' not in request.GET
 
     form = AccountCreationForm(
@@ -1895,13 +1895,13 @@ def auto_auth(request):
                 # redirect to course info page in LMS
                 redirect_url = reverse(
                     'info',
-                    kwargs={'course_id': unicode(course_id)}
+                    kwargs={'course_id': course_id}
                 )
             except NoReverseMatch:
                 # redirect to course outline page in Studio
                 redirect_url = reverse(
                     'course_handler',
-                    kwargs={'course_key_string': unicode(course_key)}
+                    kwargs={'course_key_string': course_id}
                 )
         else:
             try:


### PR DESCRIPTION
This PR builds off of PR https://github.com/edx/edx-platform/pull/6703 to enable redirecting in auto_auth.  

Main changes from the original PR:
- Python tests are added for each type of redirect (to course page, to home/dashboard page). These tests get run with both LMS and Studio servers.
- There are fixes so that the redirecting works in both LMS and Studio.  (It was only working for LMS before.)
- [x] @cptvitamin Please review to confirm that this behavior is what is needed for your use case.
- [x] @cahrens @doctoryes  I know original PR is from a long time ago, but could you review this?
