### PR TITLE
CMS: removing H1 and H2, adding H4, H5, and H6 to TinyMCE

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -82,12 +82,13 @@ class @HTMLEditingDescriptor
         image_advtab: true,
         # We may want to add "styleselect" when we collect all styles used throughout the LMS
         toolbar: "formatselect | fontselect | bold italic underline forecolor wrapAsCode | bullist numlist outdent indent blockquote | link unlink image | code",
-        block_formats: interpolate("%(paragraph)s=p;%(preformatted)s=pre;%(heading1)s=h1;%(heading2)s=h2;%(heading3)s=h3", {
+        block_formats: interpolate("%(paragraph)s=p;%(preformatted)s=pre;%(heading3)s=h3;%(heading4)s=h4;%(heading5)s=h5;%(heading6)s=h6", {
             paragraph: gettext("Paragraph"),
             preformatted: gettext("Preformatted"),
-            heading1: gettext("Heading 1"),
-            heading2: gettext("Heading 2"),
-            heading3: gettext("Heading 3")
+            heading3: gettext("Heading 3"),
+            heading4: gettext("Heading 4"),
+            heading5: gettext("Heading 5"),
+            heading6: gettext("Heading 6")
           }, true),
         width: '100%',
         height: '400px',


### PR DESCRIPTION
This work removes the the H1 and H2 heading options from the TinyMCE editor and adds H4, H5, and H6. It relates to [AC-190](https://openedx.atlassian.net/browse/AC-190).
## Background

Pages in the LMS already have an H1 and H2 present, so when additional similar headings are added we get structural failures when running automated WCAG AA checks. In order to prevent future content issues, I've removed the option to add an H1 in course content using the visual editor (writing custom HTML still allows the option at this time).

Additionally, the lower headings (H4, H5, and H6) weren't present at all, but may be useful. I've included them here.
## Sandbox

https://studio-clrux-ac-190.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc
## Reviewers
- [x] @cptvitamin (Accessibility)
- [x] @andy-armstrong (CoffeeScript, overall correctness)
- [x] @explorerleslie (TNL)
- [x] @catong (Documentation)
