### PR TITLE
mathjax can appear in any part of a problem

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -447,6 +447,13 @@ div.problem {
       }
     }
 
+    .MathJax .math {
+      & span {
+        // Needed to fix mathjax rendering bug in chrome (TNL-4080)
+        border-left-style: none !important;
+      }
+    }
+
     div.equation {
       clear: both;
       margin-top: 3px;
@@ -470,11 +477,6 @@ div.problem {
           border: 1px solid #e3e3e3;
           border-radius: 4px;
           background: #f1f1f1;
-
-          & span {
-            // Needed to fix mathjax rendering bug in chrome (TNL-4080)
-            border-left-style: none !important;
-          }
         }
       }
     }


### PR DESCRIPTION
@andy-armstrong 
@clrux 
@cahrens 

Here's a sandbox where you can see this PR: https://tnl-4080.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/4

I just realized a couple things:
1) #11459 only addresses the visual bug with math-rendered inputs, so mathjax elsewhere in the courseware wouldn't be fixed by it. For example:
![screenshot 2016-02-08 14 08 31](https://cloud.githubusercontent.com/assets/2748698/12896053/d23b6046-ce6d-11e5-9d93-34f29ba89dd0.png)

2) This PR will make mathjax appearing anywhere in capa problems render correctly, but nowhere else (including html blocks)

My question is: how comfortable are we adding this change to a main.scss or something to address this issue globally? Should this be isolated to its own hotfix?
