### PR TITLE
Redirect to login when SAML accessed without idp param

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -3,7 +3,7 @@ Slightly customized python-social-auth backend for SAML 2.0 support
 """
 import logging
 from social.backends.saml import SAMLAuth, OID_EDU_PERSON_ENTITLEMENT
-from social.exceptions import AuthForbidden
+from social.exceptions import AuthForbidden, AuthMissingParameter
 
 log = logging.getLogger(__name__)
 
@@ -32,6 +32,20 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
             return self._config.get_setting(name)
         except KeyError:
             return self.strategy.setting(name, default)
+
+    def auth_url(self):
+        """
+        Check that the request includes an 'idp' parameter before getting the
+        URL to which we must redirect in order to authenticate the user.
+
+        raise AuthMissingParameter if the 'idp' parameter is missing.
+
+        TODO: remove this method once the fix is merged upstream:
+        https://github.com/omab/python-social-auth/pull/821
+        """
+        if 'idp' not in self.strategy.request_data():
+            raise AuthMissingParameter(self, 'idp')
+        return super(SAMLAuthBackend, self).auth_url()
 
     def _check_entitlements(self, idp, attributes):
         """

--- a/common/djangoapps/third_party_auth/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/tests/test_views.py
@@ -129,3 +129,17 @@ class SAMLMetadataTest(SAMLTestCase):
         self.assertEqual(support_name_node.text, support_name)
         support_email_node = support_node.find(etree.QName(SAML_XML_NS, 'EmailAddress'))
         self.assertEqual(support_email_node.text, support_email)
+
+
+@unittest.skipUnless(AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
+class SAMLAuthTest(SAMLTestCase):
+    """
+    Test the SAML auth views
+    """
+    LOGIN_URL = '/auth/login/tpa-saml/'
+
+    def test_login_without_idp(self):
+        """ Accessing the login endpoint without an idp query param should return 302 """
+        self.enable_saml()
+        response = self.client.get(self.LOGIN_URL)
+        self.assertEqual(response.status_code, 302)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -68,6 +68,7 @@ python-dateutil==2.1
 
 # This module gets monkey-patched in third_party_auth.py to fix a Django 1.8 incompatibility.
 # When this dependency gets upgraded, the monkey patch should be removed, if possible.
+# We can also remove the fix to auth_url in third_party_auth/saml.py when that fix is included upstream.
 python-social-auth==0.2.12
 
 pytz==2015.2


### PR DESCRIPTION
See [SOL-1550](https://openedx.atlassian.net/browse/SOL-1550).

The python social auth SAML page returns a 500 response when accessed without the 'idp' query param. It should redirect to the login page if the param is missing.
