### PR TITLE
Included the requirements/edx/base.txt pip requirements file in the platform-api doc build requirements file

### DIFF
--- a/docs/en_us/platform_api/requirements.txt
+++ b/docs/en_us/platform_api/requirements.txt
@@ -1,4 +1,187 @@
--r ../../../requirements/edx/base.txt
+# -------------------------------------
+# The following requirements are copied from /requirements/edx/base.txt
+# -------------------------------------
+
+beautifulsoup4==4.1.3
+beautifulsoup==3.2.1
+bleach==1.4
+html5lib==0.999
+boto==2.32.1
+celery==3.1.18
+cssselect==0.9.1
+dealer==2.0.4
+defusedxml==0.4.1
+django-babel-underscore==0.4.2
+django-celery==3.1.16
+django-countries==3.3
+django-extensions==1.5.9
+django-filter==0.11.0
+django-ipware==1.1.0
+django-mako==0.1.5pre
+django-model-utils==2.3.1
+django-mptt==0.7.4
+django-oauth-plus==2.2.8
+django-sekizai==0.8.2
+django-ses==0.7.0
+django-simple-history==1.6.3
+django-statici18n==1.1.5
+django-storages-redux==1.3
+django-method-override==0.1.0
+# We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
+#djangorestframework>=3.1,<3.2
+git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
+django==1.8.9
+djangorestframework-jwt==1.7.2
+edx-django-oauth2-provider==0.5.0
+edx-oauth2-provider==0.5.9
+edx-opaque-keys==0.2.1
+edx-organizations==0.3.1
+edx-rest-api-client==1.2.1
+edx-search==0.1.2
+facebook-sdk==0.4.0
+feedparser==5.1.3
+firebase-token-generator==1.3.2
+GitPython==0.3.2.RC1
+glob2==0.3
+gunicorn==0.17.4
+httpretty==0.8.3
+lazy==1.1
+mako==1.0.2
+Markdown==2.2.1
+--allow-external meliae
+--allow-unverified meliae
+# Removing meliae because it's not installable with pip
+# on all OSes.
+# (https://bugs.launchpad.net/meliae/+bug/1469925)
+# meliae==0.4.0
+mongoengine==0.10.0
+# Removing MySQL-python because it can't be installed unless
+# MySQL is already present
+# MySQL-python==1.2.5
+networkx==1.7
+nose-xunitmp==0.3.2
+oauthlib==0.7.2
+paramiko==1.9.0
+path.py==7.2
+piexif==1.0.2
+Pillow==2.7.0
+polib==1.0.3
+pycrypto>=2.6
+pygments==2.0.1
+
+# Removing pygraphviz because it can't be installed unless
+# Graphviz is already installed.
+# pygraphviz==1.1
+PyJWT==1.4.0
+pymongo==2.9.1
+pyparsing==2.0.1
+python-memcached==1.48
+python-openid==2.2.5
+python-dateutil==2.1
+
+# This module gets monkey-patched in third_party_auth.py to fix a Django 1.8 incompatibility.
+# When this dependency gets upgraded, the monkey patch should be removed, if possible.
+# We can also remove the fix to auth_url in third_party_auth/saml.py when that fix is included upstream.
+python-social-auth==0.2.12
+
+pytz==2015.2
+pysrt==0.4.7
+PyYAML==3.10
+requests==2.7.0
+requests-oauthlib==0.4.1
+# Removing scipy because RTD can't install it.
+# scipy==0.14.0
+Shapely==1.2.16
+singledispatch==3.4.0.2
+sorl-thumbnail==12.3
+sortedcontainers==0.9.2
+stevedore==0.14.1
+sure==1.2.3
+sympy==0.7.1
+xmltodict==0.4.1
+django-ratelimit-backend==1.0
+unicodecsv==0.9.4
+django-require==1.0.6
+pyuca==1.1
+wrapt==1.10.5
+zendesk==1.1.1
+
+# This needs to be installed *after* Cython, which is in pre.txt
+lxml==3.4.4
+
+# Used for shopping cart's pdf invoice/receipt generation
+reportlab==3.1.44
+
+# Used for extracting/parsing pdf text
+pdfminer==20140328
+
+# Used for development operation
+watchdog==0.7.1
+
+# Metrics gathering and monitoring
+dogapi==1.2.1
+newrelic==2.56.0.42
+
+# Used for documentation gathering
+sphinx==1.1.3
+sphinx_rtd_theme==0.1.5
+
+# Used for Internationalization and localization
+Babel==1.3
+transifex-client==0.11b3
+
+# Ip network support for Embargo feature
+ipaddr==2.1.11
+
+# Used to allow to configure CORS headers for cross-domain requests
+django-cors-headers==1.1.0
+
+# Debug toolbar
+django_debug_toolbar==1.3.2
+
+# Used for testing
+before_after==0.1.3
+bok-choy==0.4.10
+chrono==1.0.2
+coverage==4.0.2
+ddt==0.8.0
+diff-cover==0.9.0
+django-crum==0.5
+django_nose==1.4.1
+factory_boy==2.5.1
+flaky==2.4.0
+freezegun==0.1.11
+mock-django==0.6.9
+mock==1.0.1
+moto==0.3.1
+nose==1.3.7
+nose-exclude
+nose-ignore-docstring
+nosexcover==1.0.7
+pep8==1.5.7
+PyContracts==1.7.1
+python-subunit==0.0.16
+pyquery==1.2.9
+radon==1.2
+rednose==0.4.3
+selenium==2.42.1
+splinter==0.5.4
+testtools==0.9.34
+testfixtures==4.5.0
+
+# Used for Segment analytics
+analytics-python==1.1.0
+
+# Needed for mailchimp(mailing djangoapp)
+mailsnake==1.6.2
+jsonfield==1.0.3
+
+# Inlines CSS styles into HTML for email notifications.
+pynliner==0.5.2
+
+# -------------------------------------
+# The following requirements apply to the documentation build
+# -------------------------------------
 
 git+https://github.com/edx/XBlock.git#egg=XBlock
 git+https://github.com/edx/django-rest-framework-oauth.git@f0b503fda8c254a38f97fef802ded4f5fe367f7a#egg=djangorestframework_oauth-master

--- a/docs/en_us/platform_api/requirements.txt
+++ b/docs/en_us/platform_api/requirements.txt
@@ -1,16 +1,5 @@
-path.py
-Django >=1.8,<1.9
-django-simple-history==1.6.3
-pytz
+-r ../../../requirements/edx/base.txt
+
 git+https://github.com/edx/XBlock.git#egg=XBlock
 git+https://github.com/edx/django-rest-framework-oauth.git@f0b503fda8c254a38f97fef802ded4f5fe367f7a#egg=djangorestframework_oauth-master
-lxml
-Babel
-lazy
 sphinxcontrib-napoleon==0.2.6
-sphinx_rtd_theme
-stevedore==0.14.1
-djangorestframework==3.2.3
-PyYAML>=3.10
-mock
-django-model-utils==2.3.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,9 +52,14 @@ mako==1.0.2
 Markdown==2.2.1
 --allow-external meliae
 --allow-unverified meliae
-meliae==0.4.0
+# Removing meliae because it's not installable with pip
+# on all OSes.
+# (https://bugs.launchpad.net/meliae/+bug/1469925)
+# meliae==0.4.0
 mongoengine==0.10.0
-MySQL-python==1.2.5
+# Removing MySQL-python because it can't be installed unless
+# MySQL is already present
+# MySQL-python==1.2.5
 networkx==1.7
 nose-xunitmp==0.3.2
 oauthlib==0.7.2
@@ -65,7 +70,10 @@ Pillow==2.7.0
 polib==1.0.3
 pycrypto>=2.6
 pygments==2.0.1
-pygraphviz==1.1
+
+# Removing pygraphviz because it can't be installed unless
+# Graphviz is already installed.
+# pygraphviz==1.1
 PyJWT==1.4.0
 pymongo==2.9.1
 pyparsing==2.0.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -34,10 +34,11 @@ django-method-override==0.1.0
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
 django==1.8.9
 djangorestframework-jwt==1.7.2
+djangorestframework-oauth==1.1.0
 edx-django-oauth2-provider==0.5.0
 edx-oauth2-provider==0.5.9
 edx-opaque-keys==0.2.1
-edx-organizations==0.3.1
+edx-organizations==0.4.0
 edx-rest-api-client==1.2.1
 edx-search==0.1.2
 facebook-sdk==0.4.0
@@ -52,14 +53,9 @@ mako==1.0.2
 Markdown==2.2.1
 --allow-external meliae
 --allow-unverified meliae
-# Removing meliae because it's not installable with pip
-# on all OSes.
-# (https://bugs.launchpad.net/meliae/+bug/1469925)
-# meliae==0.4.0
+meliae==0.4.0
 mongoengine==0.10.0
-# Removing MySQL-python because it can't be installed unless
-# MySQL is already present
-# MySQL-python==1.2.5
+MySQL-python==1.2.5
 networkx==1.7
 nose-xunitmp==0.3.2
 oauthlib==0.7.2
@@ -70,10 +66,7 @@ Pillow==2.7.0
 polib==1.0.3
 pycrypto>=2.6
 pygments==2.0.1
-
-# Removing pygraphviz because it can't be installed unless
-# Graphviz is already installed.
-# pygraphviz==1.1
+pygraphviz==1.1
 PyJWT==1.4.0
 pymongo==2.9.1
 pyparsing==2.0.1
@@ -91,8 +84,7 @@ pysrt==0.4.7
 PyYAML==3.10
 requests==2.7.0
 requests-oauthlib==0.4.1
-# Removing scipy because RTD can't install it.
-# scipy==0.14.0
+scipy==0.14.0
 Shapely==1.2.16
 singledispatch==3.4.0.2
 sorl-thumbnail==12.3

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -91,7 +91,8 @@ pysrt==0.4.7
 PyYAML==3.10
 requests==2.7.0
 requests-oauthlib==0.4.1
-scipy==0.14.0
+# Removing scipy because RTD can't install it.
+# scipy==0.14.0
 Shapely==1.2.16
 singledispatch==3.4.0.2
 sorl-thumbnail==12.3


### PR DESCRIPTION
## [DOC-2638](https://openedx.atlassian.net/browse/DOC-2638)

The requirements file for the Sphinx documentation build for the docs/en_us/platform-api guide needs to install all the requirements for importing the modules that we refer to in our Sphinx autoclass directives. Previously, we were trying to add and maintain versions for each of those modules in the docs/en_us/platform-api/requirements.txt file. The module list becomes out of date regularly, and it's a puzzle to correct it each time the doc build breaks. This change will force the documentation build environment to install the entire set of packages in requirements/edx/base.txt. It's easier to let the doc build install too many packages than to update the subset separately, and incessantly.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @nedbat 
- [ ] Doc team review (sanity check): @lamagnifica 
### HTML Draft
- [ ] http://draft-platform-api-doc.readthedocs.org/en/latest/
