### PR TITLE
Quickly change to running sqlite on disk for unit tests

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -124,7 +124,8 @@ CONTENTSTORE = {
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': TEST_ROOT / "db" / "cms.db",
+        'NAME': "cms.db",
+        'TEST_NAME': TEST_ROOT / "db" / "cms.db",
         'ATOMIC_REQUESTS': True,
     },
 }

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -182,7 +182,8 @@ CONTENTSTORE = {
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': TEST_ROOT / 'db' / 'edx.db',
+        'NAME': 'edx.db',
+        'TEST_NAME': TEST_ROOT / 'db' / 'edx.db',
         'ATOMIC_REQUESTS': True,
     },
 


### PR DESCRIPTION
This will later allow us to use --keepdb to speed up iterative testing
(and avoid migrating at unit test start).
