### PR TITLE
Set default id token expiration to 5m for Studio

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1142,3 +1142,6 @@ PROCTORING_SETTINGS = {}
 
 # OpenID Connect issuer ID. Normally the URL of the authentication endpoint.
 OAUTH_OIDC_ISSUER = 'https://www.example.com/oauth2'
+
+# 5 minute expiration time for JWT id tokens issued for external API requests.
+OAUTH_ID_TOKEN_EXPIRATION = 5 * 60


### PR DESCRIPTION
@rlucioni please review.

The value of this setting has til now been unset in Studio, so it falls back to a hardcoded value of 30.

For the Programs use case, I'm setting it a little higher, to 5m.  Setting in only on cms means that the change will not affect the present expiration values for any code currently running on the lms side.
