### PR TITLE
Add xblock-vectordraw to requirements.

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -27,3 +27,6 @@
 
 # Peer instruction xblock - prototype (from UBC; not for use on edx.org yet)
 ubcpi-xblock==0.4.4
+
+# Vector Drawing XBlock (Davidson)
+-e git+https://github.com/open-craft/xblock-vectordraw.git@ded76fc8f6c99ba4949ed57a7bf62a1f12e44683#egg=xblock-vectordraw


### PR DESCRIPTION
Replaces #10515.

The Vector Drawing XBlock was reviewed in this PR: https://github.com/open-craft/xblock-vectordraw/pull/1.
