### PR TITLE
Enable Delete User from SysAdmin

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -253,6 +253,7 @@ class Users(SysadminDashboardView):
                     error=str(err)
                 )
                 return msg
+        [pref.delete() for pref in user.preferences.all()]
         user.delete()
         return _('Deleted user {username}').format(username=uname)
 


### PR DESCRIPTION
Resolves the "User matching query does not exist." error while deleting user from admin panel.
