### PR TITLE
Use is-hidden instead of hidden for video errors.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -296,7 +296,7 @@ function (VideoPlayer, i18n, moment) {
                     .addClass('hidden');
             state.el
                 .find('.video-player .video-error')
-                    .removeClass('hidden');
+                    .removeClass('is-hidden');
 
             return false;
         }
@@ -498,7 +498,7 @@ function (VideoPlayer, i18n, moment) {
             this.el.find('.video-player div')
                 .removeClass('hidden');
             this.el.find('.video-player .video-error')
-                .addClass('hidden');
+                .addClass('is-hidden');
 
             // If in reality the timeout was to short, try to
             // continue loading the YouTube video anyways.

--- a/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
+++ b/common/lib/xmodule/xmodule/js/src/video/02_html5_video.js
@@ -100,7 +100,7 @@ function () {
                     .addClass('hidden')
                 .end()
                 .find('.video-player .video-error')
-                    .removeClass('hidden')
+                    .removeClass('is-hidden')
                 .end()
                     .addClass('is-initialized')
                 .find('.spinner')
@@ -123,9 +123,9 @@ function () {
             this.video.removeEventListener('pause', this.onPause, false);
             this.video.removeEventListener('ended', this.onEnded, false);
             this.el
-                .find('.video-player div').removeClass('hidden')
+                .find('.video-player div').removeClass('is-hidden')
                 .end()
-                .find('.video-player .video-error').addClass('hidden')
+                .find('.video-player .video-error').addClass('is-hidden')
                 .end().removeClass('is-initialized')
                 .find('.spinner').attr({'aria-hidden': 'false'});
             this.videoEl.remove();

--- a/common/test/acceptance/tests/video/test_studio_video_module.py
+++ b/common/test/acceptance/tests/video/test_studio_video_module.py
@@ -234,6 +234,7 @@ class CMSVideoTest(CMSVideoBaseTest):
         And first is private video
         When I reload the page
         Then video controls for all videos are visible
+        And the error message isn't shown
         """
         self._create_course_unit(youtube_stub_config={'youtube_api_private_video': True})
         self.video.create_video()
@@ -247,6 +248,9 @@ class CMSVideoTest(CMSVideoBaseTest):
         # again open unit page and check that video controls show for both videos
         self._navigate_to_course_unit_page()
         self.assertTrue(self.video.is_controls_visible())
+
+        # verify that the error message isn't shown by default
+        self.assertFalse(self.video.is_error_message_shown)
 
     def test_captions_shown_correctly(self):
         """

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -23,7 +23,7 @@
           <div class="video-player-pre"></div>
           <section class="video-player">
               <div id="${id}"></div>
-              <h4 class="hd hd-4 video-error hidden">${_('No playable video sources found.')}</h4>
+              <h4 class="hd hd-4 video-error is-hidden">${_('No playable video sources found.')}</h4>
           </section>
           <div class="video-player-post"></div>
           <div class="closed-captions"></div>


### PR DESCRIPTION
## [TNL-4121](https://openedx.atlassian.net/browse/TNL-4121)

This is mostly a minor CSS/JS change to use the class that's commonly used for hiding content. 
### Sandbox
- [ ] https://dianakhuang.sandbox.edx.org/
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [ ] Code review: @cahrens 

FYI: @clrux I believe this might be related to some of the video module accessibility work you did.
### Post-review
- [ ] Squash commits
