### PR TITLE
Test should wait for ajax calls to finish before checking the changes

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -839,6 +839,7 @@ class SpecialExamsPageAllowanceSection(PageObject):
         self.q(css='input#user_info').fill(username)
         self.q(css="input#addNewAllowance").click()
         self.wait_for_element_absence("div.modal div.modal-header", "Popup should be hidden")
+        self.wait_for_ajax()
 
 
 class SpecialExamsPageAttemptsSection(PageObject):


### PR DESCRIPTION
When we save the allowance after filling the form, we wait for the absence of this form(form is in the popup). Once save button is clicked, there are some ajax requests to update the allowance data. To ensure that ajax calls finish before checking the reflected changes, I put the wait_for_ajax.
Please review @raeeschachar @benpatterson @jzoldak 
