### PR TITLE
[TNL-3962] moving DEPRECATED_ADVANCED_COMPONENT_TYPES to dJango admin

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -77,7 +77,7 @@ def _advanced_component_types():
     if XBlockDeprecatedAdvancedComponentConfig:
         deprecated_xblock_types = XBlockDeprecatedAdvancedComponentConfig.disabled_block_types()
     else:
-        deprecated_xblock_types = ()
+        deprecated_xblock_types = []
 
     # Merge settings list with one in the admin config;
     if hasattr(settings, 'DEPRECATED_ADVANCED_COMPONENT_TYPES'):

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1054,6 +1054,8 @@ ADVANCED_COMPONENT_TYPES = [
 # Adding components in this list will disable the creation of new problem for
 # those components in Studio. Existing problems will work fine and one can edit
 # them in Studio.
+# Note: This setting is deprecated. This configuration has been moved to the
+# django admin and should be added there.
 DEPRECATED_ADVANCED_COMPONENT_TYPES = []
 
 # Specify XBlocks that should be treated as advanced problems. Each entry is a

--- a/common/djangoapps/xblock_django/admin.py
+++ b/common/djangoapps/xblock_django/admin.py
@@ -4,6 +4,7 @@ Django admin dashboard configuration.
 
 from django.contrib import admin
 from config_models.admin import ConfigurationModelAdmin
-from xblock_django.models import XBlockDisableConfig
+from xblock_django.models import XBlockDisableConfig, XBlockDeprecatedAdvancedComponentConfig
 
 admin.site.register(XBlockDisableConfig, ConfigurationModelAdmin)
+admin.site.register(XBlockDeprecatedAdvancedComponentConfig, ConfigurationModelAdmin)

--- a/common/djangoapps/xblock_django/migrations/0002_xblockdeprecatedadvancedcomponentconfig.py
+++ b/common/djangoapps/xblock_django/migrations/0002_xblockdeprecatedadvancedcomponentconfig.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('xblock_django', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='XBlockDeprecatedAdvancedComponentConfig',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
+                ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
+                ('disabled_blocks', models.TextField(default=b'', help_text='Space-separated list of XBlocks which should not render.', blank=True)),
+                ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
+            ],
+            options={
+                'ordering': ('-change_date',),
+                'abstract': False,
+            },
+        ),
+    ]

--- a/common/djangoapps/xblock_django/models.py
+++ b/common/djangoapps/xblock_django/models.py
@@ -68,3 +68,8 @@ class XBlockDeprecatedAdvancedComponentConfig(ConfigurationModel):
             return ()
 
         return config.disabled_blocks.split()
+
+    @classmethod
+    def __unicode__(cls):
+        config = cls.current()
+        return u"Deprectaed xblock types are {deprectated_xblocks}".format(deprectaed_xblocks=config.disabled_blocks)

--- a/common/djangoapps/xblock_django/models.py
+++ b/common/djangoapps/xblock_django/models.py
@@ -40,3 +40,31 @@ class XBlockDisableConfig(ConfigurationModel):
             return ()
 
         return config.disabled_blocks.split()
+
+
+class XBlockDeprecatedAdvancedComponentConfig(ConfigurationModel):
+    """
+    Configuration for deprecated XBlocks that should not be created in Studio.
+    """
+
+    class Meta(ConfigurationModel.Meta):
+        app_label = 'xblock_django'
+
+    disabled_blocks = TextField(
+        default='', blank=True,
+        help_text=_(
+            "Adding components in this list will disable the creation of new problem for "
+            "those components in Studio. Existing problems will work fine and one can edit"
+            "them in Studio."
+        )
+    )
+
+    @classmethod
+    def disabled_block_types(cls):
+        """ Return list of deprecated xblock types. """
+
+        config = cls.current()
+        if not config.enabled:
+            return ()
+
+        return config.disabled_blocks.split()


### PR DESCRIPTION
Adding Django Admin configuration for `DEPRECATED_ADVANCED_COMPONENT_TYPES` while still keeping it in settings file. So any components added to the settings field `DEPRECATED_ADVANCED_COMPONENT_TYPES` and any components added in the admin configuration `X block deprecated advanced component configs` will not be shown for new problems in studio.

@muhammad-ammar @muzaffaryousaf Please review.
