### PR TITLE
WIP: An experiment with test speed

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -182,6 +182,9 @@ FEATURES = {
     'ENABLE_SPECIAL_EXAMS': False,
 
     'ORGANIZATIONS_APP': False,
+
+    # Enable reporting metrics to DataDog
+    'ENABLE_DATADOG_REPORTING': False,
 }
 
 ENABLE_JASMINE = False

--- a/common/djangoapps/monitoring/startup.py
+++ b/common/djangoapps/monitoring/startup.py
@@ -1,4 +1,7 @@
-# Register signal handlers
-# pylint: disable=unused-import
-import signals
-import exceptions
+from django.conf import settings
+
+# Register signal handlers, but only if Datadog reporting has been made active
+if settings.FEATURES.get('ENABLE_DATADOG_REPORTING'):
+    # pylint: disable=unused-import
+    import signals
+    import exceptions

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -123,6 +123,8 @@ def load_function(path):
     return getattr(import_module(module_path), name)
 
 
+load_function_mapping = {}
+
 def create_modulestore_instance(
         engine,
         content_store,
@@ -136,7 +138,11 @@ def create_modulestore_instance(
     """
     This will return a new instance of a modulestore given an engine and options
     """
-    class_ = load_function(engine)
+    if engine in load_function_mapping:
+        class_ = load_function_mapping[engine]
+    else:
+        class_ = load_function(engine)
+        load_function_mapping[engine] = class_
 
     _options = {}
     _options.update(options)

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -123,8 +123,6 @@ def load_function(path):
     return getattr(import_module(module_path), name)
 
 
-load_function_mapping = {}
-
 def create_modulestore_instance(
         engine,
         content_store,
@@ -138,11 +136,7 @@ def create_modulestore_instance(
     """
     This will return a new instance of a modulestore given an engine and options
     """
-    if engine in load_function_mapping:
-        class_ = load_function_mapping[engine]
-    else:
-        class_ = load_function(engine)
-        load_function_mapping[engine] = class_
+    class_ = load_function(engine)
 
     _options = {}
     _options.update(options)

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -324,11 +324,15 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         This key may represent a course that doesn't exist in this modulestore.
         """
+        possible_keys = [
+            store.make_course_key(org, course, run)
+            for store in self.modulestores
+        ]
+
         # If there is a mapping that match this org/course/run, use that
-        for course_id, store in self.mappings.iteritems():
-            candidate_key = store.make_course_key(org, course, run)
-            if candidate_key == course_id:
-                return candidate_key
+        for key in possible_keys:
+            if key in self.mappings:
+                return self.mappings[key]
 
         # Otherwise, return the key created by the default store
         return self.default_modulestore.make_course_key(org, course, run)

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -332,7 +332,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         # If there is a mapping that match this org/course/run, use that
         for key in possible_keys:
             if key in self.mappings:
-                return self.mappings[key]
+                return key
 
         # Otherwise, return the key created by the default store
         return self.default_modulestore.make_course_key(org, course, run)

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -913,6 +913,7 @@ class ResourceTemplates(object):
     It finds the templates as directly in this directory under 'templates'.
     """
     template_packages = [__name__]
+    _cached_templates = {}
 
     @classmethod
     def templates(cls):
@@ -961,6 +962,9 @@ class ResourceTemplates(object):
         template_dir_name)
 
         """
+        if template_id in cls._cached_templates:
+            return cls._cached_templates[template_id]
+
         dirname = cls.get_template_dir()
         if dirname is not None:
             path = os.path.join(dirname, template_id)
@@ -969,6 +973,8 @@ class ResourceTemplates(object):
                     template_content = resource_string(pkg, path)
                     template = yaml.safe_load(template_content)
                     template['template_id'] = template_id
+
+                    cls._cached_templates[template_id] = template
                     return template
 
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -369,6 +369,9 @@ FEATURES = {
 
     # Enable LTI Provider feature.
     'ENABLE_LTI_PROVIDER': False,
+
+    # Enable reporting metrics to DataDog
+    'ENABLE_DATADOG_REPORTING': False,
 }
 
 # Ignore static asset files on import which match this pattern

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -79,7 +79,7 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.4#egg=XBlock==0.4.4
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@0.2.5#egg=ora2==0.2.5
 -e git+https://github.com/edx/edx-submissions.git@0.1.3#egg=edx-submissions==0.1.3
--e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
+-e git+https://github.com/edx/opaque-keys.git@490ed3b3b6625fc9a1e4ff11b77bf69ae2aac62b#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.2#egg=i18n-tools==v0.2
 git+https://github.com/edx/edx-oauth2-provider.git@0.5.8#egg=edx-oauth2-provider==0.5.8


### PR DESCRIPTION
Just playing with a few ways to make tests faster. This is just a collection of experiments. I'll probably cherry-pick things over into separate PRs once I have some decent data points.

Test runtime on master: 1h 14m
Test runtime on this branch so far: 1h 7m
- [ ] re-enable Datadog in non-test modes.
- [ ] figure out if we can make `create_course()` faster
  - [ ] figure out better way to preserve defaults set in course `__init__` so we don't have to pull it all back again?
  - [ ] remove some of the `deepcopy()`s?
  - [ ] actually, what happens if we just remove `deepcopy` from XBlock field handling to begin with? Is it really that bad?
