### PR TITLE
Ignore node_modules when checking Python quality

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -53,7 +53,7 @@
 #
 # ------------------------------
 [MASTER]
-ignore = ,migrations
+ignore = ,.git,migrations,node_modules,.pycharm_helpers
 persistent = yes
 load-plugins = edx_lint.pylint,pylint_django,pylint_celery
 
@@ -180,4 +180,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# b98d7d902efebf1f5eaafb847960e366a35fd51b
+# 42ec1461de97fc01d7191c1c5f2fd5ec67671a61

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -1,6 +1,6 @@
 # pylintrc tweaks for use with edx_lint.
 [MASTER]
-ignore+ = ,migrations
+ignore+ = ,.git,migrations,node_modules,.pycharm_helpers
 
 [BASIC]
 attr-rgx = [a-z_][a-z0-9_]{2,40}$

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ no-path-adjustment=1
 #   It's a little unusual, but we have good reasons for doing so, so we disable
 #   this rule.
 ignore=E501,E265,W602
-exclude=migrations,.git,.pycharm_helpers,test_root/staticfiles
+exclude=migrations,.git,.pycharm_helpers,test_root/staticfiles,node_modules


### PR DESCRIPTION
In preparation for the upcoming FedX work, this change updates PEP8 and PyLint to exclude anything beneath node_modules. I also added docs and .pycharm_helpers (for PyCharm users).

@nedbat @benpatterson Please review.
