### PR TITLE
Read ELASTIC_SEARCH_CONFIG setting from the cms.env.json file

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -357,6 +357,8 @@ if FEATURES['ENABLE_COURSEWARE_INDEX'] or FEATURES['ENABLE_LIBRARY_INDEX']:
     # Use ElasticSearch for the search engine
     SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
 
+ELASTIC_SEARCH_CONFIG = ENV_TOKENS.get('ELASTIC_SEARCH_CONFIG', [{}])
+
 XBLOCK_SETTINGS = ENV_TOKENS.get('XBLOCK_SETTINGS', {})
 XBLOCK_SETTINGS.setdefault("VideoDescriptor", {})["licensing_enabled"] = FEATURES.get("LICENSING", False)
 XBLOCK_SETTINGS.setdefault("VideoModule", {})['YOUTUBE_API_KEY'] = AUTH_TOKENS.get('YOUTUBE_API_KEY', YOUTUBE_API_KEY)


### PR DESCRIPTION
This PR updates the cms/envs/aws file, so that by using the configuration repo, one can update the cms ELASTIC_SEARCH_CONFIG setting the same way it forks for the lms.

Without this, the cms ELASTIC_SEARCH_CONFIG defaults to localhost and trying to index a course for the course_search feature fails when the Elasticsearch host is in another server.
