### PR TITLE
Xmodule: Syncing up blue with LMS

### DIFF
--- a/common/lib/xmodule/xmodule/css/sequence/display.scss
+++ b/common/lib/xmodule/xmodule/css/sequence/display.scss
@@ -1,5 +1,5 @@
 $sequence--border-color: #C8C8C8;
-$link-color: rgb(26, 161, 222);
+$link-color: rgb(0, 120, 176); // from LMS _variables
 // repeated extends - needed since LMS styling was referenced
 .block-link {
   border-left: 1px solid lighten($sequence--border-color, 10%);
@@ -303,4 +303,3 @@ nav.sequence-bottom {
     outline: none;
   }
 }
-


### PR DESCRIPTION
## Problem

A while back we updated the LMS variable for `$blue` to be a bit darker so it'd pass accessibility contrast checks on white and light gray (where it's used). There was another variable in an Xblock for the old, lighter color. In order to keep things synced up, I've updated the color of the Xblock blue to match that of the LMS, which will also allow it to pass checks.
## Solution

Updated the variable color to match that of the LMS.
## Reviewers
- [ ] @talbs 
