### PR TITLE
Do not clean test files with bok choy testsonly command

### DIFF
--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -68,7 +68,7 @@ class BokChoyTestSuite(TestSuite):
         self.report_dir.makedirs_p()
         test_utils.clean_reports_dir()      # pylint: disable=no-value-for-parameter
 
-        if not (self.fasttest or self.skip_clean):
+        if not (self.fasttest or self.skip_clean or self.testsonly):
             test_utils.clean_test_files()
 
         msg = colorize('green', "Checking for mongo, memchache, and mysql...")


### PR DESCRIPTION
Bok-choy static files are collected by --serversonly into test_root/staticfiles during this part of the setup:

```
Generating optimized static assets...
paver update_assets --settings=test_static_optimized
```

but then when you do --testsonly in another window, that command cleans out the test_root directory.

@benpatterson @raeeschachar 
