### PR TITLE
Remove unused header_extra.html file

### DIFF
--- a/lms/templates/header_extra.html
+++ b/lms/templates/header_extra.html
@@ -1,3 +1,0 @@
-<%
-# This template is left blank on purpose. It can be overridden by microsites.
-%>


### PR DESCRIPTION
Now that comprehensive theming is merged, we don't need this file. See the theming readme: https://github.com/edx/edx-platform/blob/master/themes/README.rst#microsites

@felipemontoya does this look good to you?
