### PR TITLE
Explicitly cut off cert eligibility.

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -326,8 +326,8 @@ class XQueueCertInterface(object):
         # analytics. Only do this if the certificate is new, or
         # already marked as ineligible -- we don't want to mark
         # existing audit certs as ineligible.
-        if (created or cert.status in (CertificateStatuses.audit_passing, CertificateStatuses.audit_notpassing)) \
-           and not is_eligible_for_certificate:
+        cutoff = settings.AUDIT_CERT_CUTOFF_DATE
+        if (cutoff and cert.created_date >= cutoff) and not is_eligible_for_certificate:
             cert.status = CertificateStatuses.audit_passing if passing else CertificateStatuses.audit_notpassing
             cert.save()
             LOGGER.info(

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -19,6 +19,8 @@ Common traits:
 import datetime
 import json
 
+import dateutil
+
 from .common import *
 from openedx.core.lib.logsettings import get_logger_config
 import os
@@ -756,3 +758,7 @@ MICROSITE_DATABASE_TEMPLATE_CACHE_TTL = ENV_TOKENS.get(
 
 # Course Content Bookmarks Settings
 MAX_BOOKMARKS_PER_COURSE = ENV_TOKENS.get('MAX_BOOKMARKS_PER_COURSE', MAX_BOOKMARKS_PER_COURSE)
+
+# Cutoff date for granting audit certificates
+if ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE', None):
+    AUDIT_CERT_CUTOFF_DATE = dateutil.parser.parse(ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE'))

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2755,6 +2755,10 @@ MOBILE_APP_USER_AGENT_REGEXES = [
 DEPRECATED_ADVANCED_COMPONENT_TYPES = []
 
 
+# Cutoff date for granting audit certificates
+
+AUDIT_CERT_CUTOFF_DATE = None
+
 ################################ Settings for Credentials Service ################################
 
 CREDENTIALS_SERVICE_USERNAME = 'credentials_service_user'


### PR DESCRIPTION
@bderusha While investigating [COR-2403](https://openedx.atlassian.net/browse/COR-2403) I kept staring at the logic for cert eligibility, and I decided it's terrible. The convoluted conditional that's in there now is really just an implicit way of encoding that audit certs granted after a particular date should be ineligible. I'd far rather be honest about it and make the code clearer for future wanderers through that code. Furthermore, this has the advantage of not hardcoding in cert eligibility logic for open source instances. If this approach seems reasonable to you I'll create the appropriate configuration PR/support ticket to set the date for our installation.
