### PR TITLE
LMS: darkening a gray on the profile page

### DIFF
--- a/common/test/acceptance/pages/lms/learner_profile.py
+++ b/common/test/acceptance/pages/lms/learner_profile.py
@@ -253,10 +253,6 @@ class LearnerProfilePage(FieldsMixin, PageObject):
         self.wait_for_ajax()
 
         self.wait_for_element_visibility('.image-wrapper', "remove button is visible")
-        self.browser.execute_script('$(".u-field-remove-button").css("opacity",1);')
-        self.mouse_hover(self.browser.find_element_by_css_selector('.image-wrapper'))
-
-        self.wait_for_element_visibility('.u-field-remove-button', "remove button is visible")
         self.q(css='.u-field-remove-button').first.click()
 
         self.wait_for_ajax()

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -767,7 +767,6 @@ class LearnerProfileA11yTest(LearnerProfileTestMixin, WebAppTest):
 
         profile_page.a11y_audit.config.set_rules({
             "ignore": [
-                'color-contrast',  # TODO: AC-232
                 'skip-link',  # TODO: AC-179
                 'link-href',  # TODO: AC-231
             ],

--- a/lms/static/sass/base/_mixins.scss
+++ b/lms/static/sass/base/_mixins.scss
@@ -39,8 +39,6 @@
 
 @mixin show-hover-state() {
     opacity: 1;
-    background-color: $shadow-d2;
-    border-radius: ($baseline/4);
 }
 
 @function em($pxval, $base: 16) {

--- a/lms/static/sass/shared/_fields.scss
+++ b/lms/static/sass/shared/_fields.scss
@@ -12,7 +12,7 @@
         border-radius: 3px;
 
         span {
-            color: $gray-l1;
+            color: $gray;
         }
 
         &:hover {

--- a/lms/static/sass/views/_learner-profile.scss
+++ b/lms/static/sass/views/_learner-profile.scss
@@ -43,6 +43,7 @@
             position: relative;
 
             .image-frame {
+                display: block;
                 position: relative;
                 width: $profile-image-dimension;
                 height: $profile-image-dimension;
@@ -50,19 +51,27 @@
             }
 
             .u-field-upload-button {
-                width: $profile-image-dimension;
-                height: $profile-image-dimension;
                 position: absolute;
                 top: 0;
-                opacity: 0;
+                width: $profile-image-dimension;
+                height: $profile-image-dimension;
+                border-radius: ($baseline/4);
+                border: 2px dashed transparent;
+                background: rgba(229,241,247, .8);
+                color: $link-color;
+                text-shadow: none;
                 @include transition(all $tmg-f1 ease-in-out 0s);
+                opacity: 0;
+                z-index: 6;
 
                 i {
-                    color: $white;
+                    color: $link-color;
                 }
 
-                &:focus {
+                &:focus,
+                &:hover {
                     @include show-hover-state();
+                    border-color: $link-color;
                 }
             }
 
@@ -70,50 +79,34 @@
                 @include show-hover-state();
             }
 
-            .upload-button-icon, .upload-button-title {
-                text-align: center;
-                transform: translateY(35px);
-                -webkit-transform: translateY(35px);
+            .upload-button-icon,
+            .upload-button-title {
                 display: block;
-                color: $white;
                 margin-bottom: ($baseline/4);
+                @include transform(translateY(35px));
                 line-height: 1.3em;
+                text-align: center;
+                z-index: 7;
             }
 
             .upload-button-input {
+                position: absolute;
+                top: -($profile-image-dimension);
+                @include left(0);
                 width: $profile-image-dimension;
                 height: 100%;
-                position: absolute;
-                top: 0;
-                @include left(0);
-                opacity: 0;
                 cursor: pointer;
+                z-index: 5;
+                outline: 0;
             }
 
             .u-field-remove-button {
-                width: $profile-image-dimension;
-                height: $baseline;
-                opacity: 0;
                 position: relative;
-                margin-top: 2px;
+                display: block;
+                width: $profile-image-dimension;
+                margin-top: ($baseline / 4);
+                padding: ($baseline / 5);
                 text-align: center;
-
-                &:active {
-                    box-shadow: none;
-                    outline: 0;
-                }
-                &:focus {
-                    @include show-hover-state();
-                    box-shadow: none;
-                    outline: 0;
-                    border: 2px dashed $link-color !important;
-                }
-            }
-
-            &:hover, &:focus {
-                .u-field-upload-button, .u-field-remove-button {
-                    @include show-hover-state();
-                }
             }
         }
     }


### PR DESCRIPTION
This work relates to [AC-201](https://openedx.atlassian.net/browse/AC-201) and [AC-232](https://openedx.atlassian.net/browse/AC-232) and darkens the gray placeholder "readonly" text on the Profile page. It also provides sufficient contrast for the "remove" button, but in order to do this, I had to change _how_ the button is hidden and shown.

The accessibility test was throwing an error on the "remove" button because its opacity was set to zero. The text was essentially reading as white on white. I've updated the "remove" button to always be visible when a profile image is uploaded.

Additionally, the "upload an image" button on hover failed contrast, so I took liberties to make the hover appear like the other profile hovers (blue, rather than the gray).

Before Brian left he saw this and was okay with it, but never got a chance to get this across the line before he left.
## Screenshots
### Before

<img width="157" alt="screen shot 2016-02-04 at 8 48 28 am" src="https://cloud.githubusercontent.com/assets/2112024/12816845/c2dc8002-cb1c-11e5-8050-a5f63275ed6f.png">
<img width="145" alt="screen shot 2016-02-04 at 8 48 56 am" src="https://cloud.githubusercontent.com/assets/2112024/12816848/c793b3a4-cb1c-11e5-84ed-8bfab031c9ef.png">
### After

<img width="156" alt="screen shot 2016-02-04 at 8 57 42 am" src="https://cloud.githubusercontent.com/assets/2112024/12816959/62a50258-cb1d-11e5-8f5a-4b86e4403fa9.png">
<img width="155" alt="screen shot 2016-02-04 at 8 57 48 am" src="https://cloud.githubusercontent.com/assets/2112024/12816961/66390a72-cb1d-11e5-9f9a-8522fb0374a3.png">
## Sandbox

http://clrux-ac-201.sandbox.edx.org/u/staff
## Reviewers
- [x] @benpatterson 
