### PR TITLE
SOL-1528: Generate Certificates for whitelisted students even if they have existing (notpassing, error etc.) certificates 

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -1421,7 +1421,11 @@ def generate_students_certificates(
     task_progress.update_task_state(extra_meta=current_step)
 
     statuses_to_regenerate = task_input.get('statuses_to_regenerate', [])
-    students_require_certs = students_require_certificate(course_id, enrolled_students, statuses_to_regenerate)
+    if students is not None and not statuses_to_regenerate:
+        # We want to skip 'filtering students' only when students are given and statuses to regenerate are not
+        students_require_certs = enrolled_students
+    else:
+        students_require_certs = students_require_certificate(course_id, enrolled_students, statuses_to_regenerate)
 
     if statuses_to_regenerate:
         # Mark existing generated certificates as 'unavailable' before regenerating


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR, it contains changes for [SOL-1528](https://openedx.atlassian.net/browse/SOL-1528).

**Description of [SOL-1528](https://openedx.atlassian.net/browse/SOL-1528):**
When PM try to generate certificate for failed users through exception list it doesn't work in first attempt but if user is removed from exception list and then again added into exception list it works.

Certificate Generation for newly whitelisted students, that were not passing before addition to whitelist, does not generate certificate.

cc: @mattdrayer  
