### PR TITLE
[firefox upgrade] Replace action chain with tinymce JS.

### DIFF
--- a/common/test/acceptance/pages/studio/html_component_editor.py
+++ b/common/test/acceptance/pages/studio/html_component_editor.py
@@ -39,18 +39,13 @@ class HtmlComponentEditorView(ComponentEditorView):
         self.cancel()
 
     def set_content(self, content):
-        """Types content into the html component, leaving the component open.
+        """Sets content in the html component, leaving the component open.
 
         Arguments:
             content (str): The content to be used.
         """
         self.q(css=self.editor_mode_css).click()
-
-        selector = '.html-editor .mce-edit-area'
-        editor = self.q(css=self._bounded_selector(selector))[0]
-        ActionChains(self.browser).click(editor).\
-            send_keys([Keys.CONTROL, 'a']).key_up(Keys.CONTROL).\
-            send_keys(content).perform()
+        self.browser.execute_script("tinyMCE.activeEditor.setContent('%s')" % content)
 
     def set_raw_content(self, content):
         """Types content in raw html mode, leaving the component open.


### PR DESCRIPTION
This action chain is not reliable across firefox versions (and
in fact, even on the older firefox, fails locally). Instead we
use native JS tinymce to set the content.
