### PR TITLE
Fix styling of vote button in forums responses. 

### DIFF
--- a/lms/static/sass/discussion/elements/_actions.scss
+++ b/lms/static/sass/discussion/elements/_actions.scss
@@ -160,7 +160,7 @@
     }
 
     &.action-vote {
-
+       display: inline-block !important;
       .action-label {
         opacity: 1;
       }


### PR DESCRIPTION
### Problem:

Styling on forums response vote button is inconsistent with main comment.
See 
![onfadeoutbug](https://cloud.githubusercontent.com/assets/7627421/13219638/2f7a9f76-d993-11e5-9aa8-d3515931f84b.png)![onhoverbug](https://cloud.githubusercontent.com/assets/7627421/13219671/58c15c94-d993-11e5-8b0a-e578bd8d6e01.png)
### Fix:

Just applying the class `display = ‘inline-block’` to the vote button.
See
![onfadeoutfix](https://cloud.githubusercontent.com/assets/7627421/13220617/ef2b109e-d998-11e5-985d-f2b0a2b953ae.png)![onhoverfix](https://cloud.githubusercontent.com/assets/7627421/13243015/966e1f08-da1c-11e5-9adf-905f2630476e.png)
### Reason

Inline css `display = "inline"` is added in upvote button on a response comment when the page is rendered. Root comment of this discussion thread has the property `display = ‘inline-block’` whereas response comments don’t have. i have just applied it  `display: inline-block !important;` to upvote button on a response comment.

[TNL-3964](https://openedx.atlassian.net/browse/TNL-3964)
