### PR TITLE
Add autogenerated migrations due to field default changes.

### DIFF
--- a/common/djangoapps/course_modes/migrations/0005_auto_20151217_0958.py
+++ b/common/djangoapps/course_modes/migrations/0005_auto_20151217_0958.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_modes', '0004_auto_20151113_1457'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='coursemode',
+            name='expiration_datetime',
+        ),
+        migrations.AddField(
+            model_name='coursemode',
+            name='_expiration_datetime',
+            field=models.DateTimeField(db_column=b'expiration_datetime', default=None, blank=True, help_text='OPTIONAL: After this date/time, users will no longer be able to enroll in this mode. Leave this blank if users can enroll in this mode until enrollment closes for the course.', null=True, verbose_name='Upgrade Deadline'),
+        ),
+    ]

--- a/lms/djangoapps/shoppingcart/migrations/0003_auto_20151217_0958.py
+++ b/lms/djangoapps/shoppingcart/migrations/0003_auto_20151217_0958.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoppingcart', '0002_auto_20151208_1034'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='courseregcodeitem',
+            name='mode',
+            field=models.SlugField(default=b'honor'),
+        ),
+        migrations.AlterField(
+            model_name='paidcourseregistration',
+            name='mode',
+            field=models.SlugField(default=b'honor'),
+        ),
+    ]


### PR DESCRIPTION
@chrisndodge @bderusha, it looks like these field changes came from some code you recently merged. Can you review?

FYI @edx/devops -- these migrations are similar to the ones introduced in #10883. That PR gave us trouble during the last release because it looked like we might be forced to run an `ALTER TABLE` over the `CourseEnrollment` table, but load testing indicated that Django really isn't hitting the database when applying migrations which change field defaults.
