### PR TITLE
Don't use using() in migrations

### DIFF
--- a/common/djangoapps/dark_lang/migrations/0002_data__enable_on_install.py
+++ b/common/djangoapps/dark_lang/migrations/0002_data__enable_on_install.py
@@ -12,9 +12,8 @@ def create_dark_lang_config(apps, schema_editor):
     release of testing languages.
     """
     DarkLangConfig = apps.get_model("dark_lang", "DarkLangConfig")
-    db_alias = schema_editor.connection.alias
 
-    objects = DarkLangConfig.objects.using(db_alias)
+    objects = DarkLangConfig.objects
     if not objects.exists():
         objects.create(enabled=True)
 

--- a/common/djangoapps/embargo/migrations/0002_data__add_countries.py
+++ b/common/djangoapps/embargo/migrations/0002_data__add_countries.py
@@ -10,15 +10,13 @@ from django_countries import countries
 def create_embargo_countries(apps, schema_editor):
     """Populate the available countries with all 2-character ISO country codes. """
     country_model = apps.get_model("embargo", "Country")
-    db_alias = schema_editor.connection.alias
     for country_code, __ in list(countries):
-        country_model.objects.using(db_alias).get_or_create(country=country_code)
+        country_model.objects.get_or_create(country=country_code)
 
 def remove_embargo_countries(apps, schema_editor):
     """Clear all available countries. """
     country_model = apps.get_model("embargo", "Country")
-    db_alias = schema_editor.connection.alias
-    country_model.objects.using(db_alias).all().delete()
+    country_model.objects.all().delete()
 
 class Migration(migrations.Migration):
 

--- a/common/djangoapps/util/migrations/0002_data__default_rate_limit_config.py
+++ b/common/djangoapps/util/migrations/0002_data__default_rate_limit_config.py
@@ -9,8 +9,7 @@ from django.db import migrations, models
 def forwards(apps, schema_editor):
     """Ensure that rate limiting is enabled by default. """
     RateLimitConfiguration = apps.get_model("util", "RateLimitConfiguration")
-    db_alias = schema_editor.connection.alias
-    objects = RateLimitConfiguration.objects.using(db_alias)
+    objects = RateLimitConfiguration.objects
     if not objects.exists():
         objects.create(enabled=True)
 

--- a/lms/djangoapps/certificates/migrations/0002_data__certificatehtmlviewconfiguration_data.py
+++ b/lms/djangoapps/certificates/migrations/0002_data__certificatehtmlviewconfiguration_data.py
@@ -33,9 +33,8 @@ def forwards(apps, schema_editor):
         }
     }
     certificate_html_view_configuration_model = apps.get_model("certificates", "CertificateHtmlViewConfiguration")
-    db_alias = schema_editor.connection.alias
 
-    objects = certificate_html_view_configuration_model.objects.using(db_alias)
+    objects = certificate_html_view_configuration_model.objects
     if not objects.exists():
         objects.create(
             configuration=json.dumps(config),
@@ -47,9 +46,8 @@ def backwards(apps, schema_editor):
     Rolling back to zero-state, so remove all currently-defined configurations
     """
     certificate_html_view_configuration_model = apps.get_model("certificates", "CertificateHtmlViewConfiguration")
-    db_alias = schema_editor.connection.alias
 
-    certificate_html_view_configuration_model.objects.using(db_alias).all().delete()
+    certificate_html_view_configuration_model.objects.all().delete()
 
 class Migration(migrations.Migration):
 

--- a/lms/djangoapps/certificates/migrations/0003_data__default_modes.py
+++ b/lms/djangoapps/certificates/migrations/0003_data__default_modes.py
@@ -10,9 +10,8 @@ from django.core.files import File
 def forwards(apps, schema_editor):
     """Add default modes"""
     BadgeImageConfiguration = apps.get_model("certificates", "BadgeImageConfiguration")
-    db_alias = schema_editor.connection.alias
 
-    objects = BadgeImageConfiguration.objects.using(db_alias)
+    objects = BadgeImageConfiguration.objects
     if not objects.exists():
         for mode in ['honor', 'verified', 'professional']:
             conf = objects.create(mode=mode)
@@ -24,6 +23,9 @@ def forwards(apps, schema_editor):
 
             conf.save()
 
+def backwards(apps, schema_editor):
+    """Do nothing, assumptions too dangerous."""
+    pass
 
 class Migration(migrations.Migration):
 
@@ -32,5 +34,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(forwards)
+        migrations.RunPython(forwards,backwards)
     ]

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -83,11 +83,11 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.4#egg=XBlock==0.4.4
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.2#egg=i18n-tools==v0.2
 git+https://github.com/edx/edx-oauth2-provider.git@0.5.8#egg=edx-oauth2-provider==0.5.8
-git+https://github.com/edx/edx-val.git@0.0.8#egg=edxval==0.0.8
+git+https://github.com/edx/edx-val.git@0.0.9#egg=edxval==0.0.9
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/pmitros/DoneXBlock.git@857bf365f19c904d7e48364428f6b93ff153fabd#egg=done-xblock
-git+https://github.com/edx/edx-milestones.git@v0.1.7#egg=edx-milestones==0.1.7
+git+https://github.com/edx/edx-milestones.git@v0.1.8#egg=edx-milestones==0.1.8
 git+https://github.com/edx/edx-lint.git@v0.4.1#egg=edx_lint==0.4.1
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive


### PR DESCRIPTION
   Remove uses of using() from migrations

This hardcoded the db_alias fetched from schema_editor and forces django
to try and migrate any second database you use, rather than routing to
the default database.  In testing a build from scratch, these do not
appear needed.

Using using() prevents us from using multiple databases behind edxapp.
