### PR TITLE
Add h filter page directive to cms mako templates without variables

### DIFF
--- a/cms/templates/dev/dev_mode.html
+++ b/cms/templates/dev/dev_mode.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%inherit file="../base.html" />
 <%block name="content">
 You're in dev mode!

--- a/cms/templates/ux/reference/index.html
+++ b/cms/templates/ux/reference/index.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%inherit file="../../base.html" />
 
 <%block name="view_notes">

--- a/cms/templates/ux/reference/modal_access-component.html
+++ b/cms/templates/ux/reference/modal_access-component.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="wrapper wrapper-modal-window wrapper-modal-window-edit-xblock"  aria-labelledby="modal-window-title" role="dialog">
   <div class="modal-window-overlay"></div>
   <div class="modal-window confirm modal-med modal-type-html modal-editor" style="top: 50px; left: 400px;" tabindex="-1" aria-labelledby="modal-window-title">

--- a/cms/templates/ux/reference/modal_bulkpublish-section.html
+++ b/cms/templates/ux/reference/modal_bulkpublish-section.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%! from django.utils.translation import ugettext as _ %>
 
 <div class="wrapper wrapper-modal-window wrapper-modal-window-bulkpublish-section" aria-labelledby="modal-window-title" role="dialog">

--- a/cms/templates/ux/reference/modal_bulkpublish-subsection.html
+++ b/cms/templates/ux/reference/modal_bulkpublish-subsection.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%! from django.utils.translation import ugettext as _ %>
 
 <div class="wrapper wrapper-modal-window wrapper-modal-window-bulkpublish-subsection" aria-labelledby="modal-window-title" role="dialog">

--- a/cms/templates/ux/reference/modal_bulkpublish-unit.html
+++ b/cms/templates/ux/reference/modal_bulkpublish-unit.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%! from django.utils.translation import ugettext as _ %>
 
 <div class="wrapper wrapper-modal-window wrapper-modal-window-bulkpublish-unit" aria-labelledby="modal-window-title"  role="dialog">

--- a/cms/templates/ux/reference/outline_add-section.html
+++ b/cms/templates/ux/reference/outline_add-section.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="add-section add-item">
   <a href="#" class="button button-new" data-category="" data-parent="" data-default-name="New Section">
     <i class="icon fa fa-plus"></i> New Section

--- a/cms/templates/ux/reference/outline_add-subsection.html
+++ b/cms/templates/ux/reference/outline_add-subsection.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="add-subsection add-item">
   <a href="#" class="button button-new" data-category="" data-parent="" data-default-name="New Subsection">
     <i class="icon fa fa-plus"></i> New Subsection

--- a/cms/templates/ux/reference/outline_add-unit.html
+++ b/cms/templates/ux/reference/outline_add-unit.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="add-unit add-item">
   <a href="#" class="button button-new" data-category="" data-parent="" data-default-name="New Unit">
     <i class="icon fa fa-plus"></i> New Unit

--- a/cms/templates/ux/reference/outline_section_header-collapsed.html
+++ b/cms/templates/ux/reference/outline_section_header-collapsed.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="section-header">
   <h3 class="section-header-details ui-toggle-expansion" title="Collapse/Expand this Section">
     <i class="icon fa fa-caret-down icon"></i>

--- a/cms/templates/ux/reference/outline_section_header-expanded.html
+++ b/cms/templates/ux/reference/outline_section_header-expanded.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="section-header">
   <h3 class="section-header-details ui-toggle-expansion" title="Collapse/Expand this Section">
     <i class="icon fa fa-caret-down icon"></i>

--- a/cms/templates/ux/reference/outline_status_grading.html
+++ b/cms/templates/ux/reference/outline_status_grading.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-grading">
   <p>
     <span class="sr status-grading-label">Graded as:</span>

--- a/cms/templates/ux/reference/outline_status_message-error.html
+++ b/cms/templates/ux/reference/outline_status_message-error.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-message">
   <i class="icon fa fa-warning"></i>
   <p class="status-message-copy">Critical error</p>

--- a/cms/templates/ux/reference/outline_status_message-lock.html
+++ b/cms/templates/ux/reference/outline_status_message-lock.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-message">
   <i class="icon fa fa-lock"></i>
   <p class="status-message-copy">Contains Staff only content</p>

--- a/cms/templates/ux/reference/outline_status_message-unpublished_changes.html
+++ b/cms/templates/ux/reference/outline_status_message-unpublished_changes.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-message">
   <i class="icon fa fa-file-o"></i>
   <p class="status-message-copy">Unpublished change(s) to live content</p>

--- a/cms/templates/ux/reference/outline_status_message-unpublished_units.html
+++ b/cms/templates/ux/reference/outline_status_message-unpublished_units.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-message">
   <i class="icon fa fa-file-o"></i>
   <p class="status-message-copy">Unpublished unit(s) will not be released</p>

--- a/cms/templates/ux/reference/outline_status_release-draft.html
+++ b/cms/templates/ux/reference/outline_status_release-draft.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-release">
   <p>
     <span class="sr status-release-label">Release Status:</span>

--- a/cms/templates/ux/reference/outline_status_release-lock.html
+++ b/cms/templates/ux/reference/outline_status_release-lock.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-release">
   <p>
     <span class="sr status-release-label">Release Status:</span>

--- a/cms/templates/ux/reference/outline_status_release-released.html
+++ b/cms/templates/ux/reference/outline_status_release-released.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-release">
   <p>
     <span class="sr status-release-label">Release Status:</span>

--- a/cms/templates/ux/reference/outline_status_release-released_with_parent.html
+++ b/cms/templates/ux/reference/outline_status_release-released_with_parent.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-release">
   <p>
     <span class="sr status-release-label">Release Status:</span>

--- a/cms/templates/ux/reference/outline_status_release-scheduled.html
+++ b/cms/templates/ux/reference/outline_status_release-scheduled.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-release">
   <p>
     <span class="sr status-release-label">Release Status:</span>

--- a/cms/templates/ux/reference/outline_status_release-scheduled_with_parent.html
+++ b/cms/templates/ux/reference/outline_status_release-scheduled_with_parent.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="status-release">
   <p>
     <span class="sr status-release-label">Release Status:</span>

--- a/cms/templates/ux/reference/outline_subsection_header-collapsed.html
+++ b/cms/templates/ux/reference/outline_subsection_header-collapsed.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="subsection-header">
   <h3 class="subsection-header-details ui-toggle-expansion" title="Collapse/Expand this Subsection">
     <i class="icon fa fa-caret-down icon"></i>

--- a/cms/templates/ux/reference/outline_subsection_header-expanded.html
+++ b/cms/templates/ux/reference/outline_subsection_header-expanded.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="subsection-header">
   <h3 class="subsection-header-details ui-toggle-expansion" title="Collapse/Expand this Subsection">
     <i class="icon fa fa-caret-down icon"></i>

--- a/cms/templates/ux/reference/outline_unit_header.html
+++ b/cms/templates/ux/reference/outline_unit_header.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="unit-header">
   <h3 class="unit-header-details">
     <span class="unit-title item-title"><a class="unit-url" href="">Unit Name</a></span>

--- a/cms/templates/widgets/_ui-dnd-indicator-after.html
+++ b/cms/templates/widgets/_ui-dnd-indicator-after.html
@@ -1,1 +1,2 @@
+<%page expression_filter="h"/>
 <span class="draggable-drop-indicator draggable-drop-indicator-after"><i class="icon fa fa-caret-right"></i></span>

--- a/cms/templates/widgets/_ui-dnd-indicator-before.html
+++ b/cms/templates/widgets/_ui-dnd-indicator-before.html
@@ -1,1 +1,2 @@
+<%page expression_filter="h"/>
 <span class="draggable-drop-indicator draggable-drop-indicator-before"><i class="icon fa fa-caret-right"></i></span>

--- a/cms/templates/widgets/_ui-dnd-indicator-initial.html
+++ b/cms/templates/widgets/_ui-dnd-indicator-initial.html
@@ -1,1 +1,2 @@
+<%page expression_filter="h"/>
 <span class="draggable-drop-indicator draggable-drop-indicator-initial"><i class="icon fa fa-caret-right"></i></span>

--- a/cms/templates/widgets/metadata-only-edit.html
+++ b/cms/templates/widgets/metadata-only-edit.html
@@ -1,1 +1,2 @@
+<%page expression_filter="h"/>
 <%include file="metadata-edit.html" />

--- a/cms/templates/widgets/sequence-edit.html
+++ b/cms/templates/widgets/sequence-edit.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <section class="sequence-edit">
   <%include file="metadata-edit.html" />
 </section>


### PR DESCRIPTION
The files to change were found with:
`ack --literal --type=html --match '${' --files-without-matches cms/templates`
