### PR TITLE
Make disabled_xblock_types a lambda so that changes do not require app restart

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -1145,7 +1145,7 @@ class ModuleStoreReadBase(BulkOperationsMixin, ModuleStoreRead):
         contentstore=None,
         doc_store_config=None,  # ignore if passed up
         metadata_inheritance_cache_subsystem=None, request_cache=None,
-        xblock_mixins=(), xblock_select=None, disabled_xblock_types=(),  # pylint: disable=bad-continuation
+        xblock_mixins=(), xblock_select=None, disabled_xblock_types=None,  # pylint: disable=bad-continuation
         # temporary parms to enable backward compatibility. remove once all envs migrated
         db=None, collection=None, host=None, port=None, tz_aware=True, user=None, password=None,
         # allow lower level init args to pass harmlessly
@@ -1162,7 +1162,7 @@ class ModuleStoreReadBase(BulkOperationsMixin, ModuleStoreRead):
         self.request_cache = request_cache
         self.xblock_mixins = xblock_mixins
         self.xblock_select = xblock_select
-        self.disabled_xblock_types = disabled_xblock_types
+        self.disabled_xblock_types = disabled_xblock_types or (lambda: ())
         self.contentstore = contentstore
 
     def get_course_errors(self, course_key):

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -171,9 +171,9 @@ def create_modulestore_instance(
         doc_store_config['read_preference'] = getattr(ReadPreference, doc_store_config['read_preference'])
 
     if XBlockDisableConfig and settings.FEATURES.get('ENABLE_DISABLING_XBLOCK_TYPES', False):
-        disabled_xblock_types = XBlockDisableConfig.disabled_block_types()
+        disabled_xblock_types = XBlockDisableConfig.disabled_block_types
     else:
-        disabled_xblock_types = ()
+        disabled_xblock_types = lambda: ()
 
     return class_(
         contentstore=content_store,

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1329,7 +1329,7 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):
     """
     # pylint: disable=bad-continuation
     def __init__(
-        self, load_item, resources_fs, error_tracker, get_policy=None, disabled_xblock_types=(), **kwargs
+        self, load_item, resources_fs, error_tracker, get_policy=None, disabled_xblock_types=None, **kwargs
     ):
         """
         load_item: Takes a Location and returns an XModuleDescriptor
@@ -1387,7 +1387,7 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):
         else:
             self.get_policy = lambda u: {}
 
-        self.disabled_xblock_types = disabled_xblock_types
+        self.disabled_xblock_types = disabled_xblock_types or (lambda: ())
 
     def get_block(self, usage_id, for_parent=None):
         """See documentation for `xblock.runtime:Runtime.get_block`"""
@@ -1397,7 +1397,7 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):
         """
         Returns a subclass of :class:`.XBlock` that corresponds to the specified `block_type`.
         """
-        if block_type in self.disabled_xblock_types:
+        if block_type in self.disabled_xblock_types():
             return self.default_class
         return super(DescriptorSystem, self).load_block_type(block_type)
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -2092,7 +2092,7 @@ class TestDisabledXBlockTypes(ModuleStoreTestCase):
         super(TestDisabledXBlockTypes, self).setUp()
 
         for store in self.store.modulestores:
-            store.disabled_xblock_types = ('video',)
+            store.disabled_xblock_types = lambda: ('video',)
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_get_item(self, default_ms):

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -372,6 +372,7 @@ class ViewsQueryCountTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSet
             with modulestore().default_store(default_store):
                 self.set_up_course(module_count=module_count)
                 self.clear_caches()
+                self.store.disabled_xblock_types()  # Cache this.
                 with self.assertNumQueries(sql_queries):
                     with check_mongo_calls(mongo_calls):
                         func(self, *args, **kwargs)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-2679

https://github.com/edx/edx-platform/pull/8704 added the ability to specific hide XBlocks in LMS. This PR make this configuration dynamic so that changes apply without requiring a restart of app.
