### PR TITLE
Switch to SharedModuleStoreTestCase in the 'student' app where possible.

### DIFF
--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -3,19 +3,23 @@ Tests student admin.py
 """
 from django.core.urlresolvers import reverse
 
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from student.tests.factories import UserFactory
 
 
-class AdminCourseRolesPageTest(ModuleStoreTestCase):
+class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
     """Test the django admin course roles form saving data in db.
     """
+    @classmethod
+    def setUpClass(cls):
+        super(AdminCourseRolesPageTest, cls).setUpClass()
+        cls.course = CourseFactory.create(org='edx')
+
     def setUp(self):
         super(AdminCourseRolesPageTest, self).setUp()
         self.user = UserFactory.create(is_staff=True, is_superuser=True)
         self.user.save()
-        self.course = CourseFactory.create(org='edx')
 
     def test_save_valid_data(self):
 

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -12,7 +12,7 @@ from mock import patch
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_TOY_MODULESTORE
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -22,15 +22,17 @@ from bulk_email.models import CourseAuthorization  # pylint: disable=import-erro
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-class TestStudentDashboardEmailView(ModuleStoreTestCase):
+class TestStudentDashboardEmailView(SharedModuleStoreTestCase):
     """
     Check for email view displayed with flag
     """
+    @classmethod
+    def setUpClass(cls):
+        super(TestStudentDashboardEmailView, cls).setUpClass()
+        cls.course = CourseFactory.create()
 
     def setUp(self):
         super(TestStudentDashboardEmailView, self).setUp()
-
-        self.course = CourseFactory.create()
 
         # Create student account
         student = UserFactory.create()
@@ -84,7 +86,7 @@ class TestStudentDashboardEmailView(ModuleStoreTestCase):
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-class TestStudentDashboardEmailViewXMLBacked(ModuleStoreTestCase):
+class TestStudentDashboardEmailViewXMLBacked(SharedModuleStoreTestCase):
     """
     Check for email view on student dashboard, with XML backed course.
     """

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -36,7 +36,6 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
     def setUp(self):
         """ Create a course and user, then log in. """
         super(EnrollmentTest, self).setUp('embargo')
-        self.course = CourseFactory.create()
         self.user = UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
         self.client.login(username=self.USERNAME, password=self.PASSWORD)
 

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -8,7 +8,7 @@ from mock import patch
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from course_modes.models import CourseMode
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from util.testing import UrlResetMixin
 from embargo.test_utils import restrict_course
@@ -18,7 +18,7 @@ from student.models import CourseEnrollment
 
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-class EnrollmentTest(UrlResetMixin, ModuleStoreTestCase):
+class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
     """
     Test student enrollment, especially with different course modes.
     """
@@ -26,6 +26,11 @@ class EnrollmentTest(UrlResetMixin, ModuleStoreTestCase):
     USERNAME = "Bob"
     EMAIL = "bob@example.com"
     PASSWORD = "edx"
+
+    @classmethod
+    def setUpClass(cls):
+        super(EnrollmentTest, cls).setUpClass()
+        cls.course = CourseFactory.create()
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):

--- a/common/djangoapps/student/tests/test_login_registration_forms.py
+++ b/common/djangoapps/student/tests/test_login_registration_forms.py
@@ -10,8 +10,7 @@ from django.core.urlresolvers import reverse
 from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.factories import CourseFactory
 from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 # This relies on third party auth being enabled in the test
 # settings with the feature flag `ENABLE_THIRD_PARTY_AUTH`
@@ -38,14 +37,19 @@ def _finish_auth_url(params):
 
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-class LoginFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleStoreTestCase):
+class LoginFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStoreTestCase):
     """Test rendering of the login form. """
+
+    @classmethod
+    def setUpClass(cls):
+        super(LoginFormTest, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     @patch.dict(settings.FEATURES, {"ENABLE_COMBINED_LOGIN_REGISTRATION": False})
     def setUp(self):
         super(LoginFormTest, self).setUp('lms.urls')
 
         self.url = reverse("signin_user")
-        self.course = CourseFactory.create()
         self.course_id = unicode(self.course.id)
         self.courseware_url = reverse("courseware", args=[self.course_id])
         self.configure_google_provider(enabled=True)
@@ -148,14 +152,19 @@ class LoginFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleStoreTestCase)
 
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-class RegisterFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleStoreTestCase):
+class RegisterFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStoreTestCase):
     """Test rendering of the registration form. """
+
+    @classmethod
+    def setUpClass(cls):
+        super(RegisterFormTest, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     @patch.dict(settings.FEATURES, {"ENABLE_COMBINED_LOGIN_REGISTRATION": False})
     def setUp(self):
         super(RegisterFormTest, self).setUp('lms.urls')
 
         self.url = reverse("register_user")
-        self.course = CourseFactory.create()
         self.course_id = unicode(self.course.id)
         self.configure_google_provider(enabled=True)
         self.configure_facebook_provider(enabled=True)

--- a/common/djangoapps/student/tests/test_refunds.py
+++ b/common/djangoapps/student/tests/test_refunds.py
@@ -41,10 +41,14 @@ class RefundableTest(SharedModuleStoreTestCase):
     Tests for dashboard utility functions
     """
 
+    @classmethod
+    def setUpClass(cls):
+        super(RefundableTest, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     def setUp(self):
         """ Setup components used by each refund test."""
         super(RefundableTest, self).setUp()
-        self.course = CourseFactory.create()
         self.user = UserFactory.create(username="jack", email="jack@fake.edx.org", password='test')
         self.verified_mode = CourseModeFactory.create(
             course_id=self.course.id,

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -12,13 +12,13 @@ from django.conf import settings
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from student.models import CourseEnrollment
 from student.helpers import DISABLE_UNENROLL_CERT_STATES
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-class TestStudentDashboardUnenrollments(ModuleStoreTestCase):
+class TestStudentDashboardUnenrollments(SharedModuleStoreTestCase):
     """
     Test to ensure that the student dashboard does not show the unenroll button for users with certificates.
     """
@@ -27,10 +27,14 @@ class TestStudentDashboardUnenrollments(ModuleStoreTestCase):
     PASSWORD = "edx"
     UNENROLL_ELEMENT_ID = "#actions-item-unenroll-0"
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestStudentDashboardUnenrollments, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
     def setUp(self):
         """ Create a course and user, then log in. """
         super(TestStudentDashboardUnenrollments, self).setUp()
-        self.course = CourseFactory.create()
         self.user = UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
         CourseEnrollmentFactory(course_id=self.course.id, user=self.user)
         self.cert_status = None


### PR DESCRIPTION
This is switching from ModuleStoreTestCase, to SharedModuleStoreTestCase, where possible. This is only for the 'student' Django application. This helps speed up some tests where there's a lot of write-once-read-many for modulestore-based data.
