### PR TITLE
Fix file upload in IE

### DIFF
--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import json
 import random
 import time
 import urlparse
@@ -7,7 +8,7 @@ import urlparse
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core import exceptions
-from django.http import Http404, HttpResponseBadRequest
+from django.http import Http404, HttpResponseBadRequest, HttpResponse
 from django.utils.translation import ugettext as _
 from django.views.decorators import csrf
 from django.views.decorators.http import require_GET, require_POST
@@ -750,13 +751,16 @@ def upload(request, course_id):  # ajax upload file to a question or answer
         result = ''
         file_url = ''
 
-    return JsonResponse({
+    # Using content-type of text/plain here instead of JSON because
+    # IE doesn't know how to handle the JSON response and prompts the
+    # user to save the JSON as a file instead of passing it to the callback.
+    return HttpResponse(json.dumps({
         'result': {
             'msg': result,
             'error': error,
             'file_url': file_url,
         }
-    })
+    }), content_type="text/plain")
 
 
 @require_GET


### PR DESCRIPTION
In the forums, when trying to add upload an image to a post/response using IE there are errors that prevent the user from uploading a file.  IE doesn't seem to know how to handle the `content-type='json'` in the file upload response.  Instead of passing the data to the callback method, it prompts the user to save or open the JSON as a file.

The solution proposed here is to return the response using `content-type='text/plain'` so that IE doesn't prevent the data from being passed to the callback method. I've tested on our other supported browsers to confirm that they continue to handle the response as expected.

See [TNL-4040](https://openedx.atlassian.net/browse/TNL-4040) for details.
## Sandbox

clytwynec-tnl-4040.sandbox.edx.org

@andy-armstrong @adampalay  Please review.
