### PR TITLE
Remove final CMS references to 'peergrading' and 'combinedopenended'

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -771,7 +771,7 @@ class CourseMetadataEditingTest(CourseTestCase):
             {
                 "advertised_start": {"value": "start A"},
                 "days_early_for_beta": {"value": 2},
-                "advanced_modules": {"value": ['combinedopenended']},
+                "advanced_modules": {"value": ['notes']},
             },
             user=self.user
         )
@@ -781,7 +781,7 @@ class CourseMetadataEditingTest(CourseTestCase):
 
         # Tab gets tested in test_advanced_settings_munge_tabs
         self.assertIn('advanced_modules', test_model, 'Missing advanced_modules')
-        self.assertEqual(test_model['advanced_modules']['value'], ['combinedopenended'], 'advanced_module is not updated')
+        self.assertEqual(test_model['advanced_modules']['value'], ['notes'], 'advanced_module is not updated')
 
     def test_validate_from_json_wrong_inputs(self):
         # input incorrectly formatted data

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -30,11 +30,11 @@ from student.auth import has_course_author_access
 from django.utils.translation import ugettext as _
 from models.settings.course_grading import CourseGradingModel
 
-__all__ = ['OPEN_ENDED_COMPONENT_TYPES',
-           'ADVANCED_COMPONENT_POLICY_KEY',
-           'container_handler',
-           'component_handler'
-           ]
+__all__ = [
+    'ADVANCED_COMPONENT_POLICY_KEY',
+    'container_handler',
+    'component_handler'
+]
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +43,6 @@ COMPONENT_TYPES = ['discussion', 'html', 'problem', 'video']
 
 # Constants for determining if these components should be enabled for this course
 SPLIT_TEST_COMPONENT_TYPE = 'split_test'
-OPEN_ENDED_COMPONENT_TYPES = ["combinedopenended", "peergrading"]
 NOTE_COMPONENT_TYPES = ['notes']
 
 if settings.FEATURES.get('ALLOW_ALL_ADVANCED_COMPONENTS'):

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -10,6 +10,7 @@ import pytz
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.test.utils import override_settings
 from django.utils.translation import ugettext as _
 
 from contentstore.courseware_index import CoursewareSearchIndexer, SearchIndexingError
@@ -440,6 +441,7 @@ class TestCourseOutline(CourseTestCase):
             info['block_types_enabled'],
             any(component in advanced_modules for component in deprecated_block_types)
         )
+
         self.assertItemsEqual(info['blocks'], expected_blocks)
         self.assertEqual(
             info['advance_settings_url'],
@@ -455,27 +457,29 @@ class TestCourseOutline(CourseTestCase):
         """
         Verify deprecated warning info for single deprecated feature.
         """
-        block_types = settings.DEPRECATED_BLOCK_TYPES
-        course_module = modulestore().get_item(self.course.location)
-        self._create_test_data(course_module, create_blocks=True, block_types=block_types, publish=publish)
-        info = _deprecated_blocks_info(course_module, block_types)
-        self._verify_deprecated_info(
-            course_module.id,
-            course_module.advanced_modules,
-            info,
-            block_types
-        )
+        block_types = ['notes']
+        with override_settings(DEPRECATED_BLOCK_TYPES=block_types):
+            course_module = modulestore().get_item(self.course.location)
+            self._create_test_data(course_module, create_blocks=True, block_types=block_types, publish=publish)
+            info = _deprecated_blocks_info(course_module, block_types)
+            self._verify_deprecated_info(
+                course_module.id,
+                course_module.advanced_modules,
+                info,
+                block_types
+            )
 
     def test_verify_deprecated_warning_message_with_multiple_features(self):
         """
         Verify deprecated warning info for multiple deprecated features.
         """
-        block_types = ['peergrading', 'combinedopenended', 'openassessment']
-        course_module = modulestore().get_item(self.course.location)
-        self._create_test_data(course_module, create_blocks=True, block_types=block_types)
+        block_types = ['notes', 'lti']
+        with override_settings(DEPRECATED_BLOCK_TYPES=block_types):
+            course_module = modulestore().get_item(self.course.location)
+            self._create_test_data(course_module, create_blocks=True, block_types=block_types)
 
-        info = _deprecated_blocks_info(course_module, block_types)
-        self._verify_deprecated_info(course_module.id, course_module.advanced_modules, info, block_types)
+            info = _deprecated_blocks_info(course_module, block_types)
+            self._verify_deprecated_info(course_module.id, course_module.advanced_modules, info, block_types)
 
     @ddt.data(
         {'delete_vertical': True},
@@ -492,7 +496,7 @@ class TestCourseOutline(CourseTestCase):
             un-published block(s). This behavior should be same if we delete
             unpublished vertical or problem.
         """
-        block_types = ['peergrading']
+        block_types = ['notes']
         course_module = modulestore().get_item(self.course.location)
 
         vertical1 = ItemFactory.create(
@@ -500,8 +504,8 @@ class TestCourseOutline(CourseTestCase):
         )
         problem1 = ItemFactory.create(
             parent_location=vertical1.location,
-            category='peergrading',
-            display_name='peergrading problem in vert1',
+            category='notes',
+            display_name='notes problem in vert1',
             publish_item=False
         )
 
@@ -515,8 +519,8 @@ class TestCourseOutline(CourseTestCase):
         )
         ItemFactory.create(
             parent_location=vertical2.location,
-            category='peergrading',
-            display_name='peergrading problem in vert2',
+            category='notes',
+            display_name='notes problem in vert2',
             pubish_item=True
         )
         # At this point CourseStructure will contain both the above
@@ -526,8 +530,8 @@ class TestCourseOutline(CourseTestCase):
         self.assertItemsEqual(
             info['blocks'],
             [
-                [reverse_usage_url('container_handler', vertical1.location), 'peergrading problem in vert1'],
-                [reverse_usage_url('container_handler', vertical2.location), 'peergrading problem in vert2']
+                [reverse_usage_url('container_handler', vertical1.location), 'notes problem in vert1'],
+                [reverse_usage_url('container_handler', vertical2.location), 'notes problem in vert2']
             ]
         )
 
@@ -542,7 +546,7 @@ class TestCourseOutline(CourseTestCase):
         # There shouldn't be any info present about un-published vertical1
         self.assertEqual(
             info['blocks'],
-            [[reverse_usage_url('container_handler', vertical2.location), 'peergrading problem in vert2']]
+            [[reverse_usage_url('container_handler', vertical2.location), 'notes problem in vert2']]
         )
 
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1011,7 +1011,6 @@ ADVANCED_COMPONENT_TYPES = [
     'rate',  # Allows up-down voting of course content. See https://github.com/pmitros/RateXBlock
 
     'split_test',
-    'peergrading',
     'notes',
     'schoolyourself_review',
     'schoolyourself_lesson',
@@ -1109,7 +1108,7 @@ CREDIT_PROVIDER_TIMESTAMP_EXPIRATION = 15 * 60
 
 ################################ Deprecated Blocks Info ################################
 
-DEPRECATED_BLOCK_TYPES = ['peergrading', 'combinedopenended']
+DEPRECATED_BLOCK_TYPES = []
 
 #### PROCTORING CONFIGURATION DEFAULTS
 


### PR DESCRIPTION
@dianakhuang @symbolist could you please look at how I've updated these tests to make sure I'm maintaining the same point to the tests?

Also, please verify that there are no more references to ORA1 within the cms/ directory, or let me know of ones I've missed. I couldn't find references to any of the following:

```
(ora1-cms-extracation)(~/devstack/edx-platform/cms) $ git grep combinedopenended
 (ora1-cms-extracation)(~/devstack/edx-platform/cms) $ git grep peergrading
 (ora1-cms-extracation)(~/devstack/edx-platform/cms) $ git grep rubric
 (ora1-cms-extracation)(~/devstack/edx-platform/cms) $ git grep staff_grading
 (ora1-cms-extracation)(~/devstack/edx-platform/cms) $ 
```
