### PR TITLE
HOTFIX for PHX-245 Updated proctored/timed exam text

### DIFF
--- a/lms/templates/courseware/proctored-exam-status.underscore
+++ b/lms/templates/courseware/proctored-exam-status.underscore
@@ -8,6 +8,7 @@
     %>
     <div class='exam-text'>
         <%= interpolate_text('You are taking "{exam_link}" as a {exam_type} exam. The timer on the right shows the time remaining in the exam.', {exam_link: "<a href='" + exam_url_path + "'>"+gtLtEscape(exam_display_name)+"</a>", exam_type: (!_.isUndefined(arguments[0].exam_type)) ? exam_type : gettext('timed')}) %>
+        <%- gettext('To receive credit on a problem, you must click "Check" or "Final Check" on it before you select "End My Exam".') %>
     </div>
     <div id="turn_in_exam_id" class="pull-right turn_in_exam">
         <span>
@@ -24,4 +25,3 @@
         </span>
     </div>
 </div>
-

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -94,7 +94,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 -e git+https://github.com/edx/edx-user-state-client.git@30c0ad4b9f57f8d48d6943eb585ec8a9205f4469#egg=edx-user-state-client
 git+https://github.com/edx/edx-organizations.git@release-2015-12-08#egg=edx-organizations==0.2.0
-git+https://github.com/edx/edx-proctoring.git@0.12.5#egg=edx-proctoring==0.12.5
+git+https://github.com/edx/edx-proctoring.git@0.12.7#egg=edx-proctoring==0.12.7
 git+https://github.com/edx/xblock-lti-consumer.git@v1.0.2#egg=xblock-lti-consumer==1.0.2
 
 # Third Party XBlocks


### PR DESCRIPTION
Learners are currently having trouble understanding that they need to submit their answer to each problem within a proctored/timed exam. This change adds additional information text to the proctored/timed exam header bar as well as the exam submission confirmation page in order to make this clear to the learner.

Related PR:
https://github.com/edx/edx-proctoring/pull/264
