### PR TITLE
Be specific about JS files for cms-squire.

### DIFF
--- a/cms/static/js_test_squire.yml
+++ b/cms/static/js_test_squire.yml
@@ -67,7 +67,11 @@ lib_paths:
 # Paths to source JavaScript files
 src_paths:
     - coffee/src
-    - js
+    # We don't include all of js because the Javascript files in js/i18n cause issues with the Squire tests.
+    - js/collections
+    - js/models
+    - js/utils
+    - js/views
     - common/js
 
 # Paths to spec (test) JavaScript files


### PR DESCRIPTION
This is to fix some flakiness introduced by https://github.com/edx/edx-platform/pull/11370.

The `cms-squire` tests are small and mostly exist for backwards-compatibility reasons, so we shouldn't be adding much in the way of new files.
