### PR TITLE
WIP- Xblock-Translations - Suggestion

### DIFF
--- a/common/lib/xmodule/xmodule/x_module_layer.py
+++ b/common/lib/xmodule/xmodule/x_module_layer.py
@@ -1,0 +1,45 @@
+from xmodule.modulestore.django import modulestore, ModuleI18nService
+from xmodule.x_module import ModuleSystem
+from xblock.exceptions import NoSuchServiceError
+
+
+class ModuleSystemLayer(ModuleSystem):  # pylint: disable=abstract-method
+    """
+    An XModule ModuleSystem for use in Studio previews
+    """
+    # xmodules can check for this attribute during rendering to determine if
+    # they are being rendered for preview (i.e. in Studio)
+    is_author_mode = True
+
+    def __init__(self, **kwargs):
+        services = kwargs.setdefault('services', {})
+        services['i18n'] = None  # This key overrides super, populated on-demand by service() below
+        super(ModuleSystemLayer, self).__init__(**kwargs)
+
+    def service(self, block, service_name):
+        """
+        Runtime-specific override for the XBlock service manager.  If a service is not currently
+        instantiated and is declared as a critical requirement, an attempt is made to load the
+        module.
+
+        Arguments:
+            block (an XBlock): this block's class will be examined for service
+                decorators.
+            service_name (string): the name of the service requested.
+
+        Returns:
+            An object implementing the requested service, or None.
+        """
+        try:
+            service = super(ModuleSystemLayer, self).service(block=block, service_name=service_name)
+        except NoSuchServiceError:
+            service_map = {
+                'i18n': ModuleI18nService,
+            }
+
+            if block.service_declaration(service_name) == "need" and service_map.get(service_name, None):
+                service = service_map[service_name](block)
+            else:
+                raise NoSuchServiceError("Service {!r} is not available.".format(service_name))
+
+        return service


### PR DESCRIPTION
@mattdrayer @cpennington As per your suggestions on [PR#11575](https://github.com/edx/edx-platform/pull/11575#discussion-diff-53782996R170) , I was trying to move the **`service`** method in parent class **`ModuleSystem`** so It could be easily available for both LMS and Studio BUT **`x_module.py`** module is not allowing me to import **`ModuleI18nService`** and It was throwing an **`ConnectionDoesNotExist exception`**. It seems me that **`x_module.py`** is independent of database so in order to place the code in common place I have introduced a middle class **`ModuleSystemLayer`** that is inherited with **`ModuleSystem`** and override the service method here. In this way both LMS and Studio have the common path to access service. 
Currently, **`ModuleSystemLayer`** initiazliaing the **`i18n`** service however if this approach is acceptable then we can add other common services of both LMS and Studio in the `__init__` here. 

I noticed that [CombinedSystem](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/x_module.py#L1824) is the class who is responsible to call `service` method in LMS / Studio modules. 

Please share your thoughts. 
##### NOTE: I am keeping this PR separate from parent. It is for review.
