### PR TITLE
Switch to SharedModuleStoreTestCase in the 'courseware' app where possible.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -436,8 +436,8 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
             org='MITx',
             number='closed',
             display_name='Closed Course To Buy',
-            enrollment_start = tomorrow,
-            enrollment_end = nextday
+            enrollment_start=tomorrow,
+            enrollment_end=nextday
         )
 
     def setUp(self):

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -30,17 +30,21 @@ from lms.djangoapps.ccx.tests.factories import CcxFactory
 
 
 @attr('shard_1')
-class CourseInfoTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
+class CourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
     Tests for the Course Info page
     """
-    def setUp(self):
-        super(CourseInfoTestCase, self).setUp()
-        self.course = CourseFactory.create()
-        self.page = ItemFactory.create(
-            category="course_info", parent_location=self.course.location,
+    @classmethod
+    def setUpClass(cls):
+        super(CourseInfoTestCase, cls).setUpClass()
+        cls.course = CourseFactory.create()
+        cls.page = ItemFactory.create(
+            category="course_info", parent_location=cls.course.location,
             data="OOGIE BLOOGIE", display_name="updates"
         )
+
+    def setUp(self):
+        super(CourseInfoTestCase, self).setUp()
 
     def test_logged_in_unenrolled(self):
         self.setup_user()
@@ -203,11 +207,15 @@ class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
     Tests for the info page of self-paced courses.
     """
 
+    @classmethod
+    def setUpClass(cls):
+        super(SelfPacedCourseInfoTestCase, cls).setUpClass()
+        cls.instructor_paced_course = CourseFactory.create(self_paced=False)
+        cls.self_paced_course = CourseFactory.create(self_paced=True)
+
     def setUp(self):
         SelfPacedConfiguration(enabled=True).save()
         super(SelfPacedCourseInfoTestCase, self).setUp()
-        self.instructor_paced_course = CourseFactory.create(self_paced=False)
-        self.self_paced_course = CourseFactory.create(self_paced=True)
         self.setup_user()
 
     def fetch_course_info_with_queries(self, course, sql_queries, mongo_queries):

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -13,17 +13,34 @@ from survey.models import SurveyForm, SurveyAnswer
 
 from common.test.utils import XssTestMixin
 from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from courseware.tests.helpers import LoginEnrollmentTestCase
 
 
 @attr('shard_1')
-class SurveyViewsTests(LoginEnrollmentTestCase, ModuleStoreTestCase, XssTestMixin):
+class SurveyViewsTests(LoginEnrollmentTestCase, SharedModuleStoreTestCase, XssTestMixin):
     """
     All tests for the views.py file
     """
 
     STUDENT_INFO = [('view@test.com', 'foo')]
+
+    @classmethod
+    def setUpClass(cls):
+        super(SurveyViewsTests, cls).setUpClass()
+        cls.test_survey_name = 'TestSurvey'
+        cls.course = CourseFactory.create(
+            display_name='<script>alert("XSS")</script>',
+            course_survey_required=True,
+            course_survey_name=cls.test_survey_name
+        )
+
+        cls.course_with_bogus_survey = CourseFactory.create(
+            course_survey_required=True,
+            course_survey_name="DoesNotExist"
+        )
+
+        cls.course_without_survey = CourseFactory.create()
 
     def setUp(self):
         """
@@ -31,28 +48,13 @@ class SurveyViewsTests(LoginEnrollmentTestCase, ModuleStoreTestCase, XssTestMixi
         """
         super(SurveyViewsTests, self).setUp()
 
-        self.test_survey_name = 'TestSurvey'
         self.test_form = '<input name="field1"></input>'
-
         self.survey = SurveyForm.create(self.test_survey_name, self.test_form)
 
         self.student_answers = OrderedDict({
             u'field1': u'value1',
             u'field2': u'value2',
         })
-
-        self.course = CourseFactory.create(
-            display_name='<script>alert("XSS")</script>',
-            course_survey_required=True,
-            course_survey_name=self.test_survey_name
-        )
-
-        self.course_with_bogus_survey = CourseFactory.create(
-            course_survey_required=True,
-            course_survey_name="DoesNotExist"
-        )
-
-        self.course_without_survey = CourseFactory.create()
 
         # Create student accounts and activate them.
         for i in range(len(self.STUDENT_INFO)):

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -13,7 +13,7 @@ from survey.models import SurveyForm, SurveyAnswer
 
 from common.test.utils import XssTestMixin
 from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from courseware.tests.helpers import LoginEnrollmentTestCase
 
 

--- a/lms/djangoapps/courseware/tests/test_credit_requirements.py
+++ b/lms/djangoapps/courseware/tests/test_credit_requirements.py
@@ -11,7 +11,7 @@ from pytz import UTC
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from util.date_utils import get_time_display, DEFAULT_SHORT_DATE_FORMAT
@@ -23,7 +23,7 @@ from openedx.core.djangoapps.credit.models import CreditCourse
 
 @patch.dict(settings.FEATURES, {"ENABLE_CREDIT_ELIGIBILITY": True})
 @ddt.ddt
-class ProgressPageCreditRequirementsTest(ModuleStoreTestCase):
+class ProgressPageCreditRequirementsTest(SharedModuleStoreTestCase):
     """
     Tests for credit requirement display on the progress page.
     """
@@ -35,11 +35,15 @@ class ProgressPageCreditRequirementsTest(ModuleStoreTestCase):
     MIN_GRADE_REQ_DISPLAY = "Final Grade Credit Requirement"
     VERIFICATION_REQ_DISPLAY = "Midterm Exam Credit Requirement"
 
+    @classmethod
+    def setUpClass(cls):
+        super(ProgressPageCreditRequirementsTest, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     def setUp(self):
         super(ProgressPageCreditRequirementsTest, self).setUp()
 
-        # Create a course and configure it as a credit course
-        self.course = CourseFactory.create()
+        # Configure course as a credit course
         CreditCourse.objects.create(course_key=self.course.id, enabled=True)
 
         # Configure credit requirements (passing grade and in-course reverification)

--- a/lms/djangoapps/courseware/tests/test_credit_requirements.py
+++ b/lms/djangoapps/courseware/tests/test_credit_requirements.py
@@ -11,7 +11,7 @@ from pytz import UTC
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from util.date_utils import get_time_display, DEFAULT_SHORT_DATE_FORMAT

--- a/lms/djangoapps/courseware/tests/test_field_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_field_overrides.py
@@ -9,7 +9,7 @@ from xblock.field_data import DictFieldData
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,
-)
+    SharedModuleStoreTestCase)
 
 from ..field_overrides import (
     disable_overrides,

--- a/lms/djangoapps/courseware/tests/test_field_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_field_overrides.py
@@ -7,9 +7,7 @@ from nose.plugins.attrib import attr
 from django.test.utils import override_settings
 from xblock.field_data import DictFieldData
 from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.modulestore.tests.django_utils import (
-    ModuleStoreTestCase,
-    SharedModuleStoreTestCase)
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from ..field_overrides import (
     disable_overrides,

--- a/lms/djangoapps/courseware/tests/test_grades.py
+++ b/lms/djangoapps/courseware/tests/test_grades.py
@@ -28,7 +28,7 @@ from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from student.tests.factories import UserFactory
 from student.models import CourseEnrollment
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 
 def _grade_with_errors(student, request, course, keep_raw_scores=False):

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -13,7 +13,7 @@ from django.core.urlresolvers import reverse
 from courseware.tests import BaseTestXmodule
 from courseware.views import get_course_lti_endpoints
 from lms.djangoapps.lms_xblock.runtime import quote_slashes
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.x_module import STUDENT_VIEW
 
@@ -125,7 +125,7 @@ class TestLTI(BaseTestXmodule):
 
 
 @attr('shard_1')
-class TestLTIModuleListing(ModuleStoreTestCase):
+class TestLTIModuleListing(SharedModuleStoreTestCase):
     """
     a test for the rest endpoint that lists LTI modules in a course
     """
@@ -133,41 +133,45 @@ class TestLTIModuleListing(ModuleStoreTestCase):
     COURSE_SLUG = "100"
     COURSE_NAME = "test_course"
 
-    def setUp(self):
-        """Create course, 2 chapters, 2 sections"""
-        super(TestLTIModuleListing, self).setUp()
-        self.course = CourseFactory.create(display_name=self.COURSE_NAME, number=self.COURSE_SLUG)
-        self.chapter1 = ItemFactory.create(
-            parent_location=self.course.location,
+    @classmethod
+    def setUpClass(cls):
+        super(TestLTIModuleListing, cls).setUpClass()
+        cls.course = CourseFactory.create(display_name=cls.COURSE_NAME, number=cls.COURSE_SLUG)
+        cls.chapter1 = ItemFactory.create(
+            parent_location=cls.course.location,
             display_name="chapter1",
             category='chapter')
-        self.section1 = ItemFactory.create(
-            parent_location=self.chapter1.location,
+        cls.section1 = ItemFactory.create(
+            parent_location=cls.chapter1.location,
             display_name="section1",
             category='sequential')
-        self.chapter2 = ItemFactory.create(
-            parent_location=self.course.location,
+        cls.chapter2 = ItemFactory.create(
+            parent_location=cls.course.location,
             display_name="chapter2",
             category='chapter')
-        self.section2 = ItemFactory.create(
-            parent_location=self.chapter2.location,
+        cls.section2 = ItemFactory.create(
+            parent_location=cls.chapter2.location,
             display_name="section2",
             category='sequential')
 
         # creates one draft and one published lti module, in different sections
-        self.lti_published = ItemFactory.create(
-            parent_location=self.section1.location,
+        cls.lti_published = ItemFactory.create(
+            parent_location=cls.section1.location,
             display_name="lti published",
             category="lti",
-            location=self.course.id.make_usage_key('lti', 'lti_published'),
+            location=cls.course.id.make_usage_key('lti', 'lti_published'),
         )
-        self.lti_draft = ItemFactory.create(
-            parent_location=self.section2.location,
+        cls.lti_draft = ItemFactory.create(
+            parent_location=cls.section2.location,
             display_name="lti draft",
             category="lti",
-            location=self.course.id.make_usage_key('lti', 'lti_draft'),
+            location=cls.course.id.make_usage_key('lti', 'lti_draft'),
             publish_item=False,
         )
+
+    def setUp(self):
+        """Create course, 2 chapters, 2 sections"""
+        super(TestLTIModuleListing, self).setUp()
 
     def expected_handler_url(self, handler):
         """convenience method to get the reversed handler urls"""

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -13,7 +13,7 @@ from django.core.urlresolvers import reverse
 from courseware.tests import BaseTestXmodule
 from courseware.views import get_course_lti_endpoints
 from lms.djangoapps.lms_xblock.runtime import quote_slashes
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.x_module import STUDENT_VIEW
 

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -11,51 +11,42 @@ from course_modes.models import CourseMode
 from xmodule.course_module import (
     CATALOG_VISIBILITY_CATALOG_AND_ABOUT, CATALOG_VISIBILITY_NONE)
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 
 
 @attr('shard_1')
-class TestMicrosites(ModuleStoreTestCase, LoginEnrollmentTestCase):
+class TestMicrosites(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     This is testing of the Microsite feature
     """
 
     STUDENT_INFO = [('view@test.com', 'foo'), ('view2@test.com', 'foo')]
 
-    def setUp(self):
-        super(TestMicrosites, self).setUp()
-
-        # use a different hostname to test Microsites since they are
-        # triggered on subdomain mappings
-        #
-        # NOTE: The Microsite Configuration is in lms/envs/test.py. The content for the Test Microsite is in
-        # test_microsites/test_microsite.
-        #
-        # IMPORTANT: For these tests to work, this domain must be defined via
-        # DNS configuration (either local or published)
-
-        self.course = CourseFactory.create(
+    @classmethod
+    def setUpClass(cls):
+        super(TestMicrosites, cls).setUpClass()
+        cls.course = CourseFactory.create(
             display_name='Robot_Super_Course',
             org='TestMicrositeX',
             emit_signals=True,
         )
-        self.chapter0 = ItemFactory.create(parent_location=self.course.location,
+        cls.chapter0 = ItemFactory.create(parent_location=cls.course.location,
                                            display_name='Overview')
-        self.chapter9 = ItemFactory.create(parent_location=self.course.location,
+        cls.chapter9 = ItemFactory.create(parent_location=cls.course.location,
                                            display_name='factory_chapter')
-        self.section0 = ItemFactory.create(parent_location=self.chapter0.location,
+        cls.section0 = ItemFactory.create(parent_location=cls.chapter0.location,
                                            display_name='Welcome')
-        self.section9 = ItemFactory.create(parent_location=self.chapter9.location,
+        cls.section9 = ItemFactory.create(parent_location=cls.chapter9.location,
                                            display_name='factory_section')
 
-        self.course_outside_microsite = CourseFactory.create(
+        cls.course_outside_microsite = CourseFactory.create(
             display_name='Robot_Course_Outside_Microsite',
             org='FooX',
             emit_signals=True,
         )
 
         # have a course which explicitly sets visibility in catalog to False
-        self.course_hidden_visibility = CourseFactory.create(
+        cls.course_hidden_visibility = CourseFactory.create(
             display_name='Hidden_course',
             org='TestMicrositeX',
             catalog_visibility=CATALOG_VISIBILITY_NONE,
@@ -63,13 +54,16 @@ class TestMicrosites(ModuleStoreTestCase, LoginEnrollmentTestCase):
         )
 
         # have a course which explicitly sets visibility in catalog and about to true
-        self.course_with_visibility = CourseFactory.create(
+        cls.course_with_visibility = CourseFactory.create(
             display_name='visible_course',
             org='TestMicrositeX',
             course="foo",
             catalog_visibility=CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
             emit_signals=True,
         )
+
+    def setUp(self):
+        super(TestMicrosites, self).setUp()
 
     def setup_users(self):
         # Create student accounts and activate them.

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -11,7 +11,7 @@ from course_modes.models import CourseMode
 from xmodule.course_module import (
     CATALOG_VISIBILITY_CATALOG_AND_ABOUT, CATALOG_VISIBILITY_NONE)
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 
 @attr('shard_1')

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -30,14 +30,10 @@ class TestMicrosites(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             org='TestMicrositeX',
             emit_signals=True,
         )
-        cls.chapter0 = ItemFactory.create(parent_location=cls.course.location,
-                                           display_name='Overview')
-        cls.chapter9 = ItemFactory.create(parent_location=cls.course.location,
-                                           display_name='factory_chapter')
-        cls.section0 = ItemFactory.create(parent_location=cls.chapter0.location,
-                                           display_name='Welcome')
-        cls.section9 = ItemFactory.create(parent_location=cls.chapter9.location,
-                                           display_name='factory_section')
+        cls.chapter0 = ItemFactory.create(parent_location=cls.course.location, display_name='Overview')
+        cls.chapter9 = ItemFactory.create(parent_location=cls.course.location, display_name='factory_chapter')
+        cls.section0 = ItemFactory.create(parent_location=cls.chapter0.location, display_name='Welcome')
+        cls.section9 = ItemFactory.create(parent_location=cls.chapter9.location, display_name='factory_section')
 
         cls.course_outside_microsite = CourseFactory.create(
             display_name='Robot_Course_Outside_Microsite',

--- a/lms/djangoapps/courseware/tests/test_middleware.py
+++ b/lms/djangoapps/courseware/tests/test_middleware.py
@@ -10,18 +10,21 @@ from nose.plugins.attrib import attr
 
 import courseware.courses as courses
 from courseware.middleware import RedirectUnenrolledMiddleware
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @attr('shard_1')
-class CoursewareMiddlewareTestCase(ModuleStoreTestCase):
+class CoursewareMiddlewareTestCase(SharedModuleStoreTestCase):
     """Tests that courseware middleware is correctly redirected"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(CoursewareMiddlewareTestCase, cls).setUpClass()
+        cls.course = CourseFactory.create()
 
     def setUp(self):
         super(CoursewareMiddlewareTestCase, self).setUp()
-
-        self.course = CourseFactory.create()
 
     def check_user_not_enrolled_redirect(self):
         """A UserNotEnrolled exception should trigger a redirect"""

--- a/lms/djangoapps/courseware/tests/test_middleware.py
+++ b/lms/djangoapps/courseware/tests/test_middleware.py
@@ -10,7 +10,7 @@ from nose.plugins.attrib import attr
 
 import courseware.courses as courses
 from courseware.middleware import RedirectUnenrolledMiddleware
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -45,7 +45,7 @@ from student.models import anonymous_id_for_user
 from xmodule.modulestore.tests.django_utils import (
     TEST_DATA_MIXED_TOY_MODULESTORE,
     TEST_DATA_XML_MODULESTORE,
-)
+    SharedModuleStoreTestCase)
 from xmodule.lti_module import LTIDescriptor
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -121,10 +121,17 @@ class GradedStatelessXBlock(XBlock):
 
 @attr('shard_1')
 @ddt.ddt
-class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
+class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Tests of courseware.module_render
     """
+
+    @classmethod
+    def setUpClass(cls):
+        super(ModuleRenderTestCase, cls).setUpClass()
+        cls.course_key = ToyCourseFactory.create().id
+        cls.toy_course = modulestore().get_course(cls.course_key)
+
     # TODO: this test relies on the specific setup of the toy course.
     # It should be rewritten to build the course it needs and then test that.
     def setUp(self):
@@ -133,8 +140,6 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
         """
         super(ModuleRenderTestCase, self).setUp()
 
-        self.course_key = ToyCourseFactory.create().id
-        self.toy_course = modulestore().get_course(self.course_key)
         self.mock_user = UserFactory()
         self.mock_user.id = 1
         self.request_factory = RequestFactory()
@@ -401,17 +406,20 @@ class ModuleRenderTestCase(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
 
 @attr('shard_1')
-class TestHandleXBlockCallback(ModuleStoreTestCase, LoginEnrollmentTestCase):
+class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test the handle_xblock_callback function
     """
+    @classmethod
+    def setUpClass(cls):
+        super(TestHandleXBlockCallback, cls).setUpClass()
+        cls.course_key = ToyCourseFactory.create().id
+        cls.toy_course = modulestore().get_course(cls.course_key)
 
     def setUp(self):
         super(TestHandleXBlockCallback, self).setUp()
 
-        self.course_key = ToyCourseFactory.create().id
         self.location = self.course_key.make_usage_key('chapter', 'Overview')
-        self.toy_course = modulestore().get_course(self.course_key)
         self.mock_user = UserFactory.create()
         self.request_factory = RequestFactory()
 
@@ -709,19 +717,24 @@ class TestTOC(ModuleStoreTestCase):
 @attr('shard_1')
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
-class TestProctoringRendering(ModuleStoreTestCase):
+class TestProctoringRendering(SharedModuleStoreTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestProctoringRendering, cls).setUpClass()
+        cls.course_key = ToyCourseFactory.create().id
+
     """Check the Table of Contents for a course"""
     def setUp(self):
         """
         Set up the initial mongo datastores
         """
         super(TestProctoringRendering, self).setUp()
-        self.course_key = ToyCourseFactory.create().id
         self.chapter = 'Overview'
         chapter_url = '%s/%s/%s' % ('/courses', self.course_key, self.chapter)
         factory = RequestFactory()
         self.request = factory.get(chapter_url)
-        self.request.user = UserFactory()
+        self.request.user = UserFactory.create()
+        self.user = UserFactory.create()
         self.modulestore = self.store._get_modulestore_for_courselike(self.course_key)  # pylint: disable=protected-access
         with self.modulestore.bulk_operations(self.course_key):
             self.toy_course = self.store.get_course(self.course_key, depth=2)
@@ -1028,7 +1041,15 @@ class TestProctoringRendering(ModuleStoreTestCase):
 
 
 @attr('shard_1')
-class TestGatedSubsectionRendering(ModuleStoreTestCase, MilestonesTestCaseMixin):
+class TestGatedSubsectionRendering(SharedModuleStoreTestCase, MilestonesTestCaseMixin):
+    @classmethod
+    def setUpClass(cls):
+        super(TestGatedSubsectionRendering, cls).setUpClass()
+        cls.course = CourseFactory.create()
+        cls.course.enable_subsection_gating = True
+        cls.course.save()
+        cls.store.update_item(cls.course, 0)
+
     """
     Test the toc for a course is rendered correctly when there is gated content
     """
@@ -1038,10 +1059,6 @@ class TestGatedSubsectionRendering(ModuleStoreTestCase, MilestonesTestCaseMixin)
         """
         super(TestGatedSubsectionRendering, self).setUp()
 
-        self.course = CourseFactory.create()
-        self.course.enable_subsection_gating = True
-        self.course.save()
-        self.store.update_item(self.course, 0)
         self.chapter = ItemFactory.create(
             parent=self.course,
             category="chapter",
@@ -1113,11 +1130,10 @@ class TestHtmlModifiers(ModuleStoreTestCase):
     """
     def setUp(self):
         super(TestHtmlModifiers, self).setUp()
-        self.user = UserFactory.create()
+        self.course = CourseFactory.create()
         self.request = RequestFactory().get('/')
         self.request.user = self.user
         self.request.session = {}
-        self.course = CourseFactory.create()
         self.content_string = '<p>This is the content<p>'
         self.rewrite_link = '<a href="/static/foo/content">Test rewrite</a>'
         self.rewrite_bad_link = '<img src="/static//file.jpg" />'
@@ -1447,8 +1463,13 @@ class DetachedXBlock(XBlock):
 @attr('shard_1')
 @patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': True, 'DISPLAY_HISTOGRAMS_TO_STAFF': True})
 @patch('courseware.module_render.has_access', Mock(return_value=True, autospec=True))
-class TestStaffDebugInfo(ModuleStoreTestCase):
+class TestStaffDebugInfo(SharedModuleStoreTestCase):
     """Tests to verify that Staff Debug Info panel and histograms are displayed to staff."""
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestStaffDebugInfo, cls).setUpClass()
+        cls.course = CourseFactory.create()
 
     def setUp(self):
         super(TestStaffDebugInfo, self).setUp()
@@ -1456,7 +1477,6 @@ class TestStaffDebugInfo(ModuleStoreTestCase):
         self.request = RequestFactory().get('/')
         self.request.user = self.user
         self.request.session = {}
-        self.course = CourseFactory.create()
 
         problem_xml = OptionResponseXMLFactory().build_xml(
             question_text='The correct answer is Correct',
@@ -1589,16 +1609,20 @@ PER_STUDENT_ANONYMIZED_DESCRIPTORS = set(
 
 @attr('shard_1')
 @ddt.ddt
-class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
+class TestAnonymousStudentId(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test that anonymous_student_id is set correctly across a variety of XBlock types
     """
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestAnonymousStudentId, cls).setUpClass()
+        cls.course_key = ToyCourseFactory.create().id
+        cls.course = modulestore().get_course(cls.course_key)
+
     def setUp(self):
-        super(TestAnonymousStudentId, self).setUp(create_user=False)
+        super(TestAnonymousStudentId, self).setUp()
         self.user = UserFactory()
-        self.course_key = ToyCourseFactory.create().id
-        self.course = modulestore().get_course(self.course_key)
 
     @patch('courseware.module_render.has_access', Mock(return_value=True, autospec=True))
     def _get_anonymous_id(self, course_id, xblock_class):
@@ -1668,10 +1692,15 @@ class TestAnonymousStudentId(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
 @attr('shard_1')
 @patch('track.views.tracker', autospec=True)
-class TestModuleTrackingContext(ModuleStoreTestCase):
+class TestModuleTrackingContext(SharedModuleStoreTestCase):
     """
     Ensure correct tracking information is included in events emitted during XBlock callback handling.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestModuleTrackingContext, cls).setUpClass()
+        cls.course = CourseFactory.create()
 
     def setUp(self):
         super(TestModuleTrackingContext, self).setUp()
@@ -1926,10 +1955,16 @@ class TestEventPublishing(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
 @attr('shard_1')
 @ddt.ddt
-class LMSXBlockServiceBindingTest(ModuleStoreTestCase):
+class LMSXBlockServiceBindingTest(SharedModuleStoreTestCase):
     """
     Tests that the LMS Module System (XBlock Runtime) provides an expected set of services.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        super(LMSXBlockServiceBindingTest, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     def setUp(self):
         """
         Set up the user and other fields that will be used to instantiate the runtime.
@@ -1937,7 +1972,6 @@ class LMSXBlockServiceBindingTest(ModuleStoreTestCase):
         super(LMSXBlockServiceBindingTest, self).setUp()
         self.user = UserFactory()
         self.student_data = Mock()
-        self.course = CourseFactory.create()
         self.track_function = Mock()
         self.xqueue_callback_url_prefix = Mock()
         self.request_token = Mock()
@@ -2012,16 +2046,21 @@ USER_NUMBERS = range(2)
 
 @attr('shard_1')
 @ddt.ddt
-class TestFilteredChildren(ModuleStoreTestCase):
+class TestFilteredChildren(SharedModuleStoreTestCase):
     """
     Tests that verify access to XBlock/XModule children work correctly
     even when those children are filtered by the runtime when loaded.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestFilteredChildren, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     # pylint: disable=attribute-defined-outside-init, no-member
     def setUp(self):
         super(TestFilteredChildren, self).setUp()
         self.users = {number: UserFactory() for number in USER_NUMBERS}
-        self.course = CourseFactory()
 
         self._old_has_access = render.has_access
         patcher = patch('courseware.module_render.has_access', self._has_access)

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -11,55 +11,59 @@ from django.test.utils import override_settings
 
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from courseware.tests.factories import GlobalStaffFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.django import modulestore
 
 
 @attr('shard_1')
-class TestNavigation(ModuleStoreTestCase, LoginEnrollmentTestCase):
+class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that navigation state is saved properly.
     """
 
     STUDENT_INFO = [('view@test.com', 'foo'), ('view2@test.com', 'foo')]
 
-    def setUp(self):
-        super(TestNavigation, self).setUp()
-        self.test_course = CourseFactory.create()
-        self.course = CourseFactory.create()
-        self.chapter0 = ItemFactory.create(parent=self.course,
+    @classmethod
+    def setUpClass(cls):
+        super(TestNavigation, cls).setUpClass()
+        cls.test_course = CourseFactory.create()
+        cls.course = CourseFactory.create()
+        cls.chapter0 = ItemFactory.create(parent=cls.course,
                                            display_name='Overview')
-        self.chapter9 = ItemFactory.create(parent=self.course,
+        cls.chapter9 = ItemFactory.create(parent=cls.course,
                                            display_name='factory_chapter')
-        self.section0 = ItemFactory.create(parent=self.chapter0,
+        cls.section0 = ItemFactory.create(parent=cls.chapter0,
                                            display_name='Welcome')
-        self.section9 = ItemFactory.create(parent=self.chapter9,
+        cls.section9 = ItemFactory.create(parent=cls.chapter9,
                                            display_name='factory_section')
-        self.unit0 = ItemFactory.create(parent=self.section0,
+        cls.unit0 = ItemFactory.create(parent=cls.section0,
                                         display_name='New Unit')
 
-        self.chapterchrome = ItemFactory.create(parent=self.course,
+        cls.chapterchrome = ItemFactory.create(parent=cls.course,
                                                 display_name='Chrome')
-        self.chromelesssection = ItemFactory.create(parent=self.chapterchrome,
+        cls.chromelesssection = ItemFactory.create(parent=cls.chapterchrome,
                                                     display_name='chromeless',
                                                     chrome='none')
-        self.accordionsection = ItemFactory.create(parent=self.chapterchrome,
+        cls.accordionsection = ItemFactory.create(parent=cls.chapterchrome,
                                                    display_name='accordion',
                                                    chrome='accordion')
-        self.tabssection = ItemFactory.create(parent=self.chapterchrome,
+        cls.tabssection = ItemFactory.create(parent=cls.chapterchrome,
                                               display_name='tabs',
                                               chrome='tabs')
-        self.defaultchromesection = ItemFactory.create(
-            parent=self.chapterchrome,
+        cls.defaultchromesection = ItemFactory.create(
+            parent=cls.chapterchrome,
             display_name='defaultchrome',
         )
-        self.fullchromesection = ItemFactory.create(parent=self.chapterchrome,
+        cls.fullchromesection = ItemFactory.create(parent=cls.chapterchrome,
                                                     display_name='fullchrome',
                                                     chrome='accordion,tabs')
-        self.tabtest = ItemFactory.create(parent=self.chapterchrome,
+        cls.tabtest = ItemFactory.create(parent=cls.chapterchrome,
                                           display_name='progress_tab',
                                           default_tab='progress')
+
+    def setUp(self):
+        super(TestNavigation, self).setUp()
 
         # Create student accounts and activate them.
         for i in range(len(self.STUDENT_INFO)):

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -11,7 +11,7 @@ from django.test.utils import override_settings
 
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from courseware.tests.factories import GlobalStaffFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.django import modulestore
 

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -17,53 +17,50 @@ from xmodule.modulestore.django import modulestore
 
 
 @attr('shard_1')
-class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
+class TestNavigation(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that navigation state is saved properly.
     """
 
     STUDENT_INFO = [('view@test.com', 'foo'), ('view2@test.com', 'foo')]
 
-    @classmethod
-    def setUpClass(cls):
-        super(TestNavigation, cls).setUpClass()
-        cls.test_course = CourseFactory.create()
-        cls.course = CourseFactory.create()
-        cls.chapter0 = ItemFactory.create(parent=cls.course,
-                                           display_name='Overview')
-        cls.chapter9 = ItemFactory.create(parent=cls.course,
-                                           display_name='factory_chapter')
-        cls.section0 = ItemFactory.create(parent=cls.chapter0,
-                                           display_name='Welcome')
-        cls.section9 = ItemFactory.create(parent=cls.chapter9,
-                                           display_name='factory_section')
-        cls.unit0 = ItemFactory.create(parent=cls.section0,
-                                        display_name='New Unit')
-
-        cls.chapterchrome = ItemFactory.create(parent=cls.course,
-                                                display_name='Chrome')
-        cls.chromelesssection = ItemFactory.create(parent=cls.chapterchrome,
-                                                    display_name='chromeless',
-                                                    chrome='none')
-        cls.accordionsection = ItemFactory.create(parent=cls.chapterchrome,
-                                                   display_name='accordion',
-                                                   chrome='accordion')
-        cls.tabssection = ItemFactory.create(parent=cls.chapterchrome,
-                                              display_name='tabs',
-                                              chrome='tabs')
-        cls.defaultchromesection = ItemFactory.create(
-            parent=cls.chapterchrome,
-            display_name='defaultchrome',
-        )
-        cls.fullchromesection = ItemFactory.create(parent=cls.chapterchrome,
-                                                    display_name='fullchrome',
-                                                    chrome='accordion,tabs')
-        cls.tabtest = ItemFactory.create(parent=cls.chapterchrome,
-                                          display_name='progress_tab',
-                                          default_tab='progress')
-
     def setUp(self):
         super(TestNavigation, self).setUp()
+
+        self.test_course = CourseFactory.create()
+        self.course = CourseFactory.create()
+        self.chapter0 = ItemFactory.create(parent=self.course,
+                                           display_name='Overview')
+        self.chapter9 = ItemFactory.create(parent=self.course,
+                                           display_name='factory_chapter')
+        self.section0 = ItemFactory.create(parent=self.chapter0,
+                                           display_name='Welcome')
+        self.section9 = ItemFactory.create(parent=self.chapter9,
+                                           display_name='factory_section')
+        self.unit0 = ItemFactory.create(parent=self.section0,
+                                        display_name='New Unit')
+
+        self.chapterchrome = ItemFactory.create(parent=self.course,
+                                                display_name='Chrome')
+        self.chromelesssection = ItemFactory.create(parent=self.chapterchrome,
+                                                    display_name='chromeless',
+                                                    chrome='none')
+        self.accordionsection = ItemFactory.create(parent=self.chapterchrome,
+                                                   display_name='accordion',
+                                                   chrome='accordion')
+        self.tabssection = ItemFactory.create(parent=self.chapterchrome,
+                                              display_name='tabs',
+                                              chrome='tabs')
+        self.defaultchromesection = ItemFactory.create(
+            parent=self.chapterchrome,
+            display_name='defaultchrome',
+        )
+        self.fullchromesection = ItemFactory.create(parent=self.chapterchrome,
+                                                    display_name='fullchrome',
+                                                    chrome='accordion,tabs')
+        self.tabtest = ItemFactory.create(parent=self.chapterchrome,
+                                          display_name='progress_tab',
+                                          default_tab='progress')
 
         # Create student accounts and activate them.
         for i in range(len(self.STUDENT_INFO)):

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -9,13 +9,13 @@ from courseware.module_render import get_module_for_descriptor
 from courseware.model_data import FieldDataCache
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from xmodule.modulestore.tests.factories import ItemFactory, CourseFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.partitions.partitions import Group, UserPartition
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
 
 
 @attr('shard_1')
-class SplitTestBase(ModuleStoreTestCase):
+class SplitTestBase(SharedModuleStoreTestCase):
     """
     Sets up a basic course and user for split test testing.
     Also provides tests of rendered HTML for two user_tag conditions, 0 and 1.
@@ -27,9 +27,10 @@ class SplitTestBase(ModuleStoreTestCase):
     HIDDEN_CONTENT = None
     VISIBLE_CONTENT = None
 
-    def setUp(self):
-        super(SplitTestBase, self).setUp()
-        self.partition = UserPartition(
+    @classmethod
+    def setUpClass(cls):
+        super(SplitTestBase, cls).setUpClass()
+        cls.partition = UserPartition(
             0,
             'first_partition',
             'First Partition',
@@ -39,21 +40,24 @@ class SplitTestBase(ModuleStoreTestCase):
             ]
         )
 
-        self.course = CourseFactory.create(
-            number=self.COURSE_NUMBER,
-            user_partitions=[self.partition]
+        cls.course = CourseFactory.create(
+            number=cls.COURSE_NUMBER,
+            user_partitions=[cls.partition]
         )
 
-        self.chapter = ItemFactory.create(
-            parent_location=self.course.location,
+        cls.chapter = ItemFactory.create(
+            parent_location=cls.course.location,
             category="chapter",
             display_name="test chapter",
         )
-        self.sequential = ItemFactory.create(
-            parent_location=self.chapter.location,
+        cls.sequential = ItemFactory.create(
+            parent_location=cls.chapter.location,
             category="sequential",
             display_name="Split Test Tests",
         )
+
+    def setUp(self):
+        super(SplitTestBase, self).setUp()
 
         self.student = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
@@ -269,14 +273,14 @@ class TestSplitTestVert(SplitTestBase):
 
 
 @attr('shard_1')
-class SplitTestPosition(ModuleStoreTestCase):
+class SplitTestPosition(SharedModuleStoreTestCase):
     """
     Check that we can change positions in a course with partitions defined
     """
-    def setUp(self):
-        super(SplitTestPosition, self).setUp()
-
-        self.partition = UserPartition(
+    @classmethod
+    def setUpClass(cls):
+        super(SplitTestPosition, cls).setUpClass()
+        cls.partition = UserPartition(
             0,
             'first_partition',
             'First Partition',
@@ -286,15 +290,18 @@ class SplitTestPosition(ModuleStoreTestCase):
             ]
         )
 
-        self.course = CourseFactory.create(
-            user_partitions=[self.partition]
+        cls.course = CourseFactory.create(
+            user_partitions=[cls.partition]
         )
 
-        self.chapter = ItemFactory.create(
-            parent_location=self.course.location,
+        cls.chapter = ItemFactory.create(
+            parent_location=cls.course.location,
             category="chapter",
             display_name="test chapter",
         )
+
+    def setUp(self):
+        super(SplitTestPosition, self).setUp()
 
         self.student = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -9,7 +9,7 @@ from courseware.module_render import get_module_for_descriptor
 from courseware.model_data import FieldDataCache
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from xmodule.modulestore.tests.factories import ItemFactory, CourseFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.partitions.partitions import Group, UserPartition
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
 

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -24,7 +24,7 @@ from courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.lms_xblock.runtime import quote_slashes
 from student.tests.factories import UserFactory
 from student.models import anonymous_id_for_user
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.partitions.partitions import Group, UserPartition
 from openedx.core.djangoapps.credit.api import (
@@ -126,13 +126,10 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
     COURSE_NAME = "test_course"
 
     def setUp(self):
-
-        super(TestSubmittingProblems, self).setUp(create_user=False)
-        # Create course
-        self.course = CourseFactory.create(display_name=self.COURSE_NAME, number=self.COURSE_SLUG)
-        assert self.course, "Couldn't load course %r" % self.COURSE_NAME
+        super(TestSubmittingProblems, self).setUp()
 
         # create a test student
+        self.course = CourseFactory.create(display_name=self.COURSE_NAME, number=self.COURSE_SLUG)
         self.student = 'view@test.com'
         self.password = 'foo'
         self.create_account('u1', self.student, self.password)

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -24,7 +24,7 @@ from courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.lms_xblock.runtime import quote_slashes
 from student.tests.factories import UserFactory
 from student.models import anonymous_id_for_user
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.partitions.partitions import Group, UserPartition
 from openedx.core.djangoapps.credit.api import (

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -393,7 +393,7 @@ class TestMasqueradedGroup(StaffMasqueradeTestCase):
         group.
         """
         self.course.cohort_config = {'cohorted': True}
-        modulestore().update_item(self.course, self.test_user.id) # pylint: disable=no-member
+        modulestore().update_item(self.course, self.test_user.id)  # pylint: disable=no-member
         cohort = CohortFactory.create(course_id=self.course.id, users=[self.test_user])
         CourseUserGroupPartitionGroup(
             course_user_group=cohort,

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -393,7 +393,7 @@ class TestMasqueradedGroup(StaffMasqueradeTestCase):
         group.
         """
         self.course.cohort_config = {'cohorted': True}
-        modulestore().update_item(self.course, self.test_user.id)
+        modulestore().update_item(self.course, self.test_user.id) # pylint: disable=no-member
         cohort = CohortFactory.create(course_id=self.course.id, users=[self.test_user])
         CourseUserGroupPartitionGroup(
             course_user_group=cohort,

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -393,7 +393,7 @@ class TestMasqueradedGroup(StaffMasqueradeTestCase):
         group.
         """
         self.course.cohort_config = {'cohorted': True}
-        self.update_course(self.course, self.test_user.id)
+        modulestore().update_item(self.course, self.test_user.id)
         cohort = CohortFactory.create(course_id=self.course.id, users=[self.test_user])
         CourseUserGroupPartitionGroup(
             course_user_group=cohort,


### PR DESCRIPTION
This is switching from ModuleStoreTestCase, to SharedModuleStoreTestCase, where possible.  This is only for the 'courseware' Django application.  This helps speed up some tests where there's a lot of write-once-read-many for modulestore-based data.
