### PR TITLE
TNL-4219 – progress status is not visible on problem blocks

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -1,4 +1,6 @@
 describe 'Problem', ->
+  problem_content_default = readFixtures('problem_content.html')
+
   beforeEach ->
     # Stub MathJax
     window.MathJax =
@@ -20,7 +22,7 @@ describe 'Problem', ->
 
     spyOn Logger, 'log'
     spyOn($.fn, 'load').andCallFake (url, callback) ->
-      $(@).html readFixtures('problem_content.html')
+      $(@).html problem_content_default
       callback()
 
   describe 'constructor', ->
@@ -96,12 +98,26 @@ describe 'Problem', ->
         @problem.renderProgressState()
         expect(@problem.$('.problem-progress').html()).toEqual "(1 point possible)"
 
+      it 'displays the number of points possible when rendering happens with the content', ->
+        @problem.el.data('progress_status', 'none')
+        @problem.el.data('progress_detail', '0/2')
+        expect(@problem.$('.problem-progress').html()).toEqual ""
+        @problem.render(problem_content_default)
+        expect(@problem.$('.problem-progress').html()).toEqual "(2 points possible)"
+
     describe 'with any other valid status', ->
       it 'reports the current score', ->
         @problem.el.data('progress_status', 'foo')
         @problem.el.data('progress_detail', '1/1')
         @problem.renderProgressState()
         expect(@problem.$('.problem-progress').html()).toEqual "(1/1 point)"
+
+      it 'shows current score when rendering happens with the content', ->
+        @problem.el.data('progress_status', 'test status')
+        @problem.el.data('progress_detail', '2/2')
+        expect(@problem.$('.problem-progress').html()).toEqual ""
+        @problem.render(problem_content_default)
+        expect(@problem.$('.problem-progress').html()).toEqual "(2/2 points)"
 
   describe 'render', ->
     beforeEach ->

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -159,6 +159,7 @@ class @Problem
         @setupInputTypes()
         @bind()
         @queueing()
+        @renderProgressState()
       @el.attr('aria-busy', 'false')
     else
       $.postWithPrefix "#{@url}/problem_get", (response) =>


### PR DESCRIPTION
[TNL-4219](https://openedx.atlassian.net/browse/TNL-4219)
### **Background**

Progress status (possible points & points earned) was invisible to the students in the courses unless they submitted the problems which was leading system to a bad user experience.
### **Fix**

Me along with @mushtaqak found the root cause quickly which seemed to be absence of progress status rendering during problem content rendering. Added the corresponding fix along with test.
### **Sandbox**

[Here](https://tnl4219.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/) is the sandbox.

@awaisdar001 , @cahrens, @ormsbee  may you please have a look. Thanks!
FYI @benpatterson 

**Before**
<img width="888" alt="screen shot 2016-03-11 at 5 07 16 pm" src="https://cloud.githubusercontent.com/assets/7848408/13701870/918adeac-e7ac-11e5-98c7-65e8e0d48371.png">

**After**
<img width="1153" alt="screen shot 2016-03-11 at 5 02 23 pm" src="https://cloud.githubusercontent.com/assets/7848408/13701880/9f8944a8-e7ac-11e5-93ae-f8c6181b6d3f.png">
