### PR TITLE
Add the ActiveTable and Vector Draw XBlocks to ADVANCED_COMPONENT_TYPES.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1006,6 +1006,8 @@ ADVANCED_COMPONENT_TYPES = [
     'pb-dashboard',
     'poll',
     'survey',
+    'activetable',
+    'vectordraw',
     # Some of the XBlocks from pmitros repos are sometimes prototypes.
     # Use with caution.
     'concept',  # Concept mapper. See https://github.com/pmitros/ConceptXBlock


### PR DESCRIPTION
These XBlocks have been added to the requirements in #10476 and #10932, respectively.  However, we failed to whitelist them.

The client (Davidson College) would like to start using them very soon, so we don't want to wait for the next release and would be greatful if this patch could still be included in the current release.
