### PR TITLE
Course Overview migrations fix: Readd the Facebook URL field

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/migrations/0009_readd_facebook_url.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0009_readd_facebook_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_overviews', '0008_remove_courseoverview_facebook_url'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseoverview',
+            name='facebook_url',
+            field=models.TextField(null=True),
+        ),
+    ]


### PR DESCRIPTION
This PR undoes the migration for removing the `facebook_url` column from the `CourseOverview` table, introduced in https://github.com/edx/edx-platform/pull/11326.  

We need a 2-phase removal of this column in order to support rolling out to multiple workers on prod.  _Plan:_
- Remove the `facebook_url` field from the django models, but do not remove the column from the underlying table.
- Release this to production.  With this 1st release, old workers that expect the column to be there will not break.
- In a subsequent release, add a migration to remove the `facebook_url` from the underlying table.  By this 2nd release, old and new workers will not expect the column to be present.

Reviewers: @jcdyer @BenjiLee 
FYI: @feanil @jibsheet 
