### PR TITLE
Update problem-builder to version 2.0.3 (release)

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@v2.0.2#egg=xblock-problem-builder==2.0.2
+git+https://github.com/open-craft/problem-builder.git@v2.0.3#egg=xblock-problem-builder==2.0.3
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
### Bug

The 'Download report' link on the problem builder dashboard is currently broken. Images are not always displayed, for 2 reasons:
- If the image is from a different domain and it has been cached by the browser, it is not converted into a data URL due to cross-domain security issues. A javascript `SecurityError` is thrown, and nothing happens.
- If the image url starts with `//` (no explicit protocol) or the url is relative (e.g. `/static/...`), _and_ it has not yet been cached by the browser, it will fail to show up in the downloaded report.
### Fix

These issues have been fixed in version 2.0.3 of problem builder (see https://github.com/open-craft/problem-builder/pull/106). This pull request updates edx-platform to use the new version.
### Partner information

Harvard GSE course hosted on edx.org (Data Wise)
### Merge deadline

ASAP, affecting students in live course

**Settings**

``` yaml
edx_platform_version: 'omar/update-problem-builder-sandbox'
```
