### PR TITLE
Correctly query for any generated certificate, not just eligible ones.

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -279,7 +279,7 @@ class XQueueCertInterface(object):
         if forced_grade:
             grade['grade'] = forced_grade
 
-        cert, created = GeneratedCertificate.eligible_certificates.get_or_create(user=student, course_id=course_id)
+        cert, created = GeneratedCertificate.objects.get_or_create(user=student, course_id=course_id)  # pylint: disable=no-member
 
         cert.mode = cert_mode
         cert.user = student

--- a/lms/djangoapps/certificates/tests/test_queue.py
+++ b/lms/djangoapps/certificates/tests/test_queue.py
@@ -205,7 +205,8 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
             else:
                 self.assertFalse(mock_send.called)
 
-    def test_old_audit_cert_eligible(self):
+    @ddt.data(True, False)
+    def test_regen_audit_certs_eligibility(self, eligibility):
         """
         Test that existing audit certificates remain eligible even if cert
         generation is re-run.
@@ -223,7 +224,7 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
             grade='1.0',
             status=CertificateStatuses.downloadable,
             mode=GeneratedCertificate.MODES.audit,
-            eligible_for_certificate=True,
+            eligible_for_certificate=eligibility,
         )
 
         # Run grading/cert generation again
@@ -232,8 +233,9 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
                 mock_send.return_value = (0, None)
                 self.xqueue.add_cert(self.user_2, self.course.id)
 
-        self.assertTrue(
-            GeneratedCertificate.objects.get(user=self.user_2, course_id=self.course.id).eligible_for_certificate  # pylint: disable=no-member
+        self.assertEqual(
+            GeneratedCertificate.objects.get(user=self.user_2, course_id=self.course.id).eligible_for_certificate,  # pylint: disable=no-member
+            eligibility
         )
 
 


### PR DESCRIPTION
@jimabramson Here's the fix. Short explanation is that the old code used the wrong queryset and filtered out some `GeneratedCertificate`s, leading to database integrity errors due to violating uniqueness constraints.
