### PR TITLE
Switch to SharedModuleStoreTestCase in the 'contentstore' app where possible.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -750,11 +750,6 @@ class TestTaskExecution(SharedModuleStoreTestCase):
             publish_item=False,
         )
 
-    def setUp(self):
-        super(TestTaskExecution, self).setUp()
-        SignalHandler.course_published.disconnect(listen_for_course_publish)
-        SignalHandler.library_updated.disconnect(listen_for_library_update)
-
     def test_task_indexing_course(self):
         """ Making sure that the receiver correctly fires off the task when invoked by signal """
         searcher = SearchEngine.get_search_engine(CoursewareSearchIndexer.INDEX_NAME)

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -20,14 +20,12 @@ from xmodule.library_tools import normalize_key_for_search
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import SignalHandler, modulestore
 from xmodule.modulestore.edit_info import EditInfoMixin
-from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.modulestore.mixed import MixedModuleStore
 from xmodule.modulestore.tests.django_utils import (
-    ModuleStoreTestCase,
     TEST_DATA_MONGO_MODULESTORE,
-    TEST_DATA_SPLIT_MODULESTORE
-)
+    TEST_DATA_SPLIT_MODULESTORE,
+    SharedModuleStoreTestCase)
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
 from xmodule.modulestore.tests.utils import (
@@ -692,7 +690,7 @@ class TestLargeCourseDeletions(MixedWithOptionsTestCase):
         self._perform_test_using_store(store_type, self._test_large_course_deletion)
 
 
-class TestTaskExecution(ModuleStoreTestCase):
+class TestTaskExecution(SharedModuleStoreTestCase):
     """
     Set of tests to ensure that the task code will do the right thing when
     executed directly. The test course and library gets created without the listeners
@@ -700,56 +698,62 @@ class TestTaskExecution(ModuleStoreTestCase):
     executed, it is done as expected.
     """
 
-    def setUp(self):
-        super(TestTaskExecution, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super(TestTaskExecution, cls).setUpClass()
         SignalHandler.course_published.disconnect(listen_for_course_publish)
         SignalHandler.library_updated.disconnect(listen_for_library_update)
-        self.course = CourseFactory.create(start=datetime(2015, 3, 1, tzinfo=UTC))
+        cls.course = CourseFactory.create(start=datetime(2015, 3, 1, tzinfo=UTC))
 
-        self.chapter = ItemFactory.create(
-            parent_location=self.course.location,
+        cls.chapter = ItemFactory.create(
+            parent_location=cls.course.location,
             category='chapter',
             display_name="Week 1",
             publish_item=True,
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        self.sequential = ItemFactory.create(
-            parent_location=self.chapter.location,
+        cls.sequential = ItemFactory.create(
+            parent_location=cls.chapter.location,
             category='sequential',
             display_name="Lesson 1",
             publish_item=True,
             start=datetime(2015, 3, 1, tzinfo=UTC),
         )
-        self.vertical = ItemFactory.create(
-            parent_location=self.sequential.location,
+        cls.vertical = ItemFactory.create(
+            parent_location=cls.sequential.location,
             category='vertical',
             display_name='Subsection 1',
             publish_item=True,
             start=datetime(2015, 4, 1, tzinfo=UTC),
         )
         # unspecified start - should inherit from container
-        self.html_unit = ItemFactory.create(
-            parent_location=self.vertical.location,
+        cls.html_unit = ItemFactory.create(
+            parent_location=cls.vertical.location,
             category="html",
             display_name="Html Content",
             publish_item=False,
         )
 
-        self.library = LibraryFactory.create()
+        cls.library = LibraryFactory.create()
 
-        self.library_block1 = ItemFactory.create(
-            parent_location=self.library.location,
+        cls.library_block1 = ItemFactory.create(
+            parent_location=cls.library.location,
             category="html",
             display_name="Html Content",
             publish_item=False,
         )
 
-        self.library_block2 = ItemFactory.create(
-            parent_location=self.library.location,
+        cls.library_block2 = ItemFactory.create(
+            parent_location=cls.library.location,
             category="html",
             display_name="Html Content 2",
             publish_item=False,
         )
+
+    def setUp(self):
+        super(TestTaskExecution, self).setUp()
+        SignalHandler.course_published.disconnect(listen_for_course_publish)
+        SignalHandler.library_updated.disconnect(listen_for_library_update)
 
     def test_task_indexing_course(self):
         """ Making sure that the receiver correctly fires off the task when invoked by signal """

--- a/cms/djangoapps/contentstore/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/tests/test_gating.py
@@ -13,32 +13,32 @@ class TestHandleItemDeleted(ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Test case for handle_score_changed django signal handler
     """
-    def setUp(self):
+    def setUp(cls):
         """
         Initial data setup
         """
-        super(TestHandleItemDeleted, self).setUp()
+        super(TestHandleItemDeleted, cls).setUp()
 
-        self.course = CourseFactory.create()
-        self.course.enable_subsection_gating = True
-        self.course.save()
-        self.chapter = ItemFactory.create(
-            parent=self.course,
+        cls.course = CourseFactory.create()
+        cls.course.enable_subsection_gating = True
+        cls.course.save()
+        cls.chapter = ItemFactory.create(
+            parent=cls.course,
             category="chapter",
             display_name="Chapter"
         )
-        self.open_seq = ItemFactory.create(
-            parent=self.chapter,
+        cls.open_seq = ItemFactory.create(
+            parent=cls.chapter,
             category='sequential',
             display_name="Open Sequential"
         )
-        self.gated_seq = ItemFactory.create(
-            parent=self.chapter,
+        cls.gated_seq = ItemFactory.create(
+            parent=cls.chapter,
             category='sequential',
             display_name="Gated Sequential"
         )
-        gating_api.add_prerequisite(self.course.id, self.open_seq.location)
-        gating_api.set_required_content(self.course.id, self.gated_seq.location, self.open_seq.location, 100)
+        gating_api.add_prerequisite(cls.course.id, cls.open_seq.location)
+        gating_api.set_required_content(cls.course.id, cls.gated_seq.location, cls.open_seq.location, 100)
 
     @patch('contentstore.signals.gating_api.set_required_content')
     @patch('contentstore.signals.gating_api.remove_prerequisite')

--- a/cms/djangoapps/contentstore/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/tests/test_gating.py
@@ -13,32 +13,32 @@ class TestHandleItemDeleted(ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Test case for handle_score_changed django signal handler
     """
-    def setUp(cls):
+    def setUp(self):
         """
         Initial data setup
         """
-        super(TestHandleItemDeleted, cls).setUp()
+        super(TestHandleItemDeleted, self).setUp()
 
-        cls.course = CourseFactory.create()
-        cls.course.enable_subsection_gating = True
-        cls.course.save()
-        cls.chapter = ItemFactory.create(
-            parent=cls.course,
+        self.course = CourseFactory.create()
+        self.course.enable_subsection_gating = True
+        self.course.save()
+        self.chapter = ItemFactory.create(
+            parent=self.course,
             category="chapter",
             display_name="Chapter"
         )
-        cls.open_seq = ItemFactory.create(
-            parent=cls.chapter,
+        self.open_seq = ItemFactory.create(
+            parent=self.chapter,
             category='sequential',
             display_name="Open Sequential"
         )
-        cls.gated_seq = ItemFactory.create(
-            parent=cls.chapter,
+        self.gated_seq = ItemFactory.create(
+            parent=self.chapter,
             category='sequential',
             display_name="Gated Sequential"
         )
-        gating_api.add_prerequisite(cls.course.id, cls.open_seq.location)
-        gating_api.set_required_content(cls.course.id, cls.gated_seq.location, cls.open_seq.location, 100)
+        gating_api.add_prerequisite(self.course.id, self.open_seq.location)
+        gating_api.set_required_content(self.course.id, self.gated_seq.location, self.open_seq.location, 100)
 
     @patch('contentstore.signals.gating_api.set_required_content')
     @patch('contentstore.signals.gating_api.remove_prerequisite')

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -14,7 +14,7 @@ from nose.plugins.skip import SkipTest
 
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.contentstore.content import StaticContent
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.exceptions import NotFoundError
 from xmodule.contentstore.django import contentstore
 from xmodule.video_module import transcripts_utils
@@ -77,7 +77,7 @@ class TestGenerateSubs(unittest.TestCase):
 
 
 @override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
-class TestSaveSubsToStore(ModuleStoreTestCase):
+class TestSaveSubsToStore(SharedModuleStoreTestCase):
     """Tests for `save_subs_to_store` function."""
 
     org = 'MITx'
@@ -92,13 +92,13 @@ class TestSaveSubsToStore(ModuleStoreTestCase):
         except NotFoundError:
             pass
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        super(TestSaveSubsToStore, cls).setUpClass()
+        cls.course = CourseFactory.create(
+            org=cls.org, number=cls.number, display_name=cls.display_name)
 
-        super(TestSaveSubsToStore, self).setUp()
-        self.course = CourseFactory.create(
-            org=self.org, number=self.number, display_name=self.display_name)
-
-        self.subs = {
+        cls.subs = {
             'start': [100, 200, 240, 390, 1000],
             'end': [200, 240, 380, 1000, 1500],
             'text': [
@@ -110,18 +110,19 @@ class TestSaveSubsToStore(ModuleStoreTestCase):
             ]
         }
 
-        self.subs_id = str(uuid4())
-        filename = 'subs_{0}.srt.sjson'.format(self.subs_id)
-        self.content_location = StaticContent.compute_location(self.course.id, filename)
-        self.addCleanup(self.clear_subs_content)
+        cls.subs_id = str(uuid4())
+        filename = 'subs_{0}.srt.sjson'.format(cls.subs_id)
+        cls.content_location = StaticContent.compute_location(cls.course.id, filename)
 
         # incorrect subs
-        self.unjsonable_subs = set([1])  # set can't be serialized
+        cls.unjsonable_subs = {1}  # set can't be serialized
 
-        self.unjsonable_subs_id = str(uuid4())
-        filename_unjsonable = 'subs_{0}.srt.sjson'.format(self.unjsonable_subs_id)
-        self.content_location_unjsonable = StaticContent.compute_location(self.course.id, filename_unjsonable)
+        cls.unjsonable_subs_id = str(uuid4())
+        filename_unjsonable = 'subs_{0}.srt.sjson'.format(cls.unjsonable_subs_id)
+        cls.content_location_unjsonable = StaticContent.compute_location(cls.course.id, filename_unjsonable)
 
+    def setUp(self):
+        self.addCleanup(self.clear_subs_content)
         self.clear_subs_content()
 
     def test_save_subs_to_store(self):
@@ -154,7 +155,7 @@ class TestSaveSubsToStore(ModuleStoreTestCase):
 
 
 @override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
-class TestDownloadYoutubeSubs(ModuleStoreTestCase):
+class TestDownloadYoutubeSubs(SharedModuleStoreTestCase):
     """Tests for `download_youtube_subs` function."""
 
     org = 'MITx'
@@ -182,10 +183,11 @@ class TestDownloadYoutubeSubs(ModuleStoreTestCase):
         for subs_id in youtube_subs.values():
             self.clear_sub_content(subs_id)
 
-    def setUp(self):
-        super(TestDownloadYoutubeSubs, self).setUp()
-        self.course = CourseFactory.create(
-            org=self.org, number=self.number, display_name=self.display_name)
+    @classmethod
+    def setUpClass(cls):
+        super(TestDownloadYoutubeSubs, cls).setUpClass()
+        cls.course = CourseFactory.create(
+            org=cls.org, number=cls.number, display_name=cls.display_name)
 
     def test_success_downloading_subs(self):
 

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -122,6 +122,7 @@ class TestSaveSubsToStore(SharedModuleStoreTestCase):
         cls.content_location_unjsonable = StaticContent.compute_location(cls.course.id, filename_unjsonable)
 
     def setUp(self):
+        super(TestSaveSubsToStore, self).setUp()
         self.addCleanup(self.clear_subs_content)
         self.clear_subs_content()
 

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.modulestore.django import modulestore
 from xmodule.partitions.partitions import UserPartition, Group
@@ -110,16 +110,17 @@ class ExtraPanelTabTestCase(TestCase):
         return course
 
 
-class XBlockVisibilityTestCase(ModuleStoreTestCase):
+class XBlockVisibilityTestCase(SharedModuleStoreTestCase):
     """Tests for xblock visibility for students."""
 
-    def setUp(self):
-        super(XBlockVisibilityTestCase, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super(XBlockVisibilityTestCase, cls).setUpClass()
 
-        self.dummy_user = ModuleStoreEnum.UserID.test
-        self.past = datetime(1970, 1, 1, tzinfo=UTC)
-        self.future = datetime.now(UTC) + timedelta(days=1)
-        self.course = CourseFactory.create()
+        cls.dummy_user = ModuleStoreEnum.UserID.test
+        cls.past = datetime(1970, 1, 1, tzinfo=UTC)
+        cls.future = datetime.now(UTC) + timedelta(days=1)
+        cls.course = CourseFactory.create()
 
     def test_private_unreleased_xblock(self):
         """Verifies that a private unreleased xblock is not visible"""
@@ -484,18 +485,18 @@ class GetUserPartitionInfoTest(ModuleStoreTestCase):
         expected = [
             {
                 "id": 0,
-                "name": "Cohort user partition",
-                "scheme": "cohort",
+                "name": u"Cohort user partition",
+                "scheme": u"cohort",
                 "groups": [
                     {
                         "id": 0,
-                        "name": "Group A",
+                        "name": u"Group A",
                         "selected": False,
                         "deleted": False,
                     },
                     {
                         "id": 1,
-                        "name": "Group B",
+                        "name": u"Group B",
                         "selected": False,
                         "deleted": False,
                     },
@@ -503,12 +504,12 @@ class GetUserPartitionInfoTest(ModuleStoreTestCase):
             },
             {
                 "id": 1,
-                "name": "Random user partition",
-                "scheme": "random",
+                "name": u"Random user partition",
+                "scheme": u"random",
                 "groups": [
                     {
                         "id": 0,
-                        "name": "Group C",
+                        "name": u"Group C",
                         "selected": False,
                         "deleted": False,
                     },


### PR DESCRIPTION
This is switching from ModuleStoreTestCase, to SharedModuleStoreTestCase, where possible. This is only for the 'contentstore' Django application. This helps speed up some tests where there's a lot of write-once-read-many for modulestore-based data.
