### PR TITLE
Harden synchronization for the Course Outline page in lettuce tests

### DIFF
--- a/common/djangoapps/terrain/ui_helpers.py
+++ b/common/djangoapps/terrain/ui_helpers.py
@@ -42,9 +42,11 @@ REQUIREJS_WAIT = {
         "js/collections/component_template", "xmodule", "coffee/src/main", "xblock/cms.runtime.v1"],
 
     # Content - Outline
-    # Note that calling your org, course number, or display name, 'course' will mess this up
+    # Note that calling your org, course number, or display name, 'course' will mess this up.
+    # Wait for the factories to load - they load everything else through dependencies.
+    # Specifying them individually as they are independent from each other.
     re.compile(r'^Course Outline \|'): [
-        "js/base", "js/models/course", "js/models/location", "js/models/section"],
+        "js/base", "js/factories/base.js", "js/factories/course.js", "js/factories/outline.js"],
 
     # Dashboard
     re.compile(r'^Studio Home \|'): [


### PR DESCRIPTION
@andy-armstrong @benpatterson 

Hopefully this should take care of the recently intermittently failing lettuce tests that the screenshots show are waiting for the Course Outline page to load.
