### PR TITLE
jia/MA-1815 retrieve count for child comments

### DIFF
--- a/lms/djangoapps/discussion_api/serializers.py
+++ b/lms/djangoapps/discussion_api/serializers.py
@@ -290,6 +290,7 @@ class CommentSerializer(_ContentSerializer):
     endorsed_by = serializers.SerializerMethodField()
     endorsed_by_label = serializers.SerializerMethodField()
     endorsed_at = serializers.SerializerMethodField()
+    child_count = serializers.IntegerField(read_only=True)
     children = serializers.SerializerMethodField(required=False)
 
     non_updatable_fields = NON_UPDATABLE_COMMENT_FIELDS

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -1136,6 +1136,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
                 "endorsed": False,
                 "abuse_flaggers": [],
                 "votes": {"up_count": 4},
+                "child_count": 0,
                 "children": [],
             },
             {
@@ -1152,6 +1153,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
                 "endorsed": False,
                 "abuse_flaggers": [str(self.user.id)],
                 "votes": {"up_count": 7},
+                "child_count": 0,
                 "children": [],
             }
         ]
@@ -1174,6 +1176,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
                 "voted": False,
                 "vote_count": 4,
                 "editable_fields": ["abuse_flagged", "voted"],
+                "child_count": 0,
                 "children": [],
             },
             {
@@ -1194,6 +1197,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
                 "voted": False,
                 "vote_count": 7,
                 "editable_fields": ["abuse_flagged", "voted"],
+                "child_count": 0,
                 "children": [],
             },
         ]
@@ -1688,7 +1692,8 @@ class CreateCommentTest(
             "voted": False,
             "vote_count": 0,
             "children": [],
-            "editable_fields": ["abuse_flagged", "raw_body", "voted"]
+            "editable_fields": ["abuse_flagged", "raw_body", "voted"],
+            "child_count": 0,
         }
         self.assertEqual(actual, expected)
         expected_url = (
@@ -2377,7 +2382,8 @@ class UpdateCommentTest(
             "voted": False,
             "vote_count": 0,
             "children": [],
-            "editable_fields": ["abuse_flagged", "raw_body", "voted"]
+            "editable_fields": ["abuse_flagged", "raw_body", "voted"],
+            "child_count": 0,
         }
         self.assertEqual(actual, expected)
         self.assertEqual(

--- a/lms/djangoapps/discussion_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion_api/tests/test_serializers.py
@@ -312,6 +312,7 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
             "abuse_flaggers": [],
             "votes": {"up_count": 4},
             "children": [],
+            "child_count": 0,
         }
         expected = {
             "id": "test_comment",
@@ -332,6 +333,7 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
             "vote_count": 4,
             "children": [],
             "editable_fields": ["abuse_flagged", "voted"],
+            "child_count": 0,
         }
         self.assertEqual(self.serialize(comment), expected)
 

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -371,6 +371,7 @@ def make_minimal_cs_comment(overrides=None):
         "abuse_flaggers": [],
         "votes": {"up_count": 0},
         "endorsed": False,
+        "child_count": 0,
         "children": [],
     }
     ret.update(overrides or {})

--- a/lms/lib/comment_client/comment.py
+++ b/lms/lib/comment_client/comment.py
@@ -12,6 +12,7 @@ class Comment(models.Model):
         'endorsed', 'parent_id', 'thread_id', 'username', 'votes', 'user_id',
         'closed', 'created_at', 'updated_at', 'depth', 'at_position_list',
         'type', 'commentable_id', 'abuse_flaggers', 'endorsement',
+        'child_count',
     ]
 
     updatable_fields = [


### PR DESCRIPTION
jia/MA-1815 retrieve count for child comments

dependent on https://github.com/edx/cs_comments_service/pull/153
