### PR TITLE
Fixup: draggable capa icons disappear in RTL layout

### DIFF
--- a/common/static/js/capa/drag_and_drop/draggables.js
+++ b/common/static/js/capa/drag_and_drop/draggables.js
@@ -175,8 +175,7 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
                 'style=" ' +
                     'width: 100px; ' +
                     'height: 100px; ' +
-                    'display: inline; ' +
-                    'float: left; ' +
+                    'display: inline-block; ' +
                     'overflow: hidden; ' +
                     'border-left: 1px solid #CCC; ' +
                     'border-right: 1px solid #CCC; ' +


### PR DESCRIPTION
# The Issue

We've had an issue with draggable CAPA questions. When the student has an Arabic (RTL) layout the draggable items will be missing:
![rtl-issue-dragdrop](https://cloud.githubusercontent.com/assets/645156/12015667/68210c4c-ad48-11e5-9eaf-a14964c3ce48.png)

---
# Fixup

With this PR it should work fine in both RTL and LTR layouts:
## RTL

![rtl-dragdrop](https://cloud.githubusercontent.com/assets/645156/12015660/556e664e-ad48-11e5-804b-3eb47c8dce15.png)
## LTR

![english-rtl-ok](https://cloud.githubusercontent.com/assets/645156/12016286/c59f9dee-ad51-11e5-9bfe-a415fc2111c7.png)
