### PR TITLE
Fix: Randomized Content Block editor did not check Studio user's permissions

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -82,11 +82,6 @@ class LibraryTestCase(ModuleStoreTestCase):
         Helper method: Uses the REST API to call the 'refresh_children' handler
         of a LibraryContent block
         """
-        if 'user' not in lib_content_block.runtime._services:  # pylint: disable=protected-access
-            mocked_user_service = Mock(user_id=self.user.id)
-            mocked_user_service.get_current_user.return_value = XBlockUser(is_current_user=True)
-            lib_content_block.runtime._services['user'] = mocked_user_service  # pylint: disable=protected-access
-
         handler_url = reverse_usage_url(
             'component_handler',
             lib_content_block.location,
@@ -724,8 +719,6 @@ class TestLibraryAccess(SignalDisconnectTestMixin, LibraryTestCase):
 
         # Try updating our library content block:
         lc_block = self._add_library_content_block(course, self.lib_key)
-        # We must use the CMS's module system in order to get permissions checks.
-        self._bind_module(lc_block, user=self.non_staff_user)
         lc_block = self._refresh_children(lc_block, status_code_expected=200 if expected_result else 403)
         self.assertEqual(len(lc_block.children), 1 if expected_result else 0)
 

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -22,7 +22,7 @@ from xblock.runtime import Mixologist
 
 from contentstore.utils import get_lms_link_for_item
 from contentstore.views.helpers import get_parent_xblock, is_unit, xblock_type_display_name
-from contentstore.views.item import create_xblock_info, add_container_page_publishing_info
+from contentstore.views.item import create_xblock_info, add_container_page_publishing_info, StudioEditModuleRuntime
 
 from opaque_keys.edx.keys import UsageKey
 
@@ -332,6 +332,7 @@ def component_handler(request, usage_key_string, handler, suffix=''):
     usage_key = UsageKey.from_string(usage_key_string)
 
     descriptor = modulestore().get_item(usage_key)
+    descriptor.xmodule_runtime = StudioEditModuleRuntime(request.user)
     # Let the module handle the AJAX
     req = django_to_webob_request(request)
 

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -14,7 +14,6 @@ from xmodule.x_module import PREVIEW_VIEWS, STUDENT_VIEW, AUTHOR_VIEW
 from xmodule.contentstore.django import contentstore
 from xmodule.error_module import ErrorDescriptor
 from xmodule.exceptions import NotFoundError, ProcessingError
-from xmodule.library_tools import LibraryToolsService
 from xmodule.services import SettingsService
 from xmodule.modulestore.django import modulestore, ModuleI18nService
 from xmodule.mixin import wrap_with_license
@@ -188,8 +187,6 @@ def _preview_module_system(request, descriptor, field_data):
         # stick the license wrapper in front
         wrappers.insert(0, wrap_with_license)
 
-    descriptor.runtime._services['studio_user_permissions'] = StudioPermissionsService(request)  # pylint: disable=protected-access
-
     return PreviewModuleSystem(
         static_url=settings.STATIC_URL,
         # TODO (cpennington): Do we want to track how instructors are using the preview problems?
@@ -215,9 +212,9 @@ def _preview_module_system(request, descriptor, field_data):
         services={
             "i18n": ModuleI18nService(),
             "field-data": field_data,
-            "library_tools": LibraryToolsService(modulestore()),
             "settings": SettingsService(),
             "user": DjangoXBlockUserService(request.user),
+            "studio_user_permissions": StudioPermissionsService(request),
         },
     )
 

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -133,28 +133,6 @@ class PreviewModuleSystem(ModuleSystem):  # pylint: disable=abstract-method
         return result
 
 
-class StudioPermissionsService(object):
-    """
-    Service that can provide information about a user's permissions.
-
-    Deprecated. To be replaced by a more general authorization service.
-
-    Only used by LibraryContentDescriptor (and library_tools.py).
-    """
-
-    def __init__(self, request):
-        super(StudioPermissionsService, self).__init__()
-        self._request = request
-
-    def can_read(self, course_key):
-        """ Does the user have read access to the given course/library? """
-        return has_studio_read_access(self._request.user, course_key)
-
-    def can_write(self, course_key):
-        """ Does the user have read access to the given course/library? """
-        return has_studio_write_access(self._request.user, course_key)
-
-
 def _preview_module_system(request, descriptor, field_data):
     """
     Returns a ModuleSystem for the specified descriptor that is specialized for
@@ -214,7 +192,6 @@ def _preview_module_system(request, descriptor, field_data):
             "field-data": field_data,
             "settings": SettingsService(),
             "user": DjangoXBlockUserService(request.user),
-            "studio_user_permissions": StudioPermissionsService(request),
         },
     )
 

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -573,12 +573,10 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
         """
         lib_tools = self.runtime.service(self, 'library_tools')
         user_perms = self.runtime.service(self, 'studio_user_permissions')
-        all_libraries = lib_tools.list_available_libraries()
-        if user_perms:
-            all_libraries = [
-                (key, name) for key, name in all_libraries
-                if user_perms.can_read(key) or self.source_library_id == unicode(key)
-            ]
+        all_libraries = [
+            (key, name) for key, name in lib_tools.list_available_libraries()
+            if user_perms.can_read(key) or self.source_library_id == unicode(key)
+        ]
         all_libraries.sort(key=lambda entry: entry[1])  # Sort by name
         if self.source_library_id and self.source_library_key not in [entry[0] for entry in all_libraries]:
             all_libraries.append((self.source_library_id, _(u"Invalid Library")))

--- a/common/lib/xmodule/xmodule/library_tools.py
+++ b/common/lib/xmodule/xmodule/library_tools.py
@@ -124,7 +124,7 @@ class LibraryToolsService(object):
         """
         return self.store.check_supports(block.location.course_key, 'copy_from_template')
 
-    def update_children(self, dest_block, user_id, user_perms=None, version=None):
+    def update_children(self, dest_block, user_id, user_perms, version=None):
         """
         This method is to be used when the library that a LibraryContentModule
         references has been updated. It will re-fetch all matching blocks from
@@ -136,7 +136,7 @@ class LibraryToolsService(object):
         store the version number of the libraries used, so we easily determine
         if dest_block is up to date or not.
         """
-        if user_perms and not user_perms.can_write(dest_block.location.course_key):
+        if not user_perms.can_write(dest_block.location.course_key):
             raise PermissionDenied()
 
         if not dest_block.source_library_id:
@@ -150,7 +150,7 @@ class LibraryToolsService(object):
         library = self._get_library(library_key)
         if library is None:
             raise ValueError("Requested library not found.")
-        if user_perms and not user_perms.can_read(library_key):
+        if not user_perms.can_read(library_key):
             raise PermissionDenied()
         filter_children = (dest_block.capa_type != ANY_CAPA_TYPE_VALUE)
         if filter_children:

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1448,8 +1448,9 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):
         """
         potential_set = set(super(DescriptorSystem, self).applicable_aside_types(block))
         if getattr(block, 'xmodule_runtime', None) is not None:
-            application_set = set(block.xmodule_runtime.applicable_aside_types(block))
-            return list(potential_set.intersection(application_set))
+            if hasattr(block.xmodule_runtime, 'applicable_aside_types'):
+                application_set = set(block.xmodule_runtime.applicable_aside_types(block))
+                return list(potential_set.intersection(application_set))
         return list(potential_set)
 
     def resource_url(self, resource):


### PR DESCRIPTION
This is an alternate fix to the Library studio permissions issues mentioned in #11331.

**Problem**: The library_content XBlock ("Randomized Content Module") would enforce permissions if the `StudioUserPermissions` service is available, and would otherwise not enforce permissions. In Studio, when rendering the `studio_view` or calling an AJAX handler outside of the `preview/author_view/student_view` context, XBlocks are loaded as "Descriptors" without access to user-specific fields or services such as `StudioUserPermissions`.

As a result, the `studio_view` for library_content blocks had no way of verifying permissions and so would let the user choose from any libraries on the system, even if (s)he should not have permission to view those libraries.

We were also loading `StudioUserPermissions` in Studio's PreviewModuleSystem runtime, which doesn't really need it.

**Fix**:
1. First, I removed all of the "`if user_perms_service_available: check_perms()`" type of code, and changed library_tools so that the user permissions service _must_ be available in order to make any changes, and if it's not available the block will raise an error rather than allowing the action.
2. The fix is to create a very minimal ModuleSystem shim (i.e. the user-specific half of a Runtime) for the studio_view and other Studio non-preview XBlock views/handlers. This minimal ModuleSystem shim does not provide access to user-scoped fields or do much at all, except that it does allow access to the UserService and StudioUserPermissions service, which will reflect the current user of Studio.

TODO:
- Tests are updated appropriately but we could add one more test for the studio_view output specifically.
