### PR TITLE
The escaping is unnecessary and confusing to the user.

### DIFF
--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -312,7 +312,7 @@
 
             updateValueInField: function () {
                 var value = (_.isUndefined(this.modelValue()) || _.isNull(this.modelValue())) ? '' : this.modelValue();
-                this.$('.u-field-value input').val(_.escape(value));
+                this.$('.u-field-value input').val(value);
             },
 
             saveValue: function () {


### PR DESCRIPTION
Imagine the user's full name has "<" or ">" in it. Upon initial load of account settings, it looks correct:

![image](https://cloud.githubusercontent.com/assets/484484/13576532/34be7952-e45c-11e5-9d96-ee0cda44db8f.png)

But after editing the full name, it looks like this until page reload:
![image](https://cloud.githubusercontent.com/assets/484484/13576557/5741dcda-e45c-11e5-8615-c9c4a91228a8.png)

And editing a second time causes the amp to be escaped as well...

As far as I can tell, there is no need to escape a string that is the value of an input field.
