### PR TITLE
Speed up comment client tests

### DIFF
--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -6,7 +6,7 @@ import ddt
 
 from django.conf import settings
 from django.core.cache import caches
-from django.test.client import Client, RequestFactory
+from django.test.client import RequestFactory
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.urlresolvers import reverse
@@ -27,7 +27,7 @@ from student.tests.factories import CourseEnrollmentFactory, UserFactory, Course
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory, CourseTeamMembershipFactory
 from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import check_mongo_calls
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import ModuleStoreEnum
@@ -177,12 +177,6 @@ class ThreadActionGroupIdTestCase(
 
 
 class ViewsTestCaseMixin(object):
-    """
-    This class is used by both ViewsQueryCountTestCase and ViewsTestCase. By
-    breaking out set_up_course into its own method, ViewsQueryCountTestCase
-    can build a course in a particular modulestore, while ViewsTestCase can
-    just run it in setUp for all tests.
-    """
 
     def set_up_course(self, module_count=0):
         """
@@ -234,7 +228,6 @@ class ViewsTestCaseMixin(object):
             CourseEnrollmentFactory(user=self.moderator, course_id=self.course.id)
             self.moderator.roles.add(Role.objects.get(name="Moderator", course_id=self.course.id))
 
-            self.client = Client()
             assert_true(self.client.login(username='student', password=self.password))
 
     def _setup_mock_request(self, mock_request, include_depth=False):
@@ -379,9 +372,7 @@ class ViewsQueryCountTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSet
 
     @ddt.data(
         (ModuleStoreEnum.Type.mongo, 3, 4, 26),
-        (ModuleStoreEnum.Type.mongo, 20, 4, 26),
         (ModuleStoreEnum.Type.split, 3, 13, 26),
-        (ModuleStoreEnum.Type.split, 20, 13, 26),
     )
     @ddt.unpack
     @count_queries
@@ -390,9 +381,7 @@ class ViewsQueryCountTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSet
 
     @ddt.data(
         (ModuleStoreEnum.Type.mongo, 3, 3, 20),
-        (ModuleStoreEnum.Type.mongo, 20, 3, 20),
         (ModuleStoreEnum.Type.split, 3, 10, 20),
-        (ModuleStoreEnum.Type.split, 20, 10, 20),
     )
     @ddt.unpack
     @count_queries
@@ -404,19 +393,62 @@ class ViewsQueryCountTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSet
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class ViewsTestCase(
         UrlResetMixin,
-        ModuleStoreTestCase,
+        SharedModuleStoreTestCase,
         MockRequestSetupMixin,
         ViewsTestCaseMixin,
         MockSignalHandlerMixin
 ):
+
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(ViewsTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create(
+                org='MITx', course='999',
+                discussion_topics={"Some Topic": {"id": "some_topic"}},
+                display_name='Robot Super Course',
+            )
+
+    @classmethod
+    def setUpTestData(cls):
+        super(ViewsTestCase, cls).setUpTestData()
+
+        cls.course_id = cls.course.id
+
+        # seed the forums permissions and roles
+        call_command('seed_permissions_roles', unicode(cls.course_id))
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         # Patching the ENABLE_DISCUSSION_SERVICE value affects the contents of urls.py,
         # so we need to call super.setUp() which reloads urls.py (because
         # of the UrlResetMixin)
-        super(ViewsTestCase, self).setUp(create_user=False)
-        self.set_up_course()
+        super(ViewsTestCase, self).setUp()
+
+        # Patch the comment client user save method so it does not try
+        # to create a new cc user when creating a django user
+        with patch('student.models.cc.User.save'):
+            uname = 'student'
+            email = 'student@edx.org'
+            self.password = 'test'  # pylint: disable=attribute-defined-outside-init
+
+            # Create the user and make them active so we can log them in.
+            self.student = User.objects.create_user(uname, email, self.password)  # pylint: disable=attribute-defined-outside-init
+            self.student.is_active = True
+            self.student.save()
+
+            # Add a discussion moderator
+            self.moderator = UserFactory.create(password=self.password)  # pylint: disable=attribute-defined-outside-init
+
+            # Enroll the student in the course
+            CourseEnrollmentFactory(user=self.student,
+                                    course_id=self.course_id)
+
+            # Enroll the moderator and give them the appropriate roles
+            CourseEnrollmentFactory(user=self.moderator, course_id=self.course.id)
+            self.moderator.roles.add(Role.objects.get(name="Moderator", course_id=self.course.id))
+
+            assert_true(self.client.login(username='student', password=self.password))
 
     @contextmanager
     def assert_discussion_signals(self, signal, user=None):
@@ -986,18 +1018,32 @@ class ViewsTestCase(
 
 @patch("lms.lib.comment_client.utils.requests.request", autospec=True)
 @disable_signal(views, 'comment_endorsed')
-class ViewPermissionsTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSetupMixin):
+class ViewPermissionsTestCase(UrlResetMixin, SharedModuleStoreTestCase, MockRequestSetupMixin):
+
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(ViewPermissionsTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(ViewPermissionsTestCase, cls).setUpTestData()
+
+        seed_permissions_roles(cls.course.id)
+
+        cls.password = "test password"
+        cls.student = UserFactory.create(password=cls.password)
+        cls.moderator = UserFactory.create(password=cls.password)
+
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
+        CourseEnrollmentFactory(user=cls.moderator, course_id=cls.course.id)
+
+        cls.moderator.roles.add(Role.objects.get(name="Moderator", course_id=cls.course.id))
+
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super(ViewPermissionsTestCase, self).setUp()
-        self.password = "test password"
-        self.course = CourseFactory.create()
-        seed_permissions_roles(self.course.id)
-        self.student = UserFactory.create(password=self.password)
-        self.moderator = UserFactory.create(password=self.password)
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
-        CourseEnrollmentFactory(user=self.moderator, course_id=self.course.id)
-        self.moderator.roles.add(Role.objects.get(name="Moderator", course_id=self.course.id))
 
     def test_pin_thread_as_student(self, mock_request):
         self._set_mock_request_data(mock_request, {})
@@ -1079,14 +1125,21 @@ class ViewPermissionsTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSet
         self.assertEqual(response.status_code, 200)
 
 
-class CreateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
-    def setUp(self):
-        super(CreateThreadUnicodeTestCase, self).setUp()
+class CreateThreadUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
 
-        self.course = CourseFactory.create()
-        seed_permissions_roles(self.course.id)
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(CreateThreadUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(CreateThreadUnicodeTestCase, cls).setUpTestData()
+
+        seed_permissions_roles(cls.course.id)
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request,):
@@ -1108,14 +1161,21 @@ class CreateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockReq
 
 
 @disable_signal(views, 'thread_edited')
-class UpdateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
-    def setUp(self):
-        super(UpdateThreadUnicodeTestCase, self).setUp()
+class UpdateThreadUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
 
-        self.course = CourseFactory.create()
-        seed_permissions_roles(self.course.id)
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(UpdateThreadUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(UpdateThreadUnicodeTestCase, cls).setUpTestData()
+
+        seed_permissions_roles(cls.course.id)
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('django_comment_client.utils.get_discussion_categories_ids', return_value=["test_commentable"])
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
@@ -1138,14 +1198,21 @@ class UpdateThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockReq
 
 
 @disable_signal(views, 'comment_created')
-class CreateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
-    def setUp(self):
-        super(CreateCommentUnicodeTestCase, self).setUp()
+class CreateCommentUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
 
-        self.course = CourseFactory.create()
-        seed_permissions_roles(self.course.id)
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(CreateCommentUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(CreateCommentUnicodeTestCase, cls).setUpTestData()
+
+        seed_permissions_roles(cls.course.id)
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
@@ -1173,14 +1240,21 @@ class CreateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRe
 
 
 @disable_signal(views, 'comment_edited')
-class UpdateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
-    def setUp(self):
-        super(UpdateCommentUnicodeTestCase, self).setUp()
+class UpdateCommentUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
 
-        self.course = CourseFactory.create()
-        seed_permissions_roles(self.course.id)
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(UpdateCommentUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(UpdateCommentUnicodeTestCase, cls).setUpTestData()
+
+        seed_permissions_roles(cls.course.id)
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
@@ -1199,17 +1273,23 @@ class UpdateCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRe
 
 
 @disable_signal(views, 'comment_created')
-class CreateSubCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
+class CreateSubCommentUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin, MockRequestSetupMixin):
     """
     Make sure comments under a response can handle unicode.
     """
-    def setUp(self):
-        super(CreateSubCommentUnicodeTestCase, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(CreateSubCommentUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
 
-        self.course = CourseFactory.create()
-        seed_permissions_roles(self.course.id)
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpTestData(cls):
+        super(CreateSubCommentUnicodeTestCase, cls).setUpTestData()
+
+        seed_permissions_roles(cls.course.id)
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
@@ -1245,7 +1325,7 @@ class CreateSubCommentUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin, Moc
 @disable_signal(views, 'comment_created')
 @disable_signal(views, 'comment_voted')
 @disable_signal(views, 'comment_deleted')
-class TeamsPermissionsTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSetupMixin):
+class TeamsPermissionsTestCase(UrlResetMixin, SharedModuleStoreTestCase, MockRequestSetupMixin):
     # Most of the test points use the same ddt data.
     # args: user, commentable_id, status_code
     ddt_permissions_args = [
@@ -1261,38 +1341,48 @@ class TeamsPermissionsTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSe
         ('moderator', 'team_commentable_id', 200)
     ]
 
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(TeamsPermissionsTestCase, cls).setUpClassAndTestData():
+            teams_configuration = {
+                'topics': [{'id': "topic_id", 'name': 'Solar Power', 'description': 'Solar power is hot'}]
+            }
+            cls.course = CourseFactory.create(teams_configuration=teams_configuration)
+
+    @classmethod
+    def setUpTestData(cls):
+        super(TeamsPermissionsTestCase, cls).setUpTestData()
+
+        cls.password = "test password"
+        seed_permissions_roles(cls.course.id)
+
+        # Create 3 users-- student in team, student not in team, discussion moderator
+        cls.student_in_team = UserFactory.create(password=cls.password)
+        cls.student_not_in_team = UserFactory.create(password=cls.password)
+        cls.moderator = UserFactory.create(password=cls.password)
+        CourseEnrollmentFactory(user=cls.student_in_team, course_id=cls.course.id)
+        CourseEnrollmentFactory(user=cls.student_not_in_team, course_id=cls.course.id)
+        CourseEnrollmentFactory(user=cls.moderator, course_id=cls.course.id)
+        cls.moderator.roles.add(Role.objects.get(name="Moderator", course_id=cls.course.id))
+
+        # Create a team.
+        cls.team_commentable_id = "team_discussion_id"
+        cls.team = CourseTeamFactory.create(
+            name=u'The Only Team',
+            course_id=cls.course.id,
+            topic_id='topic_id',
+            discussion_topic_id=cls.team_commentable_id
+        )
+
+        cls.team.add_user(cls.student_in_team)
+
+        # Dummy commentable ID not linked to a team
+        cls.course_commentable_id = "course_level_commentable"
+
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super(TeamsPermissionsTestCase, self).setUp()
-        self.password = "test password"
-        teams_configuration = {
-            'topics': [{'id': "topic_id", 'name': 'Solar Power', 'description': 'Solar power is hot'}]
-        }
-        self.course = CourseFactory.create(teams_configuration=teams_configuration)
-        seed_permissions_roles(self.course.id)
-
-        # Create 3 users-- student in team, student not in team, discussion moderator
-        self.student_in_team = UserFactory.create(password=self.password)
-        self.student_not_in_team = UserFactory.create(password=self.password)
-        self.moderator = UserFactory.create(password=self.password)
-        CourseEnrollmentFactory(user=self.student_in_team, course_id=self.course.id)
-        CourseEnrollmentFactory(user=self.student_not_in_team, course_id=self.course.id)
-        CourseEnrollmentFactory(user=self.moderator, course_id=self.course.id)
-        self.moderator.roles.add(Role.objects.get(name="Moderator", course_id=self.course.id))
-
-        # Create a team.
-        self.team_commentable_id = "team_discussion_id"
-        self.team = CourseTeamFactory.create(
-            name=u'The Only Team',
-            course_id=self.course.id,
-            topic_id='topic_id',
-            discussion_topic_id=self.team_commentable_id
-        )
-
-        self.team.add_user(self.student_in_team)
-
-        # Dummy commentable ID not linked to a team
-        self.course_commentable_id = "course_level_commentable"
 
     def _setup_mock(self, user, mock_request, data):
         user = getattr(self, user)
@@ -1501,18 +1591,26 @@ TEAM_COMMENTABLE_ID = 'test-team-discussion'
 
 @disable_signal(views, 'comment_created')
 @ddt.ddt
-class ForumEventTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
+class ForumEventTestCase(SharedModuleStoreTestCase, MockRequestSetupMixin):
     """
     Forum actions are expected to launch analytics events. Test these here.
     """
-    def setUp(self):
-        super(ForumEventTestCase, self).setUp()
-        self.course = CourseFactory.create()
-        seed_permissions_roles(self.course.id)
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
-        self.student.roles.add(Role.objects.get(name="Student", course_id=self.course.id))
-        CourseAccessRoleFactory(course_id=self.course.id, user=self.student, role='Wizard')
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(ForumEventTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(ForumEventTestCase, cls).setUpTestData()
+
+        seed_permissions_roles(cls.course.id)
+
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
+        cls.student.roles.add(Role.objects.get(name="Student", course_id=cls.course.id))
+        CourseAccessRoleFactory(course_id=cls.course.id, user=cls.student, role='Wizard')
 
     @patch('eventtracking.tracker.emit')
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
@@ -1676,7 +1774,24 @@ class ForumEventTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
         self.assertEqual(event['vote_value'], 'up')
 
 
-class UsersEndpointTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
+class UsersEndpointTestCase(SharedModuleStoreTestCase, MockRequestSetupMixin):
+
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(UsersEndpointTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(UsersEndpointTestCase, cls).setUpTestData()
+
+        seed_permissions_roles(cls.course.id)
+
+        cls.student = UserFactory.create()
+        cls.enrollment = CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
+        cls.other_user = UserFactory.create(username="other")
+        CourseEnrollmentFactory(user=cls.other_user, course_id=cls.course.id)
 
     def set_post_counts(self, mock_request, threads_count=1, comments_count=1):
         """
@@ -1686,16 +1801,6 @@ class UsersEndpointTestCase(ModuleStoreTestCase, MockRequestSetupMixin):
             "threads_count": threads_count,
             "comments_count": comments_count,
         })
-
-    def setUp(self):
-        super(UsersEndpointTestCase, self).setUp()
-
-        self.course = CourseFactory.create()
-        seed_permissions_roles(self.course.id)
-        self.student = UserFactory.create()
-        self.enrollment = CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
-        self.other_user = UserFactory.create(username="other")
-        CourseEnrollmentFactory(user=self.other_user, course_id=self.course.id)
 
     def make_request(self, method='get', course_id=None, **kwargs):
         course_id = course_id or self.course.id

--- a/lms/djangoapps/django_comment_client/forum/tests.py
+++ b/lms/djangoapps/django_comment_client/forum/tests.py
@@ -26,7 +26,8 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,
-    TEST_DATA_MONGO_MODULESTORE
+    SharedModuleStoreTestCase,
+    TEST_DATA_MONGO_MODULESTORE,
 )
 from xmodule.modulestore.tests.factories import check_mongo_calls, CourseFactory, ItemFactory
 
@@ -1282,13 +1283,20 @@ class CommentsServiceRequestHeadersTestCase(UrlResetMixin, ModuleStoreTestCase):
         self.assert_all_calls_have_header(mock_request, "X-Edx-Api-Key", "test_api_key")
 
 
-class InlineDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
-    def setUp(self):
-        super(InlineDiscussionUnicodeTestCase, self).setUp()
+class InlineDiscussionUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin):
 
-        self.course = CourseFactory.create()
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(InlineDiscussionUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(InlineDiscussionUnicodeTestCase, cls).setUpTestData()
+
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
@@ -1305,13 +1313,19 @@ class InlineDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-class ForumFormDiscussionUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
-    def setUp(self):
-        super(ForumFormDiscussionUnicodeTestCase, self).setUp()
+class ForumFormDiscussionUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin):
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(ForumFormDiscussionUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
 
-        self.course = CourseFactory.create()
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpTestData(cls):
+        super(ForumFormDiscussionUnicodeTestCase, cls).setUpTestData()
+
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
@@ -1377,13 +1391,20 @@ class ForumDiscussionXSSTestCase(UrlResetMixin, ModuleStoreTestCase):
         self.assertNotIn(malicious_code, resp.content)
 
 
-class ForumDiscussionSearchUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
-    def setUp(self):
-        super(ForumDiscussionSearchUnicodeTestCase, self).setUp()
+class ForumDiscussionSearchUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin):
 
-        self.course = CourseFactory.create()
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(ForumDiscussionSearchUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(ForumDiscussionSearchUnicodeTestCase, cls).setUpTestData()
+
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
@@ -1403,13 +1424,20 @@ class ForumDiscussionSearchUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-class SingleThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
-    def setUp(self):
-        super(SingleThreadUnicodeTestCase, self).setUp()
+class SingleThreadUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin):
 
-        self.course = CourseFactory.create(discussion_topics={'dummy_discussion_id': {'id': 'dummy_discussion_id'}})
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(SingleThreadUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create(discussion_topics={'dummy_discussion_id': {'id': 'dummy_discussion_id'}})
+
+    @classmethod
+    def setUpTestData(cls):
+        super(SingleThreadUnicodeTestCase, cls).setUpTestData()
+
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
@@ -1426,13 +1454,20 @@ class SingleThreadUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
         self.assertEqual(response_data["content"]["body"], text)
 
 
-class UserProfileUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
-    def setUp(self):
-        super(UserProfileUnicodeTestCase, self).setUp()
+class UserProfileUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin):
 
-        self.course = CourseFactory.create()
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(UserProfileUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(UserProfileUnicodeTestCase, cls).setUpTestData()
+
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
@@ -1448,13 +1483,20 @@ class UserProfileUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
         self.assertEqual(response_data["discussion_data"][0]["body"], text)
 
 
-class FollowedThreadsUnicodeTestCase(ModuleStoreTestCase, UnicodeTestMixin):
-    def setUp(self):
-        super(FollowedThreadsUnicodeTestCase, self).setUp()
+class FollowedThreadsUnicodeTestCase(SharedModuleStoreTestCase, UnicodeTestMixin):
 
-        self.course = CourseFactory.create()
-        self.student = UserFactory.create()
-        CourseEnrollmentFactory(user=self.student, course_id=self.course.id)
+    @classmethod
+    def setUpClass(cls):
+        # pylint: disable=super-method-not-called
+        with super(FollowedThreadsUnicodeTestCase, cls).setUpClassAndTestData():
+            cls.course = CourseFactory.create()
+
+    @classmethod
+    def setUpTestData(cls):
+        super(FollowedThreadsUnicodeTestCase, cls).setUpTestData()
+
+        cls.student = UserFactory.create()
+        CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):


### PR DESCRIPTION
Also accelerates forums UnicodeTestCases. There's a lot of duplication in tests inheriting from `UnicodeTestMixin`, but it was there when I started. Cleaning up that duplication might save an additional handful of seconds, but it should be done separately.

@doctoryes @bderusha please review.
