### PR TITLE
Add course/org info to New Relic in courseware and XBlock rendering.

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -1024,6 +1024,10 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course
     except InvalidKeyError:
         raise Http404
 
+    # Gather metrics for New Relic so we can slice data in New Relic Insights
+    newrelic.agent.add_custom_parameter('course_id', unicode(course_key))
+    newrelic.agent.add_custom_parameter('org', unicode(course_key.org))
+
     with modulestore().bulk_operations(course_key):
         instance, tracking_context = get_module_by_usage_id(request, course_id, usage_id, course=course)
 

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -29,6 +29,7 @@ from django.views.decorators.cache import cache_control
 from ipware.ip import get_ip
 from markupsafe import escape
 from rest_framework import status
+import newrelic.agent
 
 from courseware import grades
 from courseware.access import has_access, _adjust_start_date_for_beta_testers
@@ -317,6 +318,10 @@ def index(request, course_id, chapter=None, section=None,
     """
 
     course_key = CourseKey.from_string(course_id)
+
+    # Gather metrics for New Relic so we can slice data in New Relic Insights
+    newrelic.agent.add_custom_parameter('course_id', unicode(course_key))
+    newrelic.agent.add_custom_parameter('org', unicode(course_key.org))
 
     user = User.objects.prefetch_related("groups").get(id=request.user.id)
 


### PR DESCRIPTION
This will make it much easier for us to slice courseware requests by organization and course in Insights performance analysis.

@e0d, @benpatterson 
