### PR TITLE
Allow removing upgrade deadlines through the Commerce API.

### DIFF
--- a/lms/djangoapps/commerce/api/v1/models.py
+++ b/lms/djangoapps/commerce/api/v1/models.py
@@ -87,8 +87,7 @@ class Course(object):
             merged_mode.min_price = posted_mode.min_price
             merged_mode.currency = posted_mode.currency
             merged_mode.sku = posted_mode.sku
-            if posted_mode.expiration_datetime is not None:
-                merged_mode.expiration_datetime = posted_mode.expiration_datetime
+            merged_mode.expiration_datetime = posted_mode.expiration_datetime
             merged_mode.save()
 
             merged_modes.add(merged_mode)


### PR DESCRIPTION
@rlucioni @clintonb While working on https://github.com/edx/edx-platform/pull/11099 I noticed a similar bug lurking in the commerce API, with a similarly quick fix.

FYI @mikigoyal 
