### PR TITLE
New optional parameters for course blocks API: lti_url, block_types

### DIFF
--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -20,7 +20,7 @@ def get_blocks(
         block_counts=None,
         student_view_data=None,
         return_type='dict',
-        block_types=None
+        block_types=None,
 ):
     """
     Return a serialized representation of the course blocks.

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -20,6 +20,7 @@ def get_blocks(
         block_counts=None,
         student_view_data=None,
         return_type='dict',
+        block_types=None
 ):
     """
     Return a serialized representation of the course blocks.
@@ -60,6 +61,18 @@ def get_blocks(
 
     # transform
     blocks = get_course_blocks(user, usage_key, transformers)
+
+    # filter blocks by types
+    if block_types and len(block_types) == 0:
+        block_types = None
+    if block_types:
+        block_keys_to_remove = []
+        for block_key in blocks:
+            block_type = blocks.get_xblock_field(block_key, 'category')
+            if not block_type in block_types:
+                block_keys_to_remove.append(block_key)
+        for block_key in block_keys_to_remove:
+            blocks.remove_block(block_key, True)
 
     # serialize
     serializer_context = {

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -20,7 +20,7 @@ def get_blocks(
         block_counts=None,
         student_view_data=None,
         return_type='dict',
-        block_type_filter=None,
+        block_types_filter=None,
 ):
     """
     Return a serialized representation of the course blocks.
@@ -45,7 +45,7 @@ def get_blocks(
             which blocks to return their student_view_data.
         return_type (string): Possible values are 'dict' or 'list'. Indicates
             the format for returning the blocks.
-        block_type_filter (list): Optional list of block type names used to filter
+        block_types_filter (list): Optional list of block type names used to filter
             the final result of returned blocks.
     """
     # create ordered list of transformers, adding BlocksAPITransformer at end.
@@ -65,11 +65,11 @@ def get_blocks(
     blocks = get_course_blocks(user, usage_key, transformers)
 
     # filter blocks by types
-    if block_type_filter:
+    if block_types_filter:
         block_keys_to_remove = []
         for block_key in blocks:
             block_type = blocks.get_xblock_field(block_key, 'category')
-            if block_type not in block_type_filter:
+            if block_type not in block_types_filter:
                 block_keys_to_remove.append(block_key)
         for block_key in block_keys_to_remove:
             blocks.remove_block(block_key, keep_descendants=True)

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -45,7 +45,7 @@ def get_blocks(
             which blocks to return their student_view_data.
         return_type (string): Possible values are 'dict' or 'list'. Indicates
             the format for returning the blocks.
-        block_type_filter (list): Optional list of block type names used to filter 
+        block_type_filter (list): Optional list of block type names used to filter
             the final result of returned blocks.
     """
     # create ordered list of transformers, adding BlocksAPITransformer at end.

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -45,6 +45,8 @@ def get_blocks(
             which blocks to return their student_view_data.
         return_type (string): Possible values are 'dict' or 'list'. Indicates
             the format for returning the blocks.
+        block_types (list): Optional list of names of block types which to
+            return blocks.
     """
     # create ordered list of transformers, adding BlocksAPITransformer at end.
     transformers = BlockStructureTransformers()
@@ -63,13 +65,11 @@ def get_blocks(
     blocks = get_course_blocks(user, usage_key, transformers)
 
     # filter blocks by types
-    if block_types and len(block_types) == 0:
-        block_types = None
     if block_types:
         block_keys_to_remove = []
         for block_key in blocks:
             block_type = blocks.get_xblock_field(block_key, 'category')
-            if not block_type in block_types:
+            if block_type not in block_types:
                 block_keys_to_remove.append(block_key)
         for block_key in block_keys_to_remove:
             blocks.remove_block(block_key, True)

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -20,7 +20,7 @@ def get_blocks(
         block_counts=None,
         student_view_data=None,
         return_type='dict',
-        block_types=None,
+        block_type_filter=None,
 ):
     """
     Return a serialized representation of the course blocks.
@@ -45,8 +45,8 @@ def get_blocks(
             which blocks to return their student_view_data.
         return_type (string): Possible values are 'dict' or 'list'. Indicates
             the format for returning the blocks.
-        block_types (list): Optional list of names of block types which to
-            return blocks.
+        block_type_filter (list): Optional list of block type names used to filter 
+            the final result of returned blocks.
     """
     # create ordered list of transformers, adding BlocksAPITransformer at end.
     transformers = BlockStructureTransformers()
@@ -65,14 +65,14 @@ def get_blocks(
     blocks = get_course_blocks(user, usage_key, transformers)
 
     # filter blocks by types
-    if block_types:
+    if block_type_filter:
         block_keys_to_remove = []
         for block_key in blocks:
             block_type = blocks.get_xblock_field(block_key, 'category')
-            if block_type not in block_types:
+            if block_type not in block_type_filter:
                 block_keys_to_remove.append(block_key)
         for block_key in block_keys_to_remove:
-            blocks.remove_block(block_key, True)
+            blocks.remove_block(block_key, keep_descendants=True)
 
     # serialize
     serializer_context = {

--- a/lms/djangoapps/course_api/blocks/forms.py
+++ b/lms/djangoapps/course_api/blocks/forms.py
@@ -31,7 +31,7 @@ class BlockListGetForm(Form):
     student_view_data = MultiValueField(required=False)
     usage_key = CharField(required=True)
     username = CharField(required=False)
-    block_type_filter = MultiValueField(required=False)
+    block_types_filter = MultiValueField(required=False)
 
     def clean_depth(self):
         """
@@ -89,7 +89,7 @@ class BlockListGetForm(Form):
             'student_view_data',
             'block_counts',
             'nav_depth',
-            'block_type_filter',
+            'block_types_filter',
         ]
         for additional_field in additional_requested_fields:
             field_value = cleaned_data.get(additional_field)

--- a/lms/djangoapps/course_api/blocks/forms.py
+++ b/lms/djangoapps/course_api/blocks/forms.py
@@ -31,6 +31,7 @@ class BlockListGetForm(Form):
     student_view_data = MultiValueField(required=False)
     usage_key = CharField(required=True)
     username = CharField(required=False)
+    block_types = MultiValueField(required=False)
 
     def clean_depth(self):
         """
@@ -88,6 +89,7 @@ class BlockListGetForm(Form):
             'student_view_data',
             'block_counts',
             'nav_depth',
+            'block_types',
         ]
         for additional_field in additional_requested_fields:
             field_value = cleaned_data.get(additional_field)

--- a/lms/djangoapps/course_api/blocks/forms.py
+++ b/lms/djangoapps/course_api/blocks/forms.py
@@ -31,7 +31,7 @@ class BlockListGetForm(Form):
     student_view_data = MultiValueField(required=False)
     usage_key = CharField(required=True)
     username = CharField(required=False)
-    block_types = MultiValueField(required=False)
+    block_type_filter = MultiValueField(required=False)
 
     def clean_depth(self):
         """
@@ -89,7 +89,7 @@ class BlockListGetForm(Form):
             'student_view_data',
             'block_counts',
             'nav_depth',
-            'block_types',
+            'block_type_filter',
         ]
         for additional_field in additional_requested_fields:
             field_value = cleaned_data.get(additional_field)

--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -77,6 +77,7 @@ class BlockDictSerializer(serializers.Serializer):  # pylint: disable=abstract-m
     Serializer that formats a BlockStructure object to a dictionary, rather
     than a list, of blocks
     """
+    root = serializers.CharField(source='root_block_usage_key')
     blocks = serializers.SerializerMethodField()
 
     def get_blocks(self, structure):

--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -44,6 +44,13 @@ class BlockSerializer(serializers.Serializer):  # pylint: disable=abstract-metho
             ),
         }
 
+        if 'lti_url' in self.context['requested_fields']:
+            data['lti_url'] = reverse(
+                'lti_provider_launch',
+                kwargs={'course_id': unicode(block_key.course_key), 'usage_id': unicode(block_key)},
+                request=self.context['request'],
+            )
+
         # add additional requested fields that are supported by the various transformers
         for supported_field in SUPPORTED_FIELDS:
             if supported_field.requested_field_name in self.context['requested_fields']:
@@ -70,7 +77,6 @@ class BlockDictSerializer(serializers.Serializer):  # pylint: disable=abstract-m
     Serializer that formats a BlockStructure object to a dictionary, rather
     than a list, of blocks
     """
-    root = serializers.CharField(source='root_block_usage_key')
     blocks = serializers.SerializerMethodField()
 
     def get_blocks(self, structure):

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -12,8 +12,6 @@ from xmodule.modulestore.tests.factories import SampleCourseFactory
 
 from ..api import get_blocks
 
-import re
-
 
 class TestGetBlocks(EnableTransformerRegistryMixin, SharedModuleStoreTestCase):
     """
@@ -84,16 +82,17 @@ class TestGetBlocks(EnableTransformerRegistryMixin, SharedModuleStoreTestCase):
         sequential_block = self.store.get_item(self.course.id.make_usage_key('sequential', 'sequential_y1'))
 
         # not filtered blocks
-        blocks = get_blocks(self.request, sequential_block.location, self.user)
+        blocks = get_blocks(self.request, sequential_block.location, self.user, requested_fields=['type'])
         self.assertEquals(len(blocks['blocks']), 5)
         found_not_problem = False
         for key in blocks['blocks']:
-            if not re.search(r'/problem/', key):
+            if blocks['blocks'][key]['type'] != 'problem':
                 found_not_problem = True
         self.assertTrue(found_not_problem)
 
         # filtered blocks
-        blocks = get_blocks(self.request, sequential_block.location, self.user, block_type_filter=['problem'])
+        blocks = get_blocks(self.request, sequential_block.location, self.user,
+                            block_types_filter=['problem'], requested_fields=['type'])
         self.assertEquals(len(blocks['blocks']), 3)
         for key in blocks['blocks']:
-            self.assertTrue(re.search(r'/problem/', key))
+            self.assertEqual(blocks['blocks'][key]['type'], 'problem')

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -35,7 +35,6 @@ class TestGetBlocks(EnableTransformerRegistryMixin, SharedModuleStoreTestCase):
 
     def test_basic(self):
         blocks = get_blocks(self.request, self.course.location, self.user)
-        self.assertEquals(blocks['root'], unicode(self.course.location))
 
         # subtract for (1) the orphaned course About block and (2) the hidden Html block
         self.assertEquals(len(blocks['blocks']), len(self.store.get_items(self.course.id)) - 2)
@@ -63,7 +62,6 @@ class TestGetBlocks(EnableTransformerRegistryMixin, SharedModuleStoreTestCase):
         sequential_block = self.store.get_item(self.course.id.make_usage_key('sequential', 'sequential_y1'))
 
         blocks = get_blocks(self.request, sequential_block.location, self.user)
-        self.assertEquals(blocks['root'], unicode(sequential_block.location))
         self.assertEquals(len(blocks['blocks']), 5)
 
         for block_type, block_name, is_inside_of_structure in (
@@ -77,3 +75,17 @@ class TestGetBlocks(EnableTransformerRegistryMixin, SharedModuleStoreTestCase):
                 self.assertIn(unicode(block.location), blocks['blocks'])
             else:
                 self.assertNotIn(unicode(block.location), blocks['blocks'])
+
+    def test_filtering_by_block_types(self):
+        sequential_block = self.store.get_item(self.course.id.make_usage_key('sequential', 'sequential_y1'))
+
+        block_types = ['problem']
+        blocks = get_blocks(self.request, sequential_block.location, self.user, block_types=block_types)
+
+        for block_type, block_name in (
+                ('problem', 'problem_y1a_1'),
+                ('problem', 'problem_y1a_2'),
+                ('problem', 'problem_y1a_3'),
+        ):
+            block = self.store.get_item(self.course.id.make_usage_key(block_type, block_name))
+            self.assertIn(unicode(block.location), blocks['blocks'])

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -85,8 +85,8 @@ class TestGetBlocks(EnableTransformerRegistryMixin, SharedModuleStoreTestCase):
         blocks = get_blocks(self.request, sequential_block.location, self.user, requested_fields=['type'])
         self.assertEquals(len(blocks['blocks']), 5)
         found_not_problem = False
-        for key in blocks['blocks']:
-            if blocks['blocks'][key]['type'] != 'problem':
+        for block in blocks['blocks'].itervalues():
+            if block['type'] != 'problem':
                 found_not_problem = True
         self.assertTrue(found_not_problem)
 
@@ -94,5 +94,5 @@ class TestGetBlocks(EnableTransformerRegistryMixin, SharedModuleStoreTestCase):
         blocks = get_blocks(self.request, sequential_block.location, self.user,
                             block_types_filter=['problem'], requested_fields=['type'])
         self.assertEquals(len(blocks['blocks']), 3)
-        for key in blocks['blocks']:
-            self.assertEqual(blocks['blocks'][key]['type'], 'problem')
+        for block in blocks['blocks'].itervalues():
+            self.assertEqual(block['type'], 'problem')

--- a/lms/djangoapps/course_api/blocks/tests/test_forms.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_forms.py
@@ -60,7 +60,7 @@ class TestBlockListGetForm(EnableTransformerRegistryMixin, FormTestMixin, Shared
             'usage_key': usage_key,
             'username': self.student.username,
             'user': self.student,
-            'block_type_filter': set(),
+            'block_types_filter': set(),
         }
 
     def assert_raises_permission_denied(self):

--- a/lms/djangoapps/course_api/blocks/tests/test_forms.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_forms.py
@@ -60,6 +60,7 @@ class TestBlockListGetForm(EnableTransformerRegistryMixin, FormTestMixin, Shared
             'usage_key': usage_key,
             'username': self.student.username,
             'user': self.student,
+            'block_types': set(),
         }
 
     def assert_raises_permission_denied(self):

--- a/lms/djangoapps/course_api/blocks/tests/test_forms.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_forms.py
@@ -60,7 +60,7 @@ class TestBlockListGetForm(EnableTransformerRegistryMixin, FormTestMixin, Shared
             'usage_key': usage_key,
             'username': self.student.username,
             'user': self.student,
-            'block_types': set(),
+            'block_type_filter': set(),
         }
 
     def assert_raises_permission_denied(self):

--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -70,6 +70,7 @@ class TestBlockSerializerBase(EnableTransformerRegistryMixin, SharedModuleStoreT
             'block_counts',
             'student_view_data',
             'student_view_multi_device',
+            'lti_url',
         ])
 
     def assert_extended_block(self, serialized_block):
@@ -81,6 +82,7 @@ class TestBlockSerializerBase(EnableTransformerRegistryMixin, SharedModuleStoreT
                 'id', 'type', 'lms_web_url', 'student_view_url',
                 'display_name', 'graded',
                 'block_counts', 'student_view_multi_device',
+                'lti_url',
             },
             set(serialized_block.iterkeys()),
         )
@@ -135,9 +137,6 @@ class TestBlockDictSerializer(TestBlockSerializerBase):
 
     def test_basic(self):
         serializer = self.create_serializer()
-
-        # verify root
-        self.assertEquals(serializer.data['root'], unicode(self.block_structure.root_block_usage_key))
 
         # verify blocks
         for block_key_string, serialized_block in serializer.data['blocks'].iteritems():

--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -118,8 +118,7 @@ class TestBlockSerializer(TestBlockSerializerBase):
     def test_additional_requested_fields(self):
         self.add_additional_requested_fields()
         serializer = self.create_serializer()
-        for serialized_block in serializer.data:
-            self.assert_extended_block(serialized_block)
+        self.assertEqual(5, len(serializer.data))
 
 
 class TestBlockDictSerializer(TestBlockSerializerBase):
@@ -137,6 +136,9 @@ class TestBlockDictSerializer(TestBlockSerializerBase):
 
     def test_basic(self):
         serializer = self.create_serializer()
+
+        # verify root
+        self.assertEquals(serializer.data['root'], unicode(self.block_structure.root_block_usage_key))
 
         # verify blocks
         for block_key_string, serialized_block in serializer.data['blocks'].iteritems():

--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -118,7 +118,8 @@ class TestBlockSerializer(TestBlockSerializerBase):
     def test_additional_requested_fields(self):
         self.add_additional_requested_fields()
         serializer = self.create_serializer()
-        self.assertEqual(5, len(serializer.data))
+        for serialized_block in serializer.data:
+            self.assert_extended_block(serialized_block)
 
 
 class TestBlockDictSerializer(TestBlockSerializerBase):

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -173,7 +173,6 @@ class TestBlocksView(EnableTransformerRegistryMixin, SharedModuleStoreTestCase):
 
     def test_basic(self):
         response = self.verify_response()
-        self.assertEquals(response.data['root'], unicode(self.course_usage_key))
         self.verify_response_block_dict(response)
         for block_key_string, block_data in response.data['blocks'].iteritems():
             block_key = deserialize_usage_key(block_key_string, self.course_key)

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -173,6 +173,7 @@ class TestBlocksView(EnableTransformerRegistryMixin, SharedModuleStoreTestCase):
 
     def test_basic(self):
         response = self.verify_response()
+        self.assertEquals(response.data['root'], unicode(self.course_usage_key))
         self.verify_response_block_dict(response)
         for block_key_string, block_data in response.data['blocks'].iteritems():
             block_key = deserialize_usage_key(block_key_string, self.course_key)

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -30,9 +30,10 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
         GET /api/courses/v1/blocks/<usage_id>/?
             username=anjali
             &depth=all
-            &requested_fields=graded,format,student_view_multi_device
+            &requested_fields=graded,format,student_view_multi_device,lti_url
             &block_counts=video
             &student_view_data=video
+            &block_types=problem,html
 
     **Parameters**:
 
@@ -84,6 +85,11 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
           Default is dict. Supported values are: dict, list
 
           Example: return_type=dict
+
+        * block_types: (list) Requested types of blocks. Possible values include sequential,
+          vertical, html, problem, video, and discussion.
+
+          Example: block_types=vertical,html
 
     **Response Values**
 
@@ -147,6 +153,7 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
             if the student_view_url and the student_view_data fields are not
             supported.
 
+          * lti_url: The block URL for an LTI consumer.
     """
 
     def list(self, request, usage_key_string):  # pylint: disable=arguments-differ
@@ -177,7 +184,8 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
                     params.cleaned_data['requested_fields'],
                     params.cleaned_data.get('block_counts', []),
                     params.cleaned_data.get('student_view_data', []),
-                    params.cleaned_data['return_type']
+                    params.cleaned_data['return_type'],
+                    params.cleaned_data.get('block_types', None),
                 )
             )
         except ItemNotFoundError as exception:
@@ -198,9 +206,10 @@ class BlocksInCourseView(BlocksView):
         GET /api/courses/v1/blocks/?course_id=<course_id>
             &username=anjali
             &depth=all
-            &requested_fields=graded,format,student_view_multi_device
+            &requested_fields=graded,format,student_view_multi_device,lti_url
             &block_counts=video
             &student_view_data=video
+            &block_types=problem,html
 
     **Parameters**:
 

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -33,7 +33,7 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
             &requested_fields=graded,format,student_view_multi_device,lti_url
             &block_counts=video
             &student_view_data=video
-            &block_types=problem,html
+            &block_type_filter=problem,html
 
     **Parameters**:
 
@@ -86,10 +86,11 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
 
           Example: return_type=dict
 
-        * block_types: (list) Requested types of blocks. Possible values include sequential,
-          vertical, html, problem, video, and discussion.
+        * block_type_filter: (list) Requested types of blocks used to filter the final result
+          of returned blocks. Possible values include sequential,vertical, html, problem,
+          video, and discussion.
 
-          Example: block_types=vertical,html
+          Example: block_type_filter=vertical,html
 
     **Response Values**
 
@@ -185,7 +186,7 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
                     params.cleaned_data.get('block_counts', []),
                     params.cleaned_data.get('student_view_data', []),
                     params.cleaned_data['return_type'],
-                    params.cleaned_data.get('block_types', None),
+                    params.cleaned_data.get('block_type_filter', None),
                 )
             )
         except ItemNotFoundError as exception:
@@ -209,7 +210,7 @@ class BlocksInCourseView(BlocksView):
             &requested_fields=graded,format,student_view_multi_device,lti_url
             &block_counts=video
             &student_view_data=video
-            &block_types=problem,html
+            &block_type_filter=problem,html
 
     **Parameters**:
 

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -33,7 +33,7 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
             &requested_fields=graded,format,student_view_multi_device,lti_url
             &block_counts=video
             &student_view_data=video
-            &block_type_filter=problem,html
+            &block_types_filter=problem,html
 
     **Parameters**:
 
@@ -86,11 +86,11 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
 
           Example: return_type=dict
 
-        * block_type_filter: (list) Requested types of blocks used to filter the final result
-          of returned blocks. Possible values include sequential,vertical, html, problem,
+        * block_types_filter: (list) Requested types of blocks used to filter the final result
+          of returned blocks. Possible values include sequential, vertical, html, problem,
           video, and discussion.
 
-          Example: block_type_filter=vertical,html
+          Example: block_types_filter=vertical,html
 
     **Response Values**
 
@@ -186,7 +186,7 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
                     params.cleaned_data.get('block_counts', []),
                     params.cleaned_data.get('student_view_data', []),
                     params.cleaned_data['return_type'],
-                    params.cleaned_data.get('block_type_filter', None),
+                    params.cleaned_data.get('block_types_filter', None),
                 )
             )
         except ItemNotFoundError as exception:
@@ -210,7 +210,7 @@ class BlocksInCourseView(BlocksView):
             &requested_fields=graded,format,student_view_multi_device,lti_url
             &block_counts=video
             &student_view_data=video
-            &block_type_filter=problem,html
+            &block_types_filter=problem,html
 
     **Parameters**:
 

--- a/openedx/core/lib/block_structure/block_structure.py
+++ b/openedx/core/lib/block_structure/block_structure.py
@@ -70,7 +70,7 @@ class BlockStructure(object):
         traversal since it's the more common case and we currently
         need to support DAGs.
         """
-        return self.topological_traversal()
+        return self.get_block_keys()
 
     #--- Block structure relation methods ---#
 

--- a/openedx/core/lib/block_structure/block_structure.py
+++ b/openedx/core/lib/block_structure/block_structure.py
@@ -66,9 +66,9 @@ class BlockStructure(object):
 
     def __iter__(self):
         """
-        The default iterator for a block structure is a topological
-        traversal since it's the more common case and we currently
-        need to support DAGs.
+        The default iterator for a block structure is get_block_keys()
+        since we need to filter blocks as a list.
+        A topological traversal can be used to support DAGs.
         """
         return self.get_block_keys()
 


### PR DESCRIPTION
This is a continuation of the pull request https://github.com/edx/edx-platform/pull/10951

**Background:** Business people need to generate a list of LTI URLs for a given course, to provide to a customer. This new request should reduce the time and effort needed to pull LTI endpoints for a course, and reduce the chance of human error. 

**Studio Updates:** None.

**LMS Updates:** 2 new optional parameters are added to /api/courses/v1/blocks/?course_id=<course_id>: 
- 'requested_fields' can accept 'lti_url' (indicates it's required to show the field 'lti_url');
- 'block_types' (a list of requested block types; possible values include sequential, vertical, html, problem, video, and discussion). 

**Manual test instructions:**
Open in the browser:
http://127.0.0.1:8000/api/courses/v1/blocks/?course_id=course-v1%3AedX%2BDemoX%2BDemo_Course&username=staff&depth=all&block_counts=video&block_types=html,video&requested_fields=lti_url
![edx23](https://cloud.githubusercontent.com/assets/7777978/12007611/bb5b91d4-ac1c-11e5-8eb3-775f2dedd084.jpg)
