### PR TITLE
TNL-4136 fix topic detail endpoint's url to support alphanumeric and period characters in topic ID

### DIFF
--- a/lms/djangoapps/teams/api_urls.py
+++ b/lms/djangoapps/teams/api_urls.py
@@ -14,7 +14,7 @@ from .views import (
 
 TEAM_ID_PATTERN = r'(?P<team_id>[a-z\d_-]+)'
 USERNAME_PATTERN = r'(?P<username>[\w.+-]+)'
-TOPIC_ID_PATTERN = TEAM_ID_PATTERN.replace('team_id', 'topic_id')
+TOPIC_ID_PATTERN = r'(?P<topic_id>[A-Za-z\d_.-]+)'
 
 urlpatterns = patterns(
     '',

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -231,6 +231,11 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
                     'name': 'Public Profiles',
                     'description': 'Description for topic 6.'
                 },
+                {
+                    'id': 'Topic_6.5',
+                    'name': 'Test Accessibility Topic',
+                    'description': 'Description for Topic_6.5'
+                },
             ],
             'max_team_size': 1
         }
@@ -1192,6 +1197,9 @@ class TestDetailTopicAPI(TeamAPITestCase):
 
     def test_invalid_topic_id(self):
         self.get_topic_detail('no_such_topic', self.test_course_1.id, 404)
+
+    def test_topic_detail_with_caps_and_dot_in_id(self):
+        self.get_topic_detail('Topic_6.5', self.test_course_2.id, user='student_enrolled_public_profile')
 
     def test_team_count(self):
         """Test that team_count is included with a topic"""


### PR DESCRIPTION
[TNL-4136](https://openedx.atlassian.net/browse/TNL-4136)

**Background**
In [documentation](http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/course_features/teams/teams_setup.html#enable-and-configure-teams), following note is mentioned about choosing `topic_id`

> For topic IDs, you can use only alphanumeric characters and the underscore, hyphen, and period characters

Currently, `topic_id` cannot contain capital alphabets and period characters. That's why users were facing `404` when trying to access details & teams of a particular topic whose ID comprises capital alphabets and/or period characters.

**Fix**
I have modified `topic_id`'s regex for `topic_detail` endpoint's url to allow matching of those urls as well in which `topic_id` consists of capital alphabets and/or period characters. Test has been added to ensure the fix as well.

@mushtaqak , @adampalay Please have a look. Thanks!
