### PR TITLE
Create sample deprecated blocks for bok choy tests

### DIFF
--- a/cms/envs/bok_choy.env.json
+++ b/cms/envs/bok_choy.env.json
@@ -104,5 +104,9 @@
     "THEME_NAME": "",
     "TIME_ZONE": "America/New_York",
     "WIKI_ENABLED": true,
-    "OAUTH_OIDC_ISSUER": "https://www.example.com/oauth2"
+    "OAUTH_OIDC_ISSUER": "https://www.example.com/oauth2",
+    "DEPRECATED_BLOCK_TYPES": [
+        "poll",
+        "survey"
+    ]
 }

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -96,6 +96,9 @@ FEATURES['ENABLE_VIDEO_BUMPER'] = True  # Enable video bumper in Studio settings
 # Enable partner support link in Studio footer
 FEATURES['PARTNER_SUPPORT_EMAIL'] = 'partner-support@example.com'
 
+# Disable some block types to test block deprecation logic
+DEPRECATED_BLOCK_TYPES = ['poll', 'survey']
+
 ########################### Entrance Exams #################################
 FEATURES['ENTRANCE_EXAMS'] = True
 


### PR DESCRIPTION
As a followup to https://github.com/edx/edx-platform/commit/72f4fdcd13dd1fec10a8d1b6d5eac8881251d7ff#diff-d8eb01091f6f5be72153b83284b8776eL1623 - this bok choy test tests the deprecation logic, and used ORA1 as an example.

I removed ORA1 and replaced with poll and survey xblocks to maintain the integrity of the test. However, you cannot override django settings for a single bokchoy test (see [TE-1](https://openedx.atlassian.net/browse/TE-1)), so I need to add those xblock types to bokchoy.env.json.

![](http://i.imgur.com/DLzgGYN.jpg)
