### PR TITLE
Modified permission classes for CCX REST APIs

### DIFF
--- a/openedx/core/lib/api/tests/test_permissions.py
+++ b/openedx/core/lib/api/tests/test_permissions.py
@@ -1,10 +1,16 @@
 """ Tests for API permissions classes. """
 
 import ddt
+from django.contrib.auth.models import AnonymousUser
+from django.http import Http404
 from django.test import TestCase, RequestFactory
 
 from student.roles import CourseStaffRole, CourseInstructorRole
-from openedx.core.lib.api.permissions import IsStaffOrOwner, IsCourseInstructor
+from openedx.core.lib.api.permissions import (
+    IsStaffOrOwner,
+    IsCourseStaffInstructor,
+    IsMasterCourseStaffInstructor,
+)
 from student.tests.factories import UserFactory
 from opaque_keys.edx.keys import CourseKey
 
@@ -16,35 +22,88 @@ class TestObject(object):
         self.course_id = course_id
 
 
-class IsCourseInstructorTests(TestCase):
-    """ Test for IsCourseInstructor permission class. """
+class TestCcxObject(TestObject):
+    """ Fake class for object permission for CCX Courses """
+    def __init__(self, user=None, course_id=None):
+        super(TestCcxObject, self).__init__(user, course_id)
+        self.coach = user
+
+
+class IsCourseStaffInstructorTests(TestCase):
+    """ Test for IsCourseStaffInstructor permission class. """
 
     def setUp(self):
-        super(IsCourseInstructorTests, self).setUp()
-        self.permission = IsCourseInstructor()
+        super(IsCourseStaffInstructorTests, self).setUp()
+        self.permission = IsCourseStaffInstructor()
+        self.coach = UserFactory.create()
+        self.user = UserFactory.create()
         self.request = RequestFactory().get('/')
+        self.request.user = self.user
         self.course_key = CourseKey.from_string('edx/test123/run')
-        self.obj = TestObject(course_id=self.course_key)
+        self.obj = TestCcxObject(user=self.coach, course_id=self.course_key)
 
-    def test_course_staff_has_no_access(self):
-        user = UserFactory.create()
-        self.request.user = user
-        CourseStaffRole(course_key=self.course_key).add_users(user)
-
-        self.assertFalse(
-            self.permission.has_object_permission(self.request, None, self.obj))
+    def test_course_staff_has_access(self):
+        CourseStaffRole(course_key=self.course_key).add_users(self.user)
+        self.assertTrue(self.permission.has_object_permission(self.request, None, self.obj))
 
     def test_course_instructor_has_access(self):
-        user = UserFactory.create()
-        self.request.user = user
-        CourseInstructorRole(course_key=self.course_key).add_users(user)
+        CourseInstructorRole(course_key=self.course_key).add_users(self.user)
+        self.assertTrue(self.permission.has_object_permission(self.request, None, self.obj))
 
-        self.assertTrue(
-            self.permission.has_object_permission(self.request, None, self.obj))
+    def test_course_coach_has_access(self):
+        self.request.user = self.coach
+        self.assertTrue(self.permission.has_object_permission(self.request, None, self.obj))
+
+    def test_any_user_has_no_access(self):
+        self.assertFalse(self.permission.has_object_permission(self.request, None, self.obj))
 
     def test_anonymous_has_no_access(self):
-        self.assertFalse(
-            self.permission.has_object_permission(self.request, None, self.obj))
+        self.request.user = AnonymousUser()
+        self.assertFalse(self.permission.has_object_permission(self.request, None, self.obj))
+
+
+class IsMasterCourseStaffInstructorTests(TestCase):
+    """ Test for IsMasterCourseStaffInstructorTests permission class. """
+
+    def setUp(self):
+        super(IsMasterCourseStaffInstructorTests, self).setUp()
+        self.permission = IsMasterCourseStaffInstructor()
+        master_course_id = 'edx/test123/run'
+        self.user = UserFactory.create()
+        self.get_request = RequestFactory().get('/?master_course_id={}'.format(master_course_id))
+        self.get_request.user = self.user
+        self.post_request = RequestFactory().post('/', data={'master_course_id': master_course_id})
+        self.post_request.user = self.user
+        self.course_key = CourseKey.from_string(master_course_id)
+
+    def test_course_staff_has_access(self):
+        CourseStaffRole(course_key=self.course_key).add_users(self.user)
+        self.assertTrue(self.permission.has_permission(self.get_request, None))
+        self.assertTrue(self.permission.has_permission(self.post_request, None))
+
+    def test_course_instructor_has_access(self):
+        CourseInstructorRole(course_key=self.course_key).add_users(self.user)
+        self.assertTrue(self.permission.has_permission(self.get_request, None))
+        self.assertTrue(self.permission.has_permission(self.post_request, None))
+
+    def test_any_user_has_partial_access(self):
+        self.assertFalse(self.permission.has_permission(self.get_request, None))
+        self.assertFalse(self.permission.has_permission(self.post_request, None))
+
+    def test_anonymous_has_no_access(self):
+        user = AnonymousUser()
+        self.get_request.user = user
+        self.post_request.user = user
+        self.assertFalse(self.permission.has_permission(self.get_request, None))
+        self.assertFalse(self.permission.has_permission(self.post_request, None))
+
+    def test_wrong_course_id_raises(self):
+        get_request = RequestFactory().get('/?master_course_id=this_is_invalid')
+        with self.assertRaises(Http404):
+            self.permission.has_permission(get_request, None)
+        post_request = RequestFactory().post('/', data={'master_course_id': 'this_is_invalid'})
+        with self.assertRaises(Http404):
+            self.permission.has_permission(post_request, None)
 
 
 @ddt.ddt


### PR DESCRIPTION
This PR addresses a bug we found during the deployment on stage of https://github.com/edx/edx-platform/pull/11166. The problem was about the fact that the OAUTH user did not need to be an instructor of the master course to create CCX. Furthermore we did not take in account the fact that we want the OAUTH user to be a `staff` user on the master course and not an `instructor`.

This PR then introduces two new permission classes for the REST APIs: the first is a modified version of the old one  where we allow also `staff` members to have permission; the second is a new class that is needed to perform the check on the list view.
### Manual Testing

To test this PR, please follow the steps described in https://github.com/edx/edx-platform/pull/11166, but an extra step is to add the "dedicated user for the APIs" as a `staff member` of the master course (you can use the Instructor dashboard for this purpose).

fixes mitocw/edx-platform#193 
