### PR TITLE
(WIP) Paver edraak script to manage fork's translation

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -60,3 +60,21 @@ file_filter = conf/locale/<lang>/LC_MESSAGES/wiki.po
 source_file = conf/locale/en/LC_MESSAGES/wiki.po
 source_lang = en
 type = PO
+
+[edraak.edraak-platform-2015-theme]
+file_filter = conf/locale/<lang>/LC_MESSAGES/edraak-platform-2015-theme.po
+source_file = conf/locale/en/LC_MESSAGES/edraak-platform-2015-theme.po
+source_lang = en
+type = PO
+
+[edraak.edraak-platform]
+file_filter = conf/locale/<lang>/LC_MESSAGES/edraak-platform.po
+source_file = conf/locale/en/LC_MESSAGES/edraak-platform.po
+source_lang = en
+type = PO
+
+[edraak.edraakjs-platform]
+file_filter = conf/locale/<lang>/LC_MESSAGES/edraakjs-platform.po
+source_file = conf/locale/en/LC_MESSAGES/edraakjs-platform.po
+source_lang = en
+type = PO

--- a/common/djangoapps/edraak_i18n/management/__init__.py
+++ b/common/djangoapps/edraak_i18n/management/__init__.py
@@ -1,0 +1,1 @@
+"""Edraak i18n commands."""

--- a/common/djangoapps/edraak_i18n/management/commands/i18n_edraak_theme_push.py
+++ b/common/djangoapps/edraak_i18n/management/commands/i18n_edraak_theme_push.py
@@ -1,0 +1,64 @@
+# * Handling merge/forks of UserProfile.meta
+from django.core.management.base import BaseCommand
+from django.conf import settings
+import os
+from subprocess import call
+import polib
+
+
+class Command(BaseCommand):
+    help = '''Run theme's ./scripts/edraak_i18n_theme_push.sh'''
+
+    @staticmethod
+    def remove_ignored_messages(theme_root):
+        theme_pofile = theme_root / 'conf/locale/en/LC_MESSAGES/edraak-platform-2015-theme.po'
+        theme_po = polib.pofile(theme_pofile)
+
+        # `reversed()` is used to allow removing from the bottom
+        # instead of changing the index and introducing bugs
+        for entry in reversed(theme_po):
+            if 'edraak-ignore' in entry.comment.lower():
+                theme_po.remove(entry)
+                print 'Removed ignored translation: ', entry.msgid, '=>', entry.msgstr
+
+        theme_po.save()
+
+    @staticmethod
+    def generate_pofile(theme_root):
+        mako_pofile_relative = 'conf/locale/en/LC_MESSAGES/mako.po'
+        mako_pofile = theme_root / mako_pofile_relative
+
+        if not mako_pofile.dirname().exists():
+            os.makedirs(mako_pofile.dirname())
+
+        open(mako_pofile, 'w').close()  # Make sure the file exists and empty
+
+        call([
+            'pybabel',
+            '-q', 'extract',
+            '--mapping=conf/locale/babel_mako.cfg',
+            '--add-comments', 'Translators:',
+            '--keyword', 'interpolate',
+            '.',
+            '--output={}'.format(mako_pofile_relative),
+        ], cwd=theme_root)
+
+        call(['i18n_tool', 'segment', '--config', 'conf/locale/config.yaml', 'en'], cwd=theme_root)
+
+        if mako_pofile.exists():
+            mako_pofile.unlink()
+
+    @staticmethod
+    def transifex_push(theme_root):
+        call(['tx', 'push', '-l', 'en', '-s', '-r', 'edraak.edraak-platform-2015-theme'], cwd=theme_root)
+
+    def handle(self, *args, **options):
+        if settings.FEATURES.get('USE_CUSTOM_THEME', False) and settings.THEME_NAME:
+            theme_root = settings.ENV_ROOT / "themes" / settings.THEME_NAME
+            self.generate_pofile(theme_root)
+            self.remove_ignored_messages(theme_root)
+            self.transifex_push(theme_root)
+        else:
+            print "Error: theme files not found."
+            print "Are you sure the config is correct? Press <Enter> to continue without theme i18n..."
+            raw_input()

--- a/pavelib/__init__.py
+++ b/pavelib/__init__.py
@@ -2,3 +2,4 @@
 paver commands
 """
 from . import assets, servers, docs, prereqs, quality, tests, js_test, i18n, bok_choy, acceptance_test
+from . import edraak

--- a/pavelib/edraak.py
+++ b/pavelib/edraak.py
@@ -1,0 +1,298 @@
+"""
+Edraak internationalization tasks
+"""
+from path import path
+import yaml
+from paver.easy import task, needs, sh, call_task, BuildFailure
+import polib
+from git import Repo
+import os
+import contextlib
+from shutil import copyfile
+
+from .utils.cmd import django_cmd
+
+EDRAAK_RESOURCES = (
+    'edraak-platform',
+    'edraak-platform-2015-theme',
+)
+
+ARABIC_LOCALE_DIR = 'conf/locale/ar/LC_MESSAGES/'
+
+OTHER_RTL_LOCALES = ('eo', 'rtl', 'he', 'fa',)
+
+git_repo = Repo('.')
+
+
+@contextlib.contextmanager
+def working_directory(path):
+    """
+    A context manager which changes the working directory to the given
+    path, and then changes it back to its previous value on exit.
+    """
+    prev_cwd = os.getcwd()
+    os.chdir(path)
+    yield
+    os.chdir(prev_cwd)
+
+
+def js_nonjs(func):
+    """
+    Make a task run for both `django.po` and `djangojs.po` in a DRY way.
+    """
+    def wrapper():
+        """
+        Run it twice.
+        """
+        func(is_js=False, suffix='')
+        func(is_js=True, suffix='js')
+
+    # Keep the original name for Paver
+    wrapper.__name__ = func.__name__
+
+    return wrapper
+
+
+def run_for_js_nonjs(func):
+    """
+    Actually run the function twice, rather than decorating the function.
+    """
+
+    func2 = js_nonjs(func)
+    func2()
+
+
+@task
+def clean_repo_check():
+    # Start with clean translation state
+    clean_git_repo_msg = (
+        'The repo has local modifications. '
+        'Please stash or commit your changes.'
+    )
+
+    assert not git_repo.is_dirty(untracked_files=True), clean_git_repo_msg
+
+
+@task
+def i18n_po_pull_edraak():
+    # Get Edraak translations
+    for resource in EDRAAK_RESOURCES:
+        cmd = ' '.join([
+            'tx',
+            'pull',
+            '--force',
+            '--mode=reviewed',
+            '--language=ar',
+            '--resource=edraak.{}'.format(resource),
+        ])
+
+        sh(cmd)
+
+
+@task
+@js_nonjs
+def i18n_edraak_generate_files(is_js, suffix):
+    """
+    Append all Edraak strings to the original django.mo.
+    """
+    with working_directory(ARABIC_LOCALE_DIR):
+        django_pofile = polib.pofile('django{}.po'.format(suffix))
+
+        resources = [
+            'edraak{}-platform'.format(suffix),
+            'django{}-updates'.format(suffix),
+        ]
+
+        if not is_js:
+            resources.append('edraak-platform-2015-theme')
+
+        for resource in resources:
+            for entry in polib.pofile('{}.po'.format(resource)):
+                django_pofile.append(entry)
+
+        # Save a backup in git for later inspection,
+        # and keep django.po untouched
+        django_pofile.save('django{}-edraak-customized.po'.format(suffix))
+        django_pofile.save_as_mofile('django{}.mo'.format(suffix))
+
+
+@task
+def i18n_po_pull_edx():
+    # Pulling these languages to let `i18n_generate_latest()` work well,
+    # This will be undoed later
+    # TODO: Consider removing dummy locales
+    for lang in OTHER_RTL_LOCALES + ('ar',):
+        sh('tx pull --force --mode=reviewed --language={}'.format(lang))
+
+    i18n_generate_latest()
+
+    def create_lastest(is_js, suffix):
+        with working_directory(ARABIC_LOCALE_DIR):
+            latest = path('latest-django{}.po'.format(suffix))
+
+            if latest.exists():
+                latest.remove()
+
+            copyfile('django{}.po'.format(suffix), latest)
+
+    run_for_js_nonjs(create_lastest)
+
+    sh('git checkout -- conf/')  # Undo brutal `i18n_tool generate` chenges
+
+
+def i18n_generate_latest():
+    """
+    Compile localizable strings from sources, extracting strings first.
+    """
+
+    cmd = 'i18n_tool generate'
+    sh(cmd + ' --rtl --strict')
+
+
+@task
+@js_nonjs
+def i18n_make_updates(is_js, suffix):
+    with working_directory(ARABIC_LOCALE_DIR):
+        django_edx = polib.pofile('django{}.po'.format(suffix))
+        django_latest = polib.pofile('latest-django{}.po'.format(suffix))
+
+        edx_entries = {}
+        for entry in django_edx.translated_entries():
+            edx_entries[entry.msgid] = entry
+
+        for entry in reversed(django_latest):
+            if not entry.translated():
+                django_latest.remove(entry)
+            else:
+                edx_entry = edx_entries.get(entry.msgid)
+                if edx_entry and edx_entry.msgstr == entry.msgstr:
+                    # Remove the ones that didn't change
+                    django_latest.remove(entry)
+
+        print 'Added {} updated translations for django{}.po:'.format(
+            len(django_latest),
+            suffix,
+        )
+
+        django_latest.save('django{}-updates.po'.format(suffix))
+        path('latest-django{}.po'.format(suffix)).remove()
+
+
+@task
+@needs(
+    'pavelib.edraak.clean_repo_check',
+    'pavelib.i18n.i18n_clean',
+    'pavelib.edraak.i18n_po_pull_edx',
+    'pavelib.edraak.i18n_po_pull_edraak',
+    'pavelib.edraak.i18n_make_updates',
+    'pavelib.edraak.i18n_edraak_generate_files',
+)
+def i18n_edraak_pull():
+    """
+    Pulls  translation files.
+    """
+    files_to_add = (
+        'edraak-platform-2015-theme.po',
+        'edraak-platform.po',
+
+        'django-edraak-customized.po',
+        'djangojs-edraak-customized.po',
+
+        'django-updates.po',
+        'djangojs-updates.po',
+
+        'django.mo',
+        'djangojs.mo',
+    )
+
+    # Undo brutal `i18n_tool generate` chenges
+    for locale in OTHER_RTL_LOCALES:
+        sh('git checkout -- conf/locale/{}'.format(locale))
+
+    with working_directory(ARABIC_LOCALE_DIR):
+        # Keep it to it's original state
+        sh('git checkout -- django.po djangojs.po')
+
+        for f in files_to_add:
+            sh('git add --force {}'.format(f))
+
+        default_message = 'Update Edraak translations (autogenerated message)'
+        sh('git commit -m "{}" --edit'.format(default_message))
+
+    sh('git checkout -- conf/')  # Cleanup dirty files
+    git_push()
+
+
+def git_push():
+    """
+    A `$ git push` that fails safely, and prints a warning.
+    """
+    try:
+        print sh('git push', capture=True)
+    except BuildFailure as e:
+        print 'WARN: Git is unable to push to the remote repository.'
+        print '      This error will not interrupt the build.'
+        print '      You can `$ git push` manully to debug the error.'
+
+
+@task
+def i18n_edraak_theme_push():
+    """
+    Pushed the theme translation strings to Transifex.
+    """
+    sh(django_cmd('lms', 'devstack', 'i18n_edraak_theme_push'))
+
+
+@task
+@needs(
+    'pavelib.edraak.i18n_edraak_theme_push',
+    'pavelib.i18n.i18n_extract',
+)
+@js_nonjs
+def i18n_edraak_push(is_js, suffix):
+    """
+    Extracts  strings and appends it to the provided .PO file.
+
+    It searches for translation strings that are marked
+    with "# Translators: " comment.
+    """
+
+    edx_pofile = polib.pofile('conf/locale/ar/LC_MESSAGES/django{}.po'.format(suffix))
+
+    with open("conf/locale/config.yaml", 'r') as locale_config_file:
+        locale_config = yaml.load(locale_config_file)
+        partial_pofiles = locale_config['generate_merge']['django{}.po'.format(suffix)]
+
+    with working_directory('conf/locale/en/LC_MESSAGES'):
+        edraak_specific_path = path('edraak{}-platform.po'.format(suffix))
+
+        if edraak_specific_path.exists():
+            edraak_specific_path.unlink()
+
+        edraak_specific = polib.POFile()
+
+        edraak_specific.metadata = {
+            'Project-Id-Version': 'Edraak 1',
+            'Report-Msgid-Bugs-To': 'dev@qrf.org',
+            'POT-Creation-Date': '2014-12-15 11:17+0200',
+            'PO-Revision-Date': 'YEAR-MO-DA HO:MI+ZONE',
+            'Last-Translator': 'Edraak Dev <dev@qrf.org>',
+            'Language-Team': 'Edraak Dev <dev@qrf.org>',
+            'MIME-Version': '1.0',
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Content-Transfer-Encoding': '8bit',
+            'Generated-By': 'Paver',
+        }
+
+        for po_path in partial_pofiles:
+            print 'processing', po_path
+
+            pofile = polib.pofile(po_path)
+
+            for entry in pofile:
+                if entry not in edx_pofile:
+                    edraak_specific.append(entry)
+
+        edraak_specific.save(edraak_specific_path)
+
+        sh('tx push -l en -s -r edraak.edraak{}-platform'.format(suffix))


### PR DESCRIPTION
This is the script that we use to manage a) missing, b) additional and c) translation overrides.

I've mentioned it during the ops hangout in February, 2016.

I sort of forgot to make a PR, and here it is.

Basically the plan was to make a PR that is NOT supposed to be merged. 
Instead it would serve as a reference for those who wants to automate the translations for their forks.

Basically I have three additional Transifex resources:
- `edraak-platform-2015-theme`: For the theme's additional strings.
- `edraak-platform`: For the extra, missing or translations overrides in the server side of things.
- `edraakjs-platform`: Just like `edraak-platform` but for the JS (i.e. client) side of things.

Here's how I use at @Edraak:
1. I change the code and amend/add some translations (in English).
2. I run the command: `$ paver i18n_edraak_push` to the missing/new string to the [Edraak Transifex repo](https://www.transifex.com/edraak/edraak/).
3. I translate any new string on the [Edraak Transifex repo](https://www.transifex.com/edraak/edraak/).
4. I could also go to the [edX Transifex repo](https://www.transifex.com/open-edx/edx-platform) and translate/review some strings (in Arabic). This is required if the standard (i.e. upstream) strings are missing some translations, or need some amendments.
5. I run the script `$ paver i18n_edraak_pull` to do some magic (an excuse to skip documentation XD) and get the _right_ strings from both edX and Edraak repos.

CC: @smarnach @e0d @nedbat 
