### PR TITLE
Mark sequence link-color scss variable default.

### DIFF
--- a/common/lib/xmodule/xmodule/css/sequence/display.scss
+++ b/common/lib/xmodule/xmodule/css/sequence/display.scss
@@ -1,5 +1,5 @@
 $sequence--border-color: #C8C8C8;
-$link-color: rgb(26, 161, 222);
+$link-color: rgb(26, 161, 222) !default;
 // repeated extends - needed since LMS styling was referenced
 .block-link {
   border-left: 1px solid lighten($sequence--border-color, 10%);


### PR DESCRIPTION
There's already a global `$link-color` variable defined in [lms/static/sass/base/_variables.scss](https://github.com/edx/edx-platform/blob/10fd56e86eee24bc67c875553f6f3b0ab9a4957b/lms/static/sass/base/_variables.scss#L423).

Mark the `$link-color` variable in sequence scss file with `!default`, so that the global `$link-color` variable gets used, if defined. That makes it easy to change the color of sequence links in the courseware using a custom theme.

If sequence/display.scss file is never used outside of LMS/Studio, the alternative solution would be to remove the `$link-color` variable from sequence/display.scss. I am not sure whether sequence/display.scss is ever used outside of these systems, so I went with the safer solution.

**Partner information**: 3rd party-hosted open edX instance
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1067
