### PR TITLE
Cleanup preview settings

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -6,7 +6,7 @@ import ddt
 import json
 import copy
 import mock
-from mock import patch
+from mock import Mock, patch
 import unittest
 
 from django.conf import settings
@@ -19,7 +19,7 @@ from models.settings.course_metadata import CourseMetadata
 from models.settings.encoder import CourseSettingsEncoder
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.models.course_details import CourseDetails
-from student.roles import CourseInstructorRole
+from student.roles import CourseInstructorRole, CourseStaffRole
 from student.tests.factories import UserFactory
 from xmodule.fields import Date
 from xmodule.modulestore import ModuleStoreEnum
@@ -28,7 +28,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.tabs import InvalidTabsException
 from milestones.tests.utils import MilestonesTestCaseMixin
 
-from .utils import CourseTestCase
+from .utils import CourseTestCase, AjaxEnabledTestClient
 
 
 def get_url(course_id, handler_name='settings_handler'):
@@ -948,6 +948,23 @@ class CourseMetadataEditingTest(CourseTestCase):
         course = modulestore().get_course(self.course.id)
         tab_list.append(self.notes_tab)
         self.assertEqual(tab_list, course.tabs)
+
+    @patch.dict(settings.FEATURES, {'ENABLE_EDXNOTES': True})
+    @patch('xmodule.util.django.get_current_request')
+    def test_post_settings_with_staff_not_enrolled(self, mock_request):
+        """
+        Tests that we can post advance settings when course staff is not enrolled.
+        """
+        mock_request.return_value = Mock(META={'HTTP_HOST': 'localhost'})
+        user = UserFactory.create(is_staff=True)
+        CourseStaffRole(self.course.id).add_users(user)
+
+        client = AjaxEnabledTestClient()
+        client.login(username=user.username, password=user.password)
+        response = self.client.ajax_post(self.course_setting_url, {
+            'advanced_modules': {"value": [""]}
+        })
+        self.assertEqual(response.status_code, 200)
 
 
 class CourseGraderUpdatesTest(CourseTestCase):

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -79,7 +79,7 @@ class LMSLinksTestCase(TestCase):
         link = utils.get_lms_link_for_item(location, True)
         self.assertEquals(
             link,
-            "//preview/courses/mitX/101/test/jump_to/i4x://mitX/101/vertical/contacting_us"
+            "//preview.localhost/courses/mitX/101/test/jump_to/i4x://mitX/101/vertical/contacting_us"
         )
 
         # now test with the course' location

--- a/cms/envs/bok_choy.env.json
+++ b/cms/envs/bok_choy.env.json
@@ -73,7 +73,7 @@
         "ENABLE_S3_GRADE_DOWNLOADS": true,
         "ENTRANCE_EXAMS": true,
         "MILESTONES_APP": true,
-        "PREVIEW_LMS_BASE": "localhost:8003",
+        "PREVIEW_LMS_BASE": "preview.localhost:8003",
         "ALLOW_ALL_ADVANCED_COMPONENTS": true,
         "ENABLE_CONTENT_LIBRARIES": true,
         "ENABLE_SPECIAL_EXAMS": true,

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -136,7 +136,8 @@ if os.environ.get('DISABLE_MIGRATIONS'):
     MIGRATION_MODULES = NoOpMigrationModules()
 
 LMS_BASE = "localhost:8000"
-FEATURES['PREVIEW_LMS_BASE'] = "preview"
+FEATURES['PREVIEW_LMS_BASE'] = "preview.localhost"
+
 
 CACHES = {
     # This is the cache used for most things. Askbot will not work without a

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -78,4 +78,5 @@ def in_preview_mode():
     Returns whether the user is in preview mode or not.
     """
     hostname = get_current_request_hostname()
-    return bool(hostname and settings.PREVIEW_DOMAIN in hostname.split('.'))
+    preview_lms_base = settings.FEATURES.get('PREVIEW_LMS_BASE', None)
+    return bool(preview_lms_base and hostname and hostname.split(':')[0] == preview_lms_base.split(':')[0])

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -405,6 +405,13 @@ if 'DJFS' in AUTH_TOKENS and AUTH_TOKENS['DJFS'] is not None:
 
 ############### Module Store Items ##########
 HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = ENV_TOKENS.get('HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS', {})
+# PREVIEW DOMAIN must be present in HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS for the preview to show draft changes
+if 'PREVIEW_LMS_BASE' in FEATURES and FEATURES['PREVIEW_LMS_BASE'] != '':
+    PREVIEW_DOMAIN = FEATURES['PREVIEW_LMS_BASE'].split(':')[0]
+    # update dictionary with preview domain regex
+    HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS.update({
+        PREVIEW_DOMAIN: 'draft-preferred'
+    })
 
 ############### Mixed Related(Secure/Not-Secure) Items ##########
 LMS_SEGMENT_KEY = AUTH_TOKENS.get('SEGMENT_KEY')

--- a/lms/envs/bok_choy.env.json
+++ b/lms/envs/bok_choy.env.json
@@ -81,7 +81,7 @@
         "ENABLE_S3_GRADE_DOWNLOADS": true,
         "ENABLE_THIRD_PARTY_AUTH": true,
         "ENABLE_COMBINED_LOGIN_REGISTRATION": true,
-        "PREVIEW_LMS_BASE": "localhost:8003",
+        "PREVIEW_LMS_BASE": "preview.localhost:8003",
         "ALLOW_AUTOMATED_SIGNUPS": true,
         "AUTOMATIC_AUTH_FOR_TESTING": true,
         "MODE_CREATION_FOR_TESTING": true,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2667,9 +2667,6 @@ PROFILE_IMAGE_SECRET_KEY = 'placeholder secret key'
 PROFILE_IMAGE_MAX_BYTES = 1024 * 1024
 PROFILE_IMAGE_MIN_BYTES = 100
 
-# This is to check the domain in case of preview.
-PREVIEW_DOMAIN = 'preview'
-
 # Sets the maximum number of courses listed on the homepage
 # If set to None, all courses will be listed on the homepage
 HOMEPAGE_COURSE_MAX = None

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -394,6 +394,14 @@ YOUTUBE_PORT = 8031
 LTI_PORT = 8765
 VIDEO_SOURCE_PORT = 8777
 
+FEATURES['PREVIEW_LMS_BASE'] = "preview.localhost"
+############### Module Store Items ##########
+PREVIEW_DOMAIN = FEATURES['PREVIEW_LMS_BASE'].split(':')[0]
+HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = {
+    PREVIEW_DOMAIN: 'draft-preferred'
+}
+
+
 ################### Make tests faster
 
 #http://slacy.com/blog/2012/04/make-your-tests-faster-in-django-1-4/


### PR DESCRIPTION
## [TNL-4073](https://openedx.atlassian.net/browse/TNL-4073)
## [TNL-4273](https://openedx.atlassian.net/browse/TNL-4273)

This PR makes the following changes:
1. Use `PREVIEW_LMS_BASE` instead of `PREVIEW_DOMAIN`.
2. Use `PREVIEW_LMS_BASE` in `HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS` instead of the hardcoded value from [configuration](https://github.com/edx/configuration/blob/01716f89e0fd2bc567f6d83017bd01c1d0d5e708/playbooks/roles/edxapp/defaults/main.yml#L146).

This allows us to change the preview domain just by changing one variable instead of three.
A separate PR will be made to remove the entry in the configuration.
### Sandbox
- [x] https://domain-name.sandbox.edx.org/

On the sandbox, the `PREVIEW_LMS_BASE` value has been changed in `lms.env.json` and `cms.env.json` from "preview-domain-name.sandbox.edx.org" to "preview1-domain-name.sandbox.edx.org". To test that add `52.201.244.51 preview1-domain-name.sandbox.edx.org` to your computer's `/etc/hosts`. 

This [unit](https://studio-domain-name.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc) has an unpublished HTML block at the bottom which should only be visible when visiting `preview1-domain-name.sandbox.edx.org`.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @symbolist 
- [ ] Code review: @Reviewer2
### Post-review
- [x] Squash commits
