### PR TITLE
Convert PARTNER_SUPPORT_EMAIL to a setting.

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -387,3 +387,6 @@ OAUTH_OIDC_ISSUER = ENV_TOKENS['OAUTH_OIDC_ISSUER']
 ######################## CUSTOM COURSES for EDX CONNECTOR ######################
 if FEATURES.get('CUSTOM_COURSES_EDX'):
     INSTALLED_APPS += ('openedx.core.djangoapps.ccxcon',)
+
+# Partner support link for CMS footer
+PARTNER_SUPPORT_EMAIL = ENV_TOKENS.get('PARTNER_SUPPORT_EMAIL', PARTNER_SUPPORT_EMAIL)

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -94,7 +94,7 @@ FEATURES['ENABLE_MOBILE_REST_API'] = True  # Enable video bumper in Studio
 FEATURES['ENABLE_VIDEO_BUMPER'] = True  # Enable video bumper in Studio settings
 
 # Enable partner support link in Studio footer
-FEATURES['PARTNER_SUPPORT_EMAIL'] = 'partner-support@example.com'
+PARTNER_SUPPORT_EMAIL = 'partner-support@example.com'
 
 # Disable some block types to test block deprecation logic
 DEPRECATED_BLOCK_TYPES = ['poll', 'survey']

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1110,3 +1110,6 @@ OAUTH_OIDC_ISSUER = 'https://www.example.com/oauth2'
 
 # 5 minute expiration time for JWT id tokens issued for external API requests.
 OAUTH_ID_TOKEN_EXPIRATION = 5 * 60
+
+# Partner support link for CMS footer
+PARTNER_SUPPORT_EMAIL = ''

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -23,7 +23,7 @@ from django.core.urlresolvers import reverse
         <%!
         from django.conf import settings
 
-        partner_email = settings.FEATURES.get('PARTNER_SUPPORT_EMAIL', '')
+        partner_email = settings.PARTNER_SUPPORT_EMAIL
 
         links = [{
             'href': 'http://docs.edx.org',
@@ -49,7 +49,7 @@ from django.core.urlresolvers import reverse
             'href': 'mailto:{email}'.format(email=partner_email),
             'sr_mouseover_text': _('Send an email to {email}').format(email=partner_email),
             'text': _('Contact Us'),
-            'condition': 'PARTNER_SUPPORT_EMAIL' in settings.FEATURES
+            'condition': bool(partner_email)
         }]
         %>
 

--- a/themes/edx.org/cms/templates/widgets/sock.html
+++ b/themes/edx.org/cms/templates/widgets/sock.html
@@ -23,7 +23,7 @@ from django.core.urlresolvers import reverse
         <%!
         from django.conf import settings
 
-        partner_email = settings.FEATURES.get('PARTNER_SUPPORT_EMAIL', '')
+        partner_email = settings.PARTNER_SUPPORT_EMAIL
 
         links = [{
             'href': 'http://docs.edx.org',
@@ -49,7 +49,7 @@ from django.core.urlresolvers import reverse
             'href': 'mailto:{email}'.format(email=partner_email),
             'sr_mouseover_text': _('Send an email to {email}').format(email=partner_email),
             'text': _('Contact Us'),
-            'condition': 'PARTNER_SUPPORT_EMAIL' in settings.FEATURES
+            'condition': bool(partner_email)
         }]
         %>
 


### PR DESCRIPTION
# [TNL-3363](https://openedx.atlassian.net/browse/TNL-3363)

Cleans up the `PARTNER_SUPPORT_EMAIL` feature to be a setting instead.

@feanil, can you take a look?
