### PR TITLE
[firefox upgrade] Wait for code mirror editor to be active

### DIFF
--- a/common/test/acceptance/pages/studio/html_component_editor.py
+++ b/common/test/acceptance/pages/studio/html_component_editor.py
@@ -55,6 +55,7 @@ class HtmlComponentEditorView(ComponentEditorView):
         """
         self.q(css=self.editor_mode_css).click()
         self.q(css='[aria-label="Edit HTML"]').click()
+        self.wait_for_element_visibility('.mce-title', 'Wait for CodeMirror editor')
 
         #Focus goes to the editor by default
         ActionChains(self.browser).send_keys([Keys.CONTROL, 'a']).\


### PR DESCRIPTION
Not an issue for our tests on firefox 28; however, once we upgrade to
Firefox 42 (or later), a new wait condition is needed here. Otherwise,
the content is not set because selenium's action chain is starting too
early.
