### PR TITLE
Pass DOM element, not jQuery object to XBlock initialisation.

### DIFF
--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -43,7 +43,7 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                 fragmentsRendered.always(function() {
                     xblockElement = self.$('.xblock').first();
                     try {
-                        xblock = XBlock.initializeBlock(xblockElement);
+                        xblock = XBlock.initializeBlock(xblockElement.get(0));
                         self.xblock = xblock;
                         self.xblockReady(xblock);
                         if (successCallback) {

--- a/cms/static/js/xblock/authoring.js
+++ b/cms/static/js/xblock/authoring.js
@@ -5,6 +5,7 @@
     'use strict';
 
     function VisibilityEditorView(runtime, element) {
+        var $element = $(element);
         this.getGroupAccess = function() {
             var groupAccess = {},
                 checkboxValues,
@@ -15,12 +16,12 @@
                 // defined by VerificationPartitionScheme on the backend!
                 ALLOW_GROUP_ID = 1;
 
-            if (element.find('.visibility-level-all').prop('checked')) {
+            if ($element.find('.visibility-level-all').prop('checked')) {
                 return {};
             }
 
             // Cohort partitions (user is allowed to select more than one)
-            element.find('.field-visibility-content-group input:checked').each(function(index, input) {
+            $element.find('.field-visibility-content-group input:checked').each(function(index, input) {
                 checkboxValues = $(input).val().split("-");
                 partitionId = parseInt(checkboxValues[0], 10);
                 groupId = parseInt(checkboxValues[1], 10);
@@ -33,7 +34,7 @@
             });
 
             // Verification partitions (user can select exactly one)
-            if (element.find('#verification-access-checkbox').prop('checked')) {
+            if ($element.find('#verification-access-checkbox').prop('checked')) {
                 partitionId = parseInt($('#verification-access-dropdown').val(), 10);
                 groupAccess[partitionId] = [ALLOW_GROUP_ID];
             }
@@ -42,19 +43,19 @@
         };
 
         // When selecting "all students and staff", uncheck the specific groups
-        element.find('.field-visibility-level input').change(function(event) {
+        $element.find('.field-visibility-level input').change(function(event) {
             if ($(event.target).hasClass('visibility-level-all')) {
-                element.find('.field-visibility-content-group input, .field-visibility-verification input')
+                $element.find('.field-visibility-content-group input, .field-visibility-verification input')
                     .prop('checked', false);
             }
         });
 
         // When selecting a specific group, deselect "all students and staff" and
         // select "specific content groups" instead.`
-        element.find('.field-visibility-content-group input, .field-visibility-verification input')
+        $element.find('.field-visibility-content-group input, .field-visibility-verification input')
             .change(function() {
-                element.find('.visibility-level-all').prop('checked', false);
-                element.find('.visibility-level-specific').prop('checked', true);
+                $element.find('.visibility-level-all').prop('checked', false);
+                $element.find('.visibility-level-specific').prop('checked', true);
             });
     }
 

--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -26,7 +26,7 @@ class @HTMLEditingDescriptor
     CUSTOM_FONTS + STANDARD_FONTS
 
   constructor: (element) ->
-    @element = element
+    @element = $(element)
     @base_asset_url = @element.find("#editor-tab").data('base-asset-url')
     @editor_choice = @element.find("#editor-tab").data('editor')
     if @base_asset_url == undefined

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
@@ -13,7 +13,7 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
   @explanationTemplate: "[explanation]\n#{gettext 'Short explanation'}\n[explanation]\n"
 
   constructor: (element) ->
-    @element = element
+    @element = $(element)
 
     if $(".markdown-box", @element).length != 0
       @markdown_editor = CodeMirror.fromTextArea($(".markdown-box", element)[0], {

--- a/common/lib/xmodule/xmodule/js/src/tabs/tabs-aggregator.coffee
+++ b/common/lib/xmodule/xmodule/js/src/tabs/tabs-aggregator.coffee
@@ -2,7 +2,7 @@ class @TabsEditingDescriptor
   @isInactiveClass : "is-inactive"
 
   constructor: (element) ->
-    @element = element;
+    @element = $(element)
     ###
     Not tested on syncing of multiple editors of same type in tabs
     (Like many CodeMirrors).

--- a/common/static/js/xblock/core.js
+++ b/common/static/js/xblock/core.js
@@ -69,7 +69,7 @@
         } else {
             block = {};
         }
-        block.element = element;
+        block.element = $element;
         block.name = $element.data('name');
         block.type = $element.data('block-type');
         $element.trigger('xblock-initialized');


### PR DESCRIPTION
The function `initializeXBlock()` expects a DOM element, and is passed one in most cases.  However, when adding a new XBlock component in Studio, the function is passed a jQuery object, which ends up being forwarded to the actual initialisation function of the XBlock.  This is inconsistent, and led to buggy behaviour in one of our XBlocks.  This bug has been around for at least a year.

This fix tries to make the type of element passed on to XBlock implementations more consistent.

I assumed that this change would be backwards compatible, since currently XBlock initialisation routines need to be able to handle either a jQuery object or a DOM element.  However, some XBlock initialisers are only ever called via the code path that wrongly uses a jQuery objects, and some of these XBlocks depend on the wrong behaviour.  I fixed the problems exposed by the edx-platform test suite, but there still might be external XBlocks that will break with this patch applied.

**JIRA tickets**: [YONK-268](https://openedx.atlassian.net/browse/YONK-268)

**Sandbox URL**: [LMS](http://pr11433.sandbox.opencraft.com/) [Studio](http://studio.pr11433.sandbox.opencraft.com/)

**Partner information**: For a Solutions partner project

**Reviewers**
- [x] Code: @Kelketek
- [x] Platform: @andy-armstrong
