### PR TITLE
MAYN-154 Specify file extension in MKTG_URL_LINK_MAP

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -166,8 +166,5 @@ def render_to_response(template_name, dictionary=None, context_instance=None, na
     lookup.get_template(args[0]).render with the passed arguments.
     """
 
-    # see if there is an override template defined in the microsite
-    template_name = microsite.get_template_path(template_name)
-
     dictionary = dictionary or {}
     return HttpResponse(render_to_string(template_name, dictionary, context_instance, namespace), **kwargs)

--- a/lms/djangoapps/static_template_view/tests/test_views.py
+++ b/lms/djangoapps/static_template_view/tests/test_views.py
@@ -1,0 +1,26 @@
+import mimetypes
+
+from django.test import TestCase
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+
+class MarketingSiteViewTests(TestCase):
+    """ Tests for the marketing site views """
+
+    def _test_view(self, view_name, mimetype):
+        resp = self.client.get(reverse(view_name))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp['Content-Type'], mimetype)
+
+    def test_sitemap(self):
+        """
+        Test the sitemap view
+        """
+        self._test_view('sitemap_xml', 'application/xml')
+
+    def test_about(self):
+        """
+        Test the about view
+        """
+        self._test_view('about', 'text/html')

--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -3,6 +3,8 @@
 # List of valid templates is explicitly managed for (short-term)
 # security reasons.
 
+import mimetypes
+
 from edxmako.shortcuts import render_to_response, render_to_string
 from mako.exceptions import TopLevelLookupException
 from django.shortcuts import redirect
@@ -39,7 +41,11 @@ def render(request, template):
 
     url(r'^jobs$', 'static_template_view.views.render', {'template': 'jobs.html'}, name="jobs")
     """
-    return render_to_response('static_templates/' + template, {})
+
+    # Guess content type from file extension
+    content_type, __ = mimetypes.guess_type(template)
+
+    return render_to_response('static_templates/' + template, {}, content_type=content_type)
 
 
 @ensure_csrf_cookie

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1961,7 +1961,7 @@ MKTG_URL_LINK_MAP = {
     'PRESS': 'press',
     'BLOG': 'blog',
     'DONATE': 'donate',
-    'SITE_MAP': 'site_map',
+    'SITEMAP.XML': 'sitemap_xml',
 
     # Verified Certificates
     'WHAT_IS_VERIFIED_CERT': 'verified-certificate',

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -352,6 +352,7 @@ MKTG_URL_LINK_MAP = {
     'PRESS': 'press',
     'BLOG': 'blog',
     'DONATE': 'donate',
+    'SITEMAP.XML': 'sitemap_xml',
 
     # Verified Certificates
     'WHAT_IS_VERIFIED_CERT': 'verified-certificate',

--- a/lms/templates/static_templates/site_map.html
+++ b/lms/templates/static_templates/site_map.html
@@ -1,9 +1,0 @@
-<%! from django.utils.translation import ugettext as _ %>
-<%inherit file="../main.html" />
-
-<%block name="pagetitle">${_("Site Map")}</%block>
-
-<section class="container about">
-    <h1>${_("Site Map")}</h1>
-    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>

--- a/lms/templates/static_templates/sitemap.xml
+++ b/lms/templates/static_templates/sitemap.xml
@@ -1,0 +1,5 @@
+## This page is not used by edx.org but is left here for possible use by installations of Open edX.
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://www.example.com/</loc><lastmod>2016-01-01</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
+</urlset>

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -206,8 +206,11 @@ for key, value in settings.MKTG_URL_LINK_MAP.items():
         continue
 
     # Make the assumptions that the templates are all in the same dir
-    # and that they all match the name of the key (plus extension)
-    template = "%s.html" % key.lower()
+    # and that they all match the name of the key
+    template = key.lower()
+    if '.' not in template:
+        # Assume html if no file extension specified
+        template = "%s.html" % template
 
     # To allow theme templates to inherit from default templates,
     # prepend a standard prefix


### PR DESCRIPTION
This allows us to specify the template file extension in MKTG_URL_LINK_MAP, so that we can appropriately set the Content-Type header of the sitemap request.
- Allow file extensions in MKTG_URL_LINK_MAP template keys
- Set content type on requests for static templates based on the template key
