### PR TITLE
Move markup helpers to djangolib

### DIFF
--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -12,7 +12,7 @@ from contentstore.views.helpers import xblock_studio_url, xblock_type_display_na
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
-from util.markup import HTML, ugettext as _
+from openedx.core.djangolib.markup import HTML, ugettext as _
 %>
 <%block name="title">${xblock.display_name_with_default_escaped} ${xblock_type_display_name(xblock) | h}</%block>
 <%block name="bodyclass">is-signedin course container view-container</%block>

--- a/lms/templates/enrollment/course_enrollment_message.html
+++ b/lms/templates/enrollment/course_enrollment_message.html
@@ -1,4 +1,4 @@
-<%! from util.markup import ugettext as _ %>
+<%! from openedx.core.djangolib.markup import ugettext as _ %>
 <%page expression_filter="h"/>
 % for course_msg in course_enrollment_messages:
     <div class="wrapper-msg urgency-high">

--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -16,12 +16,12 @@ def ugettext(text):
 
     Use like this in Mako::
 
-        <% from util.markup import ugettext as _ %>
+        <% from openedx.core.djangolib.markup import ugettext as _ %>
         <p>${_("Hello, world!")}</p>
 
     Or with formatting::
 
-        <% from util.markup import HTML, ugettext as _ %>
+        <% from openedx.core.djangolib.markup import HTML, ugettext as _ %>
         ${_("Write & send {start}email{end}").format(
             start=HTML("<a href='mailto:ned@edx.org'>"),
             end=HTML("</a>"),
@@ -41,7 +41,7 @@ def HTML(html):                                 # pylint: disable=invalid-name
 
     Use this when formatting HTML into other strings::
 
-        <% from util.markup import HTML, ugettext as _ %>
+        <% from openedx.core.djangolib.markup import HTML, ugettext as _ %>
         ${_("Write & send {start}email{end}").format(
             start=HTML("<a href='mailto:ned@edx.org'>"),
             end=HTML("</a>"),

--- a/openedx/core/djangolib/tests/test_markup.py
+++ b/openedx/core/djangolib/tests/test_markup.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 """
-Tests for util.markup
+Tests for openedx.core.djangolib.markup
 """
 
 import unittest
 
 import ddt
+from mako.template import Template
 
-from edxmako.template import Template
-from util.markup import escape, HTML, ugettext as _, ungettext
+from openedx.core.djangolib.markup import escape, HTML, ugettext as _, ungettext
 
 
 @ddt.ddt
@@ -54,12 +54,12 @@ class FormatHtmlTest(unittest.TestCase):
         # The default_filters used here have to match the ones in edxmako.
         template = Template(
             """
-                <%! from util.markup import HTML, ugettext as _ %>
+                <%! from openedx.core.djangolib.markup import HTML, ugettext as _ %>
                 ${_(u"A & {BC}").format(BC=HTML("B & C"))}
             """,
             default_filters=['decode.utf8', 'h'],
         )
-        out = template.render({})
+        out = template.render()
         self.assertEqual(out.strip(), u"A &amp; B & C")
 
     def test_ungettext(self):


### PR DESCRIPTION
## [TNL-3561](https://openedx.atlassian.net/browse/TNL-3561)

This PR is a part of the Mako safe by default Epic.  It generally involves cleaning up some helpers and clarifying best practices.

The main change is moving the markup helpers from common to openedx.

Here is the related docs PR:
https://github.com/edx/edx-documentation/pull/846
### Testing
- [X] Unit, integration, acceptance tests as appropriate
### Reviewers

Note: I'm hoping to get this out quickly this morning to go out with the other refactor.
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [X] Code review: @cahrens 
- [X] Code review: @dianakhuang 
### Post-review
- [X] Rebase from master and search again for usages
- [X] Squash commits
