### PR TITLE
Removing CDN RPC

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -28,7 +28,7 @@ from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 
 from xmodule.tests import get_test_descriptor_system
-from xmodule.video_module import VideoDescriptor, create_youtube_string, get_video_from_cdn
+from xmodule.video_module import VideoDescriptor, create_youtube_string
 from xmodule.video_module.transcripts_utils import download_youtube_subs, save_to_store
 from . import LogicTest
 from .test_import import DummySystem
@@ -740,36 +740,6 @@ class VideoExportTestCase(VideoDescriptorTestBase):
         # Check that download_video field is also set to default (False) in xml for backward compatibility
         expected = '<video url_name="SampleProblem" download_video="false"/>\n'
         self.assertEquals(expected, etree.tostring(xml, pretty_print=True))
-
-
-class VideoCdnTest(unittest.TestCase):
-    """
-    Tests for Video CDN.
-    """
-    @patch('requests.get')
-    def test_get_video_success(self, cdn_response):
-        """
-        Test successful CDN request.
-        """
-        original_video_url = "http://www.original_video.com/original_video.mp4"
-        cdn_response_video_url = "http://www.cdn_video.com/cdn_video.mp4"
-        cdn_response_content = '{{"sources":["{cdn_url}"]}}'.format(cdn_url=cdn_response_video_url)
-        cdn_response.return_value = Mock(status_code=200, content=cdn_response_content)
-        fake_cdn_url = 'http://fake_cdn.com/'
-        self.assertEqual(
-            get_video_from_cdn(fake_cdn_url, original_video_url),
-            cdn_response_video_url
-        )
-
-    @patch('requests.get')
-    def test_get_no_video_exists(self, cdn_response):
-        """
-        Test if no alternative video in CDN exists.
-        """
-        original_video_url = "http://www.original_video.com/original_video.mp4"
-        cdn_response.return_value = Mock(status_code=404)
-        fake_cdn_url = 'http://fake_cdn.com/'
-        self.assertIsNone(get_video_from_cdn(fake_cdn_url, original_video_url))
 
 
 class VideoDescriptorIndexingTestCase(unittest.TestCase):

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -38,7 +38,7 @@ from xmodule.exceptions import NotFoundError
 from xmodule.contentstore.content import StaticContent
 
 from .transcripts_utils import VideoTranscriptsMixin, Transcript, get_html5_ids
-from .video_utils import create_youtube_string, get_video_from_cdn, get_poster
+from .video_utils import create_youtube_string, get_poster, rewrite_video_url
 from .bumper_utils import bumperize
 from .video_xfields import VideoFields
 from .video_handlers import VideoStudentViewHandlers, VideoStudioViewHandlers
@@ -196,6 +196,11 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
         branding_info = None
         youtube_streams = ""
 
+        # Determine if there is an alternative source for this video
+        # based on user locale.  This exists to support cases where
+        # we leverage a geography specific CDN, like China.
+        cdn_url = getattr(settings, 'VIDEO_CDN_URL', {}).get(self.system.user_location)
+
         # If we have an edx_video_id, we prefer its values over what we store
         # internally for download links (source, html5_sources) and the youtube
         # stream.
@@ -215,7 +220,12 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
                         if url not in sources:
                             sources.append(url)
                         if self.download_video:
-                            download_video_link = url
+                            # function returns None when the url cannot be re-written
+                            rewritten_link = rewrite_video_url(cdn_url, url)
+                            if rewritten_link:
+                                download_video_link = rewritten_link
+                            else:
+                                download_video_link = url
 
                 # set the youtube url
                 if val_video_urls["youtube"]:
@@ -231,12 +241,11 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
         # 'CN' is China ISO 3166-1 country code.
         # Video caching is disabled for Studio. User_location is always None in Studio.
         # CountryMiddleware disabled for Studio.
-        cdn_url = getattr(settings, 'VIDEO_CDN_URL', {}).get(self.system.user_location)
         if getattr(self, 'video_speed_optimizations', True) and cdn_url:
             branding_info = BrandingInfoConfig.get_config().get(self.system.user_location)
 
             for index, source_url in enumerate(sources):
-                new_url = get_video_from_cdn(cdn_url, source_url)
+                new_url = rewrite_video_url(cdn_url, source_url)
                 if new_url:
                     sources[index] = new_url
 


### PR DESCRIPTION
Removes the RPC for determining the China video URL in favor of symmetric URLs and host re-writing.
