### PR TITLE
Registration: don't require terms of service if checkbox is hidden

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1628,7 +1628,11 @@ def create_account_with_params(request, params):
         not do_external_auth
     )
     # Can't have terms of service for certain SHIB users, like at Stanford
+    registration_fields = getattr(settings, 'REGISTRATION_EXTRA_FIELDS', {})
     tos_required = (
+        registration_fields.get('terms_of_service') != 'hidden' or
+        registration_fields.get('honor_code') != 'hidden'
+    ) and (
         not settings.FEATURES.get("AUTH_USE_SHIB") or
         not settings.FEATURES.get("SHIB_DISABLE_TOS") or
         not do_external_auth or

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1683,6 +1683,16 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             }
         )
 
+    @override_settings(REGISTRATION_EXTRA_FIELDS={"honor_code": "hidden", "terms_of_service": "hidden"})
+    def test_register_hidden_honor_code_and_terms_of_service(self):
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+        })
+        self.assertHttpOK(response)
+
     def test_missing_fields(self):
         response = self.client.post(
             self.url,


### PR DESCRIPTION
This is a second attempt at reverted PR https://github.com/edx/edx-platform/pull/11644.

Studio tests fail in that PR because the `REGISTRATION_EXTRA_FIELDS` setting is not declared in `cms/envs/common.py`. This pull request replaces the direct attribute access with `getattr(settings, 'REGISTRATION_EXTRA_FIELDS', {})`.
