### PR TITLE
Use the Dogwood Open edX versions of the docs for online help.

### DIFF
--- a/docs/config.ini
+++ b/docs/config.ini
@@ -1,13 +1,13 @@
 # below are the server-wide settings for documentation
 [help_settings]
-url_base = http://edx.readthedocs.org/projects/edx-partner-course-staff
-version = latest
+url_base = http://edx.readthedocs.org/projects/open-edx-ca
+version = named-release/dogwood.rc
 
 
 # below are the pdf settings for the pdf file
 [pdf_settings]
-pdf_base = https://media.readthedocs.org/pdf/edx-partner-course-staff
-pdf_file = edx-partner-course-staff.pdf
+pdf_base = https://media.readthedocs.org/pdf/open-edx-ca
+pdf_file = open-edx-ca.pdf
 
 
 # below are the sub-paths to the documentation for the various pages


### PR DESCRIPTION
See
https://openedx.atlassian.net/wiki/display/DOC/Open+edX+Documentation+and+Versioning
for details
