### PR TITLE
Use has_configuration_set() during microsite initialization

### DIFF
--- a/common/djangoapps/microsite_configuration/backends/base.py
+++ b/common/djangoapps/microsite_configuration/backends/base.py
@@ -290,9 +290,8 @@ class BaseMicrositeBackend(AbstractBaseMicrositeBackend):
         in non-mako templates must be loaded before the django startup
         """
         microsites_root = settings.MICROSITE_ROOT_DIR
-        microsite_config_dict = settings.MICROSITE_CONFIGURATION
 
-        if microsite_config_dict:
+        if self.has_configuration_set():
             settings.DEFAULT_TEMPLATE_ENGINE['DIRS'].append(microsites_root)
 
 

--- a/common/djangoapps/microsite_configuration/tests/backends/test_database.py
+++ b/common/djangoapps/microsite_configuration/tests/backends/test_database.py
@@ -105,22 +105,6 @@ class DatabaseMicrositeBackendTests(DatabaseMicrositeTestCase):
         microsite.clear()
         self.assertIsNone(microsite.get_value('platform_name'))
 
-    def test_enable_microsites_pre_startup(self):
-        """
-        Tests microsite.test_enable_microsites_pre_startup works as expected.
-        """
-        # remove microsite root directory paths first
-        settings.DEFAULT_TEMPLATE_ENGINE['DIRS'] = [
-            path for path in settings.DEFAULT_TEMPLATE_ENGINE['DIRS']
-            if path != settings.MICROSITE_ROOT_DIR
-        ]
-        with patch.dict('django.conf.settings.FEATURES', {'USE_MICROSITES': False}):
-            microsite.enable_microsites_pre_startup(log)
-            self.assertNotIn(settings.MICROSITE_ROOT_DIR, settings.DEFAULT_TEMPLATE_ENGINE['DIRS'])
-        with patch.dict('django.conf.settings.FEATURES', {'USE_MICROSITES': True}):
-            microsite.enable_microsites_pre_startup(log)
-            self.assertIn(settings.MICROSITE_ROOT_DIR, settings.DEFAULT_TEMPLATE_ENGINE['DIRS'])
-
     @patch('edxmako.paths.add_lookup')
     def test_enable_microsites(self, add_lookup):
         """
@@ -172,6 +156,15 @@ class DatabaseMicrositeBackendTests(DatabaseMicrositeTestCase):
         self.assertEqual(MicrositeHistory.objects.all().count(), 2)
         with self.assertRaises(Exception):
             microsite.set_by_domain('test.microsite2.com')
+
+    def test_has_configuration_set(self):
+        """
+        Tests microsite.has_configuration_set works as expected on this backend.
+        """
+        self.assertTrue(microsite.BACKEND.has_configuration_set())
+
+        Microsite.objects.all().delete()
+        self.assertFalse(microsite.BACKEND.has_configuration_set())
 
 
 @patch(

--- a/common/djangoapps/microsite_configuration/tests/backends/test_filebased.py
+++ b/common/djangoapps/microsite_configuration/tests/backends/test_filebased.py
@@ -122,6 +122,15 @@ class FilebasedMicrositeBackendTests(TestCase):
         microsite.set_by_domain('unknown')
         self.assertEqual(microsite.get_value('university'), 'default_university')
 
+    def test_has_configuration_set(self):
+        """
+        Tests microsite.has_configuration_set works as expected.
+        """
+        self.assertTrue(microsite.BACKEND.has_configuration_set())
+
+        with patch('django.conf.settings.MICROSITE_CONFIGURATION', {}):
+            self.assertFalse(microsite.BACKEND.has_configuration_set())
+
 
 @patch(
     'microsite_configuration.microsite.TEMPLATES_BACKEND',

--- a/common/djangoapps/microsite_configuration/tests/test_microsites.py
+++ b/common/djangoapps/microsite_configuration/tests/test_microsites.py
@@ -2,12 +2,17 @@
 """
 Tests microsite_configuration templatetags and helper functions.
 """
+import logging
+
+from mock import patch
 from django.test import TestCase
 from django.conf import settings
 from microsite_configuration.templatetags import microsite as microsite_tags
 from microsite_configuration import microsite
 from microsite_configuration.backends.base import BaseMicrositeBackend
 from microsite_configuration.backends.database import DatabaseMicrositeBackend
+
+log = logging.getLogger(__name__)
 
 
 class MicrositeTests(TestCase):
@@ -74,3 +79,20 @@ class MicrositeTests(TestCase):
             ),
             DatabaseMicrositeBackend
         )
+
+    def test_enable_microsites_pre_startup(self):
+        """
+        Tests microsite.test_enable_microsites_pre_startup is not used if the feature is turned off.
+        """
+        # remove microsite root directory paths first
+        settings.DEFAULT_TEMPLATE_ENGINE['DIRS'] = [
+            path for path in settings.DEFAULT_TEMPLATE_ENGINE['DIRS']
+            if path != settings.MICROSITE_ROOT_DIR
+        ]
+
+        with patch.dict('django.conf.settings.FEATURES', {'USE_MICROSITES': False}):
+            microsite.enable_microsites_pre_startup(log)
+            self.assertNotIn(settings.MICROSITE_ROOT_DIR, settings.DEFAULT_TEMPLATE_ENGINE['DIRS'])
+        with patch.dict('django.conf.settings.FEATURES', {'USE_MICROSITES': True}):
+            microsite.enable_microsites_pre_startup(log)
+            self.assertIn(settings.MICROSITE_ROOT_DIR, settings.DEFAULT_TEMPLATE_ENGINE['DIRS'])


### PR DESCRIPTION
This PR:

Changes the `microsite_enable_pre_startup` method to use the `has_configuration_set` method to determine whether the path modifications should be made.

Before the change, the logic was tied to the settings file configuration, and could not be modified at the database backend without overriding the complete enable_pre method. After the change, both backends work well with the same enable_pre method.
