### PR TITLE
Fix help targets in Instructor Dashboard

### DIFF
--- a/common/test/acceptance/tests/discussion/test_cohort_management.py
+++ b/common/test/acceptance/tests/discussion/test_cohort_management.py
@@ -88,12 +88,12 @@ class CohortConfigurationTest(EventsTestMixin, UniqueCourseTest, CohortTestMixin
         """
         self.verify_cohort_description(
             self.manual_cohort_name,
-            'Students are added to this cohort only when you provide '
+            'Learners are added to this cohort only when you provide '
             'their email addresses or usernames on this page',
         )
         self.verify_cohort_description(
             self.auto_cohort_name,
-            'Students are added to this cohort automatically',
+            'Learners are added to this cohort automatically',
         )
 
     def test_no_content_groups(self):

--- a/lms/static/js/spec/groups/views/cohorts_spec.js
+++ b/lms/static/js/spec/groups/views/cohorts_spec.js
@@ -240,8 +240,9 @@ define(['backbone', 'jquery', 'common/js/spec_helpers/ajax_helpers', 'common/js/
                     )
                 );
                 assignmentType = assignmentType || MOCK_MANUAL_ASSIGNMENT;
-                var manualMessage = "Students are added to this cohort only when you provide their email addresses or usernames on this page.";
-                var randomMessage = "Students are added to this cohort automatically.";
+                var manualMessage = "Learners are added to this cohort only when you provide their email addresses " +
+                    "or usernames on this page.";
+                var randomMessage = "Learners are added to this cohort automatically.";
                 var message = (assignmentType == MOCK_MANUAL_ASSIGNMENT) ? manualMessage : randomMessage;
                 expect(header.find('.cohort-management-group-setup .setup-value').text().trim().split('\n')[0]).toBe(message);
             };

--- a/lms/templates/instructor/instructor_dashboard_2/cohort-group-header.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort-group-header.underscore
@@ -11,11 +11,11 @@
 <div class="cohort-management-group-setup">
     <div class="setup-value">
         <% if (cohort.get('assignment_type') == "manual") { %>
-            <%- gettext("Students are added to this cohort only when you provide their email addresses or usernames on this page.") %>
-            <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/cohorts/cohort_config.html#assign-students-to-cohort-groups-manually" class="incontext-help action-secondary action-help"><%= gettext("What does this mean?") %></a>
+            <%- gettext("Learners are added to this cohort only when you provide their email addresses or usernames on this page.") %>
+            <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohort_config.html#assign-learners-to-cohorts-manually" class="incontext-help action-secondary action-help"><%= gettext("What does this mean?") %></a>
         <% } else { %>
-            <%- gettext("Students are added to this cohort automatically.") %>
-            <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/cohorts/cohorts_overview.html#all-automated-assignment" class="incontext-help action-secondary action-help"><%- gettext("What does this mean?") %></a>
+            <%- gettext("Learners are added to this cohort automatically.") %>
+            <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohorts_overview.html#all-automated-assignment" class="incontext-help action-secondary action-help"><%- gettext("What does this mean?") %></a>
         <% } %>
     </div>
 </div>


### PR DESCRIPTION
This PR fixes the help targets linked from the Cohorts page in the Instructor Dashboard; also changes the 2 instances of "student" to "learner"

Tracked in DOC-2560
### Reviewers
- [x] T&L reviewer: @andy-armstrong 
- [x] Product owner: @explorerleslie 
- [x] Doc team sanity check: @pdesjardins 
### Post-review
- [x] Squash commits
