### PR TITLE
WIP Hided course registration from student in case of accessing ccx course direct

### DIFF
--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -23,6 +23,7 @@ from django.utils.timezone import UTC
 from django.views.decorators.http import require_GET, require_POST, require_http_methods
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import redirect
+from ccx_keys.locator import CCXLocator
 from certificates import api as certs_api
 from edxmako.shortcuts import render_to_response, render_to_string, marketing_link
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -804,6 +805,9 @@ def course_about(request, course_id):
     """
 
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+
+    if isinstance(course_key, CCXLocator):
+        return redirect(reverse('dashboard'))
 
     with modulestore().bulk_operations(course_key):
         permission = get_permission_for_course_about()


### PR DESCRIPTION
### Background

Issue https://github.com/mitocw/edx-platform/issues/138
### What is done in this PR

**Studio Updates:** None.
**LMS Updates:** 
- Hided CCX course registration from students. Because only a coach can enrol students on CCX. Now students can not self-register CCX.

@pdpinch @giocalitri 
- Student trying to access CCX. He will be redirected to dashboard.
  ![screen shot 2015-12-28 at 6 01 25 pm 2](https://cloud.githubusercontent.com/assets/10431250/12019157/6175ed36-ad8e-11e5-9ac1-ebc3c50d60d4.png)

![screen shot 2015-12-28 at 6 04 54 pm 2](https://cloud.githubusercontent.com/assets/10431250/12019158/6177801a-ad8e-11e5-8207-1a73db2c19f5.png)
- After coach enrolled him, he can access CCX
  ![screen shot 2015-12-28 at 6 05 16 pm](https://cloud.githubusercontent.com/assets/10431250/12019160/61786868-ad8e-11e5-82be-24eab05d9665.png)

![screen shot 2015-12-28 at 6 06 15 pm 2](https://cloud.githubusercontent.com/assets/10431250/12019159/6178487e-ad8e-11e5-8381-5916072a8533.png)
