### PR TITLE
Load requirejs-config before module-js

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -69,7 +69,6 @@ from branding import api as branding_api
   % else:
     <%static:js group='main_vendor'/>
     <%static:js group='application'/>
-    <%static:js group='module-js'/>
   % endif
 
   <script>
@@ -81,6 +80,10 @@ from branding import api as branding_api
     }).call(this, require || RequireJS.require);
   </script>
   <script type="text/javascript" src="${static.url("lms/js/require-config.js")}"></script>
+
+  % if not disable_courseware_js:
+    <%static:js group='module-js'/>
+  % endif
 
   <%block name="headextra"/>
 


### PR DESCRIPTION
[RequireJS error: moment](https://openedx.atlassian.net/browse/TNL-3863)

`requirejs` is not loading the moment path correctly in `video/01_initialize.js` sometimes. This happens because while loading the page if we refresh it again, `requirejs` is experiences some problem in syncing it's config paths and loading of js modules sometimes.

I found that `require-config.js` is loaded after `module-js` files in lms. So a better solution can be to load `require-config.js` before `video/01_initialize.js` or any `module-js` files are loaded.

Already reviewid in #10816

@adampalay @chrisndodge 
