### PR TITLE
Fix responsiveness issue with math inputs on mobile

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -749,12 +749,14 @@ div.problem {
 // ====================
 .problem {
   .capa_inputtype.textline, .inputtype.formulaequationinput {
+    display: inline-block;
 
     input {
       @include box-sizing(border-box);
       border: 2px solid $gray-l4;
       border-radius: 3px;
       min-width: 160px;
+      width: calc(100% - 45px);
       height: 46px;
     }
 
@@ -1491,4 +1493,3 @@ div.problem .annotation-input {
     background: url('#{$static-path}/images/partially-correct-icon.png') center center no-repeat;
   }
 }
-


### PR DESCRIPTION
## [FEDX-102](https://openedx.atlassian.net/browse/FEDX-102)

Fixes issue where the `size` attr of a `formulaequationinput` could be set to a large value that would prevent responsive layout on smaller screens.

Before: `size="40"` causes the page to not be responsive below 360px ([gif](https://i.bjacobel.com/20160317-llt9p.gif))

After: the xblock is fully responsive. ([gif](https://i.bjacobel.com/20160317-gxg10.gif))
### Sandbox
- [x] Build a sandbox for your branch and add a link here

[Sandbox showing the problem](https://mobile-dev.sandbox.edx.org/xblock/block-v1:UMT+CS501+2015-S1+type@problem+block@b0e8897114ec45d7b93b984565769959)
[Sandbox with my branch](https://bjacobel.sandbox.edx.org/xblock/block-v1:hjkl+CS101+T1+type@problem+block@b0e8897114ec45d7b93b984565769959)
### Testing
- [x] i18n
- [x] RTL
- [x] Data is properly encoded in HTML templates to avoid XSS
- [x] Unit, integration, acceptance tests as appropriate
- [x] Analytics
- [x] Performance
- [x] Database migrations are backwards-compatible
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @andy-armstrong 
- [x] @aleffert 
- [x] @AlasdairSwan 
### Post-review
- [x] Squash commits
