### PR TITLE
Test: course listing tests should use default store as Split

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -22,7 +22,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls
 from xmodule.modulestore import ModuleStoreEnum
 from opaque_keys.edx.locations import CourseLocator
-from xmodule.modulestore.django import modulestore
 from xmodule.error_module import ErrorDescriptor
 from course_action_state.models import CourseRerunState
 
@@ -49,7 +48,7 @@ class TestCourseListing(ModuleStoreTestCase):
         self.client = AjaxEnabledTestClient()
         self.client.login(username=self.user.username, password='test')
 
-    def _create_course_with_access_groups(self, course_location, user=None, store=ModuleStoreEnum.Type.mongo):
+    def _create_course_with_access_groups(self, course_location, user=None, store=ModuleStoreEnum.Type.split):
         """
         Create dummy course with 'CourseFactory' and role (instructor/staff) groups
         """
@@ -90,25 +89,31 @@ class TestCourseListing(ModuleStoreTestCase):
         # check both course lists have same courses
         self.assertEqual(courses_list, courses_list_by_groups)
 
-    def test_errored_course_global_staff(self):
+    @ddt.data(
+        (ModuleStoreEnum.Type.split, 'xmodule.modulestore.split_mongo.split_mongo_kvs.SplitMongoKVS'),
+        (ModuleStoreEnum.Type.mongo, 'xmodule.modulestore.mongo.base.MongoKeyValueStore')
+    )
+    @ddt.unpack
+    def test_errored_course_global_staff(self, store, path_to_patch):
         """
         Test the course list for global staff when get_course returns an ErrorDescriptor
         """
         GlobalStaff().add_users(self.user)
 
-        course_key = self.store.make_course_key('Org1', 'Course1', 'Run1')
-        self._create_course_with_access_groups(course_key, self.user)
+        with self.store.default_store(store):
+            course_key = self.store.make_course_key('Org1', 'Course1', 'Run1')
+            self._create_course_with_access_groups(course_key, self.user, store=store)
 
-        with patch('xmodule.modulestore.mongo.base.MongoKeyValueStore', Mock(side_effect=Exception)):
-            self.assertIsInstance(modulestore().get_course(course_key), ErrorDescriptor)
+            with patch(path_to_patch, Mock(side_effect=Exception)):
+                self.assertIsInstance(self.store.get_course(course_key), ErrorDescriptor)
 
-            # get courses through iterating all courses
-            courses_list, __ = _accessible_courses_list(self.request)
-            self.assertEqual(courses_list, [])
+                # get courses through iterating all courses
+                courses_list, __ = _accessible_courses_list(self.request)
+                self.assertEqual(courses_list, [])
 
-            # get courses by reversing group name formats
-            courses_list_by_groups, __ = _accessible_courses_list_from_groups(self.request)
-            self.assertEqual(courses_list_by_groups, [])
+                # get courses by reversing group name formats
+                courses_list_by_groups, __ = _accessible_courses_list_from_groups(self.request)
+                self.assertEqual(courses_list_by_groups, [])
 
     @ddt.data(
         (ModuleStoreEnum.Type.split, 5),
@@ -125,10 +130,11 @@ class TestCourseListing(ModuleStoreTestCase):
         GlobalStaff().add_users(self.user)
         self.assertTrue(GlobalStaff().has_user(self.user))
 
-        # Create few courses
-        for num in xrange(TOTAL_COURSES_COUNT):
-            course_location = CourseLocator('Org', 'CreatedCourse' + str(num), 'Run')
-            self._create_course_with_access_groups(course_location, self.user, default_store)
+        with self.store.default_store(default_store):
+            # Create few courses
+            for num in xrange(TOTAL_COURSES_COUNT):
+                course_location = self.store.make_course_key('Org', 'CreatedCourse' + str(num), 'Run')
+                self._create_course_with_access_groups(course_location, self.user, default_store)
 
         # Fetch accessible courses list & verify their count
         courses_list_by_staff, __ = get_courses_accessible_to_user(self.request)
@@ -141,34 +147,43 @@ class TestCourseListing(ModuleStoreTestCase):
         with check_mongo_calls(mongo_calls):
             _staff_accessible_course_list(self.request)
 
-    def test_errored_course_regular_access(self):
+    @ddt.data(
+        (ModuleStoreEnum.Type.split, 'xmodule.modulestore.split_mongo.split_mongo_kvs.SplitMongoKVS'),
+        (ModuleStoreEnum.Type.mongo, 'xmodule.modulestore.mongo.base.MongoKeyValueStore')
+    )
+    @ddt.unpack
+    def test_errored_course_regular_access(self, store, path_to_patch):
         """
         Test the course list for regular staff when get_course returns an ErrorDescriptor
         """
         GlobalStaff().remove_users(self.user)
-        CourseStaffRole(self.store.make_course_key('Non', 'Existent', 'Course')).add_users(self.user)
 
-        course_key = self.store.make_course_key('Org1', 'Course1', 'Run1')
-        self._create_course_with_access_groups(course_key, self.user)
+        with self.store.default_store(store):
+            CourseStaffRole(self.store.make_course_key('Non', 'Existent', 'Course')).add_users(self.user)
 
-        with patch('xmodule.modulestore.mongo.base.MongoKeyValueStore', Mock(side_effect=Exception)):
-            self.assertIsInstance(modulestore().get_course(course_key), ErrorDescriptor)
+            course_key = self.store.make_course_key('Org1', 'Course1', 'Run1')
+            self._create_course_with_access_groups(course_key, self.user, store)
 
-            # get courses through iterating all courses
-            courses_list, __ = _accessible_courses_list(self.request)
-            self.assertEqual(courses_list, [])
+            with patch(path_to_patch, Mock(side_effect=Exception)):
+                self.assertIsInstance(self.store.get_course(course_key), ErrorDescriptor)
 
-            # get courses by reversing group name formats
-            courses_list_by_groups, __ = _accessible_courses_list_from_groups(self.request)
-            self.assertEqual(courses_list_by_groups, [])
-            self.assertEqual(courses_list, courses_list_by_groups)
+                # get courses through iterating all courses
+                courses_list, __ = _accessible_courses_list(self.request)
+                self.assertEqual(courses_list, [])
 
-    def test_get_course_list_with_invalid_course_location(self):
+                # get courses by reversing group name formats
+                courses_list_by_groups, __ = _accessible_courses_list_from_groups(self.request)
+                self.assertEqual(courses_list_by_groups, [])
+                self.assertEqual(courses_list, courses_list_by_groups)
+
+    @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
+    def test_get_course_list_with_invalid_course_location(self, store):
         """
         Test getting courses with invalid course location (course deleted from modulestore).
         """
-        course_key = self.store.make_course_key('Org', 'Course', 'Run')
-        self._create_course_with_access_groups(course_key, self.user)
+        with self.store.default_store(store):
+            course_key = self.store.make_course_key('Org', 'Course', 'Run')
+            self._create_course_with_access_groups(course_key, self.user, store)
 
         # get courses through iterating all courses
         courses_list, __ = _accessible_courses_list(self.request)
@@ -189,7 +204,12 @@ class TestCourseListing(ModuleStoreTestCase):
         courses_list, __ = _accessible_courses_list(self.request)
         self.assertEqual(len(courses_list), 0)
 
-    def test_course_listing_performance(self):
+    @ddt.data(
+        (ModuleStoreEnum.Type.split, 150, 505),
+        (ModuleStoreEnum.Type.mongo, USER_COURSES_COUNT, 3)
+    )
+    @ddt.unpack
+    def test_course_listing_performance(self, store, courses_list_from_group_calls, courses_list_calls):
         """
         Create large number of courses and give access of some of these courses to the user and
         compare the time to fetch accessible courses for the user through traversing all courses and
@@ -199,15 +219,16 @@ class TestCourseListing(ModuleStoreTestCase):
         user_course_ids = random.sample(range(TOTAL_COURSES_COUNT), USER_COURSES_COUNT)
 
         # create courses and assign those to the user which have their number in user_course_ids
-        for number in range(TOTAL_COURSES_COUNT):
-            org = 'Org{0}'.format(number)
-            course = 'Course{0}'.format(number)
-            run = 'Run{0}'.format(number)
-            course_location = self.store.make_course_key(org, course, run)
-            if number in user_course_ids:
-                self._create_course_with_access_groups(course_location, self.user)
-            else:
-                self._create_course_with_access_groups(course_location)
+        with self.store.default_store(store):
+            for number in range(TOTAL_COURSES_COUNT):
+                org = 'Org{0}'.format(number)
+                course = 'Course{0}'.format(number)
+                run = 'Run{0}'.format(number)
+                course_location = self.store.make_course_key(org, course, run)
+                if number in user_course_ids:
+                    self._create_course_with_access_groups(course_location, self.user, store=store)
+                else:
+                    self._create_course_with_access_groups(course_location, store=store)
 
         # time the get courses by iterating through all courses
         with Timer() as iteration_over_courses_time_1:
@@ -235,29 +256,29 @@ class TestCourseListing(ModuleStoreTestCase):
         self.assertGreaterEqual(iteration_over_courses_time_2.elapsed, iteration_over_groups_time_2.elapsed)
 
         # Now count the db queries
-        with check_mongo_calls(USER_COURSES_COUNT):
+        with check_mongo_calls(courses_list_from_group_calls):
             _accessible_courses_list_from_groups(self.request)
 
+        with check_mongo_calls(courses_list_calls):
+            _accessible_courses_list(self.request)
         # Calls:
         #    1) query old mongo
         #    2) get_more on old mongo
         #    3) query split (but no courses so no fetching of data)
-        with check_mongo_calls(3):
-            _accessible_courses_list(self.request)
 
-    def test_course_listing_errored_deleted_courses(self):
+    @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
+    def test_course_listing_errored_deleted_courses(self, store):
         """
         Create good courses, courses that won't load, and deleted courses which still have
         roles. Test course listing.
         """
-        store = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo)
+        with self.store.default_store(store):
+            course_location = self.store.make_course_key('testOrg', 'testCourse', 'RunBabyRun')
+            self._create_course_with_access_groups(course_location, self.user, store)
 
-        course_location = self.store.make_course_key('testOrg', 'testCourse', 'RunBabyRun')
-        self._create_course_with_access_groups(course_location, self.user)
-
-        course_location = self.store.make_course_key('testOrg', 'doomedCourse', 'RunBabyRun')
-        self._create_course_with_access_groups(course_location, self.user)
-        store.delete_course(course_location, self.user.id)
+            course_location = self.store.make_course_key('testOrg', 'doomedCourse', 'RunBabyRun')
+            self._create_course_with_access_groups(course_location, self.user, store)
+            self.store.delete_course(course_location, self.user.id)  # pylint: disable=no-member
 
         courses_list, __ = _accessible_courses_list_from_groups(self.request)
         self.assertEqual(len(courses_list), 1, courses_list)
@@ -275,7 +296,7 @@ class TestCourseListing(ModuleStoreTestCase):
             run=org_course_one.run
         )
 
-        org_course_two = self.store.make_course_key('AwesomeOrg', 'Course2', 'RunRunRun')
+        org_course_two = self.store.make_course_key('AwesomeOrg', 'Course2', 'RunBabyRun')
         CourseFactory.create(
             org=org_course_two.org,
             number=org_course_two.course,

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -209,20 +209,20 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
             parent = course_key.make_usage_key(parent_key.type, parent_key.id)
         else:
             parent = None
-        kvs = SplitMongoKVS(
-            definition_loader,
-            converted_fields,
-            converted_defaults,
-            parent=parent,
-            field_decorator=kwargs.get('field_decorator')
-        )
-
-        if InheritanceMixin in self.modulestore.xblock_mixins:
-            field_data = inheriting_field_data(kvs)
-        else:
-            field_data = KvsFieldData(kvs)
-
         try:
+            kvs = SplitMongoKVS(
+                definition_loader,
+                converted_fields,
+                converted_defaults,
+                parent=parent,
+                field_decorator=kwargs.get('field_decorator')
+            )
+
+            if InheritanceMixin in self.modulestore.xblock_mixins:
+                field_data = inheriting_field_data(kvs)
+            else:
+                field_data = KvsFieldData(kvs)
+
             module = self.construct_xblock_from_class(
                 class_,
                 ScopeIds(None, block_key.type, definition_id, block_locator),


### PR DESCRIPTION
[TNL-3866](https://openedx.atlassian.net/browse/TNL-3866)
## Tests in ContentStore should use default store as Split
#### Issue:

Currently there are tests in `cms/djangoapps/contentstore/tests/test_course_listing.py` which were using `default_store = 'mongo'`, Change it to split module store. 
[_create_course_with_access_groups](https://github.com/edx/edx-platform/blob/062e979e0ed14161d0f882091a06e032ca76bb3e/cms/djangoapps/contentstore/tests/test_course_listing.py#L49-L58) method is using `default_store = 'mongo'` when creating courses.
#### Solution

Update `default_store` to `split`
### Note

This PR is branched from https://github.com/edx/edx-platform/pull/10749 instead of master as it is not merged into master yet. 
e.g.
`aj/tnl3779-use-get-courses-summaries-for-staff` from `aj/tnl3866-convert-contentstore-tests`

My understanding is upon merging, This PR should be merged prior to merging https://github.com/edx/edx-platform/pull/10749.
