### PR TITLE
Upgrade edx-lint to 0.4.2

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -85,7 +85,7 @@ git+https://github.com/edx/edx-val.git@0.0.9#egg=edxval==0.0.9
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/pmitros/DoneXBlock.git@857bf365f19c904d7e48364428f6b93ff153fabd#egg=done-xblock
 git+https://github.com/edx/edx-milestones.git@v0.1.8#egg=edx-milestones==0.1.8
-git+https://github.com/edx/edx-lint.git@v0.4.1#egg=edx_lint==0.4.1
+git+https://github.com/edx/edx-lint.git@v0.4.2#egg=edx_lint==0.4.2
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5


### PR DESCRIPTION
This upgrades edx-lint to the latest, 0.4.2.  The only change visible in edx-platform will be more precise messages from the `wrong-assert-type` checker, and more of those asserts flagged.
