### PR TITLE
WL-277: Remove microsite_configuration/microsite.py references from individual html templates

### DIFF
--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -6,7 +6,6 @@ from util.date_utils import get_default_time_display
 from django.utils.translation import ugettext as _
 from openedx.core.lib.js_utils import escape_json_dumps
 from contentstore.utils import reverse_usage_url
-from microsite_configuration import microsite
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 %>
 <%block name="title">${_("Course Outline")}</%block>
@@ -54,9 +53,6 @@ from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
   %endif
 
     %if deprecated_blocks_info.get('blocks') or deprecated_blocks_info.get('block_types_enabled'):
-      <%
-        platform_name = microsite.get_value('platform_name', settings.PLATFORM_NAME)
-      %>
       <div class="wrapper wrapper-alert wrapper-alert-error is-shown">
         <div class="alert announcement">
           <i class="feedback-symbol fa fa-warning" aria-hidden="true"></i><span class="sr">${_("Warning")}</span>
@@ -87,7 +83,7 @@ from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
               <div class="advance-modules-list">
                 <p class="advance-modules-remove-text">
                   ${_("To avoid errors, {platform_name} strongly recommends that you remove unsupported features from the course advanced settings. To do this, go to the {link_start}Advanced Settings page{link_end}, locate the \"Advanced Module List\" setting, and then delete the following modules from the list.").format(
-                    platform_name=platform_name,
+                    platform_name=static.get_platform_name(),
                     link_start='<a href="{advance_settings_url}">'.format(advance_settings_url=deprecated_blocks_info['advance_settings_url']), link_end="</a>"
                   )}
                 </p>

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -4,8 +4,7 @@ from pipeline_mako import compressed_css, compressed_js
 from django.utils.translation import get_language_bidi
 from mako.exceptions import TemplateLookupException
 
-from microsite_configuration import microsite
-from openedx.core.djangoapps.theming.helpers import get_page_title_breadcrumbs, get_value
+from openedx.core.djangoapps.theming.helpers import get_page_title_breadcrumbs, get_value, get_template_path, get_themed_template_path, is_request_in_themed_site
 from certificates.api import get_asset_url_by_slug
 %>
 
@@ -89,10 +88,10 @@ source, template_path = Loader(engine).load_template_source(path)
     </script>
 </%def>
 
-<%def name="optional_include_mako(file, with_microsite=False)"><%
+<%def name="optional_include_mako(file, is_theming_enabled=False)"><%
 # http://stackoverflow.com/q/21219531
-if with_microsite:
-    file = microsite.get_template_path(file)
+if is_theming_enabled:
+    file = get_template_path(file)
 try:
     tmpl = self.get_template(file)
 except TemplateLookupException:
@@ -108,4 +107,20 @@ else:
 
 <%def name="get_platform_name()"><%
     return get_value('platform_name', settings.PLATFORM_NAME)
+%></%def>
+
+<%def name="get_value(val_name, default=None, **kwargs)"><%
+    return get_value(val_name, default=default, **kwargs)
+%></%def>
+
+<%def name="get_template_path(relative_path, **kwargs)"><%
+    return get_template_path(relative_path, **kwargs)
+%></%def>
+
+<%def name="get_themed_template_path(relative_path, default_path, **kwargs)"><%
+    return get_themed_template_path(relative_path, default_path, **kwargs)
+%></%def>
+
+<%def name="is_request_in_themed_site()"><%
+    return is_request_in_themed_site()
 %></%def>

--- a/common/test/test_microsites/test_microsite/templates/footer.html
+++ b/common/test/test_microsites/test_microsite/templates/footer.html
@@ -3,7 +3,6 @@
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
-from microsite_configuration import microsite
 %>
 
 

--- a/common/test/test_microsites/test_microsite/templates/head-extra.html
+++ b/common/test/test_microsites/test_microsite/templates/head-extra.html
@@ -1,6 +1,5 @@
 <%namespace name='static' file='../../static_content.html'/>
-<%! from microsite_configuration import microsite %>
-<% style_overrides_file = microsite.get_value('css_overrides_file') %>
+<% style_overrides_file = static.get_value('css_overrides_file') %>
 
 % if style_overrides_file:
   <link rel="stylesheet" type="text/css" href="${static.url(style_overrides_file)}" />

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -1,6 +1,5 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from microsite_configuration import microsite
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from courseware.courses import get_course_about_section
@@ -213,7 +212,7 @@ from openedx.core.lib.courses import course_image_url
     <section class="course-sidebar">
       <section class="course-summary">
         <header>
-          % if microsite.get_value('course_about_show_social_links', True):
+          % if static.get_value('course_about_show_social_links', True):
           <div class="social-sharing">
             <div class="sharing-message">${_("Share with friends and family!")}</div>
             ## TODO: this should probably be an overrideable block,
@@ -228,15 +227,15 @@ from openedx.core.lib.courses import course_image_url
               </a>
             % else:
               <%
-                site_domain = microsite.get_value('site_domain', settings.SITE_NAME)
-                platform_name = microsite.get_value('platform_name', settings.PLATFORM_NAME)
+                site_domain = static.get_value('site_domain', settings.SITE_NAME)
+                platform_name = static.get_platform_name()
 
                 ## Translators: This text will be automatically posted to the student's
                 ## Twitter account. {url} should appear at the end of the text.
                 tweet_text = _("I just enrolled in {number} {title} through {account}: {url}").format(
                     number=course.number,
                     title=course.display_name_with_default_escaped,
-                    account=microsite.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
+                    account=static.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
                     url=u"http://{domain}{path}".format(
                         domain=site_domain,
                         path=reverse('about_course', args=[course.id.to_deprecated_string()])
@@ -244,7 +243,7 @@ from openedx.core.lib.courses import course_image_url
                 ).replace(u" ", u"+")
                 tweet_action = u"http://twitter.com/intent/tweet?text={tweet_text}".format(tweet_text=tweet_text)
 
-                facebook_link = microsite.get_value('course_about_facebook_link', settings.PLATFORM_FACEBOOK_ACCOUNT)
+                facebook_link = static.get_value('course_about_facebook_link', settings.PLATFORM_FACEBOOK_ACCOUNT)
 
                 email_subject = u"mailto:?subject={subject}&body={body}".format(
                     subject=_("Take a course with {platform} online").format(platform=platform_name),

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -1,7 +1,6 @@
 <%!
   import json
   from django.utils.translation import ugettext as _
-  from microsite_configuration import microsite
   from openedx.core.lib.js_utils import escape_json_dumps
 %>
 <%inherit file="../main.html" />

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -5,7 +5,6 @@ from django.utils.translation import ugettext as _
 from django.template import RequestContext
 import third_party_auth
 from third_party_auth import pipeline
-from microsite_configuration import microsite
 from django.core.urlresolvers import reverse
 import json
 %>
@@ -175,7 +174,7 @@ import json
         </li>
         % endif
 
-        <%include file="${microsite.get_template_path('dashboard/_dashboard_status_verification.html')}" />
+        <%include file="${static.get_template_path('dashboard/_dashboard_status_verification.html')}" />
 
       </ul>
     </section>

--- a/lms/templates/forgot_password_modal.html
+++ b/lms/templates/forgot_password_modal.html
@@ -1,7 +1,8 @@
+<%namespace name='static' file='static_content.html'/>
+
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
-from microsite_configuration import microsite
 %>
 
 <section id="forgot-password-modal" class="modal" role="dialog" tabindex="-1" aria-label="${_('Password Reset')}">
@@ -31,7 +32,7 @@ from microsite_configuration import microsite
             <li class="field required text" id="forgot-password-modal-field-email">
               <label for="pwd_reset_email">${_("Your E-mail Address")}</label>
               <input class="" id="pwd_reset_email" type="email" name="email" value="" placeholder="example: username@domain.com" aria-describedby="pwd_reset_email-tip" aria-required="true" />
-              <span class="tip tip-input" id="pwd_reset_email-tip">${_("This is the e-mail address you used to register with {platform}").format(platform=microsite.get_value('platform_name', settings.PLATFORM_NAME))}</span>
+              <span class="tip tip-input" id="pwd_reset_email-tip">${_("This is the e-mail address you used to register with {platform}").format(platform=static.get_platform_name())}</span>
             </li>
           </ol>
         </fieldset>

--- a/lms/templates/header.html
+++ b/lms/templates/header.html
@@ -1,15 +1,3 @@
 ## mako
 <%namespace name='static' file='static_content.html'/>
-<%!
-from microsite_configuration import microsite
-%>
-<%
-theme_enabled = settings.FEATURES.get("USE_CUSTOM_THEME", False)
-is_microsite = microsite.is_request_in_microsite()
-%>
-
-% if theme_enabled and not is_microsite:
-  <%include file="theme-header.html" />
-% else:
-  <%include file="${microsite.get_template_path('navigation.html')}" />
-% endif
+<%include file="${static.get_themed_template_path(relative_path='theme-header.html', default_path='navigation.html')}" />

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from xmodule.tabs import CourseTabList
-from microsite_configuration import microsite
 %>
 
 % if settings.FEATURES.get('ENABLE_FEEDBACK_SUBMISSION', False):

--- a/lms/templates/instructor/instructor_dashboard_2/cohort_management.html
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort_management.html
@@ -3,7 +3,6 @@
 <%!
 from django.utils.translation import ugettext as _
 from courseware.courses import get_studio_url
-from microsite_configuration import microsite
 from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition
 %>
 

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -1,8 +1,8 @@
+<%namespace name='static' file='/static_content.html'/>
 <%page args="section_data"/>
 <%!
 from django.utils.translation import ugettext as _
 from courseware.courses import get_studio_url
-from microsite_configuration import microsite
 from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition
 %>
 
@@ -83,7 +83,7 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
   <div class="request-response-error"></div>
 </div>
 
-%if microsite.get_value('ALLOW_AUTOMATED_SIGNUPS', settings.FEATURES.get('ALLOW_AUTOMATED_SIGNUPS', False)):
+%if static.get_value('ALLOW_AUTOMATED_SIGNUPS', settings.FEATURES.get('ALLOW_AUTOMATED_SIGNUPS', False)):
   <hr class="divider" />
 
   <div class="auto_enroll auto_enroll_csv">

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -6,7 +6,6 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 import third_party_auth
 from third_party_auth import provider, pipeline
-from microsite_configuration import microsite
 %>
 
 <%block name="pagetitle">${_("Log into your {platform_name} Account").format(platform_name=platform_name)}</%block>
@@ -233,8 +232,8 @@ from microsite_configuration import microsite
   <aside role="complementary">
 
 <%
-  # allow for microsite overrides on the registration sidebars, otherwise default to pre-existing ones
-  sidebar_file = microsite.get_template_path('login-sidebar.html')
+  # allow for theming overrides on the registration sidebars, otherwise default to pre-existing ones
+  sidebar_file = static.get_template_path('login-sidebar.html')
 %>
 
     <%include file="${sidebar_file}" />

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -5,7 +5,6 @@ from django.core.urlresolvers import reverse
 from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext as _
 from django.utils.translation import get_language_bidi
-from microsite_configuration import microsite
 from branding import api as branding_api
 %>
 <!DOCTYPE html>
@@ -22,9 +21,6 @@ from branding import api as branding_api
 ## into non-inheriting templates via the %namespace tag.
 <%def name="theme_enabled()">
   <% return settings.FEATURES.get("USE_CUSTOM_THEME", False) %>
-</%def>
-<%def name="is_microsite()">
-  <% return microsite.is_request_in_microsite() %>
 </%def>
 
 <%def name="stanford_theme_enabled()">
@@ -57,7 +53,7 @@ from branding import api as branding_api
 
   <script type="text/javascript" src="/i18n.js"></script>
 
-  <link rel="icon" type="image/x-icon" href="${static.url(microsite.get_value('favicon_path', settings.FAVICON_PATH))}" />
+  <link rel="icon" type="image/x-icon" href="${static.url(static.get_value('favicon_path', settings.FAVICON_PATH))}" />
 
   <%static:css group='style-vendor'/>
   ## We could do <%static:css group='style-main'/>, but that's only useful
@@ -96,7 +92,7 @@ from branding import api as branding_api
 
   <%block name="headextra"/>
 
-  <%static:optional_include_mako file="head-extra.html" with_microsite="True" />
+  <%static:optional_include_mako file="head-extra.html" is_theming_enabled="True" />
 
   <%include file="widgets/optimizely.html" />
   <%include file="widgets/segment-io.html" />
@@ -104,7 +100,7 @@ from branding import api as branding_api
   <meta name="path_prefix" content="${EDX_ROOT_URL}">
   <meta name="google-site-verification" content="_mipQ4AtZQDNmbtOkwehQDOgCxUUV2fb_C0b6wbiRHY" />
 
-<% ga_acct = microsite.get_value("GOOGLE_ANALYTICS_ACCOUNT", settings.GOOGLE_ANALYTICS_ACCOUNT) %>
+<% ga_acct = static.get_value("GOOGLE_ANALYTICS_ACCOUNT", settings.GOOGLE_ANALYTICS_ACCOUNT) %>
 % if ga_acct:
     <script type="text/javascript">
     var _gaq = _gaq || [];
@@ -122,7 +118,7 @@ from branding import api as branding_api
 </head>
 
 <body class="${static.dir_rtl()} <%block name='bodyclass'/> lang_${LANGUAGE_CODE}">
-<%static:optional_include_mako file="body-initial.html" with_microsite="True" />
+<%static:optional_include_mako file="body-initial.html" is_theming_enabled="True" />
 <div id="page-prompt"></div>
 % if not disable_window_wrap:
   <div class="window-wrap" dir="${static.dir_rtl()}">
@@ -130,7 +126,7 @@ from branding import api as branding_api
     <a class="nav-skip" href="<%block name="nav_skip">#content</%block>">${_("Skip to main content")}</a>
 
     % if not disable_header:
-        <%include file="${microsite.get_template_path('header.html')}" />
+        <%include file="${static.get_template_path('header.html')}" />
     % endif
 
     <div class="content-wrapper" id="content">
@@ -150,7 +146,7 @@ from branding import api as branding_api
   <%include file="widgets/segment-io-footer.html" />
   <script type="text/javascript" src="${static.url('js/vendor/noreferrer.js')}" charset="utf-8"></script>
   <script type="text/javascript" src="${static.url('js/utils/navigation.js')}" charset="utf-8"></script>
-  <%static:optional_include_mako file="body-extra.html" with_microsite="True" />
+  <%static:optional_include_mako file="body-extra.html" is_theming_enabled="True" />
 </body>
 </html>
 

--- a/lms/templates/navigation-edx.html
+++ b/lms/templates/navigation-edx.html
@@ -5,8 +5,6 @@
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
-from microsite_configuration import microsite
-
 # App that handles subdomain specific branding
 from branding import api as branding_api
 # app that handles site status messages

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -5,7 +5,6 @@
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
-from microsite_configuration import microsite
 from lms.djangoapps.ccx.overrides import get_current_ccx
 
 # App that handles subdomain specific branding
@@ -96,7 +95,7 @@ site_status_msg = get_site_status_msg(course_id)
         </ul>
       </li>
     </ol>
-      % if should_display_shopping_cart_func() and not (course and microsite.is_request_in_microsite()): # see shoppingcart.context_processor.user_has_cart_context_processor
+      % if should_display_shopping_cart_func() and not (course and static.is_request_in_themed_site()): # see shoppingcart.context_processor.user_has_cart_context_processor
         <ol class="user">
           <li class="primary">
             <a class="shopping-cart" href="${reverse('shoppingcart.views.show_cart')}">
@@ -108,7 +107,7 @@ site_status_msg = get_site_status_msg(course_id)
     % else:
     <ol class="left nav-global">
       <%block name="navigation_global_links">
-        % if microsite.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)):
+        % if static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)):
           <li class="nav-global-01">
             <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
           </li>

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -6,7 +6,6 @@ from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from django.utils import html
 from django_countries import countries
-from microsite_configuration import microsite
 from student.models import UserProfile
 from datetime import date
 import third_party_auth
@@ -112,8 +111,8 @@ import calendar
   <section role="main" class="content">
     <form role="form" id="register-form" method="post" data-remote="true" action="/create_account" novalidate>
 <%
-  # allow for microsite override on the registration form
-  registration_form = microsite.get_template_path('register-form.html')
+  # allow for theming override on the registration form
+  registration_form = static.get_template_path('register-form.html')
 %>
       <%include file="${registration_form}" />
     </form>
@@ -122,8 +121,8 @@ import calendar
   <aside role="complementary">
 
 <%
-  # allow for microsite overrides on the registration sidebars, otherwise default to pre-existing ones
-  sidebar_file = microsite.get_template_path('register-sidebar.html')
+  # allow for theming overrides on the registration sidebars, otherwise default to pre-existing ones
+  sidebar_file = static.get_template_path('register-sidebar.html')
 %>
 
     <%include file="${sidebar_file}" />

--- a/lms/templates/shoppingcart/receipt.html
+++ b/lms/templates/shoppingcart/receipt.html
@@ -1,10 +1,11 @@
+<%namespace name='static' file='/static_content.html'/>
+
 <%inherit file="shopping_cart_flow.html" />
 <%!
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 from django.core.urlresolvers import reverse
 from markupsafe import escape
-from microsite_configuration import microsite
 from openedx.core.lib.courses import course_image_url
 %>
 
@@ -377,8 +378,8 @@ from openedx.core.lib.courses import course_image_url
         <span class="pull-right">${_("Total")}: <b> ${currency_symbol}${"{0:0.2f}".format(order.total_cost)}  ${currency.upper()}</b></span>
       </div>
     </div>
-    ## Allow for a microsite to be able to insert additional text at the bottom of the page
-    <%include file="${microsite.get_template_path('receipt_custom_pane.html')}" />
+    ## Allow for a theming to be able to insert additional text at the bottom of the page
+    <%include file="${static.get_template_path('receipt_custom_pane.html')}" />
   </section>
 </div>
 </%block>

--- a/lms/templates/shoppingcart/receipt_custom_pane.html
+++ b/lms/templates/shoppingcart/receipt_custom_pane.html
@@ -1,2 +1,2 @@
-## Intentionally left blank. This Mako template can be overriden by a microsite template to insert brand
+## Intentionally left blank. This Mako template can be overriden by a theming template to insert brand
 ## specific HTML into the lower pane of the receipt.html page

--- a/lms/templates/shoppingcart/shopping_cart_flow.html
+++ b/lms/templates/shoppingcart/shopping_cart_flow.html
@@ -3,7 +3,6 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.conf import settings
-from microsite_configuration import microsite
 %>
 <%block name="pagetitle">${_("Shopping cart")}</%block>
 <%block name="headextra">
@@ -13,7 +12,7 @@ from microsite_configuration import microsite
 
 <div class="container">
   <header class="wrapper confirm-enrollment shopping-cart">
-  <h1> ${_("{platform_name} -  Shopping Cart").format(platform_name=microsite.get_value('platform_name', settings.PLATFORM_NAME))}</h1>
+  <h1> ${_("{platform_name} -  Shopping Cart").format(platform_name=static.get_platform_name())}</h1>
       % if shoppingcart_items:
       <ol class="steps">
           <li <%block name="review_highlight"/>>${_('Review')}</li>

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -3,7 +3,6 @@ import json
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.utils.translation import ugettext as _
-from microsite_configuration import microsite
 %>
 
 <!--<%namespace name='static' file='/static_content.html'/>-->
@@ -30,7 +29,7 @@ from microsite_configuration import microsite
 <%static:require_module module_name="js/student_account/views/account_settings_factory" class_name="AccountSettingsFactory">
     var fieldsData = ${ json.dumps(fields) };
     var authData = ${ json.dumps(auth) };
-    var platformName = ${ json.dumps(microsite.get_value('platform_name', settings.PLATFORM_NAME))};
+    var platformName = ${json.dumps(static.get_platform_name())};
 
     AccountSettingsFactory(
         fieldsData, authData, '${user_accounts_api_url}', '${user_preferences_api_url}', ${user.id}, platformName

--- a/lms/templates/themable-footer.html
+++ b/lms/templates/themable-footer.html
@@ -1,20 +1,10 @@
 ## mako
-<%!
-from microsite_configuration import microsite
-%>
-<%
-theme_enabled = settings.FEATURES.get("USE_CUSTOM_THEME", False)
-is_microsite = microsite.is_request_in_microsite()
-%>
+<%namespace name='static' file='static_content.html'/>
 
 ## This file only exists as an additional layer of indirection to preserve
-## backwards compatibility with microsites and Stanford theming
+## backwards compatibility with Stanford theming
 ## (as much as possible). If you are writing your own theme using the
 ## "comprehensive theming" system, do NOT override this file. You should
 ## override "footer.html" instead.
 
-% if theme_enabled and not is_microsite:
-  <%include file="theme-footer.html" />
-% else:
-  <%include file="${microsite.get_template_path('footer.html')}" />
-% endif
+<%include file="${static.get_themed_template_path(relative_path='theme-footer.html', default_path='footer.html')}" />

--- a/openedx/core/djangoapps/theming/helpers.py
+++ b/openedx/core/djangoapps/theming/helpers.py
@@ -3,6 +3,7 @@
 """
 from microsite_configuration import microsite
 from microsite_configuration import page_title_breadcrumbs
+from django.conf import settings
 
 
 def get_page_title_breadcrumbs(*args):
@@ -17,3 +18,37 @@ def get_value(val_name, default=None, **kwargs):
     This is a proxy function to hide microsite_configuration behind comprehensive theming.
     """
     return microsite.get_value(val_name, default=default, **kwargs)
+
+
+def get_template_path(relative_path, **kwargs):
+    """
+    This is a proxy function to hide microsite_configuration behind comprehensive theming.
+    """
+    return microsite.get_template_path(relative_path, **kwargs)
+
+
+def is_request_in_themed_site():
+    """
+    This is a proxy function to hide microsite_configuration behind comprehensive theming.
+    """
+    return microsite.is_request_in_microsite()
+
+
+def get_themed_template_path(relative_path, default_path, **kwargs):
+    """
+    This is a proxy function to hide microsite_configuration behind comprehensive theming.
+
+    The workflow considers the "Stanford theming" feature alongside of microsites.  It returns
+    the path of the themed template (i.e. relative_path) if Stanford theming is enabled AND
+    microsite theming is disabled, otherwise it will return the path of either the microsite
+    override template or the base lms template.
+
+    :param relative_path: relative path of themed template
+    :param default_path: relative path of the microsite's or lms template to use if
+        theming is disabled or microsite is enabled
+    """
+    is_stanford_theming_enabled = settings.FEATURES.get("USE_CUSTOM_THEME", False)
+    is_microsite = microsite.is_request_in_microsite()
+    if is_stanford_theming_enabled and not is_microsite:
+        return relative_path
+    return microsite.get_template_path(default_path, **kwargs)

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -5,8 +5,6 @@
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
-from microsite_configuration import microsite
-
 # App that handles subdomain specific branding
 import branding
 # app that handles site status messages

--- a/themes/red-theme/lms/templates/header.html
+++ b/themes/red-theme/lms/templates/header.html
@@ -10,7 +10,6 @@ import branding
 # app that handles site status messages
 from status.status import get_site_status_msg
 
-from microsite_configuration import microsite
 from ccx.overrides import get_current_ccx
 %>
 
@@ -109,7 +108,7 @@ site_status_msg = get_site_status_msg(course_id)
     % else:
     <ol class="left nav-global">
       <%block name="navigation_global_links">
-        % if microsite.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)):
+        % if static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)):
           <li class="nav-global-01">
             <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
           </li>


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR it contains changes of moving `microsite_configuration` references out of the individual templates into `static_content.html`.

**Description of Changes:**
We need to create definitions/functions inside `static_content.html` to abstract `microsite_configuration/microsite.py` references in templates
These two functions from `microsite_configuration/microsite.py` are used in templates we need to abstract their definitions inside `static_content.html`

*is_request_in_microsite
*get_value

Once these functions are created in `static_content.html` we will need to remove all references of `microsite_configuration/microsite.py` out of the templates and use these functions instead.

cc: @mattdrayer 
