### PR TITLE
Properly escape mixed content. text + html.

### DIFF
--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -998,6 +998,21 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         response = self.client.get(self.notes_page_url)
         self.assertContains(response, 'Highlights and notes you&#39;ve made in course content')
 
+    # pylint: disable=unused-argument
+    @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
+    @patch("edxnotes.views.get_notes", return_value={'results': []})
+    @patch("edxnotes.views.get_course_position", return_value={'display_name': 'Section 1', 'url': 'test_url'})
+    def test_edxnotes_html_tags_should_not_be_escaped(self, mock_get_notes, mock_position):
+        """
+        Tests that explicit html tags rendered correctly.
+        """
+        enable_edxnotes_for_the_course(self.course, self.user.id)
+        response = self.client.get(self.notes_page_url)
+        self.assertContains(
+            response,
+            'Get started by making a note in something you just read, like <a href="test_url">Section 1</a>'
+        )
+
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": False})
     def test_edxnotes_view_is_disabled(self):
         """

--- a/lms/templates/edxnotes/edxnotes.html
+++ b/lms/templates/edxnotes/edxnotes.html
@@ -5,6 +5,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from edxnotes.helpers import NoteJSONEncoder
+from openedx.core.djangolib.markup import Text, HTML
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>
 
@@ -78,8 +79,8 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 
               % if position is not None:
               <div class="placeholder-cta student-notes-cta">
-                <p class="placeholder-cta-copy">${_('Get started by making a note in something you just read, like {section_link}.').format(
-                  section_link='<a href="{url}">{section_name}</a>'.format(
+                <p class="placeholder-cta-copy">${Text(_('Get started by making a note in something you just read, like {section_link}.')).format(
+                  section_link=HTML('<a href="{url}">{section_name}</a>').format(
                     url=position['url'],
                     section_name=position['display_name'],
                     )


### PR DESCRIPTION
TNL-4243
