### PR TITLE
don't catch exception to raise http500

### DIFF
--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -1009,22 +1009,6 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
-    @ddt.unpack
-    @ddt.data(
-        {'side_effect': EdxNotesServiceUnavailable},
-        {'side_effect': EdxNotesServiceUnavailable},
-    )
-    def test_edxnotes_view_500_error(self, side_effect):
-        """
-        Tests that 500 status code is received for EdxNotesServiceUnavailable or EdxNotesServiceUnavailable exceptions.
-        """
-        with patch("edxnotes.views.get_notes", autospec=True) as mock_get_notes:
-            mock_get_notes.side_effect = side_effect
-            enable_edxnotes_for_the_course(self.course, self.user.id)
-            response = self.client.get(self.notes_page_url)
-            self.assertEqual(response.status_code, 500)
-
-    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
     @patch("edxnotes.views.get_notes", autospec=True)
     def test_search_notes_successfully_respond(self, mock_search):
         """

--- a/lms/djangoapps/edxnotes/views.py
+++ b/lms/djangoapps/edxnotes/views.py
@@ -46,10 +46,7 @@ def edxnotes(request, course_id):
     if not is_feature_enabled(course):
         raise Http404
 
-    try:
-        notes_info = get_notes(request, course)
-    except (EdxNotesParseError, EdxNotesServiceUnavailable) as err:
-        return JsonResponseBadRequest({"error": err.message}, status=500)
+    notes_info = get_notes(request, course)
 
     context = {
         "course": course,


### PR DESCRIPTION
## [TNL-4043](https://openedx.atlassian.net/browse/TNL-4043)

Don't handle the exception in views so that nginx can render the default HTTP 500 page.
### Testing
- [x] Unit 
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @symbolist  
- [x] Code review: @muzaffaryousaf  
- [ ] Code review: @ehteshamkafeel  
### Post-review
- [x] Squash commits
