### PR TITLE
Course API: Change field name from course_id to id

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -42,11 +42,11 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     """
 
     blocks_url = serializers.SerializerMethodField()
-    course_id = serializers.CharField(source='id', read_only=True)
     effort = serializers.CharField()
     end = serializers.DateTimeField()
     enrollment_start = serializers.DateTimeField()
     enrollment_end = serializers.DateTimeField()
+    id = serializers.CharField()  # pylint: disable=invalid-name
     media = _CourseApiMediaCollectionSerializer(source='*')
     name = serializers.CharField(source='display_name_with_default_escaped')
     number = serializers.CharField(source='display_number_with_default')
@@ -55,6 +55,9 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     start = serializers.DateTimeField()
     start_display = serializers.CharField()
     start_type = serializers.CharField()
+
+    # 'course_id' is a deprecated field, please use 'id' instead.
+    course_id = serializers.CharField(source='id', read_only=True)
 
     def get_blocks_url(self, course_overview):
         """

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -33,7 +33,7 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
         self.request_factory = APIRequestFactory()
 
         self.expected_data = {
-            'course_id': u'edX/toy/2012_Fall',
+            'id': u'edX/toy/2012_Fall',
             'name': u'Toy Course',
             'number': u'toy',
             'org': u'edX',
@@ -54,6 +54,9 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
             'enrollment_end': u'2015-07-15T00:00:00Z',
             'blocks_url': u'http://testserver/api/courses/v1/blocks/?course_id=edX%2Ftoy%2F2012_Fall',
             'effort': u'6 hours',
+
+            # 'course_id' is a deprecated field, please use 'id' instead.
+            'course_id': u'edX/toy/2012_Fall',
         }
 
     def _get_request(self, user=None):

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -27,13 +27,14 @@ class CourseDetailView(DeveloperErrorViewMixin, RetrieveAPIView):
 
         Body consists of the following fields:
 
-        * blocks_url: used to fetch the course blocks
-        * course_id: Course key
+        * blocks_url: Used to fetch the course blocks
         * effort: A textual description of the weekly hours of effort expected
             in the course.
         * end: Date the course ends
         * enrollment_end: Date enrollment ends
         * enrollment_start: Date enrollment begins
+        * id: A unique identifier of the course; a serialized representation
+            of the opaque key identifying the course.
         * media: An object that contains named media items.  Included here:
             * course_image: An image to show for the course.  Represented
               as an object with the following fields:
@@ -51,6 +52,10 @@ class CourseDetailView(DeveloperErrorViewMixin, RetrieveAPIView):
             * `"string"`: manually set
             * `"timestamp"`: generated form `start` timestamp
             * `"empty"`: the start date should not be shown
+
+        Deprecated fields:
+
+        * course_id: Course key (use 'id' instead)
 
     **Parameters:**
 


### PR DESCRIPTION
This PR changes the `course_id` field name in the Course API to simply `id` for simplicity and consistency with other endpoints.

The `course_id` field name is now deprecated and will be removed once all clients are updated.  The currently known clients are the Solutions and dedX teams.

Reviewers: @aleffert @AlasdairSwan or @BenjiLee 
FYI: @mjfrey 
