### PR TITLE
Noop the 0008 and conditional the 0009 migration

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/migrations/0008_remove_courseoverview_facebook_url.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0008_remove_courseoverview_facebook_url.py
@@ -11,8 +11,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='courseoverview',
-            name='facebook_url',
-        ),
+        # Removed because we accidentally removed this column without first
+        # removing the code that refers to this.  This can cause errors in production.
     ]

--- a/openedx/core/djangoapps/content/course_overviews/migrations/0009_readd_facebook_url.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0009_readd_facebook_url.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations, models, OperationalError, connection
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
 
 class Migration(migrations.Migration):
@@ -10,10 +11,17 @@ class Migration(migrations.Migration):
         ('course_overviews', '0008_remove_courseoverview_facebook_url'),
     ]
 
-    operations = [
-        migrations.AddField(
+    # An original version of 0008 removed the facebook_url field
+    # We need to handle the case where our noop 0008 ran AND the case
+    # where the original 0008 ran.  We do that by using Django's introspection
+    # API to query INFORMATION_SCHEMA.  _meta is unavailable as the
+    # column has already been removed from the model.
+    fields = connection.introspection.get_table_description(connection.cursor(),'course_overviews_courseoverview')
+    operations = []
+
+    if not any(f.name == 'facebook_url' for f in fields):
+        operations += migrations.AddField(
             model_name='courseoverview',
             name='facebook_url',
             field=models.TextField(null=True),
         ),
-    ]


### PR DESCRIPTION
We removed a column in the same release that we removed it
from the model.  This creates a gap where the code still looks for
a column which has been dropped until the new code has been deployed.

The initial fix was to put the column back, but that creates a window
during the alterations where views will error.

This noops the 0008 migration and effectively noops 0009 unless you've
run the old migration.
