### PR TITLE
Despite db_index=True, Django didn't generate an index

### DIFF
--- a/lms/djangoapps/coursewarehistoryextended/migrations/0002_force_studentmodule_index.py
+++ b/lms/djangoapps/coursewarehistoryextended/migrations/0002_force_studentmodule_index.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('coursewarehistoryextended', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='studentmodulehistoryextended',
+            index_together=set([('student_module',)]),
+        ),
+    ]

--- a/lms/djangoapps/coursewarehistoryextended/models.py
+++ b/lms/djangoapps/coursewarehistoryextended/models.py
@@ -31,6 +31,7 @@ class StudentModuleHistoryExtended(BaseStudentModuleHistory):
     class Meta(object):
         app_label = 'coursewarehistoryextended'
         get_latest_by = "created"
+        index_together = ['student_module']
 
     id = UnsignedBigIntAutoField(primary_key=True)  # pylint: disable=invalid-name
 


### PR DESCRIPTION
student_module_id is the primary way into this table, not having an
index is disastrous with real data.

@edx/devops
@doctoryes (mostly FYI since this is a migration only change)
