### PR TITLE
Default advanced components

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -362,6 +362,21 @@ XBLOCK_MIXINS = (
 # xblocks can be added via advanced settings
 XBLOCK_SELECT_FUNCTION = prefer_xmodules
 
+# This is a list of official, supported XBlocks which will be shown in
+# all courses to all course authors.
+DEFAULT_XBLOCKS = [
+    'done',
+    'google-calendar',
+    'google-document',
+    'library_content',
+    'lti_consumer',
+    'officemix',
+    'oppia',
+    'poll',
+    'recommender',
+    'split_test',
+    'survey']
+
 ############################ Modulestore Configuration ################################
 MODULESTORE_BRANCH = 'draft-preferred'
 
@@ -1003,6 +1018,8 @@ DEFAULT_COURSE_LANGUAGE = "en"
 #   )
 #
 # To use this block, add 'foobar-block' to the ADVANCED_COMPONENT_TYPES list.
+
+
 
 ADVANCED_COMPONENT_TYPES = [
     'annotatable',


### PR DESCRIPTION
@explorerleslie This is a pull request which turns on supported advanced components by default. The button still has the word "Advanced" and a lab beaker, so my expectation is that with the initial flip, we'll still only see these used by more intrepid course staffs. I think this would give us a fairly low-key launch, where this no longer requires mocking with JSON to use these, but at the same time, where they are a little bit out-of-the-way. Assuming the world doesn't explode, the next step would be to make the UX around these a little bit nicer (e.g. providing a bit of help text, links to documentation, possibly screenshots, etc., kind of like in an app store).

Right now, the set of fully supported components is:

`done`, `google-calendar`, `google-document`, `lti_consumer`, `officemix`, `oppia`, `poll`, `recommender`, `survey`

Of these, `officemix` and `oppia` do not appear to currently be installed in edx-platform, so do not show up.

In addition, services said that `split_test` and `library_content` are fully supported, but both will require additional work to enable platform-wide. This PR includes them in the `DEFAULT_BLOCKS` list in preparation for that, but this is not sufficient to enable them in the user interfaces. 

Since we had discussed this, my hope was to get a thumbs up from you from a product perspective before you leave, and we have either no product org or a new product owner still getting up-to-speed on the platform. Once I have your thumbs up, I can work this through the engineering org.
