### PR TITLE
Allow xblocks to clear state

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -78,8 +78,8 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.4#egg=XBlock==0.4.4
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@0.2.6#egg=ora2==0.2.6
--e git+https://github.com/edx/edx-submissions.git@0.1.3#egg=edx-submissions==0.1.3
+-e git+https://github.com/edx/edx-ora2.git@efischer/delete_state#egg=ora2
+-e git+https://github.com/edx/edx-submissions.git@efischer/soft_delete_sub#egg=edx-submissions
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.2#egg=i18n-tools==v0.2
 git+https://github.com/edx/edx-oauth2-provider.git@0.5.8#egg=edx-oauth2-provider==0.5.8


### PR DESCRIPTION
My original task was to fix clear state specifically for ORA2 problems.
As I dug in, I noticed that the reset_student_attempts code was aware
of edx-submissions, but not openassessment.

Rather than adding another IDA for edx-platform to concern itself with,
I elected to make a way for _any_ xblock to clear its state as a part
of this method, as that seems like a general problem.

As a nice side bonus, this edx-platform code no longer needs to know
about anything in edx-submissions, as openassessment will pass through
to get any submissions data removed as part of its clear method.

Sibling change to https://github.com/edx/edx-ora2/pull/862 and https://github.com/edx/edx-submissions/pull/33
