### PR TITLE
Remove unused profile name.

### DIFF
--- a/lms/djangoapps/instructor/views/gradebook_api.py
+++ b/lms/djangoapps/instructor/views/gradebook_api.py
@@ -90,7 +90,6 @@ def get_grade_book_page(request, course, course_key):
             'id': student.id,
             'email': student.email,
             'grade_summary': student_grades(student, request, course),
-            'realname': student.profile.name,
         }
         for student in enrolled_students
     ]


### PR DESCRIPTION
The profile name requires escaping when displayed. Proactively removing since it is not being used.
