### PR TITLE
Enable MathJax in Course Pages

### DIFF
--- a/common/test/acceptance/pages/lms/tab_nav.py
+++ b/common/test/acceptance/pages/lms/tab_nav.py
@@ -36,6 +36,16 @@ class TabNavPage(PageObject):
         self.wait_for_page()
         self._is_on_tab_promise(tab_name).fulfill()
 
+    def mathjax_has_rendered(self):
+        """
+        Check that MathJax has rendered in tab content
+        """
+        mathjax_container = self.q(css=".static_tab_wrapper .MathJax .math")
+        EmptyPromise(
+            lambda: mathjax_container.present and mathjax_container.visible,
+            "MathJax is not visible"
+        ).fulfill()
+
     def is_on_tab(self, tab_name):
         """
         Return a boolean indicating whether the current tab is `tab_name`.

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -571,7 +571,7 @@ class HighLevelTabTest(UniqueCourseTest):
         course_fix.add_handout('demoPDF.pdf')
 
         course_fix.add_children(
-            XBlockFixtureDesc('static_tab', 'Test Static Tab'),
+            XBlockFixtureDesc('static_tab', 'Test Static Tab', data=r"static tab data with mathjax \(E=mc^2\)"),
             XBlockFixtureDesc('chapter', 'Test Section').add_children(
                 XBlockFixtureDesc('sequential', 'Test Subsection').add_children(
                     XBlockFixtureDesc('problem', 'Test Problem 1', data=load_data_str('multiple_choice.xml')),
@@ -630,6 +630,18 @@ class HighLevelTabTest(UniqueCourseTest):
         self.course_info_page.visit()
         self.tab_nav.go_to_tab('Test Static Tab')
         self.assertTrue(self.tab_nav.is_on_tab('Test Static Tab'))
+
+    def test_static_tab_with_mathjax(self):
+        """
+        Navigate to a static tab (course content)
+        """
+        # From the course info page, navigate to the static tab
+        self.course_info_page.visit()
+        self.tab_nav.go_to_tab('Test Static Tab')
+        self.assertTrue(self.tab_nav.is_on_tab('Test Static Tab'))
+
+        # Verify that Mathjax has rendered
+        self.tab_nav.mathjax_has_rendered()
 
     def test_wiki_tab_first_time(self):
         """

--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -6,6 +6,11 @@
 <%static:css group='style-course-vendor'/>
 <%static:css group='style-course'/>
 </%block>
+<%block name="js_extra">
+
+<%include file="/mathjax_include.html" args="disable_fast_preview=True"/>
+</%block>
+
 
 <%block name="pagetitle">${tab['name']} | ${course.display_number_with_default | h}</%block>
 


### PR DESCRIPTION
[TNL-3968 - LateX (mathjax) is not working on course Pages](https://openedx.atlassian.net/browse/TNL-3968)
## Description

Mathjax does not display properly in Pages, even when using the Raw HTML element.
## Solution

Add MathJax support in course static pages
## Acceptance

Content having MathJax notation should be displayed properly. 
