### PR TITLE
LMS: re-enable Enter and Space to toggle transcript

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -217,7 +217,7 @@
                     case KEY.SPACE:
                     case KEY.ENTER:
                         event.preventDefault();
-                        this.toggle();
+                        this.toggle(event);
                 }
             },
 


### PR DESCRIPTION
This quick fix re-enables the Enter and Spacebar keys to toggle the transcripts on or off.
## Sandbox

https://clrux-ac-296.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction
## Reviewers
- [ ] @cptvitamin 
