### PR TITLE
Allow for tooltips with rich content

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -115,9 +115,6 @@
         // Underscore.js globals
         "_",
 
-        // Backbone.js globals
-        "Backbone",
-
         // RequireJS globals
         "define",
         "require",

--- a/.jshintrc
+++ b/.jshintrc
@@ -115,6 +115,9 @@
         // Underscore.js globals
         "_",
 
+        // Backbone.js globals
+        "Backbone",
+
         // RequireJS globals
         "define",
         "require",

--- a/.jshintrc
+++ b/.jshintrc
@@ -115,6 +115,9 @@
         // Underscore.js globals
         "_",
 
+        // Backbone.js globals
+        "Backbone",
+
         // RequireJS globals
         "define",
         "require",
@@ -125,8 +128,10 @@
         "describe", "xdescribe",
         "it", "xit",
         "spyOn",
+        "beforeAll",
         "beforeEach",
         "afterEach",
+        "afterAll",
         "expect",
         "waitsFor",
         "runs",
@@ -137,6 +142,7 @@
         "readFixtures",
         "setFixtures",
         "appendSetFixtures",
+        "sandbox",
         "spyOnEvent",
 
         // Django i18n catalog globals

--- a/cms/static/sass/_base.scss
+++ b/cms/static/sass/_base.scss
@@ -593,35 +593,6 @@ hr.divide {
   }
 }
 
-.tooltip {
-  @include transition(opacity $tmg-f3 ease-out 0s);
-  @extend %ui-depth5;
-  position: absolute;
-  opacity: 0.0;
-  transform: translateY(-100%);
-
-  > .tooltip-content {
-    @include font-size(12);
-    @extend %t-regular;
-    line-height: 26px !important;
-    max-width: 800px;
-    padding: 0 10px;
-    border-radius: 3px;
-    background: rgba(0, 0, 0, 0.85);
-    color: $white;
-  }
-
-  > .tooltip-arrow {
-    @include font-size(20);
-    position: absolute;
-    line-height: 26px !important;
-    bottom: -12px;
-    left: 50%;
-    margin-left: -7px;
-    color: rgba(0, 0, 0, 0.85);
-  }
-}
-
 
 // +Utility - Basic
 // ====================

--- a/cms/static/sass/_base.scss
+++ b/cms/static/sass/_base.scss
@@ -595,26 +595,27 @@ hr.divide {
 
 .tooltip {
   @include transition(opacity $tmg-f3 ease-out 0s);
-  @include font-size(12);
-  @extend %t-regular;
   @extend %ui-depth5;
   position: absolute;
-  top: 0;
-  left: 0;
-  padding: 0 10px;
-  border-radius: 3px;
-  background: rgba(0, 0, 0, 0.85);
-  line-height: 26px;
-  color: $white;
-  pointer-events: none;
   opacity: 0.0;
+  transform: translateY(-100%);
 
-  &:after {
+  > .tooltip-content {
+    @include font-size(12);
+    @extend %t-regular;
+    line-height: 26px !important;
+    max-width: 800px;
+    padding: 0 10px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.85);
+    color: $white;
+  }
+
+  > .tooltip-arrow {
     @include font-size(20);
-    content: '▾';
-    display: block;
     position: absolute;
-    bottom: -14px;
+    line-height: 26px !important;
+    bottom: -12px;
     left: 50%;
     margin-left: -7px;
     color: rgba(0, 0, 0, 0.85);

--- a/cms/static/sass/_build-v1.scss
+++ b/cms/static/sass/_build-v1.scss
@@ -81,3 +81,7 @@
 
 @import 'developer'; // used for any developer-created scss that needs further polish/refactoring
 @import 'shame';     // used for any bad-form/orphaned scss
+
+// +Tooltips
+// ====================
+@import '../../../common/static/sass/tooltips';

--- a/cms/static/sass/_build-v2.scss
+++ b/cms/static/sass/_build-v2.scss
@@ -6,4 +6,7 @@
 // Configuration
 @import 'config';
 
+// Tooltips
+@import '../../../common/static/sass/tooltips';
+
 // Extensions

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -47,7 +47,7 @@ class @Problem
       icon = $(ev.target).children "i"
       window.globalTooltipManager.openTooltip icon
     @$('.clarification').blur (ev) =>
-      window.globalTooltipManager.hide()
+      window.globalTooltipManager.hideTooltip immediately: true
 
     @bindResetCorrectness()
     if @checkButton.length

--- a/common/static/js/spec/tooltip_manager_spec.js
+++ b/common/static/js/spec/tooltip_manager_spec.js
@@ -1,7 +1,10 @@
 describe('TooltipManager', function () {
     'use strict';
-    var PAGE_X = 100, PAGE_Y = 100, WIDTH = 100, HEIGHT = 100, DELTA = 10,
-        showTooltip;
+    var showTooltip;
+
+    beforeAll(function() {
+        window.globalTooltipManager.destroy();
+    });
 
     beforeEach(function () {
         setFixtures(sandbox({
@@ -9,11 +12,10 @@ describe('TooltipManager', function () {
           'data-tooltip': 'some text here.'
         }));
         this.element = $('#test-id');
+        this.element.text('Hover me');
 
-        this.tooltip = new TooltipManager(document.body);
+        this.manager = new window.TooltipManager({el: document.body});
         jasmine.clock().install();
-        // Set default dimensions to make testing easer.
-        $('.tooltip').height(HEIGHT).width(WIDTH);
 
         // Re-write default jasmine-jquery to consider opacity.
         jasmine.addMatchers({
@@ -40,22 +42,18 @@ describe('TooltipManager', function () {
     });
 
     afterEach(function () {
-        this.tooltip.destroy();
+        this.manager.destroy();
         jasmine.clock().uninstall();
     });
 
     showTooltip = function (element) {
-        element.trigger($.Event("mouseover", {
-            pageX: PAGE_X,
-            pageY: PAGE_Y
-        }));
-        jasmine.clock().tick(500);
+        element.trigger('mouseenter');
     };
 
     it('can destroy itself', function () {
         showTooltip(this.element);
         expect($('.tooltip')).toBeVisible();
-        this.tooltip.destroy();
+        this.manager.destroy();
         expect($('.tooltip')).not.toExist();
         showTooltip(this.element);
         expect($('.tooltip')).not.toExist();
@@ -64,54 +62,50 @@ describe('TooltipManager', function () {
     it('should be shown when mouse is over the element', function () {
         showTooltip(this.element);
         expect($('.tooltip')).toBeVisible();
-        expect($('.tooltip').text()).toBe('some text here.');
+        expect($('.tooltip-content').text()).toBe('some text here.');
     });
 
     it('should be hidden when mouse is out of the element', function () {
         showTooltip(this.element);
         expect($('.tooltip')).toBeVisible();
-        this.element.trigger($.Event("mouseout"));
-        jasmine.clock().tick(50);
+        this.element.trigger('mouseleave');
+        jasmine.clock().tick(500);
         expect($('.tooltip')).toBeHidden();
+    });
+
+    it('should stay visible when mouse is over the tooltip', function () {
+        showTooltip(this.element);
+        expect($('.tooltip')).toBeVisible();
+        this.element.trigger('mouseleave');
+        jasmine.clock().tick(100);
+        this.manager.tooltip.$el.trigger('mouseenter');
+        jasmine.clock().tick(500);
+        expect($('.tooltip')).toBeVisible();
+        this.manager.tooltip.$el.trigger('mouseleave');
+        jasmine.clock().tick(500);
+        expect($('.tooltip')).toBeHidden();
+    });
+
+    it('should be shown when the element gets focus', function () {
+        this.element.trigger('focus');
+        expect($('.tooltip')).toBeVisible();
     });
 
     it('should be hidden when user clicks on the element', function () {
         showTooltip(this.element);
         expect($('.tooltip')).toBeVisible();
-        this.element.trigger($.Event("click"));
-        jasmine.clock().tick(50);
+        this.element.trigger('click');
         expect($('.tooltip')).toBeHidden();
     });
 
     it('can be configured to show when user clicks on the element', function () {
         this.element.attr('data-tooltip-show-on-click', true);
-        this.element.trigger($.Event("click"));
+        this.element.trigger('click');
         expect($('.tooltip')).toBeVisible();
     });
 
     it('can be be triggered manually', function () {
-        this.tooltip.openTooltip(this.element);
+        this.manager.openTooltip(this.element);
         expect($('.tooltip')).toBeVisible();
-    });
-
-    it('should moves correctly', function () {
-        showTooltip(this.element);
-        expect($('.tooltip')).toBeVisible();
-        // PAGE_X - 0.5 * WIDTH
-        // 100 - 0.5 * 100 = 50
-        expect(parseInt($('.tooltip').css('left'))).toBe(50);
-        // PAGE_Y - (HEIGHT + 15)
-        // 100 - (100 + 15) = -15
-        expect(parseInt($('.tooltip').css('top'))).toBe(-15);
-        this.element.trigger($.Event("mousemove", {
-            pageX: PAGE_X + DELTA,
-            pageY: PAGE_Y + DELTA
-        }));
-        // PAGE_X + DELTA - 0.5 * WIDTH
-        // 100 + 10 - 0.5 * 100 = 60
-        expect(parseInt($('.tooltip').css('left'))).toBe(60);
-        // PAGE_Y + DELTA - (HEIGHT + 15)
-        // 100 + 10 - (100 + 15) = -5
-        expect(parseInt($('.tooltip').css('top'))).toBe(-5);
     });
 });

--- a/common/static/js/src/tooltip_manager.js
+++ b/common/static/js/src/tooltip_manager.js
@@ -1,4 +1,4 @@
-require(['jquery', 'underscore', 'backbone'], function($, _, Backbone) {
+(function() {
     'use strict';
 
     var Tooltip = Backbone.View.extend({
@@ -238,4 +238,4 @@ require(['jquery', 'underscore', 'backbone'], function($, _, Backbone) {
     $(document).ready(function() {
         window.globalTooltipManager = new TooltipManager({el: document.body});
     });
-});
+}());

--- a/common/static/js/src/tooltip_manager.js
+++ b/common/static/js/src/tooltip_manager.js
@@ -1,4 +1,4 @@
-(function() {
+require(['jquery', 'underscore', 'backbone'], function($, _, Backbone) {
     'use strict';
 
     var Tooltip = Backbone.View.extend({
@@ -238,4 +238,4 @@
     $(document).ready(function() {
         window.globalTooltipManager = new TooltipManager({el: document.body});
     });
-}());
+});

--- a/common/static/js/src/tooltip_manager.js
+++ b/common/static/js/src/tooltip_manager.js
@@ -205,21 +205,23 @@
         getRelativeCoords: function(parent, width, x, y) {
             var coords = this.getCoords(width, x, y),
                 offset = parent.offset(),
-                parentWidth = parent.outerWidth();
+                parentWidth = parent.outerWidth(),
+                parentHeight = parent.outerHeight();
             coords.left -= offset.left;
             coords.right -= this.$el.outerWidth() - offset.left - parentWidth;
-            coords.top -= offset.top;
+            coords.bottom -= this.$el.outerHeight() - offset.top - parentHeight;
             return coords;
         },
 
         // Return the coordinates for a tooltip of the given width, such that
         // the tooltip does not go outside of the container element.
         getCoords: function(width, x, y) {
-            var containerWidth = this.$el.outerWidth();
+            var containerWidth = this.$el.outerWidth(),
+                containerHeight = this.$el.outerHeight();
             return {
                 left: Math.min(Math.max(0, x - width / 2), containerWidth - width),
                 right: Math.max(0, containerWidth - x - width / 2),
-                top: y - 15
+                bottom: containerHeight - y + 15
             };
         },
 

--- a/common/static/js/src/tooltip_manager.js
+++ b/common/static/js/src/tooltip_manager.js
@@ -4,7 +4,7 @@
     var Tooltip = Backbone.View.extend({
         className: 'tooltip',
 
-        template: _.template('<div class="tooltip-content"><%= content %></div><div class="tooltip-arrow">▾</div>'),
+        template: _.template('<div class="tooltip-content"><%= content %></div><div class="tooltip-arrow" aria-hidden="true">▾</div>'),
 
         events: {
             'mouseenter': 'show',

--- a/common/static/js/src/tooltip_manager.js
+++ b/common/static/js/src/tooltip_manager.js
@@ -1,109 +1,239 @@
 (function() {
     'use strict';
-    var TooltipManager = function (element) {
-        this.element = $(element);
-        // If tooltip container already exist, use it.
-        this.tooltip = $('div.' + this.className.split(/\s+/).join('.'));
-        // Otherwise, create new one.
-        if (!this.tooltip.length) {
-            this.tooltip = $('<div />', {
-                'class': this.className
-            }).appendTo(this.element);
-        }
 
-        this.hide();
-        _.bindAll(this, 'show', 'hide', 'showTooltip', 'moveTooltip', 'hideTooltip', 'click');
-        this.bindEvents();
-    };
-
-    TooltipManager.prototype = {
-        // Space separated list of class names for the tooltip container.
+    var Tooltip = Backbone.View.extend({
         className: 'tooltip',
-        SELECTOR: '[data-tooltip]',
 
-        bindEvents: function () {
-            this.element.on({
-                'mouseover.TooltipManager': this.showTooltip,
-                'mousemove.TooltipManager': this.moveTooltip,
-                'mouseout.TooltipManager': this.hideTooltip,
-                'click.TooltipManager': this.click
-            }, this.SELECTOR);
+        template: _.template('<div class="tooltip-content"><%= content %></div><div class="tooltip-arrow">▾</div>'),
+
+        events: {
+            'mouseenter': 'show',
+            'mouseleave': 'hide',
+            'focusout': 'focusout'
         },
 
-        getCoords: function (pageX, pageY) {
+        initialize: function(content) {
+            this.content = content;
+            this.timer = null;
+        },
+
+        // Display this tooltip.
+        show: function() {
+            if (this.timer) {
+                clearTimeout(this.timer);
+            }
+            this.timer = null;
+            this.$el.show().css('opacity', 1);
+        },
+
+        // Hide this tooltip. Includes a delay before the tooltip starts fading
+        // out, and a second delay to allow the tooltip to fade out. Once the
+        // tooltip is hidden, it is removed from the DOM, and the `removed`
+        // event is triggered. If `show` is called before the tooltip is
+        // removed, it is redisplayed.
+        hide: function() {
+            if (this.timer) {
+                clearTimeout(this.timer);
+            }
+            var remove = _.bind(this.remove, this);
+            var hide = _.bind(function() {
+                this.$el.css('opacity', 0);
+                _.delay(remove, 250);
+            }, this);
+            this.timer = _.delay(hide, 250);
+        },
+
+        // Remove the tooltip from the DOM, triggering the `removed` event.
+        remove: function() {
+            if (this.timer) {
+                clearTimeout(this.timer);
+            }
+            this.timer = null;
+            Backbone.View.prototype.remove.call(this);
+            this.trigger('removed');
+        },
+
+        // Triggered when an element inside the tooltip loses focus. Only hides
+        // the tooltip if the element that gains focus afterwards is not also a
+        // part of the tooltip.
+        focusout: function() {
+            var remove = _.bind(function() {
+                if (!this.$(':focus').length) {
+                    this.remove();
+                }
+            }, this);
+            _.defer(remove);
+        },
+
+        render: function() {
+            this.$el.html(this.template({content: this.content}));
+            return this;
+        }
+    });
+
+
+    // Manages tooltips within a container element. Tooltips are constrained to
+    // fit within the container element, and only one tooltip can be displayed
+    // at any given time.
+    var TooltipManager = Backbone.View.extend({
+        SELECTOR: '[data-tooltip]',
+
+        // Listen for events from elements that include the `data-tooltip`
+        // attribute.
+        events: function() {
+            var events = {
+                'mouseenter': this.showTooltip,
+                'focus': this.showTooltip,
+                'mouseleave': this.hideTooltip,
+                'click': this.click
+            };
+            var selector = this.SELECTOR;
+            var selected = {};
+            _.each(events, function(value, key) {
+                selected[key + ' ' + selector] = value;
+            });
+            return selected;
+        },
+
+        initialize: function() {
+            _.bindAll(this, 'reset');
+            this.reset();
+        },
+
+        // Reset the tooltip manager's internal state. Call this when all
+        // tooltips have been hidden.
+        reset: function() {
+            this.tooltip = null;
+            this.tooltipFor = null;
+        },
+
+        // Event handler for displaying tooltips. Opens the tooltip for the
+        // triggering element.
+        showTooltip: function(event) {
+            this.openTooltip(event.currentTarget);
+        },
+
+        // Hide the currently displayed tooltip. By default, waits for a short
+        // time before hiding the tooltip in case the mouse or focus re-enters
+        // the element or the tooltip. If `options.immediately` is true, the
+        // tooltip will be removed immediately, without a delay.
+        hideTooltip: function(options) {
+            if (!this.tooltip) {
+                return;
+            }
+            if (options && options.immediately) {
+                this.tooltip.remove();
+            } else {
+                this.tooltip.hide();
+            }
+        },
+
+        // Handles the click event for triggering elements. If the
+        // `data-tooltip-show-on-click` attribute is present, the tooltip will
+        // remain open when the element is clicked.
+        click: function(event) {
+            var element = event.currentTarget,
+                showOnClick = !!$(element).data('tooltip-show-on-click');  // Default is false
+            if (showOnClick) {
+                this.openTooltip(element);
+            } else {
+                this.hideTooltip({immediately: true});
+            }
+        },
+
+        // Open the tooltip for the given element
+        openTooltip: function(element) {
+
+            // If the tooltip for the given element is already displayed,
+            // all we need to do is cancel any queued hide actions.
+            if (this.tooltipFor === element) {
+                this.tooltip.show();
+                return;
+            }
+
+            // Determine the coordinates and content of the tooltip
+            var $element = $(element),
+                offset = $element.offset(),
+                x = offset.left + $element.outerWidth() / 2,
+                y = offset.top,
+                tooltipText = $element.data('tooltip');
+
+            // Hide the currently displayed tooltip, if any
+            this.hideTooltip({immediately: true});
+
+            // Create a new tooltip and register is as the currently displayed
+            // tooltip
+            this.tooltip = new Tooltip(tooltipText);
+            this.tooltipFor = element;
+
+            // Insert the tooltip immediately after the triggering element, so
+            // that focusable elements inside the tooltip get focus in the
+            // correct order.
+            this.tooltip.$el.insertAfter(element);
+
+            // Reset the tooltip manager's internal state when the tooltip is
+            // removed
+            this.listenToOnce(this.tooltip, 'removed', this.reset);
+
+            // Position the tooltip
+            this.displayAt(x, y);
+        },
+
+        // Display the tooltip at the given coordinates. `x` and `y` are
+        // relative to the container element.
+        displayAt: function(x, y) {
+            var parent = this.tooltip.$el.offsetParent(),
+                offset = parent.offset();
+
+            // Move the tooltip all the way to the left first so the width is
+            // calculated correctly
+            this.tooltip.show();
+            this.tooltip.$el.css({left: -offset.left});
+            this.tooltip.render();
+
+            // Position the tooltip
+            var coords = this.getRelativeCoords(parent, this.tooltip.$el.outerWidth(), x, y);
+            this.tooltip.$el.css(coords);
+
+            // If the tooltip is offset to the right by the left edge of the
+            // viewport, move the arrow so it stays over the element
+            this.tooltip.$('.tooltip-arrow').css({left: x - offset.left - coords.left});
+        },
+
+        // Return the coordinates for a tooltip of the given width, converted
+        // to be relative to the given offset parent.
+        getRelativeCoords: function(parent, width, x, y) {
+            var coords = this.getCoords(width, x, y),
+                offset = parent.offset(),
+                parentWidth = parent.outerWidth();
+            coords.left -= offset.left;
+            coords.right -= this.$el.outerWidth() - offset.left - parentWidth;
+            coords.top -= offset.top;
+            return coords;
+        },
+
+        // Return the coordinates for a tooltip of the given width, such that
+        // the tooltip does not go outside of the container element.
+        getCoords: function(width, x, y) {
+            var containerWidth = this.$el.outerWidth();
             return {
-                'left': pageX - 0.5 * this.tooltip.outerWidth(),
-                'top': pageY - (this.tooltip.outerHeight() + 15)
+                left: Math.min(Math.max(0, x - width / 2), containerWidth - width),
+                right: Math.max(0, containerWidth - x - width / 2),
+                top: y - 15
             };
         },
 
-        show: function () {
-            this.tooltip.show().css('opacity', 1);
-        },
-
-        hide: function () {
-            this.tooltip.hide().css('opacity', 0);
-        },
-
-        showTooltip: function(event) {
-            this.prepareTooltip(event.currentTarget, event.pageX, event.pageY);
-            if (this.tooltipTimer) {
-                clearTimeout(this.tooltipTimer);
-            }
-            this.tooltipTimer = setTimeout(this.show, 500);
-        },
-
-        prepareTooltip: function(element, pageX, pageY) {
-            pageX = typeof pageX !== 'undefined' ? pageX : element.offset().left + element.width()/2;
-            pageY = typeof pageY !== 'undefined' ? pageY : element.offset().top + element.height()/2;
-            var tooltipText = $(element).attr('data-tooltip');
-            this.tooltip
-                .html(tooltipText)
-                .css(this.getCoords(pageX, pageY));
-        },
-
-        // To manually trigger a tooltip to reveal, other than through user mouse movement:
-        openTooltip: function(element) {
-            this.prepareTooltip(element);
-            this.show();
-            if (this.tooltipTimer) {
-                clearTimeout(this.tooltipTimer);
-            }
-        },
-
-        moveTooltip: function(event) {
-            this.tooltip.css(this.getCoords(event.pageX, event.pageY));
-        },
-
-        hideTooltip: function() {
-            clearTimeout(this.tooltipTimer);
-            // Wait for a 50ms before hiding the tooltip to avoid blinking when
-            // the item contains nested elements.
-            this.tooltipTimer = setTimeout(this.hide, 50);
-        },
-
-        click: function(event) {
-            var showOnClick = !!$(event.currentTarget).data('tooltip-show-on-click'); // Default is false
-            if (showOnClick) {
-                this.show();
-                if (this.tooltipTimer) {
-                    clearTimeout(this.tooltipTimer);
-                }
-            } else {
-                this.hideTooltip(event);
-            }
-        },
-
         destroy: function () {
-            this.tooltip.remove();
-            // Unbind all delegated event handlers in the ".TooltipManager"
-            // namespace.
-            this.element.off('.TooltipManager', this.SELECTOR);
+            this.hideTooltip({immediately: true});
+            this.undelegateEvents();
+            this.stopListening();
         }
-    };
+    });
 
     window.TooltipManager = TooltipManager;
-    $(document).ready(function () {
-        window.globalTooltipManager = new TooltipManager(document.body);
+
+    // Instatiate a tooltip manager for the document body
+    $(document).ready(function() {
+        window.globalTooltipManager = new TooltipManager({el: document.body});
     });
 }());

--- a/common/static/sass/_tooltips.scss
+++ b/common/static/sass/_tooltips.scss
@@ -1,0 +1,29 @@
+.tooltip {
+  @include transition(opacity 0.125s ease-out 0s);
+  @extend %ui-depth5;
+  position: absolute;
+  opacity: 0.0;
+  line-height: 26px !important;
+  transform: translateY(-100%);
+
+  > .tooltip-content {
+    @extend %t-regular;
+    line-height: inherit;
+    font-size: 12px;
+    max-width: 800px;
+    padding: 0 10px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.85);
+    color: $white;
+  }
+
+  > .tooltip-arrow {
+    position: absolute;
+    line-height: inherit;
+    font-size: 20px;
+    bottom: -12px;
+    left: 50%;
+    margin-left: -7px;
+    color: rgba(0, 0, 0, 0.85);
+  }
+}

--- a/common/static/sass/_tooltips.scss
+++ b/common/static/sass/_tooltips.scss
@@ -3,17 +3,26 @@
   @extend %ui-depth5;
   position: absolute;
   opacity: 0.0;
-  line-height: 26px !important;
+  line-height: 24px !important;
 
   > .tooltip-content {
     @extend %t-regular;
     line-height: inherit;
     font-size: 12px;
     max-width: 800px;
-    padding: 0 10px;
+    padding: 2px 5px;
     border-radius: 3px;
     background: rgba(0, 0, 0, 0.85);
     color: $white;
+
+    a {
+      color: #66aed0 !important;
+    }
+
+    ol, ul {
+      margin: 5px 0 0 5px;
+      color: $white;
+    }
   }
 
   > .tooltip-arrow {

--- a/common/static/sass/_tooltips.scss
+++ b/common/static/sass/_tooltips.scss
@@ -4,7 +4,6 @@
   position: absolute;
   opacity: 0.0;
   line-height: 26px !important;
-  transform: translateY(-100%);
 
   > .tooltip-content {
     @extend %t-regular;

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -197,5 +197,5 @@ class ProblemPage(PageObject):
         """
         Get the text seen in any tooltip currently visible on the page.
         """
-        self.wait_for_element_visibility('body > .tooltip', 'A tooltip is visible.')
-        return self.q(css='body > .tooltip').text[0]
+        self.wait_for_element_visibility('.tooltip', 'A tooltip is visible.')
+        return self.q(css='.tooltip').text[0]

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -139,7 +139,7 @@ def enable_jquery_animations(page):
 
 def disable_css_animations(page):
     """
-    Disable CSS3 animations, transitions, transforms.
+    Disable CSS3 animations and transitions.
     """
     page.browser.execute_script("""
         var id = 'no-transitions';
@@ -161,11 +161,6 @@ def disable_css_animations(page):
                     '-o-transition-property: none !important;',
                     '-ms-transition-property: none !important;',
                     'transition-property: none !important;',
-                    '-webkit-transform: none !important;',
-                    '-moz-transform: none !important;',
-                    '-o-transform: none !important;',
-                    '-ms-transform: none !important;',
-                    'transform: none !important;',
                     '-webkit-animation: none !important;',
                     '-moz-animation: none !important;',
                     '-o-animation: none !important;',

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -139,7 +139,7 @@ def enable_jquery_animations(page):
 
 def disable_css_animations(page):
     """
-    Disable CSS3 animations and transitions.
+    Disable CSS3 animations, transitions, transforms.
     """
     page.browser.execute_script("""
         var id = 'no-transitions';
@@ -161,6 +161,11 @@ def disable_css_animations(page):
                     '-o-transition-property: none !important;',
                     '-ms-transition-property: none !important;',
                     'transition-property: none !important;',
+                    '-webkit-transform: none !important;',
+                    '-moz-transform: none !important;',
+                    '-o-transform: none !important;',
+                    '-ms-transform: none !important;',
+                    'transform: none !important;',
                     '-webkit-animation: none !important;',
                     '-moz-animation: none !important;',
                     '-o-animation: none !important;',

--- a/lms/static/sass/_build-course.scss
+++ b/lms/static/sass/_build-course.scss
@@ -69,3 +69,6 @@
 
 // xmodule
 @import 'xmodule/headings';
+
+// tooltips
+@import '../../../common/static/sass/tooltips';

--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -132,43 +132,6 @@ img {
   max-width: 100%;
 }
 
-.tooltip {
-  @include transition(opacity .1s linear 0s);
-  z-index: 99999;
-  position: absolute;
-  opacity: 0;
-  transform: translateY(-100%);
-
-  > .tooltip-content {
-    font-size: 11px;
-    font-weight: 400;
-    line-height: 26px !important;
-    max-width: 800px;
-    padding: 0 10px;
-    border-radius: 3px;
-    background: rgba(0, 0, 0, 0.85);
-    color: $white;
-
-    ul, ol {
-      margin: 0;
-    }
-
-    a {
-      color: $blue-l3;
-    }
-  }
-
-  > .tooltip-arrow {
-    font-size: 20px;
-    position: absolute;
-    line-height: 26px !important;
-    bottom: -9px;
-    left: 50%;
-    margin-left: -7px;
-    color: rgba(0, 0, 0, 0.85);
-  }
-}
-
 
 // +Resets - Old, Misc
 // ====================

--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -133,30 +133,39 @@ img {
 }
 
 .tooltip {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 99999;
-  padding: 0 10px;
-  border-radius: 3px;
-  background: rgba(0, 0, 0, .85);
-  font-size: 11px;
-  font-weight: 400;
-  line-height: 26px;
-  color: $white;
-  pointer-events: none;
-  opacity: 0;
   @include transition(opacity .1s linear 0s);
+  z-index: 99999;
+  position: absolute;
+  opacity: 0;
+  transform: translateY(-100%);
 
-  &:after {
-    content: '▾';
-    display: block;
+  > .tooltip-content {
+    font-size: 11px;
+    font-weight: 400;
+    line-height: 26px !important;
+    max-width: 800px;
+    padding: 0 10px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.85);
+    color: $white;
+
+    ul, ol {
+      margin: 0;
+    }
+
+    a {
+      color: $blue-l3;
+    }
+  }
+
+  > .tooltip-arrow {
+    font-size: 20px;
     position: absolute;
-    bottom: -14px;
+    line-height: 26px !important;
+    bottom: -9px;
     left: 50%;
     margin-left: -7px;
-    font-size: 20px;
-    color: rgba(0, 0, 0, .85);
+    color: rgba(0, 0, 0, 0.85);
   }
 }
 

--- a/lms/static/sass/views/_decoupled-verification.scss
+++ b/lms/static/sass/views/_decoupled-verification.scss
@@ -195,25 +195,25 @@
 
     .tooltip {
         @include transition(opacity $tmg-f3 ease-out 0s);
-        @include font-size(12);
         position: absolute;
-        width: 350px;
-        top: 0;
-        left: 0;
-        padding: 10px 20px;
-        border-radius: 3px;
-        background: rgba(0, 0, 0, 0.85);
-        line-height: 26px;
-        color: $white;
-        pointer-events: none;
         opacity: 0.0;
+        transform: translateY(-100%);
 
-        &:after {
+        > .tooltip-content {
+            @include font-size(12);
+            line-height: 26px !important;
+            width: 350px;
+            padding: 10px 20px;
+            border-radius: 3px;
+            background: rgba(0, 0, 0, 0.85);
+            color: $white;
+        }
+
+        > .tooltip-arrow {
             @include font-size(20);
-            content: '▾';
-            display: block;
             position: absolute;
-            bottom: -14px;
+            line-height: 26px !important;
+            bottom: -12px;
             left: 50%;
             margin-left: -7px;
             color: rgba(0, 0, 0, 0.85);

--- a/lms/static/sass/views/_decoupled-verification.scss
+++ b/lms/static/sass/views/_decoupled-verification.scss
@@ -192,31 +192,4 @@
             }
         }
     }
-
-    .tooltip {
-        @include transition(opacity $tmg-f3 ease-out 0s);
-        position: absolute;
-        opacity: 0.0;
-        transform: translateY(-100%);
-
-        > .tooltip-content {
-            @include font-size(12);
-            line-height: 26px !important;
-            width: 350px;
-            padding: 10px 20px;
-            border-radius: 3px;
-            background: rgba(0, 0, 0, 0.85);
-            color: $white;
-        }
-
-        > .tooltip-arrow {
-            @include font-size(20);
-            position: absolute;
-            line-height: 26px !important;
-            bottom: -12px;
-            left: 50%;
-            margin-left: -7px;
-            color: rgba(0, 0, 0, 0.85);
-        }
-    }
 }


### PR DESCRIPTION
This pull request implements tooltips with rich content, including links.

**Screenshot:**

<img width="835" alt="screen shot 2016-03-20 at 09 55 48" src="https://cloud.githubusercontent.com/assets/793379/13902626/2b7fdd9c-ee82-11e5-9a4c-4f7ba448508d.png">

**Sandbox URL:** http://pr11854.sandbox.opencraft.com/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/4828664659a64c43812b52fec58ee3fc/1 (persistent database)

**Partner Information:** 3rd party-hosted open edX instance

**Implementation:** The current tooltip implementation has three limitations that prevent it from being used for rich content:
- Tooltips follow the mouse, so it is effectively impossible to click on any links in the tooltips
- If the content is too wide, tooltips can overflow off the left side of the viewport
- Focusable elements within the tooltip cannot be focused using the keyboard

This pull request solves these problems by:
- Making tooltips static relative to the position of the parent element
- Preventing tooltips from going past the left edge of the display
- Making tooltips inline with the parent element, so that tooltip content receives focus in the correct order

**Usage:** The same as the existing tooltips. Add a `data-tooltip` attribute to any html element.

**Accessibility:** This pull request adds a focus handler to tooltip elements so that the tooltip is displayed when the element gets focus using the keyboard. Focusable elements within the tooltip can also be accessed using the keyboard.

**Settings**

``` yaml
edx_ansible_source_repo: https://github.com/open-craft/configuration.git
configuration_version: ekolpakov/celery-with-certs
```
