### PR TITLE
Registration form: removed validation of Terms of Services when the checkbox is hidden

### DIFF
--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -12,6 +12,7 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.utils.importlib import import_module
 import mock
+from mock import patch
 
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from lang_pref import LANGUAGE_KEY
@@ -282,6 +283,7 @@ class TestCreateAccountValidation(TestCase):
     """
     Test validation of various parameters in the create_account view
     """
+
     def setUp(self):
         super(TestCreateAccountValidation, self).setUp()
         self.url = reverse("create_account")
@@ -449,6 +451,7 @@ class TestCreateAccountValidation(TestCase):
             params["email"] = "another_test_email@example.com"
             self.assert_success(params)
 
+    @patch.dict(settings.FEATURES, {"ENABLE_COMBINED_LOGIN_REGISTRATION": False})
     def test_terms_of_service(self):
         params = dict(self.minimal_params)
 
@@ -470,6 +473,13 @@ class TestCreateAccountValidation(TestCase):
 
         # True
         params["terms_of_service"] = "tRUe"
+        self.assert_success(params)
+
+    # with "ENABLE_COMBINED_LOGIN_REGISTRATION" the "terms of service" checkbox is hidden
+    @patch.dict(settings.FEATURES, {"ENABLE_COMBINED_LOGIN_REGISTRATION": True})
+    def test_terms_of_service_with_combined_login_registration(self):
+        params = dict(self.minimal_params)
+        del params["terms_of_service"]
         self.assert_success(params)
 
     @ddt.data(

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1420,6 +1420,7 @@ def change_setting(request):
 
 
 class AccountValidationError(Exception):
+
     def __init__(self, message, field):
         super(AccountValidationError, self).__init__(message)
         self.field = field
@@ -1583,7 +1584,10 @@ def create_account_with_params(request, params):
         not eamap.external_domain.startswith(
             external_auth.views.SHIBBOLETH_DOMAIN_PREFIX
         )
-    )
+    ) and not (settings.FEATURES.get("ENABLE_COMBINED_LOGIN_REGISTRATION") and
+               extra_fields.get("honor_code", "required") != 'required')
+    # Honor code is required by default, unless
+    # explicitly set to "optional" in Django settings.
 
     form = AccountCreationForm(
         data=params,

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1420,6 +1420,7 @@ def change_setting(request):
 
 
 class AccountValidationError(Exception):
+
     def __init__(self, message, field):
         super(AccountValidationError, self).__init__(message)
         self.field = field
@@ -1583,7 +1584,7 @@ def create_account_with_params(request, params):
         not eamap.external_domain.startswith(
             external_auth.views.SHIBBOLETH_DOMAIN_PREFIX
         )
-    )
+    ) and not settings.FEATURES.get("ENABLE_COMBINED_LOGIN_REGISTRATION")
 
     form = AccountCreationForm(
         data=params,


### PR DESCRIPTION
**Background:**Registration form with hidden checkbox "Terms of Services" still validates it (and an error message is displayed).
![edx-74-1](https://cloud.githubusercontent.com/assets/7777978/12291466/8146c2a4-b9f8-11e5-881e-035ea6efb7ab.jpg)
![edx-74-2](https://cloud.githubusercontent.com/assets/7777978/12291473/89095e02-b9f8-11e5-9adc-01fe8f447621.png)

**Studio Updates:** None.

**LMS Updates:** Removed validation of the checkbox "Terms of Services" on the Registration form for the following settings in /edx/app/edxapp/lms.env.json:
"FEATURES" > "ENABLE_COMBINED_LOGIN_REGISTRATION" = true

**Manual test instructions:**
- Update /edx/app/edxapp/lms.env.json settings
  "FEATURES" > "ENABLE_COMBINED_LOGIN_REGISTRATION" = true
- Start LMS and go to http://127.0.0.1:8000/register and try to add a user filling in only required fields. You should add it successfully, no error message 'You must accept the terms of service' is displayed.
