### PR TITLE
Adaptation asides to be exported to the XML

### DIFF
--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -5,6 +5,7 @@ import os
 import sys
 from lxml import etree
 
+from xblock.core import XML_NAMESPACES
 from xblock.fields import Dict, Scope, ScopeIds
 from xblock.runtime import KvsFieldData
 from xmodule.x_module import XModuleDescriptor, DEPRECATION_VSCOMPAT_EVENT
@@ -428,6 +429,12 @@ class XmlParserMixin(object):
         """
         # Get the definition
         xml_object = self.definition_to_xml(self.runtime.export_fs)
+        for aside in self.runtime.get_asides(self):
+            if aside.needs_serialization():
+                aside_node = etree.Element("unknown_root", nsmap=XML_NAMESPACES)
+                aside.add_xml_to_node(aside_node)
+                xml_object.append(aside_node)
+
         self.clean_metadata_from_xml(xml_object)
 
         # Set the tag on both nodes so we get the file path right.

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -69,7 +69,7 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 
 # Our libraries:
-git+https://github.com/edx/XBlock.git@xblock-0.4.7#egg=XBlock==0.4.7
+git+https://github.com/edx/XBlock.git@xblock-0.4.8#egg=XBlock==0.4.8
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
 -e git+https://github.com/edx/js-test-tool.git@v0.1.6#egg=js_test_tool
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1


### PR DESCRIPTION
Continue working on xblock asides. Asides can be exported with the rest of courseware through the Export function within CMS.

P.S. This commit is continuation of the work that was started in
https://github.com/edx/edx-platform/pull/11562
