### PR TITLE
Fix unit tests so they are testing aria-expanded.

### DIFF
--- a/lms/static/js/fixtures/accordion.html
+++ b/lms/static/js/fixtures/accordion.html
@@ -1,11 +1,11 @@
 <div class="course-wrapper">
   <div class="accordion">
-    <a href="accordion-menu-1" role="button" class="button-chapter chapter is-open" aria-controls="accordion-menu-1">
+    <a href="accordion-menu-1" role="button" class="button-chapter chapter is-open" aria-controls="accordion-menu-1" aria-expanded="true">
       <span class="group-heading active">
           1 Introduction Chapter
       </span>
     </a>
-    <div class="chapter-content-container is-open" id="accordion-menu-1" tabindex="-1" aria-expanded="true">
+    <div class="chapter-content-container is-open" id="accordion-menu-1" tabindex="-1">
       <div class="chapter-menu is-open">
           <div class="menu-item">
           <a href="#">
@@ -25,12 +25,12 @@
           </a>
         </div>
       </div>
-      <a href="accordion-menu-2" role="button" class="button-chapter chapter" aria-controls="accordion-menu-2">
+      <a href="accordion-menu-2" role="button" class="button-chapter chapter" aria-controls="accordion-menu-2" aria-expanded="false">
         <span class="group-heading">
             2 Another Chapter
         </span>
       </a>
-      <div class="chapter-content-container" id="accordion-menu-2" tabindex="-1" aria-expanded="false">
+      <div class="chapter-content-container" id="accordion-menu-2" tabindex="-1">
         <div class="chapter-menu">
           <div class="menu-item">
             <a href="#">

--- a/lms/static/js/spec/navigation_spec.js
+++ b/lms/static/js/spec/navigation_spec.js
@@ -2,7 +2,7 @@ define(['jquery', 'js/utils/navigation'], function($) {
     'use strict';
 
     describe('Course Navigation Accordion', function() {
-        var accordion, button, heading, chapterContent, chapterMenu;
+        var accordion, chapterMenu;
 
         function keyPressEvent(key) {
             return $.Event('keydown', { which: key });
@@ -12,10 +12,7 @@ define(['jquery', 'js/utils/navigation'], function($) {
             loadFixtures('js/fixtures/accordion.html');
 
             accordion = $('.accordion');
-            button = accordion.children('.button-chapter');
-            heading = button.children('.group-heading');
-            chapterContent = accordion.children('.chapter-content-container');
-            chapterMenu = chapterContent.children('.chapter-menu');
+            chapterMenu = accordion.children('.chapter-content-container').children('.chapter-menu');
 
             this.KEY = $.ui.keyCode;
             spyOn($.fn, 'focus').andCallThrough();
@@ -31,13 +28,8 @@ define(['jquery', 'js/utils/navigation'], function($) {
                 });
 
                 it('ensures aria attributes are present', function() {
-                    expect(accordion.find('.chapter-content-container').first()).toHaveAttr({
-                        'aria-expanded': 'true'
-                    });
-
-                    expect(accordion.find('.chapter-content-container').last()).toHaveAttr({
-                        'aria-expanded': 'false'
-                    });
+                    expect(accordion.find('.button-chapter').first()).toHaveAttr('aria-expanded', 'true');
+                    expect(accordion.find('.button-chapter').last()).toHaveAttr('aria-expanded', 'false');
                 });
 
                 it('ensures only one active item', function() {
@@ -58,19 +50,17 @@ define(['jquery', 'js/utils/navigation'], function($) {
                 });
 
                 it('ensure proper aria and attrs', function() {
-                    expect(accordion.find('.chapter-content-container').first()).toHaveAttr({
-                        'aria-expanded': 'false'
-                    });
-                    expect(accordion.find('.chapter-content-container').last()).toHaveAttr({
-                        'aria-expanded': 'true'
-                    });
+                    accordion.find('.button-chapter').last().trigger('click');
+
+                    expect(accordion.find('.button-chapter').first()).toHaveAttr('aria-expanded', 'false');
+                    expect(accordion.find('.button-chapter').last()).toHaveAttr('aria-expanded', 'true');
                 });
             });
 
             describe('open section with spacebar', function() {
 
                 it('ensures new section is opened and previous section is closed', function() {
-                    accordion.find('.button-chapter').last().focus().trigger(keyPressEvent(this.KEY.SPACE)); // Spacebar
+                    accordion.find('.button-chapter').last().focus().trigger(keyPressEvent(this.KEY.SPACE));
 
                     expect(accordion.find('.chapter-content-container').first()).not.toHaveClass('is-open');
                     expect(accordion.find('.chapter-content-container').last()).toHaveClass('is-open');
@@ -80,12 +70,10 @@ define(['jquery', 'js/utils/navigation'], function($) {
                 });
 
                 it('ensure proper aria and attrs', function() {
-                    expect(accordion.find('.chapter-content-container').first()).toHaveAttr({
-                        'aria-expanded': 'false'
-                    });
-                    expect(accordion.find('.chapter-content-container').last()).toHaveAttr({
-                        'aria-expanded': 'true'
-                    });
+                    accordion.find('.button-chapter').last().focus().trigger(keyPressEvent(this.KEY.SPACE));
+
+                    expect(accordion.find('.button-chapter').first()).toHaveAttr('aria-expanded', 'false');
+                    expect(accordion.find('.button-chapter').last()).toHaveAttr('aria-expanded', 'true');
                 });
             });
         });


### PR DESCRIPTION
While searching in edx-platform to see how to test aria-expanded in a Jasmine test, I ran across this example in navigation_spec. However, when I tried the same syntax in my new test, I realized that it always passes.

This is because the calls to "toHaveAttr" in navigation_spec do not have the correct arguments. This causes the tests to pass without actually verifying the expected behavior.

Specifically, "toHaveAttr" should take 2 input arguments-- the attribute name and the expected state. In the common directory, there is a "toHaveAttrs" helper method that takes a dictionary, but that method is not present in LMS.

So I changed these test cases to have the proper signature, and two of the test methods then failed. Looking at the test, I realized that the UI elements weren't being toggled before the state was verified; however, even with that fix, the tests still failed because the wrong elements were being examined.

The moral of this story is to **always make sure your test point can fail as well as pass**-- that is, change the expected value to something that should cause the test to fail, and then verify that the test does indeed fail.

@clrux please review, FYI @andy-armstrong (code reviewer of #9525).
