### PR TITLE
Remove hardcoded url for Sysmath

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1136,3 +1136,6 @@ PROCTORING_SETTINGS = {}
 
 # OpenID Connect issuer ID. Normally the URL of the authentication endpoint.
 OAUTH_OIDC_ISSUER = 'https://www.example.com/oauth2'
+
+# URL which is used to convert math formula to Content MathML in Symbolic Response problem.
+SYMMATH_URL = 'https://math-xserver.mitx.mit.edu/snuggletex-webapp-1.2.2/ASCIIMathMLUpConversionDemo'

--- a/common/lib/symmath/symmath/formula.py
+++ b/common/lib/symmath/symmath/formula.py
@@ -17,6 +17,8 @@ import re
 import logging
 import operator
 import requests
+
+from django.conf import settings
 import sympy
 from sympy.printing.latex import LatexPrinter
 from sympy.printing.str import StrPrinter
@@ -591,7 +593,6 @@ class formula(object):
         """
         Handle requests to snuggletex API to convert the Ascii math to MathML
         """
-        url = 'https://math-xserver.mitx.mit.edu/snuggletex-webapp-1.2.2/ASCIIMathMLUpConversionDemo'
 
         payload = {
             'asciiMathInput': asciimath,
@@ -600,7 +601,7 @@ class formula(object):
         headers = {
             'User-Agent': "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13"
         }
-        request = requests.post(url, data=payload, headers=headers, verify=False)
+        request = requests.post(settings.SYMMATH_URL, data=payload, headers=headers, verify=False)
         request.encoding = 'utf-8'
         ret = request.text
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2658,3 +2658,6 @@ FINANCIAL_ASSISTANCE_MAX_LENGTH = 2500
 
 # Course Content Bookmarks Settings
 MAX_BOOKMARKS_PER_COURSE = 100
+
+# URL which is used to convert math formula to Content MathML in Symbolic Response problem.
+SYMMATH_URL = 'https://math-xserver.mitx.mit.edu/snuggletex-webapp-1.2.2/ASCIIMathMLUpConversionDemo'


### PR DESCRIPTION
[TNL-3897 - Remove hard-codes url to MITx server (symmath/formula.py)](https://openedx.atlassian.net/browse/TNL-3897)
## Problem

Remove the hard-coded url from [symmath/formula.py](https://github.com/edx/edx-platform/blob/master/common/lib/capa/capa/responsetypes.py#L2618)
## Solution

> @adampalay I vote for moving the URL into a settings file. 
