### PR TITLE
This appears to actually be in UTC (not in the django TZ default).

### DIFF
--- a/lms/templates/courseware/submission_history.html
+++ b/lms/templates/courseware/submission_history.html
@@ -4,7 +4,7 @@
 % for i, (entry, score) in enumerate(zip(history_entries, scores)):
 <hr/>
 <div>
-<b>#${len(history_entries) - i}</b>: ${entry.updated} (${TIME_ZONE} time)</br>
+<b>#${len(history_entries) - i}</b>: ${entry.updated} UTC</br>
 Score: ${score.grade} / ${score.max_grade}
 <pre>
 ${json.dumps(entry.state, indent=2, sort_keys=True) | h}


### PR DESCRIPTION
You can see the times are marked +00:00 for the ISO 8601 format date and
I see no code in the backend that tries to convert.

This contradicts 01a1bf6 but I poked around in the history of views.py and user_state_client.py and I can't see where it would ever have returned non-UTC.

> | created             | state  
> | 2015-04-21 17:01:21 | {}  
> | 2015-04-21 17:01:21 | {"seed": 1, "input_state": {"i4x-edX-DemoX_1-problem-5f4eab510455498ba7fc0fde6c7f798a_2_1": {}}} 

<img width="1141" alt="screen shot 2016-03-23 at 2 46 18 pm" src="https://cloud.githubusercontent.com/assets/57604/13996984/59f6d38e-f106-11e5-876d-2c4fc3e7c89d.png">
