### PR TITLE
Start using the HtmlUtils safe template functions

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/spec/views/instructor_tools_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/instructor_tools_spec.js
@@ -40,7 +40,6 @@ define([
             setFixtures('<div id="page-prompt"></div>');
             PageHelpers.preventBackboneChangingUrl();
             spyOn(Backbone.history, 'navigate');
-            spyOn(TeamUtils, 'showMessage');
             view = createInstructorTools().render();
             spyOn(view.teamEvents, 'trigger');
         });
@@ -66,7 +65,7 @@ define([
                     team: view.team
                 }
             );
-            expectSuccessMessage(view.team);
+            expectSuccessMessage(view);
         });
 
         it('can cancel team deletion', function() {
@@ -80,7 +79,11 @@ define([
             var requests = AjaxHelpers.requests(this);
             deleteTeam(view, true);
             AjaxHelpers.respondWithError(requests, 404);
+<<<<<<< 719dff66fb473b380cee40011e38322004514e72
             expectSuccessMessage(view.team);
+=======
+            expectSuccessMessage(view);
+>>>>>>> Convert LMS features to use safe templates
         });
 
         it('can trigger the edit membership view', function() {

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_discussion_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_discussion_spec.js
@@ -3,8 +3,9 @@ define([
     'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
     'common/js/spec_helpers/discussion_spec_helper',
     'teams/js/spec_helpers/team_spec_helpers',
-    'teams/js/views/team_discussion'
-], function(_, AjaxHelpers, DiscussionSpecHelper, TeamSpecHelpers, TeamDiscussionView) {
+    'xmodule_js/common_static/coffee/spec/discussion/discussion_spec_helper',
+    'edx-ui-toolkit/js/utils/string-utils'
+], function(_, AjaxHelpers, TeamDiscussionView, TeamSpecHelpers, DiscussionSpecHelper, StringUtils) {
     'use strict';
     xdescribe('TeamDiscussionView', function() {
         var discussionView, createDiscussionView, createPost, expandReplies, postReply;
@@ -25,14 +26,12 @@ define([
             discussionView.render();
             AjaxHelpers.expectRequest(
                 requests, 'GET',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/forum/%(discussionID)s/inline?page=1&ajax=1',
+                StringUtils.interpolate(
+                    '/courses/{courseID}/discussion/forum/{discussionID}/inline?page=1&ajax=1',
                     {
                         courseID: TeamSpecHelpers.testCourseID,
                         discussionID: TeamSpecHelpers.testTeamDiscussionID
-                    },
-                    true
-
+                    }
                 )
             );
             AjaxHelpers.respondWithJson(requests, TeamSpecHelpers.createMockDiscussionResponse(threads));
@@ -49,16 +48,15 @@ define([
             view.$('.submit').click();
             AjaxHelpers.expectRequest(
                 requests, 'POST',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/%(discussionID)s/threads/create?ajax=1',
+                StringUtils.interpolate(
+                    '/courses/{courseID}/discussion/{discussionID}/threads/create?ajax=1',
                     {
                         courseID: TeamSpecHelpers.testCourseID,
                         discussionID: TeamSpecHelpers.testTeamDiscussionID
-                    },
-                    true
+                    }
                 ),
-                interpolate(
-                    'thread_type=discussion&title=%(title)s&body=%(body)s&anonymous=false&anonymous_to_peers=false&auto_subscribe=true',
+                StringUtils.interpolate(
+                    'thread_type=discussion&title={title}&body={body}&anonymous=false&anonymous_to_peers=false&auto_subscribe=true',  // eslint-disable-line max-len
                     {
                         title: title.replace(/ /g, '+'),
                         body: body.replace(/ /g, '+')
@@ -80,14 +78,13 @@ define([
             view.$('.forum-thread-expand').first().click();
             AjaxHelpers.expectRequest(
                 requests, 'GET',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/forum/%(discussionID)s/threads/%(threadID)s?ajax=1&resp_skip=0&resp_limit=25',
+                StringUtils.interpolate(
+                    '/courses/{courseID}/discussion/forum/{discussionID}/threads/{threadID}?ajax=1&resp_skip=0&resp_limit=25',  // eslint-disable-line max-len
                     {
                         courseID: TeamSpecHelpers.testCourseID,
                         discussionID: TeamSpecHelpers.testTeamDiscussionID,
                         threadID: threadID || '999'
-                    },
-                    true
+                    }
                 )
             );
             AjaxHelpers.respondWithJson(requests, {
@@ -102,13 +99,12 @@ define([
             replyForm.find('.discussion-submit-post').click();
             AjaxHelpers.expectRequest(
                 requests, 'POST',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/threads/%(threadID)s/reply?ajax=1',
+                StringUtils.interpolate(
+                    '/courses/{courseID}/discussion/threads/{threadID}/reply?ajax=1',
                     {
                         courseID: TeamSpecHelpers.testCourseID,
                         threadID: threadID || '999'
-                    },
-                    true
+                    }
                 ),
                 'body=' + reply.replace(/ /g, '+')
             );
@@ -179,15 +175,14 @@ define([
             view.$('.submit').click();
             AjaxHelpers.expectRequest(
                 requests, 'POST',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/%(discussionID)s/threads/create?ajax=1',
+                StringUtils.interpolate(
+                    '/courses/{courseID}/discussion/{discussionID}/threads/create?ajax=1',
                     {
                         courseID: TeamSpecHelpers.testCourseID,
                         discussionID: TeamSpecHelpers.testTeamDiscussionID
-                    },
-                    true
+                    }
                 ),
-                'thread_type=discussion&title=&body=Updated+body&anonymous=false&anonymous_to_peers=false&auto_subscribe=true'
+                'thread_type=discussion&title=&body=Updated+body&anonymous=false&anonymous_to_peers=false&auto_subscribe=true'  // eslint-disable-line max-len
             );
             AjaxHelpers.respondWithJson(requests, {
                 content: TeamSpecHelpers.createMockPostResponse({

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_spec.js
@@ -1,11 +1,12 @@
 define([
     'underscore',
     'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
-    'common/js/spec_helpers/discussion_spec_helper',
-    'teams/js/spec_helpers/team_spec_helpers',
+    'edx-ui-toolkit/js/utils/string-utils',
     'teams/js/models/team',
-    'teams/js/views/team_profile'
-], function(_, AjaxHelpers, DiscussionSpecHelper, TeamSpecHelpers, TeamModel, TeamProfileView) {
+    'teams/js/views/team_profile',
+    'teams/js/spec_helpers/team_spec_helpers',
+    'xmodule_js/common_static/coffee/spec/discussion/discussion_spec_helper'
+], function(_, AjaxHelpers, StringUtils, TeamModel, TeamProfileView, TeamSpecHelpers, DiscussionSpecHelper) {
     'use strict';
     describe('TeamProfileView', function() {
         var profileView, createTeamProfileView, createTeamModelData, clickLeaveTeam,
@@ -58,13 +59,12 @@ define([
             AjaxHelpers.expectRequest(
                 requests,
                 'GET',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/forum/%(topicID)s/inline?page=1&ajax=1',
+                StringUtils.interpolate(
+                    '/courses/{courseID}/discussion/forum/{topicID}/inline?page=1&ajax=1',
                     {
                         courseID: TeamSpecHelpers.testCourseID,
                         topicID: TeamSpecHelpers.testTeamDiscussionID
-                    },
-                    true
+                    }
                 )
             );
             AjaxHelpers.respondWithJson(requests, TeamSpecHelpers.createMockDiscussionResponse());
@@ -187,7 +187,7 @@ define([
                     assertTeamDetails(view, 0, false);
                 });
 
-                it("wouldn't do anything if user click on Cancel button on dialog", function() {
+                it('should not do anything if user clicks on Cancel button on dialog', function() {
                     var requests = AjaxHelpers.requests(this);
 
                     var view = createTeamProfileView(

--- a/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
@@ -182,6 +182,9 @@ define([
                     userInfo: TeamSpecHelpers.createMockUserInfo({staff: true})
                 });
                 teamsTabView.teamsCollection = TeamSpecHelpers.createMockTeams();
+                if (expectedEvent.page_name === 'search-teams') {
+                    teamsTabView.teamsCollection.searchString = 'test search string';
+                }
                 teamsTabView.router.navigate(url, {trigger: true});
                 if (requests.length > requests.currentIndex) {
                     AjaxHelpers.respondWithJson(requests, {});

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -30,7 +30,7 @@ define([
         return _.map(_.range(startIndex, stopIndex + 1), function(i) {
             var id = 'id' + i;
             return {
-                name: 'team ' + i,
+                name: 'Team <' + i + '>',
                 id: id,
                 language: testLanguages[i % 4][0],
                 country: testCountries[i % 4][0],
@@ -151,30 +151,30 @@ define([
             ];
         }
         return {
-            'num_pages': 1,
-            'page': 1,
-            'discussion_data': threads,
-            'user_info': {
-                'username': testUser,
-                'follower_ids': [],
-                'default_sort_key': 'date',
-                'downvoted_ids': [],
-                'subscribed_thread_ids': [],
-                'upvoted_ids': [],
-                'external_id': '9',
-                'id': '9',
-                'subscribed_user_ids': [],
-                'subscribed_commentable_ids': []
+            num_pages: 1,
+            page: 1,
+            discussion_data: threads,
+            user_info: {
+                username: testUser,
+                follower_ids: [],
+                default_sort_key: 'date',
+                downvoted_ids: [],
+                subscribed_thread_ids: [],
+                upvoted_ids: [],
+                external_id: '9',
+                id: '9',
+                subscribed_user_ids: [],
+                subscribed_commentable_ids: []
             },
-            'annotated_content_info': {
+            annotated_content_info: {
             },
-            'roles': {'Moderator': [], 'Administrator': [], 'Community TA': []},
-            'course_settings': {
-                'is_cohorted': false,
-                'allow_anonymous_to_peers': false,
-                'allow_anonymous': true,
-                'category_map': {'subcategories': {}, 'children': [], 'entries': {}},
-                'cohorts': []
+            roles: {Moderator: [], Administrator: [], 'Community TA': []},
+            course_settings: {
+                is_cohorted: false,
+                allow_anonymous_to_peers: false,
+                allow_anonymous: true,
+                category_map: {subcategories: {}, children: [], entries: {}},
+                cohorts: []
             }
         };
     };
@@ -207,7 +207,7 @@ define([
                 resp_skip: 0,
                 id: '55c1323c56c02ce921000001',
                 pinned: false,
-                votes: {'count': 0, 'down_count': 0, 'point': 0, 'up_count': 0},
+                votes: {count: 0, down_count: 0, point: 0, up_count: 0},
                 resp_limit: 25,
                 abuse_flaggers: [],
                 closed: false,
@@ -229,10 +229,10 @@ define([
     createMockTopicData = function(startIndex, stopIndex) {
         return _.map(_.range(startIndex, stopIndex + 1), function(i) {
             return {
-                'description': 'Test description ' + i,
-                'name': 'Test Topic ' + i,
-                'id': 'test-topic-' + i,
-                'team_count': 0
+                description: 'Test description ' + i,
+                name: 'Test Topic ' + i,
+                id: 'test-topic-' + i,
+                team_count: 0
             };
         });
     };

--- a/lms/djangoapps/teams/static/teams/js/views/edit_team.js
+++ b/lms/djangoapps/teams/static/teams/js/views/edit_team.js
@@ -4,11 +4,12 @@
     define(['backbone',
             'underscore',
             'gettext',
+            'edx-ui-toolkit/js/utils/html-utils',
             'js/views/fields',
             'teams/js/models/team',
             'common/js/components/utils/view_utils',
             'text!teams/templates/edit-team.underscore'],
-        function(Backbone, _, gettext, FieldViews, TeamModel, ViewUtils, editTeamTemplate) {
+        function(Backbone, _, gettext, HtmlUtils, FieldViews, TeamModel, ViewUtils, editTeamTemplate) {
             return Backbone.View.extend({
 
                 maxTeamNameLength: 255,
@@ -51,7 +52,7 @@
                         valueAttribute: 'description',
                         editable: 'always',
                         showMessages: false,
-                        helpMessage: gettext('A short description of the team to help other learners understand the goals or direction of the team (maximum 300 characters).')
+                        helpMessage: gettext('A short description of the team to help other learners understand the goals or direction of the team (maximum 300 characters).')  // jshint ignore:line
                     });
 
                     this.teamLanguageField = new FieldViews.DropdownFieldView({
@@ -62,7 +63,7 @@
                         showMessages: false,
                         titleIconName: 'fa-comment-o',
                         options: this.context.languages,
-                        helpMessage: gettext('The language that team members primarily use to communicate with each other.')
+                        helpMessage: gettext('The language that team members primarily use to communicate with each other.')  // jshint ignore:line
                     });
 
                     this.teamCountryField = new FieldViews.DropdownFieldView({
@@ -78,11 +79,14 @@
                 },
 
                 render: function() {
-                    this.$el.html(_.template(editTeamTemplate)({
-                        primaryButtonTitle: this.primaryButtonTitle,
-                        action: this.action,
-                        totalMembers: _.isUndefined(this.teamModel) ? 0 : this.teamModel.get('membership').length
-                    }));
+                    HtmlUtils.setHtml(
+                        this.$el,
+                        HtmlUtils.template(editTeamTemplate)({
+                            primaryButtonTitle: this.primaryButtonTitle,
+                            action: this.action,
+                            totalMembers: _.isUndefined(this.teamModel) ? 0 : this.teamModel.get('membership').length
+                        })
+                    );
                     this.set(this.teamNameField, '.team-required-fields');
                     this.set(this.teamDescriptionField, '.team-required-fields');
                     this.set(this.teamLanguageField, '.team-optional-fields');

--- a/lms/djangoapps/teams/static/teams/js/views/instructor_tools.js
+++ b/lms/djangoapps/teams/static/teams/js/views/instructor_tools.js
@@ -5,10 +5,12 @@
             'underscore',
             'gettext',
             'edx-ui-toolkit/js/utils/string-utils',
+            'edx-ui-toolkit/js/utils/html-utils',
             'teams/js/views/team_utils',
             'common/js/components/utils/view_utils',
-            'text!teams/templates/instructor-tools.underscore'],
-        function(Backbone, _, gettext, StringUtils, TeamUtils, ViewUtils, instructorToolbarTemplate) {
+            'text!teams/templates/instructor-tools.underscore'
+        ],
+        function(Backbone, _, gettext, StringUtils, HtmlUtils, TeamUtils, ViewUtils, instructorToolbarTemplate) {
             return Backbone.View.extend({
 
                 events: {
@@ -17,13 +19,13 @@
                 },
 
                 initialize: function(options) {
-                    this.template = _.template(instructorToolbarTemplate);
+                    this.template = HtmlUtils.template(instructorToolbarTemplate);
                     this.team = options.team;
                     this.teamEvents = options.teamEvents;
                 },
 
                 render: function() {
-                    this.$el.html(this.template);
+                    HtmlUtils.setHtml(this.$el, this.template());
                     return this;
                 },
 
@@ -31,7 +33,7 @@
                     event.preventDefault();
                     ViewUtils.confirmThenRunOperation(
                         gettext('Delete this team?'),
-                        gettext('Deleting a team is permanent and cannot be undone. All members are removed from the team, and team discussions can no longer be accessed.'),
+                        gettext('Deleting a team is permanent and cannot be undone. All members are removed from the team, and team discussions can no longer be accessed.'),  // eslint-disable-line max-len
                         gettext('Delete'),
                         _.bind(this.handleDelete, this)
                     );

--- a/lms/djangoapps/teams/static/teams/js/views/my_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/my_teams.js
@@ -1,19 +1,28 @@
 (function(define) {
     'use strict';
 
-    define(['backbone', 'gettext', 'teams/js/views/teams'],
-        function(Backbone, gettext, TeamsView) {
+    define(['backbone', 'gettext',
+            'edx-ui-toolkit/js/utils/html-utils',
+            'teams/js/views/teams'],
+        function(Backbone, gettext, HtmlUtils, TeamsView) {
             var MyTeamsView = TeamsView.extend({
                 render: function() {
                     var view = this;
                     if (this.collection.isStale) {
-                        this.$el.html('');
+                        HtmlUtils.setHtml(this.$el, '');
                     }
                     this.collection.refresh()
                         .done(function() {
                             TeamsView.prototype.render.call(view);
                             if (view.collection.length === 0) {
-                                view.$el.append('<p>' + gettext('You are not currently a member of any team.') + '</p>');
+                                HtmlUtils.append(
+                                    view.$el,
+                                    HtmlUtils.joinHtml(
+                                        HtmlUtils.HTML('<p>'),
+                                        gettext('You are not currently a member of any team.'),
+                                        HtmlUtils.HTML('</p>')
+                                    )
+                                );
                             }
                         });
                     return this;

--- a/lms/djangoapps/teams/static/teams/js/views/team_profile.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_profile.js
@@ -3,19 +3,20 @@
  */
 (function(define) {
     'use strict';
-    define([
-        'backbone',
-        'underscore',
-        'gettext',
-        'edx-ui-toolkit/js/utils/html-utils',
-        'teams/js/views/team_discussion',
-        'common/js/components/utils/view_utils',
-        'teams/js/views/team_utils',
-        'text!teams/templates/team-profile.underscore',
-        'text!teams/templates/team-member.underscore'
-    ],
-        function(Backbone, _, gettext, HtmlUtils, TeamDiscussionView, ViewUtils, TeamUtils,
-                  teamTemplate, teamMemberTemplate) {
+    define(
+        [
+            'backbone',
+            'underscore',
+            'gettext',
+            'edx-ui-toolkit/js/utils/html-utils',
+            'common/js/components/utils/view_utils',
+            'teams/js/views/team_utils',
+            'teams/js/views/team_discussion',
+            'text!teams/templates/team-profile.underscore',
+            'text!teams/templates/team-member.underscore'
+        ],
+        function(Backbone, _, gettext, HtmlUtils, ViewUtils, TeamUtils, TeamDiscussionView,
+                 teamTemplate, teamMemberTemplate) {
             var TeamProfileView = Backbone.View.extend({
 
                 errorMessage: gettext('An error occurred. Try again.'),
@@ -85,17 +86,17 @@
                 },
 
                 leaveTeam: function(event) {
-                    event.preventDefault();
                     var view = this;
+                    event.preventDefault();
                     ViewUtils.confirmThenRunOperation(
                         gettext('Leave this team?'),
-                        gettext("If you leave, you can no longer post in this team's discussions. Your place will be available to another learner."),
+                        gettext("If you leave, you can no longer post in this team's discussions. Your place will be available to another learner."),  // eslint-disable-line max-len
                         gettext('Confirm'),
                         function() {
                             $.ajax({
                                 type: 'DELETE',
                                 url: view.context.teamMembershipDetailUrl.replace('team_id', view.model.get('id'))
-                            }).done(function(data) {
+                            }).done(function() {
                                 view.model.fetch()
                                     .done(function() {
                                         view.teamEvents.trigger('teams:update', {

--- a/lms/djangoapps/teams/static/teams/js/views/team_profile_header_actions.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_profile_header_actions.js
@@ -5,9 +5,10 @@
             'jquery',
             'underscore',
             'gettext',
+            'edx-ui-toolkit/js/utils/html-utils',
             'teams/js/views/team_utils',
             'text!teams/templates/team-profile-header-actions.underscore'],
-        function(Backbone, $, _, gettext, TeamUtils, teamProfileHeaderActionsTemplate) {
+        function(Backbone, $, _, gettext, HtmlUtils, TeamUtils, teamProfileHeaderActionsTemplate) {
             return Backbone.View.extend({
 
                 errorMessage: gettext('An error occurred. Try again.'),
@@ -21,7 +22,7 @@
 
                 initialize: function(options) {
                     this.teamEvents = options.teamEvents;
-                    this.template = _.template(teamProfileHeaderActionsTemplate);
+                    this.template = HtmlUtils.template(teamProfileHeaderActionsTemplate);
                     this.context = options.context;
                     this.showEditButton = options.showEditButton;
                     this.topic = options.topic;
@@ -48,11 +49,14 @@
                             }
                         }
 
-                        view.$el.html(view.template({
-                            showJoinButton: showJoinButton,
-                            message: message,
-                            showEditButton: view.showEditButton
-                        }));
+                        HtmlUtils.setHtml(
+                            view.$el,
+                            view.template({
+                                showJoinButton: showJoinButton,
+                                message: message,
+                                showEditButton: view.showEditButton
+                            })
+                        );
                     });
                     return view;
                 },
@@ -65,7 +69,7 @@
                         type: 'POST',
                         url: view.context.teamMembershipsUrl,
                         data: {'username': view.context.userInfo.username, 'team_id': view.model.get('id')}
-                    }).done(function(data) {
+                    }).done(function() {
                         view.model.fetch()
                             .done(function() {
                                 view.teamEvents.trigger('teams:update', {

--- a/lms/djangoapps/teams/static/teams/js/views/team_utils.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_utils.js
@@ -1,14 +1,14 @@
 /*  Team utility methods*/
 (function(define) {
     'use strict';
-    define(['jquery', 'underscore'
-    ], function($, _) {
+    define(['jquery', 'underscore', 'edx-ui-toolkit/js/utils/string-utils', 'edx-ui-toolkit/js/utils/html-utils'
+    ], function($, _, StringUtils, HtmlUtils) {
         return {
 
             /**
              * Convert a 2d array to an object equivalent with an additional blank element
              *
-             * @param options {Array.<Array.<string>>} Two dimensional options array
+             * @param {Array.<Array.<string>>} options Two dimensional options array
              * @returns {Object} Hash version of the input array
              * @example selectorOptionsArrayToHashWithBlank([["a", "alpha"],["b","beta"]])
              * // returns {"a":"alpha", "b":"beta", "":""}
@@ -20,21 +20,20 @@
             },
 
             teamCapacityText: function(memberCount, maxMemberCount) {
-                return interpolate(
+                return StringUtils.interpolate(
                     // Translators: The following message displays the number of members on a team.
                     ngettext(
-                        '%(memberCount)s / %(maxMemberCount)s Member',
-                        '%(memberCount)s / %(maxMemberCount)s Members',
+                        '{memberCount} / {maxMemberCount} Member',
+                        '{memberCount} / {maxMemberCount} Members',
                         maxMemberCount
                     ),
-                    {memberCount: memberCount, maxMemberCount: maxMemberCount}, true
+                    {memberCount: memberCount, maxMemberCount: maxMemberCount}
                 );
             },
 
             isUserMemberOfTeam: function(memberships, requestUsername) {
                 return _.isObject(
-                    _.find(memberships, function(membership)
-                    {
+                    _.find(memberships, function(membership) {
                         return membership.user.username === requestUsername;
                     })
                 );
@@ -45,24 +44,22 @@
             },
 
             showMessage: function(message, type) {
-                var messageElement = $('#teams-message');
-                if (_.isUndefined(type)) {
-                    type = 'warning';
-                }
-                messageElement.removeClass('is-hidden').addClass(type);
-                $('.teams-content .msg-content .copy').text(message);
-                messageElement.focus();
+                var $message = $('#teams-message');
+                $message.removeClass('is-hidden').addClass(type || 'warning');
+                HtmlUtils.setHtml($('.teams-content .msg-content .copy'), message);
+                $message.focus();
             },
 
             /**
              * Parse `data` and show user message. If parsing fails than show `genericErrorMessage`
              */
             parseAndShowMessage: function(data, genericErrorMessage, type) {
+                var errors;
                 try {
-                    var errors = JSON.parse(data.responseText);
+                    errors = JSON.parse(data.responseText);
                     this.showMessage(
-                       _.isUndefined(errors.user_message) ? genericErrorMessage : errors.user_message, type
-                   );
+                        _.isUndefined(errors.user_message) ? genericErrorMessage : errors.user_message, type
+                    );
                 } catch (error) {
                     this.showMessage(genericErrorMessage, type);
                 }

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -28,9 +28,9 @@
             'teams/js/views/instructor_tools',
             'text!teams/templates/teams_tab.underscore'],
         function(Backbone, $, _, gettext, HtmlUtils, StringUtils, SearchFieldView, HeaderView, HeaderModel,
-                  TopicModel, TopicCollection, TeamModel, TeamCollection, MyTeamsCollection, TeamAnalytics,
-                  TeamsTabbedView, TopicsView, TeamProfileView, MyTeamsView, TopicTeamsView, TeamEditView,
-                  TeamMembersEditView, TeamProfileHeaderActionsView, TeamUtils, InstructorToolsView, teamsTemplate) {
+                 TopicModel, TopicCollection, TeamModel, TeamCollection, MyTeamsCollection, TeamAnalytics,
+                 TeamsTabbedView, TopicsView, TeamProfileView, MyTeamsView, TopicTeamsView, TeamEditView,
+                 TeamMembersEditView, TeamProfileHeaderActionsView, TeamUtils, InstructorToolsView, teamsTemplate) {
             var TeamsHeaderModel = HeaderModel.extend({
                 initialize: function() {
                     _.extend(this.defaults, {nav_aria_label: gettext('Topics')});
@@ -133,7 +133,7 @@
 
                     this.mainView = this.tabbedView = this.createViewWithHeader({
                         title: gettext('Teams'),
-                        description: gettext('See all teams in your course, organized by topic. Join a team to collaborate with other learners who are interested in the same topic as you are.'),
+                        description: gettext('See all teams in your course, organized by topic. Join a team to collaborate with other learners who are interested in the same topic as you are.'),  // eslint-disable-line max-len
                         mainView: new TeamsTabbedView({
                             tabs: [{
                                 title: gettext('My Team'),
@@ -174,8 +174,7 @@
                         TeamUtils.showMessage(gettext(
                             'Your request could not be completed. Reload the page and try again.'
                         ));
-                    }
-                    else if (xhr.status === 500) {
+                    } else if (xhr.status === 500) {
                         TeamUtils.showMessage(gettext(
                             'Your request could not be completed due to a server problem. Reload the page' +
                             ' and try again. If the issue persists, click the Help tab to report the problem.'
@@ -236,7 +235,7 @@
                         view.mainView = view.createViewWithHeader({
                             topic: topic,
                             title: gettext('Create a New Team'),
-                            description: gettext("Create a new team if you can't find an existing team to join, or if you would like to learn with friends you know."),
+                            description: gettext("Create a new team if you can't find an existing team to join, or if you would like to learn with friends you know."),  // eslint-disable-line max-len
                             breadcrumbs: view.createBreadcrumbs(topic),
                             mainView: new TeamEditView({
                                 action: 'create',
@@ -270,7 +269,7 @@
                         });
                         editViewWithHeader = self.createViewWithHeader({
                             title: gettext('Edit Team'),
-                            description: gettext('If you make significant changes, make sure you notify members of the team before making these changes.'),
+                            description: gettext('If you make significant changes, make sure you notify members of the team before making these changes.'),  // eslint-disable-line max-len
                             breadcrumbs: self.createBreadcrumbs(topic, team),
                             mainView: view,
                             topic: topic,
@@ -295,14 +294,15 @@
                             context: self.context,
                             model: team
                         });
-                        self.mainView = self.createViewWithHeader({
-                            mainView: view,
-                            breadcrumbs: self.createBreadcrumbs(topic, team),
-                            title: gettext('Membership'),
-                            description: gettext("You can remove members from this team, especially if they have not participated in the team's activity."),
-                            topic: topic,
-                            team: team
-                        }
+                        self.mainView = self.createViewWithHeader(
+                            {
+                                mainView: view,
+                                breadcrumbs: self.createBreadcrumbs(topic, team),
+                                title: gettext('Membership'),
+                                description: gettext("You can remove members from this team, especially if they have not participated in the team's activity."),  // eslint-disable-line max-len
+                                topic: topic,
+                                team: team
+                            }
                         );
                         self.render();
                         TeamAnalytics.emitPageViewed('edit-team-members', topicID, teamID);
@@ -513,7 +513,7 @@
                 getTopic: function(topicID) {
                     // Try finding topic in the current page of the
                     // topicCollection.  Otherwise call the topic endpoint.
-                    var topic = this.topicsCollection.findWhere({'id': topicID}),
+                    var topic = this.topicsCollection.findWhere({id: topicID}),
                         self = this,
                         deferred = $.Deferred();
                     if (topic) {

--- a/lms/djangoapps/teams/static/teams/js/views/topic_card.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topic_card.js
@@ -3,8 +3,16 @@
  */
 (function(define) {
     'use strict';
-    define(['backbone', 'underscore', 'gettext', 'js/components/card/views/card'],
-        function(Backbone, _, gettext, CardView) {
+    define(
+        [
+            'underscore',
+            'backbone',
+            'gettext',
+            'edx-ui-toolkit/js/utils/html-utils',
+            'edx-ui-toolkit/js/utils/string-utils',
+            'js/components/card/views/card'
+        ],
+        function(_, Backbone, gettext, HtmlUtils, StringUtils, CardView) {
             var TeamCountDetailView = Backbone.View.extend({
                 tagName: 'p',
                 className: 'team-count',
@@ -14,12 +22,13 @@
                 },
 
                 render: function() {
-                    var team_count = this.model.get('team_count');
-                    this.$el.html(_.escape(interpolate(
-                        ngettext('%(team_count)s Team', '%(team_count)s Teams', team_count),
-                        {team_count: team_count},
-                        true
-                    )));
+                    var teamCount = this.model.get('team_count');
+                    this.$el.text(
+                        StringUtils.interpolate(
+                            ngettext('{team_count} Team', '{team_count} Teams', teamCount),
+                            {team_count: teamCount}
+                        )
+                    );
                     return this;
                 }
             });
@@ -41,12 +50,16 @@
                 description: function() { return this.model.get('description'); },
                 details: function() { return this.detailViews; },
                 actionClass: 'action-view',
-                actionContent: function() {
-                    var screenReaderText = _.escape(interpolate(
-                        gettext('View Teams in the %(topic_name)s Topic'),
-                        {topic_name: this.model.get('name')}, true
-                    ));
-                    return '<span class="sr">' + screenReaderText + '</span><span class="icon fa fa-arrow-right" aria-hidden="true"></span>';  // eslint-disable-line max-len
+                actionContentHtml: function() {
+                    return HtmlUtils.joinHtml(
+                        HtmlUtils.HTML('<span class="sr">'),
+                        StringUtils.interpolate(
+                            gettext('View Teams in the {topic_name} Topic'),
+                            {topic_name: this.model.get('name')}
+                        ),
+                        HtmlUtils.HTML('</span>'),
+                        HtmlUtils.HTML('<span class="icon fa fa-arrow-right" aria-hidden="true"></span>')
+                    );
                 }
             });
 

--- a/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
@@ -1,12 +1,14 @@
 (function(define) {
     'use strict';
     define([
+        'underscore',
         'backbone',
         'gettext',
+        'edx-ui-toolkit/js/utils/html-utils',
         'teams/js/views/teams',
         'common/js/components/views/paging_header',
         'text!teams/templates/team-actions.underscore'
-    ], function(Backbone, gettext, TeamsView, PagingHeader, teamActionsTemplate) {
+    ], function(_, Backbone, gettext, HtmlUtils, TeamsView, PagingHeader, teamActionsTemplate) {
         var TopicTeamsView = TeamsView.extend({
             events: {
                 'click a.browse-teams': 'browseTeams',
@@ -23,36 +25,40 @@
             },
 
             canUserCreateTeam: function() {
-                    // Note: non-staff and non-privileged users are automatically added to any team
-                    // that they create. This means that if multiple team membership is
-                    // disabled that they cannot create a new team when they already
-                    // belong to one.
+                // Note: non-staff and non-privileged users are automatically added to any team
+                // that they create. This means that if multiple team membership is
+                // disabled that they cannot create a new team when they already
+                // belong to one.
                 return this.context.staff || this.context.privileged || this.myTeamsCollection.length === 0;
             },
 
             render: function() {
                 var self = this;
                 this.collection.refresh().done(function() {
+                    var messageHtml;
                     TeamsView.prototype.render.call(self);
                     if (self.canUserCreateTeam()) {
-                        var message = interpolate_text(
-                                // Translators: this string is shown at the bottom of the teams page
-                                // to find a team to join or else to create a new one. There are three
-                                // links that need to be included in the message:
-                                // 1. Browse teams in other topics
-                                // 2. search teams
-                                // 3. create a new team
-                                // Be careful to start each link with the appropriate start indicator
-                                // (e.g. {browse_span_start} for #1) and finish it with {span_end}.
-                                _.escape(gettext("{browse_span_start}Browse teams in other topics{span_end} or {search_span_start}search teams{span_end} in this topic. If you still can't find a team to join, {create_span_start}create a new team in this topic{span_end}.")),
+                        messageHtml = HtmlUtils.interpolateHtml(
+                            // Translators: this string is shown at the bottom of the teams page
+                            // to find a team to join or else to create a new one. There are three
+                            // links that need to be included in the message:
+                            // 1. Browse teams in other topics
+                            // 2. search teams
+                            // 3. create a new team
+                            // Be careful to start each link with the appropriate start indicator
+                            // (e.g. {browse_span_start} for #1) and finish it with {span_end}.
+                            gettext('{browse_span_start}Browse teams in other topics{span_end} or {search_span_start}search teams{span_end} in this topic. If you still can\'t find a team to join, {create_span_start}create a new team in this topic{span_end}.'),  // eslint-disable-line max-len
                             {
-                                'browse_span_start': '<a class="browse-teams" href="">',
-                                'search_span_start': '<a class="search-teams" href="">',
-                                'create_span_start': '<a class="create-team" href="">',
-                                'span_end': '</a>'
+                                browse_span_start: HtmlUtils.HTML('<a class="browse-teams" href="">'),
+                                search_span_start: HtmlUtils.HTML('<a class="search-teams" href="">'),
+                                create_span_start: HtmlUtils.HTML('<a class="create-team" href="">'),
+                                span_end: HtmlUtils.HTML('</a>')
                             }
-                            );
-                        self.$el.append(_.template(teamActionsTemplate)({message: message}));
+                        );
+                        HtmlUtils.append(
+                            self.$el,
+                            HtmlUtils.template(teamActionsTemplate)({messageHtml: messageHtml})
+                        );
                     }
                 });
                 return this;
@@ -64,10 +70,10 @@
             },
 
             searchTeams: function(event) {
-                var searchField = $('.page-header-search .search-field');
+                var $searchField = $('.page-header-search .search-field');
                 event.preventDefault();
-                searchField.focus();
-                searchField.select();
+                $searchField.focus();
+                $searchField.select();
                 $('html, body').animate({
                     scrollTop: 0
                 }, 500);
@@ -76,9 +82,9 @@
             showCreateTeamForm: function(event) {
                 event.preventDefault();
                 Backbone.history.navigate(
-                        'topics/' + this.model.id + '/create-team',
-                        {trigger: true}
-                    );
+                    'topics/' + this.model.id + '/create-team',
+                    {trigger: true}
+                );
             },
 
             createHeaderView: function() {

--- a/lms/djangoapps/teams/static/teams/templates/date.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/date.underscore
@@ -1,1 +1,1 @@
-<abbr title="<%= date %>"></abbr>
+<abbr title="<%- date %>"></abbr>

--- a/lms/djangoapps/teams/static/teams/templates/edit-team-member.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/edit-team-member.underscore
@@ -1,16 +1,16 @@
 <li class="team-member">
-    <a class="member-profile" href="<%= memberProfileUrl %>">
-        <img class="image-url" src="<%= imageUrl %>" alt="<%= username %>'s profile page" />
+    <a class="member-profile" href="<%- memberProfileUrl %>">
+        <img class="image-url" src="<%- imageUrl %>" alt="<%- imageUrlAlt %>" />
     </a>
     <div class="member-info-container">
-    	<span class="primary"><%= username %></span>
+    	<span class="primary"><%- username %></span>
     	<div class="secondary">
-    		<span id="date-joined"><%= dateJoined %></span>
+    		<span id="date-joined"><%= HtmlUtils.ensureHtml(dateJoinedHtml) %></span>
     		<span> | </span>
-    		<span id="last-active"><%= lastActive %></span>
+    		<span id="last-active"><%= HtmlUtils.ensureHtml(lastActivityHtml) %></span>
     	</div>
     </div>
-    <button class="action-remove-member" data-username="<%= username %>">
-        <%- gettext("Remove") %><span class="sr">&nbsp;<%= username %></span>
+    <button class="action-remove-member" data-username="<%- username %>">
+        <%- gettext("Remove") %><span class="sr">&nbsp;<%- username %></span>
     </button>
 </li>

--- a/lms/djangoapps/teams/static/teams/templates/team-actions.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/team-actions.underscore
@@ -1,4 +1,4 @@
 <div class="team-actions">
   <h3 class="title"><%- gettext("Are you having trouble finding a team to join?") %></h3>
-  <p class="copy"><%= message %></p>
+  <p class="copy"><%= HtmlUtils.ensureHtml(messageHtml) %></p>
 </div>

--- a/lms/djangoapps/teams/static/teams/templates/team-member.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/team-member.underscore
@@ -1,8 +1,8 @@
 <li>
   <span class="team-member">
-    <a class="member-profile" href="<%= memberProfileUrl %>">
-      <p class="tooltip-custom"><%= username %></p>
-      <img class="image-url" src="<%= imageUrl %>" alt="profile page" />
+    <a class="member-profile" href="<%- memberProfileUrl %>">
+      <p class="tooltip-custom"><%- username %></p>
+      <img class="image-url" src="<%- imageUrl %>" alt="profile page" />
     </a>
   </span>
 </li>

--- a/lms/djangoapps/teams/static/teams/templates/team-membership-details.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/team-membership-details.underscore
@@ -1,4 +1,4 @@
-<span class="member-count"><%= membership_message %></span>
+<span class="member-count"><%= HtmlUtils.ensureHtml(membership_message) %></span>
 <ul class="list-member-thumbs">
     <% _.each(memberships, function (membership) { %>
         <li class="item-member-thumb"><img alt="<%- membership.user.username %>" src="<%- membership.user.profile_image.image_url_small %>"></img></li>

--- a/lms/static/js/components/card/views/card.js
+++ b/lms/static/js/components/card/views/card.js
@@ -13,15 +13,16 @@
  *      is automatically added to each rendered child view to ensure appropriate styling. Defaults to an empty list.
  * - actionClass (string or function): Class name for the action DOM element. Defaults to the empty string.
  * - actionUrl (string or function): URL to navigate to when the action button is clicked. Defaults to the empty string.
- * - actionContent: Content of the action button. This may include HTML. Default to the empty string.
+ * - actionContentHtml: Content of the action button. This may include HTML. Default to the empty string.
  */
 (function(define) {
     'use strict';
     define(['jquery',
             'underscore',
             'backbone',
+            'edx-ui-toolkit/js/utils/html-utils',
             'text!templates/components/card/card.underscore'],
-        function($, _, Backbone, cardTemplate) {
+        function($, _, Backbone, HtmlUtils, cardTemplate) {
             var CardView = Backbone.View.extend({
                 tagName: 'li',
 
@@ -46,11 +47,11 @@
                     this.render();
                 },
 
-                template: _.template(cardTemplate),
+                template: HtmlUtils.template(cardTemplate),
 
-                switchOnConfiguration: function(square_result, list_result) {
+                switchOnConfiguration: function(squareResult, listResult) {
                     return this.callIfFunction(this.configuration) === 'square_card' ?
-                        square_result : list_result;
+                        squareResult : listResult;
                 },
 
                 callIfFunction: function(value) {
@@ -63,8 +64,8 @@
 
                 className: function() {
                     var result = 'card ' +
-                                 this.switchOnConfiguration('square-card', 'list-card') + ' ' +
-                                 this.callIfFunction(this.cardClass);
+                        this.switchOnConfiguration('square-card', 'list-card') + ' ' +
+                        this.callIfFunction(this.cardClass);
                     if (this.callIfFunction(this.pennant)) {
                         result += ' has-pennant';
                     }
@@ -73,26 +74,30 @@
 
                 render: function() {
                     var maxLength = 72,
-                        description = this.callIfFunction(this.description);
+                        description = this.callIfFunction(this.description),
+                        $details;
                     if (description.length > maxLength) {
                         description = description.substring(0, maxLength).trim() + '...';
                     }
-                    this.$el.html(this.template({
-                        pennant: this.callIfFunction(this.pennant),
-                        title: this.callIfFunction(this.title),
-                        description: description,
-                        action_class: this.callIfFunction(this.actionClass),
-                        action_url: this.callIfFunction(this.actionUrl),
-                        action_content: this.callIfFunction(this.actionContent),
-                        configuration: this.callIfFunction(this.configuration),
-                        srInfo: this.srInfo
-                    }));
-                    var detailsEl = this.$el.find('.card-meta');
+                    HtmlUtils.setHtml(
+                        this.$el,
+                        this.template({
+                            pennant: this.callIfFunction(this.pennant),
+                            title: this.callIfFunction(this.title),
+                            description: description,
+                            action_class: this.callIfFunction(this.actionClass),
+                            action_url: this.callIfFunction(this.actionUrl),
+                            action_content_html: this.callIfFunction(this.actionContentHtml),
+                            configuration: this.callIfFunction(this.configuration),
+                            srInfo: this.srInfo
+                        })
+                    );
+                    $details = this.$('.card-meta');
                     _.each(this.callIfFunction(this.details), function(detail) {
                         // Call setElement to rebind event handlers
                         detail.setElement(detail.el).render();
                         detail.$el.addClass('meta-detail');
-                        detailsEl.append(detail.el);
+                        $details.append(detail.el);
                     });
                     return this;
                 },
@@ -105,7 +110,7 @@
                 details: [],
                 actionClass: '',
                 actionUrl: '',
-                actionContent: ''
+                actionContentHtml: ''
             });
 
             return CardView;

--- a/lms/static/js/components/header/views/header.js
+++ b/lms/static/js/components/header/views/header.js
@@ -3,11 +3,13 @@
  */
 (function(define) {
     'use strict';
-    define(['backbone', 'text!templates/components/header/header.underscore'],
-           function(Backbone, headerTemplate) {
+    define(['backbone',
+            'edx-ui-toolkit/js/utils/html-utils',
+            'text!templates/components/header/header.underscore'],
+           function(Backbone, HtmlUtils, headerTemplate) {
                var HeaderView = Backbone.View.extend({
                    initialize: function(options) {
-                       this.template = _.template(headerTemplate);
+                       this.template = HtmlUtils.template(headerTemplate);
                        this.headerActionsView = options.headerActionsView;
                        this.listenTo(this.model, 'change', this.render);
                        this.render();
@@ -15,7 +17,10 @@
 
                    render: function() {
                        var json = this.model.attributes;
-                       this.$el.html(this.template(json));
+                       HtmlUtils.setHtml(
+                           this.$el,
+                           this.template(json)
+                       );
                        if (this.headerActionsView) {
                            this.headerActionsView.setElement(this.$('.page-header-secondary')).render();
                        }

--- a/lms/static/js/spec/components/card/card_spec.js
+++ b/lms/static/js/spec/components/card/card_spec.js
@@ -60,20 +60,20 @@
                         description: 'A test description',
                         actionClass: 'test-action',
                         actionUrl: 'www.example.com',
-                        actionContent: 'A test action'
+                        actionContentHtml: 'A test action'
                     }))();
                     verifyContent(view);
                 });
 
                 it('can have functions for cardClass, pennant, title, description, and action', function() {
                     var view = new (CardView.extend({
-                        cardClass: function() { return 'test-card'; },
-                        pennant: function() { return 'Pennant'; },
-                        title: function() { return 'A test title'; },
-                        description: function() { return 'A test description'; },
-                        actionClass: function() { return 'test-action'; },
-                        actionUrl: function() { return 'www.example.com'; },
-                        actionContent: function() { return 'A test action'; }
+                        cardClass: function () { return 'test-card'; },
+                        pennant: function () { return 'Pennant'; },
+                        title: function () { return 'A test title'; },
+                        description: function () { return 'A test description'; },
+                        actionClass: function () { return 'test-action'; },
+                        actionUrl: function () { return 'www.example.com'; },
+                        actionContentHtml: function () { return 'A test action'; }
                     }));
                     verifyContent(view);
                 });

--- a/lms/static/js/spec/student_profile/helpers.js
+++ b/lms/static/js/spec/student_profile/helpers.js
@@ -6,7 +6,7 @@ define(['underscore', 'URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
         var fieldTitle = $element.find('.u-field-title').text().trim();
 
         if (!_.isUndefined(view.options.title)) {
-            expect(fieldTitle).toBe(view.options.title);
+            expect(fieldTitle).toEqual(view.options.title);
         }
 
         if ('fieldValue' in view || 'imageUrl' in view) {

--- a/lms/static/js/spec/views/fields_spec.js
+++ b/lms/static/js/spec/views/fields_spec.js
@@ -288,7 +288,7 @@ define(['backbone', 'jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helper
                 var view = new FieldViews.TextareaFieldView(fieldData).render();
 
                 FieldViewsSpecHelpers.expectTitleToContain(view, fieldData.title);
-                FieldViewsSpecHelpers.expectMessageContains(view, view.indicators.canEdit);
+                FieldViewsSpecHelpers.expectMessageContains(view, view.indicator_html.canEdit);
                 expect(view.el).toHaveClass('mode-placeholder');
                 expect(view.fieldValue()).toBe(fieldData.placeholderValue);
                 expect(view.$(textareaLinkClass).length).toBe(1);

--- a/lms/static/js/student_profile/views/badge_view.js
+++ b/lms/static/js/student_profile/views/badge_view.js
@@ -1,25 +1,28 @@
-(function(define, undefined) {
+(function(define) {
     'use strict';
     define(['gettext', 'jquery', 'underscore', 'backbone', 'moment',
+            'edx-ui-toolkit/js/utils/html-utils',
             'text!templates/student_profile/badge.underscore',
             'js/student_profile/views/share_modal_view'],
-        function(gettext, $, _, Backbone, Moment, badgeTemplate, ShareModalView) {
+        function(gettext, $, _, Backbone, Moment, HtmlUtils, badgeTemplate, ShareModalView) {
             var BadgeView = Backbone.View.extend({
-                initialize: function(options) {
-                    this.options = _.extend({}, options);
-                    this.context = _.extend(this.options.model.toJSON(), {
-                        'created': new Moment(this.options.model.toJSON().created),
-                        'ownProfile': options.ownProfile,
-                        'badgeMeta': options.badgeMeta
-                    });
-                },
                 attributes: {
-                    'class': 'badge-display'
+                    class: 'badge-display'
                 },
-                template: _.template(badgeTemplate),
+                template: HtmlUtils.template(badgeTemplate),
                 events: {
                     'click .share-button': 'createModal'
                 },
+
+                initialize: function(options) {
+                    this.options = _.extend({}, options);
+                    this.context = _.extend(this.options.model.toJSON(), {
+                        created: new Moment(this.options.model.toJSON().created),
+                        ownProfile: options.ownProfile,
+                        badgeMeta: options.badgeMeta
+                    });
+                },
+
                 createModal: function() {
                     var modal = new ShareModalView({
                         model: new Backbone.Model(this.context),
@@ -30,8 +33,9 @@
                     $('body').append(modal.$el);
                     modal.$el.fadeIn('short', 'swing', _.bind(modal.ready, modal));
                 },
+
                 render: function() {
-                    this.$el.html(this.template(this.context));
+                    HtmlUtils.setHtml(this.$el, this.template(this.context));
                     this.shareButton = this.$el.find('.share-button');
                     return this;
                 }

--- a/lms/static/js/student_profile/views/learner_profile_factory.js
+++ b/lms/static/js/student_profile/views/learner_profile_factory.js
@@ -1,4 +1,4 @@
-(function(define, undefined) {
+(function(define) {
     'use strict';
     define([
         'gettext',
@@ -7,26 +7,27 @@
         'backbone',
         'logger',
         'edx-ui-toolkit/js/pagination/paging-collection',
+        'edx-ui-toolkit/js/utils/html-utils',
+        'edx-ui-toolkit/js/utils/string-utils',
+        'js/views/fields',
+        'js/views/message_banner',
         'js/student_account/models/user_account_model',
         'js/student_account/models/user_preferences_model',
-        'js/views/fields',
+        'js/student_account/views/account_settings_fields',
         'js/student_profile/views/learner_profile_fields',
         'js/student_profile/views/learner_profile_view',
         'js/student_profile/models/badges_model',
-        'js/student_profile/views/badge_list_container',
-        'js/student_account/views/account_settings_fields',
-        'js/views/message_banner',
-        'string_utils'
-    ], function(gettext, $, _, Backbone, Logger, PagingCollection, AccountSettingsModel, AccountPreferencesModel,
-                 FieldsView, LearnerProfileFieldsView, LearnerProfileView, BadgeModel, BadgeListContainer,
-                 AccountSettingsFieldViews, MessageBannerView) {
+        'js/student_profile/views/badge_list_container'
+    ], function(gettext, $, _, Backbone, Logger, PagingCollection, HtmlUtils, StringUtils, FieldsView,
+                MessageBannerView, AccountSettingsModel, AccountPreferencesModel, AccountSettingsFieldViews,
+                LearnerProfileFieldsView, LearnerProfileView, BadgesModel, BadgeListContainer) {
         return function(options) {
-            var learnerProfileElement = $('.wrapper-profile');
+            var $learnerProfileElement = $('.wrapper-profile');
 
             var accountSettingsModel = new AccountSettingsModel(
                 _.extend(
                     options.account_settings_data,
-                    {'default_public_account_fields': options.default_public_account_fields}
+                    {default_public_account_fields: options.default_public_account_fields}
                 ),
                 {parse: true}
             );
@@ -51,8 +52,9 @@
                 required: true,
                 editable: 'always',
                 showMessages: false,
-                title: interpolate_text(
-                    gettext('{platform_name} learners can see my:'), {platform_name: options.platform_name}
+                title: StringUtils.interpolate(
+                    gettext('{platform_name} learners can see my:'),
+                    {platform_name: options.platform_name}
                 ),
                 valueAttribute: 'account_privacy',
                 options: [
@@ -69,10 +71,10 @@
                 valueAttribute: 'profile_image',
                 editable: editable === 'toggle',
                 messageView: messageView,
-                imageMaxBytes: options['profile_image_max_bytes'],
-                imageMinBytes: options['profile_image_min_bytes'],
-                imageUploadUrl: options['profile_image_upload_url'],
-                imageRemoveUrl: options['profile_image_remove_url']
+                imageMaxBytes: options.profile_image_max_bytes,
+                imageMinBytes: options.profile_image_min_bytes,
+                imageUploadUrl: options.profile_image_upload_url,
+                imageRemoveUrl: options.profile_image_remove_url
             });
 
             var usernameFieldView = new FieldsView.ReadonlyFieldView({
@@ -119,7 +121,7 @@
                     editable: editable,
                     showMessages: false,
                     title: gettext('About me'),
-                    placeholderValue: gettext("Tell other learners a little about yourself: where you live, what your interests are, why you're taking courses, or what you hope to learn."),
+                    placeholderValue: gettext("Tell other learners a little about yourself: where you live, what your interests are, why you're taking courses, or what you hope to learn."),  // eslint-disable-line max-len
                     valueAttribute: 'bio',
                     helpMessage: '',
                     persistChanges: true,
@@ -136,19 +138,19 @@
             badgeCollection.url = options.badges_api_url;
 
             var badgeListContainer = new BadgeListContainer({
-                'attributes': {'class': 'badge-set-display'},
-                'collection': badgeCollection,
-                'find_courses_url': options.find_courses_url,
-                'ownProfile': options.own_profile,
-                'badgeMeta': {
-                    'badges_logo': options.badges_logo,
-                    'backpack_ui_img': options.backpack_ui_img,
-                    'badges_icon': options.badges_icon
+                attributes: {class: 'badge-set-display'},
+                collection: badgeCollection,
+                find_courses_url: options.find_courses_url,
+                ownProfile: options.own_profile,
+                badgeMeta: {
+                    badges_logo: options.badges_logo,
+                    backpack_ui_img: options.backpack_ui_img,
+                    badges_icon: options.badges_icon
                 }
             });
 
             var learnerProfileView = new LearnerProfileView({
-                el: learnerProfileElement,
+                el: $learnerProfileElement,
                 ownProfile: options.own_profile,
                 has_preferences_access: options.has_preferences_access,
                 accountSettingsModel: accountSettingsModel,

--- a/lms/static/js/student_profile/views/section_two_tab.js
+++ b/lms/static/js/student_profile/views/section_two_tab.js
@@ -1,20 +1,25 @@
-(function(define, undefined) {
+(function(define) {
     'use strict';
     define([
-        'gettext', 'jquery', 'underscore', 'backbone', 'text!templates/student_profile/section_two.underscore'],
-        function(gettext, $, _, Backbone, sectionTwoTemplate) {
+            'gettext', 'jquery', 'underscore', 'backbone',
+            'edx-ui-toolkit/js/utils/html-utils',
+            'text!templates/student_profile/section_two.underscore'],
+        function(gettext, $, _, Backbone, HtmlUtils, sectionTwoTemplate) {
+
             var SectionTwoTab = Backbone.View.extend({
                 attributes: {
                     'class': 'wrapper-profile-section-two'
                 },
-                template: _.template(sectionTwoTemplate),
+                template: HtmlUtils.template(sectionTwoTemplate),
+
                 initialize: function(options) {
                     this.options = _.extend({}, options);
                 },
+
                 render: function() {
-                    var self = this;
-                    var showFullProfile = this.options.showFullProfile();
-                    this.$el.html(this.template({
+                    var self = this,
+                        showFullProfile = this.options.showFullProfile();
+                    HtmlUtils.setHtml(this.$el, this.template({
                         ownProfile: self.options.ownProfile,
                         showFullProfile: showFullProfile
                     }));

--- a/lms/static/js/student_profile/views/share_modal_view.js
+++ b/lms/static/js/student_profile/views/share_modal_view.js
@@ -1,47 +1,55 @@
-(function(define, undefined) {
+(function(define) {
     'use strict';
     define(['gettext', 'jquery', 'underscore', 'backbone', 'moment',
+            'edx-ui-toolkit/js/utils/html-utils',
             'text!templates/student_profile/share_modal.underscore'],
-        function(gettext, $, _, Backbone, Moment, badgeModalTemplate) {
+        function(gettext, $, _, Backbone, Moment, HtmlUtils, badgeModalTemplate) {
             var ShareModalView = Backbone.View.extend({
                 attributes: {
-                    'class': 'badges-overlay'
+                    class: 'badges-overlay'
                 },
-                template: _.template(badgeModalTemplate),
+                template: HtmlUtils.template(badgeModalTemplate),
                 events: {
                     'click .badges-modal': function(event) { event.stopPropagation(); },
                     'click .badges-modal .close': 'close',
                     'click .badges-overlay': 'close',
-                    'keydown': 'keyAction',
+                    keydown: 'keyAction',
                     'focus .focusguard-start': 'focusGuardStart',
                     'focus .focusguard-end': 'focusGuardEnd'
                 },
+
                 initialize: function(options) {
                     this.options = _.extend({}, options);
                 },
+
                 focusGuardStart: function() {
                     // Should only be selected directly if shift-tabbing from the start, so grab last item.
                     this.$el.find('a').last().focus();
                 },
+
                 focusGuardEnd: function() {
                     this.$el.find('.badges-modal').focus();
                 },
+
                 close: function() {
                     this.$el.fadeOut('short', 'swing', _.bind(this.remove, this));
                     this.options.shareButton.focus();
                 },
+
                 keyAction: function(event) {
                     if (event.keyCode === $.ui.keyCode.ESCAPE) {
                         this.close();
                     }
                 },
+
                 ready: function() {
                     // Focusing on the modal background directly doesn't work, probably due
                     // to its positioning.
                     this.$el.find('.badges-modal').focus();
                 },
+
                 render: function() {
-                    this.$el.html(this.template(this.model.toJSON()));
+                    HtmlUtils.setHtml(this.$el, this.template(this.model.toJSON()));
                     return this;
                 }
             });

--- a/lms/static/js/views/image_field.js
+++ b/lms/static/js/views/image_field.js
@@ -3,13 +3,15 @@
     define([
         'gettext', 'jquery', 'underscore', 'backbone', 'js/views/fields',
         'text!templates/fields/field_image.underscore',
+        'edx-ui-toolkit/js/utils/html-utils',
+        'edx-ui-toolkit/js/utils/string-utils',
         'backbone-super', 'jquery.fileupload'
-    ], function(gettext, $, _, Backbone, FieldViews, field_image_template) {
+    ], function(gettext, $, _, Backbone, FieldViews, fieldImageTemplate, HtmlUtils, StringUtils) {
         var ImageFieldView = FieldViews.FieldView.extend({
 
             fieldType: 'image',
 
-            fieldTemplate: field_image_template,
+            fieldTemplate: fieldImageTemplate,
             uploadButtonSelector: '.upload-button-input',
 
             titleAdd: gettext('Upload an image'),
@@ -22,9 +24,9 @@
             titleImageAlt: '',
             screenReaderTitle: gettext('Image'),
 
-            iconUpload: '<span class="icon fa fa-camera" aria-hidden="true"></span>',
-            iconRemove: '<span class="icon fa fa-remove" aria-hidden="true"></span>',
-            iconProgress: '<span class="icon fa fa-spinner fa-pulse fa-spin" aria-hidden="true"></span>',
+            iconUploadHtml: HtmlUtils.HTML('<span class="icon fa fa-camera" aria-hidden="true"></span>'),
+            iconRemoveHtml: HtmlUtils.HTML('<span class="icon fa fa-remove" aria-hidden="true"></span>'),
+            iconProgressHtml: HtmlUtils.HTML('<span class="icon fa fa-spinner fa-pulse fa-spin" aria-hidden="true"></span>'),
 
             errorMessage: gettext('An error has occurred. Refresh the page, and then try again.'),
 
@@ -40,21 +42,24 @@
                 this.options = _.extend({}, options);
                 this._super(options);
                 _.bindAll(this, 'render', 'imageChangeSucceeded', 'imageChangeFailed', 'fileSelected',
-                          'watchForPageUnload', 'onBeforeUnload');
+                    'watchForPageUnload', 'onBeforeUnload');
             },
 
             render: function() {
-                this.$el.html(this.template({
-                    id: this.options.valueAttribute,
-                    inputName: (this.options.inputName || 'file'),
-                    imageUrl: _.result(this, 'imageUrl'),
-                    imageAltText: _.result(this, 'imageAltText'),
-                    uploadButtonIcon: _.result(this, 'iconUpload'),
-                    uploadButtonTitle: _.result(this, 'uploadButtonTitle'),
-                    removeButtonIcon: _.result(this, 'iconRemove'),
-                    removeButtonTitle: _.result(this, 'removeButtonTitle'),
-                    screenReaderTitle: _.result(this, 'screenReaderTitle')
-                }));
+                HtmlUtils.setHtml(
+                    this.$el,
+                    this.template({
+                        id: this.options.valueAttribute,
+                        inputName: (this.options.inputName || 'file'),
+                        imageUrl: _.result(this, 'imageUrl'),
+                        imageAltText: _.result(this, 'imageAltText'),
+                        uploadButtonIconHtml: _.result(this, 'iconUploadHtml'),
+                        uploadButtonTitle: _.result(this, 'uploadButtonTitle'),
+                        removeButtonIconHtml: _.result(this, 'iconRemoveHtml', ''),
+                        removeButtonTitle: _.result(this, 'removeButtonTitle'),
+                        screenReaderTitle: _.result(this, 'screenReaderTitle')
+                    })
+                );
                 this.delegateEvents();
                 this.updateButtonsVisibility();
                 this.watchForPageUnload();
@@ -70,7 +75,7 @@
             },
 
             showErrorMessage: function(message) {
-                return message;
+                throw('showErrorMessage not implemented for error: ' + message);
             },
 
             imageUrl: function() {
@@ -144,10 +149,10 @@
                 this.render();
             },
 
-            imageChangeFailed: function(e, data) {
+            imageChangeFailed: function() {
             },
 
-            showImageChangeFailedMessage: function(status, responseText) {
+            showImageChangeFailedMessage: function() {
             },
 
             fileSelected: function(e, data) {
@@ -164,7 +169,7 @@
                 if (imageBytes < this.options.imageMinBytes) {
                     humanReadableSize = this.bytesToHumanReadable(this.options.imageMinBytes);
                     this.showErrorMessage(
-                        interpolate_text(
+                        StringUtils.interpolate(
                             gettext('The file must be at least {size} in size.'), {size: humanReadableSize}
                         )
                     );
@@ -172,7 +177,7 @@
                 } else if (imageBytes > this.options.imageMaxBytes) {
                     humanReadableSize = this.bytesToHumanReadable(this.options.imageMaxBytes);
                     this.showErrorMessage(
-                        interpolate_text(
+                        StringUtils.interpolate(
                             gettext('The file must be smaller than {size} in size.'), {size: humanReadableSize}
                         )
                     );
@@ -183,14 +188,14 @@
 
             showUploadInProgressMessage: function() {
                 this.$('.u-field-upload-button').css('opacity', 1);
-                this.$('.upload-button-icon').html(this.iconProgress);
-                this.$('.upload-button-title').html(this.titleUploading);
+                HtmlUtils.setHtml(this.$('.upload-button-icon'), this.iconProgressHtml);
+                this.$('.upload-button-title').text(this.titleUploading);
             },
 
             showRemovalInProgressMessage: function() {
                 this.$('.u-field-remove-button').css('opacity', 1);
-                this.$('.remove-button-icon').html(this.iconProgress);
-                this.$('.remove-button-title').html(this.titleRemoving);
+                HtmlUtils.setHtml(this.$('.remove-button-icon'), this.iconProgressHtml);
+                this.$('.remove-button-title').text(this.titleRemoving);
             },
 
             setCurrentStatus: function(status) {
@@ -208,9 +213,9 @@
             onBeforeUnload: function() {
                 var status = this.getCurrentStatus();
                 if (status === 'uploading') {
-                    return gettext('Upload is in progress. To avoid errors, stay on this page until the process is complete.');
+                    return gettext('Upload is in progress. To avoid errors, stay on this page until the process is complete.');  // eslint-disable-line max-len
                 } else if (status === 'removing') {
-                    return gettext('Removal is in progress. To avoid errors, stay on this page until the process is complete.');
+                    return gettext('Removal is in progress. To avoid errors, stay on this page until the process is complete.');  // eslint-disable-line max-len
                 }
             },
 

--- a/lms/static/js/views/message_banner.js
+++ b/lms/static/js/views/message_banner.js
@@ -1,24 +1,26 @@
-(function(define, undefined) {
+(function(define) {
     'use strict';
     define([
-        'gettext', 'jquery', 'underscore', 'backbone', 'text!templates/fields/message_banner.underscore'
-    ], function(gettext, $, _, Backbone, messageBannerTemplate) {
+        'gettext', 'jquery', 'underscore', 'backbone',
+        'edx-ui-toolkit/js/utils/html-utils',
+        'text!templates/fields/message_banner.underscore'
+    ], function(gettext, $, _, Backbone, HtmlUtils, messageBannerTemplate) {
         var MessageBannerView = Backbone.View.extend({
 
             initialize: function(options) {
-                if (_.isUndefined(options)) {
-                    options = {};
-                }
-                this.options = _.defaults(options, {urgency: 'high', type: ''});
+                this.options = _.defaults(options || {}, {urgency: 'high', type: ''});
             },
 
             render: function() {
                 if (_.isUndefined(this.message) || _.isNull(this.message)) {
-                    this.$el.html('');
+                    HtmlUtils.setHtml(this.$el, '');
                 } else {
-                    this.$el.html(_.template(messageBannerTemplate)(_.extend(this.options, {
-                        message: this.message
-                    })));
+                    HtmlUtils.setHtml(
+                        this.$el,
+                        HtmlUtils.template(messageBannerTemplate)(
+                            _.extend(this.options, {message: this.message})
+                        )
+                    );
                 }
                 return this;
             },

--- a/lms/templates/components/card/card.underscore
+++ b/lms/templates/components/card/card.underscore
@@ -1,45 +1,45 @@
 <% if (configuration === 'square_card') { %>
-<div class="wrapper-card-core">
-    <div class="card-core">
-        <% if (pennant) { %>
-            <small class="card-type"><%- pennant %></small>
-        <% } %>
-        <h3 class="card-title"
-            <% if (!_.isUndefined(srInfo)) { %>
-                aria-describedby="<%= srInfo.id %>"
+    <div class="wrapper-card-core">
+        <div class="card-core">
+            <% if (pennant) { %>
+                <small class="card-type"><%- pennant %></small>
             <% } %>
+            <h3 class="card-title"
+                <% if (!_.isUndefined(srInfo)) { %>
+                    aria-describedby="<%- srInfo.id %>"
+                <% } %>
             ><%- title %>
-        </h3>
+            </h3>
         <p class="card-description"><%- description %></p>
+        </div>
     </div>
-</div>
-<div class="wrapper-card-meta has-actions">
-    <div class="card-meta">
+    <div class="wrapper-card-meta has-actions">
+        <div class="card-meta">
+        </div>
+        <div class="card-actions">
+            <a class="action <%- action_class %>" href="<%- action_url %>"><%= HtmlUtils.ensureHtml(action_content_html) %></a>
+        </div>
     </div>
-    <div class="card-actions">
-        <a class="action <%= action_class %>" href="<%= action_url %>"><%= action_content %></a>
-    </div>
-</div>
 <% } else { %>
-<div class="wrapper-card-core">
-    <div class="card-core">
-        <% if (pennant) { %>
-            <small class="card-type"><%- pennant %></small>
-        <% } %>
-        <h3 class="card-title"
-            <% if (!_.isUndefined(srInfo)) { %>
-                aria-describedby="<%= srInfo.id %>"
+    <div class="wrapper-card-core">
+        <div class="card-core">
+            <% if (pennant) { %>
+                <small class="card-type"><%- pennant %></small>
             <% } %>
+            <h3 class="card-title"
+                <% if (!_.isUndefined(srInfo)) { %>
+                    aria-describedby="<%- srInfo.id %>"
+                <% } %>
             ><%- title %>
-        </h3>
+            </h3>
         <p class="card-description"><%- description %></p>
+        </div>
+        <div class="card-actions">
+            <a class="action <%- action_class %>" href="<%- action_url %>"><%= HtmlUtils.ensureHtml(action_content_html) %></a>
+        </div>
     </div>
-    <div class="card-actions">
-        <a class="action <%= action_class %>" href="<%= action_url %>"><%= action_content %></a>
+    <div class="wrapper-card-meta">
+        <div class="card-meta">
+        </div>
     </div>
-</div>
-<div class="wrapper-card-meta">
-    <div class="card-meta">
-    </div>
-</div>
 <% } %>

--- a/lms/templates/components/header/header.underscore
+++ b/lms/templates/components/header/header.underscore
@@ -4,13 +4,13 @@
         <% if (breadcrumbs !== null && breadcrumbs.length > 0) { %>
             <nav class="breadcrumbs" aria-label="<%- nav_aria_label %>">
             <% _.each(breadcrumbs, function (breadcrumb) { %>
-                <a class="nav-item" href="<%= breadcrumb.url %>"><%- breadcrumb.title %></a>
+                <a class="nav-item" href="<%- breadcrumb.url %>"><%= HtmlUtils.ensureHtml(breadcrumb.title) %></a>
                 <span class="icon fa-angle-right" aria-hidden="true"></span>
             <% }) %>
             </nav>
         <% } %>
-        <h3 class="hd hd-2 page-title"><%- title %></h3>
-        <p class="page-description"><%- description %></p>
+        <h3 class="hd hd-2 page-title"><%= HtmlUtils.ensureHtml(title) %></h3>
+        <p class="page-description"><%= HtmlUtils.ensureHtml(description) %></p>
     </div>
     <div class="page-header-secondary"></div>
 </header>

--- a/lms/templates/fields/field_image.underscore
+++ b/lms/templates/fields/field_image.underscore
@@ -1,17 +1,17 @@
 <div class="image-wrapper">
-    <img class="image-frame" src="<%- imageUrl %>"  alt="<%=imageAltText%>"/>
+    <img class="image-frame" src="<%- imageUrl %>"  alt="<%= HtmlUtils.ensureHtml(imageAltText) %>"/>
     <div class="u-field-actions">
         <label class="u-field-upload-button">
-            <span class="upload-button-icon" aria-hidden="true"><%= uploadButtonIcon %></span>
-            <span class="upload-button-title" aria-live="polite"><%= uploadButtonTitle %></span>
-            <input class="upload-button-input" type="file" name="<%= inputName %>"/>
+            <span class="upload-button-icon" aria-hidden="true"><%= HtmlUtils.ensureHtml(uploadButtonIconHtml) %></span>
+            <span class="upload-button-title" aria-live="polite"><%= HtmlUtils.ensureHtml(uploadButtonTitle) %></span>
+            <input class="upload-button-input" type="file" name="<%= HtmlUtils.ensureHtml(inputName) %>"/>
        	</label>
-       	<button class="upload-submit" type="button" hidden="true"><%= uploadButtonTitle %></button>
+       	<button class="upload-submit" type="button" hidden="true"><%= HtmlUtils.ensureHtml(uploadButtonTitle) %></button>
         
         <button class="u-field-remove-button" type="button">
-            <span class="remove-button-icon" aria-hidden="true"><%= removeButtonIcon %></span>
-            <span class="remove-button-title" aria-live="polite"><%= removeButtonTitle %></span>
-            <span class="sr"><%= screenReaderTitle %></span>
+            <span class="remove-button-icon" aria-hidden="true"><%= HtmlUtils.ensureHtml(removeButtonIconHtml) %></span>
+            <span class="remove-button-title" aria-live="polite"><%- removeButtonTitle %></span>
+            <span class="sr"><%- screenReaderTitle %></span>
         </button>
     </div>
 </div>

--- a/lms/templates/fields/message_banner.underscore
+++ b/lms/templates/fields/message_banner.underscore
@@ -1,8 +1,8 @@
-<div class="wrapper-msg urgency-<%= urgency %> <%= type %>">
+<div class="wrapper-msg urgency-<%- urgency %> <%- type %>">
     <div class="msg">
         <div class="msg-content">
             <div class="copy">
-                <p><%-message%></p>
+                <p><%= HtmlUtils.ensureHtml(message) %></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This change starts to convert the platform to use the new HtmlUtils class. I've primarily converted the Teams UI, along with the shared helper classes and Underscore templates that they depend upon.
## Sandbox
- [ ] https://andy-armstrong.sandbox.edx.org/
## Testing
- [ ] Unit, integration, acceptance tests as appropriate
## Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review #1: @cahrens 
- [ ] Code review #2: @robrap 

FYI: @AlasdairSwan @dan-f @dsjen @bjacobel 
## Post-review
- [ ] Squash commits
