### PR TITLE
userstanding is now OneToOneField

### DIFF
--- a/common/djangoapps/student/tests/test_userstanding.py
+++ b/common/djangoapps/student/tests/test_userstanding.py
@@ -58,6 +58,13 @@ class UserStandingTest(TestCase):
         # to skip tests for cms
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    def test_can_access_manage_account_page(self):
+        response = self.admin_client.get(reverse('manage_user_standing'), {
+            'user': self.admin,
+        })
+        self.assertEqual(response.status_code, 200)
+
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_disable_account(self):
         self.assertEqual(
             UserStanding.objects.filter(user=self.good_user).count(), 0

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1346,7 +1346,7 @@ def manage_user_standing(request):
     headers = ['username', 'account_changed_by']
     rows = []
     for user in all_disabled_users:
-        row = [user.username, user.standing.all()[0].changed_by]
+        row = [user.username, user.standing.changed_by]
         rows.append(row)
 
     context = {'headers': headers, 'rows': rows}


### PR DESCRIPTION
@symbolist , sometime in the django upgrade, UserStanding was changed from a ForeignKey to a one to one field. Unfortunately there was no test that checked if the main page even ever loaded :)

@Qubad786 , may you please take a quick look?

Steps to reproduce the error: 
1) run LMS
2) go to http://localhost:8000/accounts/manage_user_standing
3) disable someone's account
4) Reload page

expected behavior: no 500 error
actual behavior: 500 error
