### PR TITLE
add sr text for show/hide answer button

### DIFF
--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -29,7 +29,7 @@
     <button class="save" data-value="${_('Save')}">${_('Save')}<span class="sr"> ${_("your answer")}</span></button>
     % endif
     % if answer_available:
-    <button class="show"><span class="show-label">${_('Show Answer')}</span> </button>
+    <button class="show"><span class='sr'>${_('Toggle Answer Visibility')}</span><span class="show-label">${_('Show Answer')}</span></button>
     % endif
     % if attempts_allowed :
     <div class="submission_feedback" aria-live="polite">


### PR DESCRIPTION
## Overview

For [AC-250](https://openedx.atlassian.net/browse/AC-250).

"The button within problems that says Show Answer, when clicked, turns to Hide Answer. The button itself doesn't announce as a toggle. We either need to make this button a toggle (so the user understands it can be clicked on/off), or change the control to be something that would suggest the equivalent."
## Solution

The most straight-forward solution seems to be giving the screenreader a bit more context via an `.sr` element.

@cptvitamin @clrux  Please review.
