### PR TITLE
Modify Course API to filter visible courses by org

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -7,7 +7,6 @@ from django.http import Http404
 from rest_framework.exceptions import NotFound, PermissionDenied
 
 from lms.djangoapps.courseware.courses import get_courses, get_course_with_access
-
 from .permissions import can_view_courses_for_username
 
 
@@ -50,7 +49,7 @@ def course_detail(request, username, course_key):
     return course
 
 
-def list_courses(request, username):
+def list_courses(request, username, org=None):
     """
     Return a list of available courses.
 
@@ -66,10 +65,19 @@ def list_courses(request, username):
             The name of the user the logged-in user would like to be
             identified as
 
+    Keyword Arguments:
+        org (string):
+            If specified, visible `CourseDescriptor` objects are filtered
+            such that only those belonging to the organization with the provided
+            org code (e.g., "HarvardX") are returned. Case-insensitive.
 
     Return value:
         List of `CourseDescriptor` objects representing the collection of courses.
     """
     user = get_effective_user(request.user, username)
     courses = get_courses(user)
+
+    if org is not None:
+        courses = [course for course in courses if course.location.org.lower() == org.lower()]
+
     return courses

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -1,14 +1,13 @@
 """
-Tests for Blocks Views
+Tests for Course API views.
 """
+from hashlib import md5
 
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory
 
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-
 from .mixins import CourseApiFactoryMixin, TEST_PASSWORD
-
 from ..views import CourseDetailView
 
 
@@ -77,6 +76,29 @@ class CourseListViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase):
     def test_as_honor_for_staff(self):
         self.setup_user(self.honor_user)
         self.verify_response(expected_status_code=403, params={'username': self.staff_user.username})
+
+    def test_filter_by_org(self):
+        """Verify that CourseDescriptors are filtered by the provided org key."""
+        self.setup_user(self.staff_user)
+
+        # Create a second course to be filtered out of queries.
+        alternate_course = self.create_course(
+            org=md5(self.course.org).hexdigest()
+        )
+
+        self.assertNotEqual(alternate_course.org, self.course.org)
+
+        # No filtering.
+        unfiltered_response = self.verify_response()
+        self.assertTrue(
+            any(course['org'] == alternate_course.org for course in unfiltered_response.data['results'])  # pylint: disable=no-member
+        )
+
+        # With filtering.
+        filtered_response = self.verify_response(params={'org': self.course.org})
+        self.assertTrue(
+            all(course['org'] == self.course.org for course in filtered_response.data['results'])  # pylint: disable=no-member
+        )
 
     def test_not_logged_in(self):
         self.client.logout()

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -1,15 +1,12 @@
 """
 Course API Views
 """
-
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 
-from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey
-
 from openedx.core.lib.api.paginators import NamespacedPageNumberPagination
-
 from .api import course_detail, list_courses
 from .serializers import CourseSerializer
 
@@ -127,6 +124,11 @@ class CourseListView(ListAPIView):
             The username of the specified user whose visible courses we
             want to see.  Defaults to the current user.
 
+        org (optional):
+            If specified, visible `CourseDescriptor` objects are filtered
+            such that only those belonging to the organization with the provided
+            org code (e.g., "HarvardX") are returned. Case-insensitive.
+
     **Returns**
 
         * 200 on success, with a list of course discovery objects as returned
@@ -170,4 +172,6 @@ class CourseListView(ListAPIView):
         Return a list of courses visible to the user.
         """
         username = self.request.query_params.get('username', self.request.user.username)
-        return list_courses(self.request, username)
+        org = self.request.query_params.get('org')
+
+        return list_courses(self.request, username, org=org)


### PR DESCRIPTION
Org to filter by is provided to the Course API list view using a querystring argument. ECOM-2761.

@jimabramson and @nasthagiri, please review. This API uses session auth and will expose publicly visible courses to anonymous users. This should allow us to make requests from Programs during development and from Studio if the authoring app is being run from there.
