### PR TITLE
Get tests running successfully on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 2.7.3
+    version: 2.7.10
 
 general:
   artifacts:
@@ -20,7 +20,7 @@ dependencies:
     # cache the virtualenv at that state, so that
     # the next build will not need to install them
     # from scratch again.
-    - pip install --exists-action w -r requirements/edx/pre.txt 
+    - pip install --exists-action w -r requirements/edx/pre.txt
     - pip install --exists-action w -r requirements/edx/github.txt
     - pip install --exists-action w -r requirements/edx/local.txt
 
@@ -33,6 +33,10 @@ dependencies:
     - if [ -e requirements/edx/post.txt ]; then pip install --exists-action w -r requirements/edx/post.txt ; fi
 
     - pip install coveralls==1.0
+
+    # Output the installed python packages to the console to help
+    # with troubleshooting any issues with python requirements.
+    - pip freeze
 
 test:
   override:

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -37,7 +37,7 @@ djangorestframework-jwt==1.7.2
 edx-opaque-keys==0.2.1
 edx-organizations==0.3.1
 edx-rest-api-client==1.2.1
-edx-search==0.1.1
+edx-search==0.1.2
 facebook-sdk==0.4.0
 feedparser==5.1.3
 firebase-token-generator==1.3.2

--- a/scripts/circle-ci-tests.sh
+++ b/scripts/circle-ci-tests.sh
@@ -55,7 +55,9 @@ else
             paver run_pep8 > pep8.log || { cat pep8.log; EXIT=1; }
 
             echo "Finding pylint violations and storing in report..."
-            paver run_pylint -l $PYLINT_THRESHOLD > pylint.log || { cat pylint.log; EXIT=1; }
+            # HACK: we need to print something to the console, otherwise circleci
+            # fails and aborts the job because nothing is displayed for > 10 minutes.
+            paver run_pylint -l $PYLINT_THRESHOLD | tee pylint.log || EXIT=1
 
             mkdir -p reports
             echo "Finding jshint violations and storing report..."


### PR DESCRIPTION
- Bump the version of edx-search so that the tests subpackage will be installed
- Output the list of installed python packages to help with troubleshooting in the future
- Update to use the correct version of python
- Tee the pylint output to the console so the build doesn't timeout when computing violations

@benpatterson please review
