### PR TITLE
Move rendering of capa problems inline

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -33,7 +33,6 @@ def marketing_link(name):
     possible URLs for certain links. This function is to decides
     which URL should be provided.
     """
-
     # link_map maps URLs from the marketing site to the old equivalent on
     # the Django site
     link_map = settings.MKTG_URL_LINK_MAP

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -399,6 +399,7 @@ class CapaMixin(CapaFields):
             'ajax_url': self.runtime.ajax_url,
             'progress_status': Progress.to_js_status_str(progress),
             'progress_detail': Progress.to_js_detail_str(progress),
+            'content': self.get_problem_html(encapsulate=False)
         })
 
     def check_button_name(self):

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -5,6 +5,7 @@ class @Problem
     @id = @el.data('problem-id')
     @element_id = @el.attr('id')
     @url = @el.data('url')
+    @content = @el.data('content')
 
     # has_timed_out and has_response are used to ensure that are used to
     # ensure that we wait a minimum of ~ 1s before transitioning the check
@@ -12,7 +13,7 @@ class @Problem
     @has_timed_out = false
     @has_response = false
 
-    @render()
+    @render(@content)
 
   $: (selector) ->
     $(selector, @el)

--- a/lms/templates/problem_ajax.html
+++ b/lms/templates/problem_ajax.html
@@ -1,1 +1,1 @@
-<div id="problem_${element_id}" class="problems-wrapper" data-problem-id="${id}" data-url="${ajax_url}" data-progress_status="${progress_status}" data-progress_detail="${progress_detail}"></div>
+<div id="problem_${element_id}" class="problems-wrapper" data-problem-id="${id}" data-url="${ajax_url}" data-progress_status="${progress_status}" data-progress_detail="${progress_detail}" data-content="${content | h}"></div>


### PR DESCRIPTION
### Motivation

We want to speed up end user page load times in courseware by eliminating the extra HTTP roundtrips necessary to render a view with capa problems in them. We already take most of the hit for data access for capa problems when we display a sequence, but capa problems currently only render blank stubs as part of their `student_view()`. Each problem then individually calls across then network with an AJAX call (`problem_get`) to fill in their real content.
### Approach

This is actually a really small PR, and just pushes content into the div from the start rather than calling over the network. There's a tiny bit of refactoring of the render code, and a separate commit that adds caching to edxmako middleware in order to offset the extra server load caused by this change.
### Risks

Need to verify impact on:
- [x] Analytics/Events
- [x] Rendering performance for students
  - [x] Large numbers of capa problems
  - [x] All types of capa problems
- [x] Rendering performance for staff
  - [x] Large numbers of capa problems
  - [x] All types of capa problems
