### PR TITLE
Ignore venv directory when running jshint on circleci

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -2,3 +2,4 @@
 node_modules
 cms/static/js/i18n/**/*.js
 lms/static/js/i18n/**/*.js
+venv


### PR DESCRIPTION
@clytwynec can you please review?
Details at https://openedx.atlassian.net/browse/TE-1174.

[Here's a link](https://circleci.com/gh/jzoldak/edx-platform/115) to the passing build in CircleCI.
The [violations total](https://circle-artifacts.com/gh/jzoldak/edx-platform/115/artifacts/0/tmp/circle-junit.Xr0S52g/junit/metrics/jshint) is now 8338, which is the same as on Jenkins.

And it looks like the quality shard for this PR passed on Jenkins also.
