### PR TITLE
Reenable course home improvements check.

### DIFF
--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -61,7 +61,7 @@ $(document).ready(function(){
       ${get_course_info_section(request, masquerade_user, course, 'updates')}
     </section>
     <section aria-label="${_('Handout Navigation')}" class="handouts">
-      % if False:
+      % if SelfPacedConfiguration.current().enable_course_home_improvements:
         <h1>${_("Important Course Dates")}</h1>
         ${get_course_date_summary(course, user)}
       % endif


### PR DESCRIPTION
@bderusha PLAT-900 has been fixed for a while now, so this check can be safely turned on. The `SelfPacedConfiguration`s on stage/prod/edge all have `enable_course_home_improvements=False`, so no user-facing changes will result.
