### PR TITLE
Use a module/path mapping for RequireJS overrides instead of just paths.

### DIFF
--- a/common/djangoapps/pipeline_mako/__init__.py
+++ b/common/djangoapps/pipeline_mako/__init__.py
@@ -128,17 +128,17 @@ def render_require_js_path_overrides(path_overrides):  # pylint: disable=invalid
     </script>'''
 
     new_paths = []
-    for url_path in path_overrides:
+    for module in path_overrides:
         # Calculate the full URL, including any hashes added to the filename by the pipeline.
         # This will also include the base static URL (for example, "/static/") and the
         # ".js" extension.
-        actual_url = staticfiles_storage.url(url_path)
+        actual_url = staticfiles_storage.url(path_overrides[module])
 
         # RequireJS assumes that every file it tries to load has a ".js" extension, so
         # we need to remove ".js" from the module path.
         # RequireJS also already has a base URL set to the base static URL, so we can remove that.
         path = actual_url.replace('.js', '').replace(django_settings.STATIC_URL, '')
 
-        new_paths.append("'{module}': '{path}'".format(module=url_path.replace('.js', ''), path=path))
+        new_paths.append("'{module}': '{path}'".format(module=module, path=path))
 
     return html.format(overrides=',\n'.join(new_paths))

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -70,9 +70,21 @@ source, template_path = Loader(engine).load_template_source(path)
 <%def name="require_module(module_name, class_name)">
     <script type="text/javascript">
         (function (require) {
-            require(['${module_name}'], function (${class_name}) {
-                ${caller.body()}
-            });
+            % if settings.REQUIRE_DEBUG:
+                require(['${module_name}'], function (${class_name}) {
+                    ${caller.body()}
+                });
+            % else:
+                ## The "raw" parameter is specified to avoid the URL from being further maninpulated by
+                ## static_replace calls (as woudl happen if require_module is used within courseware).
+                ## Without specifying "raw", a call to static_replace would result in the MD5 hash being
+                ## being appended more than once, causing the import to fail in production environments.
+                require(['${staticfiles_storage.url(module_name + ".js") + "?raw"}'], function () {
+                    require(['${module_name}'], function (${class_name}) {
+                        ${caller.body()}
+                    });
+                });
+            % endif
         }).call(this, require || RequireJS.require);
     </script>
 </%def>

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -70,21 +70,9 @@ source, template_path = Loader(engine).load_template_source(path)
 <%def name="require_module(module_name, class_name)">
     <script type="text/javascript">
         (function (require) {
-            % if settings.REQUIRE_DEBUG:
-                require(['${module_name}'], function (${class_name}) {
-                    ${caller.body()}
-                });
-            % else:
-                ## The "raw" parameter is specified to avoid the URL from being further maninpulated by
-                ## static_replace calls (as woudl happen if require_module is used within courseware).
-                ## Without specifying "raw", a call to static_replace would result in the MD5 hash being
-                ## being appended more than once, causing the import to fail in production environments.
-                require(['${staticfiles_storage.url(module_name + ".js") + "?raw"}'], function () {
-                    require(['${module_name}'], function (${class_name}) {
-                        ${caller.body()}
-                    });
-                });
-            % endif
+            require(['${module_name}'], function (${class_name}) {
+                ${caller.body()}
+            });
         }).call(this, require || RequireJS.require);
     </script>
 </%def>

--- a/common/djangoapps/pipeline_mako/tests/test_render.py
+++ b/common/djangoapps/pipeline_mako/tests/test_render.py
@@ -7,20 +7,20 @@ from pipeline_mako import render_require_js_path_overrides
 class RequireJSPathOverridesTest(TestCase):
     """Test RequireJS path overrides. """
 
-    OVERRIDES = [
-        'js/vendor/jquery.min.js',
-        'js/vendor/backbone-min.js',
-        'js/vendor/text.js'
-    ]
+    OVERRIDES = {
+        'jquery': 'js/vendor/jquery.min.js',
+        'backbone': 'js/vendor/backbone-min.js',
+        'text': 'js/vendor/text.js'
+    }
 
     OVERRIDES_JS = [
         "<script type=\"text/javascript\">",
         "(function (require) {",
         "require.config({",
         "paths: {",
-        "'js/vendor/jquery.min': 'js/vendor/jquery.min',",
-        "'js/vendor/backbone-min': 'js/vendor/backbone-min',",
-        "'js/vendor/text': 'js/vendor/text'",
+        "'jquery': 'js/vendor/jquery.min',",
+        "'text': 'js/vendor/text',",
+        "'backbone': 'js/vendor/backbone-min'",
         "}",
         "});",
         "}).call(this, require || RequireJS.require);",

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1633,14 +1633,14 @@ REQUIRE_ENVIRONMENT = "node"
 # If you want to load JavaScript dependencies using RequireJS
 # but you don't want to include those dependencies in the JS bundle for the page,
 # then you need to add the js urls in this list.
-REQUIRE_JS_PATH_OVERRIDES = [
-    'js/bookmarks/views/bookmark_button.js',
-    'js/views/message_banner.js',
-    'js/vendor/moment.min.js',
-    'js/vendor/url.min.js',
-    'js/courseware/course_home_events.js',
-    'js/courseware/toggle_element_visibility.js'
-]
+REQUIRE_JS_PATH_OVERRIDES = {
+    'bookmark_button': 'js/bookmarks/views/bookmark_button.js',
+    'message_banner': 'js/views/message_banner.js',
+    'moment': 'js/vendor/moment.min.js',
+    'url': 'js/vendor/url.min.js',
+    'course_home_events': 'js/courseware/course_home_events.js',
+    'toggle_element_visibility': 'js/courseware/toggle_element_visibility.js'
+}
 ################################# CELERY ######################################
 
 # Celery's task autodiscovery won't find tasks nested in a tasks package.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1639,7 +1639,11 @@ REQUIRE_JS_PATH_OVERRIDES = {
     'moment': 'js/vendor/moment.min.js',
     'jquery.url': 'js/vendor/url.min.js',
     'js/courseware/course_home_events': 'js/courseware/course_home_events.js',
-    'js/courseware/toggle_element_visibility': 'js/courseware/toggle_element_visibility.js'
+    'js/courseware/toggle_element_visibility': 'js/courseware/toggle_element_visibility.js',
+    'js/student_account/logistration_factory': 'js/student_account/logistration_factory.js',
+    'js/student_profile/views/learner_profile_factory': 'js/student_profile/views/learner_profile_factory.js',
+    'js/bookmarks/bookmarks_factory': 'js/bookmarks/bookmarks_factory.js'
+    'js/groups/views/cohorts_dashboard_factory': 'js/groups/views/cohorts_dashboard_factory.js'
 }
 ################################# CELERY ######################################
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1642,7 +1642,7 @@ REQUIRE_JS_PATH_OVERRIDES = {
     'js/courseware/toggle_element_visibility': 'js/courseware/toggle_element_visibility.js',
     'js/student_account/logistration_factory': 'js/student_account/logistration_factory.js',
     'js/student_profile/views/learner_profile_factory': 'js/student_profile/views/learner_profile_factory.js',
-    'js/bookmarks/bookmarks_factory': 'js/bookmarks/bookmarks_factory.js'
+    'js/bookmarks/bookmarks_factory': 'js/bookmarks/bookmarks_factory.js',
     'js/groups/views/cohorts_dashboard_factory': 'js/groups/views/cohorts_dashboard_factory.js'
 }
 ################################# CELERY ######################################

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1634,12 +1634,12 @@ REQUIRE_ENVIRONMENT = "node"
 # but you don't want to include those dependencies in the JS bundle for the page,
 # then you need to add the js urls in this list.
 REQUIRE_JS_PATH_OVERRIDES = {
-    'bookmark_button': 'js/bookmarks/views/bookmark_button.js',
-    'message_banner': 'js/views/message_banner.js',
+    'js/bookmarks/views/bookmark_button': 'js/bookmarks/views/bookmark_button.js',
+    'js/views/message_banner': 'js/views/message_banner.js',
     'moment': 'js/vendor/moment.min.js',
-    'url': 'js/vendor/url.min.js',
-    'course_home_events': 'js/courseware/course_home_events.js',
-    'toggle_element_visibility': 'js/courseware/toggle_element_visibility.js'
+    'jquery.url': 'js/vendor/url.min.js',
+    'js/courseware/course_home_events': 'js/courseware/course_home_events.js',
+    'js/courseware/toggle_element_visibility': 'js/courseware/toggle_element_visibility.js'
 }
 ################################# CELERY ######################################
 


### PR DESCRIPTION
Instead of attempting to derive the module portion of a RequireJS override strictly from the path to the JS file, we now use a dictionary where the module name must be explicitly specified.  This allows us to compensate for files which do not follow a naming scheme that is compatible with RequireJS without having to normalize all files.  This is extremely important when using third-party dependencies.
