### PR TITLE
Fix bug with loading AFontGarde

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1236,9 +1236,9 @@ main_vendor_js = base_vendor_js + [
     'js/vendor/jquery-ui.min.js',
     'js/vendor/jquery.qtip.min.js',
     'js/vendor/jquery.ba-bbq.min.js',
-    'pattern-library/js/modernizr.custom.js',
-    'pattern-library/js/afontgarde.js',
-    'pattern-library/js/edx-icons.js'
+    'js/vendor/afontgarde/modernizr.fontface-generatedcontent.js',
+    'js/vendor/afontgarde/afontgarde.js',
+    'js/vendor/afontgarde/edx-icons.js'
 ]
 
 # Common files used by both RequireJS code and non-RequireJS code


### PR DESCRIPTION
The code isn't ready to start using AFontGarde from the Pattern Library yet, so I've reverted the code back to loading the copies from the vendor library.

@cahrens @dan-f  Please review.
