### PR TITLE
Ensuring page is loaded belongs in the page object.

### DIFF
--- a/common/test/acceptance/pages/studio/index.py
+++ b/common/test/acceptance/pages/studio/index.py
@@ -15,7 +15,7 @@ class DashboardPage(PageObject):
     url = BASE_URL + "/course/"
 
     def is_browser_on_page(self):
-        return self.q(css='body.view-dashboard').present
+        return self.q(css='.content-primary').visible
 
     @property
     def course_runs(self):

--- a/common/test/acceptance/tests/studio/test_studio_home.py
+++ b/common/test/acceptance/tests/studio/test_studio_home.py
@@ -49,7 +49,6 @@ class CreateLibraryTest(WebAppTest):
 
         self.auth_page.visit()
         self.dashboard_page.visit()
-        self.dashboard_page.wait_for_element_visibility('.content-primary', 'See library list.')
         self.assertFalse(self.dashboard_page.has_library(name=name, org=org, number=number))
         self.assertTrue(self.dashboard_page.has_new_library_button())
 


### PR DESCRIPTION
TNL-4151 had previously been fixed to avoid a flaky condition; however,
that only passed the flaky condition to a later point in the
test. The proper fix is to ensure the page has loaded. Putting the
definition in this method will mean that the page will wait
to load with other functions, such as `DashboardPage.visit()`.
