### PR TITLE
Fix minor typographical errors in the platform API documentation

### DIFF
--- a/docs/en_us/platform_api/source/mobile/overview.rst
+++ b/docs/en_us/platform_api/source/mobile/overview.rst
@@ -42,17 +42,17 @@ Mobile API User Resource
      - Method
      - Endpoint
    * - :ref:`Get details about a user<Get User Details>`
-     - GET 
+     - GET
      - /api/mobile/v0.5/users/{username}
    * - :ref:`Get course enrollments for a user<Get a User's Course Enrollments>`
-     - GET 
+     - GET
      - /api/mobile/v0.5/users/{username}/course_enrollments/
    * - :ref:`Get a user's status in a course<Get or Change User Status in a Course>`
-     - GET 
+     - GET
      - /api/mobile/v0.5/users/{username}/course_status_info/{course_id}
    * - :ref:`Change a user's status in a course<Get or Change User Status in a Course>`
-     - PATCH 
-     - /api/mobile/v0.5/rs/{username}/course_status_info/{course_id}
+     - PATCH
+     - /api/mobile/v0.5/users/{username}/course_status_info/{course_id}
 
 ========================================
 Mobile API Course Information Resource
@@ -67,7 +67,7 @@ Mobile API Course Information Resource
      - Endpoint
    * - :ref:`Get updates for a course<Get Course Updates>`
      - GET
-     - /api/mobile/v0.5/course_info/{organization}/{course_number}/{course_run}/updates   
+     - /api/mobile/v0.5/course_info/{organization}/{course_number}/{course_run}/updates
    * - :ref:`Get handouts for a course<Get Course Handouts>`
      - GET
      - /api/mobile/v0.5/course_info/{organization}/{course_number}/{course_run}/handouts

--- a/docs/en_us/platform_api/source/read_me.rst
+++ b/docs/en_us/platform_api/source/read_me.rst
@@ -6,7 +6,7 @@ The edX Platform API documentation is created using RST_
 files and Sphinx_. You, the user community, can help update and revise this
 documentation project on GitHub:
 
-  https://github.com/edx/edx-platform/tree/master/docs/platforms_api/source
+  https://github.com/edx/edx-platform/tree/master/docs/en_us/platform_api/source
 
 To suggest a revision, fork the project, make changes in your fork, and submit
 a pull request back to the original project: this is known as the `GitHub Flow`_.


### PR DESCRIPTION
## [DOC-2250](https://openedx.atlassian.net/browse/DOC-2250)

This change fixes two small errors in the platform API documentation.

Fixes a typo in this REST path /api/mobile/v0.5/rs/{username}/course_status_info/{course_id} which appears on this platform API guide page: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/mobile/overview.html#mobile-api-resources-and-endpoints. /rs/ should be /users/

(DOC-2250) Fixes a broken link URL on this page: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/read_me.html
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @efagin 
- [ ] Doc team review (sanity check/copy edit/dev edit): @lamagnifica @srpearce @catong 
### Post-review
- [ ] Squash commits
