### PR TITLE
Un-deprecate teams setting.

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -693,11 +693,17 @@ class CourseFields(object):
     teams_configuration = Dict(
         display_name=_("Teams Configuration"),
         help=_(
-            "Enter configuration for the teams feature. Expects two entries: max_team_size and topics, where "
-            "topics is a list of topics."
+            'Specify the maximum team size and topics for teams inside the provided set of curly braces. '
+            'Make sure that you enclose all of the sets of topic values within a set of square brackets, '
+            'with a comma after the closing curly brace for each topic, and another comma after the '
+            'closing square brackets. '
+            'For example, to specify that teams should have a maximum of 5 participants and provide a list of '
+            '2 topics, enter the configuration in this format: '
+            '{"topics": [{"name": "Topic1Name", "description": "Topic1Description", "id": "Topic1ID"}, '
+            '{"name": "Topic2Name", "description": "Topic2Description", "id": "Topic2ID"}], "max_team_size": 5}. '
+            'In "id" values, the only supported special characters are underscore, hyphen, and period.'
         ),
         scope=Scope.settings,
-        deprecated=True,  # Deprecated until the teams feature is made generally available
     )
 
     enable_proctored_exams = Boolean(

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -210,6 +210,7 @@ class AdvancedSettingsPage(CoursePage):
             'show_calculator',
             'show_reset_button',
             'static_asset_path',
+            'teams_configuration',
             'text_customization',
             'annotation_storage_url',
             'social_sharing_url',


### PR DESCRIPTION
TNL-3803

@catong this is the PR to remove deprecation of Teams config.

Can you help with this (per TNL-3803)?
"review the text string description on the advanced setting to ensure that it specifies that teams are for small group discussions, so that there's no confusion around what's available vs. not available for teams right now."

This is the current help string:
 "Enter configuration for the teams feature. Expects two entries: max_team_size and topics, where topics is a list of topics."
