### PR TITLE
Update two management commands to Django 1.8

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/management/commands/generate_course_overview.py
+++ b/openedx/core/djangoapps/content/course_overviews/management/commands/generate_course_overview.py
@@ -24,12 +24,17 @@ class Command(BaseCommand):
     args = '<course_id course_id ...>'
     help = 'Generates and stores course overview for one or more courses.'
 
-    option_list = BaseCommand.option_list + (
-        make_option('--all',
-                    action='store_true',
-                    default=False,
-                    help='Generate course overview for all courses.'),
-    )
+    def add_arguments(self, parser):
+        """
+        Add arguments to the command parser.
+        """
+        parser.add_argument(
+            '--all',
+            action='store_true',
+            dest='all',
+            default=False,
+            help='Generate course overview for all courses.',
+        )
 
     def handle(self, *args, **options):
 

--- a/openedx/core/djangoapps/course_groups/management/commands/post_cohort_membership_fix.py
+++ b/openedx/core/djangoapps/course_groups/management/commands/post_cohort_membership_fix.py
@@ -15,8 +15,21 @@ class Command(BaseCommand):
     help = '''
     Repairs any potential inconsistencies made in the window between running migrations 0005 and 0006, and deploying
     the code changes to enforce use of CohortMembership that go with said migrations.
-    |commit|: optional argument. If not provided, will dry-run and list number of operations that would be made.
+
+    commit: optional argument. If not provided, will dry-run and list number of operations that would be made.
     '''
+
+    def add_arguments(self, parser):
+        """
+        Add arguments to the command parser.
+        """
+        parser.add_argument(
+            '--commit',
+            action='store_true',
+            dest='commit',
+            default=False,
+            help='Really commit the changes, otherwise, just dry run',
+        )
 
     def handle(self, *args, **options):
         """
@@ -24,7 +37,7 @@ class Command(BaseCommand):
         with the database already migrated to post-CohortMembership state, we will use the pre-CohortMembership
         table CourseUserGroup as the canonical source of truth. This way, changes made in the window are persisted.
         """
-        commit = 'commit' in options
+        commit = options['commit']
         memberships_to_delete = 0
         memberships_to_add = 0
 


### PR DESCRIPTION
Django 1.8 requires more disciplined parsing of management command options.  The post_cohort_management_fix command now uses a `--commit` flag to perform the real work.
Also had to update generate_course_overview.
