### PR TITLE
Allowed CCX coaches to see individual students progress from grade book

### DIFF
--- a/lms/djangoapps/ccx/custom_exception.py
+++ b/lms/djangoapps/ccx/custom_exception.py
@@ -1,0 +1,17 @@
+"""
+This file has custom exceptions for ccx
+"""
+
+
+class CCXUserValidationException(Exception):
+    """
+    Custom Exception for validation of users in CCX
+    """
+    pass
+
+
+class CCXLocatorValidationException(Exception):
+    """
+    Custom Exception to validate CCX locator
+    """
+    pass

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -29,15 +29,9 @@ from student.roles import CourseCcxCoachRole
 
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import get_override_for_ccx
+from lms.djangoapps.ccx.custom_exception import CCXUserValidationException
 
 log = logging.getLogger("edx.ccx")
-
-
-class CCXUserValidationException(Exception):
-    """
-    Custom Exception for validation of users in CCX
-    """
-    pass
 
 
 def get_ccx_from_ccx_locator(course_id):

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -33,7 +33,7 @@ from rest_framework import status
 import newrelic.agent
 
 from courseware import grades
-from courseware.access import has_access, _adjust_start_date_for_beta_testers
+from courseware.access import has_access, has_ccx_coach_role, _adjust_start_date_for_beta_testers
 from courseware.access_response import StartDateError
 from courseware.access_utils import in_preview_mode
 from courseware.courses import (
@@ -97,6 +97,7 @@ from util.views import ensure_valid_course_key
 from eventtracking import tracker
 import analytics
 from courseware.url_helpers import get_redirect_url
+from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 
 from lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
@@ -918,7 +919,7 @@ def course_about(request, course_id):
 def progress(request, course_id, student_id=None):
     """ Display the progress page. """
 
-    course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    course_key = CourseKey.from_string(course_id)
 
     with modulestore().bulk_operations(course_key):
         return _progress(request, course_key, student_id)
@@ -940,13 +941,19 @@ def _progress(request, course_key, student_id):
         return redirect(reverse('course_survey', args=[unicode(course.id)]))
 
     staff_access = bool(has_access(request.user, 'staff', course))
+    try:
+        coach_access = has_ccx_coach_role(request.user, course_key)
+    except CCXLocatorValidationException:
+        coach_access = False
+
+    has_access_on_students_profiles = staff_access or coach_access
 
     if student_id is None or student_id == request.user.id:
         # always allowed to see your own profile
         student = request.user
     else:
         # Requesting access to a different student's profile
-        if not staff_access:
+        if not has_access_on_students_profiles:
             raise Http404
         try:
             student = User.objects.get(id=student_id)


### PR DESCRIPTION
### Background

https://github.com/mitocw/edx-platform/issues/88
### What is done in this PR

**Studio Updates:** None.
**LMS Updates:** 
- Coach can open grade book and click on student name to see his progress on CCX.

@pdpinch @giocalitri @justinabrahms 
- Enrollment tab on coach dashboard.
  ![screen shot 2015-12-29 at 5 32 23 pm](https://cloud.githubusercontent.com/assets/10431250/12034462/0d2b9e36-ae53-11e5-90ab-983fb7b640ed.png)
- Coach can open grade book from Student Admin tab from his dashboard
  ![screen shot 2015-12-29 at 5 32 33 pm](https://cloud.githubusercontent.com/assets/10431250/12034440/db7a8794-ae52-11e5-8546-37f93b8f536b.png)
- On grade book coach can click on student name to see his progress.
  ![screen shot 2015-12-29 at 5 32 40 pm](https://cloud.githubusercontent.com/assets/10431250/12034441/db7f5f08-ae52-11e5-8ae4-01a518a8bdb5.png)
