### PR TITLE
get_or_create race condition on LoginFailure with MySQL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -262,3 +262,4 @@ Jillian Vogel <pomegranited@gmail.com>
 Dan Powell <dan@abakas.com>
 Mariana Araújo <simbelm.ne@gmail.com>
 Muhammad Ayub Khan <ayub.khan@arbisoft.com>
+Leonardo Quiñonez <leonardo.quinonez@edunext.co>

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -784,7 +784,8 @@ class LoginFailures(models.Model):
         except ObjectDoesNotExist:
             return False
         except MultipleObjectsReturned:
-            # Clean LoginFailures Table (keeping newest lockout_until) in case get_or_create had a race condition https://code.djangoproject.com/ticket/13906#no1
+            # Clean duplicate in LoginFailures Table (keeping newest lockout_until)
+            # in case the get_or_create had a race condition.  https://code.djangoproject.com/ticket/13906
             records = LoginFailures.objects.filter(user=user).order_by('-lockout_until')
             for extra_record in records[1:]:
                 extra_record.delete()

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -33,7 +33,7 @@ from django.db import models, IntegrityError, transaction
 from django.db.models import Count
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver, Signal
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.utils.translation import ugettext_noop
 from django.core.cache import cache
 from django_countries.fields import CountryField
@@ -783,6 +783,12 @@ class LoginFailures(models.Model):
             return is_locked_out
         except ObjectDoesNotExist:
             return False
+        except MultipleObjectsReturned:
+            # Clean LoginFailures Table (keeping newest lockout_until) in case get_or_create had a race condition https://code.djangoproject.com/ticket/13906#no1
+            records = LoginFailures.objects.filter(user=user).order_by('-lockout_until')
+            for extra_record in records[1:]:
+                extra_record.delete()
+            return cls.is_user_locked_out(user)
 
     @classmethod
     def increment_lockout_counter(cls, user):


### PR DESCRIPTION
From this https://code.djangoproject.com/ticket/13906#no1 ,  the get_or_create function is vulnerable to race conditions in MySQL. This causes the LoginFailure to have, in some cases(rarely but happens), more than one row for the same user, thus breaking the login for the user with a MultipleObjectsReturned exception.

To avoid this I see two paths:

Either set the user field  as unique, which I asume would make the get_or_create throw an exception when the race condition happens avoiding the duplicate row, but throwing an exception in the increment_lockout_counter method when that happens. This will require a migration to set the unique flag and a data migration to fix the current duplicate rows.

Or add an except for MultipleObjectsReturned on the is_user_locked_out method so when the duplicate row appears on the DB, it cleans the error, deleting the row or rows with oldest lockout dates. Leaving just one row for the user and solving the login problem.

Here I propose the second option, which would  clean the duplicate rows and affect the rest of the code as little as possible.
