### PR TITLE
Allow searching enrollments by email as well as username.

### DIFF
--- a/lms/djangoapps/support/static/support/templates/enrollment.underscore
+++ b/lms/djangoapps/support/static/support/templates/enrollment.underscore
@@ -6,7 +6,7 @@
             type="text"
             name="query"
             value="<%- user %>"
-            placeholder="<%- gettext('Username') %>">
+            placeholder="<%- gettext('Username or email address') %>">
         </input>
         <input type="submit" value="<%- gettext('Search') %>" class="btn-disable-on-submit"></input>
     </form>

--- a/lms/djangoapps/support/urls.py
+++ b/lms/djangoapps/support/urls.py
@@ -11,5 +11,9 @@ urlpatterns = patterns(
     url(r'^certificates/?$', views.CertificatesSupportView.as_view(), name="certificates"),
     url(r'^refund/?$', views.RefundSupportView.as_view(), name="refund"),
     url(r'^enrollment/?$', views.EnrollmentSupportView.as_view(), name="enrollment"),
-    url(r'^enrollment/(?P<username>[\w.@+-]+)?$', views.EnrollmentSupportListView.as_view(), name="enrollment_list"),
+    url(
+        r'^enrollment/(?P<username_or_email>[\w.@+-]+)?$',
+        views.EnrollmentSupportListView.as_view(),
+        name="enrollment_list"
+    ),
 )


### PR DESCRIPTION
I noticed yesterday that Dave was trying to use a learner's email address in the enrollment support tool (https://openedx.atlassian.net/browse/DEVOPS-3444). The other support tools take either a username or email address, so I've added that functionality here.

@bderusha, since you reviewed the original code can you take a look?
