### PR TITLE
Wait for MathJax to render completely so that check can be performed

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -328,6 +328,7 @@ class ProblemPartialCredit(ProblemsTest):
         self.assertEqual(problem_page.problem_name, 'PARTIAL CREDIT TEST PROBLEM')
         problem_page.fill_answer_numerical('-1')
         problem_page.click_check()
+        problem_page.wait_for_element_visibility('use', 'MathJax rendered completely')
         problem_page.wait_for_status_icon()
         self.assertTrue(problem_page.simpleprob_is_partially_correct())
 


### PR DESCRIPTION
@raeeschachar @benpatterson @jzoldak Please review. Essentially we have to wait until mathjax rendering completes. I tried to use verify_mathjax_rendered_in_problem/verify_mathjax_rendered_in_hint but they give broken promise error. 
