### PR TITLE
Replaced Git requirements with PyPI

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -36,6 +36,7 @@ django==1.8.10
 djangorestframework-jwt==1.7.2
 djangorestframework-oauth==1.1.0
 edx-django-oauth2-provider==0.5.0
+edx-lint==0.4.3
 edx-oauth2-provider==0.5.9
 edx-opaque-keys==0.2.1
 edx-organizations==0.4.0
@@ -84,6 +85,7 @@ pysrt==0.4.7
 PyYAML==3.10
 requests==2.7.0
 requests-oauthlib==0.4.1
+rfc6266==0.0.4
 scipy==0.14.0
 Shapely==1.2.16
 singledispatch==3.4.0.2

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -44,7 +44,7 @@
 # Python libraries to install directly from github
 
 # Third-party:
--e git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline
+git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline==1.5.3
 git+https://github.com/edx/django-wiki.git@v0.0.5#egg=django-wiki==0.0.5
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
@@ -65,7 +65,6 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 # custom opaque-key implementations for CCX
 git+https://github.com/edx/ccx-keys.git@0.1.1#egg=ccx-keys==0.1.1
 
-git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 # Used for testing
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 
@@ -85,7 +84,6 @@ git+https://github.com/edx/edx-val.git@0.0.9#egg=edxval==0.0.9
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/pmitros/DoneXBlock.git@857bf365f19c904d7e48364428f6b93ff153fabd#egg=done-xblock
 git+https://github.com/edx/edx-milestones.git@v0.1.8#egg=edx-milestones==0.1.8
-git+https://github.com/edx/edx-lint.git@v0.4.2#egg=edx_lint==0.4.2
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5


### PR DESCRIPTION
Each of the replace commits can be source from PyPI rather than Git. Also, one editable requirement was removed.

ECOM-3833

This work originated with #11485.
