### PR TITLE
Added staff and instructor roles on ccx to all the staff and instructors of the master course plus fixed view as student masquerade and display name of ccx on coach dashboard 

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -27,6 +27,7 @@ from .component import (
 )
 from .item import create_xblock_info
 from .library import LIBRARIES_ENABLED
+from ccx_keys.locator import CCXLocator
 from contentstore import utils
 from contentstore.course_group_config import (
     COHORT_SCHEME,
@@ -389,6 +390,11 @@ def _accessible_courses_list(request):
         if isinstance(course, ErrorDescriptor):
             return False
 
+        # Custom Courses for edX (CCX) is an edX feature for re-using course content.
+        # CCXs cannot be edited in Studio (aka cms) and should not be shown in this dashboard.
+        if isinstance(course, CCXLocator):
+            return False
+
         # pylint: disable=fixme
         # TODO remove this condition when templates purged from db
         if course.location.course == 'templates':
@@ -433,8 +439,11 @@ def _accessible_courses_list_from_groups(request):
             except ItemNotFoundError:
                 # If a user has access to a course that doesn't exist, don't do anything with that course
                 pass
-            if course is not None and not isinstance(course, ErrorDescriptor):
-                # ignore deleted or errored courses
+
+            # Custom Courses for edX (CCX) is an edX feature for re-using course content.
+            # CCXs cannot be edited in Studio (aka cms) and should not be shown in this dashboard.
+            if course is not None and not isinstance(course, ErrorDescriptor) and not isinstance(course.id, CCXLocator):
+                # ignore deleted, errored or ccx courses
                 courses_list[course_key] = course
 
     return courses_list.values(), in_process_course_actions

--- a/lms/djangoapps/ccx/migrations/0002_add_master_course_staff_in_ccx.py
+++ b/lms/djangoapps/ccx/migrations/0002_add_master_course_staff_in_ccx.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from ccx_keys.locator import CCXLocator
+from django.db import migrations
+
+from lms.djangoapps.ccx.models import CustomCourseForEdX
+from lms.djangoapps.ccx.utils import (
+    add_master_course_staff_to_ccx,
+    reverse_add_master_course_staff_to_ccx
+)
+
+
+def add_master_course_staff_to_ccx_for_existing_ccx(apps, schema_editor):
+    """
+    Add all staff and admin of master course to respective CCX(s).
+    """
+    list_ccx = CustomCourseForEdX.objects.all()
+    for ccx in list_ccx:
+        ccx_locator = CCXLocator.from_course_locator(ccx.course_id, unicode(ccx.id))
+        add_master_course_staff_to_ccx(ccx.course, ccx_locator, ccx.display_name)
+
+
+def reverse_add_master_course_staff_to_ccx_for_existing_ccx(apps, schema_editor):
+    """
+    Add all staff and admin of master course to respective CCX(s).
+    """
+    list_ccx = CustomCourseForEdX.objects.all()
+    for ccx in list_ccx:
+        ccx_locator = CCXLocator.from_course_locator(ccx.course_id, unicode(ccx.id))
+        reverse_add_master_course_staff_to_ccx(ccx.course, ccx_locator, ccx.display_name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ccx', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            add_master_course_staff_to_ccx_for_existing_ccx,
+            reverse_code=reverse_add_master_course_staff_to_ccx_for_existing_ccx
+        )
+    ]

--- a/lms/djangoapps/ccx/tests/test_utils.py
+++ b/lms/djangoapps/ccx/tests/test_utils.py
@@ -3,17 +3,30 @@ test utils
 """
 from nose.plugins.attrib import attr
 
-from lms.djangoapps.ccx.tests.factories import CcxFactory
-from student.roles import CourseCcxCoachRole
+from ccx_keys.locator import CCXLocator
+from student.roles import (
+    CourseCcxCoachRole,
+    CourseInstructorRole,
+    CourseStaffRole,
+)
 from student.tests.factories import (
     AdminFactory,
+    CourseEnrollmentFactory,
+    UserFactory
 )
 from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,
+    SharedModuleStoreTestCase,
     TEST_DATA_SPLIT_MODULESTORE)
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.django import modulestore
 
-from ccx_keys.locator import CCXLocator
+from lms.djangoapps.instructor.access import list_with_level, allow_access
+
+from lms.djangoapps.ccx.utils import add_master_course_staff_to_ccx
+from lms.djangoapps.ccx.views import ccx_course
+from lms.djangoapps.ccx.tests.factories import CcxFactory
+from lms.djangoapps.ccx.tests.utils import CcxTestCase
 
 
 @attr('shard_1')
@@ -47,3 +60,51 @@ class TestGetCCXFromCCXLocator(ModuleStoreTestCase):
         course_key = CCXLocator.from_course_locator(self.course.id, ccx.id)
         result = self.call_fut(course_key)
         self.assertEqual(result, ccx)
+
+
+class TestStaffOnCCX(CcxTestCase, SharedModuleStoreTestCase):
+    """
+    Tests for staff on ccx courses.
+    """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
+    def setUp(self):
+        super(TestStaffOnCCX, self).setUp()
+
+        # Create instructor account
+        self.client.login(username=self.coach.username, password="test")
+
+        # create an instance of modulestore
+        self.mstore = modulestore()
+
+        # adding staff to master course.
+        staff = UserFactory()
+        allow_access(self.course, staff, 'staff')
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = UserFactory()
+        allow_access(self.course, instructor, 'instructor')
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+
+    def test_add_master_course_staff_to_ccx(self):
+        """
+        Test add staff of master course to ccx course
+        """
+        self.make_coach()
+        ccx = self.make_ccx()
+        ccx_locator = CCXLocator.from_course_locator(self.course.id, ccx.id)
+        add_master_course_staff_to_ccx(self.course, ccx_locator, ccx.display_name)
+
+        # assert that staff and instructors of master course has staff and instructor roles on ccx
+        list_staff_master_course = list_with_level(self.course, 'staff')
+        list_instructor_master_course = list_with_level(self.course, 'instructor')
+
+        with ccx_course(ccx_locator) as course_ccx:
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            self.assertEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+            self.assertEqual(list_staff_master_course[0].email, list_staff_ccx_course[0].email)
+
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+            self.assertEqual(len(list_instructor_ccx_course), len(list_instructor_master_course))
+            self.assertEqual(list_instructor_ccx_course[0].email, list_instructor_master_course[0].email)

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -15,6 +15,8 @@ from courseware.courses import get_course_by_id
 from courseware.tests.factories import StudentModuleFactory
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from courseware.tabs import get_course_tab_list
+from instructor.access import list_with_level, allow_access
+
 from django.conf import settings
 from django.core.urlresolvers import reverse, resolve
 from django.utils.timezone import UTC
@@ -23,7 +25,11 @@ from django.test import RequestFactory
 from edxmako.shortcuts import render_to_response
 from request_cache.middleware import RequestCache
 from opaque_keys.edx.keys import CourseKey
-from student.roles import CourseCcxCoachRole
+from student.roles import (
+    CourseCcxCoachRole,
+    CourseInstructorRole,
+    CourseStaffRole,
+)
 from student.models import (
     CourseEnrollment,
     CourseEnrollmentAllowed,
@@ -49,6 +55,7 @@ from ccx_keys.locator import CCXLocator
 
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import get_override_for_ccx, override_field_for_ccx
+from lms.djangoapps.ccx.views import ccx_course
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 from lms.djangoapps.ccx.tests.utils import (
     CcxTestCase,
@@ -136,6 +143,16 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         # Login with the instructor account
         self.client.login(username=self.coach.username, password="test")
 
+        # adding staff to master course.
+        staff = UserFactory()
+        allow_access(self.course, staff, 'staff')
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = UserFactory()
+        allow_access(self.course, instructor, 'instructor')
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+
     def assert_elements_in_schedule(self, url, n_chapters=2, n_sequentials=4, n_verticals=8):
         """
         Helper function to count visible elements in the schedule
@@ -221,6 +238,19 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         # assert ccx creator has role=ccx_coach
         role = CourseCcxCoachRole(course_key)
         self.assertTrue(role.has_user(self.coach))
+
+        # assert that staff and instructors of master course has staff and instructor roles on ccx
+        list_staff_master_course = list_with_level(self.course, 'staff')
+        list_instructor_master_course = list_with_level(self.course, 'instructor')
+
+        with ccx_course(course_key) as course_ccx:
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            self.assertEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+            self.assertEqual(list_staff_master_course[0].email, list_staff_ccx_course[0].email)
+
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+            self.assertEqual(len(list_instructor_ccx_course), len(list_instructor_master_course))
+            self.assertEqual(list_instructor_ccx_course[0].email, list_instructor_master_course[0].email)
 
     def test_get_date(self):
         """

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -52,6 +52,7 @@ from lms.djangoapps.ccx.overrides import (
     bulk_delete_ccx_override_fields,
 )
 from lms.djangoapps.ccx.utils import (
+    add_master_course_staff_to_ccx,
     assign_coach_role_to_ccx,
     ccx_course,
     ccx_students_enrolling_center,
@@ -146,6 +147,9 @@ def dashboard(request, course, ccx=None):
         context['grading_policy_url'] = reverse(
             'ccx_set_grading_policy', kwargs={'course_id': ccx_locator})
 
+        with ccx_course(ccx_locator) as course:
+            context['course'] = course
+
     else:
         context['create_ccx_url'] = reverse(
             'create_ccx', kwargs={'course_id': course.id})
@@ -208,7 +212,7 @@ def create_ccx(request, course, ccx=None):
     )
 
     assign_coach_role_to_ccx(ccx_id, request.user, course.id)
-
+    add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
     return redirect(url)
 
 

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -132,9 +132,6 @@ def has_access(user, action, obj, course_key=None):
     if not user:
         user = AnonymousUser()
 
-    if isinstance(course_key, CCXLocator):
-        course_key = course_key.to_course_locator()
-
     # delegate the work to type-specific functions.
     # (start with more specific types, then get more general)
     if isinstance(obj, CourseDescriptor):


### PR DESCRIPTION
### Background

fixes https://github.com/mitocw/edx-platform/issues/126, https://github.com/mitocw/edx-platform/issues/155 and https://github.com/mitocw/edx-platform/issues/115
### What is done in this PR

**Studio Updates:** 
- Remove ccx from staff dashboard inside studio. Because  a master course can have unlimited ccx. If we allow display of all ccx of logged in staff (who is also staff of master course ) in studio dashboard then his (staff's) dashboard can be populate with huge list of ccx along with master course 

**LMS Updates:** 
- Now when a coach creates a new ccx, I am assigning staff role on this ccx course to all staff of master course.
- Now staff of master course has staff rights on master course as well as ccx courses.
- This is for course staff to see what ccx coaches are doing with course.
- Added instructors of master course as instructor(s) in ccx.
- **Note:** This code will add/enrol staff and instructors in ccx and now max student limit for ccx depends on number of staff and admins. 
- Fixed view as student issue on ccx, now staff can view as student and see how ccx  view will appear to student
- Fixed display name on ccx coach dashboard. Previously it was show display name of master course on coach dashboard.

@pdpinch @giocalitri @pwilkins 
- Staff on Master course
  ![screen shot 2015-11-30 at 5 12 54 pm](https://cloud.githubusercontent.com/assets/10431250/11471231/ba5e9cc8-9785-11e5-95c5-0cdcea97f780.png)
- Staff on CCX
  ![screen shot 2015-11-30 at 5 13 04 pm](https://cloud.githubusercontent.com/assets/10431250/11471234/c2d0a9dc-9785-11e5-865f-a1b7d79a34db.png)
- Admin/instructors on master course
  ![screen shot 2015-12-10 at 5 10 18 pm](https://cloud.githubusercontent.com/assets/10431250/11715098/08685ed0-9f61-11e5-8b79-87defb82c2c9.png)
- Admin/instructors on ccx
  ![screen shot 2015-12-10 at 5 10 22 pm](https://cloud.githubusercontent.com/assets/10431250/11715099/11ada5ae-9f61-11e5-92c3-d0316f1b6190.png)
#### Fixed view as student

![screen shot 2015-12-17 at 7 21 37 pm 2](https://cloud.githubusercontent.com/assets/10431250/11871777/8eb3d64e-a4f3-11e5-9b32-d0df4a0dd0a6.png)
![screen shot 2015-12-17 at 7 21 53 pm 2](https://cloud.githubusercontent.com/assets/10431250/11871778/8eb92040-a4f3-11e5-9bb7-49c691d4bb24.png)
![screen shot 2015-12-17 at 7 22 05 pm 2](https://cloud.githubusercontent.com/assets/10431250/11871779/8ebdc94c-a4f3-11e5-9e7d-0ee44b1652c3.png)
#### Fixed display name of ccx on coach dashboard.

![screen shot 2015-12-18 at 3 29 34 pm](https://cloud.githubusercontent.com/assets/10431250/11894922/3f39bfa8-a59c-11e5-82e9-0dabd349e963.png)
![screen shot 2015-12-18 at 3 29 44 pm](https://cloud.githubusercontent.com/assets/10431250/11894921/3f3880de-a59c-11e5-9d38-da5de6837b8a.png)
![screen shot 2015-12-18 at 3 29 55 pm](https://cloud.githubusercontent.com/assets/10431250/11894923/3f411bf4-a59c-11e5-80bb-b79b5073c936.png)
