### PR TITLE
asadiqbal08/SOL-1492 - WebCerts: Generate Cert from Support Tool

### DIFF
--- a/lms/djangoapps/certificates/urls.py
+++ b/lms/djangoapps/certificates/urls.py
@@ -27,8 +27,9 @@ urlpatterns = patterns(
     # End-points used by student support
     # The views in the lms/djangoapps/support use these end-points
     # to retrieve certificate information and regenerate certificates.
-    url(r'search', views.search_by_user, name="search"),
+    url(r'search', views.search_certificates, name="search"),
     url(r'regenerate', views.regenerate_certificate_for_user, name="regenerate_certificate_for_user"),
+    url(r'generate', views.generate_certificate_for_user, name="generate_certificate_for_user"),
 )
 
 

--- a/lms/djangoapps/support/static/support/js/collections/certificate.js
+++ b/lms/djangoapps/support/static/support/js/collections/certificate.js
@@ -6,15 +6,24 @@
                 model: CertModel,
 
                 initialize: function(options) {
-                    this.userQuery = options.userQuery || '';
+                    this.userFilter = options.userFilter || '';
+                    this.courseFilter = options.courseFilter || '';
                 },
 
-                setUserQuery: function(userQuery) {
-                    this.userQuery = userQuery;
+                setUserFilter: function(userFilter) {
+                    this.userFilter = userFilter;
+                },
+
+                setCourseFilter: function(courseFilter) {
+                    this.courseFilter = courseFilter;
                 },
 
                 url: function() {
-                    return '/certificates/search?query=' + this.userQuery;
+                    var url = '/certificates/search?user=' + this.userFilter;
+                    if (this.courseFilter) {
+                        url += '&course_id=' + this.courseFilter;
+                    }
+                    return url;
                 }
             });
     });

--- a/lms/djangoapps/support/static/support/js/spec/views/certificates_spec.js
+++ b/lms/djangoapps/support/static/support/js/spec/views/certificates_spec.js
@@ -9,7 +9,7 @@ define([
 
         var view = null,
 
-        SEARCH_RESULTS = [
+        REGENERATE_SEARCH_RESULTS = [
             {
                 'username': 'student',
                 'status': 'notpassing',
@@ -18,7 +18,8 @@ define([
                 'type': 'honor',
                 'course_key': 'course-v1:edX+DemoX+Demo_Course',
                 'download_url': null,
-                'modified': '2015-08-06T19:47:07+00:00'
+                'modified': '2015-08-06T19:47:07+00:00',
+                'regenerate': true
             },
             {
                 'username': 'student',
@@ -28,8 +29,23 @@ define([
                 'type': 'verified',
                 'course_key': 'edx/test/2015',
                 'download_url': 'http://www.example.com/certificate.pdf',
-                'modified': '2015-08-06T19:47:05+00:00'
-            },
+                'modified': '2015-08-06T19:47:05+00:00',
+                'regenerate': true
+            }
+        ],
+
+        GENERATE_SEARCH_RESULTS = [
+            {
+                'username': 'student',
+                'status': '',
+                'created': '',
+                'grade': '',
+                'type': '',
+                'course_key': 'edx/test1/2016',
+                'download_url': null,
+                'modified': '',
+                'regenerate': false
+            }
         ],
 
         getSearchResults = function() {
@@ -49,18 +65,28 @@ define([
             return results;
         },
 
-        searchFor = function(query, requests, response) {
+        searchFor = function(user_filter, course_filter, requests, response) {
             // Enter the search term and submit
-            view.setUserQuery(query);
+            var url = '/certificates/search?user=' + user_filter;
+            view.setUserFilter(user_filter);
+            if (course_filter) {
+                view.setCourseFilter(course_filter);
+                url += '&course_id=' + course_filter;
+            }
             view.triggerSearch();
 
             // Simulate a response from the server
-            AjaxHelpers.expectJsonRequest(requests, 'GET', '/certificates/search?query=student@example.com');
+            AjaxHelpers.expectJsonRequest(requests, 'GET', url);
             AjaxHelpers.respondWithJson(requests, response);
         },
 
         regenerateCerts = function(username, courseKey) {
             var sel = '.btn-cert-regenerate[data-course-key="' + courseKey + '"]';
+            $(sel).click();
+        },
+
+        generateCerts = function(username, courseKey) {
+            var sel = '.btn-cert-generate[data-course-key="' + courseKey + '"]';
             $(sel).click();
         };
 
@@ -80,35 +106,49 @@ define([
             var requests = AjaxHelpers.requests(this),
                 results = [];
 
-            searchFor('student@example.com', requests, SEARCH_RESULTS);
+            searchFor('student@example.com', '', requests, REGENERATE_SEARCH_RESULTS);
             results = getSearchResults();
 
             // Expect that the results displayed on the page match the results
             // returned by the server.
-            expect(results.length).toEqual(SEARCH_RESULTS.length);
+            expect(results.length).toEqual(REGENERATE_SEARCH_RESULTS.length);
 
             // Check the first row of results
-            expect(results[0][0]).toEqual(SEARCH_RESULTS[0].course_key);
-            expect(results[0][1]).toEqual(SEARCH_RESULTS[0].type);
-            expect(results[0][2]).toEqual(SEARCH_RESULTS[0].status);
+            expect(results[0][0]).toEqual(REGENERATE_SEARCH_RESULTS[0].course_key);
+            expect(results[0][1]).toEqual(REGENERATE_SEARCH_RESULTS[0].type);
+            expect(results[0][2]).toEqual(REGENERATE_SEARCH_RESULTS[0].status);
             expect(results[0][3]).toContain('Not available');
-            expect(results[0][4]).toEqual(SEARCH_RESULTS[0].grade);
-            expect(results[0][5]).toEqual(SEARCH_RESULTS[0].modified);
+            expect(results[0][4]).toEqual(REGENERATE_SEARCH_RESULTS[0].grade);
+            expect(results[0][5]).toEqual(REGENERATE_SEARCH_RESULTS[0].modified);
 
             // Check the second row of results
-            expect(results[1][0]).toEqual(SEARCH_RESULTS[1].course_key);
-            expect(results[1][1]).toEqual(SEARCH_RESULTS[1].type);
-            expect(results[1][2]).toEqual(SEARCH_RESULTS[1].status);
-            expect(results[1][3]).toContain(SEARCH_RESULTS[1].download_url);
-            expect(results[1][4]).toEqual(SEARCH_RESULTS[1].grade);
-            expect(results[1][5]).toEqual(SEARCH_RESULTS[1].modified);
+            expect(results[1][0]).toEqual(REGENERATE_SEARCH_RESULTS[1].course_key);
+            expect(results[1][1]).toEqual(REGENERATE_SEARCH_RESULTS[1].type);
+            expect(results[1][2]).toEqual(REGENERATE_SEARCH_RESULTS[1].status);
+            expect(results[1][3]).toContain(REGENERATE_SEARCH_RESULTS[1].download_url);
+            expect(results[1][4]).toEqual(REGENERATE_SEARCH_RESULTS[1].grade);
+            expect(results[1][5]).toEqual(REGENERATE_SEARCH_RESULTS[1].modified);
+
+
+            searchFor('student@example.com', 'edx/test1/2016', requests, GENERATE_SEARCH_RESULTS);
+            results = getSearchResults();
+            expect(results.length).toEqual(GENERATE_SEARCH_RESULTS.length);
+
+            // Check the first row of results
+            expect(results[0][0]).toEqual(GENERATE_SEARCH_RESULTS[0].course_key);
+            expect(results[0][1]).toEqual(GENERATE_SEARCH_RESULTS[0].type);
+            expect(results[0][2]).toEqual(GENERATE_SEARCH_RESULTS[0].status);
+            expect(results[0][3]).toContain('Not available');
+            expect(results[0][4]).toEqual(GENERATE_SEARCH_RESULTS[0].grade);
+            expect(results[0][5]).toEqual(GENERATE_SEARCH_RESULTS[0].modified);
+
         });
 
         it('searches for certificates and displays a message when there are no results', function() {
             var requests = AjaxHelpers.requests(this),
                 results = [];
 
-            searchFor('student@example.com', requests, []);
+            searchFor('student@example.com', '', requests, []);
             results = getSearchResults();
 
             // Expect that no results are found
@@ -118,30 +158,30 @@ define([
             expect($('.certificates-results').text()).toContain('No results');
         });
 
-        it('automatically searches for an initial query if one is provided', function() {
+        it('automatically searches for an initial filter if one is provided', function() {
             var requests = AjaxHelpers.requests(this),
                 results = [];
 
-            // Re-render the view, this time providing an initial query.
+            // Re-render the view, this time providing an initial filter.
             view = new CertificatesView({
                 el: $('.certificates-content'),
-                userQuery: 'student@example.com'
+                userFilter: 'student@example.com'
             }).render();
 
             // Simulate a response from the server
-            AjaxHelpers.expectJsonRequest(requests, 'GET', '/certificates/search?query=student@example.com');
-            AjaxHelpers.respondWithJson(requests, SEARCH_RESULTS);
+            AjaxHelpers.expectJsonRequest(requests, 'GET', '/certificates/search?user=student@example.com');
+            AjaxHelpers.respondWithJson(requests, REGENERATE_SEARCH_RESULTS);
 
             // Check the search results
             results = getSearchResults();
-            expect(results.length).toEqual(SEARCH_RESULTS.length);
+            expect(results.length).toEqual(REGENERATE_SEARCH_RESULTS.length);
         });
 
         it('regenerates a certificate for a student', function() {
             var requests = AjaxHelpers.requests(this);
 
             // Trigger a search
-            searchFor('student@example.com', requests, SEARCH_RESULTS);
+            searchFor('student@example.com', '', requests, REGENERATE_SEARCH_RESULTS);
 
             // Click the button to regenerate certificates for a user
             regenerateCerts('student', 'course-v1:edX+DemoX+Demo_Course');
@@ -159,5 +199,29 @@ define([
             // Respond with success
             AjaxHelpers.respondWithJson(requests, '');
         });
+
+         it('generate a certificate for a student', function() {
+            var requests = AjaxHelpers.requests(this);
+
+            // Trigger a search
+            searchFor('student@example.com', 'edx/test1/2016', requests, GENERATE_SEARCH_RESULTS);
+
+            // Click the button to generate certificates for a user
+            generateCerts('student', 'edx/test1/2016');
+
+            // Expect a request to the server
+            AjaxHelpers.expectPostRequest(
+                requests,
+                '/certificates/generate',
+                $.param({
+                    username: 'student',
+                    course_key: 'edx/test1/2016'
+                })
+            );
+
+            // Respond with success
+            AjaxHelpers.respondWithJson(requests, '');
+        });
+
     });
 });

--- a/lms/djangoapps/support/static/support/js/views/certificates.js
+++ b/lms/djangoapps/support/static/support/js/views/certificates.js
@@ -12,24 +12,27 @@
         return Backbone.View.extend({
             events: {
                 'submit .certificates-form': 'search',
-                'click .btn-cert-regenerate': 'regenerateCertificate'
+                'click .btn-cert-regenerate': 'regenerateCertificate',
+                'click .btn-cert-generate': 'generateCertificate'
             },
 
             initialize: function(options) {
                 _.bindAll(this, 'search', 'updateCertificates', 'regenerateCertificate', 'handleSearchError');
                 this.certificates = new CertCollection({});
-                this.initialQuery = options.userQuery || null;
+                this.initialFilter = options.userFilter || null;
+                this.courseFilter = options.courseFilter || null;
             },
 
             render: function() {
                 this.$el.html(_.template(certificatesTpl));
 
-                // If there is an initial query, then immediately trigger a search.
+                // If there is an initial filter, then immediately trigger a search.
                 // This is useful because it allows users to share search results:
-                // if the URL contains ?query="foo" then anyone who loads that URL
-                // will automatically search for "foo".
-                if (this.initialQuery) {
-                    this.setUserQuery(this.initialQuery);
+                // if the URL contains ?user_filter="foo"&course_id="xyz" then anyone who loads that URL
+                // will automatically search for "foo" and course "xyz".
+                if (this.initialFilter) {
+                    this.setUserFilter(this.initialFilter);
+                    this.setCourseFilter(this.courseFilter);
                     this.triggerSearch();
                 }
 
@@ -38,7 +41,7 @@
 
             renderResults: function() {
                 var context = {
-                    certificates: this.certificates,
+                    certificates: this.certificates
                 };
 
                 this.setResults(_.template(resultsTpl, context));
@@ -52,23 +55,54 @@
             search: function(event) {
 
                 // Fetch the certificate collection for the given user
-                var query = this.getUserQuery(),
-                    url = '/support/certificates?query=' + query;
+                var url = '/support/certificates?user=' + this.getUserFilter();
+
+                //course id is optional.
+                if (this.getCourseFilter()) {
+                    url += '&course_id=' + this.getCourseFilter();
+                }
 
                 // Prevent form submission, since we're handling it ourselves.
                 event.preventDefault();
 
-                // Push a URL into history with the search query as a GET parameter.
+                // Push a URL into history with the search filter as a GET parameter.
                 // That way, if the user reloads the page or sends someone the link
                 // then the same search will be performed on page load.
                 window.history.pushState({}, window.document.title, url);
 
                 // Perform a search for the user's certificates.
                 this.disableButtons();
-                this.certificates.setUserQuery(query);
+                this.certificates.setUserFilter(this.getUserFilter());
+                this.certificates.setCourseFilter(this.getCourseFilter());
                 this.certificates.fetch({
                     success: this.updateCertificates,
                     error: this.handleSearchError
+                });
+            },
+
+
+            generateCertificate: function(event) {
+                var $button = $(event.target);
+
+                // Generate certificates for a particular user and course.
+                // If this is successful, reload the certificate results so they show
+                // the updated status.
+                this.disableButtons();
+                $.ajax({
+                    url: '/certificates/generate',
+                    type: 'POST',
+                    data: {
+                        username: $button.data('username'),
+                        course_key: $button.data('course-key')
+                    },
+                    context: this,
+                    success: function() {
+                        this.certificates.fetch({
+                            success: this.updateCertificates,
+                            error: this.handleSearchError
+                        });
+                    },
+                    error: this.handleGenerationsError
                 });
             },
 
@@ -84,16 +118,16 @@
                     type: 'POST',
                     data: {
                         username: $button.data('username'),
-                        course_key: $button.data('course-key'),
+                        course_key: $button.data('course-key')
                     },
                     context: this,
                     success: function() {
                         this.certificates.fetch({
                             success: this.updateCertificates,
-                            error: this.handleSearchError,
+                            error: this.handleSearchError
                         });
                     },
-                    error: this.handleRegenerateError
+                    error: this.handleGenerationsError
                 });
             },
 
@@ -102,12 +136,12 @@
                 this.enableButtons();
             },
 
-            handleSearchError: function(jqxhr) {
-                this.renderError(jqxhr.responseText);
+            handleSearchError: function(jqxhr, response) {
+                this.renderError(response.responseText);
                 this.enableButtons();
             },
 
-            handleRegenerateError: function(jqxhr) {
+            handleGenerationsError: function(jqxhr) {
                 // Since there are multiple "regenerate" buttons on the page,
                 // it's difficult to show the error message in the UI.
                 // Since this page is used only by internal staff, I think the
@@ -120,12 +154,20 @@
                 $('.certificates-form').submit();
             },
 
-            getUserQuery: function() {
-                return $('.certificates-form input[name="query"]').val();
+            getUserFilter: function() {
+                return $('.certificates-form > #certificate-user-filter-input').val();
             },
 
-            setUserQuery: function(query) {
-                $('.certificates-form input[name="query"]').val(query);
+            setUserFilter: function(filter) {
+                $('.certificates-form > #certificate-user-filter-input').val(filter);
+            },
+
+            getCourseFilter: function() {
+                return $('.certificates-form > #certificate-course-filter-input').val();
+            },
+
+            setCourseFilter: function(course_id) {
+                $('.certificates-form > #certificate-course-filter-input').val(course_id);
             },
 
             setResults: function(html) {

--- a/lms/djangoapps/support/static/support/templates/certificates.underscore
+++ b/lms/djangoapps/support/static/support/templates/certificates.underscore
@@ -1,13 +1,20 @@
 
 <div class="certificates-search">
     <form class="certificates-form">
-        <label class="sr" for="certificate-query-input"><%- gettext("Search") %></label>
+        <label class="sr" for="certificate-user-filter-input"><%- gettext("Search") %></label>
         <input
-            id="certificate-query-input"
+            id="certificate-user-filter-input"
             type="text"
             name="query"
             value=""
             placeholder="<%- gettext("username or email") %>">
+        </input>
+        <input
+            id="certificate-course-filter-input"
+            type="text"
+            name="query"
+            value=""
+            placeholder="<%- gettext("course id") %>">
         </input>
         <input type="submit" value="<%- gettext("Search") %>" class="btn-disable-on-submit"></input>
     </form>

--- a/lms/djangoapps/support/static/support/templates/certificates_results.underscore
+++ b/lms/djangoapps/support/static/support/templates/certificates_results.underscore
@@ -29,12 +29,21 @@
         <td><%- cert.get("grade") %></td>
         <td><%- cert.get("modified") %></td>
         <td>
+            <% if (cert.get("regenerate")) { %>
             <button
                 class="btn-cert-regenerate btn-disable-on-submit"
                 data-username="<%- cert.get("username") %>"
                 data-course-key="<%- cert.get("course_key") %>"
             ><%- gettext("Regenerate") %></button>
             <span class="sr"><%- gettext("Regenerate the user's certificate") %></span>
+             <% } else { %>
+             <button
+                class="btn-cert-generate btn-disable-on-submit"
+                data-username="<%- cert.get("username") %>"
+                data-course-key="<%- cert.get("course_key") %>"
+            ><%- gettext("Generate") %></button>
+            <span class="sr"><%- gettext("Generate the user's certificate") %></span>
+            <% } %>
         </td>
     </tr>
     <% } %>

--- a/lms/djangoapps/support/views/certificate.py
+++ b/lms/djangoapps/support/views/certificate.py
@@ -30,6 +30,7 @@ class CertificatesSupportView(View):
     def get(self, request):
         """Render the certificates support view. """
         context = {
-            "user_query": request.GET.get("query", "")
+            "user_filter": request.GET.get("user", ""),
+            "course_filter": request.GET.get("course_id", "")
         }
         return render_to_response("support/certificates.html", context)

--- a/lms/static/sass/views/_support.scss
+++ b/lms/static/sass/views/_support.scss
@@ -3,11 +3,14 @@
 // ===================================================================
 
 .certificates-search, .enrollment-search {
-    margin: 40px 0;
-
-    input[name="query"] {
-        width: 476px;
-    }
+  margin: 40px 0;
+  input[name="query"] {
+    width: 350px;
+  }
+  .certificates-form {
+    max-width: 850px;
+    margin: 0 auto;
+  }
 }
 
 
@@ -28,6 +31,10 @@
 }
 
 .btn-cert-regenerate {
+    font-size: 12px;
+}
+
+.btn-cert-generate {
     font-size: 12px;
 }
 

--- a/lms/templates/support/certificates.html
+++ b/lms/templates/support/certificates.html
@@ -9,7 +9,8 @@ from django.utils.translation import ugettext as _
 <%block name="js_extra">
 <%static:require_module module_name="support/js/certificates_factory" class_name="CertificatesFactory">
     new CertificatesFactory({
-        userQuery: '${ user_query }'
+        userFilter: '${ user_filter }',
+        courseFilter: '${course_filter}'
     });
 </%static:require_module>
 </%block>


### PR DESCRIPTION
[SOL-1492](https://openedx.atlassian.net/browse/SOL-1492)

<img width="1244" alt="screen shot 2015-12-15 at 6 06 38 pm" src="https://cloud.githubusercontent.com/assets/7334669/11870809/c88761b2-a4ec-11e5-9fb5-6989d5a0d5cb.png">
<img width="1275" alt="screen shot 2015-12-17 at 8 01 51 pm" src="https://cloud.githubusercontent.com/assets/7334669/11872806/1b595a56-a4f9-11e5-8f07-b9569cb81c16.png">
<img width="1267" alt="screen shot 2015-12-15 at 6 10 55 pm" src="https://cloud.githubusercontent.com/assets/7334669/11870810/c888513a-a4ec-11e5-994f-8f84674d9570.png">

As a edX Support team member, I often need to Generate a certificate on behalf of a student who does not know how to generate a cert in a self-paced course.

Acceptance Criteria
Add a new feature in courses.edx.org/support that allows edX Support to generate a certificate for a student
1. Allow Support to Add Username or Email address (validate exist in edX system)
2. Allow support to Add CourseID (validate a good courseID and that user is enrolled in the course)
3. If Username/email/CourseID are valid, add user to Certificate Generation queue (all changes on Student Dashboard and Progress page must be reflected)
4. Add record to Cert generation history table, with audit trail of who (edX username) added the cert with a time stamp
@ziafazal please review it.
cc: @mattdrayer 
