### PR TITLE
Add additional data to custom SSO auth form extension points

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/test_google.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_google.py
@@ -80,13 +80,16 @@ class GoogleOauth2IntegrationTest(base.Oauth2IntegrationTest):
         data_parsed = json.loads(data_decoded)
         # The user's details get passed to the custom page as a base64 encoded query parameter:
         self.assertEqual(data_parsed, {
+            'auth_entry': 'custom1',
+            'backend_name': 'google-oauth2',
+            'provider_id': 'oa2-google-oauth2',
             'user_details': {
                 'username': 'email_value',
                 'email': 'email_value@example.com',
                 'fullname': 'name_value',
                 'first_name': 'given_name_value',
                 'last_name': 'family_name_value',
-            }
+            },
         })
         # Check the hash that is used to confirm the user's data in the GET parameter is correct
         secret_key = settings.THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS['custom1']['secret_key']

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -74,7 +74,7 @@ def post_to_custom_auth_form(request):
     # Verify the format of pipeline_data:
     data = {
         'post_url': pipeline_data['post_url'],
-        # The user's name, email, etc. as base64 encoded JSON
+        # data: The provider info and user's name, email, etc. as base64 encoded JSON
         # It's base64 encoded because it's signed cryptographically and we don't want whitespace
         # or ordering issues affecting the hash/signature.
         'data': pipeline_data['data'],


### PR DESCRIPTION
This is a follow-up to my recently-merged PR #9903. In order to meet a solutions client's needs, we needed to slightly expand the capabilities of the new custom extension point introduced in that PR. Specifically, a bit more information is now sent to the custom registration form/app: Previously, the custom registration form page/app would only get user details like name, email, etc. but could not directly tell what remote SAML provider was being used. Now, the ID of the specific provider is included in the data

This PR is identical to https://github.com/edx-solutions/edx-platform/pull/576 which has already merged on the solutions fork, and I'm submitting it upstream to benefit the larger community and reduce code drift.

**Merge deadline**: No hard deadline

**Reviewers**: @e-kolpakov @douglashall + possibly a Platform reviewer?

No sandbox for this PR since the change is not easily demonstrable. We have tested the code with the solutions client's app.
