### PR TITLE
ziafazal/WL-209:Cert Social Sharing customization

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -48,6 +48,7 @@ from xmodule_django.models import CourseKeyField, NoneToEmptyManager
 from certificates.models import GeneratedCertificate
 from course_modes.models import CourseMode
 from enrollment.api import _default_course_mode
+from microsite_configuration import microsite
 import lms.lib.comment_client as cc
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client, ECOMMERCE_DATE_FORMAT
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -1842,8 +1843,9 @@ class LinkedInAddToProfileConfiguration(ConfigurationModel):
             target (str): An identifier for the occurrance of the button.
 
         """
+        company_identifier = microsite.get_value('LINKEDIN_COMPANY_ID', self.company_identifier)
         params = OrderedDict([
-            ('_ed', self.company_identifier),
+            ('_ed', company_identifier),
             ('pfCertificationName', self._cert_name(course_name, cert_mode).encode('utf-8')),
             ('pfCertificationUrl', cert_url),
             ('source', source)
@@ -1863,7 +1865,7 @@ class LinkedInAddToProfileConfiguration(ConfigurationModel):
             cert_mode,
             _(u"{platform_name} Certificate for {course_name}")
         ).format(
-            platform_name=settings.PLATFORM_NAME,
+            platform_name=microsite.get_value('platform_name', settings.PLATFORM_NAME),
             course_name=course_name
         )
 

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -250,9 +250,9 @@ def _update_social_context(request, context, course, user, user_certificate, pla
     """
     Updates context dictionary with info required for social sharing.
     """
-    share_settings = getattr(settings, 'SOCIAL_SHARING_SETTINGS', {})
+    share_settings = microsite.get_value("SOCIAL_SHARING_SETTINGS", settings.SOCIAL_SHARING_SETTINGS)
     context['facebook_share_enabled'] = share_settings.get('CERTIFICATE_FACEBOOK', False)
-    context['facebook_app_id'] = getattr(settings, "FACEBOOK_APP_ID", None)
+    context['facebook_app_id'] = microsite.get_value("FACEBOOK_APP_ID", settings.FACEBOOK_APP_ID)
     context['facebook_share_text'] = share_settings.get(
         'CERTIFICATE_FACEBOOK_TEXT',
         _("I completed the {course_title} course on {platform_name}.").format(
@@ -282,10 +282,8 @@ def _update_social_context(request, context, course, user, user_certificate, pla
     # Clicking this button sends the user to LinkedIn where they
     # can add the certificate information to their profile.
     linkedin_config = LinkedInAddToProfileConfiguration.current()
-
-    # posting certificates to LinkedIn is not currently
-    # supported in microsites/White Labels
-    if linkedin_config.enabled and not microsite.is_request_in_microsite():
+    linkedin_share_enabled = share_settings.get('CERTIFICATE_LINKEDIN', linkedin_config.enabled)
+    if linkedin_share_enabled:
         context['linked_in_url'] = linkedin_config.add_to_profile_url(
             course.id,
             course.display_name,

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -449,6 +449,8 @@ MICROSITE_CONFIGURATION = {
         "ENABLE_SHOPPING_CART": True,
         "ENABLE_PAID_COURSE_REGISTRATION": True,
         "SESSION_COOKIE_DOMAIN": "test_microsite.localhost",
+        "LINKEDIN_COMPANY_ID": "test",
+        "FACEBOOK_APP_ID": "12345678908",
         "urls": {
             'ABOUT': 'testmicrosite/about',
             'PRIVACY': 'testmicrosite/privacy',


### PR DESCRIPTION
This PR allows customization of Facebook APP ID for sharing web certs on White Label sites. It also makes LinkedIn sharing support available for White Label sites and customization of `LINKEDIN_COMPANY_ID`.
@asadiqbal08 please review.
@mattdrayer FYI
