### PR TITLE
Extract hint from html instead of text

### DIFF
--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -37,6 +37,13 @@ class ProblemPage(PageObject):
         return self.q(css="div.problem span.message").text[0]
 
     @property
+    def extract_hint_text_from_html(self):
+        """
+        Return the "hint" text of the problem from html
+        """
+        return self.q(css="div.problem div.problem-hint").html[0].split(' <', 1)[0]
+
+    @property
     def hint_text(self):
         """
         Return the "hint" text of the problem from its div.

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -288,13 +288,13 @@ class ProblemWithMathjax(ProblemsTest):
 
         # The hint button rotates through multiple hints
         problem_page.click_hint()
-        self.assertIn("Hint (1 of 2): mathjax should work1", problem_page.hint_text)
+        self.assertIn("Hint (1 of 2): mathjax should work1", problem_page.extract_hint_text_from_html)
         problem_page.verify_mathjax_rendered_in_hint()
 
         # Rotate the hint and check the problem hint
         problem_page.click_hint()
 
-        self.assertIn("Hint (2 of 2): mathjax should work2", problem_page.hint_text)
+        self.assertIn("Hint (2 of 2): mathjax should work2", problem_page.extract_hint_text_from_html)
         problem_page.verify_mathjax_rendered_in_hint()
 
 


### PR DESCRIPTION
It was a strange thing for me to encounter. Somehow BrowserQuery.title was not working as expected returning broken promise error but BrowserQuery.html was working fine. One obvious thing happening might be that html is not valid but I was unable to ascertain. To fix the error I just made another function which extracts hint from the BrowserQuery.html. 
@raeeschachar @benpatterson @jzoldak Please review
