### PR TITLE
info page course id -> display_number_with_default

### DIFF
--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -127,6 +127,45 @@ class CourseInfoTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
         content = pq(info_page_response.content)
         self.assertEqual(content('.page-header-secondary .last-accessed-link').attr('href'), section_url)
 
+    def test_info_title(self):
+        """
+        Test the info page on a course without any display_* settings against
+        one that does.
+        """
+        url = reverse('info', args=(unicode(self.course.id),))
+        response = self.client.get(url)
+        content = pq(response.content)
+        expected_title = "Welcome to {org}'s {course_name}!".format(
+            org=self.course.display_org_with_default,
+            course_name=self.course.display_number_with_default
+        )
+        display_course = CourseFactory.create(
+            org="HogwartZ",
+            number="Potions_3",
+            display_organization="HogwartsX",
+            display_coursenumber="Potions",
+            display_name="Introduction_to_Potions"
+        )
+        display_url = reverse('info', args=(unicode(display_course.id),))
+        display_response = self.client.get(display_url)
+        display_content = pq(display_response.content)
+        expected_display_title = "Welcome to {org}'s {course_name}!".format(
+            org=display_course.display_org_with_default,
+            course_name=display_course.display_number_with_default
+        )
+        self.assertIn(
+            expected_title,
+            content('h1.page-title').contents()
+        )
+        self.assertIn(
+            expected_display_title,
+            display_content('h1.page-title').contents()
+        )
+        self.assertIn(
+            display_course.display_name_with_default,
+            display_content('h2.page-subtitle').contents()
+        )
+
 
 class CourseInfoTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -1,10 +1,10 @@
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from django.utils.translation import ugettext as _
 from courseware.courses import get_course_info_section, get_course_date_summary
 
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
+from openedx.core.djangolib.markup import HTML, ugettext as _
 %>
 
 <%block name="pagetitle">${_("{course_number} Course Info").format(course_number=course.display_number_with_default)}</%block>
@@ -21,9 +21,9 @@ from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
       <h2 class="title">${_("You are not enrolled yet")}</h2>
       <div class="copy">
         <p class='enroll-message'>
-          ${_(u"You are not currently enrolled in this course. {link_start}Sign up now!{link_end}").format(
-          link_start=u"<a href={}>".format(url_to_enroll),
-          link_end=u"</a>"
+          ${_("You are not currently enrolled in this course. {link_start}Sign up now!{link_end}").format(
+                link_start=HTML("<a href={}>").format(url_to_enroll),
+                link_end=HTML("</a>")
           )}
         </p>
       </div>
@@ -54,8 +54,8 @@ from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 <section class="container">
   <div class="home">
     <div class="page-header-main">
-        <h1 class="page-title">${_("Welcome to {org}'s {course_name}!").format(org=course.id.org, course_name=course.id.course) | h}</h1>
-        <h2 class="page-subtitle">${course.display_name | h}</h2>
+        <h1 class="page-title">${_("Welcome to {org}'s {course_name}!").format(org=course.display_org_with_default, course_name=course.display_number_with_default) | h}</h1>
+        <h2 class="page-subtitle">${course.display_name_with_default | h}</h2>
     </div>
     % if last_accessed_courseware_url:
       <div class="page-header-secondary">


### PR DESCRIPTION
It looks like the new info pages are using the course.id.course values, which can look ugly in some courses. This change uses the display_number_with_default value instead.  
