### PR TITLE
Wait for numerical selection to load before continuing.

### DIFF
--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -91,6 +91,7 @@ class ProblemPage(PageObject):
         Fill in the answer to a numerical problem.
         """
         self.q(css='div.problem section.inputtype input').fill(text)
+        self.wait_for_element_invisibility('.loading', 'wait for loading icon to disappear')
         self.wait_for_ajax()
 
     def click_check(self):

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -6,8 +6,6 @@ See also old lettuce tests in lms/djangoapps/courseware/features/problems.featur
 """
 from textwrap import dedent
 
-from flaky import flaky
-
 from ..helpers import UniqueCourseTest
 from ...pages.studio.auto_auth import AutoAuthPage
 from ...pages.lms.courseware import CoursewarePage
@@ -360,7 +358,6 @@ class LogoutDuringAnswering(ProblemsTest):
         """
         self.browser.delete_cookie('sessionid')
 
-    @flaky  # TNL-4272
     def test_logout_after_click_redirect(self):
         """
         1) User goes to a problem page.


### PR DESCRIPTION
Fixes race condition for this test: common.test.acceptance.tests.lms.test_lms_problems.LogoutDuringAnswering.test_logout_after_click_redirect
