### PR TITLE
MAYN-167: Bulk uploads (CSV) of manual enrollments on white labels should be performed as 'honor' modes

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -9,7 +9,6 @@ import random
 import pytz
 import io
 import json
-import requests
 import shutil
 import tempfile
 from urllib import quote
@@ -51,8 +50,6 @@ from student.models import (
 )
 from student.tests.factories import UserFactory, CourseModeFactory, AdminFactory
 from student.roles import CourseBetaTesterRole, CourseSalesAdminRole, CourseFinanceAdminRole, CourseInstructorRole
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.fields import Date

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -397,10 +397,10 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         CourseModeFactory(course_id=cls.audit_course.id, mode_slug=CourseMode.AUDIT)
 
         cls.url = reverse(
-            'register_and_enroll_students', kwargs={'course_id': cls.course.id.to_deprecated_string()}
+            'register_and_enroll_students', kwargs={'course_id': unicode(cls.course.id)}
         )
         cls.audit_course_url = reverse(
-            'register_and_enroll_students', kwargs={'course_id': cls.audit_course.id.to_deprecated_string()}
+            'register_and_enroll_students', kwargs={'course_id': unicode(cls.audit_course.id)}
         )
 
     def setUp(self):
@@ -416,7 +416,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         )
 
         self.white_label_course_url = reverse(
-            'register_and_enroll_students', kwargs={'course_id': self.white_label_course.id.to_deprecated_string()}
+            'register_and_enroll_students', kwargs={'course_id': unicode(self.white_label_course.id)}
         )
 
         self.request = RequestFactory().request()
@@ -650,7 +650,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
                       "test_student2@example.com,test_student_1,tester2,US"
 
         uploaded_file = SimpleUploadedFile("temp.csv", csv_content)
-        with patch('instructor.views.api.create_and_enroll_user') as mock:
+        with patch('instructor.views.api.create_manual_course_enrollment') as mock:
             mock.side_effect = NonExistentCourseError()
             response = self.client.post(self.url, {'students_list': uploaded_file})
 


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 

Kindly Review this PR, it contains the following changes.

**Description of changes:**
Manual enrollments of white label courses via csv uploads in instructor dashboard should use the default course mode defined in **DEFAULT_SHOPPINGCART_MODE_SLUG** .

This is a regression on the changeover from having "audit" become the default course mode. In a manner similar to what we did for manual enrollments via dashboard, we need to use the **DEFAULT_SHOPPINGCART_MODE_SLUG** in this user-case.
This feature is rarely used, but we should fix it.

cc: @mattdrayer 
