### PR TITLE
Fix Instructor tool "View as Specific Student" doesn't work on the course updates page.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -260,3 +260,4 @@ Jacek Bzdak <jbzdak@gmail.com>
 Jillian Vogel <pomegranited@gmail.com>
 Dan Powell <dan@abakas.com>
 Mariana Araújo <simbelm.ne@gmail.com>
+Muhammad Ayub Khan <ayub.khan@arbisoft.com>

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -242,7 +242,7 @@ def get_course_about_section(request, course, section_key):
     raise KeyError("Invalid about key " + str(section_key))
 
 
-def get_course_info_section_module(request, course, section_key):
+def get_course_info_section_module(request, user, course, section_key):
     """
     This returns the course info module for a given section_key.
 
@@ -255,10 +255,10 @@ def get_course_info_section_module(request, course, section_key):
     usage_key = course.id.make_usage_key('course_info', section_key)
 
     # Use an empty cache
-    field_data_cache = FieldDataCache([], course.id, request.user)
+    field_data_cache = FieldDataCache([], course.id, user)
 
     return get_module(
-        request.user,
+        user,
         request,
         usage_key,
         field_data_cache,
@@ -269,7 +269,7 @@ def get_course_info_section_module(request, course, section_key):
     )
 
 
-def get_course_info_section(request, course, section_key):
+def get_course_info_section(request, user, course, section_key):
     """
     This returns the snippet of html to be rendered on the course info page,
     given the key for the section.
@@ -280,7 +280,7 @@ def get_course_info_section(request, course, section_key):
     - updates
     - guest_updates
     """
-    info_module = get_course_info_section_module(request, course, section_key)
+    info_module = get_course_info_section_module(request, user, course, section_key)
 
     html = ''
     if info_module is not None:

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -277,7 +277,7 @@ class CoursesRenderTest(ModuleStoreTestCase):
 
     def test_get_course_info_section_render(self):
         # Test render works okay
-        course_info = get_course_info_section(self.request, self.course, 'handouts')
+        course_info = get_course_info_section(self.request, self.request.user, self.course, 'handouts')
         self.assertEqual(course_info, u"<a href='/c4x/edX/toy/asset/handouts_sample_handout.txt'>Sample</a>")
 
         # Test when render raises an exception
@@ -285,7 +285,7 @@ class CoursesRenderTest(ModuleStoreTestCase):
             mock_module_render.return_value = mock.MagicMock(
                 render=mock.Mock(side_effect=Exception('Render failed!'))
             )
-            course_info = get_course_info_section(self.request, self.course, 'handouts')
+            course_info = get_course_info_section(self.request, self.request.user, self.course, 'handouts')
             self.assertIn("this module is temporarily unavailable", course_info)
 
     def test_get_course_about_section_render(self):
@@ -315,7 +315,7 @@ class XmlCoursesRenderTest(ModuleStoreTestCase):
         request = get_request_for_user(UserFactory.create())
 
         # Test render works okay. Note the href is different in XML courses.
-        course_info = get_course_info_section(request, course, 'handouts')
+        course_info = get_course_info_section(request, request.user, course, 'handouts')
         self.assertEqual(course_info, "<a href='/static/toy/handouts/sample_handout.txt'>Sample</a>")
 
         # Test when render raises an exception
@@ -323,7 +323,7 @@ class XmlCoursesRenderTest(ModuleStoreTestCase):
             mock_module_render.return_value = mock.MagicMock(
                 render=mock.Mock(side_effect=Exception('Render failed!'))
             )
-            course_info = get_course_info_section(request, course, 'handouts')
+            course_info = get_course_info_section(request, request.user, course, 'handouts')
             self.assertIn("this module is temporarily unavailable", course_info)
 
 

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -41,6 +41,11 @@ class MasqueradeTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         # working properly, we must use start dates and set a start date in the past (otherwise the access
         # checks exist prematurely).
         self.course = CourseFactory.create(number='masquerade-test', metadata={'start': datetime.now(UTC())})
+        # Creates info page and puts random data in it for specific student info page test
+        self.info_page = ItemFactory.create(
+            category="course_info", parent_location=self.course.location,
+            data="OOGIE BLOOGIE", display_name="updates"
+        )
         self.chapter = ItemFactory.create(
             parent_location=self.course.location,
             category="chapter",
@@ -85,6 +90,18 @@ class MasqueradeTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
                 'course_id': unicode(self.course.id),
                 'chapter': self.chapter.location.name,
                 'section': self.sequential.location.name,
+            }
+        )
+        return self.client.get(url)
+
+    def get_course_info_page(self):
+        """
+        Returns the server response for course info page.
+        """
+        url = reverse(
+            'info',
+            kwargs={
+                'course_id': unicode(self.course.id),
             }
         )
         return self.client.get(url)
@@ -297,6 +314,24 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         # Verify the student state did not change.
         self.login_student()
         self.assertEqual(self.get_progress_detail(), u'2/2')
+
+    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    def test_masquerade_as_specific_student_course_info(self):
+        """
+        Test masquerading as a specific user for course info page.
+
+        We login with login_staff and check course info page content if it's working and then we
+        set masquerade to view same page as a specific student and test if it's working or not.
+        """
+        # Log in as staff, and check we can see the info page.
+        self.login_staff()
+        content = self.get_course_info_page().content
+        self.assertIn("OOGIE BLOOGIE", content)
+
+        # Masquerade as the student, and check we can see the info page.
+        self.update_masquerade(role='student', user_name=self.student_user.username)
+        content = self.get_course_info_page().content
+        self.assertIn("OOGIE BLOOGIE", content)
 
 
 @attr('shard_1')

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1152,7 +1152,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
 
     def test_get_course_info_section(self):
         self.course.static_asset_path = "toy_course_dir"
-        get_course_info_section(self.request, self.course, "handouts")
+        get_course_info_section(self.request, self.request.user, self.course, "handouts")
         # NOTE: check handouts output...right now test course seems to have no such content
         # at least this makes sure get_course_info_section returns without exception
 

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -704,9 +704,9 @@ def course_info(request, course_id):
             url_to_enroll = marketing_link('COURSES')
 
         show_enroll_banner = request.user.is_authenticated() and not CourseEnrollment.is_enrolled(user, course.id)
-
         context = {
             'request': request,
+            'masquerade_user': user,
             'course_id': course_key.to_deprecated_string(),
             'cache': None,
             'course': course,

--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -37,7 +37,7 @@ class CourseUpdatesList(generics.ListAPIView):
 
     @mobile_course_access()
     def list(self, request, course, *args, **kwargs):
-        course_updates_module = get_course_info_section_module(request, course, 'updates')
+        course_updates_module = get_course_info_section_module(request, request.user, course, 'updates')
         update_items = get_course_update_items(course_updates_module)
 
         updates_to_show = [
@@ -77,7 +77,7 @@ class CourseHandoutsList(generics.ListAPIView):
 
     @mobile_course_access()
     def list(self, request, course, *args, **kwargs):
-        course_handouts_module = get_course_info_section_module(request, course, 'handouts')
+        course_handouts_module = get_course_info_section_module(request, request.user, course, 'handouts')
         if course_handouts_module:
             handouts_html = course_handouts_module.data
             handouts_html = replace_static_urls(

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -58,7 +58,7 @@ $(document).ready(function(){
       % endif
 
       <h1>${_("Course Updates &amp; News")}</h1>
-      ${get_course_info_section(request, course, 'updates')}
+      ${get_course_info_section(request, masquerade_user, course, 'updates')}
     </section>
     <section aria-label="${_('Handout Navigation')}" class="handouts">
       % if False:
@@ -67,16 +67,16 @@ $(document).ready(function(){
       % endif
 
       <h1>${_(course.info_sidebar_name)}</h1>
-      ${get_course_info_section(request, course, 'handouts')}
+      ${get_course_info_section(request, masquerade_user, course, 'handouts')}
     </section>
     % else:
     <section class="updates">
       <h1>${_("Course Updates &amp; News")}</h1>
-      ${get_course_info_section(request, course, 'guest_updates')}
+      ${get_course_info_section(request, masquerade_user, course, 'guest_updates')}
     </section>
     <section aria-label="${_('Handout Navigation')}" class="handouts">
       <h1>${_("Course Handouts")}</h1>
-      ${get_course_info_section(request, course, 'guest_handouts')}
+      ${get_course_info_section(request, masquerade_user, course, 'guest_handouts')}
     </section>
     % endif
   </div>


### PR DESCRIPTION
Created from https://github.com/edx/edx-platform/pull/10930.

[TNL-3556](https://openedx.atlassian.net/browse/TNL-3556)

**Background:**
The "View as a specific student” feature doesn’t seem to reflect what the student can actually see in Edge. The page is always blank.
To reproduce:
1. As an instructor, create a few posts on the Course Updates page. Enroll a student. Open course by setting start date in the past.
2. On the Course updates page in the LMS, "View as a Specific Student" - see that the page is blank, even though the courseware is available. 
3. As the student, log in to the course to verify that the student can actually see the course updates.

**Solution:**
In courses.py get_course_info_section_module it was sending request user which was staff to get the module. which was causing exception on module_render.py line no 668 as there was no attribute real_user. As it is "View as a specific student" so we should have sent masquerade user to get the module which was created in views.py course_info method. So masquerade user was sent in context and from info.html to get_course_info_section in courses.py and from there it was sent to get_course_info_section_module to call the get_module for masquerade user.

**After Solution:**
![solved](https://cloud.githubusercontent.com/assets/7721119/11719392/52e58b52-9f7c-11e5-9ff0-aea537547213.png)
