### PR TITLE
Adding the -n option to the Sphinx build invocation

### DIFF
--- a/docs/en_us/platform_api/Makefile
+++ b/docs/en_us/platform_api/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -n
 SPHINXBUILD   ?= sphinx-build
 PAPER         ?=
 BUILDDIR      ?= build


### PR DESCRIPTION
## [DOC-2638](https://openedx.atlassian.net/browse/DOC-2638)

This change makes the Sphinx documentation build for the platform API documentation treat WARNINGs as ERRORs. This will prevent builds from silently failing to import docstring content for the APIs. Currently, if Sphinx is unable to import a module that contains docstrings, it will emit a WARNING and the build will succeed. The resulting HTML will have missing content (the docstring information) but it will replace the last published version on Read the Docs.

This change adds the -n option to the Sphinx build so that it will build in nit-picky mode (http://www.sphinx-doc.org/en/stable/invocation.html#invocation-of-sphinx-build).

This PR replaces https://github.com/edx/edx-platform/pull/11663, which was not working properly on the Read the Docs servers. PR 11663 was also an attempt to make platform API doc builds work correctly. Unexpectedly, the documentation build on the master branch is passing cleanly today. So the build breaks regularly, and apparently gets fixed also. This change will make build import failures less destructive and make it easier to see how often they occur.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @nedbat 
- [ ] Doc team review (sanity check/copy edit/dev edit): @lamagnifica @catong @srpearce 
### HTML Version (optional)
- [x] http://draft-platform-api-doc.readthedocs.org/
### Post-review
- [ ] Squash commits
