### PR TITLE
[PERF-224] Serve course assets from a CDN

### DIFF
--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -5,6 +5,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.contrib.staticfiles import finders
 from django.conf import settings
 
+from static_replace.models import AssetBaseUrlConfig
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.contentstore.content import StaticContent
@@ -180,7 +181,8 @@ def replace_static_urls(text, data_directory=None, course_id=None, static_asset_
             else:
                 # if not, then assume it's courseware specific content and then look in the
                 # Mongo-backed database
-                url = StaticContent.convert_legacy_static_url_with_course_id(rest, course_id)
+                base_url = AssetBaseUrlConfig.get_base_url()
+                url = StaticContent.get_canonicalized_asset_path(course_id, rest, base_url)
 
                 if AssetLocator.CANONICAL_NAMESPACE in url:
                     url = url.replace('block@', 'block/', 1)

--- a/common/djangoapps/static_replace/admin.py
+++ b/common/djangoapps/static_replace/admin.py
@@ -1,0 +1,30 @@
+"""
+Django admin page for AssetBaseUrlConfig, which allows you to set the base URL
+that gets prepended to asset URLs in order to serve them from, say, a CDN.
+"""
+from django.contrib import admin
+
+from config_models.admin import ConfigurationModelAdmin
+from .models import AssetBaseUrlConfig
+
+
+class AssetBaseUrlConfigAdmin(ConfigurationModelAdmin):
+    """
+    Basic configuration for asset base URL.
+    """
+    list_display = [
+        'base_url'
+    ]
+
+    def get_list_display(self, request):
+        """
+        Restore default list_display behavior.
+
+        ConfigurationModelAdmin overrides this, but in a way that doesn't
+        respect the ordering. This lets us customize it the usual Django admin
+        way.
+        """
+        return self.list_display
+
+
+admin.site.register(AssetBaseUrlConfig, AssetBaseUrlConfigAdmin)

--- a/common/djangoapps/static_replace/models.py
+++ b/common/djangoapps/static_replace/models.py
@@ -1,0 +1,29 @@
+"""
+Models for static_replace
+"""
+
+from django.db.models.fields import TextField
+from config_models.models import ConfigurationModel
+
+
+class AssetBaseUrlConfig(ConfigurationModel):
+    """Configuration for the base URL used for static assets."""
+
+    class Meta(object):
+        app_label = 'static_replace'
+
+    base_url = TextField(
+        blank=True,
+        help_text="The alternative hostname to serve static assets from.  Should be in the form of hostname[:port]."
+    )
+
+    @classmethod
+    def get_base_url(cls):
+        """Gets the base URL to use for serving static assets, if present"""
+        return cls.current().base_url
+
+    def __repr__(self):
+        return '<AssetBaseUrlConfig(base_url={})>'.format(self.get_base_url())
+
+    def __unicode__(self):
+        return unicode(repr(self))

--- a/common/lib/xmodule/xmodule/tests/test_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_content.py
@@ -4,6 +4,7 @@ import os
 import unittest
 import ddt
 from path import Path as path
+
 from xmodule.contentstore.content import StaticContent, StaticContentStream
 from xmodule.contentstore.content import ContentStore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey, AssetLocation
@@ -94,11 +95,6 @@ class ContentTest(unittest.TestCase):
         content = StaticContent('loc', 'name', 'content_type', 'data')
         self.assertIsNone(content.thumbnail_location)
 
-    def test_static_url_generation_from_courseid(self):
-        course_key = SlashSeparatedCourseKey('foo', 'bar', 'bz')
-        url = StaticContent.convert_legacy_static_url_with_course_id('images_course_image.jpg', course_key)
-        self.assertEqual(url, '/c4x/foo/bar/asset/images_course_image.jpg')
-
     @ddt.data(
         (u"monsters__.jpg", u"monsters__.jpg"),
         (u"monsters__.png", u"monsters__-png.jpg"),
@@ -122,9 +118,9 @@ class ContentTest(unittest.TestCase):
         self.assertEqual(AssetLocation(u'mitX', u'400', u'ignore', u'asset', u'subs__1eo_jXvZnE_.srt.sjson', None), asset_location)
 
     def test_get_location_from_path(self):
-        asset_location = StaticContent.get_location_from_path(u'/c4x/foo/bar/asset/images_course_image.jpg')
+        asset_location = StaticContent.get_location_from_path(u'/c4x/a/b/asset/images_course_image.jpg')
         self.assertEqual(
-            AssetLocation(u'foo', u'bar', None, u'asset', u'images_course_image.jpg', None),
+            AssetLocation(u'a', u'b', None, u'asset', u'images_course_image.jpg', None),
             asset_location
         )
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1104,7 +1104,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
         result_fragment = module.render(STUDENT_VIEW)
 
         self.assertIn(
-            '/c4x/{org}/{course}/asset/_file.jpg'.format(
+            '/c4x/{org}/{course}/asset/file.jpg'.format(
                 org=self.course.location.org,
                 course=self.course.location.course,
             ),


### PR DESCRIPTION
This work provides a simpler and cleaner mechanism for taking any style of asset path -- c4x, opaque key, "/static/" -- and converting it into a relative URL, consistent with the configured contentstore.

Further, but primarily, it also builds in the support to convert those paths to absolute URLs using a configurable hostname value.  This lets operators serve static content through a specific domain which may be backed by a CDN or caching server, ultimately reducing load on the underlying contentstore (GridFS, in almost all cases).

cc @ormsbee 
