### PR TITLE
Allow certificates with 'auditing' status to be regenerated.

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -220,7 +220,8 @@ class XQueueCertInterface(object):
             status.deleted,
             status.error,
             status.notpassing,
-            status.downloadable
+            status.downloadable,
+            status.auditing,
         ]
 
         cert_status = certificate_status_for_student(student, course_id)['status']

--- a/lms/djangoapps/certificates/tests/test_queue.py
+++ b/lms/djangoapps/certificates/tests/test_queue.py
@@ -181,6 +181,30 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
         self.assertFalse(certificate.eligible_for_certificate)
         self.assertEqual(certificate.mode, expected_mode)
 
+    @ddt.data(
+        (CertificateStatuses.restricted, False),
+        (CertificateStatuses.deleting, False),
+        (CertificateStatuses.generating, True),
+        (CertificateStatuses.unavailable, True),
+        (CertificateStatuses.deleted, True),
+        (CertificateStatuses.error, True),
+        (CertificateStatuses.notpassing, True),
+        (CertificateStatuses.downloadable, True),
+        (CertificateStatuses.auditing, True),
+    )
+    @ddt.unpack
+    def test_add_cert_statuses(self, status, should_generate):
+        """
+        Test that certificates can or cannot be generated with the given
+        certificate status.
+        """
+        with patch('certificates.queue.certificate_status_for_student', Mock(return_value={'status': status})):
+            mock_send = self.add_cert_to_queue('verified')
+            if should_generate:
+                self.assertTrue(mock_send.called)
+            else:
+                self.assertFalse(mock_send.called)
+
 
 @attr('shard_1')
 @override_settings(CERT_QUEUE='certificates')


### PR DESCRIPTION
# [ECOM-3401](https://openedx.atlassian.net/browse/ECOM-3401)

The fix is simple, but the root cause is slightly more complicated and probably deserves explanation:
- User enrolls in course, in the audit track
- They then proceed to go through the course and pass it.
- They generate a cert through the progress page, which results in a `GeneratedCertificate` with mode `'audit'`. This causes `certificate_status_for_student` to return `{'status': 'auditing'}`.
- They then pay and upgrade to verified.
- When certs are regenerated through any means, the certificate status is checked in `XQueueCertInterface.add_cert` against this list:

``` python
[
    status.generating,
    status.unavailable,
    status.deleted,
    status.error,
    status.notpassing,
    status.downloadable
]
```

Since `status.auditing` isn't there, the code short-circuits and no cert is generated. Students are sad.

Every affected user in the ticket shows the same ordering of enrollment and certificate events.

When this merges and is released, the students (or course team) should be able to regenerate their certs and the cert will get correctly regenerated in verified mode.

@bderusha, can you review?
