### PR TITLE
Bump the version of the Drag&Drop XBlock to 2.0.4.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -94,4 +94,4 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.0.3#egg=xblock-lti-consume
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 -e git+https://github.com/open-craft/xblock-poll@e7a6c95c300e95c51e42bfd1eba70489c05a6527#egg=xblock-poll
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.3#egg=xblock-drag-and-drop-v2==2.0.3
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.4#egg=xblock-drag-and-drop-v2==2.0.4


### PR DESCRIPTION
This includes edx-solutions/xblock-drag-and-drop-v2#65.

JIRA: [SOL-1661](https://openedx.atlassian.net/browse/SOL-1661)

Here's a sandbox with a slightly older version of edx-platform: http://studio.master.dndv2.sandbox.opencraft.com/container/block-v1:TestX+TST-DNDV2-M+now+type@vertical+block@1e63181ae0c74ef4beae234aa38f7798

I currently don't manage to get a new sandbox built (due to problems with the deployment process that are completely unrelated to this PR).
