### PR TITLE
ziafazal/WL-305: removed constraints on MicrositeHistory model to allow Updates on Microsite

### DIFF
--- a/common/djangoapps/microsite_configuration/migrations/0002_auto_20160202_0228.py
+++ b/common/djangoapps/microsite_configuration/migrations/0002_auto_20160202_0228.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('microsite_configuration', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='micrositehistory',
+            name='key',
+            field=models.CharField(max_length=63, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='micrositehistory',
+            name='site',
+            field=models.ForeignKey(related_name='microsite_history', to='sites.Site'),
+        ),
+    ]

--- a/common/djangoapps/microsite_configuration/models.py
+++ b/common/djangoapps/microsite_configuration/models.py
@@ -63,8 +63,8 @@ class MicrositeHistory(TimeStampedModel):
     This is an archive table for Microsites model, so that we can maintain a history of changes. Note that the
     key field is no longer unique
     """
-    site = models.OneToOneField(Site, related_name='microsite_history')
-    key = models.CharField(max_length=63, db_index=True, unique=True)
+    site = models.ForeignKey(Site, related_name='microsite_history')
+    key = models.CharField(max_length=63, db_index=True)
     values = JSONField(null=False, blank=True, load_kwargs={'object_pairs_hook': collections.OrderedDict})
 
     def __unicode__(self):

--- a/common/djangoapps/microsite_configuration/tests/test_admin.py
+++ b/common/djangoapps/microsite_configuration/tests/test_admin.py
@@ -1,0 +1,49 @@
+"""
+Tests for microsite admin
+"""
+from django.contrib.admin.sites import AdminSite
+from django.http import HttpRequest
+
+from microsite_configuration.admin import MicrositeAdmin
+from microsite_configuration.models import Microsite
+from microsite_configuration.tests.tests import DatabaseMicrositeTestCase
+
+
+class MicrositeAdminTests(DatabaseMicrositeTestCase):
+    """
+    Test class for MicrositeAdmin
+    """
+
+    def setUp(self):
+        super(MicrositeAdminTests, self).setUp()
+        self.adminsite = AdminSite()
+        self.microsite_admin = MicrositeAdmin(Microsite, self.adminsite)
+        self.request = HttpRequest()
+
+    def test_fields_in_admin_form(self):
+        """
+        Tests presence of form fields for Microsite.
+        """
+        microsite_form = self.microsite_admin.get_form(self.request, self.microsite)
+        self.assertEqual(
+            list(microsite_form.base_fields),
+            ["site", "key", "values"]
+        )
+
+    def test_save_action_admin_form(self):
+        """
+        Tests save action for Microsite model form.
+        """
+        new_values = {
+            "domain_prefix": "testmicrosite_new",
+            "platform_name": "Test Microsite New"
+        }
+        microsite_form = self.microsite_admin.get_form(self.request)(instance=self.microsite, data={
+            "key": self.microsite.key,
+            "site": self.microsite.site.id,
+            "values": new_values,
+        })
+        self.assertTrue(microsite_form.is_valid())
+        microsite_form.save()
+        new_microsite = Microsite.objects.get(key=self.microsite.key)
+        self.assertEqual(new_microsite.values, new_values)


### PR DESCRIPTION
`MicrositeHistory` model had unique constraint on `key` field and `OneToOne` on site field which was causing database error when any updates were made to `Microsite` mode via Django admin interface. Removed constraints on `MicrositeHistory` model to allow updates on `Microsite` model.
@saleem-latif please review it.
@mattdrayer FYI.
