### PR TITLE
Remove default django template loaders.

### DIFF
--- a/common/djangoapps/edxmako/makoloader.py
+++ b/common/djangoapps/edxmako/makoloader.py
@@ -19,6 +19,7 @@ class MakoLoader(object):
     This is a Django loader object which will load the template as a
     Mako template if the first line is "## mako". It is based off BaseLoader
     in django.template.loader.
+    We need this in order to be able to include mako templates inside main_django.html.
     """
 
     is_usable = False

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -472,12 +472,10 @@ TEMPLATES = [
         # Options specific to this backend.
         'OPTIONS': {
             'loaders': [
+                # We have to use mako-aware template loaders to be able to include
+                # mako templates inside django templates (such as main_django.html).
                 'edxmako.makoloader.MakoFilesystemLoader',
                 'edxmako.makoloader.MakoAppDirectoriesLoader',
-
-                'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader',
-
             ],
             'context_processors': [
                 'django.template.context_processors.request',


### PR DESCRIPTION
Mako filesystem/app_directories loaders already wrap default django template loaders.

Mako loaders delegate the [`load_template_source`](https://github.com/edx/edx-platform/blob/8c26178df36b6beca1036e47047ef56b96c172bd/common/djangoapps/edxmako/makoloader.py#L68-L70) method to the base loader [that they wrap](https://github.com/edx/edx-platform/blob/8c26178df36b6beca1036e47047ef56b96c172bd/common/djangoapps/edxmako/makoloader.py#L76-L89), so there's no reason to explicitly include the two django loaders in the settings.

**Partner information**: 3rd party-hosted open edX instance
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1084
**Sandbox URLs**: TBD
