### PR TITLE
Remove deprecation warnings from Django models.

### DIFF
--- a/common/djangoapps/course_modes/migrations/0006_auto_20160208_1407.py
+++ b/common/djangoapps/course_modes/migrations/0006_auto_20160208_1407.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_modes', '0005_auto_20151217_0958'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='coursemodeexpirationconfig',
+            options={},
+        ),
+    ]

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -30,6 +30,9 @@ class CourseMode(models.Model):
     We would like to offer a course in a variety of modes.
 
     """
+    class Meta(object):
+        app_label = "course_modes"
+
     # the course that this mode is attached to
     course_id = CourseKeyField(max_length=255, db_index=True, verbose_name=_("Course"))
 
@@ -636,6 +639,9 @@ class CourseModesArchive(models.Model):
     field pair in CourseModes. Having a separate table allows us to have an audit trail of any changes
     such as course price changes
     """
+    class Meta(object):
+        app_label = "course_modes"
+
     # the course that this mode is attached to
     course_id = CourseKeyField(max_length=255, db_index=True)
 
@@ -665,6 +671,9 @@ class CourseModeExpirationConfig(ConfigurationModel):
     """
     Configuration for time period from end of course to auto-expire a course mode.
     """
+    class Meta(object):
+        app_label = "course_modes"
+
     verification_window = models.DurationField(
         default=timedelta(days=10),
         help_text=_(

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -65,7 +65,6 @@ from model_utils.models import TimeStampedModel
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED
 
 from config_models.models import ConfigurationModel
-from course_modes.models import CourseMode
 from instructor_task.models import InstructorTask
 from util.milestones_helpers import fulfill_course_milestone, is_prerequisite_courses_enabled
 from xmodule.modulestore.django import modulestore
@@ -206,6 +205,9 @@ class GeneratedCertificate(models.Model):
     """
     Base model for generated certificates
     """
+    # Import here instead of top of file since this module gets imported before
+    # the course_modes app is loaded, resulting in a Django deprecation warning.
+    from course_modes.models import CourseMode
 
     # Only returns eligible certificates. This should be used in
     # preference to the default `objects` manager in most cases.
@@ -463,6 +465,9 @@ def certificate_status_for_student(student, course_id):
     If the student has been graded, the dictionary also contains their
     grade for the course with the key "grade".
     '''
+    # Import here instead of top of file since this module gets imported before
+    # the course_modes app is loaded, resulting in a Django deprecation warning.
+    from course_modes.models import CourseMode
 
     try:
         generated_certificate = GeneratedCertificate.objects.get(  # pylint: disable=no-member
@@ -545,6 +550,9 @@ class ExampleCertificateSet(TimeStampedModel):
             ExampleCertificateSet
 
         """
+        # Import here instead of top of file since this module gets imported before
+        # the course_modes app is loaded, resulting in a Django deprecation warning.
+        from course_modes.models import CourseMode
         cert_set = cls.objects.create(course_key=course_key)
 
         ExampleCertificate.objects.bulk_create([

--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -58,6 +58,9 @@ class InstructorTask(models.Model):
     `created` stores date that entry was first created
     `updated` stores date that entry was last modified
     """
+    class Meta(object):
+        app_label = "instructor_task"
+
     task_type = models.CharField(max_length=50, db_index=True)
     course_id = CourseKeyField(max_length=255, db_index=True)
     task_key = models.CharField(max_length=255, db_index=True)


### PR DESCRIPTION
Add app_label definitions in Meta classes for models.
Move import of course_mode model into methods to prevent importing the models at startup time.

These warnings currently show up at runtime like this:

```
/edx/app/edxapp/edx-platform/common/djangoapps/course_modes/models.py:28: RemovedInDjango19Warning: Model class course_modes.models.CourseMode doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class CourseMode(models.Model):

2016-02-08 13:59:00,285 WARNING 32741 [py.warnings] base.py:116 - /edx/app/edxapp/edx-platform/common/djangoapps/course_modes/models.py:28: RemovedInDjango19Warning: Model class course_modes.models.CourseMode doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class CourseMode(models.Model):
```

@peter-fogg @bderusha  Please review.
@edx/devops This has a migration that's close to a no-op.
