### PR TITLE
Prevent ordering closed courses, and give a good user message.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -701,6 +701,10 @@ def dashboard(request):
         redirect_message = _("The course you are looking for does not start until {date}.").format(
             date=request.GET['notlive']
         )
+    elif 'course_closed' in request.GET:
+        redirect_message = _("The course you are looking for is closed for enrollment as of {date}.").format(
+            date=request.GET['course_closed']
+        )
     else:
         redirect_message = ''
 

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -100,6 +100,13 @@ class BasketsView(APIView):
             msg = Messages.ENROLLMENT_EXISTS.format(course_id=course_id, username=user.username)
             return DetailResponse(msg, status=HTTP_409_CONFLICT)
 
+        # Check to see if enrollment for this course is closed.
+        course = courses.get_course(course_key)
+        if CourseEnrollment.is_enrollment_closed(user, course):
+            msg = Messages.ENROLLMENT_CLOSED.format(course_id=course_id)
+            log.info(u'Unable to enroll user %s in closed course %s.', user.id, course_id)
+            return DetailResponse(msg, status=HTTP_406_NOT_ACCEPTABLE)
+
         # If there is no audit or honor course mode, this most likely
         # a Prof-Ed course. Return an error so that the JS redirects
         # to track selection.

--- a/lms/djangoapps/commerce/constants.py
+++ b/lms/djangoapps/commerce/constants.py
@@ -17,3 +17,4 @@ class Messages(object):
     NO_HONOR_MODE = u'Course {course_id} does not have an honor mode.'
     NO_DEFAULT_ENROLLMENT_MODE = u'Course {course_id} does not have an honor or audit mode.'
     ENROLLMENT_EXISTS = u'User {username} is already enrolled in {course_id}.'
+    ENROLLMENT_CLOSED = u'Enrollment is closed for {course_id}.'


### PR DESCRIPTION
# [ECOM-2317](https://openedx.atlassian.net/browse/ECOM-2317)

When Drupal attempts to enroll a user in a closed course, a 406 will be returned. This causes the marketing site to redirect to the track selection page for that course, which will then redirect to the dashboard with a nice message.

@bderusha @clintonb 
