### PR TITLE
Use yaml.safe_load, since we have no need for the greater power of .load

### DIFF
--- a/cms/envs/yaml_config.py
+++ b/cms/envs/yaml_config.py
@@ -129,7 +129,7 @@ LOCAL_LOGLEVEL = 'INFO'
 #
 
 with open(CONFIG_ROOT / CONFIG_PREFIX + "env.yaml") as env_file:
-    ENV_TOKENS = yaml.load(env_file)
+    ENV_TOKENS = yaml.safe_load(env_file)
 
 ENV_TOKENS = convert_tokens(ENV_TOKENS)
 
@@ -220,7 +220,7 @@ MICROSITE_ROOT_DIR = path(MICROSITE_ROOT_DIR)
 #
 
 with open(CONFIG_ROOT / CONFIG_PREFIX + "auth.yaml") as auth_file:
-    AUTH_TOKENS = yaml.load(auth_file)
+    AUTH_TOKENS = yaml.safe_load(auth_file)
 
 AUTH_TOKENS = convert_tokens(AUTH_TOKENS)
 

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -161,7 +161,7 @@ if os.environ.get('QUEUE') == 'high_mem':
 #
 
 with open(CONFIG_ROOT / CONFIG_PREFIX + "env.yaml") as env_file:
-    ENV_TOKENS = yaml.load(env_file)
+    ENV_TOKENS = yaml.safe_load(env_file)
 
 # Works around an Ansible bug
 ENV_TOKENS = convert_tokens(ENV_TOKENS)
@@ -266,7 +266,7 @@ STATIC_ROOT = path(STATIC_ROOT_BASE)
 #
 
 with open(CONFIG_ROOT / CONFIG_PREFIX + "auth.yaml") as auth_file:
-    AUTH_TOKENS = yaml.load(auth_file)
+    AUTH_TOKENS = yaml.safe_load(auth_file)
 
 # Works around an Ansible bug
 AUTH_TOKENS = convert_tokens(AUTH_TOKENS)


### PR DESCRIPTION
yaml.load can load arbitrary Python objects.  Our yaml configuration files are meant to only be yaml primitive types (strings, numbers, lists, dicts), so there's no need to allow the full power of .load.

This make the system just slightly more secure.
