### PR TITLE
lms: Only show welcome video if show_homepage_promo_video is set

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -264,3 +264,4 @@ Mariana Araújo <simbelm.ne@gmail.com>
 Muhammad Ayub Khan <ayub.khan@arbisoft.com>
 Kaloian Doganov <doganov@gmail.com>
 Sanford Student <sstudent@edx.org>
+Florian Haas <florian@hastexo.com>

--- a/common/test/acceptance/tests/lms/test_lms_index.py
+++ b/common/test/acceptance/tests/lms/test_lms_index.py
@@ -48,9 +48,8 @@ class LmsIndexPageTest(BaseLmsIndexTest):
         # Ensure the introduction video element is not shown
         self.assertFalse(self.page.intro_video_element.visible)
 
-        # @fghaas: The below presence check can now be modified along with your changeset
         # Still need to figure out how to swap platform settings in the context of a bok choy test
         # but we can at least prevent accidental exposure with these validations going forward
         # Note: 'present' is a DOM check, whereas 'visible' is an actual browser/screen check
-        self.assertTrue(self.page.video_modal_element.present)
+        self.assertFalse(self.page.video_modal_element.present)
         self.assertFalse(self.page.video_modal_element.visible)

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -53,16 +53,18 @@ from django.core.urlresolvers import reverse
 
 </section>
 
-<section id="video-modal" class="modal home-page-video-modal video-modal">
-  <div class="inner-wrapper">
-    <%
-      youtube_video_id = homepage_promo_video_youtube_id
-      if self.stanford_theme_enabled():
-        youtube_video_id = "2gmreZObCY4"
-    %>
-    <iframe title="YouTube Video" width="640" height="360" src="//www.youtube.com/embed/${youtube_video_id}?showinfo=0" frameborder="0" allowfullscreen></iframe>
-  </div>
-</section>
+% if show_homepage_promo_video:
+  <section id="video-modal" class="modal home-page-video-modal video-modal">
+    <div class="inner-wrapper">
+      <%
+        youtube_video_id = homepage_promo_video_youtube_id
+        if self.stanford_theme_enabled():
+          youtube_video_id = "2gmreZObCY4"
+      %>
+      <iframe title="YouTube Video" width="640" height="360" src="//www.youtube.com/embed/${youtube_video_id}?showinfo=0" frameborder="0" allowfullscreen></iframe>
+    </div>
+  </section>
+% endif
 
 <%block name="js_extra">
    <script type="text/javascript">


### PR DESCRIPTION
While `show_homepage_promo_video` would previously toggle the control to play the welcome video on and off, the YouTube embed iframe would be included in `index.html` unconditionally. This created the ugly situation that YouTube would try to pull in a non-existent video, and that a DoubleClick tracking beacon would be introduced to the start page for no reason.

Instead, make sure `show_homepage_promo_video` toggles the entire modal video section on and off, suppressing it altogether unless `show_homepage_promo_video` is set.
