### PR TITLE
Make 'Explanation' CAPA header translatable.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.coffee
@@ -505,7 +505,7 @@ class @MarkdownEditingDescriptor extends XModule.Descriptor
 
       // replace explanations
       xml = xml.replace(/\[explanation\]\n?([^\]]*)\[\/?explanation\]/gmi, function(match, p1) {
-          var selectString = '<solution>\n<div class="detailed-solution">\nExplanation\n\n' + p1 + '\n</div>\n</solution>';
+          var selectString = '<solution>\n<div class="detailed-solution">\n' + gettext('Explanation') + '\n\n' + p1 + '\n</div>\n</solution>';
 
           return selectString;
       });


### PR DESCRIPTION
### Description

CAPA `[explanation]` nodes get transformed into a HTML `<div>` block that contains the word 'Explanation'. This patch makes it translatable.
### How to test
1. Set up the `~/.transifexrc` file in your devstack, as described on https://github.com/edx/edx-platform/wiki/Internationalization-and-localization
2. Execute `paver i18n_robot_pull`.
3. Switch to the dummy `eo` locale in the Studio by appending `?preview-lang=eo` to your Studio URL.
4. Add a 'Multiple Choice' problem to a unit in the studio, hit Edit, then Save (it's important to re-save, because the default content is not translated, it only gets translated when you edit & save).
5. Click the 'Show Answer' button.
6. The 'Explanation' header should be translated.
### Screenshots

The 'Explanation' header is automatically added to this content when it gets rendered:

![screen shot 2016-02-10 at 11 15 44](https://cloud.githubusercontent.com/assets/32585/12944793/ba53fdd0-cfe9-11e5-93a5-41e01fdc8a61.png)

Without this patch, the 'Explanation' string was not getting translated.

![screen shot 2016-02-10 at 11 15 15](https://cloud.githubusercontent.com/assets/32585/12944797/bfeb287c-cfe9-11e5-9e8b-6872f53f2478.png)

With this patch, the string is translated correctly:

![screen shot 2016-02-10 at 11 27 12](https://cloud.githubusercontent.com/assets/32585/12944799/c2a1df20-cfe9-11e5-8fb7-32eeb0e181ad.png)

**Partner information**: 3rd party-hosted open edX instance
**JIRA Ticket**: https://openedx.atlassian.net/browse/OSPR-1136
