### PR TITLE
Shr/bug/tnl 2622 course import status message fix test

### DIFF
--- a/cms/static/js/views/import.js
+++ b/cms/static/js/views/import.js
@@ -98,7 +98,7 @@ define(
                 file: file,
                 date: moment().valueOf(),
                 completed: completed || false
-            }));
+            }), {path: window.location.pathname});
         };
 
         /**

--- a/common/test/acceptance/tests/studio/base_studio_test.py
+++ b/common/test/acceptance/tests/studio/base_studio_test.py
@@ -20,6 +20,12 @@ class StudioCourseTest(UniqueCourseTest):
         Install a course with no content using a fixture.
         """
         super(StudioCourseTest, self).setUp()
+        self.install_course_fixture(is_staff)
+
+    def install_course_fixture(self, is_staff=False):
+        """
+        Install a course fixture
+        """
         self.course_fixture = CourseFixture(
             self.course_info['org'],
             self.course_info['number'],

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -364,6 +364,34 @@ class TestCourseImport(ImportTestMixin, StudioCourseTest):
         """
         self.assertEqual(self.import_page.header_text, 'Course Import')
 
+    def test_multiple_course_import_message(self):
+        """
+        Given that I visit an empty course before import
+        When I visit the import page
+        And I upload a course with file name 2015.lzdwNM.tar.gz
+        Then timestamp is visible after course is updated successfully
+        And then I create a new course
+        When I visit the import page of this new course
+        Then timestamp is not visible
+        """
+        self.import_page.visit()
+        self.import_page.upload_tarball(self.tarball_name)
+        self.import_page.wait_for_upload()
+        self.assertTrue(self.import_page.is_timestamp_visible())
+
+        # Create a new course and visit the import page
+        self.course_info = {
+            'org': 'orgX',
+            'number': self.unique_id + '_2',
+            'run': 'test_run_2',
+            'display_name': 'Test Course 2' + self.unique_id
+        }
+        self.install_course_fixture()
+        self.import_page = self.import_page_class(*self.page_args())
+        self.import_page.visit()
+        # As this is new course which is never import so timestamp should not present
+        self.assertFalse(self.import_page.is_timestamp_visible())
+
 
 @attr('shard_4')
 class TestLibraryImport(ImportTestMixin, StudioLibraryTest):


### PR DESCRIPTION
[TNL-2622](https://openedx.atlassian.net/browse/TNL-2622)

**History**
This was first merged into master and already reviewed at https://github.com/edx/edx-platform/pull/10506# but after merging the test related to https://github.com/edx/edx-platform/pull/10506# start failing and reverted at https://github.com/edx/edx-platform/pull/10999.

**Findings and Solution**
After investigation the problem seems to be with organization of course, there is change in system we have to first register organization in system and then we can attached organiztion with course etc.For bokchoy courses a test organization `orgX` already present so use this existing test organization `orgX` for tests now.
