### PR TITLE
Ensure window.course is available before anyone accesses it.

### DIFF
--- a/cms/static/cms/js/build.js
+++ b/cms/static/cms/js/build.js
@@ -35,7 +35,6 @@
             'js/factories/asset_index',
             'js/factories/base',
             'js/factories/container',
-            'js/factories/course',
             'js/factories/course_create_rerun',
             'js/factories/course_info',
             'js/factories/edit_tabs',

--- a/cms/static/js/factories/base.js
+++ b/cms/static/js/factories/base.js
@@ -1,2 +1,2 @@
 define(['js/base', 'coffee/src/main', 'js/src/logger', 'datepair', 'accessibility',
-'ieshim', 'tooltip_manager', 'lang_edx']);
+'ieshim', 'tooltip_manager', 'lang_edx', 'js/models/course']);

--- a/cms/static/js/factories/course.js
+++ b/cms/static/js/factories/course.js
@@ -1,6 +1,0 @@
-define(['js/models/course'], function(Course) {
-    'use strict';
-    return function (courseInfo) {
-        window.course = new Course(courseInfo);
-    }
-});

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -82,24 +82,24 @@ from openedx.core.djangolib.js_utils import (
     <script type="text/javascript">
       require(['common/js/common_libraries'], function () {
           require(['js/factories/base'], function () {
-            % if context_course:
-              require(['js/factories/course'], function(CourseFactory) {
-                  CourseFactory({
-                      id: "${context_course.id | n, js_escaped_string}",
-                      name: "${context_course.display_name_with_default_escaped | h}",
-                      url_name: "${context_course.location.name | h}",
-                      org: "${context_course.location.org | h}",
-                      num: "${context_course.location.course | h}",
-                      display_course_number: "${context_course.display_coursenumber | n, js_escaped_string}",
-                      revision: "${context_course.location.revision | h}",
-                      self_paced: ${context_course.self_paced | n, dump_js_escaped_json}
-                  });
-              });
-            % endif
-            % if user.is_authenticated():
-                require(['js/sock']);
-            % endif
-            <%block name='requirejs'></%block>
+               require(['js/models/course'], function(Course) {
+                   % if context_course:
+                       window.course = new Course({
+                           id: "${context_course.id | n, js_escaped_string}",
+                           name: "${context_course.display_name_with_default_escaped | h}",
+                           url_name: "${context_course.location.name | h}",
+                           org: "${context_course.location.org | h}",
+                           num: "${context_course.location.course | h}",
+                           display_course_number: "${context_course.display_coursenumber | n, js_escaped_string}",
+                           revision: "${context_course.location.revision | h}",
+                           self_paced: ${context_course.self_paced | n, dump_js_escaped_json}
+                       });
+                   % endif
+                   % if user.is_authenticated():
+                       require(['js/sock']);
+                   % endif
+                   <%block name='requirejs'></%block>
+               });
           });
       });
     </script>


### PR DESCRIPTION
## [TNL-4106](https://openedx.atlassian.net/browse/TNL-4106)

Ensure window.course is available before anyone accesses it. Previously there was a race condition because of the code outside of the nested require. Moving all the code inside means that js/models/course will always be loaded in Studio (even if no "course_context"), but the amount of code being loaded is extremely small, and the vast majority of time the course_context does exist.
### Sandbox
- [x] https://studio-courseglobal.sandbox.edx.org/course/course-v1:edX+DemoX+Demo_Course
### Testing
- [x] manual testing, verified that js/models/course does not get downloaded separately. I was never able to reproduce the original issue.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @efischer19 

FYI: @peter-fogg 
### Post-review
- [x] Squash commits
