### PR TITLE
AC-339 Synchronizes the two page header templates used in edx-platform

### DIFF
--- a/lms/templates/navigation-edx.html
+++ b/lms/templates/navigation-edx.html
@@ -83,7 +83,7 @@ site_status_msg = get_site_status_msg(course_id)
           username = user.username
           profile_image_url = get_profile_image_urls_for_user(user)['medium']
           %>
-          <img class="user-image-frame" src="${profile_image_url}" alt="${_('Profile image for {username}').format(username=username)}">
+          <img class="user-image-frame" src="${profile_image_url}" alt="">
           <div class="label-username">${username}</div>
         </a>
       </li>

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -87,7 +87,7 @@ site_status_msg = get_site_status_msg(course_id)
         </a>
       </li>
       <li class="primary">
-        <a href="#" class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span> &#9662;</a>
+        <button href="#" class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span> &#9662;</button>
         <ul class="dropdown-menu" aria-label="More Options" role="menu">
           <%block name="navigation_dropdown_menu_links" >
             <li><a href="${reverse('dashboard')}">${_("Dashboard")}</a></li>

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -87,7 +87,7 @@ site_status_msg = get_site_status_msg(course_id)
         </a>
       </li>
       <li class="primary">
-        <a href="#" class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span> &#9662;</a>
+        <button class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span> &#9662;</button>
         <ul class="dropdown-menu" aria-label="More Options" role="menu">
           <%block name="navigation_dropdown_menu_links" >
             <li><a href="${reverse('dashboard')}">${_("Dashboard")}</a></li>

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -87,7 +87,7 @@ site_status_msg = get_site_status_msg(course_id)
         </a>
       </li>
       <li class="primary">
-        <button href="#" class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span> &#9662;</button>
+        <a href="#" class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span> &#9662;</a>
         <ul class="dropdown-menu" aria-label="More Options" role="menu">
           <%block name="navigation_dropdown_menu_links" >
             <li><a href="${reverse('dashboard')}">${_("Dashboard")}</a></li>


### PR DESCRIPTION
While verifying the work on that avatar alt text (https://openedx.atlassian.net/browse/AC-332) it became apparent that there are two different templates responsible for creating the header HTML in edx-platform:
-  themes/edx.org/lms/templates/header.html
-  lms/templates/navigation-edx.html

I noticed that they have become out of sync in two important places:
- The code used for the avatar (alt text is different)
- the code used for the user menu (one is link the other is button)

Both controls should use identical code:
- empty alt
- button, not link

Reviewers: @clrux @clytwynec 
