### PR TITLE
Installing edx-opaque-keys from PyPI

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -32,6 +32,7 @@ django-method-override==0.1.0
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
 django==1.8.7
+edx-opaque-keys==0.2.0
 edx-rest-api-client==1.2.1
 edx-search==0.1.1
 facebook-sdk==0.4.0
@@ -91,6 +92,7 @@ unicodecsv==0.9.4
 django-require==1.0.6
 pyuca==1.1
 wrapt==1.10.5
+zendesk==1.1.1
 
 # This needs to be installed *after* Cython, which is in pre.txt
 lxml==3.4.4
@@ -153,7 +155,6 @@ rednose==0.4.3
 selenium==2.42.1
 splinter==0.5.4
 testtools==0.9.34
-zendesk==1.1.1
 
 # Used for Segment analytics
 analytics-python==1.1.0

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -78,7 +78,6 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.4#egg=XBlock==0.4.4
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@0.2.6#egg=ora2==0.2.6
 -e git+https://github.com/edx/edx-submissions.git@0.1.3#egg=edx-submissions==0.1.3
--e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.2#egg=i18n-tools==v0.2
 git+https://github.com/edx/edx-oauth2-provider.git@0.5.8#egg=edx-oauth2-provider==0.5.8


### PR DESCRIPTION
The package formerly known as opaque-keys now lives on PyPI as edx-opaque-keys. Additionally, the zendesk requirement has been moved to the correct location.
