### PR TITLE
Add xseries certificates sidebar section in edx.org theme

### DIFF
--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -180,6 +180,19 @@ import json
       </ul>
     </section>
   </section>
+  % if xseries_credentials:
+    <div class="wrapper-xseries-certificates">
+      <p class="title">${_("XSeries Program Certificates")}</p>
+      <p class="copy">${_("You have received a certificate for the following XSeries programs:")}</p>
+      <ul>
+      % for xseries_credential in xseries_credentials:
+        <li>
+          <a class="copy" href="${xseries_credential['credential_url']}">${xseries_credential['display_name']}</a>
+        </li>
+      % endfor
+      </ul>
+    </div>
+  % endif
 </section>
 
 <section id="email-settings-modal" class="modal" aria-hidden="true">


### PR DESCRIPTION
ECOM-3604
Recently the [theme for edx.org](https://github.com/edx/edx-platform/pull/11287) was merged to `edx-platform` and it doesn't include the [xseries certificates sidebar section which was added on the default `dashboard.html` as part of [credentials feature branch for LMS](https://github.com/edx/edx-platform/pull/11347).

@zubair-arbi @awais786 @tasawernawaz 
