### PR TITLE
Move any uncached JS to be cached

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1633,7 +1633,11 @@ REQUIRE_ENVIRONMENT = "node"
 # then you need to add the js urls in this list.
 REQUIRE_JS_PATH_OVERRIDES = [
     'js/bookmarks/views/bookmark_button.js',
-    'js/views/message_banner.js'
+    'js/views/message_banner.js',
+    'js/vendor/moment.min.js',
+    'js/vendor/url.min.js',
+    'js/courseware/course_home_events.js',
+    'js/courseware/toggle_element_visibility.js'
 ]
 ################################# CELERY ######################################
 

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -5,7 +5,6 @@ from django.utils.translation import ugettext as _
 from django.template.defaultfilters import escapejs
 from django.conf import settings
 from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
-from pipeline_mako import render_require_js_path_overrides
 %>
 <%
   include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and (course.enable_proctored_exams or course.enable_timed_exams)
@@ -15,10 +14,6 @@ from pipeline_mako import render_require_js_path_overrides
 </%def>
 
 <%block name="bodyclass">view-in-course view-courseware courseware ${course.css_class or ''}</%block>
-
-<%block name="js_overrides">
-${render_require_js_path_overrides(settings.REQUIRE_JS_PATH_OVERRIDES)}
-</%block>
 
 <%block name="title"><title>
     % if section_title:

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -6,6 +6,7 @@ from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext as _
 from django.utils.translation import get_language_bidi
 from branding import api as branding_api
+from pipeline_mako import render_require_js_path_overrides
 %>
 <!DOCTYPE html>
 <!--[if lte IE 9]><html class="ie ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
@@ -77,8 +78,8 @@ from branding import api as branding_api
     }).call(this, require || RequireJS.require);
   </script>
   <script type="text/javascript" src="${static.url("lms/js/require-config.js")}"></script>
-
   <%block name="js_overrides">
+    ${render_require_js_path_overrides(settings.REQUIRE_JS_PATH_OVERRIDES)}
   </%block>
 
   % if not disable_courseware_js:


### PR DESCRIPTION
This is moving things to get bundled where applicable and then also adding RequireJS path overrides so RequireJS uses the hashed versions of assets which provide superior cacheability.
