### PR TITLE
Translate preferred languages in user account settings

### DIFF
--- a/common/djangoapps/lang_pref/api.py
+++ b/common/djangoapps/lang_pref/api.py
@@ -4,6 +4,7 @@
 from collections import namedtuple
 
 from django.conf import settings
+from django.utils.translation import ugettext as _
 from dark_lang.models import DarkLangConfig
 
 
@@ -45,3 +46,16 @@ def released_languages():
     ]
 
     return released_languages
+
+
+def all_languages():
+    """Retrieve the list of all languages, translated and sorted.
+
+    Returns:
+        list of (language code (str), language name (str)): the language names
+        are translated in the current activated language and the results sorted
+        alphabetically.
+
+    """
+    languages = [(lang[0], _(lang[1])) for lang in settings.ALL_LANGUAGES]  # pylint: disable=translation-of-non-string
+    return sorted(languages, key=lambda lang: lang[1])

--- a/common/djangoapps/lang_pref/tests/test_api.py
+++ b/common/djangoapps/lang_pref/tests/test_api.py
@@ -2,6 +2,8 @@
 """ Tests for the language API. """
 
 from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import translation
 from lang_pref import api as language_api
 
 
@@ -10,3 +12,15 @@ class LanguageApiTest(TestCase):
     def test_released_languages(self):
         released_languages = language_api.released_languages()
         self.assertGreaterEqual(len(released_languages), 1)
+
+    @override_settings(ALL_LANGUAGES=[[u"cs", u"Czech"], [u"nl", u"Dutch"]])
+    def test_all_languages(self):
+        with translation.override('fr'):
+            all_languages = language_api.all_languages()
+
+        self.assertEqual(2, len(all_languages))
+        self.assertLess(all_languages[0][1], all_languages[1][1])
+        self.assertEqual("nl", all_languages[0][0])
+        self.assertEqual("cs", all_languages[1][0])
+        self.assertEqual(u"Hollandais", all_languages[0][1])
+        self.assertEqual(u"Tchèque", all_languages[1][1])

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -18,7 +18,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 
-from lang_pref.api import released_languages
+from lang_pref.api import released_languages, all_languages
 from edxmako.shortcuts import render_to_response
 from microsite_configuration import microsite
 
@@ -385,7 +385,7 @@ def account_settings_context(request):
             }, 'year_of_birth': {
                 'options': year_of_birth_options,
             }, 'preferred_language': {
-                'options': settings.ALL_LANGUAGES,
+                'options': all_languages(),
             }
         },
         'platform_name': settings.PLATFORM_NAME,


### PR DESCRIPTION
The listed languages in the "preferred languages" input dropdown should be translated in the user language.
