### PR TITLE
Fix issue with unicode characters in certificates.

### DIFF
--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -523,6 +523,16 @@ class CertificatesViewsTests(ModuleStoreTestCase, EventTrackingTestCase):
         response = self.client.get(test_url)
         self.assertIn('invalid', response.content)
 
+    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED, PLATFORM_NAME=u'Űńíćődé Űńívéŕśítӳ')
+    def test_render_html_view_with_unicode_platform_name(self):
+        test_url = get_certificate_url(
+            user_id=self.user.id,
+            course_id=unicode(self.course)
+        )
+        self._add_course_certificates(count=1, signatory_count=0)
+        response = self.client.get(test_url)
+        self.assertEqual(response.status_code, 200)
+
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_html_view_with_preview_mode(self):
         """

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -153,7 +153,7 @@ def _update_context_with_basic_info(context, course_id, platform_name, configura
 
     # Translators:  'All rights reserved' is a legal term used in copyrighting to protect published content
     reserved = _("All rights reserved")
-    context['copyright_text'] = '&copy; {year} {platform_name}. {reserved}.'.format(
+    context['copyright_text'] = u'&copy; {year} {platform_name}. {reserved}.'.format(
         year=settings.COPYRIGHT_YEAR,
         platform_name=platform_name,
         reserved=reserved


### PR DESCRIPTION
**Description**: This PR fixes a problem where certificate web view would break if the `PLATFORM_NAME` setting or the translation of `"All rights reserved"` text contained non-ascii characters. The strings were being into a plain python strings. This PR changes the code to use a unicode string instead.
**Partner information**: 3rd party-hosted open edX instance
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1011
