### PR TITLE
Specify high priority queue for credentials generation task.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -849,9 +849,6 @@ INSTALLED_APPS = (
     # Microsite configuration application
     'microsite_configuration',
 
-    # Credentials support
-    'openedx.core.djangoapps.credentials',
-
     # edx-milestones service
     'milestones',
 
@@ -1129,8 +1126,3 @@ USERNAME_PATTERN = r'(?P<username>[\w.@+-]+)'
 
 # Partner support link for CMS footer
 PARTNER_SUPPORT_EMAIL = ''
-
-
-################################ Settings for Credentials Service ################################
-
-CREDENTIALS_SERVICE_USERNAME = 'credentials_service_user'

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -762,3 +762,7 @@ MAX_BOOKMARKS_PER_COURSE = ENV_TOKENS.get('MAX_BOOKMARKS_PER_COURSE', MAX_BOOKMA
 # Cutoff date for granting audit certificates
 if ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE', None):
     AUDIT_CERT_CUTOFF_DATE = dateutil.parser.parse(ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE'))
+
+################################ Settings for Credentials Service ################################
+
+CREDENTIALS_GENERATION_ROUTING_KEY = HIGH_PRIORITY_QUEUE

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2768,3 +2768,4 @@ AUDIT_CERT_CUTOFF_DATE = None
 ################################ Settings for Credentials Service ################################
 
 CREDENTIALS_SERVICE_USERNAME = 'credentials_service_user'
+CREDENTIALS_GENERATION_ROUTING_KEY = HIGH_PRIORITY_QUEUE

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -313,3 +313,7 @@ if FEATURES.get('INDIVIDUAL_DUE_DATES'):
 if FEATURES.get('ENABLE_LTI_PROVIDER'):
     INSTALLED_APPS += ('lti_provider',)
     AUTHENTICATION_BACKENDS += ('lti_provider.users.LtiBackend', )
+
+################################ Settings for Credentials Service ################################
+
+CREDENTIALS_GENERATION_ROUTING_KEY = HIGH_PRIORITY_QUEUE

--- a/openedx/core/djangoapps/credentials/tests/test_models.py
+++ b/openedx/core/djangoapps/credentials/tests/test_models.py
@@ -1,9 +1,14 @@
 """Tests for models supporting Credentials-related functionality."""
 
+import unittest
+
+from django.conf import settings
 from django.test import TestCase
+
 from openedx.core.djangoapps.credentials.tests.mixins import CredentialsApiConfigMixin
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TestCredentialsApiConfig(CredentialsApiConfigMixin, TestCase):
     """Tests covering the CredentialsApiConfig model."""
     def test_url_construction(self):

--- a/openedx/core/djangoapps/credentials/tests/test_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_utils.py
@@ -1,4 +1,7 @@
 """Tests covering Credentials utilities."""
+import unittest
+
+from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
 import httpretty
@@ -15,6 +18,7 @@ from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from student.tests.factories import UserFactory
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TestCredentialsRetrieval(ProgramsApiConfigMixin, CredentialsApiConfigMixin, CredentialsDataMixin,
                                ProgramsDataMixin, TestCase):
     """ Tests covering the retrieval of user credentials from the Credentials

--- a/openedx/core/djangoapps/programs/tasks/v1/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks/v1/tasks.py
@@ -17,6 +17,8 @@ from openedx.core.lib.token_utils import get_id_token
 
 
 LOGGER = get_task_logger(__name__)
+# Under cms the following setting is not defined, leading to errors during tests.
+ROUTING_KEY = getattr(settings, 'CREDENTIALS_GENERATION_ROUTING_KEY', None)
 
 
 def get_api_client(api_config, student):
@@ -115,7 +117,7 @@ def award_program_certificate(client, username, program_id):
     })
 
 
-@task(bind=True, ignore_result=True)
+@task(bind=True, ignore_result=True, routing_key=ROUTING_KEY)
 def award_program_certificates(self, username):
     """
     This task is designed to be called whenever a student's completion status

--- a/openedx/core/djangoapps/programs/tasks/v1/tests/test_tasks.py
+++ b/openedx/core/djangoapps/programs/tasks/v1/tests/test_tasks.py
@@ -9,6 +9,7 @@ from edx_rest_api_client.client import EdxRestApiClient
 import httpretty
 import json
 import mock
+import unittest
 
 from oauth2_provider.tests.factories import ClientFactory
 from openedx.core.djangoapps.credentials.tests.mixins import CredentialsApiConfigMixin
@@ -20,6 +21,7 @@ from student.tests.factories import UserFactory
 TASKS_MODULE = 'openedx.core.djangoapps.programs.tasks.v1.tasks'
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class GetApiClientTestCase(TestCase, ProgramsApiConfigMixin):
     """
     Test the get_api_client function
@@ -44,6 +46,7 @@ class GetApiClientTestCase(TestCase, ProgramsApiConfigMixin):
         self.assertEqual(api_client._store['session'].auth.token, 'test-token')  # pylint: disable=protected-access
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class GetCompletedCoursesTestCase(TestCase):
     """
     Test the get_completed_courses function
@@ -87,6 +90,7 @@ class GetCompletedCoursesTestCase(TestCase):
         ])
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class GetCompletedProgramsTestCase(TestCase):
     """
     Test the get_completed_programs function
@@ -113,6 +117,7 @@ class GetCompletedProgramsTestCase(TestCase):
         self.assertEqual(result, [1, 2, 3])
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class GetAwardedCertificateProgramsTestCase(TestCase):
     """
     Test the get_awarded_certificate_programs function
@@ -153,6 +158,7 @@ class GetAwardedCertificateProgramsTestCase(TestCase):
         self.assertEqual(result, [1])
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class AwardProgramCertificateTestCase(TestCase):
     """
     Test the award_program_certificate function
@@ -181,6 +187,7 @@ class AwardProgramCertificateTestCase(TestCase):
         self.assertEqual(json.loads(httpretty.last_request().body), expected_body)
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @ddt.ddt
 @mock.patch(TASKS_MODULE + '.award_program_certificate')
 @mock.patch(TASKS_MODULE + '.get_awarded_certificate_programs')

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -1,4 +1,7 @@
 """Tests covering Programs utilities."""
+import unittest
+
+from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
 import httpretty
@@ -15,6 +18,7 @@ from openedx.core.djangoapps.programs.utils import (
 from student.tests.factories import UserFactory
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TestProgramRetrieval(ProgramsApiConfigMixin, ProgramsDataMixin,
                            CredentialsApiConfigMixin, TestCase):
     """Tests covering the retrieval of programs from the Programs service."""

--- a/openedx/core/lib/tests/test_edx_api_utils.py
+++ b/openedx/core/lib/tests/test_edx_api_utils.py
@@ -1,5 +1,7 @@
 """Tests covering Api utils."""
+import unittest
 
+from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
 import httpretty
@@ -95,6 +97,8 @@ class TestApiDataRetrieval(CredentialsApiConfigMixin, CredentialsDataMixin, Prog
             )
             self.assertEqual(actual, [])
 
+    # this test is skipped under cms because the credentials app is only installed under LMS.
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     @httpretty.activate
     def test_get_edx_api_data_multiple_page(self):
         """Verify that all data is retrieve for multiple page response."""


### PR DESCRIPTION
Also, disable / remove credentials-related settings and tests that are irrelevant under cms.

ECOM-3638

@rlucioni @cpennington please review.
@zubair-arbi @ahsan-ul-haq FYI.
