### PR TITLE
Remove skip from studio page bok choy test

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_general.py
+++ b/common/test/acceptance/tests/studio/test_studio_general.py
@@ -2,7 +2,6 @@
 Acceptance tests for Studio.
 """
 
-from unittest import skip
 from bok_choy.web_app_test import WebAppTest
 
 from ...pages.studio.asset_index import AssetIndexPage
@@ -95,7 +94,6 @@ class CoursePagesTest(StudioCourseTest):
         self.dashboard_page.visit()
         self.assertEqual(self.browser.current_url.strip('/').rsplit('/')[-1], 'home')
 
-    @skip('Intermittently failing with Page not found error for Assets. TE-418')
     def test_page_existence(self):
         """
         Make sure that all these pages are accessible once you have a course.


### PR DESCRIPTION
@benpatterson and @jzoldak please review.

While working on a different project, I noticed that this test was skipped. The comment indicated it was because the asset page didn't always load, so given @dianakhuang's recent change, I decided to try removing the skip.

This has passed 41 times. The JIRA ticket referenced doesn't exist, but I did find a couple related to this test where the ticket was closed because nobody had seen the failure in awhile (which perhaps was because it was skipped...).
