### PR TITLE
update mathjax to 2.6 (TNL-4104) and (TNL-4094)

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -14,7 +14,7 @@
         // Since we are serving the gettext catalog as static files,
         // the URL for the gettext file will vary depending on which locale
         // needs to be served. To handle this, we load the correct file in the
-        // rendered template and then use this to ensure that RequireJS knows 
+        // rendered template and then use this to ensure that RequireJS knows
         // how to find it.
         define("gettext", function () { return window.gettext; });
     }
@@ -91,7 +91,7 @@
             // end of Annotation tool files
 
             // externally hosted files
-            "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured", // jshint ignore:line
+            "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured", // jshint ignore:line
             "youtube": [
                 // youtube URL does not end in ".js". We add "?noext" to the path so
                 // that require.js adds the ".js" to the query component of the URL,
@@ -289,16 +289,16 @@
             },
             "ova":{
                 exports: "ova",
-                deps: ["annotator", "annotator-harvardx", "video.dev", "vjs.youtube", 
-                       "rangeslider", "share-annotator", "richText-annotator", "reply-annotator", 
-                       "tags-annotator", "flagging-annotator", "grouping-annotator", "diacritic-annotator", 
+                deps: ["annotator", "annotator-harvardx", "video.dev", "vjs.youtube",
+                       "rangeslider", "share-annotator", "richText-annotator", "reply-annotator",
+                       "tags-annotator", "flagging-annotator", "grouping-annotator", "diacritic-annotator",
                        "jquery-Watch", "catch", "handlebars", "URI"]
             },
             "osda":{
                 exports: "osda",
-                deps: ["annotator", "annotator-harvardx", "video.dev", "vjs.youtube", 
-                       "rangeslider", "share-annotator", "richText-annotator", "reply-annotator", 
-                       "tags-annotator", "flagging-annotator", "grouping-annotator", "diacritic-annotator", 
+                deps: ["annotator", "annotator-harvardx", "video.dev", "vjs.youtube",
+                       "rangeslider", "share-annotator", "richText-annotator", "reply-annotator",
+                       "tags-annotator", "flagging-annotator", "grouping-annotator", "diacritic-annotator",
                        "openseadragon", "jquery-Watch", "catch", "handlebars", "URI"]
             }
             // end of annotation tool files

--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -51,7 +51,7 @@ requirejs.config({
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
         "mock-ajax": "xmodule_js/common_static/js/vendor/mock-ajax",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix",

--- a/cms/static/coffee/spec/main_squire.coffee
+++ b/cms/static/coffee/spec/main_squire.coffee
@@ -42,7 +42,7 @@ requirejs.config({
         "domReady": "xmodule_js/common_static/js/vendor/domReady",
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix"

--- a/common/djangoapps/terrain/ui_helpers.py
+++ b/common/djangoapps/terrain/ui_helpers.py
@@ -346,9 +346,9 @@ def css_contains_text(css_selector, partial_text, index=0):
     # If we're expecting a non-empty string, give the page
     # a chance to fill in text fields.
     if partial_text:
-        wait_for(lambda _: css_text(css_selector, index=index))
+        wait_for(lambda _: css_html(css_selector, index=index))
 
-    actual_text = css_text(css_selector, index=index)
+    actual_text = css_html(css_selector, index=index)
 
     return partial_text in actual_text
 

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -463,18 +463,13 @@ div.problem {
       span {
         margin-bottom: 0;
 
-        &.math {
+        &.MathJax_CHTML, &.MathJax, &.MathJax_SVG {
           display: inline-block;
           padding: 6px;
           min-width: 30px;
           border: 1px solid #e3e3e3;
           border-radius: 4px;
           background: #f1f1f1;
-
-          & span {
-            // Needed to fix mathjax rendering bug in chrome (TNL-4080)
-            border-left-style: none !important;
-          }
         }
       }
     }

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -76,4 +76,4 @@
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -126,7 +126,7 @@ class DiscussionThreadPage(PageObject, DiscussionPageMixin):
     def verify_mathjax_rendered(self):
         """ Checks that MathJax css class is present """
         self.wait_for(
-            lambda: self._is_element_visible(".MathJax"),
+            lambda: self._is_element_visible(".MathJax_CHTML"),
             description="MathJax Preview is rendered"
         )
 

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -49,7 +49,7 @@ class ProblemPage(PageObject):
         """
         def mathjax_present():
             """ Returns True if MathJax css is present in the problem body """
-            mathjax_container = self.q(css="div.problem p .MathJax .math")
+            mathjax_container = self.q(css="div.problem p .MathJax_CHTML")
             return mathjax_container.visible and mathjax_container.present
 
         self.wait_for(
@@ -63,7 +63,7 @@ class ProblemPage(PageObject):
         """
         def mathjax_present():
             """ Returns True if MathJax css is present in the problem body """
-            mathjax_container = self.q(css="div.problem div.problem-hint .MathJax .math")
+            mathjax_container = self.q(css="div.problem div.problem-hint .MathJax_CHTML")
             return mathjax_container.visible and mathjax_container.present
 
         self.wait_for(

--- a/common/test/acceptance/pages/lms/tab_nav.py
+++ b/common/test/acceptance/pages/lms/tab_nav.py
@@ -40,7 +40,7 @@ class TabNavPage(PageObject):
         """
         Check that MathJax has rendered in tab content
         """
-        mathjax_container = self.q(css=".static_tab_wrapper .MathJax .math")
+        mathjax_container = self.q(css=".static_tab_wrapper .MathJax_CHTML")
         EmptyPromise(
             lambda: mathjax_container.present and mathjax_container.visible,
             "MathJax is not visible"

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -49,7 +49,7 @@
             'jasmine.async': 'xmodule_js/common_static/js/vendor/jasmine.async',
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly.pkgd',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
-            'mathjax': '//cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&delayStartupUntil=configured', // jshint ignore:line
+            'mathjax': '//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured', // jshint ignore:line
             'youtube': '//www.youtube.com/player_api?noext',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',
             'coffee/src/instructor_dashboard/student_admin': 'coffee/src/instructor_dashboard/student_admin',


### PR DESCRIPTION
update mathjax class names to support common html, html-css, and svg

@nasthagiri , this is the mathjax update I was talking to you about — still needs a review on the original PR: https://github.com/edx/edx-platform/pull/11507

@cahrens and @cptvitamin , FYIs. One #11507 is reviewed, the plan is to try to merge this onto the RC so that this fix goes out with the release.

Thanks all!
