### PR TITLE
Remove gating api import from course xmodule

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -780,6 +780,10 @@ def _get_gating_info(course, xblock):
     """
     info = {}
     if xblock.category == 'sequential' and course.enable_subsection_gating:
+        if not hasattr(course, 'gating_prerequisites'):
+            # Cache gating prerequisites on course module so that we are not
+            # hitting the database for every xblock in the course
+            setattr(course, 'gating_prerequisites', gating_api.get_prerequisites(course.id))  # pylint: disable=literal-used-as-attribute
         info["is_prereq"] = gating_api.is_prerequisite(course.id, xblock.location)
         info["prereqs"] = [
             p for p in course.gating_prerequisites if unicode(xblock.location) not in p['namespace']

--- a/cms/djangoapps/contentstore/views/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/views/tests/test_gating.py
@@ -108,7 +108,7 @@ class TestSubsectionGating(CourseTestCase):
             ''
         )
 
-    @patch('xmodule.course_module.gating_api.get_prerequisites')
+    @patch('contentstore.views.item.gating_api.get_prerequisites')
     @patch('contentstore.views.item.gating_api.get_required_content')
     @patch('contentstore.views.item.gating_api.is_prerequisite')
     def test_get_prerequisite(self, mock_is_prereq, mock_get_required_content, mock_get_prereqs):

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -14,7 +14,6 @@ from path import Path as path
 from xblock.core import XBlock
 from xblock.fields import Scope, List, String, Dict, Boolean, Integer, Float
 
-from openedx.core.lib.gating import api as gating_api
 from xmodule import course_metadata_utils
 from xmodule.course_metadata_utils import DEFAULT_START_DATE
 from xmodule.exceptions import UndefinedContext
@@ -1394,18 +1393,6 @@ class CourseDescriptor(CourseFields, SequenceDescriptor, LicenseMixin):
           bool: False if the course has already started, True otherwise.
         """
         return datetime.now(UTC()) <= self.start
-
-    @property
-    def gating_prerequisites(self):
-        """
-        Course content that can be used to gate other course content within this course.
-
-        Returns:
-            list: Returns a list of dicts containing the gating milestone data
-        """
-        if not self._gating_prerequisites:
-            self._gating_prerequisites = gating_api.get_prerequisites(self.id)
-        return self._gating_prerequisites
 
 
 class CourseSummary(object):


### PR DESCRIPTION
This avoids a problem when running tests with importing django related modules into a non-django related module.
