### PR TITLE
Fix in reset button appears to not work

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -922,6 +922,10 @@ div.problem .action {
     }
   }
 
+  .inline {
+    display: inline;
+  }
+
   .submission_feedback {
     // background: #F3F3F3;
     // border: 1px solid #ddd;
@@ -1496,4 +1500,3 @@ div.problem .annotation-input {
     background: url('../images/partially-correct-icon.png') center center no-repeat;
   }
 }
-

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -926,6 +926,15 @@ div.problem .action {
     display: inline;
   }
 
+  .copy-error {
+    @include font-size(14);
+    color: $error-color;
+
+    i {
+      font-style: inherit;
+    }
+  }
+
   .submission_feedback {
     // background: #F3F3F3;
     // border: 1px solid #ddd;

--- a/common/lib/xmodule/xmodule/js/fixtures/problem_content.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/problem_content.html
@@ -16,6 +16,11 @@
     <button class="reset">Reset</button>
     <button class="save">Save</button>
     <button class="show"><span class="show-label">Show Answer(s)</span> <span class="sr">(for question(s) above - adjacent to each field)</span></button>
+    <div class="copy-error is-hidden">
+      <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+      <span class="sr">Warning:</span>
+      <span class="inline"></span>
+    </div>
     <a href="/courseware/6.002_Spring_2012/${ explain }" class="new-page">Explanation</a>
     <div class="submission_feedback"></div>
   </div>

--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -109,6 +109,15 @@ describe 'Problem', ->
       @bind = @problem.bind
       spyOn @problem, 'bind'
 
+    describe 'error', ->
+      it 'show error message when not null', ->
+        @problem.render('', 'foo');
+        expect(@problem.el.find('.copy-error')).not.toHaveClass('is-hidden')
+
+      it 'hide error message when not null', ->
+        @problem.render()
+        expect(@problem.el.find('.copy-error')).toHaveClass('is-hidden')
+
     describe 'with content given', ->
       beforeEach ->
         @problem.render 'Hello World'
@@ -234,6 +243,16 @@ describe 'Problem', ->
   describe 'reset', ->
     beforeEach ->
       @problem = new Problem($('.xblock-student_view'))
+    it 'call render with error', ->
+      spyOn(@problem, 'render').andCallThrough()
+      spyOn($, 'postWithPrefix').andCallFake (url, answers, callback) ->
+        response =
+          error: 'foo'
+        callback(response)
+        promise =
+          always: (callable) -> callable()
+      @problem.reset()
+      expect(@problem.render).toHaveBeenCalledWith undefined, 'foo'
 
     it 'log the problem_reset event', ->
       spyOn($, 'postWithPrefix').andCallFake (url, answers, callback) ->

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -150,7 +150,7 @@ class @Problem
     $.postWithPrefix "#{url}/input_ajax", data, callback
 
 
-  render: (content) ->
+  render: (content, error) ->
     if content
       @el.attr({'aria-busy': 'true', 'aria-live': 'off', 'aria-atomic': 'false'})
       @el.html(content)
@@ -159,6 +159,9 @@ class @Problem
         @bind()
         @queueing()
       @el.attr('aria-busy', 'false')
+    else if error
+      @el.find('span.inline').html(error)
+      @el.find('.copy-error').removeClass('is-hidden')
     else
       $.postWithPrefix "#{@url}/problem_get", (response) =>
         @el.html(response.html)
@@ -328,7 +331,7 @@ class @Problem
   reset_internal: =>
     Logger.log 'problem_reset', @answers
     $.postWithPrefix "#{@url}/problem_reset", id: @id, (response) =>
-        @render(response.html)
+        @render(response.html, response.error)
         @updateProgress response
 
   # TODO this needs modification to deal with javascript responses; perhaps we

--- a/lms/static/sass/_developer.scss
+++ b/lms/static/sass/_developer.scss
@@ -288,7 +288,8 @@
 }
 
 //mehrozezahid - TNL-1437
-// problem content in problem.html
+//copied from /lms/static/sass/course/instructor/_instructor_2.scss#L118
+// for problem content in problem.html
 div.problem .action {
   .copy-error {
     @include font-size(14);

--- a/lms/static/sass/_developer.scss
+++ b/lms/static/sass/_developer.scss
@@ -286,3 +286,12 @@
     }
   }
 }
+
+//mehrozezahid - TNL-1437
+// problem content in problem.html
+div.problem .action {
+  .copy-error {
+    @include font-size(14);
+    color: $error-color;
+  }
+}

--- a/lms/static/sass/_developer.scss
+++ b/lms/static/sass/_developer.scss
@@ -286,13 +286,3 @@
     }
   }
 }
-
-//mehrozezahid - TNL-1437
-//copied from /lms/static/sass/course/instructor/_instructor_2.scss#L118
-// for problem content in problem.html
-div.problem .action {
-  .copy-error {
-    @include font-size(14);
-    color: $error-color;
-  }
-}

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -31,6 +31,10 @@
     % if answer_available:
     <button class="show"><span class='sr'>${_('Toggle Answer Visibility')}</span><span class="show-label">${_('Show Answer')}</span></button>
     % endif
+    <div class="copy-error is-hidden">
+      <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+      <span class="sr">Warning:</span>
+      <span class="inline"></span>
     % if attempts_allowed :
     <div class="submission_feedback" aria-live="polite">
       ${_("You have used {num_used} of {num_total} submissions").format(num_used=attempts_used, num_total=attempts_allowed)}


### PR DESCRIPTION
[TNL-1437](https://openedx.atlassian.net/browse/TNL-1437)

**Background:**

In Matlab problem, Reset button appears to not work

Steps to reproduce:
1. Go to: https://preview.edge.edx.org/courses/MathWorksX/PlasmaPhysicsDemoX/2030_T1/courseware/e2b7bee1a06c48deac87ed84c540a47e/f68df6e40e6747b1af10bfe655401097/1 
2. Press "Run Code" 
3. Press Reset 

Expected Behavior: Problem will be reset 
Actual Behavior: It appears the problem is not reset (You still see the error message).

<img width="1203" alt="screen shot 2015-02-20 at 5 58 46 pm" src="https://cloud.githubusercontent.com/assets/10980715/12553343/b6606928-c398-11e5-996a-54232cbc67d8.png">

**Solution:**

Proposed Solution: Show the error message as shown in screen shot to users so it is clear to all.

The reset_problem view in capa_base.py is responsible for returning this error. Following the response of the reset_problem view, the get_problem_html view from capa_base.py is called automatically to refresh the problem content. The solution implemented was to take the reset error in the response and pass it to the js function responsible for the POST call (render function in display.coffee). A null will be passed if the reset error has not occurred. An error message div is also added to the problem.html file with it's visibility set to hidden. If the render function in display.coffee receives an error as part of its arguments, the error message is inserted into html and made visible and the POST call is blocked, else it proceeds with the POST call. Relevant unit tests have been added in display_spec.coffee. The error is visible in both LMS and Studio.

Pressing Reset without Check first:

![screen shot 2016-02-09 at 9 13 04 pm](https://cloud.githubusercontent.com/assets/10980715/12922103/f659530c-cf71-11e5-8976-83c88590e399.png)

Pressing Reset after pressing Check:

![screen shot 2016-01-25 at 7 05 00 pm](https://cloud.githubusercontent.com/assets/10980715/12553526/dc578886-c399-11e5-9e70-0e7fa26d0428.png)
