### PR TITLE
Disable Courseware JS from loading on Student Dashboard.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -710,6 +710,7 @@ def dashboard(request):
         'courses_requirements_not_met': courses_requirements_not_met,
         'nav_hidden': True,
         'course_programs': course_programs,
+        'disable_courseware_js': True,
     }
 
     return render_to_response('dashboard.html', context)


### PR DESCRIPTION
This would remove lms-modules.js (133K compressed, 510K uncompressed -- one of the most expensive assets after thumbnails are activated) from the student dashboard, which doesn't seem to use it for anything.

@andy-armstrong, @dianakhuang, @rlucioni: Is there any reason not to do this?
