### PR TITLE
Render lms main navigation (tabs) with template

### DIFF
--- a/common/test/test_microsites/test_microsite/templates/courseware/tabs.html
+++ b/common/test/test_microsites/test_microsite/templates/courseware/tabs.html
@@ -1,0 +1,33 @@
+## mako
+<%namespace name='static' file='/static_content.html'/>
+<%!
+ from django.utils.translation import ugettext as _
+ from django.core.urlresolvers import reverse
+ %>
+<%page args="tab_list, active_page, default_tab, tab_image" />
+
+<%
+def url_class(is_active):
+  if is_active:
+    return "active"
+  return ""
+%>
+% for tab in tab_list:
+  <%
+    tab_is_active = tab.tab_id in (active_page, default_tab)
+    tab_class = url_class(tab_is_active)
+  %>
+  <li>
+  <a href="${tab.link_func(course, reverse) | h}" class="${tab_class}">
+  Test Microsite Tab: ${_(tab.name) | h}
+  % if tab_is_active:
+      <span class="sr">, current location</span>
+  %endif
+  % if tab_image:
+      ## Translators: 'needs attention' is an alternative string for the
+      ## notification image that indicates the tab "needs attention".
+      <img src="${tab_image}" alt="${_('needs attention')}" />
+  %endif
+  </a>
+  </li>
+% endfor

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -209,6 +209,21 @@ class TestMicrosites(ModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertNotContains(resp, 'Robot_Super_Course')
         self.assertContains(resp, 'Robot_Course_Outside_Microsite')
 
+    def test_microsite_course_custom_tabs(self):
+        """
+        Enroll user in a course scoped in a Microsite and make sure that
+        template with tabs is overridden
+        """
+        self.setup_users()
+
+        email, password = self.STUDENT_INFO[1]
+        self.login(email, password)
+        self.enroll(self.course, True)
+
+        resp = self.client.get(reverse('courseware', args=[unicode(self.course.id)]),
+                               HTTP_HOST=settings.MICROSITE_TEST_HOSTNAME)
+        self.assertContains(resp, 'Test Microsite Tab:')
+
     @override_settings(SITE_NAME=settings.MICROSITE_TEST_HOSTNAME)
     def test_visible_about_page_settings(self):
         """

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -15,11 +15,6 @@ if active_page is None and active_page_context is not UNDEFINED:
   # If active_page is not passed in as an argument, it may be in the context as active_page_context
   active_page = active_page_context
 
-def url_class(is_active):
-  if is_active:
-    return "active"
-  return ""
-
 def selected(is_selected):
   return "selected" if is_selected else ""
 
@@ -83,27 +78,14 @@ include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
 % if disable_tabs is UNDEFINED or not disable_tabs:
 <nav class="${active_page} wrapper-course-material" aria-label="${_('Course Material')}">
   <div class="course-material">
-    <ol class="course-tabs">
-      % for tab in get_course_tab_list(request, course):
-        <%
-            tab_is_active = (tab.tab_id == active_page) or (tab.tab_id == default_tab)
-        %>
-          <li>
-             <a href="${tab.link_func(course, reverse) | h}" class="${url_class(tab_is_active)}">
-                 ${_(tab.name) | h}
-                 % if tab_is_active:
-                   <span class="sr">, current location</span>
-                 %endif
-                 % if tab_image:
-                   ## Translators: 'needs attention' is an alternative string for the
-                   ## notification image that indicates the tab "needs attention".
-                   <img src="${tab_image}" alt="${_('needs attention')}" />
-                 %endif
-             </a>
-          </li>
-      % endfor
+     <%
+      tab_list = get_course_tab_list(request, course)
+      tabs_tmpl = static.get_template_path('/courseware/tabs.html')
+      %>
+      <ol class="course-tabs">
+      <%include file="${tabs_tmpl}" args="tab_list=tab_list,active_page=active_page,default_tab=default_tab,tab_image=tab_image" />
       <%block name="extratabs" />
-    </ol>
+      </ol>
   </div>
 </nav>
 %endif

--- a/lms/templates/courseware/tabs.html
+++ b/lms/templates/courseware/tabs.html
@@ -1,0 +1,33 @@
+## mako
+<%namespace name='static' file='/static_content.html'/>
+<%!
+ from django.utils.translation import ugettext as _
+ from django.core.urlresolvers import reverse
+ %>
+<%page args="tab_list, active_page, default_tab, tab_image" />
+
+<%
+def url_class(is_active):
+  if is_active:
+    return "active"
+  return ""
+%>
+% for tab in tab_list:
+  <%
+    tab_is_active = tab.tab_id in (active_page, default_tab)
+    tab_class = url_class(tab_is_active)
+  %>
+  <li>
+  <a href="${tab.link_func(course, reverse) | h}" class="${tab_class}">
+  ${_(tab.name) | h}
+  % if tab_is_active:
+      <span class="sr">, current location</span>
+  %endif
+  % if tab_image:
+      ## Translators: 'needs attention' is an alternative string for the
+      ## notification image that indicates the tab "needs attention".
+      <img src="${tab_image}" alt="${_('needs attention')}" />
+  %endif
+  </a>
+  </li>
+% endfor


### PR DESCRIPTION
The reason for this pull requests is the conversation with @singingwolfboy in Slack:
https://openedx.slack.com/archives/theming/p1449519743000017

Someone wants to rename the “Courseware” tab in the LMS navigation and for now there is no ability to make it easy (only one way to do it is to override the entire template).

With this little improvement every tab could be redefined (for example in microsite theme) with adding specific template (by default courseware/tab_default.html will be taken):

```
courseware/tab_courseware.html 
courseware/tab_info.html 
courseware/tab_discussion.html 
courseware/tab_wiki.html 
courseware/tab_progress.html
courseware/tab_instructor.html
```
