### PR TITLE
Adjusting .sr mixins for NVDA/JAWS on Windows

### DIFF
--- a/common/static/sass/_mixins.scss
+++ b/common/static/sass/_mixins.scss
@@ -404,14 +404,10 @@
 // +Content - Screenreader Text - Extend
 // ====================
 %cont-text-sr {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
+  // clip has been deprecated but is still supported
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px, 1px, 1px, 1px);
   position: absolute;
-  width: 1px;
 }
 
 // +Content - Text Wrap - Extend

--- a/common/static/sass/_mixins.scss
+++ b/common/static/sass/_mixins.scss
@@ -404,10 +404,18 @@
 // +Content - Screenreader Text - Extend
 // ====================
 %cont-text-sr {
-  // clip has been deprecated but is still supported
-  clip: rect(1px 1px 1px 1px);
-  clip: rect(1px, 1px, 1px, 1px);
-  position: absolute;
+    // clip has been deprecated but is still supported
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px);
+    position: absolute;
+    margin: -1px;
+    height: 1px;
+    width: 1px;
+    border: 0;
+    padding: 0;
+    overflow: hidden;
+    // ensure there are spaces in sr text
+    word-wrap: normal;
 }
 
 // +Content - Text Wrap - Extend

--- a/lms/static/sass/base/_mixins.scss
+++ b/lms/static/sass/base/_mixins.scss
@@ -125,14 +125,10 @@
 
 // extends -hidden elems - screenreaders
 %text-sr {
-  border: 0;
+  // clip has been deprecated but is still supported
   clip: rect(1px 1px 1px 1px);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
+  clip: rect(1px, 1px, 1px, 1px);
   position: absolute;
-  width: 1px;
 }
 
 // extends - ensures proper contrast for automated checkers

--- a/lms/static/sass/base/_mixins.scss
+++ b/lms/static/sass/base/_mixins.scss
@@ -125,10 +125,18 @@
 
 // extends -hidden elems - screenreaders
 %text-sr {
-  // clip has been deprecated but is still supported
-  clip: rect(1px 1px 1px 1px);
-  clip: rect(1px, 1px, 1px, 1px);
-  position: absolute;
+    // clip has been deprecated but is still supported
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px);
+    position: absolute;
+    margin: -1px;
+    height: 1px;
+    width: 1px;
+    border: 0;
+    padding: 0;
+    overflow: hidden;
+    // ensure there are spaces in sr text
+    word-wrap: normal;
 }
 
 // extends - ensures proper contrast for automated checkers


### PR DESCRIPTION
This work resolves issue [AC-323](https://openedx.atlassian.net/browse/AC-323) which details an issue on Windows machines using NVDA and JAWS where `.sr` text would be without spaces. For example, "Course nav menu" as the `.sr` text - using the original `.sr` class would be read as "Coursenavmenu".

After simplifying our mixins to utilize just the rules specified in the article, the text worked properly.
## Solution

There was a rogue `word-wrap: break-word` property that, when removed, allowed spaces to appear in the text. I've added `word-wrap: normal` to the `.sr` mixins which ensures that spaces within text will flow as normal without interrupting any inheritance.

As an interesting side note, removing `height` and `width` from the `.sr` mixin also seems to work. It seems to be the combination of dimension with word-wrapping. See [this JSFiddle for further examples and experimentation](https://jsfiddle.net/clrux/42atyze3/) with this.
## Platforms and browsers

This change has been tested on the following platforms and browsers:

| Platform | Version | Browser | Version | Passed |
| --- | --- | --- | --- | --- |
| Windows | 8 | IE | 11 | Yes |
| Windows | 8 | Firefox | 43.0 | Yes |
| Windows | 8 | Chrome | 47.0 | Yes |
| Windows | 10 | Edge | 25.1 | Yes |
| Windows | 10 | Firefox | 43.0 | Yes |
| Windows | 10 | Chrome | 47.0 | Yes |
| Mac | 10.11 | Chrome | 47.0 | Yes |
| Mac | 10.11 | Firefox | 43.0 | Yes |
| Mac | 10.11 | Safari | 9.0.1 | Yes |
## Sandbox

http://clrux-ac-323.sandbox.edx.org
http://studio-clrux-ac-323.sandbox.edx.org
## Reviewers
- [x] @cptvitamin 
- [x] @talbs or @chris-mike 

---

**Note: Similar work will need to be done on a different repo for the marketing site. I will follow up with someone from that team to implement the changes there and request the three of us be tagged on that PR.**
