### PR TITLE
Use Course ID in logging an exception

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -289,8 +289,8 @@ def get_course_info_section(request, user, course, section_key):
         except Exception:  # pylint: disable=broad-except
             html = render_to_string('courseware/error-message.html', None)
             log.exception(
-                u"Error rendering course=%s, section_key=%s",
-                course, section_key
+                u"Error rendering course_id=%s, section_key=%s",
+                unicode(course.id), section_key
             )
 
     return html


### PR DESCRIPTION
Logging an exception log `CourseDescriptor`, changed it to log `course_id`
[TNL-4115](https://openedx.atlassian.net/browse/TNL-4115)
