### PR TITLE
Update Mobile API for PDF certificates and Course Detail

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -183,7 +183,7 @@ def certificate_downloadable_status(student, course_key):
 
     if current_status['status'] == CertificateStatuses.downloadable:
         response_data['is_downloadable'] = True
-        response_data['download_url'] = get_certificate_url(student.id, course_key)
+        response_data['download_url'] = current_status['download_url'] or get_certificate_url(student.id, course_key)
 
     return response_data
 

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -142,7 +142,11 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             }
         )
 
-    def test_with_downloadable_pdf_cert(self):
+    def verify_downloadable_pdf_cert(self):
+        """
+        Verifies certificate_downloadable_status returns the
+        correct response for PDF certificates.
+        """
         GeneratedCertificateFactory.create(
             user=self.student,
             course_id=self.course.id,
@@ -159,6 +163,13 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
                 'download_url': 'www.google.com'
             }
         )
+
+    @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
+    def test_pdf_cert_with_html_enabled(self):
+        self.verify_downloadable_pdf_cert()
+
+    def test_pdf_cert_with_html_disabled(self):
+        self.verify_downloadable_pdf_cert()
 
     @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
     def test_with_downloadable_web_cert(self):

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -55,6 +55,14 @@ class CourseOverviewField(serializers.RelatedField):
             ).to_json(),
 
             # various URLs
+            # course_image is sent in both new and old formats
+            # (within media to be compatible with the new Course API)
+            'media': {
+                'course_image': {
+                    'uri': course_overview.course_image_url,
+                    'name': 'Course Image',
+                }
+            },
             'course_image': course_overview.course_image_url,
             'course_about': reverse(
                 'about_course',

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -21,6 +21,7 @@ from courseware.access_response import (
     VisibilityError,
 )
 from course_modes.models import CourseMode
+from openedx.core.lib.courses import course_image_url
 from student.models import CourseEnrollment
 from util.milestones_helpers import (
     set_prerequisite_courses,
@@ -97,6 +98,11 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         self.assertEqual(found_course['id'], unicode(self.course.id))
         self.assertEqual(courses[0]['mode'], CourseMode.DEFAULT_MODE_SLUG)
         self.assertEqual(courses[0]['course']['subscription_id'], self.course.clean_id(padding_char='_'))
+
+        expected_course_image_url = course_image_url(self.course)
+        self.assertIsNotNone(expected_course_image_url)
+        self.assertIn(expected_course_image_url, found_course['course_image'])
+        self.assertIn(expected_course_image_url, found_course['media']['course_image']['uri'])
 
     def verify_failure(self, response, error_type=None):
         self.assertEqual(response.status_code, 200)
@@ -187,7 +193,11 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         certificate_data = response.data[0]['certificate']
         self.assertDictEqual(certificate_data, {})
 
-    def test_pdf_certificate(self):
+    def verify_pdf_certificate(self):
+        """
+        Verifies the correct URL is returned in the response
+        for PDF certificates.
+        """
         self.login_and_enroll()
 
         certificate_url = "http://test_certificate_url"
@@ -202,6 +212,20 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         response = self.api_response()
         certificate_data = response.data[0]['certificate']
         self.assertEquals(certificate_data['url'], certificate_url)
+
+    @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': False})
+    def test_pdf_certificate_with_html_cert_disabled(self):
+        """
+        Tests PDF certificates with CERTIFICATES_HTML_VIEW set to False.
+        """
+        self.verify_pdf_certificate()
+
+    @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
+    def test_pdf_certificate_with_html_cert_enabled(self):
+        """
+        Tests PDF certificates with CERTIFICATES_HTML_VIEW set to True.
+        """
+        self.verify_pdf_certificate()
 
     @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
     def test_web_certificate(self):


### PR DESCRIPTION
- Fixes issue with incorrect PDF certificate URL returning when HTML certificate setting is enabled (MA-1767).
- Updates API to return course_image within a "media" field, to be in synch with the new CourseDetail API.

Reviewers: @aleffert @BenjiLee 
