### PR TITLE
Safe template linter should use DOTALL

### DIFF
--- a/scripts/safe_template_linter.py
+++ b/scripts/safe_template_linter.py
@@ -773,7 +773,7 @@ class UnderscoreTemplateLinter(object):
                 end_index: The index of the end of the expression.
                 expression: The text of the expression.
         """
-        unescaped_expression_regex = re.compile("<%=.*?%>", re.MULTILINE)
+        unescaped_expression_regex = re.compile("<%=.*?%>", re.DOTALL)
 
         expressions = []
         for match in unescaped_expression_regex.finditer(underscore_template):


### PR DESCRIPTION
MULTILINE has to do with how '^' and '$' behave, DOTALL will make the
'.' match newlines as well. This catches several failures that were
previously missed.

From https://docs.python.org/2/library/re.html

```
re.MULTILINE
When specified, the pattern character '^' matches at the beginning of the string and at the beginning of each line (immediately following each newline); and the pattern character '$' matches at the end of the string and at the end of each line (immediately preceding each newline). By default, '^' matches only at the beginning of the string, and '$' only at the end of the string and immediately before the newline (if any) at the end of the string.
```

```
re.DOTALL
Make the '.' special character match any character at all, including a newline; without this flag, '.' will match anything except a newline.
```

@robrap @nedbat Can I get thumbs? I've confirmed this picks up issues that were previously missed, such as:

```
lms/templates/verify_student/intro_step.underscore: 5:7: underscore-not-escaped:         ) %>
lms/templates/verify_student/intro_step.underscore: 6:1:                               <%= _.sprintf(
lms/templates/verify_student/intro_step.underscore: 7:1:                                   gettext( "Thanks for returning to verify your ID in: %(courseName)s"),
lms/templates/verify_student/intro_step.underscore: 8:1:                                   { courseName: '<span class="course-title">' + courseName + '</span>' }
```
