### PR TITLE
Adds staff and instructor users of the master course to CCX

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -27,6 +27,7 @@ from .component import (
 )
 from .item import create_xblock_info
 from .library import LIBRARIES_ENABLED
+from ccx_keys.locator import CCXLocator
 from contentstore import utils
 from contentstore.course_group_config import (
     COHORT_SCHEME,
@@ -390,6 +391,11 @@ def _accessible_courses_list(request):
         if isinstance(course, ErrorDescriptor):
             return False
 
+        # Custom Courses for edX (CCX) is an edX feature for re-using course content.
+        # CCXs cannot be edited in Studio (aka cms) and should not be shown in this dashboard.
+        if isinstance(course.id, CCXLocator):
+            return False
+
         # pylint: disable=fixme
         # TODO remove this condition when templates purged from db
         if course.location.course == 'templates':
@@ -434,8 +440,11 @@ def _accessible_courses_list_from_groups(request):
             except ItemNotFoundError:
                 # If a user has access to a course that doesn't exist, don't do anything with that course
                 pass
-            if course is not None and not isinstance(course, ErrorDescriptor):
-                # ignore deleted or errored courses
+
+            # Custom Courses for edX (CCX) is an edX feature for re-using course content.
+            # CCXs cannot be edited in Studio (aka cms) and should not be shown in this dashboard.
+            if course is not None and not isinstance(course, ErrorDescriptor) and not isinstance(course.id, CCXLocator):
+                # ignore deleted, errored or ccx courses
                 courses_list[course_key] = course
 
     return courses_list.values(), in_process_course_actions

--- a/lms/djangoapps/ccx/api/v0/views.py
+++ b/lms/djangoapps/ccx/api/v0/views.py
@@ -34,6 +34,7 @@ from lms.djangoapps.ccx.overrides import (
     override_field_for_ccx,
 )
 from lms.djangoapps.ccx.utils import (
+    add_master_course_staff_to_ccx,
     assign_coach_role_to_ccx,
     is_email,
     get_course_chapters,
@@ -506,6 +507,13 @@ class CCXListView(GenericAPIView):
             )
             # assign coach role for the coach to the newly created ccx
             assign_coach_role_to_ccx(ccx_course_key, coach, master_course_object.id)
+            # assign staff role for all the staff and instructor of the master course to the newly created ccx
+            add_master_course_staff_to_ccx(
+                master_course_object,
+                ccx_course_key,
+                ccx_course_object.display_name,
+                send_email=False
+            )
 
         serializer = self.get_serializer(ccx_course_object)
         return Response(

--- a/lms/djangoapps/ccx/migrations/0003_add_master_course_staff_in_ccx.py
+++ b/lms/djangoapps/ccx/migrations/0003_add_master_course_staff_in_ccx.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from ccx_keys.locator import CCXLocator
+from courseware.courses import get_course_by_id
+from django.db import migrations
+
+from lms.djangoapps.ccx.utils import (
+    add_master_course_staff_to_ccx,
+    remove_master_course_staff_from_ccx,
+)
+
+
+def add_master_course_staff_to_ccx_for_existing_ccx(apps, schema_editor):
+    """
+    Add all staff and admin of master course to respective CCX(s).
+
+    Arguments:
+        apps (Applications): Apps in edX platform.
+        schema_editor (SchemaEditor): For editing database schema i.e create, delete field (column)
+
+    """
+    CustomCourseForEdX = apps.get_model("ccx", "CustomCourseForEdX")
+    list_ccx = CustomCourseForEdX.objects.all()
+    for ccx in list_ccx:
+        if ccx.course_id.deprecated:
+            # prevent migration for deprecated course ids.
+            continue
+        ccx_locator = CCXLocator.from_course_locator(ccx.course_id, unicode(ccx.id))
+        add_master_course_staff_to_ccx(
+            get_course_by_id(ccx.course_id),
+            ccx_locator,
+            ccx.display_name,
+            send_email=False
+        )
+
+
+def remove_master_course_staff_from_ccx_for_existing_ccx(apps, schema_editor):
+    """
+    Remove all staff and instructors of master course from respective CCX(s).
+
+    Arguments:
+        apps (Applications): Apps in edX platform.
+        schema_editor (SchemaEditor): For editing database schema i.e create, delete field (column)
+
+    """
+    CustomCourseForEdX = apps.get_model("ccx", "CustomCourseForEdX")
+    list_ccx = CustomCourseForEdX.objects.all()
+    for ccx in list_ccx:
+        if ccx.course_id.deprecated:
+            # prevent migration for deprecated course ids.
+            continue
+        ccx_locator = CCXLocator.from_course_locator(ccx.course_id, unicode(ccx.id))
+        remove_master_course_staff_from_ccx(
+            get_course_by_id(ccx.course_id),
+            ccx_locator,
+            ccx.display_name,
+            send_email=False
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ccx', '0001_initial'),
+        ('ccx', '0002_customcourseforedx_structure_json'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=add_master_course_staff_to_ccx_for_existing_ccx,
+            reverse_code=remove_master_course_staff_from_ccx_for_existing_ccx
+        )
+    ]

--- a/lms/djangoapps/ccx/tests/test_utils.py
+++ b/lms/djangoapps/ccx/tests/test_utils.py
@@ -2,22 +2,44 @@
 test utils
 """
 import mock
+import uuid
 from nose.plugins.attrib import attr
+from smtplib import SMTPException
 
-from student.roles import CourseCcxCoachRole
+from ccx_keys.locator import CCXLocator
+from student.roles import (
+    CourseCcxCoachRole,
+    CourseInstructorRole,
+    CourseStaffRole,
+)
 from student.tests.factories import (
     AdminFactory,
+    CourseEnrollmentFactory,
+    UserFactory
 )
+
+from student.models import CourseEnrollment, CourseEnrollmentException
+
 from xmodule.modulestore.tests.django_utils import (
     ModuleStoreTestCase,
-    TEST_DATA_SPLIT_MODULESTORE)
+    SharedModuleStoreTestCase,
+    TEST_DATA_SPLIT_MODULESTORE
+)
 from xmodule.modulestore.tests.factories import CourseFactory
 from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
 
 from lms.djangoapps.ccx import utils
+from lms.djangoapps.instructor.access import (
+    list_with_level,
+)
+from lms.djangoapps.ccx.utils import (
+    add_master_course_staff_to_ccx,
+    ccx_course,
+    remove_master_course_staff_from_ccx
+)
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 from lms.djangoapps.ccx.tests.utils import CcxTestCase
-from ccx_keys.locator import CCXLocator
 
 
 @attr('shard_1')
@@ -93,3 +115,307 @@ class TestGetCourseChapters(CcxTestCase):
             sorted(course_chapters),
             sorted([unicode(child) for child in self.course.children])
         )
+
+
+class TestStaffOnCCX(CcxTestCase):
+    """
+    Tests for staff on ccx courses.
+    """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
+    def setUp(self):
+        super(TestStaffOnCCX, self).setUp()
+
+        # Create instructor account
+        self.client.login(username=self.coach.username, password="test")
+
+        # create an instance of modulestore
+        self.mstore = modulestore()
+
+        self.make_coach()
+        self.ccx = self.make_ccx()
+        self.ccx_locator = CCXLocator.from_course_locator(self.course.id, self.ccx.id)
+
+    def test_add_master_course_staff_to_ccx(self):
+        """
+        Test add staff of master course to ccx course
+        """
+        # adding staff to master course.
+        staff = self.make_staff()
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = self.make_instructor()
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+
+        add_master_course_staff_to_ccx(self.course, self.ccx_locator, self.ccx.display_name)
+
+        # assert that staff and instructors of master course has staff and instructor roles on ccx
+        list_staff_master_course = list_with_level(self.course, 'staff')
+        list_instructor_master_course = list_with_level(self.course, 'instructor')
+
+        with ccx_course(self.ccx_locator) as course_ccx:
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            self.assertEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+            self.assertEqual(list_staff_master_course[0].email, list_staff_ccx_course[0].email)
+
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+            self.assertEqual(len(list_instructor_ccx_course), len(list_instructor_master_course))
+            self.assertEqual(list_instructor_ccx_course[0].email, list_instructor_master_course[0].email)
+
+    def test_add_master_course_staff_to_ccx_with_exception(self):
+        """
+        When exception raise from ``enroll_email`` assert that enrollment skipped for that staff or
+        instructor.
+        """
+        staff = self.make_staff()
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = self.make_instructor()
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+
+        with mock.patch.object(CourseEnrollment, 'enroll_by_email', side_effect=CourseEnrollmentException()):
+            add_master_course_staff_to_ccx(self.course, self.ccx_locator, self.ccx.display_name)
+
+            self.assertFalse(
+                CourseEnrollment.objects.filter(course_id=self.ccx_locator, user=staff).exists()
+            )
+            self.assertFalse(
+                CourseEnrollment.objects.filter(course_id=self.ccx_locator, user=instructor).exists()
+            )
+
+        with mock.patch.object(CourseEnrollment, 'enroll_by_email', side_effect=SMTPException()):
+            add_master_course_staff_to_ccx(self.course, self.ccx_locator, self.ccx.display_name)
+
+            self.assertFalse(
+                CourseEnrollment.objects.filter(course_id=self.ccx_locator, user=staff).exists()
+            )
+            self.assertFalse(
+                CourseEnrollment.objects.filter(course_id=self.ccx_locator, user=instructor).exists()
+            )
+
+    def test_remove_master_course_staff_from_ccx(self):
+        """
+        Test remove staff of master course to ccx course
+        """
+        staff = self.make_staff()
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = self.make_instructor()
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+
+        add_master_course_staff_to_ccx(self.course, self.ccx_locator, self.ccx.display_name, send_email=False)
+
+        list_staff_master_course = list_with_level(self.course, 'staff')
+        list_instructor_master_course = list_with_level(self.course, 'instructor')
+
+        with ccx_course(self.ccx_locator) as course_ccx:
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            self.assertEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+            self.assertEqual(list_staff_master_course[0].email, list_staff_ccx_course[0].email)
+
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+            self.assertEqual(len(list_instructor_ccx_course), len(list_instructor_master_course))
+            self.assertEqual(list_instructor_ccx_course[0].email, list_instructor_master_course[0].email)
+
+            # assert that role of staff and instructors of master course removed from ccx.
+            remove_master_course_staff_from_ccx(
+                self.course, self.ccx_locator, self.ccx.display_name, send_email=False
+            )
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            self.assertNotEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+            self.assertNotEqual(len(list_instructor_ccx_course), len(list_instructor_master_course))
+
+            for user in list_staff_master_course:
+                self.assertNotIn(user, list_staff_ccx_course)
+            for user in list_instructor_master_course:
+                self.assertNotIn(user, list_instructor_ccx_course)
+
+    def test_remove_master_course_staff_from_ccx_idempotent(self):
+        """
+        Test remove staff of master course from ccx course
+        """
+        staff = self.make_staff()
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = self.make_instructor()
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+
+        outbox = self.get_outbox()
+        self.assertEqual(len(outbox), 0)
+        add_master_course_staff_to_ccx(self.course, self.ccx_locator, self.ccx.display_name, send_email=False)
+
+        list_staff_master_course = list_with_level(self.course, 'staff')
+        list_instructor_master_course = list_with_level(self.course, 'instructor')
+
+        with ccx_course(self.ccx_locator) as course_ccx:
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            self.assertEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+            self.assertEqual(list_staff_master_course[0].email, list_staff_ccx_course[0].email)
+
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+            self.assertEqual(len(list_instructor_ccx_course), len(list_instructor_master_course))
+            self.assertEqual(list_instructor_ccx_course[0].email, list_instructor_master_course[0].email)
+
+            # assert that role of staff and instructors of master course removed from ccx.
+            remove_master_course_staff_from_ccx(
+                self.course, self.ccx_locator, self.ccx.display_name, send_email=True
+            )
+            self.assertEqual(len(outbox), len(list_staff_master_course) + len(list_instructor_master_course))
+
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            self.assertNotEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+            self.assertNotEqual(len(list_instructor_ccx_course), len(list_instructor_master_course))
+
+            for user in list_staff_master_course:
+                self.assertNotIn(user, list_staff_ccx_course)
+            for user in list_instructor_master_course:
+                self.assertNotIn(user, list_instructor_ccx_course)
+
+        # Run again
+        remove_master_course_staff_from_ccx(self.course, self.ccx_locator, self.ccx.display_name)
+        self.assertEqual(len(outbox), len(list_staff_master_course) + len(list_instructor_master_course))
+
+        with ccx_course(self.ccx_locator) as course_ccx:
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            self.assertNotEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+            self.assertNotEqual(len(list_instructor_ccx_course), len(list_instructor_master_course))
+
+            for user in list_staff_master_course:
+                self.assertNotIn(user, list_staff_ccx_course)
+            for user in list_instructor_master_course:
+                self.assertNotIn(user, list_instructor_ccx_course)
+
+    def test_add_master_course_staff_to_ccx_display_name(self):
+        """
+        Test add staff of master course to ccx course.
+        Specific test to check that a passed display name is in the
+        subject of the email sent to the enrolled users.
+        """
+        staff = self.make_staff()
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = self.make_instructor()
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+        outbox = self.get_outbox()
+        # create a unique display name
+        display_name = 'custom_display_{}'.format(uuid.uuid4())
+        list_staff_master_course = list_with_level(self.course, 'staff')
+        list_instructor_master_course = list_with_level(self.course, 'instructor')
+        self.assertEqual(len(outbox), 0)
+        # give access to the course staff/instructor
+        add_master_course_staff_to_ccx(self.course, self.ccx_locator, display_name)
+        self.assertEqual(len(outbox), len(list_staff_master_course) + len(list_instructor_master_course))
+        for email in outbox:
+            self.assertIn(display_name, email.subject)
+
+    def test_remove_master_course_staff_from_ccx_display_name(self):
+        """
+        Test remove role of staff of master course on ccx course.
+        Specific test to check that a passed display name is in the
+        subject of the email sent to the unenrolled users.
+        """
+        staff = self.make_staff()
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = self.make_instructor()
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+        outbox = self.get_outbox()
+        add_master_course_staff_to_ccx(self.course, self.ccx_locator, self.ccx.display_name, send_email=False)
+        # create a unique display name
+        display_name = 'custom_display_{}'.format(uuid.uuid4())
+        list_staff_master_course = list_with_level(self.course, 'staff')
+        list_instructor_master_course = list_with_level(self.course, 'instructor')
+        self.assertEqual(len(outbox), 0)
+        # give access to the course staff/instructor
+        remove_master_course_staff_from_ccx(self.course, self.ccx_locator, display_name)
+        self.assertEqual(len(outbox), len(list_staff_master_course) + len(list_instructor_master_course))
+        for email in outbox:
+            self.assertIn(display_name, email.subject)
+
+    def test_add_master_course_staff_to_ccx_idempotent(self):
+        """
+        Test add staff of master course to ccx course multiple time will
+        not result in multiple enrollments.
+        """
+        staff = self.make_staff()
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = self.make_instructor()
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+        outbox = self.get_outbox()
+        list_staff_master_course = list_with_level(self.course, 'staff')
+        list_instructor_master_course = list_with_level(self.course, 'instructor')
+        self.assertEqual(len(outbox), 0)
+
+        # run the assignment the first time
+        add_master_course_staff_to_ccx(self.course, self.ccx_locator, self.ccx.display_name)
+        self.assertEqual(len(outbox), len(list_staff_master_course) + len(list_instructor_master_course))
+        with ccx_course(self.ccx_locator) as course_ccx:
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+        self.assertEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+        for user in list_staff_master_course:
+            self.assertIn(user, list_staff_ccx_course)
+        self.assertEqual(len(list_instructor_master_course), len(list_instructor_ccx_course))
+        for user in list_instructor_master_course:
+            self.assertIn(user, list_instructor_ccx_course)
+
+        # run the assignment again
+        add_master_course_staff_to_ccx(self.course, self.ccx_locator, self.ccx.display_name)
+        # there are no new duplicated email
+        self.assertEqual(len(outbox), len(list_staff_master_course) + len(list_instructor_master_course))
+        # there are no duplicated staffs
+        with ccx_course(self.ccx_locator) as course_ccx:
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+        self.assertEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+        for user in list_staff_master_course:
+            self.assertIn(user, list_staff_ccx_course)
+        self.assertEqual(len(list_instructor_master_course), len(list_instructor_ccx_course))
+        for user in list_instructor_master_course:
+            self.assertIn(user, list_instructor_ccx_course)
+
+    def test_add_master_course_staff_to_ccx_no_email(self):
+        """
+        Test add staff of master course to ccx course without
+        sending enrollment email.
+        """
+        staff = self.make_staff()
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = self.make_instructor()
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+        outbox = self.get_outbox()
+        self.assertEqual(len(outbox), 0)
+        add_master_course_staff_to_ccx(self.course, self.ccx_locator, self.ccx.display_name, send_email=False)
+        self.assertEqual(len(outbox), 0)
+
+    def test_remove_master_course_staff_from_ccx_no_email(self):
+        """
+        Test remove role of staff of master course on ccx course without
+        sending enrollment email.
+        """
+        staff = self.make_staff()
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = self.make_instructor()
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+        outbox = self.get_outbox()
+        self.assertEqual(len(outbox), 0)
+        remove_master_course_staff_from_ccx(self.course, self.ccx_locator, self.ccx.display_name, send_email=False)
+        self.assertEqual(len(outbox), 0)

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -15,6 +15,11 @@ from courseware.courses import get_course_by_id
 from courseware.tests.factories import StudentModuleFactory
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from courseware.tabs import get_course_tab_list
+from instructor.access import (
+    allow_access,
+    list_with_level,
+)
+
 from django.conf import settings
 from django.core.urlresolvers import reverse, resolve
 from django.utils.translation import ugettext as _
@@ -27,7 +32,7 @@ from opaque_keys.edx.keys import CourseKey
 from student.roles import (
     CourseCcxCoachRole,
     CourseInstructorRole,
-    CourseStaffRole
+    CourseStaffRole,
 )
 from student.models import (
     CourseEnrollment,
@@ -54,6 +59,7 @@ from ccx_keys.locator import CCXLocator
 
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import get_override_for_ccx, override_field_for_ccx
+from lms.djangoapps.ccx.views import ccx_course
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 from lms.djangoapps.ccx.tests.utils import (
     CcxTestCase,
@@ -210,6 +216,16 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         # Login with the instructor account
         self.client.login(username=self.coach.username, password="test")
 
+        # adding staff to master course.
+        staff = UserFactory()
+        allow_access(self.course, staff, 'staff')
+        self.assertTrue(CourseStaffRole(self.course.id).has_user(staff))
+
+        # adding instructor to master course.
+        instructor = UserFactory()
+        allow_access(self.course, instructor, 'instructor')
+        self.assertTrue(CourseInstructorRole(self.course.id).has_user(instructor))
+
     def assert_elements_in_schedule(self, url, n_chapters=2, n_sequentials=4, n_verticals=8):
         """
         Helper function to count visible elements in the schedule
@@ -323,6 +339,19 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         # assert ccx creator has role=ccx_coach
         role = CourseCcxCoachRole(course_key)
         self.assertTrue(role.has_user(self.coach))
+
+        # assert that staff and instructors of master course has staff and instructor roles on ccx
+        list_staff_master_course = list_with_level(self.course, 'staff')
+        list_instructor_master_course = list_with_level(self.course, 'instructor')
+
+        with ccx_course(course_key) as course_ccx:
+            list_staff_ccx_course = list_with_level(course_ccx, 'staff')
+            self.assertEqual(len(list_staff_master_course), len(list_staff_ccx_course))
+            self.assertEqual(list_staff_master_course[0].email, list_staff_ccx_course[0].email)
+
+            list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
+            self.assertEqual(len(list_instructor_ccx_course), len(list_instructor_master_course))
+            self.assertEqual(list_instructor_ccx_course[0].email, list_instructor_master_course[0].email)
 
     @ddt.data("CCX demo 1", "CCX demo 2", "CCX demo 3")
     def test_create_multiple_ccx(self, ccx_name):

--- a/lms/djangoapps/ccx/tests/utils.py
+++ b/lms/djangoapps/ccx/tests/utils.py
@@ -8,9 +8,13 @@ from django.conf import settings
 
 from lms.djangoapps.ccx.overrides import override_field_for_ccx
 from lms.djangoapps.ccx.tests.factories import CcxFactory
-from student.roles import CourseCcxCoachRole
+from student.roles import (
+    CourseCcxCoachRole,
+    CourseInstructorRole,
+    CourseStaffRole
+)
 from student.tests.factories import (
-    AdminFactory,
+    UserFactory,
 )
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import (
@@ -76,9 +80,29 @@ class CcxTestCase(SharedModuleStoreTestCase):
         super(CcxTestCase, self).setUp()
 
         # Create instructor account
-        self.coach = AdminFactory.create()
+        self.coach = UserFactory.create()
         # create an instance of modulestore
         self.mstore = modulestore()
+
+    def make_staff(self):
+        """
+        create staff user.
+        """
+        staff = UserFactory.create(password="test")
+        role = CourseStaffRole(self.course.id)
+        role.add_users(staff)
+
+        return staff
+
+    def make_instructor(self):
+        """
+        create instructor user.
+        """
+        instructor = UserFactory.create(password="test")
+        role = CourseInstructorRole(self.course.id)
+        role.add_users(instructor)
+
+        return instructor
 
     def make_coach(self):
         """

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -13,24 +13,30 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 from django.core.validators import validate_email
 from django.core.urlresolvers import reverse
+from smtplib import SMTPException
 
 from courseware.courses import get_course_by_id
 from courseware.model_data import FieldDataCache
 from courseware.module_render import get_module_for_descriptor
 from instructor.enrollment import (
     enroll_email,
+    get_email_params,
     unenroll_email,
 )
-from instructor.access import allow_access
+from instructor.access import (
+    allow_access,
+    list_with_level,
+    revoke_access,
+)
 from instructor.views.tools import get_student_from_identifier
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.content.course_structures.models import CourseStructure
-from student.models import CourseEnrollment
+from student.models import CourseEnrollment, CourseEnrollmentException
 from student.roles import CourseCcxCoachRole
 
-from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import get_override_for_ccx
 from lms.djangoapps.ccx.custom_exception import CCXUserValidationException
+from lms.djangoapps.ccx.models import CustomCourseForEdX
 
 log = logging.getLogger("edx.ccx")
 
@@ -334,3 +340,117 @@ def get_course_chapters(course_key):
         return course_struct['blocks'][course_struct['root']].get('children', [])
     except KeyError:
         return []
+
+
+def add_master_course_staff_to_ccx(master_course, ccx_key, display_name, send_email=True):
+    """
+    Add staff and instructor roles on ccx to all the staff and instructors members of master course.
+
+    Arguments:
+        master_course (CourseDescriptorWithMixins): Master course instance.
+        ccx_key (CCXLocator): CCX course key.
+        display_name (str): ccx display name for email.
+        send_email (bool): flag to switch on or off email to the users on access grant.
+
+    """
+    list_staff = list_with_level(master_course, 'staff')
+    list_instructor = list_with_level(master_course, 'instructor')
+
+    with ccx_course(ccx_key) as course_ccx:
+        email_params = get_email_params(course_ccx, auto_enroll=True, course_key=ccx_key, display_name=display_name)
+        list_staff_ccx = list_with_level(course_ccx, 'staff')
+        list_instructor_ccx = list_with_level(course_ccx, 'instructor')
+        for staff in list_staff:
+            # this call should be idempotent
+            if staff not in list_staff_ccx:
+                try:
+                    # Enroll the staff in the ccx
+                    enroll_email(
+                        course_id=ccx_key,
+                        student_email=staff.email,
+                        auto_enroll=True,
+                        email_students=send_email,
+                        email_params=email_params,
+                    )
+
+                    # allow 'staff' access on ccx to staff of master course
+                    allow_access(course_ccx, staff, 'staff')
+                except CourseEnrollmentException:
+                    log.warning(
+                        "Unable to enroll staff %s to course with id %s",
+                        staff.email,
+                        ccx_key
+                    )
+                    continue
+                except SMTPException:
+                    continue
+
+        for instructor in list_instructor:
+            # this call should be idempotent
+            if instructor not in list_instructor_ccx:
+                try:
+                    # Enroll the instructor in the ccx
+                    enroll_email(
+                        course_id=ccx_key,
+                        student_email=instructor.email,
+                        auto_enroll=True,
+                        email_students=send_email,
+                        email_params=email_params,
+                    )
+
+                    # allow 'instructor' access on ccx to instructor of master course
+                    allow_access(course_ccx, instructor, 'instructor')
+                except CourseEnrollmentException:
+                    log.warning(
+                        "Unable to enroll instructor %s to course with id %s",
+                        instructor.email,
+                        ccx_key
+                    )
+                    continue
+                except SMTPException:
+                    continue
+
+
+def remove_master_course_staff_from_ccx(master_course, ccx_key, display_name, send_email=True):
+    """
+    Remove staff and instructor roles on ccx to all the staff and instructors members of master course.
+
+    Arguments:
+        master_course (CourseDescriptorWithMixins): Master course instance.
+        ccx_key (CCXLocator): CCX course key.
+        display_name (str): ccx display name for email.
+        send_email (bool): flag to switch on or off email to the users on revoke access.
+
+    """
+    list_staff = list_with_level(master_course, 'staff')
+    list_instructor = list_with_level(master_course, 'instructor')
+
+    with ccx_course(ccx_key) as course_ccx:
+        list_staff_ccx = list_with_level(course_ccx, 'staff')
+        list_instructor_ccx = list_with_level(course_ccx, 'instructor')
+        email_params = get_email_params(course_ccx, auto_enroll=True, course_key=ccx_key, display_name=display_name)
+        for staff in list_staff:
+            if staff in list_staff_ccx:
+                # revoke 'staff' access on ccx.
+                revoke_access(course_ccx, staff, 'staff')
+
+                # Unenroll the staff on ccx.
+                unenroll_email(
+                    course_id=ccx_key,
+                    student_email=staff.email,
+                    email_students=send_email,
+                    email_params=email_params,
+                )
+
+        for instructor in list_instructor:
+            if instructor in list_instructor_ccx:
+                # revoke 'instructor' access on ccx.
+                revoke_access(course_ccx, instructor, 'instructor')
+
+                # Unenroll the instructor on ccx.
+                unenroll_email(
+                    course_id=ccx_key,
+                    student_email=instructor.email,
+                    email_students=send_email,
+                    email_params=email_params,
+                )

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -53,6 +53,7 @@ from lms.djangoapps.ccx.overrides import (
     bulk_delete_ccx_override_fields,
 )
 from lms.djangoapps.ccx.utils import (
+    add_master_course_staff_to_ccx,
     assign_coach_role_to_ccx,
     ccx_course,
     ccx_students_enrolling_center,
@@ -155,6 +156,9 @@ def dashboard(request, course, ccx=None):
         context['grading_policy_url'] = reverse(
             'ccx_set_grading_policy', kwargs={'course_id': ccx_locator})
 
+        with ccx_course(ccx_locator) as course:
+            context['course'] = course
+
     else:
         context['create_ccx_url'] = reverse(
             'create_ccx', kwargs={'course_id': course.id})
@@ -224,7 +228,7 @@ def create_ccx(request, course, ccx=None):
     )
 
     assign_coach_role_to_ccx(ccx_id, request.user, course.id)
-
+    add_master_course_staff_to_ccx(course, ccx_id, ccx.display_name)
     return redirect(url)
 
 

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -135,9 +135,6 @@ def has_access(user, action, obj, course_key=None):
     if not user:
         user = AnonymousUser()
 
-    if isinstance(course_key, CCXLocator):
-        course_key = course_key.to_course_locator()
-
     if in_preview_mode():
         if not bool(has_staff_access_to_preview_mode(user=user, obj=obj, course_key=course_key)):
             return ACCESS_DENIED


### PR DESCRIPTION
### Background

fixes https://github.com/mitocw/edx-platform/issues/126, fixes https://github.com/mitocw/edx-platform/issues/155, fixes https://github.com/mitocw/edx-platform/issues/115 and fixes https://github.com/mitocw/edx-platform/issues/205

This is an updated version of https://github.com/edx/edx-platform/pull/10877 which had to be reverted. 
### What is done in this PR

**Studio Updates:** 
- Remove ccx from staff dashboard inside studio. Because  a master course can have unlimited ccx, staff's dashboard can be populated with a huge list of ccx along with master course 

**LMS Updates:** 
- This is for course staff to see what ccx coaches are doing with course.
- Now when a coach creates a new ccx, I am assigning staff role on this ccx course to all staff of master course.
- Added instructors of master course as instructor(s) in ccx.
- Also adds the master course staff users to new CCX created via the CCX REST APIs
- **Note:** This code will add/enrol staff and instructors in ccx and now max student limit for ccx depends on number of staff and admins. 
- Fixed view as student issue on ccx, now staff can view as student and see how ccx  view will appear to student
- Fixed display name on ccx coach dashboard. Previously it was show display name of master course on coach dashboard.
##### To run migration manually on devstack
- `python manage.py lms migrate ccx 0003 --settings=devstack`
  ##### To reverse migration manually on devstack
- `python manage.py lms migrate ccx 0002 --settings=devstack`

@pdpinch @giocalitri 
- Staff on Master course
  ![screen shot 2015-11-30 at 5 12 54 pm](https://cloud.githubusercontent.com/assets/10431250/11471231/ba5e9cc8-9785-11e5-95c5-0cdcea97f780.png)
- Staff on CCX
  ![screen shot 2015-11-30 at 5 13 04 pm](https://cloud.githubusercontent.com/assets/10431250/11471234/c2d0a9dc-9785-11e5-865f-a1b7d79a34db.png)
- Admin/instructors on master course
  ![screen shot 2015-12-10 at 5 10 18 pm](https://cloud.githubusercontent.com/assets/10431250/11715098/08685ed0-9f61-11e5-8b79-87defb82c2c9.png)
- Admin/instructors on ccx
  ![screen shot 2015-12-10 at 5 10 22 pm](https://cloud.githubusercontent.com/assets/10431250/11715099/11ada5ae-9f61-11e5-92c3-d0316f1b6190.png)
#### Fixed view as student

![screen shot 2015-12-17 at 7 21 37 pm 2](https://cloud.githubusercontent.com/assets/10431250/11871777/8eb3d64e-a4f3-11e5-9b32-d0df4a0dd0a6.png)
![screen shot 2015-12-17 at 7 21 53 pm 2](https://cloud.githubusercontent.com/assets/10431250/11871778/8eb92040-a4f3-11e5-9bb7-49c691d4bb24.png)
![screen shot 2015-12-17 at 7 22 05 pm 2](https://cloud.githubusercontent.com/assets/10431250/11871779/8ebdc94c-a4f3-11e5-9e7d-0ee44b1652c3.png)
#### Fixed display name of ccx on coach dashboard.

![screen shot 2015-12-18 at 3 29 34 pm](https://cloud.githubusercontent.com/assets/10431250/11894922/3f39bfa8-a59c-11e5-82e9-0dabd349e963.png)
![screen shot 2015-12-18 at 3 29 44 pm](https://cloud.githubusercontent.com/assets/10431250/11894921/3f3880de-a59c-11e5-9d38-da5de6837b8a.png)
![screen shot 2015-12-18 at 3 29 55 pm](https://cloud.githubusercontent.com/assets/10431250/11894923/3f411bf4-a59c-11e5-80bb-b79b5073c936.png)
