### PR TITLE
Fix spurious Zendesk warnings.

### DIFF
--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -233,7 +233,7 @@ def _record_feedback_in_zendesk(
             new_ticket['ticket']['group_id'] = group['id']
     try:
         ticket_id = zendesk_api.create_ticket(new_ticket)
-        if group is None:
+        if group_name is not None and group is None:
             # Support uses Zendesk groups to track tickets. In case we
             # haven't been able to correctly group this ticket, log its ID
             # so it can be found later.


### PR DESCRIPTION
We were logging warnings about group names when no group names were requested. This will clean up Splunk a little bit.

@bderusha, can you take a quick look?
