### PR TITLE
Allow multiple instances of ccx

### DIFF
--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -203,7 +203,7 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
             '<form action=".+create_ccx"',
             response.content))
 
-    def test_create_ccx(self):
+    def test_create_ccx(self, ccx_name='New CCX'):
         """
         Create CCX. Follow redirect to coach dashboard, confirm we see
         the coach dashboard for the new CCX.
@@ -214,7 +214,7 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
             'create_ccx',
             kwargs={'course_id': unicode(self.course.id)})
 
-        response = self.client.post(url, {'name': 'New CCX'})
+        response = self.client.post(url, {'name': ccx_name})
         self.assertEqual(response.status_code, 302)
         url = response.get('location')  # pylint: disable=no-member
         response = self.client.get(url)
@@ -251,6 +251,10 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
             list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
             self.assertEqual(len(list_instructor_ccx_course), len(list_instructor_master_course))
             self.assertEqual(list_instructor_ccx_course[0].email, list_instructor_master_course[0].email)
+
+    @ddt.data("CCX demo 1", "CCX demo 2", "CCX demo 3")
+    def test_create_multiple_ccx(self, ccx_name):
+        self.test_create_ccx(ccx_name)
 
     def test_get_date(self):
         """

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -128,6 +128,30 @@ def get_ccx_for_coach(course, coach):
     return None
 
 
+def get_ccx_by_ccx_id(course, coach, ccx_id):
+    """
+    Finds a CCX of given coach on given master course.
+
+    Arguments:
+        course (CourseDescriptor): Master course
+        coach (User): Coach to ccx
+        ccx_id (long): Id of ccx
+
+    Returns:
+     ccx (CustomCourseForEdX): Instance of CCX.
+    """
+    try:
+        ccx = CustomCourseForEdX.objects.get(
+            id=ccx_id,
+            course_id=course.id,
+            coach=coach
+        )
+    except CustomCourseForEdX.DoesNotExist:
+        return None
+
+    return ccx
+
+
 def get_valid_student_email(identifier):
     """
     Helper function to get an user email from an identifier and validate it.

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -57,6 +57,7 @@ from lms.djangoapps.ccx.utils import (
     ccx_course,
     ccx_students_enrolling_center,
     get_ccx_for_coach,
+    get_ccx_by_ccx_id,
     get_date,
     parse_date,
     prep_course_for_grading,
@@ -94,8 +95,8 @@ def coach_dashboard(view):
 
         # if there is a ccx, we must validate that it is the ccx for this coach
         if ccx is not None:
-            coach_ccx = get_ccx_for_coach(course, request.user)
-            if coach_ccx is None or coach_ccx.id != ccx.id:
+            coach_ccx = get_ccx_by_ccx_id(course, request.user, ccx.id)
+            if coach_ccx is None:
                 return HttpResponseForbidden(
                     _('You must be the coach for this ccx to access this view')
                 )


### PR DESCRIPTION
### Background

This work fixes mitocw#175
Fixes bug where coach with multiple CCXs can't view coach dashboard.

**LMS Updates:** 
- Now a coach can have multiple instance of ccx on same master course.

@pdpinch @giocalitri @justinabrahms  @pwilkins 
