### PR TITLE
Disable badge issuance for courses where badges are disabled.

### DIFF
--- a/lms/djangoapps/badges/events/course_complete.py
+++ b/lms/djangoapps/badges/events/course_complete.py
@@ -82,6 +82,8 @@ def get_completion_badge(course_id, user):
         return None
     mode = badge_classes[0].mode
     course = modulestore().get_course(course_id)
+    if not course.issue_badges:
+        return None
     return BadgeClass.get_badge_class(
         slug=course_slug(course_id, mode),
         issuing_component='',

--- a/lms/djangoapps/badges/models.py
+++ b/lms/djangoapps/badges/models.py
@@ -37,6 +37,12 @@ def validate_lowercase(string):
         raise ValidationError(_(u"This value must be all lowercase."))
 
 
+class CourseBadgesDisabledError(Exception):
+    """
+    Exception raised when Course Badges aren't enabled, but an attempt to fetch one is made anyway.
+    """
+
+
 class BadgeClass(models.Model):
     """
     Specifies a badge class to be registered with a backend.
@@ -67,6 +73,8 @@ class BadgeClass(models.Model):
         """
         slug = slug.lower()
         issuing_component = issuing_component.lower()
+        if course_id and not modulestore().get_course(course_id).issue_badges:
+            raise CourseBadgesDisabledError("This course does not have badges enabled.")
         if not course_id:
             course_id = CourseKeyField.Empty
         try:

--- a/lms/djangoapps/badges/service.py
+++ b/lms/djangoapps/badges/service.py
@@ -7,5 +7,22 @@ from badges.models import BadgeClass
 class BadgingService(object):
     """
     A class that provides functions for managing badges which XBlocks can use.
+
+    If course_enabled is True, course-level badges are permitted for this course.
+
+    If it is False, any badges that are awarded should be non-course specific.
     """
+    course_badges_enabled = False
+
+    def __init__(self, course_id=None, modulestore=None):
+        """
+        Sets the 'course_badges_enabled' parameter.
+        """
+        if not (course_id and modulestore):
+            return
+
+        course = modulestore.get_course(course_id)
+        if course:
+            self.course_badges_enabled = course.issue_badges
+
     get_badge_class = BadgeClass.get_badge_class

--- a/lms/djangoapps/badges/tests/test_models.py
+++ b/lms/djangoapps/badges/tests/test_models.py
@@ -12,8 +12,10 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from badges.models import CourseCompleteImageConfiguration, validate_badge_image, BadgeClass, BadgeAssertion, \
+from badges.models import (
+    CourseCompleteImageConfiguration, validate_badge_image, BadgeClass, BadgeAssertion,
     CourseBadgesDisabledError
+)
 from badges.tests.factories import BadgeClassFactory, BadgeAssertionFactory, RandomBadgeClassFactory
 from certificates.tests.test_models import TEST_DATA_ROOT
 from student.tests.factories import UserFactory
@@ -112,12 +114,12 @@ class BadgeClassTest(ModuleStoreTestCase):
         exception.
         """
         course_key = CourseFactory.create(metadata={'issue_badges': False}).location.course_key
-        self.assertRaises(
-            CourseBadgesDisabledError, BadgeClass.get_badge_class,
-            slug='test_slug', issuing_component='test_component', description='Attempted override',
-            criteria='test', display_name='Testola', image_file_handle=get_image('good'),
-            course_id=course_key,
-        )
+        with self.assertRaises(CourseBadgesDisabledError):
+            BadgeClass.get_badge_class(
+                slug='test_slug', issuing_component='test_component', description='Attempted override',
+                criteria='test', display_name='Testola', image_file_handle=get_image('good'),
+                course_id=course_key,
+            )
 
     def test_get_badge_class_create(self):
         """

--- a/lms/djangoapps/badges/tests/test_models.py
+++ b/lms/djangoapps/badges/tests/test_models.py
@@ -12,7 +12,8 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from badges.models import CourseCompleteImageConfiguration, validate_badge_image, BadgeClass, BadgeAssertion
+from badges.models import CourseCompleteImageConfiguration, validate_badge_image, BadgeClass, BadgeAssertion, \
+    CourseBadgesDisabledError
 from badges.tests.factories import BadgeClassFactory, BadgeAssertionFactory, RandomBadgeClassFactory
 from certificates.tests.test_models import TEST_DATA_ROOT
 from student.tests.factories import UserFactory
@@ -104,6 +105,19 @@ class BadgeClassTest(ModuleStoreTestCase):
         )
         self.assertNotEqual(badge_class.id, course_badge_class.id)
         self.assertEqual(course_badge_class.id, premade_badge_class.id)
+
+    def test_get_badge_class_course_disabled(self):
+        """
+        Verify attempting to fetch a badge class for a course which does not issue badges raises an
+        exception.
+        """
+        course_key = CourseFactory.create(metadata={'issue_badges': False}).location.course_key
+        self.assertRaises(
+            CourseBadgesDisabledError, BadgeClass.get_badge_class,
+            slug='test_slug', issuing_component='test_component', description='Attempted override',
+            criteria='test', display_name='Testola', image_file_handle=get_image('good'),
+            course_id=course_key,
+        )
 
     def test_get_badge_class_create(self):
         """

--- a/lms/djangoapps/certificates/management/commands/regenerate_user.py
+++ b/lms/djangoapps/certificates/management/commands/regenerate_user.py
@@ -111,11 +111,13 @@ class Command(BaseCommand):
                 course_id
             )
 
-            badge_class = get_completion_badge(course_id, student)
-            badge = badge_class.get_for_user(student)
-            if badge:
-                badge.delete()
-                LOGGER.info(u"Cleared badge for student %s.", student.id)
+            if course.issue_badges:
+                badge_class = get_completion_badge(course_id, student)
+                badge = badge_class.get_for_user(student)
+
+                if badge:
+                    badge.delete()
+                    LOGGER.info(u"Cleared badge for student %s.", student.id)
 
             # Add the certificate request to the queue
             ret = regenerate_user_certificates(

--- a/lms/djangoapps/certificates/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/tests/test_cert_management.py
@@ -148,6 +148,7 @@ class ResubmitErrorCertificatesTest(CertificateManagementTest):
         self._assert_cert_status(phantom_course, self.user, CertificateStatuses.error)
 
 
+@ddt.ddt
 @attr('shard_1')
 class RegenerateCertificatesTest(CertificateManagementTest):
     """
@@ -162,20 +163,23 @@ class RegenerateCertificatesTest(CertificateManagementTest):
         super(RegenerateCertificatesTest, self).setUp()
         self.course = self.courses[0]
 
+    @ddt.data(True, False)
     @override_settings(CERT_QUEUE='test-queue')
     @patch('certificates.api.XQueueCertInterface', spec=True)
-    def test_clear_badge(self, xqueue):
+    def test_clear_badge(self, issue_badges, xqueue):
         """
         Given that I have a user with a badge
         If I run regeneration for a user
         Then certificate generation will be requested
-        And the badge will be deleted
+        And the badge will be deleted if badge issuing is enabled
         """
         key = self.course.location.course_key
         self._create_cert(key, self.user, CertificateStatuses.downloadable)
         badge_class = get_completion_badge(key, self.user)
         BadgeAssertionFactory(badge_class=badge_class, user=self.user)
         self.assertTrue(BadgeAssertion.objects.filter(user=self.user, badge_class=badge_class))
+        self.course.issue_badges = issue_badges
+        self.store.update_item(self.course, None)
         self._run_command(
             username=self.user.email, course=unicode(key), noop=False, insecure=False, template_file=None,
             grade_value=None
@@ -188,7 +192,9 @@ class RegenerateCertificatesTest(CertificateManagementTest):
             template_file=None,
             generate_pdf=True
         )
-        self.assertFalse(BadgeAssertion.objects.filter(user=self.user, badge_class=badge_class))
+        self.assertEquals(
+            bool(BadgeAssertion.objects.filter(user=self.user, badge_class=badge_class)), not issue_badges
+        )
 
     @override_settings(CERT_QUEUE='test-queue')
     @patch('capa.xqueue_interface.XQueueInterface.send_to_queue', spec=True)

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -14,7 +14,7 @@ from django.test.client import Client
 from django.test.utils import override_settings
 
 from badges.events.course_complete import get_completion_badge
-from badges.tests.factories import BadgeAssertionFactory, CourseCompleteImageConfigurationFactory
+from badges.tests.factories import BadgeAssertionFactory, CourseCompleteImageConfigurationFactory, BadgeClassFactory
 from openedx.core.lib.tests.assertions.events import assert_event_matches
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from student.roles import CourseStaffRole
@@ -223,6 +223,26 @@ class CertificatesViewsTests(ModuleStoreTestCase, EventTrackingTestCase):
             response.content
         )
         self.assertIn('logo_test1.png', response.content)
+
+    @ddt.data(True, False)
+    @patch('certificates.views.webview.get_completion_badge')
+    @override_settings(FEATURES=FEATURES_WITH_BADGES_ENABLED)
+    def test_fetch_badge_info(self, issue_badges, mock_get_completion_badge):
+        """
+        Test: Fetch badge class info if badges are enabled.
+        """
+        badge_class = BadgeClassFactory(course_id=self.course_id, mode=self.cert.mode)
+        mock_get_completion_badge.return_value = badge_class
+
+        self._add_course_certificates(count=1, signatory_count=1, is_active=True)
+        test_url = get_certificate_url(course_id=self.cert.course_id, uuid=self.cert.verify_uuid)
+        response = self.client.get(test_url)
+        self.assertEqual(response.status_code, 200)
+
+        if issue_badges:
+            mock_get_completion_badge.assertCalled()
+        else:
+            mock_get_completion_badge.assertNotCalled()
 
     @override_settings(FEATURES=FEATURES_WITH_BADGES_ENABLED)
     @patch.dict("django.conf.settings.SOCIAL_SHARING_SETTINGS", {

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -361,7 +361,11 @@ def _track_certificate_events(request, context, course, user, user_certificate):
 
     if 'evidence_visit' in request.GET:
         badge_class = get_completion_badge(course_key, user)
-        badges = badge_class.get_for_user(user)
+        if not badge_class:
+            log.warning('Visit to evidence URL for badge, but badges not configured for course "%s"', course_key)
+            badges = []
+        else:
+            badges = badge_class.get_for_user(user)
         if badges:
             # There should only ever be one of these.
             badge = badges[0]
@@ -443,7 +447,7 @@ def _update_badge_context(context, course, user):
     Updates context with badge info.
     """
     badge = None
-    if settings.FEATURES.get('ENABLE_OPENBADGES'):
+    if settings.FEATURES.get('ENABLE_OPENBADGES') and course.issue_badges:
         badges = get_completion_badge(course.location.course_key, user).get_for_user(user)
         if badges:
             badge = badges[0]

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -210,11 +210,12 @@ class LmsModuleSystem(ModuleSystem):  # pylint: disable=abstract-method
             track_function=kwargs.get('track_function', None),
             cache=request_cache_dict
         )
-        services['library_tools'] = LibraryToolsService(modulestore())
+        store = modulestore()
+        services['library_tools'] = LibraryToolsService(store)
         services['fs'] = xblock.reference.plugins.FSService()
         services['settings'] = SettingsService()
         if settings.FEATURES["ENABLE_OPENBADGES"]:
-            services['badging'] = BadgingService()
+            services['badging'] = BadgingService(course_id=kwargs.get('course_id'), modulestore=store)
         self.request_token = kwargs.pop('request_token', None)
         super(LmsModuleSystem, self).__init__(**kwargs)
 

--- a/lms/djangoapps/lms_xblock/test/test_runtime.py
+++ b/lms/djangoapps/lms_xblock/test/test_runtime.py
@@ -190,6 +190,7 @@ class TestUserServiceAPI(TestCase):
             self.runtime.service(self.mock_block, 'user_tags').get_tag('fake_scope', self.key)
 
 
+@ddt
 class TestBadgingService(ModuleStoreTestCase):
     """Test the badging service interface"""
 
@@ -229,17 +230,12 @@ class TestBadgingService(ModuleStoreTestCase):
         runtime = self.create_runtime()
         self.assertFalse(runtime.service(self.mock_block, 'badging'))
 
+    @data(True, False)
     @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
-    def test_course_badges_disabled(self):
-        self.course_id = CourseFactory.create(metadata={'issue_badges': False}).location.course_key
+    def test_course_badges_toggle(self, toggle):
+        self.course_id = CourseFactory.create(metadata={'issue_badges': toggle}).location.course_key
         runtime = self.create_runtime()
-        self.assertFalse(runtime.service(self.mock_block, 'badging').course_badges_enabled)
-
-    @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
-    def test_course_badges_enabled(self):
-        self.course_id = CourseFactory.create(metadata={'issue_badges': True}).location.course_key
-        runtime = self.create_runtime()
-        self.assertTrue(runtime.service(self.mock_block, 'badging').course_badges_enabled)
+        self.assertIs(runtime.service(self.mock_block, 'badging').course_badges_enabled, toggle)
 
     @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
     def test_get_badge_class(self):

--- a/lms/djangoapps/lms_xblock/test/test_runtime.py
+++ b/lms/djangoapps/lms_xblock/test/test_runtime.py
@@ -11,6 +11,7 @@ from urlparse import urlparse
 
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import BlockUsageLocator, CourseLocator, SlashSeparatedCourseKey
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from badges.tests.factories import BadgeClassFactory
 from badges.tests.test_models import get_image
@@ -18,6 +19,7 @@ from lms.djangoapps.lms_xblock.runtime import quote_slashes, unquote_slashes, Lm
 from xblock.fields import ScopeIds
 
 from student.tests.factories import UserFactory
+from xmodule.modulestore.tests.factories import CourseFactory
 
 TEST_STRINGS = [
     '',
@@ -188,15 +190,12 @@ class TestUserServiceAPI(TestCase):
             self.runtime.service(self.mock_block, 'user_tags').get_tag('fake_scope', self.key)
 
 
-class TestBadgingService(TestCase):
+class TestBadgingService(ModuleStoreTestCase):
     """Test the badging service interface"""
 
     def setUp(self):
         super(TestBadgingService, self).setUp()
         self.course_id = CourseKey.from_string('course-v1:org+course+run')
-
-        self.user = User(username='test_robot', email='test_robot@edx.org', password='test', first_name='Test')
-        self.user.save()
 
         self.mock_block = Mock()
         self.mock_block.service_declaration.return_value = 'needs'
@@ -229,6 +228,18 @@ class TestBadgingService(TestCase):
     def test_no_service_rendered(self):
         runtime = self.create_runtime()
         self.assertFalse(runtime.service(self.mock_block, 'badging'))
+
+    @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
+    def test_course_badges_disabled(self):
+        self.course_id = CourseFactory.create(metadata={'issue_badges': False}).location.course_key
+        runtime = self.create_runtime()
+        self.assertFalse(runtime.service(self.mock_block, 'badging').course_badges_enabled)
+
+    @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
+    def test_course_badges_enabled(self):
+        self.course_id = CourseFactory.create(metadata={'issue_badges': True}).location.course_key
+        runtime = self.create_runtime()
+        self.assertTrue(runtime.service(self.mock_block, 'badging').course_badges_enabled)
 
     @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
     def test_get_badge_class(self):


### PR DESCRIPTION
**Description**: Makes the new badging framework respect the `issue_badges` setting on courses.

@itsjeyd @antoviaque @catong @pbaruah 

This should resolve the comment in https://github.com/edx/edx-documentation/pull/735/files#r48468490
