### PR TITLE
Use latest version of drag and drop xblock

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -96,4 +96,4 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.0.3#egg=xblock-lti-consume
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 -e git+https://github.com/open-craft/xblock-poll@e7a6c95c300e95c51e42bfd1eba70489c05a6527#egg=xblock-poll
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.1#egg=xblock-drag-and-drop-v2==2.0.1
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.2#egg=xblock-drag-and-drop-v2==2.0.2


### PR DESCRIPTION
Bumps the new Drag and Drop XBlock from version 2.0.1 to 2.0.2, which includes [some important bugfixes](https://github.com/edx-solutions/xblock-drag-and-drop-v2/blob/master/Changelog.md#version-202-2016-02-18), mostly from this single PR: https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/55.

JIRA: [SOL-1642](https://openedx.atlassian.net/browse/SOL-1642), [YONK-264](https://openedx.atlassian.net/browse/YONK-264)

Sandbox: http://studio.master.dndv2.sandbox.opencraft.com/ and http://master.dndv2.sandbox.opencraft.com/ 

**Test instructions**: See the list of bugs at https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/55 and confirm that they are fixed using http://studio.master.dndv2.sandbox.opencraft.com/ ("staff" login). Feel free to edit any content on that sandbox except the "Drag and Drop Demos" course.
