### PR TITLE
Resetting password shows empty page.

### DIFF
--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -86,6 +86,26 @@ class ResetPasswordPage(PageObject):
             self.q(css="#password-reset-form").visible
         )
 
+    def fill_password_reset_form(self, email):
+        """
+        Fill in the form and submit it
+        """
+        self.wait_for_element_visibility('#password-reset-email', 'Reset Email field is shown')
+        self.q(css="#password-reset-email").fill(email)
+        self.q(css="button.js-reset").click()
+
+    def is_success_visible(self, selector):
+        """
+        Check element is visible
+        """
+        self.wait_for_element_visibility(selector, 'Success div is shown')
+
+    def get_success_message(self):
+        """
+        Return a success message displayed to the user
+        """
+        return self.q(css=".submission-success h4").text
+
 
 class CombinedLoginAndRegisterPage(PageObject):
     """Interact with combined login and registration page.

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -51,7 +51,17 @@ class ForgotPasswordPageTest(UniqueCourseTest):
     def setUp(self):
         """ Initialize the page object """
         super(ForgotPasswordPageTest, self).setUp()
+        self.user_info = self._create_user()
         self.reset_password_page = ResetPasswordPage(self.browser)
+
+    def _create_user(self):
+        """
+        Create a unique user
+        """
+        auto_auth = AutoAuthPage(self.browser).visit()
+        user_info = auto_auth.user_info
+        LogoutPage(self.browser).visit()
+        return user_info
 
     def test_reset_password_form_visibility(self):
         # Navigate to the password reset page
@@ -59,6 +69,18 @@ class ForgotPasswordPageTest(UniqueCourseTest):
 
         # Expect that reset password form is visible on the page
         self.assertTrue(self.reset_password_page.is_form_visible())
+
+    def test_reset_password_confirmation_box_visibility(self):
+        # Navigate to the password reset page
+        self.reset_password_page.visit()
+
+        # Navigate to the password reset form and try to submit it
+        self.reset_password_page.fill_password_reset_form(self.user_info['email'])
+
+        self.reset_password_page.is_success_visible(".submission-success")
+
+        # Expect that we're shown a success message
+        self.assertIn("Password Reset Email Sent", self.reset_password_page.get_success_message())
 
 
 @attr('shard_8')

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -102,9 +102,9 @@
                 //get & check current url hash part & load form accordingly
                 if (Backbone.history.getHash() === 'forgot-password-modal') {
                     this.resetPassword();
-                } else {
-                    this.loadForm(this.activeForm);
                 }
+                this.loadForm(this.activeForm);
+
             },
 
             loadForm: function( type ) {


### PR DESCRIPTION
### Description

Resetting your password on studio doesn't display any confirmation box instead displays an empty page
### Sandbox

https://pr.sandbox.edx.org/login#forgot-password-modal

[TNL-3573](https://openedx.atlassian.net/browse/TNL-3573)
