### PR TITLE
Fix failing condition for firefox 42.

### DIFF
--- a/common/test/acceptance/pages/studio/users.py
+++ b/common/test/acceptance/pages/studio/users.py
@@ -80,6 +80,7 @@ class UsersPageMixin(PageObject):
         """ Submit the "New User" form """
         self.q(css='.form-create.create-user .action-primary').click()
         wait_for_ajax_or_reload(self.browser)
+        self.wait_for_element_visibility('.user-list', 'wait for team to load')
 
     def get_user(self, email):
         """ Gets user wrapper by email """


### PR DESCRIPTION
Firefox 42 is faster than the version we're currently using for platform tests. This failure
occurs in the brief amount of time where the teams page is reloading. Waiting for the actual
team list to appear before moving on with tests solves the issue. Approx 4 testcases are fixed.

Below is an example of error that was appearing in firefox 42 tests:

```
Error Message

Not on the correct page to use '<common.test.acceptance.pages.studio.users.CourseTeamPage object at 0x7feb9fdb0490>' at URL 'http://localhost:8031/course_team/course-v1:test_org+321550032104190792981383915127220335686+test_run'
-------------------- >> begin captured logging << --------------------
bok_choy.browser: INFO: Using local browser: firefox [Default is firefox]
--------------------- >> end captured logging << ---------------------
Stacktrace

  File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/home/jenkins/workspace/edx-platform-test-subset/common/test/acceptance/tests/studio/test_studio_course_team.py", line 147, in test_added_users_cannot_add_or_delete_other_users
    self._assert_user_present(self.other_user, present=True)
  File "/home/jenkins/workspace/edx-platform-test-subset/common/test/acceptance/tests/studio/test_studio_course_team.py", line 78, in _assert_user_present
    description="Wait for user to be present"
  File "/home/jenkins/edx-venv/local/lib/python2.7/site-packages/bok_choy/page_object.py", line 490, in wait_for
    return EmptyPromise(promise_check_func, description, timeout=timeout).fulfill()
  File "/home/jenkins/edx-venv/local/lib/python2.7/site-packages/bok_choy/promise.py", line 92, in fulfill
    is_fulfilled, result = self._check_fulfilled()
  File "/home/jenkins/edx-venv/local/lib/python2.7/site-packages/bok_choy/promise.py", line 118, in _check_fulfilled
    is_fulfilled, result = self._check_func()
  File "/home/jenkins/edx-venv/local/lib/python2.7/site-packages/bok_choy/promise.py", line 173, in <lambda>
    full_check_func = lambda: (check_func(), None)
  File "/home/jenkins/workspace/edx-platform-test-subset/common/test/acceptance/tests/studio/test_studio_course_team.py", line 77, in <lambda>
    lambda: user.get('username') in self.page.usernames,
  File "/home/jenkins/edx-venv/local/lib/python2.7/site-packages/bok_choy/page_object.py", line 66, in wrapper
    self._verify_page()  # pylint: disable=protected-access
  File "/home/jenkins/edx-venv/local/lib/python2.7/site-packages/bok_choy/page_object.py", line 331, in _verify_page
    raise WrongPageError(msg)
"Not on the correct page to use '<common.test.acceptance.pages.studio.users.CourseTeamPage object at 0x7feb9fdb0490>' at URL 'http://localhost:8031/course_team/course-v1:test_org+321550032104190792981383915127220335686+test_run'\n-------------------- >> begin captured logging << --------------------\nbok_choy.browser: INFO: Using local browser: firefox [Default is firefox]\n--------------------- >> end captured logging << ---------------------"
```
