### PR TITLE
Added configuration model for credentials

### DIFF
--- a/openedx/core/djangoapps/credentials/admin.py
+++ b/openedx/core/djangoapps/credentials/admin.py
@@ -1,0 +1,16 @@
+"""
+django admin pages for credentials support models.
+"""
+
+from django.contrib import admin
+
+from config_models.admin import ConfigurationModelAdmin
+
+from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
+
+
+class CredentialsApiConfigAdmin(ConfigurationModelAdmin):  # pylint: disable=missing-docstring
+    pass
+
+
+admin.site.register(CredentialsApiConfig, CredentialsApiConfigAdmin)

--- a/openedx/core/djangoapps/credentials/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/credentials/migrations/0001_initial.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CredentialsApiConfig',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
+                ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
+                ('api_version_number', models.IntegerField(verbose_name='API Version')),
+                ('internal_service_url', models.URLField(verbose_name='Internal Service URL')),
+                ('public_service_url', models.URLField(verbose_name='Public Service URL')),
+                ('enable_learner_issuance', models.BooleanField(default=False, help_text='Enable issuance of credentials via Credential Service.', verbose_name='Enable Learner Issuance')),
+                ('enable_studio_authoring', models.BooleanField(default=False, help_text='Enable authoring of Credential Service credentials in Studio.', verbose_name='Enable Authoring of Credential in Studio')),
+                ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
+            ],
+            options={
+                'ordering': ('-change_date',),
+                'abstract': False,
+            },
+        ),
+    ]

--- a/openedx/core/djangoapps/credentials/models.py
+++ b/openedx/core/djangoapps/credentials/models.py
@@ -1,3 +1,67 @@
 """
 Models for credentials support for the LMS and Studio.
 """
+
+from urlparse import urljoin
+
+from django.utils.translation import ugettext_lazy as _
+from django.db import models
+
+from config_models.models import ConfigurationModel
+
+
+class CredentialsApiConfig(ConfigurationModel):
+    """
+    Manages configuration for connecting to the Credential service and using its
+    API.
+    """
+    api_version_number = models.IntegerField(verbose_name=_("API Version"))
+    internal_service_url = models.URLField(verbose_name=_("Internal Service URL"))
+    public_service_url = models.URLField(verbose_name=_("Public Service URL"))
+
+    enable_learner_issuance = models.BooleanField(
+        verbose_name=_("Enable Learner Issuance"),
+        default=False,
+        help_text=_(
+            "Enable issuance of credentials via Credential Service."
+        )
+    )
+    enable_studio_authoring = models.BooleanField(
+        verbose_name=_("Enable Authoring of Credential in Studio"),
+        default=False,
+        help_text=_(
+            "Enable authoring of Credential Service credentials in Studio."
+        )
+    )
+
+    def __unicode__(self):
+        return self.api_version_number
+
+    @property
+    def internal_api_url(self):
+        """
+        Generate a URL based on internal service URL and API version number.
+        """
+        return urljoin(self.internal_service_url, '/api/v{}/'.format(self.api_version_number))
+
+    @property
+    def public_api_url(self):
+        """
+        Generate a URL based on public service URL and API version number.
+        """
+        return urljoin(self.public_service_url, '/api/v{}/'.format(self.api_version_number))
+
+    @property
+    def is_learner_issuance_enabled(self):
+        """
+        Indicates whether the learner credential should be enabled or not.
+        """
+        return self.enabled and self.enable_learner_issuance
+
+    @property
+    def is_studio_authoring_enabled(self):
+        """
+        Indicates whether Studio functionality related to Credential should
+        be enabled or not.
+        """
+        return self.enabled and self.enable_studio_authoring

--- a/openedx/core/djangoapps/credentials/tests/mixins.py
+++ b/openedx/core/djangoapps/credentials/tests/mixins.py
@@ -1,0 +1,23 @@
+"""Mixins for use during testing."""
+
+from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
+
+
+class CredentialsApiConfigMixin(object):
+    """Utilities for working with Credentials configuration during testing."""
+
+    DEFAULTS = {
+        'enabled': True,
+        'api_version_number': 1,
+        'internal_service_url': 'http://internal.credentials.org/',
+        'public_service_url': 'http://public.credentials.org/',
+        'enable_learner_issuance': True,
+        'enable_studio_authoring': True,
+    }
+
+    def create_config(self, **kwargs):
+        """Creates a new CredentialsApiConfig with DEFAULTS, updated with any provided overrides."""
+        fields = dict(self.DEFAULTS, **kwargs)
+        CredentialsApiConfig(**fields).save()
+
+        return CredentialsApiConfig.current()

--- a/openedx/core/djangoapps/credentials/tests/test_models.py
+++ b/openedx/core/djangoapps/credentials/tests/test_models.py
@@ -1,0 +1,52 @@
+"""Tests for models supporting Credentials-related functionality."""
+
+from django.test import TestCase
+from openedx.core.djangoapps.credentials.tests.mixins import CredentialsApiConfigMixin
+
+
+class TestCredentialsApiConfig(CredentialsApiConfigMixin, TestCase):
+    """Tests covering the CredentialsApiConfig model."""
+    def test_url_construction(self):
+        """Verify that URLs returned by the model are constructed correctly."""
+        credentials_config = self.create_config()
+
+        self.assertEqual(
+            credentials_config.internal_api_url,
+            credentials_config.internal_service_url.strip('/') + '/api/v{}/'.format(
+                credentials_config.api_version_number
+            )
+        )
+        self.assertEqual(
+            credentials_config.public_api_url,
+            credentials_config.public_service_url.strip('/') + '/api/v{}/'.format(
+                credentials_config.api_version_number
+            )
+        )
+
+    def test_is_learner_issuance_enabled(self):
+        """
+        Verify that the property controlling display on the student dashboard is only True
+        when configuration is enabled and all required configuration is provided.
+        """
+        credentials_config = self.create_config(enabled=False)
+        self.assertFalse(credentials_config.is_learner_issuance_enabled)
+
+        credentials_config = self.create_config(enable_learner_issuance=False)
+        self.assertFalse(credentials_config.is_learner_issuance_enabled)
+
+        credentials_config = self.create_config()
+        self.assertTrue(credentials_config.is_learner_issuance_enabled)
+
+    def test_is_studio_authoring_enabled(self):
+        """
+        Verify that the property controlling display in the Studio authoring is only True
+        when configuration is enabled and all required configuration is provided.
+        """
+        credentials_config = self.create_config(enabled=False)
+        self.assertFalse(credentials_config.is_studio_authoring_enabled)
+
+        credentials_config = self.create_config(enable_studio_authoring=False)
+        self.assertFalse(credentials_config.is_studio_authoring_enabled)
+
+        credentials_config = self.create_config()
+        self.assertTrue(credentials_config.is_studio_authoring_enabled)


### PR DESCRIPTION
ECOM-3033
- Added configuration model `CredentialsApiConfig` for toggling credentials support for `LMS` and `Studio`
- Added unit tests.

@ahsan-ul-haq @awais786 @afeef @zubair-arbi 
