### PR TITLE
SOL-1431: Remove no-op translations from devstack.py

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -162,17 +162,16 @@ FEATURES['CERTIFICATES_HTML_VIEW'] = True
 
 
 ########################## Course Discovery #######################
-_ = lambda s: s
-LANGUAGE_MAP = {'terms': {lang: display for lang, display in ALL_LANGUAGES}, 'name': _('Language')}
+LANGUAGE_MAP = {'terms': {lang: display for lang, display in ALL_LANGUAGES}, 'name': 'Language'}
 COURSE_DISCOVERY_MEANINGS = {
     'org': {
-        'name': _('Organization'),
+        'name': 'Organization',
     },
     'modes': {
-        'name': _('Course Type'),
+        'name': 'Course Type',
         'terms': {
-            'honor': _('Honor'),
-            'verified': _('Verified'),
+            'honor': 'Honor',
+            'verified': 'Verified',
         },
     },
     'language': LANGUAGE_MAP,


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly Review this PR, it contains changes for [SOL-1431](https://openedx.atlassian.net/browse/SOL-1431).

**Description of [SOL-1431](https://openedx.atlassian.net/browse/SOL-1431):**

This is a setting in `lms/envs/devstack.py`. It used Django translations. We had to change those for the Django 1.8 upgrade, to be no-op translations. We didn't understand why there were translated strings there in the first place, nor why this setting is set in `devstack.py` and nowhere else.
I think we should remove the `_()` function invocations entirely, since there seems to be no point to them. But we thought perhaps a Solutions person would know better.

cc: @mattdrayer , @nedbat 
