### PR TITLE
Moved white label sites to logistration.

### DIFF
--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1200,6 +1200,17 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             }
         )
 
+    def test_registration_form_state(self):
+        self._assert_reg_field(
+            {"state": "optional"},
+            {
+                "name": "state",
+                "type": "text",
+                "required": False,
+                "label": "State/Province/Region",
+            }
+        )
+
     def test_registration_form_country(self):
         country_options = (
             [{"name": "--", "value": "", "default": True}] +
@@ -1374,6 +1385,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             "mailing_address": "optional",
             "goals": "optional",
             "city": "optional",
+            "state": "optional",
             "country": "required",
             "honor_code": "required",
         },
@@ -1394,6 +1406,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             "favorite_movie",
             "favorite_editor",
             "city",
+            "state",
             "country",
             "gender",
             "year_of_birth",

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -20,6 +20,7 @@ from rest_framework.views import APIView
 from rest_framework.exceptions import ParseError
 from django_countries import countries
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from microsite_configuration import microsite
 
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 import third_party_auth
@@ -160,6 +161,7 @@ class RegistrationView(APIView):
 
     EXTRA_FIELDS = [
         "city",
+        "state",
         "country",
         "gender",
         "year_of_birth",
@@ -187,7 +189,9 @@ class RegistrationView(APIView):
 
         # Backwards compatibility: Honor code is required by default, unless
         # explicitly set to "optional" in Django settings.
-        self._extra_fields_setting = copy.deepcopy(settings.REGISTRATION_EXTRA_FIELDS)
+        self._extra_fields_setting = copy.deepcopy(microsite.get_value('REGISTRATION_EXTRA_FIELDS'))
+        if not self._extra_fields_setting:
+            self._extra_fields_setting = copy.deepcopy(settings.REGISTRATION_EXTRA_FIELDS)
         self._extra_fields_setting["honor_code"] = self._extra_fields_setting.get("honor_code", "required")
 
         # Check that the setting is configured correctly
@@ -605,6 +609,26 @@ class RegistrationView(APIView):
         form_desc.add_field(
             "city",
             label=city_label,
+            required=required
+        )
+
+    def _add_state_field(self, form_desc, required=False):
+        """Add a State/Province/Region field to a form description.
+
+        Arguments:
+            form_desc: A form description
+
+        Keyword Arguments:
+            required (bool): Whether this field is required; defaults to False
+
+        """
+        # Translators: This label appears above a field on the registration form
+        # which allows the user to input the State/Province/Region in which they live.
+        state_label = _(u"State/Province/Region")
+
+        form_desc.add_field(
+            "state",
+            label=state_label,
             required=required
         )
 


### PR DESCRIPTION
[ECOM-2948](https://openedx.atlassian.net/browse/ECOM-2948)

Removed feature flag `ENABLE_COMBINED_LOGIN_REGISTRATION` and made logistration default for white label sites. Added `State/Province/Region` extra field, now logistration is fully supported with extra fields.
