### PR TITLE
WL-294: Remove stanford_theme_enabled from themes templates

### DIFF
--- a/themes/edx.org/lms/templates/emails/activation_email.txt
+++ b/themes/edx.org/lms/templates/emails/activation_email.txt
@@ -1,4 +1,3 @@
-<%namespace file="../main.html" import="stanford_theme_enabled" />
 <%! from django.utils.translation import ugettext as _ %>
 ${_("Thank you for signing up for {platform_name}.").format(platform_name=settings.PLATFORM_NAME)}
 

--- a/themes/red-theme/lms/templates/header.html
+++ b/themes/red-theme/lms/templates/header.html
@@ -1,6 +1,6 @@
 ## mako
 <%namespace name='static' file='static_content.html'/>
-<%namespace file='main.html' import="login_query, stanford_theme_enabled"/>
+<%namespace file='main.html' import="login_query"/>
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 ,

Kindly review this PR, it contains changes for the removal of `stanford_theme_enabled` function from themes templates.

**Description of Changes:**
There are references to stanford_theme_enabled method that is defined in `edx-platform/lms/templates/main.html`. Here is a list of all the references,
- `edx-platform/themes/red-theme/lms/templates/header.html` at line 3
- `edx-platform/themes/edx.org/lms/templates/emails/activation_email.txt` at line 1

`stanford_theme_enabled` is used for customizing Stanford theme and no such customizations are needed for `red-theme` or `edx.org` which are already a separate theme applied via comprehensive theming.
We should remove all such references from html templates to avoid confusion.

cc: @mattdrayer 
