### PR TITLE
Improve logging in certification generation

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -281,6 +281,21 @@ class XQueueCertInterface(object):
         if forced_grade:
             grade['grade'] = forced_grade
 
+        LOGGER.info(
+            (
+                u"Certificate generated for student %s in the course: %s with template: %s. "
+                u"given template: %s, "
+                u"user is verified: %s, "
+                u"mode is verified: %s"
+            ),
+            student.username,
+            unicode(course_id),
+            template_pdf,
+            template_file,
+            user_is_verified,
+            mode_is_verified
+        )
+
         cert, created = GeneratedCertificate.objects.get_or_create(user=student, course_id=course_id)  # pylint: disable=no-member
 
         cert.mode = cert_mode


### PR DESCRIPTION
Add log in certification generation with information about which pdf template is selected.
## Reason

There are a lot of issues complaining about the certificate user got is not what it supposed to be. (e.g. verified user got honor certificate). In order to verify that we have to go through the code and check users' verification. This will give a first hand information about what `template_pdf` was selected and if the user and enrollment mode was verified. 

[ECOM-3688](https://openedx.atlassian.net/browse/ECOM-3688)
