### PR TITLE
copy event on write

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -177,7 +177,10 @@ class GoogleAnalyticsProcessor(object):
         context = event.get('context', {})
         course_id = context.get('course_id')
 
+        copied_event = event.copy()
         if course_id is not None:
-            event['label'] = course_id
+            copied_event['label'] = course_id
 
-        event['nonInteraction'] = 1
+        copied_event['nonInteraction'] = 1
+
+        return copied_event


### PR DESCRIPTION
When recently digging in to the eventing code, I stumbled across this bug again, so I fixed it.

This fixes https://openedx.atlassian.net/browse/AN-5951

Given that this is just a shallow copy, I expect it to be very fast and not worth performance testing in load test. Since this code is called so frequently, I did micro-benchmark the old and the new using time.clock() to measure the execution time and found comparable results between both versions of the code, they were both roughly ~20 microseconds.

Reviewer: @brianhw
