### PR TITLE
Reverted rfc6266 change

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -85,7 +85,6 @@ pysrt==0.4.7
 PyYAML==3.10
 requests==2.7.0
 requests-oauthlib==0.4.1
-rfc6266==0.0.4
 scipy==0.14.0
 Shapely==1.2.16
 singledispatch==3.4.0.2

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -65,6 +65,9 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 # custom opaque-key implementations for CCX
 git+https://github.com/edx/ccx-keys.git@0.1.1#egg=ccx-keys==0.1.1
 
+# NOTE (CCB): This must remain. There is one commit on the upstream repo that has not been released to PyPI.
+git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
+
 # Used for testing
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 


### PR DESCRIPTION
The fork actually does include a commit that is not in the PyPI version.

ECOM-3833

@jibsheet @tobz @adampalay 
