### PR TITLE
Disable button while adding/removing bookmark to a unit.

### DIFF
--- a/lms/static/js/bookmarks/views/bookmark_button.js
+++ b/lms/static/js/bookmarks/views/bookmark_button.js
@@ -26,6 +26,8 @@
             toggleBookmark: function(event) {
                 event.preventDefault();
 
+                this.$el.prop('disabled', true);
+
                 if (this.$el.hasClass('bookmarked')) {
                     this.removeBookmark();
                 } else {
@@ -48,6 +50,9 @@
                         var response = jqXHR.responseText ? JSON.parse(jqXHR.responseText) : '';
                         var userMessage = response ? response.user_message : '';
                         view.showError(userMessage);
+                    },
+                    complete: function () {
+                        view.$el.prop('disabled', false);
                     }
                 });
             },
@@ -65,6 +70,9 @@
                     },
                     error: function() {
                         view.showError();
+                    },
+                    complete: function() {
+                        view.$el.prop('disabled', false);
                     }
                 });
             },

--- a/lms/static/js/spec/bookmarks/bookmark_button_view_spec.js
+++ b/lms/static/js/spec/bookmarks/bookmark_button_view_spec.js
@@ -85,6 +85,8 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
 
                     bookmarkButtonView.$el.click();
 
+                    expect(bookmarkButtonView.$el).toHaveAttr('disabled', 'disabled');
+
                     AjaxHelpers.expectRequest(
                         requests, firstActionData.method,
                         firstActionData.url,
@@ -96,12 +98,14 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                     expect(firstActionData.event).toHaveBeenTriggeredOn(bookmarkButtonView.$el);
                     bookmarkButtonView[firstActionData.handler].reset();
 
+                    expect(bookmarkButtonView.$el).not.toHaveAttr('disabled');
                     verifyBookmarkButtonState(bookmarkButtonView, secondActionData.bookmarked);
 
                     spyOn(bookmarkButtonView, secondActionData.handler).andCallThrough();
                     spyOnEvent(bookmarkButtonView.$el, secondActionData.event);
 
                     bookmarkButtonView.$el.click();
+                    expect(bookmarkButtonView.$el).toHaveAttr('disabled', 'disabled');
 
                     AjaxHelpers.expectRequest(
                         requests,
@@ -114,6 +118,7 @@ define(['backbone', 'jquery', 'underscore', 'common/js/spec_helpers/ajax_helpers
                     AjaxHelpers.respondWithJson(requests, {});
                     expect(secondActionData.event).toHaveBeenTriggeredOn(bookmarkButtonView.$el);
 
+                    expect(bookmarkButtonView.$el).not.toHaveAttr('disabled');
                     verifyBookmarkButtonState(bookmarkButtonView, firstActionData.bookmarked);
                     bookmarkButtonView.undelegateEvents();
                 });


### PR DESCRIPTION
The purpose of this PR to disable the bookmark button after the click event occur and enable it once we get response from server.

TNL-4004
