### PR TITLE
Remove ThemingAware storage mixins and ComprehensiveThemeFinder

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -484,7 +484,6 @@ STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
 # List of finder classes that know how to find static files in various locations.
 # Note: the pipeline finder is included to be able to discover optimized files
 STATICFILES_FINDERS = [
-    'openedx.core.djangoapps.theming.finders.ComprehensiveThemeFinder',
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -41,7 +41,6 @@ STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
 STATICFILES_FINDERS = [
-    'openedx.core.djangoapps.theming.finders.ComprehensiveThemeFinder',
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1154,7 +1154,6 @@ STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
 # List of finder classes that know how to find static files in various locations.
 # Note: the pipeline finder is included to be able to discover optimized files
 STATICFILES_FINDERS = [
-    'openedx.core.djangoapps.theming.finders.ComprehensiveThemeFinder',
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -99,7 +99,6 @@ STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
 STATICFILES_FINDERS = [
-    'openedx.core.djangoapps.theming.finders.ComprehensiveThemeFinder',
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]

--- a/openedx/core/storage.py
+++ b/openedx/core/storage.py
@@ -4,11 +4,9 @@ Django storage backends for Open edX.
 from django.contrib.staticfiles.storage import StaticFilesStorage, CachedFilesMixin
 from pipeline.storage import PipelineMixin, NonPackagingMixin
 from require.storage import OptimizedFilesMixin
-from openedx.core.djangoapps.theming.storage import ComprehensiveThemingAwareMixin
 
 
 class ProductionStorage(
-        ComprehensiveThemingAwareMixin,
         OptimizedFilesMixin,
         PipelineMixin,
         CachedFilesMixin,
@@ -22,7 +20,6 @@ class ProductionStorage(
 
 
 class DevelopmentStorage(
-        ComprehensiveThemingAwareMixin,
         NonPackagingMixin,
         PipelineMixin,
         StaticFilesStorage


### PR DESCRIPTION
Collectstatic failed in production when comprehensive theme contained custom css files.
This patch fixes that problem by removing `ComprehensiveThemeFinder` from `STATICFILES_FINDERS` and `ComprehensiveThemingAware` mixin from `STATICFILES_STORAGE`.

Comprehensive theme static dirs are added to the top of the `STATICFILES_DIRS` entry, which means that the default django `FilesystemFinder` will find theme static files, and since the theme folder is at the top of `STATICFILES_DIRS`, theme files will take precedence over default LMS/CMS static files.

This change means that theme static file URLs are no longer prefixed with `'themes/<theme-name>/'`, but since we currently only support one comprehensive theme at a time, that shouldn't be a problem.

If/when we want to make the choice of a theme dynamic per-request (comprehensive theming for microsites?), we will have to bring custom theme finders and storage mixins back, but for now, it looks like we don't need them.

**Prior discussion**: https://groups.google.com/forum/#!topic/edx-code/ixHe-CvE1AQ
**Partner information**: 3rd party-hosted open edX instance
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1086
**Sandbox URLs**: TBD

---

**Settings**

``` yaml
COMPREHENSIVE_THEME_DIR: '/edx/app/edxapp/edx-platform/themes/red-theme/'
```
