### PR TITLE
generate_course_overview management command error handling

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/management/commands/generate_course_overview.py
+++ b/openedx/core/djangoapps/content/course_overviews/management/commands/generate_course_overview.py
@@ -33,7 +33,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        course_keys = []
         if options['all']:
             course_keys = [course.id for course in modulestore().get_courses()]
         else:
@@ -42,9 +41,6 @@ class Command(BaseCommand):
             try:
                 course_keys = [CourseKey.from_string(arg) for arg in args]
             except InvalidKeyError:
-                log.fatal('Invalid key specified.')
-
-            if not course_keys:
-                log.fatal('No courses specified.')
+                raise CommandError('Invalid key specified.')
 
         CourseOverview.get_select_courses(course_keys)

--- a/openedx/core/djangoapps/content/course_overviews/management/commands/tests/test_generate_course_overview.py
+++ b/openedx/core/djangoapps/content/course_overviews/management/commands/tests/test_generate_course_overview.py
@@ -56,13 +56,12 @@ class TestGenerateCourseOverview(ModuleStoreTestCase):
         self._assert_courses_in_overview(self.course_key_1)
         self._assert_courses_not_in_overview(self.course_key_2)
 
-    @patch('openedx.core.djangoapps.content.course_overviews.management.commands.generate_course_overview.log')
-    def test_invalid_key(self, mock_log):
+    def test_invalid_key(self):
         """
-        Test that invalid key errors are logged.
+        Test that CommandError is raised for invalid key.
         """
-        self.command.handle('not/found', all=False)
-        self.assertTrue(mock_log.fatal.called)
+        with self.assertRaises(CommandError):
+            self.command.handle('not/found', all=False)
 
     @patch('openedx.core.djangoapps.content.course_overviews.models.log')
     def test_not_found_key(self, mock_log):


### PR DESCRIPTION
As follow up from discussion on PR https://github.com/edx/edx-platform/pull/10959, raising `CommandError` instead of calling `log.fatal`.

@robrap @dsjen Please review.
