### PR TITLE
Fixed the other half of forgot password flow accourding to logistration.

### DIFF
--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -100,7 +100,7 @@ class StudentAccountUpdateTest(UrlResetMixin, TestCase):
             follow=True
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Your password has been set.")
+        self.assertContains(response, "Your password has been reset.")
 
         # Log the user out to clear session data
         self.client.logout()
@@ -116,7 +116,7 @@ class StudentAccountUpdateTest(UrlResetMixin, TestCase):
             follow=True
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "The password reset link was invalid, possibly because the link has already been used.")
+        self.assertContains(response, "This password reset link is invalid. It may have been used already.")
 
         self.client.logout()
 

--- a/lms/static/js/student_account/password_reset.js
+++ b/lms/static/js/student_account/password_reset.js
@@ -1,0 +1,15 @@
+/**
+ * Password reset template JS.
+ */
+$(function() {
+    'use strict';
+    // adding js class for styling with accessibility in mind
+    $("body").addClass("js");
+
+    // form field label styling on focus
+    $("form :input").focus(function() {
+        $("label[for='" + this.id + "']").parent().addClass("is-focused");
+    }).blur(function() {
+        $("label").parent().removeClass("is-focused");
+    });
+});

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -10,8 +10,6 @@
 
   {% stylesheet 'style-vendor' %}
   {% stylesheet 'style-main' %}
-  {% stylesheet 'style-course-vendor' %}
-  {% stylesheet 'style-course' %}
 
   {% block main_vendor_js %}
   {% javascript 'main_vendor' %}

--- a/lms/templates/registration/password_reset_complete.html
+++ b/lms/templates/registration/password_reset_complete.html
@@ -6,49 +6,30 @@
 {% endblock %}
 
 {% block bodyextra %}
-  <script type="text/javascript">
-    $(function() {
-
-      // adding js class for styling with accessibility in mind
-      $('body').addClass('js');
-
-      // new window/tab opening
-      $('a[rel="external"], a[class="new-vp"]')
-      .click( function() {
-      window.open( $(this).attr('href') );
-      return false;
-      });
-
-      // form field label styling on focus
-      $("form :input").focus(function() {
-        $("label[for='" + this.id + "']").parent().addClass("is-focused");
-      }).blur(function() {
-        $("label").parent().removeClass("is-focused");
-      });
-    });
-  </script>
+    <script type="text/javascript">
+        $(function() {
+            'use strict';
+            // adding js class for styling with accessibility in mind
+            $('body').addClass('js');
+        });
+    </script>
 {% endblock %}
 
 {% block bodyclass %}view-passwordreset{% endblock %}
 
 {% block body %}
-  <section class="introduction">
-    <header>
-      <h1 class="title">
-        <span class="title-super">
-          {% trans "Your Password Reset is Complete" %}
-        </span>
-      </h1>
-    </header>
-  </section>
-
-  <section class="passwordreset container">
-    {% block content %}
-    <section role="main" class="content">
-      {% blocktrans with link_start='<a href="/login">' link_end='</a>' %}
-      Your password has been set.  You may go ahead and {{ link_start }}log in{{ link_end }} now.
-      {% endblocktrans %}
+<div id="password-reset-complete-container" class="login-register">
+    <section id="password-reset-complete-anchor" class="form-type">
+        <div id="password-reset-complete" class="form-wrapper" aria-hidden="true">
+            <div class="status submission-success" aria-live="polite">
+                <h4 class="message-title">{% trans "Password Reset Complete" %}</h4>
+                <ul class="message-copy">
+                {% blocktrans with link_start='<a href="/login">' link_end='</a>' %}
+                    Your password has been reset. {{ link_start }}Sign in to your account.{{ link_end }}
+                {% endblocktrans %}
+                </ul>
+            </div>
+        </div>
     </section>
-    {% endblock %}
-  </section>
+</div>
 {% endblock %}

--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -3,148 +3,70 @@
 
 {% block title %}
 <title>
-  {% blocktrans with platform_name=platform_name %}
-      Reset Your {{ platform_name }} Password
-  {% endblocktrans %}
+{% blocktrans with platform_name=platform_name %}
+    Reset Your {{ platform_name }} Password
+{% endblocktrans %}
 </title>
 {% endblock %}
 
 {% block bodyextra %}
-  <script type="text/javascript">
-    $(function() {
-
-      // adding js class for styling with accessibility in mind
-      $('body').addClass('js');
-
-      // new window/tab opening
-      $('a[rel="external"], a[class="new-vp"]')
-      .click( function() {
-      window.open( $(this).attr('href') );
-      return false;
-      });
-
-      // form field label styling on focus
-      $("form :input").focus(function() {
-        $("label[for='" + this.id + "']").parent().addClass("is-focused");
-      }).blur(function() {
-        $("label").parent().removeClass("is-focused");
-      });
-    });
-  </script>
+<script type="text/javascript" src="{{STATIC_URL}}js/student_account/password_reset.js"></script>
 {% endblock %}
 
 {% block bodyclass %}view-passwordreset{% endblock %}
 
 {% block body %}
-  <section class="introduction">
-    <header>
-      <h1 class="title">
-        <span class="title-super">
-          {% blocktrans with platform_name=platform_name %}
-          Reset Your {{ platform_name }} Password
-          {% endblocktrans %}
-        </span>
-      </h1>
-    </header>
-  </section>
+<div id="password-reset-confirm-container" class="login-register">
+    <section id="password-reset-confirm-anchor" class="form-type">
+        <div id="password-reset-confirm-form" class="form-wrapper" aria-hidden="true">
+            <div class="status submission-error {% if not err_msg %} hidden {% endif %}" aria-live="polite">
+                <h4 class="message-title">{% trans "Error Resetting Password" %}</h4>
+                <ul class="message-copy">
+                {% if err_msg %}
+                    <li>{{err_msg}}</li>
+                {% else %}
+                    <li>{% trans "You must enter and confirm your new password." %}</li>
+                    <li>{% trans "The text in both password fields must match." %}</li>
+                {% endif %}
+                </ul>
+            </div>
+            {% if validlink %}
 
-  <section class="passwordreset container">
-    <section role="main" class="content">
-      {% if validlink %}
-      <header>
-      <h2 class="sr">{% trans "Password Reset Form" %}</h2>
-      </header>
+            <form role="form" id="passwordreset-form" method="post" action="">{% csrf_token %}
+                <div class="section-title lines">
+                    <h2>
+                        <span class="text">
+                        {% trans "Reset Your Password" %}
+                        </span>
+                    </h2>
+                </div>
 
-      <form role="form" id="passwordreset-form" method="post" action="">{% csrf_token %}
-        <!-- status messages -->
-        <div role="alert" class="status message">
-          <h3 class="message-title">
-            {% blocktrans %}
-                We're sorry, but this version of your browser is not supported. Try again using a different browser or a newer version of your browser.
-            {% endblocktrans %}
-          </h3>
-        </div>
+                <p class="action-label">
+                    {% trans "Enter and confirm your new password." %}
+                </p>
 
-        {% if err_msg %}
-        <div role="alert" class="status message submission-error" style="display: block;">
-        {% else %}
-        <div role="alert" class="status message submission-error" style="display: none;">
-        {% endif %}
-          <h3 class="message-title">{% trans "The following errors occurred while processing your registration: " %}</h3>
-          <ul class="message-copy">
-            {% if err_msg %}
-              <li>{{err_msg}}</li>
+                <div class="form-field new_password1-new_password1">
+                    <label for="new_password1">{% trans "New Password" %}</label>
+                    <input id="new_password1" type="password" name="new_password1" placeholder="*****" />
+                </div>
+                <div class="form-field new_password2-new_password2">
+                    <label for="new_password2">{% trans "Confirm Password" %}</label>
+                    <input id="new_password2" type="password" name="new_password2" placeholder="*****" />
+                </div>
+
+                <button type="submit" class="action action-primary action-update js-reset">{% trans "Reset My Password" %}</button>
+            </form>
             {% else %}
-              <li>{% trans "You must complete all fields." %}</li>
-              <li>{% trans "The two password fields didn't match." %}</li>
+            <div class="status submission-error" aria-live="polite">
+                <h4 class="message-title">{% trans "Invalid Password Reset Link" %}</h4>
+                <ul class="message-copy">
+                {% blocktrans with start_link='<a href="/login">' end_link='</a>' %}
+                    This password reset link is invalid. It may have been used already. To reset your password, go to the {{ start_link }}sign-in{{ end_link }} page and select <strong>Forgot password</strong>.
+                {% endblocktrans %}
+                </ul>
+            </div>
             {% endif %}
-          </ul>
         </div>
-
-        <div role="alert" class="status message system-error">
-          <h3 class="message-title">{% trans "We're sorry, our systems seem to be having trouble processing your password reset" %}</h3>
-          <p class="message-copy">
-            {% blocktrans with start_link='<a href="{{MKTG_URL_CONTACT}}">' end_link='</a>' %}
-                Someone has been made aware of this issue. Please try again shortly. Please {{ start_link }}contact us{{ end_link }} about any concerns you have.
-            {% endblocktrans %}
-          </p>
-        </div>
-
-        <p class="instructions">
-        {% trans 'Please enter your new password twice so we can verify you typed it in correctly.' %}
-        <br />
-        {% blocktrans with bold_start='<strong class="indicator">' bold_end='</strong>' %}
-        Required fields are noted by {{bold_start}}bold text and an asterisk (*){{bold_end}}.
-        {% endblocktrans %}
-        </p>
-
-        <fieldset class="group group-form group-form-requiredinformation">
-          <legend class="sr">{% trans "Required Information" %}</legend>
-
-          <ol class="list-input">
-            <li class="field required password" id="field-new_password1">
-              <label for="new_password1">{% trans "Your New Password" %}</label>
-              <input id="new_password1" type="password" name="new_password1" placeholder="*****" />
-            </li>
-            <li class="field required password" id="field-new_password2">
-              <label for="new_password2">{% trans "Your New Password Again" %}</label>
-              <input id="new_password2" type="password" name="new_password2" placeholder="*****" />
-            </li>
-          </ol>
-        </fieldset>
-
-        <div class="form-actions">
-          <button name="submit" type="submit" id="submit" class="action action-primary action-update">{% trans "Change My Password" %}</button>
-        </div>
-      </form>
-
-      {% else %}
-
-      <header>
-        <h2 class="sr">{% trans "Your Password Reset Was Unsuccessful" %}</h2>
-      </header>
-      <p>
-        {% blocktrans with start_link='<a href="/login">' end_link='</a>' %}
-            The password reset link was invalid, possibly because the link has already been used.  Please return to the {{ start_link }}login page{{ end_link }} and start the password reset process again.
-        {% endblocktrans %}
-      </p>
-
-      {% endif %}
     </section>
-
-    <aside role="complementary">
-      <header>
-      <h3 class="sr">{% trans "Password Reset Help" %}</h3>
-      </header>
-
-      <div class="cta cta-help">
-        <h3>{% trans "Need Help?" %}</h3>
-        <p>
-          {% blocktrans with start_link='<a href="{{MKTG_URL_FAQ}}">' end_link='</a>' %}
-              View our {{ start_link }}help section for contact information and answers to commonly asked questions{{ end_link }}
-          {% endblocktrans %}
-        </p>
-      </div>
-    </aside>
-  </section>
+</div>
 {% endblock %}


### PR DESCRIPTION
[ECOM-2947](https://openedx.atlassian.net/browse/ECOM-2947)

Currently, logistration only supports the first half of the process (sending the password reset email).
Now it supports both halves (sending the password reset email and the actual resetting of the password).
# Old password reset confirm:

<img width="763" alt="screen shot 2016-02-18 at 3 33 48 pm" src="https://cloud.githubusercontent.com/assets/2851134/13140678/4b01666c-d655-11e5-9b79-c8188c08df9a.png">
# New password reset confirm:

<img width="781" alt="screen shot 2016-02-18 at 3 23 38 pm" src="https://cloud.githubusercontent.com/assets/2851134/13140706/71f30f3c-d655-11e5-9e80-bb5f306fee3b.png">
# Old password reset complete:

<img width="755" alt="screen shot 2016-02-18 at 3 34 56 pm" src="https://cloud.githubusercontent.com/assets/2851134/13140731/91dad67c-d655-11e5-9d7f-238cf69b57ad.png">
# New password reset complete:

<img width="758" alt="screen shot 2016-02-18 at 3 23 52 pm" src="https://cloud.githubusercontent.com/assets/2851134/13140744/a41b7c4c-d655-11e5-808a-f5d56fcfac44.png">
# Old invalid link:

<img width="761" alt="screen shot 2016-02-18 at 3 34 28 pm" src="https://cloud.githubusercontent.com/assets/2851134/13140761/bc9a5edc-d655-11e5-96ef-c74bd86ac6e0.png">
# New invalid link:

<img width="752" alt="screen shot 2016-02-18 at 3 24 21 pm" src="https://cloud.githubusercontent.com/assets/2851134/13140774/c8f8310e-d655-11e5-9e0e-2515f11efe68.png">
