### PR TITLE
WL-276: Move microsite_configuration/templatetags/microsite.py from individual templates to static_content.html

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -5,6 +5,7 @@ from django.utils.translation import get_language_bidi
 from mako.exceptions import TemplateLookupException
 
 from microsite_configuration import microsite
+from openedx.core.djangoapps.theming.helpers import get_page_title_breadcrumbs, get_value
 from certificates.api import get_asset_url_by_slug
 %>
 
@@ -98,4 +99,13 @@ except TemplateLookupException:
     pass
 else:
     tmpl.render_context(context)
+%></%def>
+
+
+<%def name="get_page_title_breadcrumbs(*args)"><%
+    return get_page_title_breadcrumbs(*args)
+%></%def>
+
+<%def name="get_platform_name()"><%
+    return get_value('platform_name', settings.PLATFORM_NAME)
 %></%def>

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -3,7 +3,6 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.template.defaultfilters import escapejs
-from microsite_configuration import page_title_breadcrumbs
 from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
 %>
 <%def name="course_name()">
@@ -13,9 +12,9 @@ from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
 <%block name="bodyclass">view-in-course view-courseware courseware ${course.css_class or ''}</%block>
 <%block name="title"><title>
     % if section_title:
-${page_title_breadcrumbs(section_title, course_name())}
+${static.get_page_title_breadcrumbs(section_title, course_name())}
     % else:
-${page_title_breadcrumbs(course_name())}
+${static.get_page_title_breadcrumbs(course_name())}
     %endif
 </title></%block>
 

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -3,7 +3,6 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.template.defaultfilters import escapejs
-from microsite_configuration import page_title_breadcrumbs
 from django.conf import settings
 from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
 %>
@@ -17,9 +16,9 @@ from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
 <%block name="bodyclass">view-in-course view-courseware courseware ${course.css_class or ''}</%block>
 <%block name="title"><title>
     % if section_title:
-${page_title_breadcrumbs(section_title, course_name())}
+${static.get_page_title_breadcrumbs(section_title, course_name())}
     % else:
-${page_title_breadcrumbs(course_name())}
+${static.get_page_title_breadcrumbs(course_name())}
     %endif
 </title></%block>
 

--- a/lms/templates/dashboard/_dashboard_status_verification.html
+++ b/lms/templates/dashboard/_dashboard_status_verification.html
@@ -2,7 +2,6 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
-from microsite_configuration.templatetags.microsite import platform_name
 %>
 
 %if verification_status == 'approved':
@@ -40,7 +39,7 @@ from microsite_configuration.templatetags.microsite import platform_name
 
 %if verification_status in ['must_reverify', 'expired']:
 <li class="status status-verification is-denied">
-<span class="title status-title">${_("{platform_name} Verification Status").format(platform_name=platform_name())}</span>
+<span class="title status-title">${_("{platform_name} Verification Status").format(platform_name=static.get_platform_name())}</span>
 
   <div class="status-data">
     <span class="status-data-message">${verification_msg}</span>

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -8,7 +8,6 @@ from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from xmodule.tabs import CourseTabList
 from microsite_configuration import microsite
-from microsite_configuration.templatetags.microsite import platform_name
 %>
 
 % if settings.FEATURES.get('ENABLE_FEEDBACK_SUBMISSION', False):
@@ -17,7 +16,7 @@ from microsite_configuration.templatetags.microsite import platform_name
   <a href="#help-modal" rel="leanModal" role="button">${_("Help")}</a>
 </div>
 
-<section id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-label="${_("{platform_name} Help").format(platform_name=platform_name())}">
+<section id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-label="${_("{platform_name} Help").format(platform_name=static.get_platform_name())}">
   <div class="inner-wrapper" id="help_wrapper">
     ## TODO: find a way to refactor this
     <button class="close-modal "tabindex="0">
@@ -31,7 +30,7 @@ from microsite_configuration.templatetags.microsite import platform_name
     <header>
       <h2>
 	${_('{platform_name} Help').format(
-	    platform_name=u'<span class="edx">{}</span>'.format(platform_name())
+	    platform_name=u'<span class="edx">{}</span>'.format(static.get_platform_name())
 	)}
       </h2>
       <hr>
@@ -55,11 +54,11 @@ from microsite_configuration.templatetags.microsite import platform_name
           url=marketing_link('FAQ')
         ),
         link_end='</a>',
-        platform_name=platform_name())}
+        platform_name=static.get_platform_name())}
       </p>
 
     <p>${_('Have a <strong>question about something specific</strong>? You can contact the {platform_name} general support team directly:').format(
-        platform_name=platform_name()
+        platform_name=static.get_platform_name()
       )}</p>
     <hr>
 
@@ -70,7 +69,7 @@ from microsite_configuration.templatetags.microsite import platform_name
     </div>
 
     <p class="note">${_('Please note: The {platform_name} support team is English speaking. While we will do our best to address your inquiry in any language, our responses will be in English.').format(
-        platform_name=platform_name()
+        platform_name=static.get_platform_name()
       )}</p>
 
   </div>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -6,7 +6,6 @@ from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext as _
 from django.utils.translation import get_language_bidi
 from microsite_configuration import microsite
-from microsite_configuration import page_title_breadcrumbs
 from branding import api as branding_api
 %>
 <!DOCTYPE html>
@@ -41,7 +40,7 @@ from branding import api as branding_api
 <%def name="pagetitle()" />
   <%block name="title">
       <title>
-       ${page_title_breadcrumbs(self.pagetitle())}
+       ${static.get_page_title_breadcrumbs(self.pagetitle())}
       </title>
   </%block>
 

--- a/lms/templates/navigation-edx.html
+++ b/lms/templates/navigation-edx.html
@@ -6,7 +6,6 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from microsite_configuration import microsite
-from microsite_configuration.templatetags.microsite import platform_name
 
 # App that handles subdomain specific branding
 from branding import api as branding_api
@@ -41,7 +40,7 @@ site_status_msg = get_site_status_msg(course_id)
     <h1 class="logo" itemscope="" itemtype="http://schema.org/Organization">
       <a href="${marketing_link('ROOT')}" itemprop="url">
         <%block name="navigation_logo">
-            <img src="${static.url(branding_api.get_logo_url())}" alt="${_("{platform_name} Home Page").format(platform_name=platform_name())}" itemprop="logo" />
+            <img src="${static.url(branding_api.get_logo_url())}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}" itemprop="logo" />
         </%block>
       </a>
     </h1>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -6,7 +6,6 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from microsite_configuration import microsite
-from microsite_configuration.templatetags.microsite import platform_name
 from lms.djangoapps.ccx.overrides import get_current_ccx
 
 # App that handles subdomain specific branding
@@ -42,7 +41,7 @@ site_status_msg = get_site_status_msg(course_id)
     <h1 class="logo">
       <a href="${marketing_link('ROOT')}">
         <%block name="navigation_logo">
-            <img src="${static.url(branding_api.get_logo_url())}" alt="${_("{platform_name} Home Page").format(platform_name=platform_name())}"/>
+            <img src="${static.url(branding_api.get_logo_url())}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
         </%block>
       </a>
     </h1>

--- a/lms/templates/ux/reference/teams-base.html
+++ b/lms/templates/ux/reference/teams-base.html
@@ -1,6 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from django.template.defaultfilters import escapejs %>
-<%! from microsite_configuration import page_title_breadcrumbs %>
 <%! from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled %>
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>

--- a/lms/templates/ux/reference/teams-create.html
+++ b/lms/templates/ux/reference/teams-create.html
@@ -1,6 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from django.template.defaultfilters import escapejs %>
-<%! from microsite_configuration import page_title_breadcrumbs %>
 <%! from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled %>
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>

--- a/openedx/core/djangoapps/theming/helpers.py
+++ b/openedx/core/djangoapps/theming/helpers.py
@@ -1,0 +1,19 @@
+"""
+    Helpers for accessing comprehensive theming related variables.
+"""
+from microsite_configuration import microsite
+from microsite_configuration import page_title_breadcrumbs
+
+
+def get_page_title_breadcrumbs(*args):
+    """
+    This is a proxy function to hide microsite_configuration behind comprehensive theming.
+    """
+    return page_title_breadcrumbs(*args)
+
+
+def get_value(val_name, default=None, **kwargs):
+    """
+    This is a proxy function to hide microsite_configuration behind comprehensive theming.
+    """
+    return microsite.get_value(val_name, default=default, **kwargs)

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -6,7 +6,6 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from microsite_configuration import microsite
-from microsite_configuration.templatetags.microsite import platform_name
 
 # App that handles subdomain specific branding
 import branding
@@ -41,7 +40,7 @@ site_status_msg = get_site_status_msg(course_id)
     <h1 class="logo" itemscope="" itemtype="http://schema.org/Organization">
       <a href="${marketing_link('ROOT')}" itemprop="url">
         <%block name="navigation_logo">
-            <img src="${static.url("images/logo.png")}" alt="${_("{platform_name} Home Page").format(platform_name=platform_name())}" itemprop="logo" />
+            <img src="${static.url("images/logo.png")}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}" itemprop="logo" />
         </%block>
       </a>
     </h1>

--- a/themes/red-theme/lms/templates/footer.html
+++ b/themes/red-theme/lms/templates/footer.html
@@ -3,7 +3,6 @@
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
-from microsite_configuration.templatetags.microsite import platform_name
 %>
 
 <div class="wrapper wrapper-footer">

--- a/themes/red-theme/lms/templates/header.html
+++ b/themes/red-theme/lms/templates/header.html
@@ -11,7 +11,6 @@ import branding
 from status.status import get_site_status_msg
 
 from microsite_configuration import microsite
-from microsite_configuration.templatetags.microsite import platform_name
 from ccx.overrides import get_current_ccx
 %>
 
@@ -43,7 +42,7 @@ site_status_msg = get_site_status_msg(course_id)
     <h1 class="logo">
       <a href="${marketing_link('ROOT')}">
         <%block name="navigation_logo">
-            <img src="${static.url("images/logo.png")}" alt="${_("{platform_name} Home Page").format(platform_name=platform_name())}"/>
+            <img src="${static.url("images/logo.png")}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
         </%block>
       </a>
     </h1>


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly Review this PR, it contains changes for moving `microsite_configuration/templatetags/microsite.py` out of the templates into `static_content.html`.

**Description of changes:**
Create definitions/functions for microsite template tags in `static_content.html`.
We found that every template in comprehensive theming uses static_content.html namespace. So we can create definitions/functions for following microsite tags defined in `microsite_configuration/templatetags/microsite.py` in static_content.html that will make them available inside every template.
- microsite_template_path
- platform_name
- page_title_breadcrumbs_tag

Other tags are no longer in use.

Once these functions are created in `static_content.html` we will need to remove all references of `microsite_configuration/templatetags/microsite.py` out of the templates and use these functions instead.

cc: @mattdrayer 
