### PR TITLE
Updated certificate_url for view certificate on learner dashboard

### DIFF
--- a/openedx/core/djangoapps/credentials/tests/mixins.py
+++ b/openedx/core/djangoapps/credentials/tests/mixins.py
@@ -41,7 +41,8 @@ class CredentialsDataMixin(object):
                     "program_id": 1
                 },
                 "status": "awarded",
-                "uuid": "dummy-uuid-1"
+                "uuid": "dummy-uuid-1",
+                "certificate_url": "http://credentials.edx.org/credentials/dummy-uuid-1/"
             },
             {
                 "id": 2,
@@ -51,7 +52,8 @@ class CredentialsDataMixin(object):
                     "program_id": 2
                 },
                 "status": "awarded",
-                "uuid": "dummy-uuid-2"
+                "uuid": "dummy-uuid-2",
+                "certificate_url": "http://credentials.edx.org/credentials/dummy-uuid-2/"
             },
             {
                 "id": 3,
@@ -61,7 +63,8 @@ class CredentialsDataMixin(object):
                     "program_id": 3
                 },
                 "status": "revoked",
-                "uuid": "dummy-uuid-3"
+                "uuid": "dummy-uuid-3",
+                "certificate_url": "http://credentials.edx.org/credentials/dummy-uuid-3/"
             },
             {
                 "id": 4,
@@ -72,7 +75,8 @@ class CredentialsDataMixin(object):
                     "certificate_type": "honor"
                 },
                 "status": "awarded",
-                "uuid": "dummy-uuid-4"
+                "uuid": "dummy-uuid-4",
+                "certificate_url": "http://credentials.edx.org/credentials/dummy-uuid-4/"
             },
             {
                 "id": 5,
@@ -83,7 +87,8 @@ class CredentialsDataMixin(object):
                     "certificate_type": "verified"
                 },
                 "status": "awarded",
-                "uuid": "dummy-uuid-5"
+                "uuid": "dummy-uuid-5",
+                "certificate_url": "http://credentials.edx.org/credentials/dummy-uuid-5/"
             },
             {
                 "id": 6,
@@ -94,7 +99,8 @@ class CredentialsDataMixin(object):
                     "certificate_type": "honor"
                 },
                 "status": "revoked",
-                "uuid": "dummy-uuid-6"
+                "uuid": "dummy-uuid-6",
+                "certificate_url": "http://credentials.edx.org/credentials/dummy-uuid-6/"
             }
         ]
     }
@@ -110,7 +116,8 @@ class CredentialsDataMixin(object):
                     "program_id": 7
                 },
                 "status": "awarded",
-                "uuid": "dummy-uuid-7"
+                "uuid": "dummy-uuid-7",
+                "certificate_url": "http://credentials.edx.org/credentials/dummy-uuid-7"
             },
             {
                 "id": 8,
@@ -120,7 +127,8 @@ class CredentialsDataMixin(object):
                     "program_id": 8
                 },
                 "status": "awarded",
-                "uuid": "dummy-uuid-8"
+                "uuid": "dummy-uuid-8",
+                "certificate_url": "http://credentials.edx.org/credentials/dummy-uuid-8/"
             }
         ]
     }

--- a/openedx/core/djangoapps/credentials/tests/test_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_utils.py
@@ -80,7 +80,7 @@ class TestCredentialsRetrieval(ProgramsApiConfigMixin, CredentialsApiConfigMixin
     def test_get_user_programs_credentials(self):
         """Verify program credentials data can be retrieved and parsed correctly."""
         # create credentials and program configuration
-        credentials_config = self.create_credentials_config()
+        self.create_credentials_config()
         self.create_programs_config()
 
         # Mocking the API responses from programs and credentials
@@ -89,10 +89,6 @@ class TestCredentialsRetrieval(ProgramsApiConfigMixin, CredentialsApiConfigMixin
 
         actual = get_user_program_credentials(self.user)
         expected = self.PROGRAMS_API_RESPONSE['results']
-        expected[0]['credential_url'] = \
-            credentials_config.public_service_url + 'credentials/' + self.PROGRAMS_CREDENTIALS_DATA[0]['uuid']
-        expected[1]['credential_url'] = \
-            credentials_config.public_service_url + 'credentials/' + self.PROGRAMS_CREDENTIALS_DATA[1]['uuid']
 
         # checking response from API is as expected
         self.assertEqual(len(actual), 2)

--- a/openedx/core/djangoapps/programs/tests/mixins.py
+++ b/openedx/core/djangoapps/programs/tests/mixins.py
@@ -56,6 +56,7 @@ class ProgramsDataMixin(object):
                 'category': 'xseries',
                 'status': 'unpublished',
                 'marketing_slug': '',
+                'credential_url': 'http://credentials.edx.org/credentials/dummy-uuid-1/',
                 'organizations': [
                     {
                         'display_name': 'Test Organization A',
@@ -122,6 +123,7 @@ class ProgramsDataMixin(object):
                 'category': 'xseries',
                 'status': 'unpublished',
                 'marketing_slug': '',
+                'credential_url': 'http://credentials.edx.org/credentials/dummy-uuid-2/',
                 'organizations': [
                     {
                         'display_name': 'Test Organization B',
@@ -193,7 +195,8 @@ class ProgramsDataMixin(object):
                 "program_id": 1
             },
             "status": "awarded",
-            "uuid": "dummy-uuid-1"
+            "uuid": "dummy-uuid-1",
+            "certificate_url": "http://credentials.edx.org/credentials/dummy-uuid-1/"
         },
         {
             "id": 2,
@@ -203,7 +206,8 @@ class ProgramsDataMixin(object):
                 "program_id": 2
             },
             "status": "awarded",
-            "uuid": "dummy-uuid-2"
+            "uuid": "dummy-uuid-2",
+            "certificate_url": "http://credentials.edx.org/credentials/dummy-uuid-2/"
         }
     ]
 

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -137,15 +137,11 @@ class TestProgramRetrieval(ProgramsApiConfigMixin, ProgramsDataMixin,
     def test_get_program_for_certificates(self):
         """Verify programs data can be retrieved and parsed correctly for certificates."""
         self.create_programs_config()
-        credentials_config = self.create_credentials_config()
         self.mock_programs_api()
 
         actual = get_programs_for_credentials(self.user, self.PROGRAMS_CREDENTIALS_DATA)
         expected = self.PROGRAMS_API_RESPONSE['results']
-        expected[0]['credential_url'] = \
-            credentials_config.public_service_url + 'credentials/' + self.PROGRAMS_CREDENTIALS_DATA[0]['uuid']
-        expected[1]['credential_url'] = \
-            credentials_config.public_service_url + 'credentials/' + self.PROGRAMS_CREDENTIALS_DATA[1]['uuid']
+
         self.assertEqual(len(actual), 2)
         self.assertEqual(actual, expected)
 

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -1,8 +1,6 @@
 """Helper functions for working with Programs."""
 import logging
-from urlparse import urljoin
 
-from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.lib.edx_api_utils import get_edx_api_data
 
@@ -98,12 +96,10 @@ def get_programs_for_credentials(user, programs_credentials):
         log.debug('No programs found for the user with ID %d.', user.id)
         return certificate_programs
 
-    credential_configuration = CredentialsApiConfig.current()
     for program in programs:
         for credential in programs_credentials:
             if program['id'] == credential['credential']['program_id']:
-                credentials_url = 'credentials/' + credential['uuid']
-                program['credential_url'] = urljoin(credential_configuration.public_service_url, credentials_url)
+                program['credential_url'] = credential['certificate_url']
                 certificate_programs.append(program)
 
     return certificate_programs


### PR DESCRIPTION
ECOM-3281
- Updated `certificate_url` field for view certificate on learner dashboard.
- Updated relevant tests.

Please review this @zubair-arbi @ahsan-ul-haq @awais786 
