### PR TITLE
Revert "Remove staff debug category type whitelist."

### DIFF
--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -6,6 +6,7 @@ from django.template.defaultfilters import escapejs
 
 ## The JS for this is defined in xqa_interface.html
 ${block_content}
+%if location.category in ['problem','video','html','combinedopenended','graphical_slider_tool', 'library_content']:
 %  if edit_link:
   <div>
       <a href="${edit_link}">Edit</a>
@@ -141,3 +142,5 @@ $(function () {
     );
 });
 </script>
+%endif
+


### PR DESCRIPTION
This reverts commit bb25473a7cbcff3f6dc9ee1506b20451ac0ed5d2.

Reason for revert: Was breaking display on Course About and Info pages.

@dianakhuang 

@mtyaka: Reverting this for now so that we can get the release out. Let's follow up on this later when we've confirmed we can add this functionality without leaking out of the courseware pages.
