### PR TITLE
Replace property min-width value

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -228,6 +228,7 @@ Richard Moch <richard.moch@gmail.com>
 Albert Liang <albertliangcode@gmail.com>
 Pan Luo <pan.luo@ubc.ca>
 Tyler Nickerson <nickersoft@gmail.com>
+Daniel Naranjo <daniel.naranjo@edunext.co>
 Vedran Karačić <vedran@edx.org>
 William Ono <william.ono@ubc.ca>
 Dongwook Yoon <dy252@cornell.edu>

--- a/lms/static/sass/base/_layouts.scss
+++ b/lms/static/sass/base/_layouts.scss
@@ -72,7 +72,7 @@ body.view-in-course {
   // post-container footer (creative commons)
   .container-footer {
     max-width: none;
-    min-width: none;
+    min-width: 0;
     width: auto;
   }
 


### PR DESCRIPTION
The min-width property accept only values <length> | <percentage> | inherit. to reset better set to 0.
Properties documentation: https://www.w3.org/TR/CSS2/visudet.html#min-max-widths

This error generates an invalid style, and, therefore, this value is set to 760px by: https://github.com/edx/edx-platform/blob/master/lms/static/sass/course/courseware/_courseware.scss#L50
