### PR TITLE
TNL-3429: implement display_name_with_default for studio text sanitation

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -886,7 +886,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
 
     xblock_info = {
         "id": unicode(xblock.location),
-        "display_name": xblock.display_name_with_default_escaped,
+        "display_name": xblock.display_name_with_default,
         "category": xblock.category,
         "edited_on": get_default_time_display(xblock.subtree_edited_on) if xblock.subtree_edited_on else None,
         "published": published,
@@ -1158,4 +1158,4 @@ def _xblock_type_and_display_name(xblock):
     """
     return _('{section_or_subsection} "{display_name}"').format(
         section_or_subsection=xblock_type_display_name(xblock),
-        display_name=xblock.display_name_with_default_escaped)
+        display_name=xblock.display_name_with_default)

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -85,11 +85,11 @@ if (is_proctored_exam) {
         <% } %>
                 <% if (xblockInfo.isVertical()) { %>
                     <span class="unit-title item-title">
-                        <a href="<%= xblockInfo.get('studio_url') %>"><%= xblockInfo.get('display_name') %></a>
+                        <a href="<%= xblockInfo.get('studio_url') %>"><%- xblockInfo.get('display_name') %></a>
                     </span>
                 <% } else { %>
                     <span class="wrapper-<%= xblockType %>-title wrapper-xblock-field incontext-editor is-editable" data-field="display_name" data-field-display-name="<%= gettext("Display Name") %>">
-                        <span class="<%= xblockType %>-title item-title xblock-field-value incontext-editor-value"><%= xblockInfo.get('display_name') %></span>
+                        <span class="<%= xblockType %>-title item-title xblock-field-value incontext-editor-value"><%- xblockInfo.get('display_name') %></span>
                     </span>
                 <% } %>
             </h3>

--- a/cms/templates/js/unit-outline.underscore
+++ b/cms/templates/js/unit-outline.underscore
@@ -4,7 +4,7 @@
         <div class="<%= xblockType %>-header">
             <h3 class="<%= xblockType %>-header-details">
                 <span class="<%= xblockType %>-title item-title">
-                    <a href="<%= xblockInfo.get('studio_url') %>"><%= xblockInfo.get('display_name') %></a>
+                    <a href="<%= xblockInfo.get('studio_url') %>"><%- xblockInfo.get('display_name') %></a>
                 </span>
             </h3>
         </div>

--- a/cms/templates/js/xblock-outline.underscore
+++ b/cms/templates/js/xblock-outline.underscore
@@ -17,10 +17,10 @@
             <% } %>
 
                 <% if (xblockInfo.get('studio_url') && xblockInfo.get('category') !== 'chapter') { %>
-                    <a href="<%= xblockInfo.get('studio_url') %>"><%= xblockInfo.get('display_name') %></a>
+                    <a href="<%= xblockInfo.get('studio_url') %>"><%- xblockInfo.get('display_name') %></a>
                 <% } else { %>
                     <span class="wrapper-xblock-field is-editable" data-field="display_name">
-                        <span class="xblock-field-value"><%= xblockInfo.get('display_name') %></span>
+                        <span class="xblock-field-value"><%- xblockInfo.get('display_name') %></span>
                     </span>
                 <% } %>
             </h3>

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -11,7 +11,7 @@ xblock_url = xblock_studio_url(xblock)
 show_inline = xblock.has_children and not xblock_url
 section_class = "level-nesting" if show_inline else "level-element"
 collapsible_class = "is-collapsible" if xblock.has_children else ""
-label = xblock.display_name_with_default_escaped or xblock.scope_ids.block_type
+label = xblock.display_name_with_default or xblock.scope_ids.block_type
 messages = xblock.validate().to_json()
 %>
 


### PR DESCRIPTION
**JIRA tickets**: [TNL-3429](https://openedx.atlassian.net/browse/TNL-3429)

**Discussion**: 
This PR replaces https://github.com/edx/edx-platform/pull/11588.  It builds on work done by @robrap in https://github.com/edx/edx-platform/pull/10962, for [TNL-3425](https://openedx.atlassian.net/browse/TNL-3425).

These changes aim to follow https://openedx.atlassian.net/wiki/display/TNL/XSS+Protection .

The change to cms/templates/container.html replaces calls to display_name_with_default_escaped, which is deprecated and does not properly perform HTML-escaping, with display_name_with_default, which makes use of the |h filter for escaping.

The changes to these three files selectively apply escaping, using either the deprecated display_name_with_default_escaped or the preferred display_name_with_default, depending on the context, so that only the course outline and unit pages get the non-escaped data:
- cms/djangoapps/contentstore/views/component.py
- cms/djangoapps/contentstore/views/course.py
- cms/djangoapps/contentstore/views/item.py

These two templates are changed to HTML-escape the display name fields:
- cms/templates/js/course-outline.underscore
- cms/templates/js/unit-outline.underscore

**Dependencies**: None

**Sandbox**: [LMS](http://pr11697.sandbox.opencraft.com/) [Studio](http://studio.pr11697.sandbox.opencraft.com/)

**Testing instructions**:
_Note: in the screenshots, the fields of interest are highlighted in purple._
1. Start up Studio as the edxapp user: "paver devstack studio".
2. Open a browser to Studio: http://127.0.0.1:8001. The home page loads.
3. Click the "Sign in" button. The sign in page loads.
4. Sign in as as the "staff@example.com" user.
5. Click on "edX Demonstration Course". This opens the course outline page.
6. Scroll to the bottom of the page.
7. Click "New Section" and create a section named `§: Intro to <HTML> & "JS"`
8. Click "New Subsection" and create a subsection named `§§: Intro to <HTML> & "JS"`. Both names are rendered correctly on the course outline page.
   ![outline-page-loaded-before](https://cloud.githubusercontent.com/assets/6389399/13157632/ab99d284-d691-11e5-99b4-acfdece15435.png)
9. If necessary, click on the triangle alongside the subsection name to expand the field.
10. Click "New Unit". The unit page loads.
11. Without the fix, this reproduces bug TNL-3429:
    ![unit-page-loaded-before](https://cloud.githubusercontent.com/assets/6389399/13157716/2a946c66-d692-11e5-9b56-0f3df0e138de.png)
12. With the fix, the text is rendered correctly:
    ![unit-page-loaded-after](https://cloud.githubusercontent.com/assets/6389399/13157725/33bec066-d692-11e5-8a60-4904a0d679c1.png)
13. Return to the course outline page.  Click to edit the section name.  Without the fix, the text is rendered in the text-field incorrectly (the < and > characters are HTML-escaped, but not the & and " characters, which appear as expected; the partial escaping is obvious with this particular test-data):
    ![outline-page-edited-before](https://cloud.githubusercontent.com/assets/6389399/13157651/c20af1c4-d691-11e5-946f-7d8544e7a9e9.png)

With these changes, the text is rendered as correctly:
![outline-page-edit-after](https://cloud.githubusercontent.com/assets/6389399/13157874/e6b7e4d6-d692-11e5-8012-884157d17550.png)

This editing bug occurs on the unit page too, and is also fixed by this change.  I am not aware of any JIRA ticket tracking this issue.

**Author notes and concerns**:
This PR changes the  way that display_name text is sent via JSON. Previously, the < and > characters would be escaped to `&lt;` and `&gt;`. No other HTML-sensitive characters were handled.  Now, these characters are sent as-is.  For the course outline page and the unit page, the escaping to HTML is performed on the browser by the underscore templates (properly, not just for angle-brackets).

**Reviewers**
- [ ] @smarnach, TBD
