### PR TITLE
making the welcome_back template safe

### DIFF
--- a/lms/templates/courseware/welcome-back.html
+++ b/lms/templates/courseware/welcome-back.html
@@ -1,12 +1,14 @@
+<%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _ 
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import Text, HTML
 %>
 
-<h2>${chapter_module.display_name_with_default_escaped}</h2>
+<h2>${chapter_module.display_name_with_default}</h2>
 
-<p>${_("You were most recently in {section_link}.  If you\'re done with that, choose another section on the left.").format(
-	    section_link=u'<a href="{url}">{section_name}</a>'.format(
+<p>${Text(_("You were most recently in {section_link}.  If you're done with that, choose another section on the left.")).format(
+	    section_link=HTML('<a href="{url}">{section_name}</a>').format(
 	        url=prev_section_url,
-	        section_name=prev_section.display_name_with_default_escaped,
+	        section_name=prev_section.display_name_with_default,
 	    )
     )}</p>


### PR DESCRIPTION
@nasthagiri @jcdyer more simple(r) changes. Per my reading of 

http://draft-safe-templates-2016-03-23.readthedocs.org/en/latest/conventions/safe_templates.html#html-context-in-mako

I don't need to wrap either of the parameters to the inner `format` call in `Text()` or `HTML()` but let me know if I read that wrong. Nested `format` calls are okay per 

http://draft-safe-templates-2016-03-23.readthedocs.org/en/latest/conventions/internationalization/i18n.html#mako-template-files
