### PR TITLE
Use default JWT_LEEWAY of 10s

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2060,7 +2060,7 @@ JWT_AUTH = {
     'JWT_ISSUER': None,
     'JWT_PAYLOAD_GET_USERNAME_HANDLER': lambda d: d.get('username'),
     'JWT_AUDIENCE': None,
-    'JWT_LEEWAY': 1,
+    'JWT_LEEWAY': 10,
     'JWT_DECODE_HANDLER': 'openedx.core.lib.api.jwt_decode_handler.decode',
 }
 


### PR DESCRIPTION
@maxrothman @zubair-arbi @tasawernawaz @rlucioni FYI.

This should fix 401 errors we are seeing in the load test environment, where clock drift across hosts is problematic.
