### PR TITLE
Disable staff markup on 'detached' blocks.

### DIFF
--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -6,7 +6,7 @@ from django.template.defaultfilters import escapejs
 
 ## The JS for this is defined in xqa_interface.html
 ${block_content}
-%if location.category in ['problem','video','html','combinedopenended','library_content']:
+%if 'detached' not in tags:
 %  if edit_link:
   <div>
       <a href="${edit_link}">Edit</a>

--- a/openedx/core/lib/xblock_utils.py
+++ b/openedx/core/lib/xblock_utils.py
@@ -293,6 +293,7 @@ def add_staff_markup(user, has_instructor_access, disable_staff_debug_info, bloc
     staff_context = {
         'fields': field_contents,
         'xml_attributes': getattr(block, 'xml_attributes', {}),
+        'tags': block._class_tags,  # pylint: disable=protected-access
         'location': block.location,
         'xqa_key': block.xqa_key,
         'source_file': source_file,


### PR DESCRIPTION
Enable staff debug everywhere except on detached blocks.

Staff markup was enabled on all block types in https://github.com/edx/edx-platform/pull/10903

This works well inside the courseware, but it breaks layout of the course about page, which is also an XModule, see https://github.com/edx/edx-platform/pull/10903#issuecomment-164266342

This commit disables staff markup/staff debug on all blocks except blocks tagged with 'detached'. Detached blocks include course about and info pages, and static tabs.

**Partner information**: 3rd party-hosted open edX instance
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1033
**Sandbox URLs**: [LMS](http://pr10970.sandbox.opencraft.com/), [Studio](http://studio.pr10970.sandbox.opencraft.com/)
