### PR TITLE
Harden page objects

### DIFF
--- a/common/test/acceptance/pages/lms/learner_profile.py
+++ b/common/test/acceptance/pages/lms/learner_profile.py
@@ -43,7 +43,10 @@ class LearnerProfilePage(FieldsMixin, PageObject):
         """
         Check if browser is showing correct page.
         """
-        return self.q(css='body.view-profile .account-settings-container').present
+        return all([
+            self.q(css='body.view-profile .account-settings-container').present,
+            not self.q(css='ui-loading-indicator').visible
+        ])
 
     @property
     def privacy(self):

--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -454,7 +454,11 @@ class CourseOutlinePage(CoursePage, CourseOutlineContainer):
     BOTTOM_ADD_SECTION_BUTTON = '.outline > .add-section .button-new'
 
     def is_browser_on_page(self):
-        return self.q(css='body.view-outline').present and self.q(css='div.ui-loading.is-hidden').present
+        return all([
+            self.q(css='body.view-outline').present,
+            self.q(css='.content-primary').present,
+            self.q(css='div.ui-loading.is-hidden').present
+        ])
 
     def view_live(self):
         """

--- a/common/test/acceptance/pages/studio/settings_group_configurations.py
+++ b/common/test/acceptance/pages/studio/settings_group_configurations.py
@@ -19,17 +19,10 @@ class GroupConfigurationsPage(CoursePage):
         """
         Verify that the browser is on the page and it is not still loading.
         """
-        EmptyPromise(
-            lambda: self.q(css='body.view-group-configurations').present,
-            'On the group configuration page'
-        ).fulfill()
-
-        EmptyPromise(
-            lambda: not self.q(css='span.spin').visible,
-            'Group Configurations are finished loading'
-        ).fulfill()
-
-        return True
+        return all([
+            self.q(css='body.view-group-configurations').present,
+            self.q(css='div.ui-loading.is-hidden').present
+        ])
 
     @property
     def experiment_group_configurations(self):


### PR DESCRIPTION
@raeeschachar @benpatterson please review.
I modified these is_browser_on_page methods for a few page objects in order for the tests to run better on phantomjs. They should make things better for chrome/firefox also which is why I'd like to get them into the platform.
