### PR TITLE
removes alt attribute value

### DIFF
--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -82,7 +82,7 @@ site_status_msg = get_site_status_msg(course_id)
           username = user.username
           profile_image_url = get_profile_image_urls_for_user(user)['medium']
           %>
-          <img class="user-image-frame" src="${profile_image_url}" alt="${_('Profile image for {username}').format(username=username)}">
+          <img class="user-image-frame" src="${profile_image_url}" alt="">
           <div class="label-username">${username}</div>
         </a>
       </li>


### PR DESCRIPTION
Fixes the issue outlined in AC-232 where the alt attribute value for the new avatar image was adding unnecessary, confusing, and overly verbose output for screen reader users.

https://openedx.atlassian.net/browse/AC-332

@clrux @clytwynec can you give a quick thumbs on this?
