### PR TITLE
Added target='_blank' to both cohort external doc links.

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/cohort-group-header.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort-group-header.underscore
@@ -12,10 +12,10 @@
     <div class="setup-value">
         <% if (cohort.get('assignment_type') == "manual") { %>
             <%- gettext("Learners are added to this cohort only when you provide their email addresses or usernames on this page.") %>
-            <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohort_config.html#assign-learners-to-cohorts-manually" class="incontext-help action-secondary action-help"><%= gettext("What does this mean?") %></a>
+            <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohort_config.html#assign-learners-to-cohorts-manually" class="incontext-help action-secondary action-help" target="_blank"><%= gettext("What does this mean?") %></a>
         <% } else { %>
             <%- gettext("Learners are added to this cohort automatically.") %>
-            <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohorts_overview.html#all-automated-assignment" class="incontext-help action-secondary action-help"><%- gettext("What does this mean?") %></a>
+            <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohorts_overview.html#all-automated-assignment" class="incontext-help action-secondary action-help" target="_blank"><%- gettext("What does this mean?") %></a>
         <% } %>
     </div>
 </div>


### PR DESCRIPTION
[TNL-4096](https://openedx.atlassian.net/browse/TNL-4096)

**Description**

In LMS: Instructor Dashboard, Cohorts tab
Select Enable Cohorts checkbox.
Add a cohort, name it, choose Manual for Cohort Assignment Method and No content group for Associated Content Group, and save the cohort.
On the page that appears, you see the UI text "Learners are added to this cohort only when..." followed by "What does this mean" link. 
--> This link should open the RTD file in a separate browser tab. Please add the target="_blank" directive to the href.
Similarly, if you Add a cohort, name it, choose Automatic for Cohort Assignment Method and No content group for Associated Content Group, and save the cohort.
In the cohort, you see the UI text "Learners are added to this cohort automatically" followed by "What does this mean" link.
--> This link should also open the RTD file in a separate browser tab. Please add the target="_blank" directive to the href.

**Solution**

Proposed Solution: Add target="_blank" to both href attributes.

Both href attributes were located in the cohort-group-header.underscore file. target="_blank" added to both attributes. Link now opens in a new tab instead of the same window. Change only affects LMS.

**Summary**
RTD links in cohorts used to open in the same browser window as LMS. Now they open in a new tab.
