### PR TITLE
Invalid display courseware through the LTI iframe in IE 10+

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -358,6 +358,9 @@ MIDDLEWARE_CLASSES = (
 # Clickjacking protection can be enabled by setting this to 'DENY'
 X_FRAME_OPTIONS = 'ALLOW'
 
+# Platform for Privacy Preferences header
+P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
+
 ############# XBlock Configuration ##########
 
 # Import after sys.path fixup

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -374,3 +374,22 @@ def accepts(request, media_type):
     """Return whether this request has an Accept header that matches type"""
     accept = parse_accept_header(request.META.get("HTTP_ACCEPT", ""))
     return media_type in [t for (t, p, q) in accept]
+
+
+def add_p3p_header(view_func):
+    """
+    This decorator should only be used with views which may be displayed through the iframe.
+    It adds additional headers to response and therefore gives IE browsers an ability to save cookies inside the iframe
+    Details:
+    http://blogs.msdn.com/b/ieinternals/archive/2013/09/17/simple-introduction-to-p3p-cookie-blocking-frame.aspx
+    http://stackoverflow.com/questions/8048306/what-is-the-most-broad-p3p-header-that-will-work-with-ie
+    """
+    @wraps(view_func)
+    def inner(request, *args, **kwargs):
+        """
+        Helper function
+        """
+        response = view_func(request, *args, **kwargs)
+        response['P3P'] = settings.P3P_HEADER
+        return response
+    return inner

--- a/lms/djangoapps/lti_provider/views.py
+++ b/lms/djangoapps/lti_provider/views.py
@@ -14,6 +14,7 @@ from lti_provider.users import authenticate_lti_user
 from lms_xblock.runtime import unquote_slashes
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys import InvalidKeyError
+from util.views import add_p3p_header
 
 log = logging.getLogger("edx.lti_provider")
 
@@ -32,6 +33,7 @@ OPTIONAL_PARAMETERS = [
 
 
 @csrf_exempt
+@add_p3p_header
 def lti_launch(request, course_id, usage_id):
     """
     Endpoint for all requests to embed edX content via the LTI protocol. This

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1151,6 +1151,9 @@ MIDDLEWARE_CLASSES = (
 # Clickjacking protection can be enabled by setting this to 'DENY'
 X_FRAME_OPTIONS = 'ALLOW'
 
+# Platform for Privacy Preferences header
+P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
+
 ############################### PIPELINE #######################################
 
 PIPELINE_ENABLED = True


### PR DESCRIPTION
When using in-frame LTI navigation in IE 10 & 11, problems are not rendering properly. The problems render properly in IE 10 & 11 when using edX directly, or when opening LTI in a new tab. This is reproducible in Canvas and D2L:
![ie_bug1](https://cloud.githubusercontent.com/assets/1876893/13189079/5e6d9132-d766-11e5-8f0f-e29e8feb2f86.jpeg)
This problem happens because in iframe JS couldn't get Cookie for the CSRF protection and sends always `null`:
![ie_bug2](https://cloud.githubusercontent.com/assets/1876893/13189156/c5ed21b0-d766-11e5-9cce-2ce926f7f2ca.jpeg)
So per every such question LTI server returns HTTP 403:

```
"POST /courses/course-v1:OrgX+CS101+qwerty1/xblock/block-v1:OrgX+CS101+qwerty1+type@problem+block@5932e9abc0224b04af13c048a174553f/handler/xmodule_handler/problem_get HTTP/1.0" 200 3847
```

instead of:

```
"POST /courses/course-v1:OrgX+CS101+qwerty1/xblock/block-v1:OrgX+CS101+qwerty1+type@problem+block@5932e9abc0224b04af13c048a174553f/handler/xmodule_handler/problem_get HTTP/1.0" 403 9976
```

It is connected with the cookie-restricting privacy feature called P3P. More details can be found here: http://blogs.msdn.com/b/ieinternals/archive/2013/09/17/simple-introduction-to-p3p-cookie-blocking-frame.aspx
I'v created a little fix. You could see it in this pull request. I know only one case of using iframe to display courseware so I'm not sure that this fix should be applied only for the LTI views. May be it should be used globally for all other entry points.
Display questions after the fix:
![ie_bug3](https://cloud.githubusercontent.com/assets/1876893/13189434/72f65b28-d768-11e5-8e20-d94340f6812b.jpeg)
