### PR TITLE
Dynamic values for the selectboxes with tags (tags are stored in the database tables)

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -903,6 +903,9 @@ INSTALLED_APPS = (
 
     # Management commands used for configuration automation
     'edx_management_commands.management_commands',
+
+    # Tagging
+    'cms.lib.xblock.tagging',
 )
 
 

--- a/cms/lib/xblock/tagging/__init__.py
+++ b/cms/lib/xblock/tagging/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""
+Structured Tagging based on XBlockAsides
+"""
+
+from .tagging import StructuredTagsAside

--- a/cms/lib/xblock/tagging/migrations/0001_initial.py
+++ b/cms/lib/xblock/tagging/migrations/0001_initial.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TagAvailableValues',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('value', models.CharField(max_length=255)),
+            ],
+            options={
+                'ordering': ('id',),
+            },
+        ),
+        migrations.CreateModel(
+            name='TagCategories',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=255, unique=True)),
+                ('title', models.CharField(max_length=255)),
+            ],
+            options={
+                'ordering': ('title',),
+            },
+        ),
+        migrations.AddField(
+            model_name='tagavailablevalues',
+            name='category',
+            field=models.ForeignKey(to='tagging.TagCategories'),
+        ),
+    ]

--- a/cms/lib/xblock/tagging/models.py
+++ b/cms/lib/xblock/tagging/models.py
@@ -1,0 +1,40 @@
+"""
+Django Model for tags
+"""
+from django.db import models
+
+
+class TagCategories(models.Model):
+    """
+    This model represents tag categories.
+    """
+    name = models.CharField(max_length=255, unique=True)
+    title = models.CharField(max_length=255)
+
+    class Meta(object):
+        app_label = "tagging"
+        ordering = ('title',)
+
+    def __unicode__(self):
+        return "[TagCategories] {}: {}".format(self.name, self.title)
+
+    def get_values(self):
+        """
+        Return the list of available values for the particular category
+        """
+        return [t.value for t in TagAvailableValues.objects.filter(category=self)]
+
+
+class TagAvailableValues(models.Model):
+    """
+    This model represents available values for tags.
+    """
+    category = models.ForeignKey(TagCategories, db_index=True)
+    value = models.CharField(max_length=255)
+
+    class Meta(object):
+        app_label = "tagging"
+        ordering = ('id',)
+
+    def __unicode__(self):
+        return "[TagAvailableValues] {}: {}".format(self.category, self.value)

--- a/cms/templates/structured_tags_block.html
+++ b/cms/templates/structured_tags_block.html
@@ -1,16 +1,16 @@
-<div class="xblock-render">
+<div class="xblock-render" class="studio-xblock-wrapper">
     % for tag in tags:
-    <label for="problem_tags_${tag['key']}">${tag['title']}</label>:
-    <select id="problem_tags_${tag['key']}" name="${tag['key']}">
+    <label for="tags_${tag['key']}_${block_location}">${tag['title']}</label>:
+    <select id="tags_${tag['key']}_${block_location}" name="${tag['key']}">
         <option value="" ${'' if tag['current_value'] else 'selected=""'}>Not selected</option>
-        % for k,v in tag['values'].iteritems():
+        % for v in tag['values']:
             <%
                 selected = ''
-                if k == tag['current_value']:
+                if v == tag['current_value']:
                     selected = 'selected'
             %>
-            <option value="${k}" ${selected}>${v}</option>
+            <option value="${v}" ${selected}>${v}</option>
         % endfor
-    % endfor
     </select>
+    % endfor
 </div>


### PR DESCRIPTION
Continue working with tags feature (based on xblock asides).

With this PR: tags and available values for each tag are stored in the database tables.
So they could be managed manually with updating related tables in DB.

P.S. This commit is continuation of the work that was started in
https://github.com/edx/edx-platform/pull/11562
