### PR TITLE
Summarily disable migrations in the “test” env.

### DIFF
--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -188,9 +188,25 @@ DATABASES = {
 
 }
 
-# This hack disables migrations during tests. We want to create tables directly from the models for speed.
-# See https://groups.google.com/d/msg/django-developers/PWPj3etj3-U/kCl6pMsQYYoJ.
-MIGRATION_MODULES = {app: "app.migrations_not_used_in_tests" for app in INSTALLED_APPS}
+# Set this env variable to summarily disable all migrations, regardless of how
+# apps get installed/imported.  This speeds up local testing significantly.
+if os.getenv('DISABLE_MIGRATIONS'):
+
+    class DisableMigrations(object):  # pylint: disable=missing-docstring
+
+        def __contains__(self, item):
+            return True
+
+        def __getitem__(self, item):
+            return "notmigrations"
+
+    MIGRATION_MODULES = DisableMigrations()
+else:
+    # By default, fall back to an earlier optimization which disables *some*
+    # migrations, but not all.  A number of tests are written against this
+    # optimization and require that migrations have been skipped in order
+    # to pass.
+    MIGRATION_MODULES = {app: "app.migrations_not_used_in_tests" for app in INSTALLED_APPS}
 
 CACHES = {
     # This is the cache used for most things.


### PR DESCRIPTION
This is a terser alternative to #11060 which I have been using locally for a while with success.

To use it, one simply must set 'DISABLE_MIGRATIONS' in the env where test commands are executed, e.g.: 

```
DISABLE_MIGRATIONS=1 paver test_system -s ... #etc
```

@rlucioni @douglashall @nedbat @benpatterson @symbolist  thoughts?
