### PR TITLE
Updating test case code to handle feedback XBlock

### DIFF
--- a/openedx/tests/xblock_integration/test_done.py
+++ b/openedx/tests/xblock_integration/test_done.py
@@ -26,13 +26,19 @@ class TestDone(XBlockTestCase):
     # normal workbench scenarios
     test_configuration = [
         {
-            "urlname": "two_done_block_test_case",
+            "urlname": "two_done_block_test_case_0",
             #"olx": self.olx_scenarios[0],
             "xblocks": [  # Stopgap until we handle OLX
                 {
                     'blocktype': 'done',
                     'urlname': 'done_0'
-                },
+                }
+            ]
+        },
+        {
+            "urlname": "two_done_block_test_case_1",
+            #"olx": self.olx_scenarios[0],
+            "xblocks": [  # Stopgap until we handle OLX
                 {
                     'blocktype': 'done',
                     'urlname': 'done_1'


### PR DESCRIPTION
This will:
- Resolve several bugs in the test framework
- Allow us to test XBlock rendered HTML

This is the first commit of https://github.com/edx/edx-platform/pull/10747 and was reviewed there. I am extracting this so that other XBlocks can merge tests which trigger previous bugs. I will merge as soon as test are run. @cahrens 
