### PR TITLE
Updated expected version for python_uninstall_version.txt

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -164,7 +164,7 @@ def uninstall_python_packages():
     """
     # So that we don't constantly uninstall things, use a version number of the
     # uninstallation needs.  Check it, and skip this if we're up to date.
-    expected_version = 2
+    expected_version = 3
     state_file_path = os.path.join(PREREQS_STATE_DIR, "python_uninstall_version.txt")
     if os.path.isfile(state_file_path):
         with open(state_file_path) as state_file:


### PR DESCRIPTION
Follow up to #11432. This value needs to be incremented to ensure the old package is uninstalled.

ECOM-3647
