### PR TITLE
Revert "Registration: don't require terms of service if checkbox is hidden"

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1628,7 +1628,7 @@ def create_account_with_params(request, params):
         not do_external_auth
     )
     # Can't have terms of service for certain SHIB users, like at Stanford
-    tos_required = settings.REGISTRATION_EXTRA_FIELDS.get('terms_of_service') != 'hidden' and (
+    tos_required = (
         not settings.FEATURES.get("AUTH_USE_SHIB") or
         not settings.FEATURES.get("SHIB_DISABLE_TOS") or
         not do_external_auth or

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1683,16 +1683,6 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             }
         )
 
-    @override_settings(REGISTRATION_EXTRA_FIELDS={"honor_code": "hidden", "terms_of_service": "hidden"})
-    def test_register_hidden_honor_code_and_terms_of_service(self):
-        response = self.client.post(self.url, {
-            "email": self.EMAIL,
-            "name": self.NAME,
-            "username": self.USERNAME,
-            "password": self.PASSWORD,
-        })
-        self.assertHttpOK(response)
-
     def test_missing_fields(self):
         response = self.client.post(
             self.url,


### PR DESCRIPTION
Reverts edx/edx-platform#11644

[Broke master](https://build.testeng.edx.org/job/edx-platform-python-unittests-master/2675/)
