### PR TITLE
Ensure old audit certs don't get marked ineligible.

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -279,7 +279,7 @@ class XQueueCertInterface(object):
         if forced_grade:
             grade['grade'] = forced_grade
 
-        cert, __ = GeneratedCertificate.eligible_certificates.get_or_create(user=student, course_id=course_id)
+        cert, created = GeneratedCertificate.eligible_certificates.get_or_create(user=student, course_id=course_id)
 
         cert.mode = cert_mode
         cert.user = student
@@ -290,8 +290,9 @@ class XQueueCertInterface(object):
 
         # If this user's enrollment is not eligible to receive a
         # certificate, mark it as such for reporting and
-        # analytics.
-        if not is_eligible_for_certificate:
+        # analytics. Only do this if the certificate is new -- we
+        # don't want to mark existing audit certs as ineligible.
+        if created and not is_eligible_for_certificate:
             cert.eligible_for_certificate = False
             cert.status = CertificateStatuses.auditing
             cert.save()

--- a/lms/djangoapps/certificates/tests/test_queue.py
+++ b/lms/djangoapps/certificates/tests/test_queue.py
@@ -30,7 +30,7 @@ from certificates.models import (
     CertificateStatuses,
 )
 from certificates.queue import XQueueCertInterface
-from certificates.tests.factories import CertificateWhitelistFactory
+from certificates.tests.factories import CertificateWhitelistFactory, GeneratedCertificateFactory
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
 
 
@@ -204,6 +204,37 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
                 self.assertTrue(mock_send.called)
             else:
                 self.assertFalse(mock_send.called)
+
+    def test_old_audit_cert_eligible(self):
+        """
+        Test that existing audit certificates remain eligible even if cert
+        generation is re-run.
+        """
+        # Create an existing audit enrollment and certificate
+        CourseEnrollmentFactory(
+            user=self.user_2,
+            course_id=self.course.id,
+            is_active=True,
+            mode=CourseMode.AUDIT,
+        )
+        GeneratedCertificateFactory(
+            user=self.user_2,
+            course_id=self.course.id,
+            grade='1.0',
+            status=CertificateStatuses.downloadable,
+            mode=GeneratedCertificate.MODES.audit,
+            eligible_for_certificate=True,
+        )
+
+        # Run grading/cert generation again
+        with patch('courseware.grades.grade', Mock(return_value={'grade': 'Pass', 'percent': 0.75})):
+            with patch.object(XQueueInterface, 'send_to_queue') as mock_send:
+                mock_send.return_value = (0, None)
+                self.xqueue.add_cert(self.user_2, self.course.id)
+
+        self.assertTrue(
+            GeneratedCertificate.objects.get(user=self.user_2, course_id=self.course.id).eligible_for_certificate  # pylint: disable=no-member
+        )
 
 
 @attr('shard_1')


### PR DESCRIPTION
@bderusha I just realized that there's a gap in the changes to `add_cert` -- any existing `GeneratedCertificate`s could get invalidated if certs are run again. The fix is to only mark a cert ineligible if it's new. Can you review?
