### PR TITLE
Performance enhancement in see_exists: reverse order of checks

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -318,7 +318,7 @@ def _has_access_course(user, action, courselike):
         Can see if can enroll, but also if can load it: if user enrolled in a course and now
         it's past the enrollment period, they should still see it.
         """
-        return ACCESS_GRANTED if (can_enroll() or can_load()) else ACCESS_DENIED
+        return ACCESS_GRANTED if (can_load() or can_enroll()) else ACCESS_DENIED
 
     def can_see_in_catalog():
         """


### PR DESCRIPTION
This PR improves the performance of the Course Catalog API (e.g., http://localhost:8000/api/courses/v1/courses/?username=staff).  

It eliminates unneeded SQL calls by reversing the order of checks in the see_exists `has_access` function.  We now check for `can_load` before checking for `can_enroll`.  Not only is the former more often likely to succeed than the latter, but it also requires 0 SQL calls while the latter requires 1 SQL call.

Before this PR, the number of SQL calls made by the Course Catalog API always grew linearly with the number of courses in the system.  Now, it would be constant (1 or 2) in the best case, linear in the worst case, and much less in the common case.

Reviewers: @ormsbee  @robrap  Please review.
