### PR TITLE
Fix displaying wrong number of units in content group configuration

### DIFF
--- a/cms/djangoapps/contentstore/course_group_config.py
+++ b/cms/djangoapps/contentstore/course_group_config.py
@@ -190,7 +190,9 @@ class GroupConfiguration(object):
         """
         Get usage information for content groups.
         """
-        items = store.get_items(course.id, settings={'group_access': {'$exists': True}})
+        # Set `include_orphans` kwarg to False to get only items present in the course tree.
+        # This will not fetch orphans.
+        items = store.get_items(course.id, settings={'group_access': {'$exists': True}}, include_orphans=False)
 
         return GroupConfiguration._get_content_groups_usage_info(course, items)
 


### PR DESCRIPTION
[Content group used in Units displaying wrong number of Units.](https://openedx.atlassian.net/browse/TNL-3727)

Use `include_orphans` kwarg to get only those items that are present in the course tree. This will not fetch orphans.

This solution uses #10994 
