### PR TITLE
Allow course images to be served from the CDN.

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -3,6 +3,7 @@ Declaration of CourseOverview model
 """
 import json
 import logging
+from urlparse import urlunparse
 
 from django.db import models, transaction
 from django.db.models.fields import BooleanField, DateTimeField, DecimalField, TextField, FloatField, IntegerField
@@ -17,6 +18,7 @@ from opaque_keys.edx.keys import CourseKey
 from config_models.models import ConfigurationModel
 from lms.djangoapps import django_comment_client
 from openedx.core.djangoapps.models.course_details import CourseDetails
+from static_replace.models import AssetBaseUrlConfig
 from util.date_utils import strftime_localized
 from xmodule import course_metadata_utils
 from xmodule.course_module import CourseDescriptor, DEFAULT_START_DATE
@@ -549,7 +551,28 @@ class CourseOverview(TimeStampedModel):
             urls['small'] = self.image_set.small_url or raw_image_url
             urls['large'] = self.image_set.large_url or raw_image_url
 
-        return urls
+        return self._apply_cdn(urls)
+
+    def _apply_cdn(self, image_urls):
+        """
+        Given a dict of resolutions -> urls, return a copy with CDN applied.
+
+        If CDN does not exist or is disabled, just returns the original. The
+        URLs that we store in CourseOverviewImageSet are all already top level
+        paths, so we don't need to go through the /static remapping magic that
+        happens with other course assets. We just need to add the CDN server if
+        appropriate.
+        """
+        cdn_config = AssetBaseUrlConfig.current()
+        if not cdn_config.enabled:
+            return image_urls
+
+        base_url = cdn_config.base_url
+
+        return {
+            resolution: urlunparse((None, base_url, url, None, None, None))
+            for resolution, url in image_urls.items()
+        }
 
     def __unicode__(self):
         """Represent ourselves with the course key."""


### PR DESCRIPTION
Okay, various mistakes with StaticContent and a yak shaving session with caches and tests... to lead to this very anti-climactic PR putting course images behind the CDN. :-P

@tobz, @benpatterson: review please?
