### PR TITLE
Update edx-organization version and organization URL

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -102,6 +102,7 @@ urlpatterns = (
     url(r'^api/commerce/', include('commerce.api.urls', namespace='commerce_api')),
     url(r'^api/credit/', include('openedx.core.djangoapps.credit.urls', app_name="credit", namespace='credit')),
     url(r'^rss_proxy/', include('rss_proxy.urls', namespace='rss_proxy')),
+    url(r'^api/organizations/', include('organizations.urls', namespace='organizations')),
 )
 
 if settings.FEATURES["ENABLE_COMBINED_LOGIN_REGISTRATION"]:

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -93,7 +93,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 -e git+https://github.com/edx/edx-user-state-client.git@30c0ad4b9f57f8d48d6943eb585ec8a9205f4469#egg=edx-user-state-client
-git+https://github.com/edx/edx-organizations.git@release-2015-12-08#egg=edx-organizations==0.2.0
+git+https://github.com/edx/edx-organizations.git@release-2016-01-22#egg=edx-organizations==0.3.0
 git+https://github.com/edx/edx-proctoring.git@0.12.5#egg=edx-proctoring==0.12.5
 git+https://github.com/edx/xblock-lti-consumer.git@v1.0.2#egg=xblock-lti-consumer==1.0.2
 


### PR DESCRIPTION
ECOM-3486
- Add organization api url to `GET` organizations.
- Update github requirements for updated `edx-organizations` version
