### PR TITLE
AC-328 LMS updating heading styles

### DIFF
--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -187,17 +187,38 @@
     }
   }
 
-  //UI: default internal xblock content styles
+  // UI: default internal xblock content styles
   // ====================
-  // TO-DO: clean-up / remove this reset
-  // internal headings for problems and video components
-  h2 {
-    @extend %t-title5;
-    margin: ($baseline*1.5) ($baseline*2) ($baseline*1.5) 0;
-    color: $gray;
-    letter-spacing: 1px;
-    text-transform: uppercase;
-  }
+    h1 {
+        // unused as of ac-313, ac-328
+    }
+
+    h2 {
+        // unused as of ac-313, ac-328
+    }
+
+    h3 {
+        // formerly h2
+        @extend %t-title5;
+        @extend %t-regular;
+        margin: ($baseline*1.5) ($baseline*2) ($baseline*1.5) 0;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+    }
+
+    h4 {
+        // formerly h3
+        @extend %t-title5;
+    }
+
+    h5 {
+        // h4 and h5
+        @extend %t-title5;
+    }
+
+    h6 {
+        @extend %t-title6;
+    }
 
 
   // ====================

--- a/common/lib/xmodule/xmodule/css/html/display.scss
+++ b/common/lib/xmodule/xmodule/css/html/display.scss
@@ -10,7 +10,8 @@ h1 {
     margin: 0 0 1.416em 0;
   }
 
-h2 {
+h2, // backwards-compatibility
+h3 {
   color: #646464;
   font: normal 1.2em/1.2em $sans-serif;
   letter-spacing: 1px;
@@ -22,14 +23,6 @@ h2 {
 h3, h4, h5, h6 {
   margin: 0 0 ($baseline/2) 0;
   font-weight: 600;
-}
-
-h3 {
-  font-size: 1.2em;
-}
-
-h4 {
-  font-size: 1em;
 }
 
 h5 {
@@ -152,7 +145,7 @@ th {
 
 // modal - image zoom, fill window
 .wrapper-modal-image {
-  
+
   .modal-ui-icon {
     @extend %ui-fake-link;
     position: absolute;
@@ -163,32 +156,32 @@ th {
     background: $white;
     color: $black;
     border: 2px solid $black;
-    
+
     .label {
       font-weight: bold;
     }
-    
+
     i {
       font-style: normal;
     }
   }
-  
+
   .image-link {
     @extend %ui-fake-link;
     position: relative;
     display: block;
-    
+
     .action-fullscreen {
       display: none;
       top: 10px;
       left: 10px;
     }
-    
+
     &:hover .action-fullscreen {
       display: block;
     }
   }
-  
+
   .image-modal {
     @extend %ui-fake-link;
     @extend %ui-depth5;
@@ -199,7 +192,7 @@ th {
     height: 100%;
     width: 100%;
     background-color: rgba(0, 0, 0, 0.7);
-  
+
     .image-content {
       position: relative;
       top: 2.5%;
@@ -208,10 +201,10 @@ th {
       width: 95%;
       margin: auto;
       overflow: hidden;
-      
+
       .image-wrapper {
         position: relative;
-        
+
         img {
           position: relative;
           display: block;
@@ -221,12 +214,12 @@ th {
           cursor: default;
         }
       }
-      
+
       .action-close {
         top: 10px;
         right: 10px;
       }
-      
+
       .image-controls {
         position: absolute;
         right: 10px;
@@ -234,16 +227,16 @@ th {
         margin: 0;
         padding: 0;
         list-style: none;
-          
+
         .image-control {
           position: relative;
           display: inline-block;
           margin: 0;
           padding: 0;
-          
+
           .modal-ui-icon {
             position: relative;
-            
+
             &.action-zoom-in {
               margin-right: ($baseline/4);
             }
@@ -258,17 +251,17 @@ th {
         }
       }
     }
-    
+
     &.image-is-fit-to-screen {
       display: block;
-      
+
       // !important used here to override jQuery.
       .image-content .image-wrapper {
         top: 0 !important;
         left: 0 !important;
         width: 100% !important;
         height: 100% !important;
-        
+
         img {
           top: 0 !important;
           left: 0 !important;
@@ -277,9 +270,9 @@ th {
     }
     &.image-is-zoomed {
       display: block;
-      
+
       .image-content .image-wrapper {
-        
+
         img {
           max-width: none;
           max-height: none;

--- a/lms/static/sass/course/base/_extends.scss
+++ b/lms/static/sass/course/base/_extends.scss
@@ -9,7 +9,7 @@
 }
 
 // Older Course Extends - to review/remove with LMS cleanup
-h1.top-header {
+.top-header {
   border-bottom: 1px solid $border-color-2;
   @include text-align(left);
   font-size: em(24);

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -416,7 +416,7 @@ html.video-fullscreen {
     }
 
     div#seq_content {
-      h1 {
+      h3 {
         background: none;
         margin-bottom: lh();
         padding-bottom: 0;
@@ -445,12 +445,12 @@ html.video-fullscreen {
           margin-bottom: -16px;
           border-bottom: 0;
 
-          h1 {
+          h3 {
             margin: 0;
             font-size: 1em;
           }
 
-          h2 {
+          h4 {
             float: right;
             margin: 12px 0 0;
             text-align: right;
@@ -661,5 +661,3 @@ section.self-assessment {
     font-weight: bold;
   }
 }
-
-

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -416,6 +416,7 @@ html.video-fullscreen {
     }
 
     div#seq_content {
+      h1,
       h3 {
         background: none;
         margin-bottom: lh();
@@ -445,11 +446,13 @@ html.video-fullscreen {
           margin-bottom: -16px;
           border-bottom: 0;
 
+          h1, // for backwards-compatibility
           h3 {
             margin: 0;
             font-size: 1em;
           }
 
+          h2, // for backwards-compatibility
           h4 {
             float: right;
             margin: 12px 0 0;

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -416,8 +416,7 @@ html.video-fullscreen {
     }
 
     div#seq_content {
-      h1,
-      h3 {
+      h1 {
         background: none;
         margin-bottom: lh();
         padding-bottom: 0;
@@ -441,19 +440,17 @@ html.video-fullscreen {
         }
 
         header {
-          @extend h1.top-header;
+          @extend .top-header;
           border-radius: 0 4px 0 0;
           margin-bottom: -16px;
           border-bottom: 0;
 
-          h1, // for backwards-compatibility
-          h3 {
+          h1 {
             margin: 0;
             font-size: 1em;
           }
 
-          h2, // for backwards-compatibility
-          h4 {
+          h2 {
             float: right;
             margin: 12px 0 0;
             text-align: right;


### PR DESCRIPTION
# [AC-328](https://openedx.atlassian.net/browse/AC-328)

After removing H1s and H2s from the available formatting options in CMS, I needed to adjust the styles of the H3s, H4s, and so on, to use the styles of their higher siblings so things looked like they did before. For example, since using H1 and H2 is unavailable, using an H3 in the editor, should look like an H1 style-wise. There should be no visual differences between what students saw previously and what they see now.
## Sandbox

https://clrux-ac-328.sandbox.edx.org
## Reviewers
- [ ] @cptvitamin 
- [x] @lamagnifica (Docs heads-up)
