### PR TITLE
Remove course about 'Overview' link/tab.

### DIFF
--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -260,41 +260,6 @@
         }
       }
     }
-
-    nav {
-      border-bottom: 1px solid $border-color-2;
-      @include box-sizing(border-box);
-      @include clearfix();
-      margin: 40px 0;
-      width: flex-grid(12);
-
-      &::after {
-        @extend %faded-hr-divider;
-        content: "";
-        display: none;
-      }
-
-      a {
-        border-bottom: 3px solid transparent;
-        color: $lighter-base-font-color;
-        display: inline-block;
-        letter-spacing: 1px;
-        margin: 0 15px;
-        padding: 0px 5px 15px;
-        text-align: center;
-        text-transform: lowercase;
-
-        &:first-child {
-          margin-left: 0px;
-        }
-
-        &:hover, &:active, &:focus {
-          border-color: $border-color-2;
-          color: $base-font-color;
-          text-decoration: none;
-        }
-      }
-    }
   }
 
   .details {

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -193,15 +193,6 @@ from openedx.core.lib.courses import course_image_url
         </div>
       % endif
 
-      <nav aria-label="${_('Course About')}">
-        <a href="#" class="active">${_("Overview")}</a>
-      ##  <a href="#">${_("FAQ")}</a>
-      ##  <a href="#">${_("Requirements")}</a>
-      ##  <a href="#">${_("Text-book")}</a>
-      ##  <a href="#">${_("Syllabus")}</a>
-      ##  <a href="#">${_("Reviews")}</a>
-      </nav>
-
       <div class="inner-wrapper">
         ${get_course_about_section(request, course, "overview")}
       </div>


### PR DESCRIPTION
It looks like in the past there used to be several tabs on the course about page, but the other tabs have been commented out years ago. Having a single tab is pointless and confusing, so this PR removes it.

![screen shot 2016-02-15 at 08 38 14](https://cloud.githubusercontent.com/assets/32585/13042470/b8100af2-d3c0-11e5-941a-6c1dd4619752.png)

This PR removes the single tab:

![screen shot 2016-02-15 at 08 41 04](https://cloud.githubusercontent.com/assets/32585/13042493/c95bca9e-d3c0-11e5-9499-f2551f75f802.png)

**Partner information**: 3rd party-hosted open edX instance
**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1146
**LMS Sandbox**: http://pr11547.sandbox.opencraft.com/
**Studio Sandbox**: http://studio.pr11547.sandbox.opencraft.com/
