### PR TITLE
remove aria-hidden from staff lms controls

### DIFF
--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -21,7 +21,7 @@ ${block_content}
   </div>
 %  endif
 %  if not disable_staff_debug_info:
-<div class="wrap-instructor-info" aria-hidden="true">
+<div class="wrap-instructor-info">
   <a class="instructor-info-action" href="#${element_id}_debug" id="${element_id}_trig">${_("Staff Debug Info")}</a>
 
   %  if settings.FEATURES.get('ENABLE_STUDENT_HISTORY_VIEW') and \


### PR DESCRIPTION
## Overview

[AC-303](https://openedx.atlassian.net/browse/AC-303)
The `.instructor-info-action` links (submission history, staff debug info, etc.) in the courseware are aria-hidden.  This means a staff user that is using a screenreader would not be able to access them.   This PR removes `aria-hidden="true"` from these links.

@clrux @cptvitamin Please review.
