### PR TITLE
Add static HtmlUtils/StringUtils into edx namespace

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -142,8 +142,12 @@
         // Django i18n catalog globals
         "interpolate",
         "gettext",
+        "ngettext",
 
         // Miscellaneous globals
-        "JSON"
+        "JSON",
+
+        // edX globals
+        "edx"
     ]
 }

--- a/common/static/common/js/common_libraries.js
+++ b/common/static/common/js/common_libraries.js
@@ -1,1 +1,21 @@
-define(['domReady!', 'jquery', 'backbone', 'underscore', 'gettext']);
+define([
+        'edx-ui-toolkit/js/utils/string-utils',
+        'edx-ui-toolkit/js/utils/html-utils',
+        'domReady!',
+        'jquery',
+        'backbone',
+        'underscore',
+        'gettext'
+    ],
+    function(StringUtils, HtmlUtils) {
+        'use strict';
+
+        // Install utility classes in the edX namespace to make them
+        // available to code that doesn't use RequireJS,
+        // e.g. XModules and XBlocks.
+        if (window) {
+            window.edx = window.edx || {};
+            window.edx.StringUtils = StringUtils;
+            window.edx.HtmlUtils = HtmlUtils;
+        }
+    });

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1252,6 +1252,13 @@ base_vendor_js = [
     'js/vendor/url.min.js',
     'common/js/vendor/underscore.js',
     'js/vendor/underscore.string.min.js',
+
+    # Make some edX UI Toolkit utilities available in the global "edx" namespace
+    'edx-ui-toolkit/js/utils/global-loader.js',
+    'edx-ui-toolkit/js/utils/string-utils.js',
+    'edx-ui-toolkit/js/utils/html-utils.js',
+
+    # Finally load RequireJS and dependent vendor libraries
     'js/vendor/requirejs/require.js',
     'js/RequireJS-namespace-undefine.js',
     'js/vendor/URI.min.js',

--- a/lms/static/lms/js/build.js
+++ b/lms/static/lms/js/build.js
@@ -70,7 +70,11 @@
             'logger': 'empty:',
             'utility': 'empty:',
             'URI': 'empty:',
-            'DiscussionModuleView': 'empty:'
+            'DiscussionModuleView': 'empty:',
+
+            // Don't bundle UI Toolkit helpers as they are loaded into the "edx" namespace
+            'edx-ui-toolkit/js/utils/html-utils': 'empty:',
+            'edx-ui-toolkit/js/utils/string-utils': 'empty:'
         },
 
         /**

--- a/lms/static/lms/js/require-config.js
+++ b/lms/static/lms/js/require-config.js
@@ -4,13 +4,23 @@
     // into the optimized files. Therefore load these libraries through script tags and explicitly define them.
     // Note that when the optimizer executes this code, window will not be defined.
     if (window) {
-        var defineDependency = function (globalVariable, name, noShim) {
-            if (window[globalVariable]) {
+        var defineDependency = function (globalName, name, noShim) {
+            var getGlobalValue = function(name) {
+                var globalNamePath = name.split('.'),
+                    result = window,
+                    i;
+                for (i = 0; i < globalNamePath.length; i++) {
+                    result = result[globalNamePath[i]];
+                }
+                return result;
+            },
+                globalValue = getGlobalValue(globalName);
+            if (globalValue) {
                 if (noShim) {
                     define(name, {});
                 }
                 else {
-                    define(name, [], function() {return window[globalVariable];});
+                    define(name, [], function() { return globalValue; });
                 }
             }
             else {
@@ -29,6 +39,10 @@
         defineDependency("Logger", "logger");
         defineDependency("URI", "URI");
         defineDependency("Backbone", "backbone");
+
+        // Add the UI Toolkit helper classes that have been installed in the "edx" namespace
+        defineDependency("edx.HtmlUtils", "edx-ui-toolkit/js/utils/html-utils");
+        defineDependency("edx.StringUtils", "edx-ui-toolkit/js/utils/string-utils");
 
         // utility.js adds two functions to the window object, but does not return anything
         defineDependency("isExternal", "utility", true);
@@ -84,18 +98,12 @@
             // end of files needed by OVA
         },
         shim: {
-            "gettext": {
-                exports: "gettext"
-            },
             "annotator_1.2.9": {
                 deps: ["jquery"],
                 exports: "Annotator"
             },
             "date": {
                 exports: "Date"
-            },
-            "jquery": {
-                exports: "$"
             },
             "jquery.cookie": {
                 deps: ["jquery"],
@@ -116,13 +124,6 @@
             "jquery.tinymce": {
                 deps: ["jquery", "tinymce"],
                 exports: "jQuery.fn.tinymce"
-            },
-            "underscore": {
-                exports: "_"
-            },
-            "backbone": {
-                deps: ["underscore", "jquery"],
-                exports: "Backbone"
             },
             "backbone.paginator": {
                 deps: ["backbone"],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "coffee-script": "1.6.1",
     "edx-pattern-library": "0.10.4",
-    "edx-ui-toolkit": "~0.8.0",
+    "edx-ui-toolkit": "0.9.0",
     "requirejs": "~2.1.22",
     "uglify-js": "2.4.24",
     "underscore": "~1.8.3"


### PR DESCRIPTION
This change loads key UI Toolkit classes into the `edx` namespace so that they can be consumed by parts of the platform that cannot use RequireJS yet (mostly XBlocks and XModules). This was straightforward in Studio because the classes can be loaded by RequireJS and be guaranteed that they load before any other code. In the LMS that isn't possible, so there the code relies on the following UI Toolkit PR that lets classes load into the `edx` namespace if RequireJS is not available: https://github.com/edx/edx-ui-toolkit/pull/46
### Sandbox
- [x] https://andy-armstrong.sandbox.edx.org/dashboard
### Testing
- [x] manual testing on devstack and my sandbox
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens
- [x] Code review: @efischer19  

FYI: @robrap @AlasdairSwan @bjacobel @tobz @peter-fogg 
### Post-review
- [x] Squash commits
