### PR TITLE
Update help text for Pages page in Studio to reflect Courseware-Course etc change

### DIFF
--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -140,7 +140,7 @@
     <aside class="content-supplementary" role="complementary">
       <div class="bit">
         <h3 class="title-3">${_("What are pages?")}</h3>
-        <p>${_("Pages are listed horizontally at the top of your course. Default pages (Courseware, Course info, Discussion, Wiki, and Progress) are followed by textbooks and custom pages that you create.")}</p>
+        <p>${_("Pages are listed horizontally at the top of your course. Default pages (Home, Course, Discussion, Wiki, and Progress) are followed by textbooks and custom pages that you create.")}</p>
       </div>
       <div class="bit">
         <h3 class="title-3">${_("Custom pages")}</h3>
@@ -159,7 +159,7 @@
   <h3 class="title">${_("Pages in Your Course")}</h3>
   <figure>
     <img src="${static.url("images/preview-lms-staticpages.png")}" alt="${_('Preview of Pages in your course')}" />
-    <figcaption class="description">${_("Pages appear in your course's top navigation bar. The default pages (Courseware, Course Info, Discussion, Wiki, and Progress) are followed by textbooks and custom pages.")}</figcaption>
+    <figcaption class="description">${_("Pages appear in your course's top navigation bar. The default pages (Home, Course, Discussion, Wiki, and Progress) are followed by textbooks and custom pages.")}</figcaption>
   </figure>
 
   <a href="#" rel="view" class="action action-modal-close">


### PR DESCRIPTION
Updating per DOC-2692: Help text on Pages page says default page names are Courseware, Course Info... instead of Home, Course...

@marcotuts Please do a quick tech review/sanity check.
