### PR TITLE
Add Drag-and-drop XBlock to requirements.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -97,3 +97,4 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.0.3#egg=xblock-lti-consume
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 -e git+https://github.com/open-craft/xblock-poll@e7a6c95c300e95c51e42bfd1eba70489c05a6527#egg=xblock-poll
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.1#egg=xblock-drag-and-drop-v2==2.0.1


### PR DESCRIPTION
**Description**: Adds the Drag and Drop XBlock to `github.txt` in the requirements, making it available on edx.org.
**Jira**: https://openedx.atlassian.net/browse/SOL-1413
**Merge deadline**: January 29th, 2016

**Reviewers**
- [x] Internal: @itsjeyd 
- [x] Platform: @nedbat 

**Note:** The hash in this PR will be updated one more time to point to an actual version tag on the repo once https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/34 is approved and passing tests. The primary request ahead of this is making sure there are no other changes needed to make the block available other than those currently in the PR, and that the change does allow the block to be used.

**Testing Instructions**
- Add `drag-and-drop-v2` to the list of advanced components in a course's advanced settings.
- Add a Drag and Drop component.

**Sandbox**:
[LMS](http://pr11364.sandbox.opencraft.com/) [Studio](http://studio.pr11364.sandbox.opencraft.com/)
