### PR TITLE
Speed up Sass compilation with libsass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
-gem 'sass', '3.3.5'
 gem 'bourbon', '~> 4.0.2'
 gem 'neat', '~> 1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     neat (1.6.0)
       bourbon (>= 3.1)
       sass (>= 3.3)
-    sass (3.3.5)
+    sass (3.4.21)
     thor (0.19.1)
 
 PLATFORMS
@@ -16,4 +16,3 @@ PLATFORMS
 DEPENDENCIES
   bourbon (~> 4.0.2)
   neat (~> 1.6.0)
-  sass (= 3.3.5)

--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,7 @@ dependencies:
     # Install a version which falls within that range.
     - pip install  --exists-action w pbr==0.9.0
     - pip install --exists-action w -r requirements/edx/base.txt
+    - pip install --exists-action w -r requirements/edx/paver.txt
     - if [ -e requirements/edx/post.txt ]; then pip install --exists-action w -r requirements/edx/post.txt ; fi
 
     - pip install coveralls==1.0

--- a/common/static/sass/bourbon/addons/_directional-values.scss
+++ b/common/static/sass/bourbon/addons/_directional-values.scss
@@ -49,7 +49,7 @@
   @return false;
 }
 
-@mixin directional-property($pre, $suf, $vals) {
+@mixin directional-property($pre, $suf, $vals...) {
   // Property Names
   $top:    $pre + "-top"    + if($suf, "-#{$suf}", "");
   $bottom: $pre + "-bottom" + if($suf, "-#{$suf}", "");

--- a/pavelib/acceptance_test.py
+++ b/pavelib/acceptance_test.py
@@ -30,7 +30,7 @@ __test__ = False  # do not collect
 ])
 def test_acceptance(options):
     """
-    Run the acceptance tests for the either lms or cms
+    Run the acceptance tests for either lms or cms
     """
     opts = {
         'fasttest': getattr(options, 'fasttest', False),

--- a/pavelib/paver_tests/test_assets.py
+++ b/pavelib/paver_tests/test_assets.py
@@ -1,0 +1,58 @@
+"""Unit tests for the Paver asset tasks."""
+
+import ddt
+from paver.easy import call_task
+
+from .utils import PaverTestCase
+
+
+@ddt.ddt
+class TestPaverAssetTasks(PaverTestCase):
+    """
+    Test the Paver asset tasks.
+    """
+    @ddt.data(
+        [""],
+        ["--force"],
+        ["--debug"],
+        ["--system=lms"],
+        ["--system=lms --force"],
+        ["--system=studio"],
+        ["--system=studio --force"],
+        ["--system=lms,studio"],
+        ["--system=lms,studio --force"],
+    )
+    @ddt.unpack
+    def test_compile_sass(self, options):
+        """
+        Test the "compile_sass" task.
+        """
+        parameters = options.split(" ")
+        system = []
+        if "--system=studio" not in parameters:
+            system += ["lms"]
+        if "--system=lms" not in parameters:
+            system += ["studio"]
+        debug = "--debug" in parameters
+        force = "--force" in parameters
+        self.reset_task_messages()
+        call_task('pavelib.assets.compile_sass', options={"system": system, "debug": debug, "force": force})
+        expected_messages = []
+        if force:
+            expected_messages.append("rm -rf common/static/css/*.css")
+        expected_messages.append("libsass common/static/sass")
+        if "lms" in system:
+            if force:
+                expected_messages.append("rm -rf lms/static/css/*.css")
+            expected_messages.append("libsass lms/static/sass")
+            if force:
+                expected_messages.append("rm -rf lms/static/css/*.css")
+            expected_messages.append("libsass lms/static/themed_sass")
+            if force:
+                expected_messages.append("rm -rf lms/static/certificates/css/*.css")
+            expected_messages.append("libsass lms/static/certificates/sass")
+        if "studio" in system:
+            if force:
+                expected_messages.append("rm -rf cms/static/css/*.css")
+            expected_messages.append("libsass cms/static/sass")
+        self.assertEquals(self.task_messages, expected_messages)

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -24,6 +24,7 @@ PYTHON_REQ_FILES = [
     'requirements/edx/github.txt',
     'requirements/edx/local.txt',
     'requirements/edx/base.txt',
+    'requirements/edx/paver.txt',
     'requirements/edx/post.txt',
 ]
 

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -5,3 +5,4 @@ lazy==1.1
 path.py==7.2
 watchdog==0.7.1
 python-memcached
+libsass==0.10.0


### PR DESCRIPTION
Note that this is not even the slightest attempt at the brave new world of a better pipeline -- it's just taking what we have and swapping out the ruby sass compilation for using a python binding over the C++ libsass for performance glory. We could probably make this even faster with multiprocessing, but I'm working on baby steps for the moment. :-P
- [ ] Do diffs on generated CSS between master and this branch, investigate any differences
- [ ] Fix paverlib tests (it's mostly testing to see that certain commands have been called, which is no longer relevant).
- [ ] Make sure there's a watch mechanism for Sass that doesn't recompile everything (there's no ./sass-cache with libsass).
- [ ] Update docs and comments

Reducing the scope of this to only be the switchover to libsass, with the Ruby removal to come in a follow-on PR.
