### PR TITLE
Remove staff debug category type whitelist.

### DIFF
--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -6,7 +6,6 @@ from django.template.defaultfilters import escapejs
 
 ## The JS for this is defined in xqa_interface.html
 ${block_content}
-%if location.category in ['problem','video','html','combinedopenended','graphical_slider_tool', 'library_content']:
 %  if edit_link:
   <div>
       <a href="${edit_link}">Edit</a>
@@ -142,5 +141,3 @@ $(function () {
     );
 });
 </script>
-%endif
-


### PR DESCRIPTION
**Description**: This PR makes the 'Staff debug' button visible on all blocks, including custom xblocks. Staff debug was only available on selected components for historical reasons, because it used to be much more intrusive in the past. Now that it only renders a button, we believe it makes sense to enable it on all block types.

**Discussion**: https://groups.google.com/forum/#!topic/edx-code/j2LJsYRD2RM

**Partner information**: 3rd party-hosted open edX instance
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1018
