### PR TITLE
restoring @jolyonb's 'Fixing spacing in tooltip'

### DIFF
--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -25,7 +25,7 @@
            tabindex="0">
             <i class="icon fa seq_${item['type']}" aria-hidden="true"></i>
             <i class="fa fa-fw fa-bookmark bookmark-icon ${"is-hidden" if not item['bookmarked'] else "bookmarked"}" aria-hidden="true"></i>
-            <p><span class="sr">${item['type']}</span> ${item['title']}<span class="sr bookmark-icon-sr">&nbsp;${_("Bookmarked") if item['bookmarked'] else ""}</span></p>
+            <p><span class="sr">${item['type']}</span>${item['title']}<span class="sr bookmark-icon-sr">&nbsp;${_("Bookmarked") if item['bookmarked'] else ""}</span></p>
           </a>
         </li>
         % endfor


### PR DESCRIPTION
@jolyonb removed a space in 3015c4a but it came back in 3cbbb8f
