### PR TITLE
Remove the certificate generation button from progress page for audit student

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -857,7 +857,7 @@ class ProgressPageTests(ModuleStoreTestCase):
         )
 
         self.course = modulestore().get_course(course.id)
-        CourseEnrollmentFactory(user=self.user, course_id=self.course.id)
+        CourseEnrollmentFactory(user=self.user, course_id=self.course.id, mode=CourseMode.HONOR)
 
         self.chapter = ItemFactory.create(category='chapter', parent_location=self.course.location)
         self.section = ItemFactory.create(category='sequential', parent_location=self.chapter.location)
@@ -1044,7 +1044,7 @@ class ProgressPageTests(ModuleStoreTestCase):
         self.assertContains(resp, u"Download Your Certificate")
 
     @ddt.data(
-        *itertools.product(((40, 4, True), (40, 4, False)), (True, False))
+        *itertools.product(((41, 4, True), (41, 4, False)), (True, False))
     )
     @ddt.unpack
     def test_query_counts(self, (sql_calls, mongo_calls, self_paced), self_paced_enabled):
@@ -1054,6 +1054,27 @@ class ProgressPageTests(ModuleStoreTestCase):
         with self.assertNumQueries(sql_calls), check_mongo_calls(mongo_calls):
             resp = views.progress(self.request, course_id=unicode(self.course.id))
         self.assertEqual(resp.status_code, 200)
+
+    @patch('courseware.grades.grade', Mock(return_value={
+        'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': []
+    }))
+    @ddt.data(
+        (CourseMode.AUDIT, False),
+        (CourseMode.HONOR, True),
+        (CourseMode.VERIFIED, True),
+        (CourseMode.PROFESSIONAL, True),
+        (CourseMode.NO_ID_PROFESSIONAL_MODE, True),
+        (CourseMode.CREDIT_MODE, True),
+    )
+    @ddt.unpack
+    def test_show_certificate_request_button(self, course_mode, show_button):
+        """Verify that the Request Certificate is not displayed in audit mode."""
+        CertificateGenerationConfiguration(enabled=True).save()
+        certs_api.set_cert_generation_enabled(self.course.id, True)
+        CourseEnrollment.enroll(self.user, self.course.id, mode=course_mode)
+
+        resp = views.progress(self.request, course_id=unicode(self.course.id))
+        self.assertEqual(show_button, 'Request Certificate' in resp.content)
 
 
 @attr('shard_1')

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -1043,7 +1043,11 @@ def _progress(request, course_key, student_id):
         raise Http404
 
     # checking certificate generation configuration
-    show_generate_cert_btn = certs_api.cert_generation_enabled(course_key)
+    enrollment_mode, is_active = CourseEnrollment.enrollment_mode_for_user(student, course_key)
+    show_generate_cert_btn = (
+        is_active and CourseMode.is_eligible_for_certificate(enrollment_mode)
+        and certs_api.cert_generation_enabled(course_key)
+    )
 
     context = {
         'course': course,


### PR DESCRIPTION
ECOM-3345: Hide the certificate generation button from the progress page if the student is enrolled as an audit.

@awaisdar001, @mushtaqak, @Shrhawk Please review this PR.
