### PR TITLE
Remove unnecessary p tag from XSeries dashboard message

### DIFF
--- a/lms/static/js/fixtures/dashboard/dashboard.html
+++ b/lms/static/js/fixtures/dashboard/dashboard.html
@@ -92,7 +92,6 @@
                     <div class="xseries-action">
                         <div class="message-copy xseries-msg">
                             <p><b class="message-copy-bold">XSeries Program: Interested in more courses in this subject?</b></p>
-                            <p></p>
                             <p class="message-copy">
                                 This course is 1 of 3 courses in the <a href="https://www.edx.org/xseries/water-management">Water Management</a> XSeries.
                             </p>


### PR DESCRIPTION
@marcotuts @ahsan-ul-haq 

This takes us from here:

![](https://i.imgur.com/oxrIGKc.png)

To here:

![](https://i.imgur.com/QpgMHcV.png)

Programs with long titles have their titles wrapped so that they don't overlap with the button.

![](https://i.imgur.com/kharzLT.png)
