### PR TITLE
Properly escape Studio base.html

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -1,7 +1,7 @@
 #-*- coding: utf-8 -*-
 
 """
-Group Configuration Tests.
+Certificates Tests.
 """
 import json
 import mock

--- a/cms/static/js/certificates/views/certificate_editor.js
+++ b/cms/static/js/certificates/views/certificate_editor.js
@@ -97,11 +97,11 @@ function($, _, Backbone, gettext,
             return {
                 id: this.model.get('id'),
                 uniqueId: _.uniqueId(),
-                name: this.model.escape('name'),
-                description: this.model.escape('description'),
-                course_title: this.model.escape('course_title'),
-                org_logo_path: this.model.escape('org_logo_path'),
-                is_active: this.model.escape('is_active'),
+                name: this.model.get('name'),
+                description: this.model.get('description'),
+                course_title: this.model.get('course_title'),
+                org_logo_path: this.model.get('org_logo_path'),
+                is_active: this.model.get('is_active'),
                 isNew: this.model.isNew()
             };
         },

--- a/cms/static/js/views/edit_chapter.js
+++ b/cms/static/js/views/edit_chapter.js
@@ -12,8 +12,8 @@ define(["js/views/baseview", "underscore", "underscore.string", "jquery", "gette
         },
         render: function() {
             this.$el.html(this.template({
-                name: this.model.escape('name'),
-                asset_path: this.model.escape('asset_path'),
+                name: this.model.get('name'),
+                asset_path: this.model.get('asset_path'),
                 order: this.model.get('order'),
                 error: this.model.validationError
             }));
@@ -52,8 +52,10 @@ define(["js/views/baseview", "underscore", "underscore.string", "jquery", "gette
                 asset_path: this.$("input.chapter-asset-path").val()
             });
             var msg = new FileUploadModel({
-                title: _.template(gettext("Upload a new PDF to “<%= name %>”"),
-                    {name: course.escape('name')}),
+                title: _.template(
+                    gettext("Upload a new PDF to “<%= name %>”"),
+                    {name: window.course.escape('name')}
+                ),
                 message: gettext("Please select a PDF file to upload."),
                 mimeTypes: ['application/pdf']
             });

--- a/cms/static/js/views/edit_textbook.js
+++ b/cms/static/js/views/edit_textbook.js
@@ -13,7 +13,7 @@ define(["js/views/baseview", "underscore", "jquery", "js/views/edit_chapter", "c
         className: "textbook",
         render: function() {
             this.$el.html(this.template({
-                name: this.model.escape('name'),
+                name: this.model.get('name'),
                 error: this.model.validationError
             }));
             this.addAll();

--- a/cms/static/js/views/show_textbook.js
+++ b/cms/static/js/views/show_textbook.js
@@ -29,8 +29,10 @@ define(["js/views/baseview", "underscore", "gettext", "common/js/components/view
             if(e && e.preventDefault) { e.preventDefault(); }
             var textbook = this.model, collection = this.model.collection;
             var msg = new PromptView.Warning({
-                title: _.template(gettext("Delete “<%= name %>”?"),
-                    {name: textbook.escape('name')}),
+                title: _.template(
+                    gettext("Delete “<%= name %>”?"),
+                    {name: textbook.get('name')}
+                ),
                 message: gettext("Deleting a textbook cannot be undone and once deleted any reference to it in your courseware's navigation will also be removed."),
                 actions: {
                     primary: {

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -1,11 +1,12 @@
 ## coding=utf-8
 <%namespace name='static' file='static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import ugettext as _
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
 %>
+<%page expression_filter="h"/>
 <!doctype html>
 <!--[if lte IE 9]><html class="ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
 <!--[if !IE]><<!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
@@ -16,9 +17,9 @@ from openedx.core.djangolib.js_utils import (
         <%block name="title"></%block> |
         % if context_course:
         <% ctx_loc = context_course.location %>
-        ${context_course.display_name_with_default_escaped | h} |
+        ${context_course.display_name_with_default} |
         % elif context_library:
-        ${context_library.display_name_with_default_escaped | h} |
+        ${context_library.display_name_with_default} |
         % endif
         ${settings.STUDIO_NAME}
     </title>
@@ -82,24 +83,24 @@ from openedx.core.djangolib.js_utils import (
     <script type="text/javascript">
       require(['common/js/common_libraries'], function () {
           require(['js/factories/base'], function () {
-               require(['js/models/course'], function(Course) {
-                   % if context_course:
-                       window.course = new Course({
-                           id: "${context_course.id | n, js_escaped_string}",
-                           name: "${context_course.display_name_with_default_escaped | h}",
-                           url_name: "${context_course.location.name | h}",
-                           org: "${context_course.location.org | h}",
-                           num: "${context_course.location.course | h}",
-                           display_course_number: "${context_course.display_coursenumber | n, js_escaped_string}",
-                           revision: "${context_course.location.revision | h}",
-                           self_paced: ${context_course.self_paced | n, dump_js_escaped_json}
-                       });
-                   % endif
-                   % if user.is_authenticated():
-                       require(['js/sock']);
-                   % endif
-                   <%block name='requirejs'></%block>
-               });
+              require(['js/models/course'], function(Course) {
+                  % if context_course:
+                      window.course = new Course({
+                          id: "${context_course.id | n, js_escaped_string}",
+                          name: "${context_course.display_name_with_default | n, js_escaped_string}",
+                          url_name: "${context_course.location.name | n, js_escaped_string}",
+                          org: "${context_course.location.org | n, js_escaped_string}",
+                          num: "${context_course.location.course | n, js_escaped_string}",
+                          display_course_number: "${context_course.display_coursenumber | n, js_escaped_string}",
+                          revision: "${context_course.location.revision | n, js_escaped_string}",
+                          self_paced: ${context_course.self_paced | n, dump_js_escaped_json}
+                      });
+                  % endif
+                  % if user.is_authenticated():
+                      require(['js/sock']);
+                  % endif
+                  <%block name='requirejs'></%block>
+              });
           });
       });
     </script>

--- a/cms/templates/js/certificate-details.underscore
+++ b/cms/templates/js/certificate-details.underscore
@@ -1,46 +1,46 @@
 <div class="collection-details wrapper-certificate">
     <header class="collection-header">
         <h3 class="sr title">
-            <%= name %>
+            <%- name %>
         </h3>
     </header>
 
    <ol class="collection-info certificate-info certificate-info-<% if(showDetails){ print('block'); } else { print('inline'); } %>">
      <% if (!_.isUndefined(id)) { %>
          <li class="sr certificate-id">
-            <span class="certificate-label"><%= gettext('ID') %>: </span>
-            <span class="certificate-value"><%= id %></span>
+            <span class="certificate-label"><%- gettext('ID') %>: </span>
+            <span class="certificate-value"><%- id %></span>
         </li>
      <% } %>
      <% if (showDetails) { %>
          <section class="certificate-settings course-details">
              <header>
-               <h2 class="title title-2"><%= gettext("Certificate Details") %></h2>
+               <h2 class="title title-2"><%- gettext("Certificate Details") %></h2>
              </header>
              <div class='certificate-info-section'>
                  <div class='course-title-section pull-left'>
                     <p class="actual-course-title">
-                            <span class="certificate-label"><%= gettext('Course Title') %>: </span>
-                            <span class="certificate-value"><%= course.get('name') %></span>
+                            <span class="certificate-label"><%- gettext('Course Title') %>: </span>
+                            <span class="certificate-value"><%- course.get('name') %></span>
                     </p>
                     <% if (course_title) { %>
                         <p class="course-title-override">
-                            <span class="certificate-label"><b><%= gettext('Course Title Override') %>: </b></span>
-                            <span class="certificate-value"><%= course_title %></span>
+                            <span class="certificate-label"><b><%- gettext('Course Title Override') %>: </b></span>
+                            <span class="certificate-value"><%- course_title %></span>
                         </p>
                     <% } %>
                  </div>
 
                 <div class='course-number-section pull-left'>
                     <p class="actual-course-number">
-                            <span class="certificate-label"><b><%= gettext('Course Number') %>: </b> </span>
-                            <span class="certificate-value"><%= course.get('num') %></span>
+                            <span class="certificate-label"><b><%- gettext('Course Number') %>: </b> </span>
+                            <span class="certificate-value"><%- course.get('num') %></span>
                     </p>
 
                     <% if (course.get('display_course_number')) { %>
                         <p class="course-number-override">
-                            <span class="certificate-label"><b><%= gettext('Course Number Override') %>: </b></span>
-                            <span class="certificate-value"><%= course.get('display_course_number') %></span>
+                            <span class="certificate-label"><b><%- gettext('Course Number Override') %>: </b></span>
+                            <span class="certificate-value"><%- course.get('display_course_number') %></span>
                         </p>
                     <% } %>
                 </div>
@@ -50,9 +50,9 @@
 
         <section class="certificate-settings signatories">
              <header>
-               <h2 class="title title-2"><%= gettext("Certificate Signatories") %></h2>
+               <h2 class="title title-2"><%- gettext("Certificate Signatories") %></h2>
              </header>
-             <p class="instructions"><%= gettext("It is strongly recommended that you include four or fewer signatories. If you include additional signatories, preview the certificate in Print View to ensure the certificate will print correctly on one page.") %></p>
+             <p class="instructions"><%- gettext("It is strongly recommended that you include four or fewer signatories. If you include additional signatories, preview the certificate in Print View to ensure the certificate will print correctly on one page.") %></p>
              <div class="signatory-details-list"></div>
         </section>
     <% } %>
@@ -61,10 +61,10 @@
     <ul class="actions certificate-actions">
         <% if (CMS.User.isGlobalStaff || !is_active) { %>
         <li class="action action-edit">
-            <button class="edit"><i class="icon fa fa-pencil" aria-hidden="true"></i> <%= gettext("Edit") %></button>
+            <button class="edit"><i class="icon fa fa-pencil" aria-hidden="true"></i> <%- gettext("Edit") %></button>
         </li>
-        <li class="action action-delete wrapper-delete-button" data-tooltip="<%= gettext('Delete') %>">
-            <button class="delete action-icon"><i class="icon fa fa-trash-o" aria-hidden="true"></i><span><%= gettext("Delete") %></span></button>
+        <li class="action action-delete wrapper-delete-button" data-tooltip="<%- gettext('Delete') %>">
+            <button class="delete action-icon"><i class="icon fa fa-trash-o" aria-hidden="true"></i><span><%- gettext("Delete") %></span></button>
         </li>
         <% } %>
     </ul>

--- a/cms/templates/js/certificate-editor.underscore
+++ b/cms/templates/js/certificate-editor.underscore
@@ -2,52 +2,52 @@
     <div aria-live="polite">
     <% if (error && error.message) { %>
         <div class="certificate-edit-error message message-status message-status error is-shown" name="certificate-edit-error">
-          <%= gettext(error.message) %>
+          <%- gettext(error.message) %>
         </div>
     <% } %>
     </div>
     <div class="wrapper-form">
         <fieldset class="collection-fields certificate-fields">
-            <legend class="sr"><%= gettext("Certificate Information") %></legend>
+            <legend class="sr"><%- gettext("Certificate Information") %></legend>
             <div class="sr input-wrap field text required add-collection-name add-certificate-name <% if(error && error.attributes && error.attributes.name) { print('error'); } %>">
-                <label for="certificate-name-<%= uniqueId %>"><%= gettext("Certificate Name") %></label>
-                <input id="certificate-name-<%= uniqueId %>" class="collection-name-input input-text" name="certificate-name" type="text" placeholder="<%= gettext("Name of the certificate") %>" value="<%= name %>" aria-describedby="certificate-name-<%=uniqueId %>-tip" />
-                <span id="certificate-name-<%= uniqueId %>-tip" class="tip tip-stacked"><%= gettext("Name of the certificate") %></span>
+                <label for="certificate-name-<%- uniqueId %>"><%- gettext("Certificate Name") %></label>
+                <input id="certificate-name-<%- uniqueId %>" class="collection-name-input input-text" name="certificate-name" type="text" placeholder="<%- gettext("Name of the certificate") %>" value="<%- name %>" aria-describedby="certificate-name-<%-uniqueId %>-tip" />
+                <span id="certificate-name-<%- uniqueId %>-tip" class="tip tip-stacked"><%- gettext("Name of the certificate") %></span>
             </div>
             <div class="sr input-wrap field text add-certificate-description">
-                <label for="certificate-description-<%= uniqueId %>"><%= gettext("Description") %></label>
-                <textarea id="certificate-description-<%= uniqueId %>" class="certificate-description-input text input-text" name="certificate-description" placeholder="<%= gettext("Description of the certificate") %>" aria-describedby="certificate-description-<%=uniqueId %>-tip"><%= description %></textarea>
-                <span id="certificate-description-<%= uniqueId %>-tip" class="tip tip-stacked"><%= gettext("Description of the certificate") %></span>
+                <label for="certificate-description-<%- uniqueId %>"><%- gettext("Description") %></label>
+                <textarea id="certificate-description-<%- uniqueId %>" class="certificate-description-input text input-text" name="certificate-description" placeholder="<%- gettext("Description of the certificate") %>" aria-describedby="certificate-description-<%-uniqueId %>-tip"><%- description %></textarea>
+                <span id="certificate-description-<%- uniqueId %>-tip" class="tip tip-stacked"><%- gettext("Description of the certificate") %></span>
             </div>
             <header>
-              <h2 class="title title-2"><%= gettext("Certificate Details") %></h2>
+              <h2 class="title title-2"><%- gettext("Certificate Details") %></h2>
             </header>
             <div class="actual-course-title">
-                <span class="actual-course-title"><%= gettext("Course Title") %>: </span>
-                <span class="actual-title"><%= course.get('name') %></span>
+                <span class="actual-course-title"><%- gettext("Course Title") %>: </span>
+                <span class="actual-title"><%- course.get('name') %></span>
             </div>
             <div class="input-wrap field text add-certificate-course-title">
-                <label for="certificate-course-title-<%= uniqueId %>"><%= gettext("Course Title Override") %></label>
-                <input id="certificate-course-title-<%= uniqueId %>" class="certificate-course-title-input input-text" name="certificate-course-title" type="text" placeholder="<%= gettext("Course title") %>" value="<%= course_title %>" aria-describedby="certificate-course-title-<%=uniqueId %>-tip" />
-                <span id="certificate-course-title-<%= uniqueId %>-tip" class="tip tip-stacked"><%= gettext("Specify an alternative to the official course title to display on certificates. Leave blank to use the official course title.") %></span>
+                <label for="certificate-course-title-<%- uniqueId %>"><%- gettext("Course Title Override") %></label>
+                <input id="certificate-course-title-<%- uniqueId %>" class="certificate-course-title-input input-text" name="certificate-course-title" type="text" placeholder="<%- gettext("Course title") %>" value="<%- course_title %>" aria-describedby="certificate-course-title-<%-uniqueId %>-tip" />
+                <span id="certificate-course-title-<%- uniqueId %>-tip" class="tip tip-stacked"><%- gettext("Specify an alternative to the official course title to display on certificates. Leave blank to use the official course title.") %></span>
             </div>
         </fieldset>
          <header>
-            <h2 class="title title-2"><%= gettext("Certificate Signatories") %></h2>
+            <h2 class="title title-2"><%- gettext("Certificate Signatories") %></h2>
          </header>
-         <p class="instructions"><%= gettext("It is strongly recommended that you include four or fewer signatories. If you include additional signatories, preview the certificate in Print View to ensure the certificate will print correctly on one page.") %></p>
+         <p class="instructions"><%- gettext("It is strongly recommended that you include four or fewer signatories. If you include additional signatories, preview the certificate in Print View to ensure the certificate will print correctly on one page.") %></p>
         <div class="signatory-edit-list"> </div>
         <span>
-           <button class="action action-add-signatory" type="button"><%= gettext("Add Additional Signatory") %></button>
-           <span class="tip tip-stacked"><%= gettext("(Add signatories for a certificate)") %></span>
+           <button class="action action-add-signatory" type="button"><%- gettext("Add Additional Signatory") %></button>
+           <span class="tip tip-stacked"><%- gettext("(Add signatories for a certificate)") %></span>
         </span>
     </div>
     <div class="actions">
         <button class="action action-primary" type="submit"><% if (isNew) { print(gettext("Create")) } else { print(gettext("Save")) } %></button>
-        <button class="action action-secondary action-cancel"><%= gettext("Cancel") %></button>
+        <button class="action action-secondary action-cancel"><%- gettext("Cancel") %></button>
         <% if (!isNew && (CMS.User.isGlobalStaff || !is_active)) { %>
             <span class="wrapper-delete-button">
-                <a class="button action-delete delete" href="#"><%= gettext("Delete") %></a>
+                <a class="button action-delete delete" href="#"><%- gettext("Delete") %></a>
             </span>
         <% } %>
     </div>

--- a/cms/templates/js/edit-chapter.underscore
+++ b/cms/templates/js/edit-chapter.underscore
@@ -1,14 +1,14 @@
-<div class="input-wrap field text required field-add-chapter-name chapter<%= order %>-name
+<div class="input-wrap field text required field-add-chapter-name chapter<%- order %>-name
     <% if (error && error.attributes && error.attributes.name) { print('error'); } %>">
-  <label for="chapter<%= order %>-name"><%= gettext("Chapter Name") %></label>
-  <input id="chapter<%= order %>-name" name="chapter<%= order %>-name" class="chapter-name short" placeholder="<%= _.str.sprintf(gettext("Chapter %s"), order) %>" value="<%= name %>" type="text">
-  <span class="tip tip-stacked"><%= gettext("provide the title/name of the chapter that will be used in navigating") %></span>
+  <label for="chapter<%- order %>-name"><%- gettext("Chapter Name") %></label>
+  <input id="chapter<%- order %>-name" name="chapter<%- order %>-name" class="chapter-name short" placeholder="<%- _.str.sprintf(gettext("Chapter %s"), order) %>" value="<%- name %>" type="text">
+  <span class="tip tip-stacked"><%- gettext("provide the title/name of the chapter that will be used in navigating") %></span>
 </div>
-<div class="input-wrap field text required field-add-chapter-asset chapter<%= order %>-asset
+<div class="input-wrap field text required field-add-chapter-asset chapter<%- order %>-asset
     <% if (error && error.attributes && error.attributes.asset_path) { print('error'); } %>">
-  <label for="chapter<%= order %>-asset-path"><%= gettext("Chapter Asset") %></label>
-  <input id="chapter<%= order %>-asset-path" name="chapter<%= order %>-asset-path" class="chapter-asset-path" placeholder="<%= _.str.sprintf(gettext("path/to/introductionToCookieBaking-CH%d.pdf"), order) %>" value="<%= asset_path %>" type="text" dir="ltr">
-  <span class="tip tip-stacked"><%= gettext("upload a PDF file or provide the path to a Studio asset file") %></span>
-<button class="action action-upload"><%= gettext("Upload PDF") %></button>
+  <label for="chapter<%- order %>-asset-path"><%- gettext("Chapter Asset") %></label>
+  <input id="chapter<%- order %>-asset-path" name="chapter<%- order %>-asset-path" class="chapter-asset-path" placeholder="<%- _.str.sprintf(gettext("path/to/introductionToCookieBaking-CH%d.pdf"), order) %>" value="<%- asset_path %>" type="text" dir="ltr">
+  <span class="tip tip-stacked"><%- gettext("upload a PDF file or provide the path to a Studio asset file") %></span>
+<button class="action action-upload"><%- gettext("Upload PDF") %></button>
 </div>
-<a href="" class="action action-close"><i class="icon fa fa-times-circle"></i> <span class="sr"><%= gettext("delete chapter") %></span></a>
+<a href="" class="action action-close"><i class="icon fa fa-times-circle"></i> <span class="sr"><%- gettext("delete chapter") %></span></a>

--- a/cms/templates/js/edit-textbook.underscore
+++ b/cms/templates/js/edit-textbook.underscore
@@ -2,27 +2,27 @@
   <div class="wrapper-form">
   <% if (error && error.message) { %>
     <div id="edit_textbook_error" class="message message-status message-status error is-shown" name="edit_textbook_error">
-      <%= gettext(error.message) %>
+      <%- gettext(error.message) %>
     </div>
   <% } %>
 
   <fieldset class="textbook-fields">
-    <legend class="sr"><%= gettext("Textbook information") %></legend>
+    <legend class="sr"><%- gettext("Textbook information") %></legend>
         <div class="input-wrap field text required add-textbook-name <% if(error && error.attributes && error.attributes.name) { print('error'); } %>">
-          <label for="textbook-name-input"><%= gettext("Textbook Name") %></label>
-          <input id="textbook-name-input" name="textbook-name" type="text" placeholder="<%= gettext("Introduction to Cookie Baking") %>" value="<%= name %>">
-          <span class="tip tip-stacked"><%= gettext("provide the title/name of the text book as you would like your students to see it") %></span>
+          <label for="textbook-name-input"><%- gettext("Textbook Name") %></label>
+          <input id="textbook-name-input" name="textbook-name" type="text" placeholder="<%- gettext("Introduction to Cookie Baking") %>" value="<%- name %>">
+          <span class="tip tip-stacked"><%- gettext("provide the title/name of the text book as you would like your students to see it") %></span>
         </div>
   </fieldset>
   <fieldset class="chapters-fields">
-    <legend class="sr"><%= gettext("Chapter information") %></legend>
+    <legend class="sr"><%- gettext("Chapter information") %></legend>
       <ol class="chapters list-input enum"></ol>
 
-    <button class="action action-add-chapter"><i class="icon fa fa-plus"></i> <%= gettext("Add a Chapter") %></button>
+    <button class="action action-add-chapter"><i class="icon fa fa-plus"></i> <%- gettext("Add a Chapter") %></button>
   </fieldset>
   </div>
   <div class="actions">
-    <button class="action action-primary" type="submit"><%= gettext("Save") %></button>
-    <button class="action action-secondary action-cancel"><%= gettext("Cancel") %></button>
+    <button class="action action-primary" type="submit"><%- gettext("Save") %></button>
+    <button class="action action-secondary action-cancel"><%- gettext("Cancel") %></button>
   </div>
 </form>

--- a/cms/templates/js/publish-xblock.underscore
+++ b/cms/templates/js/publish-xblock.underscore
@@ -19,43 +19,43 @@ if (visibilityState === 'live') {
 
 var visibleToStaffOnly = visibilityState === 'staff_only';
 %>
-<div class="bit-publishing <%= visibilityClass %> <% if (releaseDate) { %>is-scheduled<% } %>">
-    <h3 class="bar-mod-title pub-status"><span class="sr"><%= gettext("Publishing Status") %></span>
-        <%= title %>
+<div class="bit-publishing <%- visibilityClass %> <% if (releaseDate) { %>is-scheduled<% } %>">
+    <h3 class="bar-mod-title pub-status"><span class="sr"><%- gettext("Publishing Status") %></span>
+        <%- title %>
     </h3>
 
     <div class="wrapper-last-draft bar-mod-content">
         <p class="copy meta">
             <% if (hasChanges && editedOn && editedBy) {
                 var message = gettext("Draft saved on %(last_saved_date)s by %(edit_username)s") %>
-                <%= interpolate(message, {
-                    last_saved_date: '<span class="date">' + editedOn + '</span>',
-                    edit_username: '<span class="user">' + editedBy + '</span>' }, true) %>
+                <%= interpolate(_.escape(message), {
+                    last_saved_date: '<span class="date">' + _.escape(editedOn) + '</span>',
+                    edit_username: '<span class="user">' + _.escape(editedBy) + '</span>' }, true) %>
             <% } else if (publishedOn && publishedBy) {
                 var message = gettext("Last published %(last_published_date)s by %(publish_username)s"); %>
-                <%= interpolate(message, {
-                    last_published_date: '<span class="date">' + publishedOn + '</span>',
-                    publish_username: '<span class="user">' + publishedBy + '</span>' }, true) %>
+                <%= interpolate(_.escape(message), {
+                    last_published_date: '<span class="date">' + _.escape(publishedOn) + '</span>',
+                    publish_username: '<span class="user">' + _.escape(publishedBy) + '</span>' }, true) %>
             <% } else { %>
-                <%= gettext("Previously published") %>
+                <%- gettext("Previously published") %>
             <% } %>
         </p>
     </div>
 
     <% if (!course.get('self_paced')) { %>
         <div class="wrapper-release bar-mod-content">
-            <h5 class="title"><%= releaseLabel %></h5>
+            <h5 class="title"><%- releaseLabel %></h5>
             <p class="copy">
                 <% if (releaseDate) { %>
-                    <span class="release-date"><%= releaseDate %></span>
+                    <span class="release-date"><%- releaseDate %></span>
                     <span class="release-with">
-                        <%= interpolate(
+                        <%- interpolate(
                             gettext('with %(release_date_from)s'), { release_date_from: releaseDateFrom }, true
                         ) %>
                     </span>
 
                 <% } else { %>
-                    <%= gettext("Unscheduled") %>
+                    <%- gettext("Unscheduled") %>
                 <% } %>
             </p>
         </div>
@@ -64,40 +64,40 @@ var visibleToStaffOnly = visibilityState === 'staff_only';
     <div class="wrapper-visibility bar-mod-content">
         <h5 class="title">
             <% if (released && published && !hasChanges) { %>
-                <%= gettext("Is Visible To:") %>
+                <%- gettext("Is Visible To:") %>
             <% } else { %>
-                <%= gettext("Will Be Visible To:") %>
+                <%- gettext("Will Be Visible To:") %>
             <% } %>
         </h5>
         <% if (visibleToStaffOnly) { %>
             <p class="visbility-copy copy">
-                <%= gettext("Staff Only") %>
+                <%- gettext("Staff Only") %>
                 <% if (!hasExplicitStaffLock) { %>
                     <span class="inherited-from">
-                        <%= interpolate(
+                        <%- interpolate(
                             gettext("with %(section_or_subsection)s"),{ section_or_subsection: staffLockFrom }, true
                         ) %>
                     </span>
                 <% } %>
             </p>
         <% } else { %>
-            <p class="visbility-copy copy"><%= gettext("Staff and Students") %></p>
+            <p class="visbility-copy copy"><%- gettext("Staff and Students") %></p>
         <% } %>
             <% if (hasContentGroupComponents) { %>
                 <p class="note-visibility">
                     <i class="icon fa fa-eye" aria-hidden="true"></i>
-                    <span class="note-copy"><%= gettext("Some content in this unit is visible only to particular content groups") %></span>
+                    <span class="note-copy"><%- gettext("Some content in this unit is visible only to particular content groups") %></span>
                 </p>
             <% } %>
         <ul class="actions-inline">
             <li class="action-inline">
-                <a href="" class="action-staff-lock" role="button" aria-pressed="<%= hasExplicitStaffLock %>">
+                <a href="" class="action-staff-lock" role="button" aria-pressed="<%- hasExplicitStaffLock %>">
                 <% if (hasExplicitStaffLock) { %>
                     <i class="icon fa fa-check-square-o" aria-hidden="true"></i>
                 <% } else { %>
                     <i class="icon fa fa-square-o" aria-hidden="true"></i>
                 <% } %>
-                <%= gettext('Hide from students') %>
+                <%- gettext('Hide from students') %>
             </a>
             </li>
         </ul>
@@ -107,12 +107,12 @@ var visibleToStaffOnly = visibilityState === 'staff_only';
         <ul class="action-list">
             <li class="action-item">
                 <a class="action-publish action-primary <% if (published && !hasChanges) { %>is-disabled<% } %>"
-                   href="" aria-disabled="<% if (published && !hasChanges) { %>true<% } else { %>false<% } %>" ><%= gettext("Publish") %>
+                   href="" aria-disabled="<% if (published && !hasChanges) { %>true<% } else { %>false<% } %>" ><%- gettext("Publish") %>
                 </a>
             </li>
             <li class="action-item">
                 <a class="action-discard action-secondary <% if (!published || !hasChanges) { %>is-disabled<% } %>"
-                   href="" aria-disabled="<% if (!published || !hasChanges) { %>true<% } else { %>false<% } %>"><%= gettext("Discard Changes") %>
+                   href="" aria-disabled="<% if (!published || !hasChanges) { %>true<% } else { %>false<% } %>"><%- gettext("Discard Changes") %>
                 </a>
             </li>
         </ul>

--- a/cms/templates/js/show-textbook.underscore
+++ b/cms/templates/js/show-textbook.underscore
@@ -1,19 +1,19 @@
- <div class="view-textbook">
+<div class="view-textbook">
 
 <div class="wrap-textbook">
     <header>
-        <h3 class="textbook-title"><%= name %></h3>
+        <h3 class="textbook-title"><%- name %></h3>
     </header>
 
 <% if(chapters.length > 1) {%>
     <p><a href="#" class="chapter-toggle
         <% if(showChapters){ print('hide'); } else { print('show'); } %>-chapters">
         <i class="ui-toggle-expansion icon fa fa-caret-<% if(showChapters){ print('down'); } else { print('right'); } %>"></i>
-        <%= chapters.length %> PDF Chapters
+        <%- chapters.length %> PDF Chapters
     </a></p>
 <% } else if(chapters.length === 1) { %>
     <p dir="ltr">
-        <%= chapters.at(0).get("asset_path") %>
+        <%- chapters.at(0).get("asset_path") %>
     </p>
 <% } %>
 
@@ -22,8 +22,8 @@
 <ol class="chapters">
   <% chapters.each(function(chapter) { %>
     <li class="chapter">
-        <span class="chapter-name"><%= chapter.get('name') %></span>
-        <span class="chapter-asset-path"><%= chapter.get('asset_path') %></span>
+        <span class="chapter-name"><%- chapter.get('name') %></span>
+        <span class="chapter-asset-path"><%- chapter.get('asset_path') %></span>
     </li>
   <% }) %>
 </ol>
@@ -34,13 +34,13 @@
 
 <ul  class="actions textbook-actions">
     <li class="action action-view">
-        <a href="//<%= CMS.URL.LMS_BASE %>/courses/<%= course.id %>/pdfbook/<%= bookindex %>/" class="view"><%= gettext("View Live") %></a>
+        <a href="//<%- CMS.URL.LMS_BASE %>/courses/<%- course.id %>/pdfbook/<%- bookindex %>/" class="view"><%- gettext("View Live") %></a>
     </li>
     <li class="action action-edit">
-        <button class="edit"><%= gettext("Edit") %></button>
+        <button class="edit"><%- gettext("Edit") %></button>
     </li>
     <li class="action action-delete">
-        <button class="delete action-icon"><i class="icon fa fa-trash-o"></i><span><%= gettext("Delete") %></span></button>
+        <button class="delete action-icon"><i class="icon fa fa-trash-o"></i><span><%- gettext("Delete") %></span></button>
     </li>
 </ul>
 

--- a/cms/templates/js/signatory-details.underscore
+++ b/cms/templates/js/signatory-details.underscore
@@ -2,30 +2,30 @@
   <% if (CMS.User.isGlobalStaff || !certificate.get('is_active')) { %>
   <div class="actions certificate-actions signatory-panel-edit">
     <span class="action action-edit-signatory">
-      <a href="javascript:void(0);" class="edit-signatory"><i class="icon fa fa-pencil" aria-hidden="true"></i> <%= gettext("Edit") %></a>
+      <a href="javascript:void(0);" class="edit-signatory"><i class="icon fa fa-pencil" aria-hidden="true"></i> <%- gettext("Edit") %></a>
     </span>
   </div>
   <% } %>
-  <div class="signatory-panel-header"><%= gettext("Signatory") %> <%= signatory_number %>&nbsp;</div>
+  <div class="signatory-panel-header"><%- gettext("Signatory") %> <%- signatory_number %>&nbsp;</div>
   <div class="signatory-panel-body">
     <div>
         <div>
-          <span class="signatory-name-label"><b><%= gettext("Name") %>:</b>&nbsp;</span>
-          <span class="signatory-name-value"><%= name %></span>
+          <span class="signatory-name-label"><b><%- gettext("Name") %>:</b>&nbsp;</span>
+          <span class="signatory-name-value"><%- name %></span>
         </div>
         <div>
-          <span class="signatory-title-label"><b><%= gettext("Title") %>:</b>&nbsp;</span>
-          <span class="signatory-title-value"><%= title.replace(new RegExp('\r?\n','g'), '<br />') %></span>
+          <span class="signatory-title-label"><b><%- gettext("Title") %>:</b>&nbsp;</span>
+          <span class="signatory-title-value"><%= _.escape(title).replace(new RegExp('\r?\n','g'), '<br />') %></span>
         </div>
         <div>
-          <span class="signatory-organization-label"><b><%= gettext("Organization") %>:</b>&nbsp;</span>
-          <span class="signatory-organization-value"><%= organization %></span>
+          <span class="signatory-organization-label"><b><%- gettext("Organization") %>:</b>&nbsp;</span>
+          <span class="signatory-organization-value"><%- organization %></span>
         </div>
     </div>
     <div class="signatory-image">
       <% if (signature_image_path != "") { %>
             <div class="wrapper-signature-image">
-                <img class="signature-image" src="<%= signature_image_path %>" alt="<%= gettext('Signature Image') %>">
+                <img class="signature-image" src="<%- signature_image_path %>" alt="<%- gettext('Signature Image') %>">
             </div>
       <% } %>
     </div>

--- a/cms/templates/js/signatory-editor.underscore
+++ b/cms/templates/js/signatory-editor.underscore
@@ -2,48 +2,48 @@
        <% if (is_editing_all_collections && signatories_count > 1 && (total_saved_signatories > 1 || isNew) ) { %>
        <a class="signatory-panel-delete" href="#" data-tooltip="Delete">
           <i class="icon fa fa-trash-o" aria-hidden="true"></i>
-          <span class="sr action-button-text"><%= gettext("Delete") %></span>
+          <span class="sr action-button-text"><%- gettext("Delete") %></span>
        </a>
        <% } %>
-       <div class="signatory-panel-header"><%= gettext("Signatory") %> <%= signatory_number %></div>
+       <div class="signatory-panel-header"><%- gettext("Signatory") %> <%- signatory_number %></div>
        <div class="signatory-panel-body">
          <fieldset class="collection-fields signatory-fields">
-            <legend class="sr"><%= gettext("Certificate Signatory Configuration") %></legend>
+            <legend class="sr"><%- gettext("Certificate Signatory Configuration") %></legend>
             <div class="input-wrap field text add-signatory-name <% if(error && error.name) { print('error'); } %>">
-                <label for="signatory-name-<%= signatory_number %>"><%= gettext("Name ") %></label>
-                <input id="signatory-name-<%= signatory_number %>" class="collection-name-input input-text signatory-name-input" name="signatory-name" type="text" placeholder="<%= gettext("Name of the signatory") %>" value="<%= name %>"  aria-describedby="signatory-name-<%= signatory_number %>-tip" />
-                <span id="signatory-name-<%= signatory_number %>-tip" class="tip tip-stacked"><%= gettext("The name of this signatory as it should appear on certificates.") %></span>
+                <label for="signatory-name-<%- signatory_number %>"><%- gettext("Name ") %></label>
+                <input id="signatory-name-<%- signatory_number %>" class="collection-name-input input-text signatory-name-input" name="signatory-name" type="text" placeholder="<%- gettext("Name of the signatory") %>" value="<%- name %>"  aria-describedby="signatory-name-<%- signatory_number %>-tip" />
+                <span id="signatory-name-<%- signatory_number %>-tip" class="tip tip-stacked"><%- gettext("The name of this signatory as it should appear on certificates.") %></span>
                 <% if(error && error.name) { %>
-                  <span class="message-error"><%= error.name %></span>
+                  <span class="message-error"><%- error.name %></span>
                 <% } %>
             </div>
             <div class="input-wrap field text add-signatory-title <% if(error && error.title) { print('error'); } %>">
-                <label for="signatory-title-<%= signatory_number %>"><%= gettext("Title ") %></label>
-                <textarea id="signatory-title-<%= signatory_number %>" class="collection-name-input text input-text signatory-title-input" name="signatory-title" placeholder="<%= gettext("Title of the signatory") %>"  aria-describedby="signatory-title-<%= signatory_number %>-tip" ><%= title %></textarea>
-                <span id="signatory-title-<%= signatory_number %>-tip" class="tip tip-stacked"><%= gettext("Titles more than 100 characters may prevent students from printing their certificate on a single page.") %></span>
+                <label for="signatory-title-<%- signatory_number %>"><%- gettext("Title ") %></label>
+                <textarea id="signatory-title-<%- signatory_number %>" class="collection-name-input text input-text signatory-title-input" name="signatory-title" placeholder="<%- gettext("Title of the signatory") %>"  aria-describedby="signatory-title-<%- signatory_number %>-tip" ><%- title %></textarea>
+                <span id="signatory-title-<%- signatory_number %>-tip" class="tip tip-stacked"><%- gettext("Titles more than 100 characters may prevent students from printing their certificate on a single page.") %></span>
                 <% if(error && error.title) { %>
-                  <span class="message-error"><%= error.title %></span>
+                  <span class="message-error"><%- error.title %></span>
                 <% } %>
             </div>
             <div class="input-wrap field text add-signatory-organization <% if(error && error.organization) { print('error'); } %>">
-                <label for="signatory-organization-<%= signatory_number %>"><%= gettext("Organization ") %></label>
-                <input id="signatory-organization-<%= signatory_number %>" class="collection-name-input input-text signatory-organization-input" name="signatory-organization" type="text" placeholder="<%= gettext("Organization of the signatory") %>" value="<%= organization %>"  aria-describedby="signatory-organization-<%= signatory_number %>-tip" />
-                <span id="signatory-organization-<%= signatory_number %>-tip" class="tip tip-stacked"><%= gettext("The organization that this signatory belongs to, as it should appear on certificates.") %></span>
+                <label for="signatory-organization-<%- signatory_number %>"><%- gettext("Organization ") %></label>
+                <input id="signatory-organization-<%- signatory_number %>" class="collection-name-input input-text signatory-organization-input" name="signatory-organization" type="text" placeholder="<%- gettext("Organization of the signatory") %>" value="<%- organization %>"  aria-describedby="signatory-organization-<%- signatory_number %>-tip" />
+                <span id="signatory-organization-<%- signatory_number %>-tip" class="tip tip-stacked"><%- gettext("The organization that this signatory belongs to, as it should appear on certificates.") %></span>
                 <% if(error && error.organization) { %>
-                  <span class="message-error"><%= error.organization %></span>
+                  <span class="message-error"><%- error.organization %></span>
                 <% } %>
             </div>
             <div class="input-wrap field text add-signatory-signature">
-                <label for="signatory-signature-<%= signatory_number %>"><%= gettext("Signature Image") %></label>
+                <label for="signatory-signature-<%- signatory_number %>"><%- gettext("Signature Image") %></label>
                 <% if (signature_image_path != "") { %>
-                    <div class="current-signature-image"><span class="wrapper-signature-image"><img class="signature-image" src="<%= signature_image_path %>" alt="Signature Image"></span></div>
+                    <div class="current-signature-image"><span class="wrapper-signature-image"><img class="signature-image" src="<%- signature_image_path %>" alt="Signature Image"></span></div>
                 <% } %>
                 <div class="signature-upload-wrapper">
                   <div class="signature-upload-input-wrapper">
-                    <input id="signatory-signature-<%= signatory_number %>" class="collection-name-input input-text signatory-signature-input" name="signatory-signature-url" type="text" placeholder="<%= gettext("Path to Signature Image") %>" value="<%= signature_image_path %>"  aria-describedby="signatory-signature-<%= signatory_number %>-tip" readonly />
-                    <span id="signatory-signature-<%= signatory_number %>-tip" class="tip tip-stacked"><%= gettext("Image must be in PNG format") %></span>
+                    <input id="signatory-signature-<%- signatory_number %>" class="collection-name-input input-text signatory-signature-input" name="signatory-signature-url" type="text" placeholder="<%- gettext("Path to Signature Image") %>" value="<%- signature_image_path %>"  aria-describedby="signatory-signature-<%- signatory_number %>-tip" readonly />
+                    <span id="signatory-signature-<%- signatory_number %>-tip" class="tip tip-stacked"><%- gettext("Image must be in PNG format") %></span>
                   </div>
-                  <button type="button" class="action action-upload-signature"><%= gettext("Upload Signature Image") %></button>
+                  <button type="button" class="action action-upload-signature"><%- gettext("Upload Signature Image") %></button>
                 </div>
             </div>
          </fieldset>


### PR DESCRIPTION
## [TNL-3425](https://openedx.atlassian.net/browse/TNL-3425)

The impetus for this PR was to remove display_name_with_default_escaped from base.html and to learn about the process for fixing templates according to our guidelines.

Make base.html Mako template safe by default by:
1. Add page-level default of html escaping
2. Fix escaping of all variables in base.html
3. Fix escaping of all dependent underscore templates
Also includes additional best practices for certificates and textbooks JavaScript/Underscore in order to complete those areas.
### Sandbox
- [x] [Sandbox](https://robrap.sandbox.edx.org).
### Testing
- [X] Data is properly encoded in HTML templates to avoid XSS
- [X] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @nedbat 
- [x] Code review: @mattdrayer
### Post-review
- [ ] Squash commits
