### PR TITLE
TNL-4140 – Configure code jail for Studio

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -176,6 +176,14 @@ SERVER_EMAIL = ENV_TOKENS.get('SERVER_EMAIL', SERVER_EMAIL)
 MKTG_URLS = ENV_TOKENS.get('MKTG_URLS', MKTG_URLS)
 TECH_SUPPORT_EMAIL = ENV_TOKENS.get('TECH_SUPPORT_EMAIL', TECH_SUPPORT_EMAIL)
 
+for name, value in ENV_TOKENS.get("CODE_JAIL", {}).items():
+    oldvalue = CODE_JAIL.get(name)
+    if isinstance(oldvalue, dict):
+        for subname, subvalue in value.items():
+            oldvalue[subname] = subvalue
+    else:
+        CODE_JAIL[name] = value
+
 COURSES_WITH_UNSAFE_CODE = ENV_TOKENS.get("COURSES_WITH_UNSAFE_CODE", [])
 
 ASSET_IGNORE_REGEX = ENV_TOKENS.get('ASSET_IGNORE_REGEX', ASSET_IGNORE_REGEX)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -342,6 +342,8 @@ MIDDLEWARE_CLASSES = (
     # Detects user-requested locale from 'accept-language' header in http request
     'django.middleware.locale.LocaleMiddleware',
 
+    'codejail.django_integration.ConfigureCodeJailMiddleware',
+
     # needs to run after locale middleware (or anything that modifies the request context)
     'edxmako.middleware.MakoMiddleware',
 
@@ -410,6 +412,21 @@ MODULESTORE = {
             ]
         }
     }
+}
+
+#################### Python sandbox ############################################
+
+CODE_JAIL = {
+    # Path to a sandboxed Python executable.  None means don't bother.
+    'python_bin': None,
+    # User to run as in the sandbox.
+    'user': 'sandbox',
+
+    # Configurable limits.
+    'limits': {
+        # How many CPU seconds can jailed code use?
+        'CPU': 1,
+    },
 }
 
 ############################ DJANGO_BUILTINS ################################


### PR DESCRIPTION
[TNL-4140](https://openedx.atlassian.net/browse/TNL-4140)

**Background**
Code jail was not configured for studio like it was for lms. That's why, importing `matplotlib` in _Python Script Problem_ results in error saying 'File Too Large'. 

**Fix**
Required code jail configurations were added in configuration repo by [this](https://github.com/edx/configuration/pull/2819) PR for Studio (ticket: [DEVOPS-3753](https://openedx.atlassian.net/browse/DEVOPS-3753)). I am loading this configuration from configuration file and adding `ConfigureCodeJailMiddleware` to `MIDDLEWARE_CLASSES` in order to configure code jail instance for Studio.

**Sandbox**
I have added the relevant problem in my sandbox as follow: 
https://studio-codejailconfigscms.sandbox.edx.org/container/block-v1:edX+Test101+course+type@vertical+block@2e2b2dc6e7b04a8d93a20efd16a49e37

@feanil , @adampalay please have a look.

Thanks.
