### PR TITLE
Move JSON samples out of translated strings so translators can't make mistakes

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -701,16 +701,22 @@ class CourseFields(object):
 
     teams_configuration = Dict(
         display_name=_("Teams Configuration"),
+        # Translators: please don't translate "id".
         help=_(
             'Specify the maximum team size and topics for teams inside the provided set of curly braces. '
             'Make sure that you enclose all of the sets of topic values within a set of square brackets, '
             'with a comma after the closing curly brace for each topic, and another comma after the '
             'closing square brackets. '
             'For example, to specify that teams should have a maximum of 5 participants and provide a list of '
-            '2 topics, enter the configuration in this format: '
-            '{"topics": [{"name": "Topic1Name", "description": "Topic1Description", "id": "Topic1ID"}, '
-            '{"name": "Topic2Name", "description": "Topic2Description", "id": "Topic2ID"}], "max_team_size": 5}. '
+            '2 topics, enter the configuration in this format: {example_format}. '
             'In "id" values, the only supported special characters are underscore, hyphen, and period.'
+        ).format(
+            # Put the sample JSON into a format variable so that translators
+            # don't muck with it.
+            example_format=(
+                '{"topics": [{"name": "Topic1Name", "description": "Topic1Description", "id": "Topic1ID"}, '
+                '{"name": "Topic2Name", "description": "Topic2Description", "id": "Topic2ID"}], "max_team_size": 5}'
+            ),
         ),
         scope=Scope.settings,
     )

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -169,12 +169,17 @@ class InheritanceMixin(XBlockMixin):
     video_bumper = Dict(
         display_name=_("Video Pre-Roll"),
         help=_(
-            """Identify a video, 5-10 seconds in length, to play before course videos. Enter the video ID from"""
-            """ the Video Uploads page and one or more transcript files in the following format:"""
-            """ {"video_id": "ID", "transcripts": {"language": "/static/filename.srt"}}."""
-            """ For example, an entry for a video with two transcripts looks like this:"""
-            """ {"video_id": "77cef264-d6f5-4cf2-ad9d-0178ab8c77be","""
-            """ "transcripts": {"en": "/static/DemoX-D01_1.srt", "uk": "/static/DemoX-D01_1_uk.srt"}}"""
+            "Identify a video, 5-10 seconds in length, to play before course videos. Enter the video ID from "
+            "the Video Uploads page and one or more transcript files in the following format: {format}. "
+            "For example, an entry for a video with two transcripts looks like this: {example}"
+        ).format(
+            format='{"video_id": "ID", "transcripts": {"language": "/static/filename.srt"}}',
+            example=(
+                '{'
+                '"video_id": "77cef264-d6f5-4cf2-ad9d-0178ab8c77be", '
+                '"transcripts": {"en": "/static/DemoX-D01_1.srt", "uk": "/static/DemoX-D01_1_uk.srt"}'
+                '}'
+            ),
         ),
         scope=Scope.settings
     )
@@ -183,8 +188,11 @@ class InheritanceMixin(XBlockMixin):
     default_reset_button = getattr(settings, reset_key) if hasattr(settings, reset_key) else False
     show_reset_button = Boolean(
         display_name=_("Show Reset Button for Problems"),
-        help=_("Enter true or false. If true, problems in the course default to always displaying a 'Reset' button. You can "
-               "override this in each problem's settings. All existing problems are affected when this course-wide setting is changed."),
+        help=_(
+            "Enter true or false. If true, problems in the course default to always displaying a 'Reset' button. "
+            "You can override this in each problem's settings. All existing problems are affected when "
+            "this course-wide setting is changed."
+        ),
         scope=Scope.settings,
         default=default_reset_button
     )


### PR DESCRIPTION
When translated strings have JSON in them, it's an invitation to translators to translate the English they find there, which isn't what we want.
