### PR TITLE
Bump edx-organizations version to 0.4.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -34,10 +34,11 @@ django-method-override==0.1.0
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
 django==1.8.9
 djangorestframework-jwt==1.7.2
+djangorestframework-oauth==1.1.0
 edx-django-oauth2-provider==0.5.0
 edx-oauth2-provider==0.5.9
 edx-opaque-keys==0.2.1
-edx-organizations==0.3.1
+edx-organizations==0.4.0
 edx-rest-api-client==1.2.1
 edx-search==0.1.2
 facebook-sdk==0.4.0

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -47,7 +47,6 @@
 -e git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline
 git+https://github.com/edx/django-wiki.git@v0.0.5#egg=django-wiki==0.0.5
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
--e git+https://github.com/edx/django-rest-framework-oauth.git@f0b503fda8c254a38f97fef802ded4f5fe367f7a#egg=djangorestframework-oauth==1.0.1
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev


### PR DESCRIPTION
Also install djangorestframework-oauth from PyPI. Requires https://github.com/edx/edx-organizations/pull/25.

@jimabramson or @clintonb please review.
