### PR TITLE
fix for handling course number display string as none

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -289,6 +289,27 @@ class TestCourseIndex(CourseTestCase):
         response = self.client.get_html(course_outline_url_split)
         self.assertEqual(response.status_code, 404)
 
+    def test_course_outline_with_display_course_number_as_none(self):
+        """
+        Tests course outline when 'display_coursenumber' field is none.
+        """
+        # Change 'display_coursenumber' field to None and update the course.
+        self.course.display_coursenumber = None
+        updated_course = self.update_course(self.course, self.user.id)
+
+        # Assert that 'display_coursenumber' field has been changed successfully.
+        self.assertEqual(updated_course.display_coursenumber, None)
+
+        # Perform GET request on course outline url with the course id.
+        course_outline_url = reverse_course_url('course_handler', updated_course.id)
+        response = self.client.get_html(course_outline_url)
+
+        # Assert that response code is 200.
+        self.assertEqual(response.status_code, 200)
+
+        # Assert that 'display_course_number' is being set to "" (as display_coursenumber was None).
+        self.assertIn('display_course_number: ""', response.content)
+
 
 @ddt.ddt
 class TestCourseOutline(CourseTestCase):

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -85,7 +85,7 @@ from openedx.core.lib.js_utils import (
                       url_name: "${context_course.location.name | h}",
                       org: "${context_course.location.org | h}",
                       num: "${context_course.location.course | h}",
-                      display_course_number: "${_(context_course.display_coursenumber)}",
+                      display_course_number: "${_(context_course.display_coursenumber) if context_course.display_coursenumber else ''}",
                       revision: "${context_course.location.revision | h}",
                       self_paced: ${escape_json_dumps(context_course.self_paced) | n}
                   });


### PR DESCRIPTION
[TNL-3998](https://openedx.atlassian.net/browse/TNL-3998)

Currently, `display_coursenumber` is being overridden to `None` when we change "Course Number Display String" to `null` from Advanced Settings of a course. In this PR, I have properly handled `display_coursenumber` field to avoid `NoneType` being passed to ugettext. 

@adampalay, @mushtaqak, @awaisdar001 please review.
