### PR TITLE
Registration: don't require terms of service if checkbox is hidden

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1628,7 +1628,7 @@ def create_account_with_params(request, params):
         not do_external_auth
     )
     # Can't have terms of service for certain SHIB users, like at Stanford
-    tos_required = (
+    tos_required = settings.REGISTRATION_EXTRA_FIELDS.get('terms_of_service') != 'hidden' and (
         not settings.FEATURES.get("AUTH_USE_SHIB") or
         not settings.FEATURES.get("SHIB_DISABLE_TOS") or
         not do_external_auth or

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1683,6 +1683,16 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             }
         )
 
+    @override_settings(REGISTRATION_EXTRA_FIELDS={"honor_code": "hidden", "terms_of_service": "hidden"})
+    def test_register_hidden_honor_code_and_terms_of_service(self):
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+        })
+        self.assertHttpOK(response)
+
     def test_missing_fields(self):
         response = self.client.post(
             self.url,


### PR DESCRIPTION
**Background:** The `honor_code` checkbox can be removed from the user registration form by setting `REGISTRATION_EXTRA_FIELDS['honor_code']` to `hidden`. This breaks the registration form, however: without the `honor_code` form field, registration fails with a 'you must accept the terms of service' error message.

The view uses the `honor_code` POST param to set the required `terms_of_service` param: https://github.com/open-craft/edx-platform/blob/d114be732f69cd87289b68375207de4deeea1675/openedx/core/djangoapps/user_api/views.py#L322-L330

**LMS updates:** This pull request modifies the handler to not require terms of service if `REGISTRATION_EXTRA_FIELDS['terms_of_service']` is set to `hidden`.

**Testing:** Register at http://pr11644.sandbox.opencraft.com/register

**Settings**

``` yaml
FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
REGISTRATION_EXTRA_FIELDS:
  level_of_education: 'optional'
  gender: 'optional'
  year_of_birth: 'optional'
  mailing_address: 'optional'
  goals: 'optional'
  honor_code: 'hidden'
  terms_of_service: 'hidden'
  city: 'hidden'
  country: 'hidden'
```
