### PR TITLE
SOL-1496: added a slug field to reference template asset using this field

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -5,6 +5,7 @@ from django.utils.translation import get_language_bidi
 from mako.exceptions import TemplateLookupException
 
 from microsite_configuration import microsite
+from certificates.api import get_asset_url_by_slug
 %>
 
 <%def name='url(file, raw=False)'><%
@@ -13,6 +14,13 @@ try:
 except:
     url = file
 %>${url}${"?raw" if raw else ""}</%def>
+
+<%def name='certificate_asset_url(slug)'><%
+try:
+    url = get_asset_url_by_slug(slug)
+except:
+    url = ''
+%>${url}</%def>
 
 <%def name='css(group, raw=False)'>
   <%

--- a/lms/djangoapps/certificates/admin.py
+++ b/lms/djangoapps/certificates/admin.py
@@ -45,7 +45,8 @@ class CertificateTemplateAssetAdmin(admin.ModelAdmin):
     """
     Django admin customizations for CertificateTemplateAsset model
     """
-    list_display = ('description', '__unicode__')
+    list_display = ('description', 'asset_slug',)
+    prepopulated_fields = {"asset_slug": ("description",)}
 
 
 class GeneratedCertificateAdmin(admin.ModelAdmin):

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -26,6 +26,7 @@ from certificates.models import (
     ExampleCertificateSet,
     GeneratedCertificate,
     CertificateTemplate,
+    CertificateTemplateAsset,
 )
 from certificates.queue import XQueueCertInterface
 
@@ -477,3 +478,16 @@ def emit_certificate_event(event_name, user, course_id, course=None, event_data=
 
     with tracker.get_tracker().context(event_name, context):
         tracker.emit(event_name, event_data)
+
+
+def get_asset_url_by_slug(asset_slug):
+    """
+    Returns certificate template asset url for given asset_slug.
+    """
+    asset_url = ''
+    try:
+        template_asset = CertificateTemplateAsset.objects.get(asset_slug=asset_slug)
+        asset_url = template_asset.asset.url
+    except CertificateTemplateAsset.DoesNotExist:
+        pass
+    return asset_url

--- a/lms/djangoapps/certificates/migrations/0006_certificatetemplateasset_asset_slug.py
+++ b/lms/djangoapps/certificates/migrations/0006_certificatetemplateasset_asset_slug.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('certificates', '0005_auto_20151208_0801'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='certificatetemplateasset',
+            name='asset_slug',
+            field=models.SlugField(help_text="Asset's unique slug. We can reference the asset in templates using this value.", max_length=255, unique=True, null=True),
+        ),
+    ]

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -945,6 +945,12 @@ class CertificateTemplateAsset(TimeStampedModel):
         upload_to=template_assets_path,
         help_text=_(u'Asset file. It could be an image or css file.'),
     )
+    asset_slug = models.SlugField(
+        max_length=255,
+        unique=True,
+        null=True,
+        help_text=_(u'Asset\'s unique slug. We can reference the asset in templates using this value.'),
+    )
 
     def save(self, *args, **kwargs):
         """save the certificate template asset """


### PR DESCRIPTION
This PR adds a new slug field to certificate template asset model. Value of this fields should unique and error would be if user tries to add same slug for more than one asset. This PR also define a new method in static_content.html which can be used in templates to grab url of asset by its slug like this `${static.certificate_asset_url(slug_name)}.`
@saleem-latif please review it.
@mattdrayer FYI.
