### PR TITLE
Translatable bulk_email from Address based on platform`s default language

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -29,6 +29,8 @@ from celery import task, current_task  # pylint: disable=no-name-in-module
 from celery.states import SUCCESS, FAILURE, RETRY  # pylint: disable=no-name-in-module, import-error
 from celery.exceptions import RetryTaskError  # pylint: disable=no-name-in-module, import-error
 
+from django.utils.translation import ugettext as _
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.mail import EmailMultiAlternatives, get_connection
@@ -400,14 +402,17 @@ def _get_source_address(course_id, course_title):
     """
     course_title_no_quotes = re.sub(r'"', '', course_title)
 
-    # For the email address, get the course.  Then make sure that it can be used
-    # in an email address, by substituting a '_' anywhere a non-(ascii, period, or dash)
-    # character appears.
-    from_addr = u'"{0}" Course Staff <{1}-{2}>'.format(
-        course_title_no_quotes,
-        re.sub(r"[^\w.-]", '_', course_id.course),
-        settings.BULK_EMAIL_DEFAULT_FROM_EMAIL
+    # Translators: Bulk email from address e.g. ("Physics 101" Course Staff)
+    course_staff_title = _('"{course_name}" Course Staff')
+
+    from_addr_format = course_staff_title + u' <{course_id}-{from_email}>'
+
+    from_addr = from_addr_format.format(
+        course_name=course_title_no_quotes,
+        course_id=re.sub(r"[^\w.-]", '_', course_id.course),
+        from_email=settings.BULK_EMAIL_DEFAULT_FROM_EMAIL
     )
+
     return from_addr
 
 


### PR DESCRIPTION
This PR is different from previous PR since it sets the default language to the LANGUAGE_CODE using `language_override` util from Django.

It is much simpler than #9808 because it avoid relying on the user specific profile to fix performance issue.

This PR is a follow up on:
- #9808 Translatable bulk_email From address based on user pref. lang
- #6889 Translatable bulk email "from address"
