### PR TITLE
Only allow ecommerce checkout if user is also activated

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -151,7 +151,7 @@ class ChooseModeView(View):
 
             if verified_mode.sku:
                 ecommerce_service = EcommerceService()
-                context["use_ecommerce_payment_flow"] = ecommerce_service.is_enabled()
+                context["use_ecommerce_payment_flow"] = ecommerce_service.is_enabled(request)
                 context["ecommerce_payment_page"] = ecommerce_service.payment_page_url()
                 context["sku"] = verified_mode.sku
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -739,7 +739,7 @@ def dashboard(request):
     }
 
     ecommerce_service = EcommerceService()
-    if ecommerce_service.is_enabled():
+    if ecommerce_service.is_enabled(request):
         context.update({
             'use_ecommerce_payment_flow': True,
             'ecommerce_payment_page': ecommerce_service.payment_page_url(),

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -44,9 +44,10 @@ class EcommerceService(object):
     def __init__(self):
         self.config = CommerceConfiguration.current()
 
-    def is_enabled(self):
-        """ Check if the service is enabled and that the site is not a microsite. """
-        return self.config.checkout_on_ecommerce_service and not helpers.is_request_in_themed_site()
+    def is_enabled(self, request):
+        """ Check if the user is activated, if the service is enabled and that the site is not a microsite. """
+        return (request.user.is_active and self.config.checkout_on_ecommerce_service and not
+                helpers.is_request_in_themed_site())
 
     def payment_page_url(self):
         """ Return the URL for the checkout page.

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -39,6 +39,7 @@ from courseware.testutils import RenderXBlockTestMixin
 from courseware.tests.factories import StudentModuleFactory
 from courseware.user_state_client import DjangoXBlockUserStateClient
 from edxmako.tests import mako_middleware_process_request
+from lms.djangoapps.commerce.utils import EcommerceService  # pylint: disable=import-error
 from milestones.tests.utils import MilestonesTestCaseMixin
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.lib.gating import api as gating_api
@@ -271,13 +272,23 @@ class ViewsTestCase(ModuleStoreTestCase):
 
     @ddt.data(True, False)
     def test_ecommerce_checkout(self, is_anonymous):
-        self.assert_enrollment_link_present(is_anonymous=is_anonymous)
+        if not is_anonymous:
+            self.assert_enrollment_link_present(is_anonymous=is_anonymous)
+        else:
+            request = self.request_factory.get("foo")
+            request.user = AnonymousUser()
+            self.assertEqual(EcommerceService().is_enabled(request), False)
 
     @ddt.data(True, False)
     @unittest.skipUnless(settings.FEATURES.get('ENABLE_SHOPPING_CART'), 'Shopping Cart not enabled in settings')
     @patch.dict(settings.FEATURES, {'ENABLE_PAID_COURSE_REGISTRATION': True})
     def test_ecommerce_checkout_shopping_cart_enabled(self, is_anonymous):
-        self.assert_enrollment_link_present(is_anonymous=is_anonymous, _id=True)
+        if not is_anonymous:
+            self.assert_enrollment_link_present(is_anonymous=is_anonymous, _id=True)
+        else:
+            request = self.request_factory.get("foo")
+            request.user = AnonymousUser()
+            self.assertEqual(EcommerceService().is_enabled(request), False)
 
     def test_user_groups(self):
         # depreciated function

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -906,7 +906,7 @@ def course_about(request, course_id):
         ecommerce_checkout_link = ''
         professional_mode = ''
         ecomm_service = EcommerceService()
-        if ecomm_service.is_enabled() and (
+        if ecomm_service.is_enabled(request) and (
                 CourseMode.PROFESSIONAL in modes or CourseMode.NO_ID_PROFESSIONAL_MODE in modes
         ):
             professional_mode = modes.get(CourseMode.PROFESSIONAL, '') or \
@@ -944,7 +944,7 @@ def course_about(request, course_id):
             'is_cosmetic_price_enabled': settings.FEATURES.get('ENABLE_COSMETIC_DISPLAY_PRICE'),
             'course_price': course_price,
             'in_cart': in_cart,
-            'ecommerce_checkout': ecomm_service.is_enabled(),
+            'ecommerce_checkout': ecomm_service.is_enabled(request),
             'ecommerce_checkout_link': ecommerce_checkout_link,
             'professional_mode': professional_mode,
             'reg_then_add_to_cart_link': reg_then_add_to_cart_link,


### PR DESCRIPTION
This is to fix SOL-1652.  Do not allow a leaner to purchase a course if the account has not yet been activated.  This check will make the logic fall through and verification will happen in the existing pay_and_verify view.
