### PR TITLE
Resolving errors for selenium upgrade.

### DIFF
--- a/common/test/acceptance/pages/lms/edxnotes.py
+++ b/common/test/acceptance/pages/lms/edxnotes.py
@@ -384,7 +384,7 @@ class EdxNotesUnitPage(CoursePage):
         Moves mouse to the element that matches `selector(str)`.
         """
         body = self.q(css=selector)[0]
-        ActionChains(self.browser).move_to_element(body).release().perform()
+        ActionChains(self.browser).move_to_element(body).perform()
         return self
 
     def click(self, selector):
@@ -532,7 +532,7 @@ class EdxNoteHighlight(NoteChild):
         """
         Creates selection for the element and clicks `add note` button.
         """
-        ActionChains(self.browser).double_click(self.element).release().perform()
+        ActionChains(self.browser).double_click(self.element).perform()
         self.wait_for_adder_visibility()
         self.q(css=self._bounded_selector(self.ADDER_SELECTOR)).first.click()
         self.wait_for_editor_visibility()
@@ -542,7 +542,7 @@ class EdxNoteHighlight(NoteChild):
         """
         Clicks on the highlighted text.
         """
-        ActionChains(self.browser).move_to_element(self.element).click().release().perform()
+        ActionChains(self.browser).move_to_element(self.element).click().perform()
         return self
 
     def click_on_viewer(self):
@@ -556,7 +556,7 @@ class EdxNoteHighlight(NoteChild):
         """
         Hover over highlighted text -> shows note.
         """
-        ActionChains(self.browser).move_to_element(self.element).release().perform()
+        ActionChains(self.browser).move_to_element(self.element).perform()
         self.wait_for_viewer_visibility()
         return self
 


### PR DESCRIPTION
These action chains are invalid for later versions of selenium (which are needed for upgrading the version of firefox we test on); they will result in output like this:

```
 WebDriverException: Message: UnknownError: Cannot release a button when no button is pressed.'UnknownError: Cannot release a button when no button is pressed.' when calling method: [wdIMouse::up]
   Stacktrace:
       at FirefoxDriver.prototype.mouseButtonUp (file:///tmp/tmp6LL1Ye/extensions/fxdriver@googlecode.com/components/driver-component.js:10979)
       at DelayedCommand.prototype.executeInternal_/h (file:///tmp/tmp6LL1Ye/extensions/fxdriver@googlecode.com/components/command-processor.js:12534)
       at DelayedCommand.prototype.executeInternal_ (file:///tmp/tmp6LL1Ye/extensions/fxdriver@googlecode.com/components/command-processor.js:12539)
       at DelayedCommand.prototype.execute/< (file:///tmp/tmp6LL1Ye/extensions/fxdriver@googlecode.com/components/command-processor.js:12481)

```
