### PR TITLE
Remove unused filter field from Randomized Content Block edit form.

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -99,7 +99,6 @@ class LibraryContentFields(object):
         values=_get_capa_types(),
         scope=Scope.settings,
     )
-    filters = String(default="")  # TBD
     has_score = Boolean(
         display_name=_("Scored"),
         help=_("Set this value to True if this module is either a graded assignment or a practice problem."),


### PR DESCRIPTION
The "filter" field is displayed on the form but there isn't any code behind it.
