### PR TITLE
commerce: use explicit relative module imports

### DIFF
--- a/lms/djangoapps/commerce/admin.py
+++ b/lms/djangoapps/commerce/admin.py
@@ -2,7 +2,7 @@
 
 from django.contrib import admin
 
-from commerce.models import CommerceConfiguration
+from .models import CommerceConfiguration
 from config_models.admin import ConfigurationModelAdmin
 
 admin.site.register(CommerceConfiguration, ConfigurationModelAdmin)

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -4,7 +4,7 @@ from urlparse import urljoin
 
 from django.conf import settings
 
-from commerce.models import CommerceConfiguration
+from .models import CommerceConfiguration
 from openedx.core.djangoapps.theming import helpers
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
@rlucioni @zubair-arbi @clintonb @maxrothman @vkaracic   We are contemplating a patch release for this change.  The implicit relative import style was confusing celery workers, causing tasks to crash.  Switching to explicit absolute also caused problems.

(example tracebacks: https://gist.github.com/jimabramson/64b3e04169da21b88186)

If we go ahead with a patch I will close and recreate this PR accordingly.

Note: the rest of this package is still using implicit relative imports - generally frowned upon, but changing the entire package is too big a change for the patch we need to fix celery tasks, so that will come in another PR.
