### PR TITLE
MA-2164 adding youtube url to encoded videos

### DIFF
--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1013,11 +1013,14 @@ class TestVideoDescriptorStudentViewJson(TestCase):
         'file_size': 222,
     }
     TEST_EDX_VIDEO_ID = 'test_edx_video_id'
+    TEST_YOUTUBE_ID = 'test_youtube_id'
+    TEST_YOUTUBE_EXPECTED_URL = 'https://www.youtube.com/watch?v=test_youtube_id'
 
     def setUp(self):
         super(TestVideoDescriptorStudentViewJson, self).setUp()
+        video_declaration = "<video display_name='Test Video' youtube_id_1_0=\'" + self.TEST_YOUTUBE_ID + "\'>"
         sample_xml = (
-            "<video display_name='Test Video'> " +
+            video_declaration +
             "<source src='" + self.TEST_SOURCE_URL + "'/> " +
             "<transcript language='" + self.TEST_LANGUAGE + "' src='german_translation.srt' /> " +
             "</video>"
@@ -1055,7 +1058,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
         }
         return self.video.student_view_data(context)
 
-    def verify_result_with_fallback_url(self, result):
+    def verify_result_with_fallback_url_and_youtube_url(self, result):
         """
         Verifies the result is as expected when returning "fallback" video data (not from VAL).
         """
@@ -1065,7 +1068,21 @@ class TestVideoDescriptorStudentViewJson(TestCase):
                 "only_on_web": False,
                 "duration": None,
                 "transcripts": {self.TEST_LANGUAGE: self.transcript_url},
-                "encoded_videos": {"fallback": {"url": self.TEST_SOURCE_URL, "file_size": 0}},
+                "encoded_videos": {"fallback": {"url": self.TEST_SOURCE_URL, "file_size": 0}, "youtube": {"url": self.TEST_YOUTUBE_EXPECTED_URL, "file_size": 0}},
+            }
+        )
+
+    def verify_result_with_youtube_url(self, result):
+        """
+        Verifies the result is as expected when returning "fallback" video data (not from VAL).
+        """
+        self.assertDictEqual(
+            result,
+            {
+                "only_on_web": False,
+                "duration": None,
+                "transcripts": {self.TEST_LANGUAGE: self.transcript_url},
+                "encoded_videos": {"youtube": {"url": self.TEST_YOUTUBE_EXPECTED_URL, "file_size": 0}},
             }
         )
 
@@ -1093,7 +1110,21 @@ class TestVideoDescriptorStudentViewJson(TestCase):
 
     def test_no_edx_video_id(self):
         result = self.get_result()
-        self.verify_result_with_fallback_url(result)
+        self.verify_result_with_fallback_url_and_youtube_url(result)
+
+    def test_no_edx_video_id_and_no_fallback(self):
+        video_declaration = "<video display_name='Test Video' youtube_id_1_0=\'{}\'>".format(self.TEST_YOUTUBE_ID)
+        # the video has no source listed, only a youtube link, so no fallback url will be provided
+        sample_xml = (
+            video_declaration +
+            "<transcript language='" + self.TEST_LANGUAGE + "' src='german_translation.srt' /> " +
+            "</video>"
+        )
+        self.transcript_url = "transcript_url"
+        self.video = instantiate_descriptor(data=sample_xml)
+        self.video.runtime.handler_url = Mock(return_value=self.transcript_url)
+        result = self.get_result()
+        self.verify_result_with_youtube_url(result)
 
     @ddt.data(
         *itertools.product([True, False], [True, False], [True, False])
@@ -1107,7 +1138,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
         if video_exists_in_val and (associate_course_in_val or allow_cache_miss):
             self.verify_result_with_val_profile(result)
         else:
-            self.verify_result_with_fallback_url(result)
+            self.verify_result_with_fallback_url_and_youtube_url(result)
 
 
 @attr('shard_1')


### PR DESCRIPTION
@nasthagiri @jcdyer 

Fixes https://openedx.atlassian.net/browse/MA-2164

I chose the "Youtube approach" by which we return a YouTube URL alongside a fallback url (if one is available) in the case that no mobile-encoded videos exist for a given block.
