### PR TITLE
Fix bug with discussion response "More..." actions

### DIFF
--- a/common/static/coffee/spec/discussion/view/discussion_view_spec_helper.coffee
+++ b/common/static/coffee/spec/discussion/view/discussion_view_spec_helper.coffee
@@ -14,6 +14,12 @@ class @DiscussionViewSpecHelper
           body: "",
           title: "dummy title",
           created_at: "2014-08-18T01:02:03Z"
+          ability: {
+              can_delete: false,
+              can_reply: true,
+              can_vote: false,
+              editable: false,
+            }
         }
         $.extend(thread, props)
 
@@ -72,7 +78,7 @@ class @DiscussionViewSpecHelper
         spy.reset()
         button.trigger($.Event("keydown", {which: 32}))
         expect(spy).toHaveBeenCalled()
-        
+
     @checkVoteButtonEvents = (view) ->
         @checkButtonEvents(view, "toggleVote", ".action-vote")
 

--- a/common/static/coffee/src/discussion/views/discussion_content_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_content_view.coffee
@@ -1,12 +1,12 @@
 if Backbone?
   class @DiscussionContentView extends Backbone.View
 
-  
+
     events:
       "click .discussion-flag-abuse": "toggleFlagAbuse"
       "keydown .discussion-flag-abuse":
         (event) -> DiscussionUtil.activateOnSpace(event, @toggleFlagAbuse)
-  
+
     attrRenderer:
       ability: (ability) ->
         for action, selector of @abilityRenderer
@@ -56,7 +56,7 @@ if Backbone?
 
     setWmdContent: (cls_identifier, text) =>
       DiscussionUtil.setWmdContent @$el, $.proxy(@$, @), cls_identifier, text
-      
+
 
     initialize: ->
       @model.bind('change', @renderPartialAttrs, @)

--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -278,7 +278,6 @@ if Backbone?
       comment = new Comment(body: body, created_at: (new Date()).toISOString(), username: window.user.get("username"), votes: { up_count: 0 }, abuse_flaggers:[], endorsed: false, user_id: window.user.get("id"))
       comment.set('thread', @model.get('thread'))
       @renderResponseToList(comment, ".js-response-list")
-      @renderAttrs()
       @model.addComment()
       @renderAddResponseButton()
 


### PR DESCRIPTION
## [TNL-3788](https://openedx.atlassian.net/browse/TNL-3788)

Fixes an issue with `Edit` and `Delete` functionality being hidden due to an overzealous call to a mis-scoped `renderAttrs` call.
### Sandbox

https://efischer19.sandbox.edx.org/
### Testing
- [X] Unit tests updated to more accurately render thread responses to allow the bug to be reproduced, and new tests to cover the bug added.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [ ] Code review: @cahrens 
  This is a bugfix, with only a tiny code change and a lot of test changes, so I think TNL review is sufficient here.

FYI: @andy-armstrong @robrap 
### Post-review
- [ ] Squash commits
