### PR TITLE
clear search input when search results tab is closed

### DIFF
--- a/lms/static/js/edxnotes/views/search_box.js
+++ b/lms/static/js/edxnotes/views/search_box.js
@@ -29,7 +29,13 @@ define([
             this.logger = NotesLogger.getLogger('search_box', this.options.debug);
             this.$el.removeClass('is-hidden');
             this.isDisabled = false;
+            this.searchInput = this.$el.find('#search-notes-input');
             this.logger.log('initialized');
+        },
+
+        clearInput: function() {
+            // clear the search input box
+            this.searchInput.val('');
         },
 
         submitHandler: function (event) {

--- a/lms/static/js/edxnotes/views/tabs/search_results.js
+++ b/lms/static/js/edxnotes/views/tabs/search_results.js
@@ -105,6 +105,7 @@ define([
 
         onClose: function () {
             this.searchResults = null;
+            this.searchBox.clearInput();
         },
 
         onBeforeSearchStart: function () {

--- a/lms/static/js/spec/edxnotes/views/search_box_spec.js
+++ b/lms/static/js/spec/edxnotes/views/search_box_spec.js
@@ -164,5 +164,11 @@ define([
                 '   '
             );
         });
+
+        it('can clear its input box', function () {
+            this.searchBox.$('.search-notes-input').val('search me');
+            this.searchBox.clearInput();
+            expect(this.searchBox.$('#search-notes-input').val()).toEqual('');
+        });
     });
 });

--- a/lms/static/js/spec/edxnotes/views/tabs/search_results_spec.js
+++ b/lms/static/js/spec/edxnotes/views/tabs/search_results_spec.js
@@ -146,12 +146,14 @@ define([
         it('can clear search results if tab is closed', function () {
             var view = getView(this.tabsCollection),
                 requests = AjaxHelpers.requests(this);
+            spyOn(view.searchBox, 'clearInput').andCallThrough();
 
             submitForm(view.searchBox, 'test_query');
             Helpers.respondToRequest(requests, responseJson, true);
             expect(view.searchResults).toBeDefined();
             this.tabsCollection.at(0).destroy();
             expect(view.searchResults).toBeNull();
+            expect(view.searchBox.clearInput).toHaveBeenCalled();
         });
 
         it('can correctly show/hide error messages', function () {


### PR DESCRIPTION
## [TNL-4055](https://openedx.atlassian.net/browse/TNL-4055)

This will clear the search input box when we close the `Search Results` tab.

[**Sandbox**](https://notes-pagination.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/edxnotes/)
### Testing
- [x] Jasmine
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @symbolist 
- [x] Code review: @muzaffaryousaf 
- [x] Code review: @ehteshamkafeel  
### Post-review
- [x] Squash commits
