### PR TITLE
ECOM-3177 fix flaky js tests on dashboard.TrackEvents

### DIFF
--- a/lms/static/js/dashboard/track_events.js
+++ b/lms/static/js/dashboard/track_events.js
@@ -31,65 +31,73 @@ var edx = edx || {};
         };
     };
 
-    edx.dashboard.trackEvents = function() {
-        var $courseTitleLink = $('.course-title > a'),
-            $courseImageLink = $('.cover'),
-            $enterCourseLink = $('.enter-course'),
-            $optionsDropdown = $('.wrapper-action-more'),
-            $courseLearnVerified = $('.verified-info'),
-            $findCoursesBtn = $('.btn-find-courses'),
-            $xseriesBtn = $('.xseries-action .btn');
-
-        // Emit an event when the 'course title link' is clicked.
+    // Emit an event when the 'course title link' is clicked.
+    edx.dashboard.trackCourseTitleClicked = function($courseTitleLink, properties){
+        var trackProperty = properties || edx.dashboard.generateTrackProperties;
         window.analytics.trackLink(
             $courseTitleLink,
             'edx.bi.dashboard.course_title.clicked',
-            edx.dashboard.generateTrackProperties
+            trackProperty
         );
+    };
 
-        // Emit an event  when the 'course image' is clicked.
+    // Emit an event  when the 'course image' is clicked.
+    edx.dashboard.trackCourseImageLinkClicked = function($courseImageLink, properties){
+        var trackProperty = properties || edx.dashboard.generateTrackProperties;
         window.analytics.trackLink(
             $courseImageLink,
             'edx.bi.dashboard.course_image.clicked',
-            edx.dashboard.generateTrackProperties
+            trackProperty
         );
+    };
 
-        // Emit an event  when the 'View Course' button is clicked.
+    // Emit an event  when the 'View Course' button is clicked.
+    edx.dashboard.trackEnterCourseLinkClicked = function($enterCourseLink, properties){
+        var trackProperty = properties || edx.dashboard.generateTrackProperties;
         window.analytics.trackLink(
             $enterCourseLink,
             'edx.bi.dashboard.enter_course.clicked',
-            edx.dashboard.generateTrackProperties
+            trackProperty
         );
+    };
 
-        // Emit an event when the options dropdown is engaged.
+    // Emit an event when the options dropdown is engaged.
+    edx.dashboard.trackCourseOptionDropdownClicked = function($optionsDropdown, properties){
+        var trackProperty = properties || edx.dashboard.generateTrackProperties;
         window.analytics.trackLink(
             $optionsDropdown,
             'edx.bi.dashboard.course_options_dropdown.clicked',
-            edx.dashboard.generateTrackProperties
+            trackProperty
         );
+    };
 
-        // Emit an event  when the 'Learn about verified' link is clicked.
+    // Emit an event  when the 'Learn about verified' link is clicked.
+    edx.dashboard.trackLearnVerifiedLinkClicked = function($courseLearnVerified, properties){
+        var trackProperty = properties || edx.dashboard.generateTrackProperties;
         window.analytics.trackLink(
             $courseLearnVerified,
             'edx.bi.dashboard.verified_info_link.clicked',
-            edx.dashboard.generateTrackProperties
+            trackProperty
         );
+    };
 
-        // Emit an event  when the 'Find Courses' button is clicked.
+    // Emit an event  when the 'Find Courses' button is clicked.
+    edx.dashboard.trackFindCourseBtnClicked = function($findCoursesBtn, properties){
+        var trackProperty = properties || { category: 'dashboard', label: null };
         window.analytics.trackLink(
             $findCoursesBtn,
             'edx.bi.dashboard.find_courses_button.clicked',
-            {
-                category: 'dashboard',
-                label: null
-            }
+            trackProperty
         );
+    };
 
-        // Emit an event when the 'View XSeries Details' button is clicked
+    // Emit an event when the 'View XSeries Details' button is clicked
+    edx.dashboard.trackXseriesBtnClicked = function($xseriesBtn, properties){
+        var trackProperty = properties || edx.dashboard.generateProgramProperties;
         window.analytics.trackLink(
             $xseriesBtn,
             'edx.bi.dashboard.xseries_cta_message.clicked',
-            edx.dashboard.generateProgramProperties
+            trackProperty
         );
     };
 
@@ -102,7 +110,13 @@ var edx = edx || {};
     };
 
     $(document).ready(function() {
-        edx.dashboard.trackEvents();
+        edx.dashboard.trackCourseTitleClicked($('.course-title > a'));
+        edx.dashboard.trackCourseImageLinkClicked($('.cover'));
+        edx.dashboard.trackEnterCourseLinkClicked($('.enter-course'));
+        edx.dashboard.trackCourseOptionDropdownClicked($('.wrapper-action-more'));
+        edx.dashboard.trackLearnVerifiedLinkClicked($('.verified-info'));
+        edx.dashboard.trackFindCourseBtnClicked($('.btn-find-courses'));
+        edx.dashboard.trackXseriesBtnClicked($('.xseries-action .btn'));
         edx.dashboard.xseriesTrackMessages();
     });
 })(jQuery);

--- a/lms/static/js/spec/dashboard/track_events_spec.js
+++ b/lms/static/js/spec/dashboard/track_events_spec.js
@@ -11,22 +11,29 @@
                 // Stub the analytics event tracker
                 window.analytics = jasmine.createSpyObj('analytics', ['track', 'page', 'trackLink']);
                 loadFixtures('js/fixtures/dashboard/dashboard.html');
-                window.edx.dashboard.trackEvents();
             });
 
             it('sends an analytics event when the user clicks course title link', function() {
+                var $courseTitle = $('.course-title > a');
+                window.edx.dashboard.trackCourseTitleClicked(
+                    $courseTitle,
+                    window.edx.dashboard.generateTrackProperties);
                 // Verify that analytics events fire when the 'course title link' is clicked.
                 expect(window.analytics.trackLink).toHaveBeenCalledWith(
-                    $('.course-title > a'),
+                    $courseTitle,
                     'edx.bi.dashboard.course_title.clicked',
                      window.edx.dashboard.generateTrackProperties
                 );
             });
 
             it('sends an analytics event when the user clicks course image link', function() {
+                var $courseImage = $('.cover');
+                window.edx.dashboard.trackCourseImageLinkClicked(
+                    $courseImage,
+                    window.edx.dashboard.generateTrackProperties);
                 // Verify that analytics events fire when the 'course image link' is clicked.
                 expect(window.analytics.trackLink).toHaveBeenCalledWith(
-                    $('.cover'),
+                    $courseImage,
                     'edx.bi.dashboard.course_image.clicked',
                     window.edx.dashboard.generateTrackProperties
                 );
@@ -34,47 +41,67 @@
 
 
             it('sends an analytics event when the user clicks enter course link', function() {
+                var $enterCourse = $('.enter-course');
+                window.edx.dashboard.trackEnterCourseLinkClicked(
+                    $enterCourse,
+                    window.edx.dashboard.generateTrackProperties);
                 // Verify that analytics events fire when the 'enter course link' is clicked.
                 expect(window.analytics.trackLink).toHaveBeenCalledWith(
-                    $('.enter-course'),
+                    $enterCourse,
                     'edx.bi.dashboard.enter_course.clicked',
                     window.edx.dashboard.generateTrackProperties
                 );
             });
 
             it('sends an analytics event when the user clicks enter course link', function() {
+                var $dropDown = $('.wrapper-action-more');
+                window.edx.dashboard.trackCourseOptionDropdownClicked(
+                    $dropDown,
+                    window.edx.dashboard.generateTrackProperties);
                 // Verify that analytics events fire when the options dropdown is engaged.
                 expect(window.analytics.trackLink).toHaveBeenCalledWith(
-                    $('.wrapper-action-more'),
+                    $dropDown,
                     'edx.bi.dashboard.course_options_dropdown.clicked',
                     window.edx.dashboard.generateTrackProperties
                 );
             });
 
             it('sends an analytics event when the user clicks the learned about verified track link', function() {
+                var $learnVerified = $('.verified-info');
+                window.edx.dashboard.trackLearnVerifiedLinkClicked(
+                    $learnVerified,
+                    window.edx.dashboard.generateTrackProperties);
                 //Verify that analytics events fire when the 'Learned about verified track' link is clicked.
                 expect(window.analytics.trackLink).toHaveBeenCalledWith(
-                    $('.verified-info'),
+                    $learnVerified,
                     'edx.bi.dashboard.verified_info_link.clicked',
                     window.edx.dashboard.generateTrackProperties
                 );
             });
 
             it('sends an analytics event when the user clicks find courses button', function() {
-                // Verify that analytics events fire when the 'user clicks find the course' button.
-                expect(window.analytics.trackLink).toHaveBeenCalledWith(
-                    $('.btn-find-courses'),
-                    'edx.bi.dashboard.find_courses_button.clicked',
-                    {
+                var $findCourse = $('.btn-find-courses'),
+                    property = {
                         category: 'dashboard',
                         label: null
-                    }
+                    };
+                window.edx.dashboard.trackFindCourseBtnClicked($findCourse, property);
+                // Verify that analytics events fire when the 'user clicks find the course' button.
+                expect(window.analytics.trackLink).toHaveBeenCalledWith(
+                    $findCourse,
+                    'edx.bi.dashboard.find_courses_button.clicked',
+                    property
                 );
             });
 
             it('sends an analytics event when the user clicks the \'View XSeries Details\' button', function() {
+                var $xseries = $('.xseries-action .btn');
+                window.edx.dashboard.trackXseriesBtnClicked(
+                    $xseries,
+                    window.edx.dashboard.generateProgramProperties);
+
                 expect(window.analytics.trackLink).toHaveBeenCalledWith(
-                    $('.xseries-action .btn'),
+                    $xseries,
                     'edx.bi.dashboard.xseries_cta_message.clicked',
                     window.edx.dashboard.generateProgramProperties
                 );


### PR DESCRIPTION
@adampalay @benpatterson Please review
FYI @rock345 
This is a pure js unit test change.
It's implemented according to the suggestion provided by @adampalay on the jira ticket ECOM-3177

I am not able to really answer why these test cases don't fail every single time before this change, but my hope is after this change, the test would pass all the time unless it catches a real bug.
