### PR TITLE
Change broken course_modes migration to not touch the database.

### DIFF
--- a/common/djangoapps/course_modes/migrations/0005_auto_20151217_0958.py
+++ b/common/djangoapps/course_modes/migrations/0005_auto_20151217_0958.py
@@ -11,13 +11,18 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='coursemode',
-            name='expiration_datetime',
-        ),
-        migrations.AddField(
-            model_name='coursemode',
-            name='_expiration_datetime',
-            field=models.DateTimeField(db_column=b'expiration_datetime', default=None, blank=True, help_text='OPTIONAL: After this date/time, users will no longer be able to enroll in this mode. Leave this blank if users can enroll in this mode until enrollment closes for the course.', null=True, verbose_name='Upgrade Deadline'),
-        ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                    migrations.RemoveField(
+                        model_name='coursemode',
+                        name='expiration_datetime',
+                    ),
+                    migrations.AddField(
+                        model_name='coursemode',
+                        name='_expiration_datetime',
+                        field=models.DateTimeField(db_column=b'expiration_datetime', default=None, blank=True, help_text='OPTIONAL: After this date/time, users will no longer be able to enroll in this mode. Leave this blank if users can enroll in this mode until enrollment closes for the course.', null=True, verbose_name='Upgrade Deadline'),
+                    ),
+            ]
+        )
     ]


### PR DESCRIPTION
@adampalay @bderusha @clintonb Here's the fix for the broken migration.

Changing a field name in the way that we did (updating the Python variable name and switching it to point to the old DB column) confuses Django's migration autodetector. No DB changes are actually necessary, but it thinks that a field has been removed and a new one added. This means that Django will ask users to generate the migration it thinks is necessary, which ended up with us dropping data. The fix is to run the same migration on Django's internal model of the DB state, but not actually touch the DB.

To test the fix, I did the following:
- Migrated back to the previous state with `./manage.py lms migrate course_modes 0004 --settings=devstack`.
- Checked in MySQL that I had test courses with upgrade deadlines in the LMS with `select * from course_modes_coursemode where expiration_datetime is not null;`.
- Ran the migration with `paver update_db`.
- Verified that the output of the previous MySQL query was unchanged.
- Ran `./manage.py lms makemigrations --settings=devstack`. Output was `No changes detected in app 'course_modes'`.
