### PR TITLE
Add optional trailing slashes to the Enrollment API.

### DIFF
--- a/common/djangoapps/enrollment/urls.py
+++ b/common/djangoapps/enrollment/urls.py
@@ -15,20 +15,20 @@ from .views import (
 urlpatterns = patterns(
     'enrollment.views',
     url(
-        r'^enrollment/{username},{course_key}$'.format(
+        r'^enrollment/{username},{course_key}/$'.format(
             username=settings.USERNAME_PATTERN, course_key=settings.COURSE_ID_PATTERN
         ),
         EnrollmentView.as_view(),
         name='courseenrollment'
     ),
     url(
-        r'^enrollment/{course_key}$'.format(course_key=settings.COURSE_ID_PATTERN),
+        r'^enrollment/{course_key}/$'.format(course_key=settings.COURSE_ID_PATTERN),
         EnrollmentView.as_view(),
         name='courseenrollment'
     ),
     url(r'^enrollment$', EnrollmentListView.as_view(), name='courseenrollments'),
     url(
-        r'^course/{course_key}$'.format(course_key=settings.COURSE_ID_PATTERN),
+        r'^course/{course_key}/$'.format(course_key=settings.COURSE_ID_PATTERN),
         EnrollmentCourseDetailView.as_view(),
         name='courseenrollmentdetails'
     ),


### PR DESCRIPTION
This allows the edX REST API Client to perform a sucessful GET against this API, since Slumber (which our client is based off of) appends the trailing slash by default.

In general, I lean towards allowing the trailing slash so that our APIs are more flexible when interacting with different clients (which have different opinions on whether or not the slash is important).

@edx/ecommerce 
