### PR TITLE
Fixed progress exception for credit courses

### DIFF
--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -1091,11 +1091,9 @@ def _credit_course_requirements(course_key, student):
     if not (settings.FEATURES.get("ENABLE_CREDIT_ELIGIBILITY", False) and is_credit_course(course_key)):
         return None
 
-    # If student is enrolled not enrolled in verified or credit mode,
-    # short-circuit and return None. This indicates that
-    # credit requirements should NOT be displayed on the progress page.
+    # This indicates that credit requirements should NOT be displayed on the progress page.
     enrollment = CourseEnrollment.get_enrollment(student, course_key)
-    if enrollment.mode not in REQUIREMENTS_DISPLAY_MODES:
+    if enrollment and enrollment.mode not in REQUIREMENTS_DISPLAY_MODES:
         return None
 
     # Credit requirement statuses for which user does not remain eligible to get credit.


### PR DESCRIPTION
[ECOM-3603](https://openedx.atlassian.net/browse/ECOM-3603)

**Description:**
TracedError reported from New Relic
Application: [prod-edx-edxapp-lms](https://rpm.newrelic.com/accounts/88178/applications/3343327/filterable_errors.48d5d4-77157150-c8f0-11e5-9b9f-f8bc12425d50#/show/48d5d4-77157150-c8f0-11e5-9b9f-f8bc12425d50/stack_trace)
Timestamp: February 01, 2016 04:31
Exception Class: exceptions:AttributeError
Error Action: /courseware.views:progress
Uri: /courses/course-v1:ASUx+EXW100x+1T2016/progress/5321129/

**Fix:**
Added a safe check that only check for enrollment.mode when enrollment is not None.
