### PR TITLE
asadiqbal08/SOL-1538 Incorrect Course Number Override appears on certificate setup page

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -85,7 +85,7 @@ from openedx.core.lib.js_utils import (
                       url_name: "${context_course.location.name | h}",
                       org: "${context_course.location.org | h}",
                       num: "${context_course.location.course | h}",
-                      display_course_number: "${_(context_course.display_number_with_default)}",
+                      display_course_number: "${_(context_course.display_coursenumber)}",
                       revision: "${context_course.location.revision | h}",
                       self_paced: ${escape_json_dumps(context_course.self_paced) | n}
                   });

--- a/common/test/acceptance/pages/studio/settings_certificates.py
+++ b/common/test/acceptance/pages/studio/settings_certificates.py
@@ -68,6 +68,12 @@ class CertificatesPage(CoursePage):
         """
         return self.q(css='.course-number-override .certificate-value').first.text[0]
 
+    def course_number_override(self):
+        """
+        Return Course Number Override selector
+        """
+        return self.q(css='.course-number-override')
+
     ################
     # Properties
     ################

--- a/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
@@ -274,8 +274,9 @@ class CertificatesTest(StudioCourseTest):
         Scenario: Ensure that Course Number Override is displayed in certificate details view
 
         Given I have a certificate
-        When I visit certificate details page on studio
-        Then I see Course Number Override next to Course Name
+        When I visit certificate details page on studio then course number override should be hidden.
+        Then I visit the course advance settings page and set the value for course override number.
+        Then I see Course Number Override next to Course Name in certificate settings page.
         """
 
         self.course_advanced_settings.update(
@@ -288,7 +289,7 @@ class CertificatesTest(StudioCourseTest):
             0,
             [self.make_signatory_data('first')]
         )
-
+        self.assertFalse(self.certificates_page.course_number_override().present)
         certificate.wait_for_certificate_delete_button()
 
         # Make sure certificate is created
@@ -302,3 +303,4 @@ class CertificatesTest(StudioCourseTest):
         self.certificates_page.visit()
         course_number_override = self.certificates_page.get_course_number_override()
         self.assertEqual(self.course_advanced_settings['Course Number Display String'], course_number_override)
+        self.assertTrue(self.certificates_page.course_number_override().present)


### PR DESCRIPTION
For those courses in which there is no Course override number is set in advance setting, course override number should not appear on certificate set up age.
@ziafazal @mattdrayer FYI.
