### PR TITLE
Remove all request.REQUEST usages.

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -61,7 +61,7 @@ def assets_handler(request, course_key_string=None, asset_key_string=None):
     if not has_course_author_access(request.user, course_key):
         raise PermissionDenied()
 
-    response_format = request.REQUEST.get('format', 'html')
+    response_format = request.GET.get('format') or request.POST.get('format') or 'html'
     if response_format == 'json' or 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
         if request.method == 'GET':
             return _assets_json(request, course_key)
@@ -97,10 +97,10 @@ def _assets_json(request, course_key):
 
     Supports start (0-based index into the list of assets) and max query parameters.
     """
-    requested_page = int(request.REQUEST.get('page', 0))
-    requested_page_size = int(request.REQUEST.get('page_size', 50))
-    requested_sort = request.REQUEST.get('sort', 'date_added')
-    requested_filter = request.REQUEST.get('asset_type', '')
+    requested_page = int(request.GET.get('page', 0))
+    requested_page_size = int(request.GET.get('page_size', 50))
+    requested_sort = request.GET.get('sort', 'date_added')
+    requested_filter = request.GET.get('asset_type', '')
     requested_file_types = settings.FILES_AND_UPLOAD_TYPE_FILTERS.get(
         requested_filter, None)
     filter_params = None
@@ -124,7 +124,7 @@ def _assets_json(request, course_key):
             }
 
     sort_direction = DESCENDING
-    if request.REQUEST.get('direction', '').lower() == 'asc':
+    if request.GET.get('direction', '').lower() == 'asc':
         sort_direction = ASCENDING
 
     # Convert the field name to the Mongo name

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -96,7 +96,7 @@ def container_handler(request, usage_key_string):
             component_templates = get_component_templates(course)
             ancestor_xblocks = []
             parent = get_parent_xblock(xblock)
-            action = request.REQUEST.get('action', 'view')
+            action = request.GET.get('action', 'view')
 
             is_unit_page = is_unit(xblock)
             unit = xblock if is_unit_page else None

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -165,7 +165,7 @@ def course_notifications_handler(request, course_key_string=None, action_state_i
     if not course_key_string or not action_state_id:
         return HttpResponseBadRequest()
 
-    response_format = request.REQUEST.get('format', 'html')
+    response_format = request.GET.get('format') or request.POST.get('format') or 'html'
 
     course_key = CourseKey.from_string(course_key_string)
 
@@ -251,7 +251,7 @@ def course_handler(request, course_key_string=None):
         json: delete this branch from this course (leaving off /branch/draft would imply delete the course)
     """
     try:
-        response_format = request.REQUEST.get('format', 'html')
+        response_format = request.GET.get('format') or request.POST.get('format') or 'html'
         if response_format == 'json' or 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
             if request.method == 'GET':
                 course_key = CourseKey.from_string(course_key_string)
@@ -591,7 +591,7 @@ def course_index(request, course_key):
             reindex_link = "/course/{course_id}/search_reindex".format(course_id=unicode(course_key))
         sections = course_module.get_children()
         course_structure = _course_outline_json(request, course_module)
-        locator_to_show = request.REQUEST.get('show', None)
+        locator_to_show = request.GET.get('show', None)
         course_release_date = get_default_time_display(course_module.start) if course_module.start != DEFAULT_START_DATE else _("Unscheduled")
         settings_url = reverse_course_url('settings_handler', course_key)
 

--- a/cms/djangoapps/contentstore/views/entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/entrance_exam.py
@@ -83,7 +83,7 @@ def entrance_exam(request, course_key_string):
 
     # Create a new entrance exam for the specified course (returns 201 if created)
     elif request.method == 'POST':
-        response_format = request.REQUEST.get('format', 'html')
+        response_format = request.POST.get('format', 'html')
         http_accept = request.META.get('http_accept')
         if response_format == 'json' or 'application/json' in http_accept:
             ee_min_score = request.POST.get('entrance_exam_minimum_score_pct', None)

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -498,7 +498,7 @@ def export_handler(request, course_key_string):
     context['export_url'] = export_url + '?_accept=application/x-tgz'
 
     # an _accept URL parameter will be preferred over HTTP_ACCEPT in the header.
-    requested_format = request.REQUEST.get('_accept', request.META.get('HTTP_ACCEPT', 'text/html'))
+    requested_format = request.GET.get('_accept', request.META.get('HTTP_ACCEPT', 'text/html'))
 
     if 'application/x-tgz' in requested_format:
         try:

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -140,7 +140,7 @@ def xblock_handler(request, usage_key_string):
             accept_header = request.META.get('HTTP_ACCEPT', 'application/json')
 
             if 'application/json' in accept_header:
-                fields = request.REQUEST.get('fields', '').split(',')
+                fields = request.GET.get('fields', '').split(',')
                 if 'graderType' in fields:
                     # right now can't combine output of this w/ output of _get_module_info, but worthy goal
                     return JsonResponse(CourseGradingModel.get_section_grader_type(usage_key))
@@ -254,24 +254,24 @@ def xblock_view_handler(request, usage_key_string, view_name):
 
             paging = None
             try:
-                if request.REQUEST.get('enable_paging', 'false') == 'true':
+                if request.GET.get('enable_paging', 'false') == 'true':
                     paging = {
-                        'page_number': int(request.REQUEST.get('page_number', 0)),
-                        'page_size': int(request.REQUEST.get('page_size', 0)),
+                        'page_number': int(request.GET.get('page_number', 0)),
+                        'page_size': int(request.GET.get('page_size', 0)),
                     }
             except ValueError:
                 return HttpResponse(
                     content="Couldn't parse paging parameters: enable_paging: "
                             "{0}, page_number: {1}, page_size: {2}".format(
-                                request.REQUEST.get('enable_paging', 'false'),
-                                request.REQUEST.get('page_number', 0),
-                                request.REQUEST.get('page_size', 0)
+                                request.GET.get('enable_paging', 'false'),
+                                request.GET.get('page_number', 0),
+                                request.GET.get('page_size', 0)
                             ),
                     status=400,
                     content_type="text/plain",
                 )
 
-            force_render = request.REQUEST.get('force_render', None)
+            force_render = request.GET.get('force_render', None)
 
             # Set up the context to be passed to each XBlock's render method.
             context = {
@@ -325,7 +325,7 @@ def xblock_outline_handler(request, usage_key_string):
     if not has_studio_read_access(request.user, usage_key.course_key):
         raise PermissionDenied()
 
-    response_format = request.REQUEST.get('format', 'html')
+    response_format = request.GET.get('format', 'html')
     if response_format == 'json' or 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
         store = modulestore()
         with store.bulk_operations(usage_key.course_key):
@@ -354,7 +354,7 @@ def xblock_container_handler(request, usage_key_string):
     if not has_studio_read_access(request.user, usage_key.course_key):
         raise PermissionDenied()
 
-    response_format = request.REQUEST.get('format', 'html')
+    response_format = request.GET.get('format', 'html')
     if response_format == 'json' or 'application/json' in request.META.get('HTTP_ACCEPT', 'application/json'):
         with modulestore().bulk_operations(usage_key.course_key):
             response = _get_module_info(

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -86,7 +86,7 @@ def _display_library(library_key_string, request):
 
     response_format = 'html'
     if (
-            request.REQUEST.get('format', 'html') == 'json' or
+            request.GET.get('format', 'html') == 'json' or
             'application/json' in request.META.get('HTTP_ACCEPT', 'text/html')
     ):
         response_format = 'json'

--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -756,7 +756,10 @@ def provider_login(request):
     # first check to see if the request is an OpenID request.
     # If so, the client will have specified an 'openid.mode' as part
     # of the request.
-    querydict = dict(request.REQUEST.items())
+    if request.method == 'GET':
+        querydict = dict(request.GET.items())
+    else:
+        querydict = dict(request.POST.items())
     error = False
     if 'openid.mode' in request.GET or 'openid.mode' in request.POST:
         # decode request
@@ -899,9 +902,8 @@ def provider_login(request):
         return HttpResponseRedirect(openid_request_url)
 
     # determine consumer domain if applicable
-    return_to = ''
-    if 'openid.return_to' in request.REQUEST:
-        return_to = request.REQUEST['openid.return_to']
+    return_to = request.GET.get('openid.return_to') or request.POST.get('openid.return_to') or ''
+    if return_to:
         matches = re.match(r'\w+:\/\/([\w\.-]+)', return_to)
         return_to = matches.group(1)
 

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -176,7 +176,7 @@ class InstructorTaskCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase)
     def get_task_status(task_id):
         """Use api method to fetch task status, using mock request."""
         mock_request = Mock()
-        mock_request.REQUEST = {'task_id': task_id}
+        mock_request.GET = mock_request.POST = {'task_id': task_id}
         response = instructor_task_status(mock_request)
         status = json.loads(response.content)
         return status

--- a/lms/djangoapps/instructor_task/views.py
+++ b/lms/djangoapps/instructor_task/views.py
@@ -76,11 +76,11 @@ def instructor_task_status(request):
 
     """
     output = {}
-    if 'task_id' in request.REQUEST:
-        task_id = request.REQUEST['task_id']
+    task_id = request.GET.get('task_id') or request.POST.get('task_id')
+    tasks = request.GET.get('task_ids[]') or request.POST.get('task_ids[]')
+    if task_id:
         output = _get_instructor_task_status(task_id)
-    elif 'task_ids[]' in request.REQUEST:
-        tasks = request.REQUEST.getlist('task_ids[]')
+    elif tasks:
         for task_id in tasks:
             task_output = _get_instructor_task_status(task_id)
             if task_output is not None:

--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -217,7 +217,7 @@ def remove_item(request):
     """
     This will remove an item from the user cart and also delete the corresponding coupon codes redemption.
     """
-    item_id = request.REQUEST.get('id', '-1')
+    item_id = request.GET.get('id') or request.POST.get('id') or '-1'
 
     items = OrderItem.objects.filter(id=item_id, status='cart').select_subclasses()
 


### PR DESCRIPTION
Replace with request.GET and/or request.POST to eliminate Django deprecation messages. These messages are of the following format:

```
/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/item.py:355: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  response_format = request.REQUEST.get('format', 'html')

2016-02-18 13:30:43,718 WARNING 20265 [py.warnings] wsgi.py:124 - /edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/item.py:355: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  response_format = request.REQUEST.get('format', 'html')
```

Getting rid of these message will reduce the noise in the logs and stdout.

@macdiesel @nedbat - Since this is Django upgrade-related, please review.
