### PR TITLE
Relax the origin constraint on JSInput.

### DIFF
--- a/common/static/js/capa/src/jsinput.js
+++ b/common/static/js/capa/src/jsinput.js
@@ -43,7 +43,7 @@ var JSInput = (function ($, undefined) {
             sectionAttr = function (e) { return $(section).attr(e); },
             iframe = $(elem).find('iframe[name^="iframe_"]').get(0),
             cWindow = iframe.contentWindow,
-            path = iframe.src.substring(0, iframe.src.lastIndexOf("/")+1),
+            path = window.location.origin,
             // Get the hidden input field to pass to customresponse
             inputField = $(elem).parent().find('input[id^="input_"]'),
             // Get the grade function name

--- a/common/static/js/capa/src/jsinput.js
+++ b/common/static/js/capa/src/jsinput.js
@@ -43,7 +43,6 @@ var JSInput = (function ($, undefined) {
             sectionAttr = function (e) { return $(section).attr(e); },
             iframe = $(elem).find('iframe[name^="iframe_"]').get(0),
             cWindow = iframe.contentWindow,
-            path = window.location.origin,
             // Get the hidden input field to pass to customresponse
             inputField = $(elem).parent().find('input[id^="input_"]'),
             // Get the grade function name
@@ -66,7 +65,7 @@ var JSInput = (function ($, undefined) {
         if (!sop) {
             channel = Channel.build({
                 window: cWindow,
-                origin: path,
+                origin: '*',
                 scope: "JSInput"
             });
          }   


### PR DESCRIPTION
When serving an iframe from a third-party origin, like a CDN, the JSInput code would create a JSChannel pointing to the iframe's source as the only allowed origin to talk to.  This would then break immediately upon trying to invoke postMessage.

Here, we're setting the target origin to be a wildcard, which allows communication in both directions.
