### PR TITLE
Do not flush the database when using bok-choy in testsonly mode.

### DIFF
--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -104,7 +104,10 @@ class BokChoyTestSuite(TestSuite):
         print msg
 
         # Clean up data we created in the databases
-        sh("./manage.py lms --settings bok_choy flush --traceback --noinput")
+        if not self.testsonly:
+            # Using testsonly will leave all fixtures in place (Note: the db will also be dirtier.)
+            sh("./manage.py lms --settings bok_choy flush --traceback --noinput")
+
         bokchoy_utils.clear_mongo()
 
     def verbosity_processes_string(self):

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -100,15 +100,16 @@ class BokChoyTestSuite(TestSuite):
     def __exit__(self, exc_type, exc_value, traceback):
         super(BokChoyTestSuite, self).__exit__(exc_type, exc_value, traceback)
 
-        msg = colorize('green', "Cleaning up databases...")
-        print msg
-
-        # Clean up data we created in the databases
-        if not self.testsonly:
-            # Using testsonly will leave all fixtures in place (Note: the db will also be dirtier.)
+        # Using testsonly will leave all fixtures in place (Note: the db will also be dirtier.)
+        if self.testsonly:
+            msg = colorize('green', 'Running in testsonly mode... SKIPPING database cleanup.')
+            print msg
+        else:
+            # Clean up data we created in the databases
+            msg = colorize('green', "Cleaning up databases...")
+            print msg
             sh("./manage.py lms --settings bok_choy flush --traceback --noinput")
-
-        bokchoy_utils.clear_mongo()
+            bokchoy_utils.clear_mongo()
 
     def verbosity_processes_string(self):
         """


### PR DESCRIPTION
Testsonly will not work currently, because the database flush will
remove some data fixtures. Even when they are loaded at the beginning
of the next test run, there are database corruptions. Instead of
flushing, do not do anything with the database at the end of the
testsonly test run. That way, tests that use dynamic data can be
run many times in a row.
