### PR TITLE
Allow python variable interpolation in CustomResponse "expect" field

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -2208,7 +2208,7 @@ class CustomResponse(LoncapaResponse):
 
         # if <customresponse> has an "expect" (or "answer") attribute then save
         # that
-        self.expect = xml.get('expect') or xml.get('answer')
+        self.expect = contextualize_text(xml.get('expect') or xml.get('answer'), self.context)
 
         log.debug('answer_ids=%s', self.answer_ids)
 

--- a/common/lib/capa/capa/tests/response_xml_factory.py
+++ b/common/lib/capa/capa/tests/response_xml_factory.py
@@ -264,11 +264,15 @@ class CustomResponseXMLFactory(ResponseXMLFactory):
         *expect*: The value passed to the function cfn
 
         *answer*: Inline script that calculates the answer
+
+        *answer_attr*: The "answer" attribute on the tag itself (treated as an
+        alias to "expect", though "expect" takes priority if both are given)
         """
 
         # Retrieve **kwargs
         cfn = kwargs.get('cfn', None)
         expect = kwargs.get('expect', None)
+        answer_attr = kwargs.get('answer_attr', None)
         answer = kwargs.get('answer', None)
         options = kwargs.get('options', None)
         cfn_extra_args = kwargs.get('cfn_extra_args', None)
@@ -281,6 +285,9 @@ class CustomResponseXMLFactory(ResponseXMLFactory):
 
         if expect:
             response_element.set('expect', str(expect))
+
+        if answer_attr:
+            response_element.set('answer', str(answer_attr))
 
         if answer:
             answer_element = etree.SubElement(response_element, "answer")

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -1799,6 +1799,33 @@ class CustomResponseTest(ResponseTest):  # pylint: disable=missing-docstring
         self.assertEqual(correct_map.get_npoints('1_2_1'), 0.5)
         self.assertEqual(correct_map.get_correctness('1_2_1'), 'partially-correct')
 
+    def test_script_context(self):
+        # Ensure that python script variables can be used in the "expect" and "answer" fields,
+
+        script = script = textwrap.dedent("""
+            expected_ans = 42
+
+            def check_func(expect, answer_given):
+                return answer_given == expect
+        """)
+
+        problems = (
+            self.build_problem(script=script, cfn="check_func", expect="$expected_ans"),
+            self.build_problem(script=script, cfn="check_func", answer_attr="$expected_ans")
+        )
+
+        input_dict = {'1_2_1': '42'}
+
+        for problem in problems:
+            correctmap = problem.grade_answers(input_dict)
+
+            # CustomResponse also adds 'expect' to the problem context; check that directly first:
+            self.assertEqual(problem.context['expect'], '42')
+
+            # Also make sure the problem was graded correctly:
+            correctness = correctmap.get_correctness('1_2_1')
+            self.assertEqual(correctness, 'correct')
+
     def test_function_code_multiple_input_no_msg(self):
 
         # Check functions also have the option of returning


### PR DESCRIPTION
**Summary**:  This PR adds python variable interpolation to custom response problems (a behavior present in most other response types which appears to have been accidentally omitted here). The behavior is implemented by wrapping the `expect`/`answer` value in the same `contextualize_text` function used in the other response types, with a unit test to make sure it works.

**Background**: The edX platform allows python variable interpolation in various places within advanced problems. This behavior is particularly useful for randomized problems (see the example in "[Create a Randomized Custom Python-Evaluated Input Problem](http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/custom_python.html#create-a-randomized-custom-python-evaluated-input-problem)") and also mentioned in the docs for [math expression input problems](http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/math_expression_input.html) and [numerical input problems](http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/numerical_input.html) (search for "$" on either page to find examples). A look at the platform source shows that it is supported in a wide variety of locations:
- In capa `<solution></solution>` stanzas: [capa_problem.py#L463](https://github.com/edx/edx-platform/blob/222bdd988bf1e72cf6359f5c6de82934fd9efacf/common/lib/capa/capa/capa_problem.py#L463)
- In capa HTML content: [capa_problem.py#L558](https://github.com/edx/edx-platform/blob/222bdd988bf1e72cf6359f5c6de82934fd9efacf/common/lib/capa/capa/capa_problem.py#L558)
- In the `correct_answer` field of input problems: [responsetypes.py#L217](https://github.com/edx/edx-platform/blob/dcc86a3b1b4f03bc84da8e78e063b1ef553714cc/common/lib/capa/capa/responsetypes.py#L217)
- In the `value` field of response parameters: [responsetypes.py#L713](https://github.com/edx/edx-platform/blob/dcc86a3b1b4f03bc84da8e78e063b1ef553714cc/common/lib/capa/capa/responsetypes.py#L713)
- In the `name` and `correct` fields of multiple choice items: [responsetypes.py#L1173](https://github.com/edx/edx-platform/blob/dcc86a3b1b4f03bc84da8e78e063b1ef553714cc/common/lib/capa/capa/responsetypes.py#L1173)
- In the `correct` field of option response items: [responsetypes.py#L1606](https://github.com/edx/edx-platform/blob/dcc86a3b1b4f03bc84da8e78e063b1ef553714cc/common/lib/capa/capa/responsetypes.py#L1606)
- In the `answer` field and tolerance parameter of numerical response problems: [responsetypes.py#L1682](https://github.com/edx/edx-platform/blob/dcc86a3b1b4f03bc84da8e78e063b1ef553714cc/common/lib/capa/capa/responsetypes.py#L1682)
- In the `answer` field of string response problems, as well as in the `answer` fields of their `<additional_answer>` children and in any hints: [responsetypes.py#L1997](https://github.com/edx/edx-platform/blob/dcc86a3b1b4f03bc84da8e78e063b1ef553714cc/common/lib/capa/capa/responsetypes.py#L1997), [responsetypes.py#L2158](https://github.com/edx/edx-platform/blob/dcc86a3b1b4f03bc84da8e78e063b1ef553714cc/common/lib/capa/capa/responsetypes.py#L2158)
- In the `answer`/`sample` fields and tolerance parameter of formula response problems, as well as in their hints: [responsetypes.py#L3145](https://github.com/edx/edx-platform/blob/dcc86a3b1b4f03bc84da8e78e063b1ef553714cc/common/lib/capa/capa/responsetypes.py#L3145), [responsetypes.py#L3314](https://github.com/edx/edx-platform/blob/dcc86a3b1b4f03bc84da8e78e063b1ef553714cc/common/lib/capa/capa/responsetypes.py#L3314)
- In the `answer` and `tolerance` fields of choice text response problems: [responsetypes.py#L3718](https://github.com/edx/edx-platform/blob/dcc86a3b1b4f03bc84da8e78e063b1ef553714cc/common/lib/capa/capa/responsetypes.py#L3718)

Unfortunately, variable interpolation is _not_ implemented in the `expect` field (and its fallback alias, `answer`) of custom response problems; in these problems, the un-interpolated variable name is displayed when showing the answer, and the problem does not grade correctly. This seems to be a simple oversight, not an intentional design decision.

**Testing**: Python variable interpolation should work in the `expect` (or `answer`) field of custom response problems. The following (slightly-contrived) OLX should display a random integer when the answer is shown, not the literal string "$divisor", and should grade the problem correctly when the randomly-generated divisor is entered as an answer.

``` xml
<problem>
<script type="loncapa/python">
divisor = random.randint(1, 10)

def test_divisible(expect, ans):
    try:
        ans=int(ans)
        return ans % int(expect) == 0
    except ValueError:
        return False
</script>
<p>Enter an integer divisible by $divisor. </p>
<customresponse cfn="test_divisible" expect="$divisor">
    <textline size="10"/>
</customresponse>
</problem>
```

**Studio**: No changes necessary (this is an advanced problem type).

**Accessibility**: No effect; this behavior is concerned with how answers are generated by custom python code, not with how they're displayed in studio or the LMS.

**Documentation**: No changes are strictly necessary since the behavior added by this PR is consistent with variable interpolation in other problem fields, many of which are likewise not explicitly mentioned in the docs. Eventually it might be nice to document all the places where interpolated variables can be used (the list in the background section above should be a good start), but that seems like its own issue.
