### PR TITLE
fix TNL-767 When students click "check" without submitting an answer,…

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -2134,6 +2134,10 @@ class StringResponse(LoncapaResponse):
         Note: for old code, which supports _or_ separator, we add some  backward compatibility handling.
         Should be removed soon. When to remove it, is up to Lyla Fisher.
         """
+        # if given ans is empty.
+        if not given:
+            return False
+
         _ = self.capa_system.i18n.ugettext
         # backward compatibility, should be removed in future.
         if self.backward:

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -946,6 +946,14 @@ class StringResponseTest(ResponseTest):  # pylint: disable=missing-docstring
         hint = correct_map.get_hint('1_2_1')
         self.assertEqual(hint, self._get_random_number_result(problem.seed))
 
+    def test_empty_answer(self):
+        """
+        This Method checks if question is graded for empty answers if correct answer
+        is also not given. Fails if empty answer is scored.
+        """
+        problem = self.build_problem(answer=" ", case_sensitive=False, regexp=True)
+        self.assert_grade(problem, u" ", "incorrect")
+
 
 class CodeResponseTest(ResponseTest):  # pylint: disable=missing-docstring
     xml_factory_class = CodeResponseXMLFactory


### PR DESCRIPTION
[TNL-767](https://openedx.atlassian.net/browse/TNL-767)

When students click "check" without submitting an answer, our basic problem types respond in inconsistent ways.

**Description**
[See all basic problems here](https://edge.edx.org/courses/edX/JAx/1/courseware/e3a5ff6d6c1c4fdebe1cbb4bade77788/ed72307fb8254e7ebef25e8ad451c276/2)
1. For each problem type, as a student, click "check" without selecting any answer. 
2. Notice that some problems give no credit, and some problems (text response) give credit. 

[See table here (or screenshot) for behavior](https://docs.google.com/spreadsheets/d/1SWLdrrolhYhTTdaF6PiIabMYGQZtbhridY55BogOgrk/edit?usp=sharing)
For check boxes it was already fixed in [TNL-765](https://openedx.atlassian.net/browse/TNL-765)
