### PR TITLE
Check both url and title for the presence of code

### DIFF
--- a/common/test/acceptance/tests/lms/test_oauth2.py
+++ b/common/test/acceptance/tests/lms/test_oauth2.py
@@ -54,8 +54,12 @@ class OAuth2PermissionDelegationTests(WebAppTest):
         self._auth()
         assert self.oauth_page.visit()
         self.oauth_page.confirm()
-
-        # This redirects to an invalid URI.
         self.oauth_page.wait_for_element_absence('input[name=authorize]', 'Authorization button is not present')
-        query = self._qs(self.browser.current_url) or self._qs(self.browser.title)
+
+        # This redirects to an invalid URI based on the selected browser.
+        if self.browser.name == 'chrome':
+            query = self._qs(self.browser.title)
+        else:
+            query = self._qs(self.browser.current_url)
+
         self.assertIn('code', query)

--- a/common/test/acceptance/tests/lms/test_oauth2.py
+++ b/common/test/acceptance/tests/lms/test_oauth2.py
@@ -56,5 +56,6 @@ class OAuth2PermissionDelegationTests(WebAppTest):
         self.oauth_page.confirm()
 
         # This redirects to an invalid URI.
-        query = self._qs(self.browser.current_url)
+        self.oauth_page.wait_for_element_absence('input[name=authorize]', 'Authorization button is not present')
+        query = self._qs(self.browser.current_url) or self._qs(self.browser.title)
         self.assertIn('code', query)


### PR DESCRIPTION
Problem was this bug https://bugs.chromium.org/p/chromedriver/issues/detail?id=1272. To solve it using our existing version, we have to check the presence of code in title of the chrome tab but it is not the case for the firefox. So we are using either one (url or title) with code present. wait from authorization button absence in important for the pass of test on firefox. 

Please review @raeeschachar @benpatterson @jzoldak 
