### PR TITLE
SOL-1418: display certificate generate history in reverse chronological order

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -268,7 +268,8 @@ class CertificateGenerationHistory(TimeStampedModel):
         """
         Return "regenerated" if record corresponds to Certificate Regeneration task, otherwise returns 'generated'
         """
-        return "regenerated" if self.is_regeneration else "generated"
+        # Translators: This is a past-tense verb that is used for task action messages.
+        return _("regenerated") if self.is_regeneration else _("generated")
 
     def get_certificate_generation_candidates(self):
         """
@@ -285,7 +286,8 @@ class CertificateGenerationHistory(TimeStampedModel):
             task_input_json = json.loads(task_input)
         except ValueError:
             # if task input is empty, it means certificates were generated for all learners
-            return "All learners"
+            # Translators: This string represents task was executed for all learners.
+            return _("All learners")
 
         # get statuses_to_regenerate from task_input convert statuses to human readable strings and return
         statuses = task_input_json.get('statuses_to_regenerate', None)
@@ -296,7 +298,8 @@ class CertificateGenerationHistory(TimeStampedModel):
 
         # If students is present in task_input then, certificate generation task was run to
         # generate certificates for white listed students otherwise it is for all students.
-        return "For exceptions" if 'students' in task_input_json else "All learners"
+        # Translators: This string represents task was executed for students having exceptions.
+        return _("For exceptions") if 'students' in task_input_json else _("All learners")
 
     class Meta(object):
         app_label = "certificates"

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -294,9 +294,9 @@ class CertificateGenerationHistory(TimeStampedModel):
                 [CertificateStatuses.readable_statuses.get(status, "") for status in statuses]
             )
 
-        # If statuses_to_regenerate is not present in task_input then, certificate generation task was run to
-        # generate certificates for white listed students
-        return "for exceptions"
+        # If students is present in task_input then, certificate generation task was run to
+        # generate certificates for white listed students otherwise it is for all students.
+        return "For exceptions" if 'students' in task_input_json else "All learners"
 
     class Meta(object):
         app_label = "certificates"

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -10,14 +10,13 @@ import json
 import logging
 import re
 import time
-import requests
 from django.conf import settings
 from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
 from django.views.decorators.http import require_POST, require_http_methods
 from django.views.decorators.cache import cache_control
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.core.mail.message import EmailMessage
-from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, transaction
 from django.core.urlresolvers import reverse
 from django.core.validators import validate_email
@@ -25,11 +24,9 @@ from django.utils.translation import ugettext as _
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotFound
 from django.utils.html import strip_tags
 from django.shortcuts import redirect
-from util.db import outer_atomic
 import string
 import random
 import unicodecsv
-import urllib
 import decimal
 from student import auth
 from student.roles import GlobalStaff, CourseSalesAdminRole, CourseFinanceAdminRole
@@ -52,7 +49,7 @@ from django_comment_common.models import (
     FORUM_ROLE_MODERATOR,
     FORUM_ROLE_COMMUNITY_TA,
 )
-from edxmako.shortcuts import render_to_response, render_to_string
+from edxmako.shortcuts import render_to_string
 from courseware.models import StudentModule
 from shoppingcart.models import (
     Coupon,
@@ -108,7 +105,6 @@ from .tools import (
     set_due_date_extension,
     strip_if_string,
     bulk_email_is_enabled_for_course,
-    add_block_ids,
 )
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -324,7 +324,8 @@ def _section_certificates(course):
         'active_certificate': certs_api.get_active_web_certificate(course),
         'certificate_statuses_with_count': certificate_statuses_with_count,
         'status': CertificateStatuses,
-        'certificate_generation_history': CertificateGenerationHistory.objects.filter(course_id=course.id),
+        'certificate_generation_history':
+            CertificateGenerationHistory.objects.filter(course_id=course.id).order_by("-created"),
         'urls': {
             'generate_example_certificates': reverse(
                 'generate_example_certificates',

--- a/lms/static/js/certificates/views/certificate_whitelist.js
+++ b/lms/static/js/certificates/views/certificate_whitelist.js
@@ -32,7 +32,12 @@
                 render: function(){
                     var template = this.loadTemplate('certificate-white-list');
                     this.$el.html(template({certificates: this.collection.models}));
-
+                    if (this.collection.isEmpty()) {
+                        this.$("#generate-exception-certificates").addClass("is-disabled");
+                    }
+                    else {
+                        this.$("#generate-exception-certificates").removeClass("is-disabled");
+                    }
                 },
 
                 loadTemplate: function(name) {


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly take a look at this PR, it contains review changes for SOL-1418. I have removed some unused imports from `lms/djangoapps/instructor/views/api.py`.

Description of the changes:

1 - updated allowed statuses that user can select to ('downloadable', 'error', 'unavailable')
2 - displayed certificate generate history in reverse chronological order.

@griffresch I am attaching a screen shot of current UI, take a look and let me know if there are some changes requires.

<img width="1241" alt="screen shot 2015-12-14 at 12 45 08 pm" src="https://cloud.githubusercontent.com/assets/7114956/11775447/b6603808-a260-11e5-9c97-513b70e02703.png">

cc: @mattdrayer 
