### PR TITLE
Add Django's --keepdb flag to paver

### DIFF
--- a/cms/envs/test_keepdb.py
+++ b/cms/envs/test_keepdb.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""
+This config file runs the simplest dev environment using sqlite, and db-based
+sessions which will be stored on disk. Assumes structure:
+
+/envroot/
+        /db   # This is where it'll write the database file
+        /edx-platform  # The location of this repo
+        /log  # Where we're going to write log files
+"""
+
+from .test import *  # pylint: disable=wildcard-import
+from .aws import *  # pylint: disable=wildcard-import
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'edx.db',
+        'TEST_NAME': TEST_ROOT / 'db' / 'edx.db',
+        'ATOMIC_REQUESTS': True,
+    },
+    'student_module_history': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'student_module_history.db',
+        'TEST_NAME': TEST_ROOT / 'db' / 'student_module_history.db'
+    },
+}

--- a/docs/en_us/internal/testing.rst
+++ b/docs/en_us/internal/testing.rst
@@ -173,6 +173,15 @@ To run cms python tests without ``collectstatic`` use this command.
 
     paver test_system -s cms --fasttest
 
+To run unit tests but retain your database between test runs (which is nice performance boost
+when iterating on a single test) use this command.  Your first test run will run at the normal
+speed since the database needs to be created, but any future ``--keepdb`` runs will use the
+cached database and run significantly faster.
+
+::
+
+    paver test_system -s lms --keepdb
+
 To run a single django test class use this command.
 
 ::

--- a/lms/envs/test_keepdb.py
+++ b/lms/envs/test_keepdb.py
@@ -16,12 +16,12 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': 'edx.db',
-        'TEST_NAME': TEST_ROOT / 'db' / 'edx.db',
+        'TEST_NAME': '/dev/shm/edx.db',
         'ATOMIC_REQUESTS': True,
     },
     'student_module_history': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'student_module_history.db',
-        'TEST_NAME': TEST_ROOT / 'db' / 'student_module_history.db'
+        'NAME': TEST_ROOT / 'db' / 'student_module_history.db',
+        'TEST_NAME': '/dev/shm/student_module_history.db'
     },
 }

--- a/lms/envs/test_keepdb.py
+++ b/lms/envs/test_keepdb.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""
+This config file runs the simplest dev environment using sqlite, and db-based
+sessions which will be stored on disk. Assumes structure:
+
+/envroot/
+        /db   # This is where it'll write the database file
+        /edx-platform  # The location of this repo
+        /log  # Where we're going to write log files
+"""
+
+from .test import *  # pylint: disable=wildcard-import
+from .aws import *  # pylint: disable=wildcard-import
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'edx.db',
+        'TEST_NAME': TEST_ROOT / 'db' / 'edx.db',
+        'ATOMIC_REQUESTS': True,
+    },
+    'student_module_history': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'student_module_history.db',
+        'TEST_NAME': TEST_ROOT / 'db' / 'student_module_history.db'
+    },
+}

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -35,6 +35,11 @@ __test__ = False  # do not collect
     make_option("-v", "--verbosity", action="count", dest="verbosity", default=1),
     make_option("--pdb", action="store_true", help="Drop into debugger on failures or errors"),
     make_option(
+        "--keepdb",
+        action="store_true",
+        help="Keep your sqlite database around to save time during initial setup on subsequent runs"
+    ),
+    make_option(
         '--disable-migrations',
         action='store_true',
         dest='disable_migrations',
@@ -56,6 +61,7 @@ def test_system(options):
         'extra_args': getattr(options, 'extra_args', ''),
         'cov_args': getattr(options, 'cov_args', ''),
         'skip_clean': getattr(options, 'skip_clean', False),
+        'keepdb': getattr(options, 'keepdb', False),
         'pdb': getattr(options, 'pdb', False),
         'disable_migrations': getattr(options, 'disable_migrations', False),
     }

--- a/pavelib/utils/test/suites/nose_suite.py
+++ b/pavelib/utils/test/suites/nose_suite.py
@@ -101,6 +101,9 @@ class NoseTestSuite(TestSuite):
         if self.pdb:
             opts += " --pdb"
 
+        if self.keepdb:
+            opts += " --keepdb"
+
         return opts
 
 
@@ -120,13 +123,14 @@ class SystemTestSuite(NoseTestSuite):
     def cmd(self):
         cmd = (
             './manage.py {system} test --verbosity={verbosity} '
-            '{test_id} {test_opts} --settings=test {extra} '
+            '{test_id} {test_opts} --settings={settings} {extra} '
             '--with-xunit --xunit-file={xunit_report}'.format(
                 system=self.root,
                 verbosity=self.verbosity,
                 test_id=self.test_id,
                 test_opts=self.test_options_flags,
                 extra=self.extra_args,
+                settings="test_keepdb" if self.keepdb else "test",
                 xunit_report=self.report_dir / "nosetests.xml",
             )
         )

--- a/pavelib/utils/test/suites/suite.py
+++ b/pavelib/utils/test/suites/suite.py
@@ -26,6 +26,7 @@ class TestSuite(object):
         self.verbosity = kwargs.get('verbosity', 1)
         self.skip_clean = kwargs.get('skip_clean', False)
         self.pdb = kwargs.get('pdb', False)
+        self.keepdb = kwargs.get('keepdb', False)
 
     def __enter__(self):
         """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -141,7 +141,7 @@ coverage==4.0.2
 ddt==0.8.0
 diff-cover==0.9.0
 django-crum==0.5
-django_nose==1.4.1
+django_nose==1.4.3
 factory_boy==2.5.1
 flaky==2.4.0
 freezegun==0.1.11


### PR DESCRIPTION
This requires a django-nose upgrade to allow it to pass through cleanly
to django's manage.py.

This makes your first paver test_system just as slow as normal, but
dramatically speeds up future test runs.

Rather than forcing every unit test run to keep the database, this shims
in a new settings file when invoked.

django-nose changelog https://pypi.python.org/pypi/django-nose (1.4.1 -> 1.4.3)

End result is that for many unit tests, you run paver test_system -t this.is.my.tests --keepdb, sit through the database setup and migration for 30-45s and then when you run it a second time with --keepdb it takes 7-10 seconds instead.

Compatible with --disable-migrations which is also a recent addition.
