### PR TITLE
Updated the last updated date for the release notes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
                   <a class="item-link__action" rel="external" href="http://edx.readthedocs.org/projects/edx-release-notes/en/latest/">
 
                     <h4 class="item-link__title">Release Notes</h4>
-                    <div class="item-link__updated-date">Last Updated: 16 December 2015</div>
+                    <div class="item-link__updated-date">Last Updated: 6 January 2016</div>
                     <div class="item-link__copy">
                       <p>A cumulative list of released changes to edX.org and edX Edge.</p>
                     </div>


### PR DESCRIPTION
I updated the date shown under the edx.org release notes. Now it shows January 6, 2016.
