### PR TITLE
Address ProgramsApiConfig deprecation warning

### DIFF
--- a/openedx/core/djangoapps/programs/signals.py
+++ b/openedx/core/djangoapps/programs/signals.py
@@ -6,7 +6,6 @@ import logging
 from django.dispatch import receiver
 
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED
-from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 
 
 LOGGER = logging.getLogger(__name__)
@@ -35,6 +34,10 @@ def handle_course_cert_awarded(sender, user, course_key, mode, status, **kwargs)
         None
 
     """
+    # Import here instead of top of file since this module gets imported before
+    # the programs app is loaded, resulting in a Django deprecation warning.
+    from openedx.core.djangoapps.programs.models import ProgramsApiConfig
+
     if not ProgramsApiConfig.current().is_certification_enabled:
         return
 


### PR DESCRIPTION
Does away with the following Django 1.9 deprecation warning:

> WARNING:py.warnings:/edx/app/edxapp/edx-platform/openedx/core/djangoapps/programs/models.py:14: RemovedInDjango19Warning: Model class openedx.core.djangoapps.programs.models.ProgramsApiConfig doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
>   class ProgramsApiConfig(ConfigurationModel):

@doctoryes @bderusha please review.
