### PR TITLE
WL-286 Upgrading django-oauth2-provider requirement

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -46,7 +46,7 @@
 # Third-party:
 -e git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline
 git+https://github.com/edx/django-wiki.git@v0.0.5#egg=django-wiki==0.0.5
--e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-6a#egg=django-oauth2-provider==0.2.7-fork-edx-6
+git+https://github.com/edx/django-oauth2-provider.git@1.0.0#egg=django-oauth2-provider==1.0.0
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 -e git+https://github.com/edx/django-rest-framework-oauth.git@f0b503fda8c254a38f97fef802ded4f5fe367f7a#egg=djangorestframework-oauth==1.0.1
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0


### PR DESCRIPTION
This upgrade enables multiple redirect URI support for a single client.

Related PR:
https://github.com/edx/django-oauth2-provider/pull/24
