### PR TITLE
Mathjax doesn't render inline inside choicehints (TNL-3252)

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -148,6 +148,14 @@ div.problem {
       margin-top: $baseline;
     }
   }
+
+  .MathJax_Preview {
+    display: inline-block;
+  }
+
+  .MathJax, .MathJax_CHTML, .MathJax_PHTML, .MathJax_MathML, .MathJax_SVG, .MathJax_PlainSource {
+    display: inline;
+  }
 }
 
 // +Problem - Choice Group


### PR DESCRIPTION
[TNL-3252](https://openedx.atlassian.net/browse/TNL-3252)

CSS fix to display mathjax expressions inline inside problems.

**Before fix**
![screen shot 2015-09-09 at 12 35 14 pm](https://cloud.githubusercontent.com/assets/3198290/13109087/041af2ac-d599-11e5-8f87-264e25f9018b.png)

**After fix**
![capture image](https://cloud.githubusercontent.com/assets/3198290/13109252/fb71d6f6-d599-11e5-8005-51d7e1affcdb.jpg)

@cptvitamin @marcotuts @mushtaqak please review.
