### PR TITLE
Avoid MultipleObjectsReturned errors with LoginFailures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -265,3 +265,4 @@ Muhammad Ayub Khan <ayub.khan@arbisoft.com>
 Kaloian Doganov <doganov@gmail.com>
 Sanford Student <sstudent@edx.org>
 Florian Haas <florian@hastexo.com>
+Leonardo Quiñonez <leonardo.quinonez@edunext.co>


### PR DESCRIPTION
Initially reported and fixed by @laq in https://github.com/edx/edx-platform/pull/11313, replayed here after some git craziness. Original PR comments follow:

```
From this https://code.djangoproject.com/ticket/13906#no1 , the get_or_create function is vulnerable to race conditions in MySQL. This causes the LoginFailure to have, in some cases(rarely but happens), more than one row for the same user, thus breaking the login for the user with a MultipleObjectsReturned exception.

To avoid this I see two paths:

Either set the user field as unique, which I asume would make the get_or_create throw an exception when the race condition happens avoiding the duplicate row, but throwing an exception in the increment_lockout_counter method when that happens. This will require a migration to set the unique flag and a data migration to fix the current duplicate rows.

Or add an except for MultipleObjectsReturned on the is_user_locked_out method so when the duplicate row appears on the DB, it cleans the error, deleting the row or rows with oldest lockout dates. Leaving just one row for the user and solving the login problem.

Here I propose the second option, which would clean the duplicate rows and affect the rest of the code as little as possible.
```
