### PR TITLE
Removing importants from heading styles

### DIFF
--- a/cms/static/sass/xmodule/_headings.scss
+++ b/cms/static/sass/xmodule/_headings.scss
@@ -25,49 +25,49 @@ $headings-base-color:                       $gray-d2;
 }
 
 %hd-1 {
-    margin-bottom: 1.41575em !important;
-    font-size: 2em !important;
-    line-height: 1.4em !important;
+    margin-bottom: 1.41575em;
+    font-size: 2em;
+    line-height: 1.4em;
 }
 
 
 %hd-2 {
-    margin-bottom: 1em !important;
-    font-size: 1.5em !important;
-    font-weight: $headings-font-weight-normal !important;
-    line-height: 1.4em !important;
+    margin-bottom: 1em;
+    font-size: 1.5em;
+    font-weight: $headings-font-weight-normal;
+    line-height: 1.4em;
 }
 
 
 %hd-3 {
-    margin-bottom: ($baseline / 2) !important;
-    font-size: 1.35em !important;
-    font-weight: $headings-font-weight-normal !important;
-    line-height: 1.4em !important;
+    margin-bottom: ($baseline / 2);
+    font-size: 1.35em;
+    font-weight: $headings-font-weight-normal;
+    line-height: 1.4em;
 }
 
 
 %hd-4 {
-    margin-bottom: ($baseline / 2) !important;
-    font-size: 1.25em !important;
-    font-weight: $headings-font-weight-bold !important;
-    line-height: 1.4em !important;
+    margin-bottom: ($baseline / 2);
+    font-size: 1.25em;
+    font-weight: $headings-font-weight-bold;
+    line-height: 1.4em;
 }
 
 
 %hd-5 {
-    margin-bottom: ($baseline / 2) !important;
-    font-size: 1.1em !important;
-    font-weight: $headings-font-weight-bold !important;
-    line-height: 1.4em !important;
+    margin-bottom: ($baseline / 2);
+    font-size: 1.1em;
+    font-weight: $headings-font-weight-bold;
+    line-height: 1.4em;
 }
 
 
 %hd-6 {
-    margin-bottom: ($baseline / 2) !important;
-    font-size: 1em !important;
-    font-weight: $headings-font-weight-bold !important;
-    line-height: 1.4em !important;
+    margin-bottom: ($baseline / 2);
+    font-size: 1em;
+    font-weight: $headings-font-weight-bold;
+    line-height: 1.4em;
 }
 
 %hd-7 {
@@ -88,7 +88,7 @@ $headings-base-color:                       $gray-d2;
     letter-spacing: 1px;
 }
 
-.wrapper-xblock {
+.content-primary .wrapper-xblock .xblock-render .xblock .xblock-render .xblock {
 
     .hd-1,
     .hd-2,
@@ -114,7 +114,7 @@ $headings-base-color:                       $gray-d2;
 
     h3 {
         @extend %hd-2;
-        font-weight: $headings-font-weight-normal !important;
+        font-weight: $headings-font-weight-normal;
         // override external modules and xblocks that use inline CSS
         text-transform: initial;
     }

--- a/lms/static/sass/xmodule/_headings.scss
+++ b/lms/static/sass/xmodule/_headings.scss
@@ -25,49 +25,49 @@ $headings-base-color:                       $gray-d2;
 }
 
 %hd-1 {
-    margin-bottom: 1.41575em !important;
-    font-size: 2em !important;
-    line-height: 1.4em !important;
+    margin-bottom: 1.41575em;
+    font-size: 2em;
+    line-height: 1.4em;
 }
 
 
 %hd-2 {
-    margin-bottom: 1em !important;
-    font-size: 1.5em !important;
-    font-weight: $headings-font-weight-normal !important;
-    line-height: 1.4em !important;
+    margin-bottom: 1em;
+    font-size: 1.5em;
+    font-weight: $headings-font-weight-normal;
+    line-height: 1.4em;
 }
 
 
 %hd-3 {
-    margin-bottom: ($baseline / 2) !important;
-    font-size: 1.35em !important;
-    font-weight: $headings-font-weight-normal !important;
-    line-height: 1.4em !important;
+    margin-bottom: ($baseline / 2);
+    font-size: 1.35em;
+    font-weight: $headings-font-weight-normal;
+    line-height: 1.4em;
 }
 
 
 %hd-4 {
-    margin-bottom: ($baseline / 2) !important;
-    font-size: 1.25em !important;
-    font-weight: $headings-font-weight-bold !important;
-    line-height: 1.4em !important;
+    margin-bottom: ($baseline / 2);
+    font-size: 1.25em;
+    font-weight: $headings-font-weight-bold;
+    line-height: 1.4em;
 }
 
 
 %hd-5 {
-    margin-bottom: ($baseline / 2) !important;
-    font-size: 1.1em !important;
-    font-weight: $headings-font-weight-bold !important;
-    line-height: 1.4em !important;
+    margin-bottom: ($baseline / 2);
+    font-size: 1.1em;
+    font-weight: $headings-font-weight-bold;
+    line-height: 1.4em;
 }
 
 
 %hd-6 {
-    margin-bottom: ($baseline / 2) !important;
-    font-size: 1em !important;
-    font-weight: $headings-font-weight-bold !important;
-    line-height: 1.4em !important;
+    margin-bottom: ($baseline / 2);
+    font-size: 1em;
+    font-weight: $headings-font-weight-bold;
+    line-height: 1.4em;
 }
 
 %hd-7 {
@@ -88,7 +88,7 @@ $headings-base-color:                       $gray-d2;
     letter-spacing: 1px;
 }
 
-#seq_content {
+#seq_content .xblock {
 
     .hd-1,
     .hd-2,
@@ -114,7 +114,7 @@ $headings-base-color:                       $gray-d2;
 
     h3 {
         @extend %hd-2;
-        font-weight: $headings-font-weight-normal !important;
+        font-weight: $headings-font-weight-normal;
         // override external modules and xblocks that use inline CSS
         text-transform: initial;
     }


### PR DESCRIPTION
This small work removes `!importants` from recently added heading styles, mainly for cleanup and integrity.
