### PR TITLE
LMS: addressing contrast on the Instructor dashboard

### DIFF
--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -303,7 +303,7 @@
     display: none;
 
     p {
-      color: #a2a2a2;
+      color: $gray-d2;
       font-style: italic;
     }
   }


### PR DESCRIPTION
This work addresses a gray that is too light at the bottom of the instructor dashboard by darkening it with a defined variable for consistency. It relates to [AC-178](https://openedx.atlassian.net/browse/AC-178).
## Reviewers
- [x] @frrrances 
