### PR TITLE
use users anonymous id for subject field in JWT

### DIFF
--- a/openedx/core/lib/tests/test_token_utils.py
+++ b/openedx/core/lib/tests/test_token_utils.py
@@ -12,6 +12,7 @@ from oauth2_provider.tests.factories import ClientFactory
 from provider.constants import CONFIDENTIAL
 
 from openedx.core.lib.token_utils import get_id_token
+from student.models import anonymous_id_for_user
 from student.tests.factories import UserFactory, UserProfileFactory
 
 
@@ -53,7 +54,7 @@ class TestIdTokenGeneration(TestCase):
             'exp': calendar.timegm(expiration.utctimetuple()),
             'iat': calendar.timegm(now.utctimetuple()),
             'aud': self.oauth2_client.client_id,
-            'sub': self.user.id,  # pylint: disable=no-member
+            'sub': anonymous_id_for_user(self.user, None),
         }
 
         self.assertEqual(payload, expected_payload)

--- a/openedx/core/lib/token_utils.py
+++ b/openedx/core/lib/token_utils.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ImproperlyConfigured
 import jwt
 from provider.oauth2.models import Client
 
-from student.models import UserProfile
+from student.models import UserProfile, anonymous_id_for_user
 
 
 def get_id_token(user, client_name):
@@ -54,7 +54,7 @@ def get_id_token(user, client_name):
         'exp': now + datetime.timedelta(seconds=expires_in),
         'iat': now,
         'aud': client.client_id,
-        'sub': user.id,
+        'sub': anonymous_id_for_user(user, None),
     }
 
     return jwt.encode(payload, client.client_secret)


### PR DESCRIPTION
edx-notes-api uses JWT for authentication and excepts that value of subject field in JWT should be set to users anonymous id. 
