### PR TITLE
Update Peer Instruction XBlock to 0.5

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -24,8 +24,8 @@
 -e git+https://github.com/pmitros/AnimationXBlock.git@d2b551bb8f49a138088e10298576102164145b87#egg=animation-xblock
 -e git+https://github.com/pmitros/ProfileXBlock.git@4aeaa24aa2bc7d9cb2d2bb60d6f05def3b856be0#egg=profile-xblock
 
-# Peer instruction xblock - prototype (from UBC; not for use on edx.org yet)
-ubcpi-xblock==0.4.4
+# Peer instruction XBlock - prototype (from UBC; not for use on edx.org yet)
+ubcpi-xblock==0.5.0
 
 # Vector Drawing and ActiveTable XBlocks (Davidson)
 -e git+https://github.com/open-craft/xblock-vectordraw.git@ded76fc8f6c99ba4949ed57a7bf62a1f12e44683#egg=xblock-vectordraw


### PR DESCRIPTION
This is PR is to update Peer Instructor XBlock to prepare for edx.org release. For more details about the changes, please see here: https://github.com/ubc/ubcpi/pull/55
