### PR TITLE
LMS: Adding missing third topic state

### DIFF
--- a/lms/static/sass/discussion/elements/_navigation.scss
+++ b/lms/static/sass/discussion/elements/_navigation.scss
@@ -176,13 +176,15 @@
   background-color: $gray-l6;
 
   &.is-unread {
+    background: $white;
+    color: $blue-d1;
 
     .forum-nav-thread-comments-count {
-      background-color: $blue-d1;
-      color: $white;
+      background-color: tint($blue-d1, 90%);;
+      color: $blue-d1;
 
       &:after {
-        border-right-color: $blue-d1;
+        border-right-color: tint($blue-d1, 90%);;
       }
     }
   }
@@ -192,13 +194,8 @@
   display: block;
   padding: ($baseline/4) ($baseline/2);
 
-  &.is-active,
-  &:hover,
-  &:focus {
-    background-color: $forum-color-active-thread;
-  }
-
   &.is-active {
+    background-color: $white;
     color: $base-font-color;
 
     .forum-nav-thread-comments-count {
@@ -207,6 +204,19 @@
 
       &:after {
         border-right-color: $gray-l4;
+      }
+    }
+  }
+
+  .forum-nav-thread-comments-count {
+
+    // topic read, but has unread comments
+    &.is-unread {
+      background-color: $blue-d1;
+      color: $white;
+
+      &:after {
+        border-right-color: $blue-d1;
       }
     }
   }


### PR DESCRIPTION
This small piece of work adds a missing topic state. Details can be found on [AC-295](https://openedx.atlassian.net/browse/AC-295).
## New look for forum topics and comment notifications

![forum-colors](https://cloud.githubusercontent.com/assets/2112024/11936528/7df20cb8-a7dc-11e5-9a6c-4b67ecc0da5c.png)
### States
#### Unread topic / Unread comments

This state has a _white_ background with _blue_ link text. The comments bubble is _light blue_ with _dark blue_ numerical text.
#### Read topic / Partially unread comments

This state has a _light gray_ background with _blue_ link text. The comments bubble is _dark blue_ with _white_ numerical text.
#### Read topic / Read comments

This state has a _light gray_ background with _blue_ link text. The comments bubble is _gray_ with _darker gray_ numerical text.
#### Active topic

The selected or active topic has a _white_ background with _darker gray_ link text.
#### Hover states

Hovering over a topic will cause the link text to shift from blue to _pink_.
## Reviewers
- [x] @frrrances 
