### PR TITLE
Fixed package uninstall for django-oauth2-provider

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -195,7 +195,7 @@ def uninstall_python_packages():
             uninstalled = True
 
         # Uninstall django-oauth2-provider
-        if any("django-oauth2-provider==" in line for line in frozen):
+        if any(line.startswith("django-oauth2-provider==") for line in frozen):
             sh("pip uninstall --disable-pip-version-check -y django-oauth2-provider")
             uninstalled = True
 


### PR DESCRIPTION
edx-django-oauth2-provider is being mistaken for django-oauth2-provider. Making the filter less liberal ensures we properly uninstall django-oauth2-provider once.

ECOM-3647
