### PR TITLE
Fix build failures in the docs/en_us/platform_api guide.

### DIFF
--- a/docs/en_us/platform_api/source/conf.py
+++ b/docs/en_us/platform_api/source/conf.py
@@ -143,6 +143,14 @@ MOCK_MODULES = [
     'rest_framework_oauth.authentication',
     'certificates.api',
     'courseware.date_summary',
+    'rest_framework_jwt',
+    'rest_framework_jwt.authentication',
+    'microsite_configuration',
+    'xmodule.assetstore',
+    'xmodule.assetstore.assetmgr',
+    'xmodule.assetstore.assetmgr.AssetManager',
+    'xmodule.contentstore.django',
+    'piexif',
 ]
 
 for mod_name in MOCK_MODULES:


### PR DESCRIPTION
I added modules to the mock modules list. This allows Sphinx to import the modules that it needs for autoclass docstring including without having to satisfy the intricate web of import prerequisites throughout the platform. Addresses https://openedx.atlassian.net/browse/DOC-2638.
