### PR TITLE
Upgrade to bok-choy 0.4.10

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -126,7 +126,7 @@ django_debug_toolbar==1.3.2
 
 # Used for testing
 before_after==0.1.3
-bok-choy==0.4.7
+bok-choy==0.4.10
 chrono==1.0.2
 coverage==4.0.2
 ddt==0.8.0


### PR DESCRIPTION
This will provide us with backwards-compatibility options for an upcoming browser upgrade. See changelog for more.
