### PR TITLE
TNL-4080 Upgrade to MathJax 2.6

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -90,7 +90,7 @@
             // end of Annotation tool files
 
             // externally hosted files
-            "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured", // jshint ignore:line
+            "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured", // jshint ignore:line
             "youtube": [
                 // youtube URL does not end in ".js". We add "?noext" to the path so
                 // that require.js adds the ".js" to the query component of the URL,

--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -51,7 +51,7 @@ requirejs.config({
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
         "mock-ajax": "xmodule_js/common_static/js/vendor/mock-ajax",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix",

--- a/cms/static/coffee/spec/main_squire.coffee
+++ b/cms/static/coffee/spec/main_squire.coffee
@@ -42,7 +42,7 @@ requirejs.config({
         "domReady": "xmodule_js/common_static/js/vendor/domReady",
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix"

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -76,4 +76,4 @@
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -49,7 +49,7 @@
             'jasmine.async': 'xmodule_js/common_static/js/vendor/jasmine.async',
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly.pkgd',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
-            'mathjax': '//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured', // jshint ignore:line
+            'mathjax': '//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured', // jshint ignore:line
             'youtube': '//www.youtube.com/player_api?noext',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',
             'coffee/src/instructor_dashboard/student_admin': 'coffee/src/instructor_dashboard/student_admin',


### PR DESCRIPTION
_Summary_
Because of MathJax, rendering issues were coming in Chrome. Steps to reproduce them are mentioned in [TNL-4080](https://openedx.atlassian.net/browse/TNL-4080) and [TNL-4094](https://openedx.atlassian.net/browse/TNL-4094).
It was mentioned [here](https://github.com/mathjax/MathJax/issues/1300) that those issues are coming because of the MathJex 2.5 and were fixed in MathJex 2.6.
Before Upgrading:
Dot issue:
![screenshot from 2016-02-03 17 58 25](https://cloud.githubusercontent.com/assets/7721119/12782912/fbed64ba-ca9f-11e5-9a6f-04e1c3b0fcb2.png)
Vertical Line issue:
![screenshot from 2016-02-03 17 58 39](https://cloud.githubusercontent.com/assets/7721119/12782923/0dc5cc86-caa0-11e5-9a5e-7892b74ff3b3.png)

After Upgrading:
Dot issue:
![screenshot from 2016-02-03 17 52 10](https://cloud.githubusercontent.com/assets/7721119/12782779/433164da-ca9f-11e5-9dfb-ac2244fe7836.png)
Vertical Line issue:
![screenshot from 2016-02-03 17 52 41](https://cloud.githubusercontent.com/assets/7721119/12782785/4d7249b4-ca9f-11e5-90aa-39cd4e9d06b5.png)
