### PR TITLE
Fix list index out of range in Textbook's chapters.

### DIFF
--- a/lms/djangoapps/staticbook/tests.py
+++ b/lms/djangoapps/staticbook/tests.py
@@ -227,6 +227,17 @@ class StaticPdfBookTest(StaticBookTest):
         self.assertContains(response, 'file=/static/awesomesauce/{}'.format(
             PORTABLE_PDF_BOOK['chapters'][0]['url'].replace('/static/', '')))
 
+    def test_invalid_chapter_id(self):
+        """
+        Test that 1st chapter is displayed to the user when an invalid chapter id is provided
+        """
+        self.make_course(pdf_textbooks=[PDF_BOOK])
+        invalid_chapter = len(PDF_BOOK['chapters']) + 1
+        url = self.make_url('pdf_book', book_index=0, chapter=invalid_chapter)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Chapter 1 for PDF")
+
 
 class StaticHtmlBookTest(StaticBookTest):
     """

--- a/lms/djangoapps/staticbook/views.py
+++ b/lms/djangoapps/staticbook/views.py
@@ -99,7 +99,7 @@ def pdf_index(request, course_id, book_index, chapter=None, page=None):
     if 'chapters' in textbook:
         for entry in textbook['chapters']:
             entry['url'] = remap_static_url(entry['url'], course)
-        if chapter is not None:
+        if chapter is not None and int(chapter) <= (len(textbook['chapters'])):
             current_chapter = textbook['chapters'][int(chapter) - 1]
         else:
             current_chapter = textbook['chapters'][0]


### PR DESCRIPTION
### Description

When someone accesses the book with an invalid chapter, chapter `1` will be displayed.

[TNL-3848](https://openedx.atlassian.net/browse/TNL-3848)
