### PR TITLE
render mathjax in svg by default (TNL-4145)

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -91,7 +91,7 @@
             // end of Annotation tool files
 
             // externally hosted files
-            "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured", // jshint ignore:line
+            "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured", // jshint ignore:line
             "youtube": [
                 // youtube URL does not end in ".js". We add "?noext" to the path so
                 // that require.js adds the ".js" to the query component of the URL,

--- a/cms/static/coffee/spec/main.coffee
+++ b/cms/static/coffee/spec/main.coffee
@@ -51,7 +51,7 @@ requirejs.config({
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
         "mock-ajax": "xmodule_js/common_static/js/vendor/mock-ajax",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix",

--- a/cms/static/coffee/spec/main_squire.coffee
+++ b/cms/static/coffee/spec/main_squire.coffee
@@ -42,7 +42,7 @@ requirejs.config({
         "domReady": "xmodule_js/common_static/js/vendor/domReady",
         "URI": "xmodule_js/common_static/js/vendor/URI.min",
 
-        "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured",
+        "mathjax": "//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured",
         "youtube": "//www.youtube.com/player_api?noext",
 
         "coffee/src/ajax_prefix": "xmodule_js/common_static/coffee/src/ajax_prefix"

--- a/common/djangoapps/terrain/ui_helpers.py
+++ b/common/djangoapps/terrain/ui_helpers.py
@@ -346,7 +346,7 @@ def css_contains_text(css_selector, partial_text, index=0):
     # If we're expecting a non-empty string, give the page
     # a chance to fill in text fields.
     if partial_text:
-        wait_for(lambda _: css_html(css_selector, index=index))
+        wait_for(lambda _: css_html(css_selector, index=index), timeout=8)
 
     actual_text = css_html(css_selector, index=index)
 

--- a/common/lib/capa/capa/templates/formulaequationinput.html
+++ b/common/lib/capa/capa/templates/formulaequationinput.html
@@ -20,7 +20,7 @@
       <p id="answer_${id}" class="answer"></p>
 
       <div id="input_${id}_preview" class="equation">
-        \[\]
+        \(\)
         <img src="${STATIC_URL}images/spinner.gif" class="loading" alt="Loading"/>
       </div>
   </div>

--- a/common/static/js/capa/spec/formula_equation_preview_spec.js
+++ b/common/static/js/capa/spec/formula_equation_preview_spec.js
@@ -139,7 +139,7 @@ describe("Formula Equation Preview", function () {
             // Either it makes a request or jumps straight into displaying ''.
             waitsFor(function () {
                 // (Short circuit if `inputAjax` is indeed called)
-                return Problem.inputAjax.wasCalled || 
+                return Problem.inputAjax.wasCalled ||  // jshint ignore:line
                     MathJax.Hub.Queue.wasCalled;
             }, "AJAX never called on user input", 1000);
 
@@ -266,7 +266,7 @@ describe("Formula Equation Preview", function () {
 
                 // We should look in the preview div for the MathJax.
                 var previewElement = $("#input_THE_ID_preview")[0];
-                expect(previewElement.firstChild.data).toEqual("\\[THE_FORMULA\\]");
+                expect(previewElement.firstChild.data).toEqual("\\(THE_FORMULA\\)");
 
                 // Refresh the MathJax.
                 expect(MathJax.Hub.Queue).toHaveBeenCalledWith(

--- a/common/static/js/capa/src/formula_equation_preview.js
+++ b/common/static/js/capa/src/formula_equation_preview.js
@@ -145,7 +145,7 @@ formulaEquationPreview.enable = function () {
                             console.log("[FormulaEquationInput] Oops no mathjax for ", latex);
                             // Fall back to modifying the actual element.
                             var textNode = previewElement.childNodes[0];
-                            textNode.data = "\\[" + latex + "\\]";
+                            textNode.data = "\\(" + latex + "\\)";
                             MathJax.Hub.Queue(["Typeset", MathJax.Hub, previewElement]);
                         }
                     });

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -76,4 +76,4 @@
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG"></script>

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -126,7 +126,7 @@ class DiscussionThreadPage(PageObject, DiscussionPageMixin):
     def verify_mathjax_rendered(self):
         """ Checks that MathJax css class is present """
         self.wait_for(
-            lambda: self._is_element_visible(".MathJax_CHTML"),
+            lambda: self._is_element_visible(".MathJax_SVG"),
             description="MathJax Preview is rendered"
         )
 

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -49,7 +49,7 @@ class ProblemPage(PageObject):
         """
         def mathjax_present():
             """ Returns True if MathJax css is present in the problem body """
-            mathjax_container = self.q(css="div.problem p .MathJax_CHTML")
+            mathjax_container = self.q(css="div.problem p .MathJax_SVG")
             return mathjax_container.visible and mathjax_container.present
 
         self.wait_for(
@@ -63,7 +63,7 @@ class ProblemPage(PageObject):
         """
         def mathjax_present():
             """ Returns True if MathJax css is present in the problem body """
-            mathjax_container = self.q(css="div.problem div.problem-hint .MathJax_CHTML")
+            mathjax_container = self.q(css="div.problem div.problem-hint .MathJax_SVG")
             return mathjax_container.visible and mathjax_container.present
 
         self.wait_for(

--- a/common/test/acceptance/pages/lms/tab_nav.py
+++ b/common/test/acceptance/pages/lms/tab_nav.py
@@ -40,7 +40,7 @@ class TabNavPage(PageObject):
         """
         Check that MathJax has rendered in tab content
         """
-        mathjax_container = self.q(css=".static_tab_wrapper .MathJax_CHTML")
+        mathjax_container = self.q(css=".static_tab_wrapper .MathJax_SVG")
         EmptyPromise(
             lambda: mathjax_container.present and mathjax_container.visible,
             "MathJax is not visible"

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -5,6 +5,7 @@ Tests for discussion pages
 import datetime
 from uuid import uuid4
 
+from flaky import flaky
 from nose.plugins.attrib import attr
 from pytz import UTC
 
@@ -400,6 +401,7 @@ class DiscussionCommentDeletionTest(BaseDiscussionTestCase):
         )
         view.push()
 
+    @flaky  # TODO: TNL-4151
     def test_comment_deletion_as_student(self):
         self.setup_user()
         self.setup_view()

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -49,7 +49,7 @@
             'jasmine.async': 'xmodule_js/common_static/js/vendor/jasmine.async',
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly.pkgd',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
-            'mathjax': '//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_CHTML&delayStartupUntil=configured', // jshint ignore:line
+            'mathjax': '//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured', // jshint ignore:line
             'youtube': '//www.youtube.com/player_api?noext',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',
             'coffee/src/instructor_dashboard/student_admin': 'coffee/src/instructor_dashboard/student_admin',


### PR DESCRIPTION
@mikekatz , I'd like to tack this onto the RC if possible. Once tests pass, I'll ask for reviews.

After fix:
<img width="404" alt="after" src="https://cloud.githubusercontent.com/assets/2748698/13222355/a4868230-d94d-11e5-8230-14831e3b186a.png">

Before fix:
<img width="445" alt="before" src="https://cloud.githubusercontent.com/assets/2748698/13222356/a48aa0c2-d94d-11e5-96aa-61be676017c3.png">
