### PR TITLE
Added visible_to_staff_only field to course blocks API

### DIFF
--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -6,10 +6,12 @@ from mock import MagicMock
 from course_blocks.tests.helpers import EnableTransformerRegistryMixin
 from openedx.core.lib.block_structure.transformers import BlockStructureTransformers
 from student.tests.factories import UserFactory
+from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ToyCourseFactory
 from lms.djangoapps.course_blocks.api import get_course_blocks, COURSE_BLOCK_ACCESS_TRANSFORMERS
 
+from student.roles import CourseStaffRole
 from ..transformers.blocks_api import BlocksAPITransformer
 from ..serializers import BlockSerializer, BlockDictSerializer
 from .helpers import deserialize_usage_key
@@ -25,10 +27,17 @@ class TestBlockSerializerBase(EnableTransformerRegistryMixin, SharedModuleStoreT
 
         cls.course = ToyCourseFactory.create()
 
+        # Hide the html block
+        key = cls.course.id.make_usage_key('html', 'secret:toylab')
+        cls.html_block = cls.store.get_item(key)
+        cls.html_block.visible_to_staff_only = True
+        cls.store.update_item(cls.html_block, ModuleStoreEnum.UserID.test)
+
     def setUp(self):
         super(TestBlockSerializerBase, self).setUp()
 
         self.user = UserFactory.create()
+
         blocks_api_transformer = BlocksAPITransformer(
             block_types_to_count=['video'],
             requested_student_view_data=['video'],
@@ -58,11 +67,13 @@ class TestBlockSerializerBase(EnableTransformerRegistryMixin, SharedModuleStoreT
             {'id', 'type', 'lms_web_url', 'student_view_url'},
         )
 
-    def add_additional_requested_fields(self):
+    def add_additional_requested_fields(self, context=None):
         """
         Adds additional fields to the requested_fields context for the serializer.
         """
-        self.serializer_context['requested_fields'].extend([
+        if context is None:
+            context = self.serializer_context
+        context['requested_fields'].extend([
             'children',
             'display_name',
             'graded',
@@ -71,6 +82,7 @@ class TestBlockSerializerBase(EnableTransformerRegistryMixin, SharedModuleStoreT
             'student_view_data',
             'student_view_multi_device',
             'lti_url',
+            'visible_to_staff_only',
         ])
 
     def assert_extended_block(self, serialized_block):
@@ -83,6 +95,7 @@ class TestBlockSerializerBase(EnableTransformerRegistryMixin, SharedModuleStoreT
                 'display_name', 'graded',
                 'block_counts', 'student_view_multi_device',
                 'lti_url',
+                'visible_to_staff_only',
             },
             set(serialized_block.iterkeys()),
         )
@@ -96,18 +109,48 @@ class TestBlockSerializerBase(EnableTransformerRegistryMixin, SharedModuleStoreT
             self.assertIn('student_view_multi_device', serialized_block)
             self.assertTrue(serialized_block['student_view_multi_device'])
 
+    def create_staff_context(self):
+        """
+        Create staff user and course blocks accessible by that user
+        """
+        # Create a staff user to be able to test visible_to_staff_only
+        staff_user = UserFactory.create()
+        CourseStaffRole(self.course.location.course_key).add_users(staff_user)
+
+        block_structure = get_course_blocks(
+            staff_user,
+            self.course.location,
+            BlockStructureTransformers(COURSE_BLOCK_ACCESS_TRANSFORMERS),
+        )
+        return {
+            'request': MagicMock(),
+            'block_structure': block_structure,
+            'requested_fields': ['type'],
+        }
+
+    def assert_staff_fields(self, serialized_block):
+        """
+        Test fields accessed by a staff user
+        """
+        if serialized_block['id'] == unicode(self.html_block.location):
+            self.assertTrue(serialized_block['visible_to_staff_only'])
+        else:
+            self.assertFalse(serialized_block['visible_to_staff_only'])
+
 
 class TestBlockSerializer(TestBlockSerializerBase):
     """
     Tests the BlockSerializer class, which returns a list of blocks.
     """
 
-    def create_serializer(self):
+    def create_serializer(self, context=None):
         """
         creates a BlockSerializer
         """
+        if context is None:
+            context = self.serializer_context
         return BlockSerializer(
-            self.block_structure, many=True, context=self.serializer_context,
+            context['block_structure'], many=True, context=context,
         )
 
     def test_basic(self):
@@ -121,18 +164,31 @@ class TestBlockSerializer(TestBlockSerializerBase):
         for serialized_block in serializer.data:
             self.assert_extended_block(serialized_block)
 
+    def test_staff_fields(self):
+        """
+        Test fields accessed by a staff user
+        """
+        context = self.create_staff_context()
+        self.add_additional_requested_fields(context)
+        serializer = self.create_serializer(context)
+        for serialized_block in serializer.data:
+            self.assert_extended_block(serialized_block)
+            self.assert_staff_fields(serialized_block)
+
 
 class TestBlockDictSerializer(TestBlockSerializerBase):
     """
     Tests the BlockDictSerializer class, which returns a dict of blocks key-ed by its block_key.
     """
 
-    def create_serializer(self):
+    def create_serializer(self, context=None):
         """
         creates a BlockDictSerializer
         """
+        if context is None:
+            context = self.serializer_context
         return BlockDictSerializer(
-            self.block_structure, many=False, context=self.serializer_context,
+            context['block_structure'], many=False, context=context,
         )
 
     def test_basic(self):
@@ -151,3 +207,14 @@ class TestBlockDictSerializer(TestBlockSerializerBase):
         serializer = self.create_serializer()
         for serialized_block in serializer.data['blocks'].itervalues():
             self.assert_extended_block(serialized_block)
+
+    def test_staff_fields(self):
+        """
+        Test fields accessed by a staff user
+        """
+        context = self.create_staff_context()
+        self.add_additional_requested_fields(context)
+        serializer = self.create_serializer(context)
+        for serialized_block in serializer.data['blocks'].itervalues():
+            self.assert_extended_block(serialized_block)
+            self.assert_staff_fields(serialized_block)

--- a/lms/djangoapps/course_api/blocks/transformers/__init__.py
+++ b/lms/djangoapps/course_api/blocks/transformers/__init__.py
@@ -2,6 +2,7 @@
 Course API Block Transformers
 """
 
+from lms.djangoapps.course_blocks.transformers.visibility import VisibilityTransformer
 from .student_view import StudentViewTransformer
 from .block_counts import BlockCountsTransformer
 from .navigation import BlockNavigationTransformer
@@ -50,5 +51,12 @@ SUPPORTED_FIELDS = [
         BlockNavigationTransformer,
         requested_field_name='nav_depth',
         serializer_field_name='descendants',
+    ),
+
+    # Provide the staff visibility info stored when VisibilityTransformer ran previously
+    SupportedFieldType(
+        'merged_visible_to_staff_only',
+        VisibilityTransformer,
+        requested_field_name='visible_to_staff_only',
     )
 ]


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitocw/edx-platform/issues/211
#### What's this PR do?

This PR adds an optional field `visible_to_staff_only` to the course blocks API in LMS at `/api/courses/v1/blocks/`. The new field is not present by default but it can be enabled by adding the field to `requested_fields`. Example URL: http://localhost:8000/api/courses/v1/blocks/?course_id=course-v1%3AedX%2BDemoX%2BDemo_Course&all_blocks=1&requested_fields=visible_to_staff_only&depth=all

This change is useful to us at MIT ODL because it allows us to filter out chapters for courses which have been marked as hidden. The CCXCon application will have staff access for certain courses and it needs to be able to hide from the user chapters which are not available for use by students.
#### How should this be manually tested?

It should be enough to adjust the example URL listed above to view the course blocks API in your local openedX instance. You should see the new `visible_to_staff_only` field for each block listed with a true or false value.
#### Any background context you want to provide?

This uses the existing `VisibilityTransformer` transformer which already marks blocks with the `merged_visible_to_staff_only` attribute. This PR just exposes that value in the API and adds tests for its functionality.
