### PR TITLE
Resolved ccx-keys dependency on edx-opaque-keys

### DIFF
--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -46,7 +46,7 @@ XBLOCKS = [
 
 setup(
     name="XModule",
-    version="0.1",
+    version="0.1.1",
     packages=find_packages(exclude=["tests"]),
     install_requires=[
         'setuptools',
@@ -54,7 +54,7 @@ setup(
         'capa',
         'path.py',
         'webob',
-        'opaque-keys',
+        'edx-opaque-keys>=0.2.1,<1.0.0',
     ],
     package_data={
         'xmodule': ['js/module/*'],

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -32,7 +32,7 @@ django-method-override==0.1.0
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
 django==1.8.7
-edx-opaque-keys==0.2.0
+edx-opaque-keys==0.2.1
 edx-organizations==0.3.1
 edx-rest-api-client==1.2.1
 edx-search==0.1.1

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -63,8 +63,10 @@ git+https://github.com/mitocw/django-cas.git@60a5b8e5a62e63e0d5d224a87f0b489201a
 git+https://github.com/pmitros/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b
 # The officially released version of django-debug-toolbar-mongo doesn't support DJDT 1.x. This commit does.
 git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808
-# custom opaque-key implementations for ccx
--e git+https://github.com/jazkarta/ccx-keys.git@e6b03704b1bb97c1d2f31301ecb4e3a687c536ea#egg=ccx-keys
+
+# custom opaque-key implementations for CCX
+git+https://github.com/edx/ccx-keys.git@0.1.1#egg=ccx-keys==0.1.1
+
 git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 # Used for testing
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -92,7 +92,7 @@ git+https://github.com/edx/edx-lint.git@v0.4.1#egg=edx_lint==0.4.1
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
--e git+https://github.com/edx/edx-user-state-client.git@30c0ad4b9f57f8d48d6943eb585ec8a9205f4469#egg=edx-user-state-client
+git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/edx-proctoring.git@0.12.6#egg=edx-proctoring==0.12.6
 git+https://github.com/edx/xblock-lti-consumer.git@v1.0.3#egg=xblock-lti-consumer==1.0.3
 


### PR DESCRIPTION
ccx-keys has been updated to use the edx-opaque-keys library from PyPI, rather than simply expect the package to be pre-installed. The edx-opaque-keys version has been bumped as it was updated to export test packages needed by ccx-keys.
