### PR TITLE
Display studio name properly on empty course page.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -8,6 +8,7 @@ from chrono import Timer
 from mock import patch, Mock
 import ddt
 
+from django.conf import settings
 from django.test import RequestFactory
 from django.test.client import Client
 
@@ -98,6 +99,15 @@ class TestCourseListing(ModuleStoreTestCase, XssTestMixin):
         response = self.client.get('/home')
         self.assertEqual(response.status_code, 200)
         self.assert_no_xss(response, escaping_content)
+
+    def test_empty_course_listing(self):
+        """
+        Test on empty course listing, studio name is properly displayed
+        """
+        message = "Are you staff on an existing {studio_name} course?".format(studio_name=settings.STUDIO_SHORT_NAME)
+        response = self.client.get('/home')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(message, response.content)
 
     def test_get_course_list(self):
         """

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -346,7 +346,7 @@
       <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices courses-tab active">
         <div class="notice-item">
           <div class="msg">
-            <h3 class="title">${_("Are you staff on an existing {studio_name} course?").format(studio_name=set)}</h3>
+            <h3 class="title">${_("Are you staff on an existing {studio_name} course?").format(studio_name=settings.STUDIO_SHORT_NAME)}</h3>
             <div class="copy">
               <p>${_('The course creator must give you access to the course. Contact the course creator or administrator for the course you are helping to author.')}</p>
             </div>


### PR DESCRIPTION
[TNL-4167](https://openedx.atlassian.net/browse/TNL-4167)

Properly display studio name on empty course list page.

@awaisdar001 @adampalay Please review.
