### PR TITLE
ECOM-3706: Restricted the enrollment in credit modes directly

### DIFF
--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -522,9 +522,9 @@ class PayAndVerifyView(View):
             if mode.min_price > 0 and not CourseMode.is_credit_mode(mode):
                 return mode
 
-        # Otherwise, find the first expired mode
+        # Otherwise, find the first non credit expired paid mode
         for mode in all_modes[course_key]:
-            if mode.min_price > 0:
+            if mode.min_price > 0 and not CourseMode.is_credit_mode(mode):
                 return mode
 
         # Otherwise, return None and so the view knows to respond with a 404.


### PR DESCRIPTION
Verify Now button on the dashboard is redirecting the user back to dashboard for credit courses. 
Updated the condition to exclude the credit mode from upgrading directly to this mode. 
