### PR TITLE
mattdrayer/index-page-bokchoy: Refactor+cover Open edX LMS index page

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -169,7 +169,27 @@ def index(request, extra_context=None, user=AnonymousUser()):
 
     context = {'courses': courses}
 
+    context['homepage_overlay_html'] = microsite.get_value('homepage_overlay_html')
+
+    # This appears to be an unused context parameter, at least for the master templates...
+    context['show_partners'] = microsite.get_value('show_partners', True)
+
+    # TO DISPLAY A YOUTUBE WELCOME VIDEO
+    # 1) Change False to True
+    context['show_homepage_promo_video'] = microsite.get_value('show_homepage_promo_video', False)
+
+    # 2) Add your video's YouTube ID (11 chars, eg "123456789xX"), or specify via microsite config
+    # Note: This value should be moved into a configuration setting and plumbed-through to the
+    # context via the microsite configuration workflow, versus living here
+    youtube_video_id = microsite.get_value('homepage_promo_video_youtube_id', "your-youtube-id")
+    context['homepage_promo_video_youtube_id'] = youtube_video_id
+
+    # allow for microsite override of the courses list
+    context['courses_list'] = microsite.get_template_path('courses_list.html')
+
+    # Insert additional context for use in the template
     context.update(extra_context)
+
     return render_to_response('index.html', context)
 
 

--- a/common/test/acceptance/pages/lms/index.py
+++ b/common/test/acceptance/pages/lms/index.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+LMS index (home) page.
+"""
+from bok_choy.page_object import PageObject
+from . import BASE_URL
+
+BANNER_SELECTOR = 'section.home header div.outer-wrapper div.title hgroup h1'
+INTRO_VIDEO_SELECTOR = 'div.play-intro'
+VIDEO_MODAL_SELECTOR = 'section#video-modal.modal.home-page-video-modal.video-modal'
+
+
+class IndexPage(PageObject):
+    """
+    LMS index (home) page, the default landing page for Open edX users when they are not logged in
+    """
+    def __init__(self, browser):
+        """Initialize the page.
+
+        Arguments:
+            browser (Browser): The browser instance.
+        """
+        super(IndexPage, self).__init__(browser)
+
+    url = "{base}/".format(base=BASE_URL)
+
+    def is_browser_on_page(self):
+        """
+        Returns a browser query object representing the video modal element
+        """
+        element = self.q(css=BANNER_SELECTOR)
+        return element.visible and element.text[0] == "Welcome to Open edX!"
+
+    @property
+    def banner_element(self):
+        """
+        Returns a browser query object representing the video modal element
+        """
+        return self.q(css=BANNER_SELECTOR)
+
+    @property
+    def intro_video_element(self):
+        """
+        Returns a browser query object representing the video modal element
+        """
+        return self.q(css=INTRO_VIDEO_SELECTOR)
+
+    @property
+    def video_modal_element(self):
+        """
+        Returns a browser query object representing the video modal element
+        """
+        return self.q(css=VIDEO_MODAL_SELECTOR)

--- a/common/test/acceptance/tests/lms/test_lms_index.py
+++ b/common/test/acceptance/tests/lms/test_lms_index.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+End-to-end tests for the LMS Index page (aka, Home page).  Note that this is different than
+what students see @ edx.org because we redirect requests to a separate web application.
+"""
+import datetime
+
+from bok_choy.web_app_test import WebAppTest
+from ...pages.lms.index import IndexPage
+
+
+class BaseLmsIndexTest(WebAppTest):
+    """ Base test suite for the LMS Index (Home) page """
+
+    def setUp(self):
+        """
+        Initializes the components (page objects, courses, users) for this test suite
+        """
+        # Some state is constructed by the parent setUp() routine
+        super(BaseLmsIndexTest, self).setUp()
+
+        # Load page objects for use by the tests
+        self.page = IndexPage(self.browser)
+
+        # Navigate to the index page and get testing!
+        self.page.visit()
+
+
+class LmsIndexPageTest(BaseLmsIndexTest):
+    """ Test suite for the LMS Index (Home) page """
+
+    def setUp(self):
+        super(LmsIndexPageTest, self).setUp()
+
+        # Useful to capture the current datetime for our tests
+        self.now = datetime.datetime.now()
+
+    def test_index_basic_request(self):
+        """
+        Perform a general validation of the index page, renders normally, no exceptions raised, etc.
+        """
+        self.assertTrue(self.page.banner_element.visible)
+
+    def test_intro_video_hidden_by_default(self):
+        """
+        Confirm that the intro video is not displayed when using the default configuration
+        """
+        # Ensure the introduction video element is not shown
+        self.assertFalse(self.page.intro_video_element.visible)
+
+        # @fghaas: The below presence check can now be modified along with your changeset
+        # Still need to figure out how to swap platform settings in the context of a bok choy test
+        # but we can at least prevent accidental exposure with these validations going forward
+        # Note: 'present' is a DOM check, whereas 'visible' is an actual browser/screen check
+        self.assertTrue(self.page.video_modal_element.present)
+        self.assertFalse(self.page.video_modal_element.visible)

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -3,18 +3,6 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
-from microsite_configuration import microsite
-%>
-
-<%
-  homepage_overlay_html = microsite.get_value('homepage_overlay_html')
-
-  ## To display a welcome video, change False to True, and add a YouTube ID (11 chars, eg "123456789xX") in the following line
-  show_homepage_promo_video = microsite.get_value('show_homepage_promo_video', False)
-  homepage_promo_video_youtube_id = microsite.get_value('homepage_promo_video_youtube_id', "your-youtube-id")
-
-  show_partners = microsite.get_value('show_partners', True)
-
 %>
 
 <section class="home">
@@ -61,10 +49,6 @@ from microsite_configuration import microsite
     </div>
 
   </header>
-  <%
-    # allow for microsite override of the courses list
-    courses_list = microsite.get_template_path('courses_list.html')
-  %>
   <%include file="${courses_list}" />
 
 </section>


### PR DESCRIPTION
@fghaas -- I took a stab at adding some basic bok choy coverage to the index page template for the LMS, as we discussed in #11138.  Please take a look when you have a moment and let me know what you think.  

I tried to avoid diving into a lot of refactoring of the actual template/view, because we're going to be tackling this in the near future as part of our work to consolidate all of the various branding/skinning implementations into comprehensive theming.

@douglashall would be great to get a review from you, as well (not time-sensitive)
