### PR TITLE
Make modifies_courseware robust to exceptions raised during tests

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -317,10 +317,20 @@ class SharedModuleStoreTestCase(TestCase):
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
             """Call the object method, and reset the test case afterwards."""
-            return_val = f(*args, **kwargs)
-            obj = args[0]
-            obj.reset()
-            return return_val
+            try:
+                # Attempt execution of the test.
+                return_val = f(*args, **kwargs)
+            except:
+                # If the test raises an exception, re-raise it.
+                raise
+            else:
+                # Otherwise, return the test's return value.
+                return return_val
+            finally:
+                # In either case, call SharedModuleStoreTestCase.reset() "on the way out."
+                # For more, see here: https://docs.python.org/2/tutorial/errors.html#defining-clean-up-actions.
+                obj = args[0]
+                obj.reset()
 
         return wrapper
 


### PR DESCRIPTION
Guarantees that SharedModuleStoreTestCase's `reset()` method is always called, regardless of whether decorated test cases raise exceptions.

@ormsbee, please review.
