### PR TITLE
Update course wiki_slug during import if it points to the old wiki.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -355,6 +355,7 @@ class XMLModuleStore(ModuleStoreReadBase):
         self.modules = defaultdict(dict)  # course_id -> dict(location -> XBlock)
         self.courses = {}  # course_dir -> XBlock for the course
         self.errored_courses = {}  # course_dir -> errorlog, for dirs that failed to load
+        self.course_run = None  # course run for course being imported from
 
         if course_ids is not None:
             course_ids = [SlashSeparatedCourseKey.from_deprecated_string(course_id) for course_id in course_ids]
@@ -538,6 +539,7 @@ class XMLModuleStore(ModuleStoreReadBase):
                 else:
                     url_name = None
 
+            self.course_run = course_data.get('run')
             course_id = self.get_id(org, course, url_name)
 
             if course_ids is not None and course_id not in course_ids:

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -524,10 +524,15 @@ class CourseImportManager(ImportManager):
         # If we are importing into a course with a different course_id and wiki_slug is equal to either of these default
         # values then remap it so that the wiki does not point to the old wiki.
         if courselike_key != course.id:
+            if self.xml_module_store.course_run is None:
+                original_course_run = courselike_key.run
+            else:
+                original_course_run = self.xml_module_store.course_run
+
             original_unique_wiki_slug = u'{0}.{1}.{2}'.format(
                 courselike_key.org,
                 courselike_key.course,
-                courselike_key.run
+                original_course_run,
             )
             if course.wiki_slug == original_unique_wiki_slug or course.wiki_slug == courselike_key.course:
                 course.wiki_slug = u'{0}.{1}.{2}'.format(

--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -38,23 +38,29 @@ def is_pointer_tag(xml_obj):
     Check if xml_obj is a pointer tag: <blah url_name="something" />.
     No children, one attribute named url_name, no text.
 
-    Special case for course roots: the pointer is
+    Special case for course roots: the pointer for old courses is
       <course url_name="something" org="myorg" course="course">
+      and for new courses, it is
+      <course url_name="something" org="myorg" run="myrun" course="course">
 
     xml_obj: an etree Element
 
     Returns a bool.
     """
     if xml_obj.tag != "course":
+        old_expected_attr = None
         expected_attr = set(['url_name'])
     else:
-        expected_attr = set(['url_name', 'course', 'org'])
+        # previously expected attributes consisted of 'url_name', 'course', 'org'
+        old_expected_attr = set(['url_name', 'course', 'org'])
+        # new expected attributes 'url_name', 'course', 'run', 'org'
+        expected_attr = set(['url_name', 'course', 'run', 'org'])
 
     actual_attr = set(xml_obj.attrib.keys())
 
     has_text = xml_obj.text is not None and len(xml_obj.text.strip()) > 0
 
-    return len(xml_obj) == 0 and actual_attr == expected_attr and not has_text
+    return len(xml_obj) == 0 and (actual_attr == expected_attr or actual_attr == old_expected_attr) and not has_text
 
 
 def serialize_field(value):

--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -453,9 +453,10 @@ class XmlParserMixin(object):
 
         # Special case for course pointers:
         if self.category == 'course':
-            # add org and course attributes on the pointer tag
+            # add org, course and run attributes on the pointer tag
             node.set('org', self.location.org)
             node.set('course', self.location.course)
+            node.set('run', self.location.run)
 
     def definition_to_xml(self, resource_fs):
         """


### PR DESCRIPTION
[PLAT-908](https://openedx.atlassian.net/browse/PLAT-908)

Background: When user exports a course say CourseA and then imports the CourseA to another course say CourseB. Wiki for CourseB points to the wiki for CourseA because wiki_slug of CourseA is copied over wiki_slug for CourseB. This PR updates the wiki_slug if it points to the old wiki, to achive this we need course id including organization, course number and course run but the exported course file do not include course run. So this PR includes course run in the exported course and during import compares if wiki_slug points to old wiki_slug it updates it. Because courses exported in the past do not include course run, this PR change won't work for imports using those exported files.

@awaisdar001 @ziafazal @adampalay please review.
