### PR TITLE
Enable safe by default in the activation flow

### DIFF
--- a/lms/templates/registration/activate_account_notice.html
+++ b/lms/templates/registration/activate_account_notice.html
@@ -1,14 +1,21 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%page expression_filter="h"/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
 <div class="wrapper-msg urgency-high">
     <div class="msg">
         <div class="msg-content">
             <h2 class="title">${_("Thanks for Registering!")}</h2>
             <div class="copy">
-                <p class='activation-message'>${_(
+                <p class='activation-message'>${Text(_(
                         "You've successfully created an account on {platform_name}. We've sent an account "
-                        "activation message to {email}. To activate your account and start enrolling in "
+                        "activation message to {email_start}{email}{email_end}. To activate your account and start enrolling in "
                         "courses, click the link in the message."
-                        ).format(email="<strong>{}</strong>".format(email), platform_name=platform_name
+                        )).format(email_start=HTML("<strong>"),
+                                  email_end=HTML("</strong>"),
+                                  email=email,
+                                  platform_name=platform_name
                     )}
                 </p>
             </div>

--- a/lms/templates/registration/activation_complete.html
+++ b/lms/templates/registration/activation_complete.html
@@ -1,8 +1,10 @@
+<%page expression_filter="h"/>
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <section class="container activation">
@@ -23,9 +25,11 @@ from django.core.urlresolvers import reverse
       %endif
 
       %if user_logged_in:
-        ${_("Visit your {link_start}dashboard{link_end} to see your courses.").format(link_start='<a href="{url}">'.format(url=reverse('dashboard')), link_end='</a>')}
+        ${Text(_("Visit your {link_start}dashboard{link_end} to see your courses.")).format(
+            link_start=HTML('<a href="{url}">').format(url=reverse('dashboard')), link_end=HTML('</a>'))}
       %else:
-        ${_("You can now {link_start}log in{link_end}.").format(link_start='<a href="{url}">'.format(url=reverse('signin_user')), link_end='</a>')}
+        ${Text(_("You can now {link_start}log in{link_end}.")).format(
+            link_start=HTML('<a href="{url}">').format(url=reverse('signin_user')), link_end=HTML('</a>'))}
       %endif
     </p>
   </section>

--- a/lms/templates/registration/activation_invalid.html
+++ b/lms/templates/registration/activation_invalid.html
@@ -1,8 +1,10 @@
+<%page expression_filter="h"/>
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <section class="container activation">
@@ -11,11 +13,16 @@ from django.core.urlresolvers import reverse
     <h1 class="invalid">${_("Activation Invalid")}</h1>
     <hr class="horizontal-divider">
 
-    <p>${_('Something went wrong. Check to make sure the URL you went to was '
-           'correct -- e-mail programs will sometimes split it into two '
-           'lines. If you still have issues, e-mail us to let us know what happened '
-           'at {email}.').format(email='<a href="mailto:{email}">{email}</a>'.format(email=settings.BUGS_EMAIL))}</p>
+    <p>${Text(_('Something went wrong. Check to make sure the URL you went to was '
+                'correct -- e-mail programs will sometimes split it into two '
+                'lines. If you still have issues, e-mail us to let us know what happened '
+                'at {email_start}{email}{email_end}.')).format(
+		    email_start=HTML('<a href="mailto:{}">').format(settings.BUGS_EMAIL),
+		    email=settings.BUGS_EMAIL,
+		    email_end=HTML('</a>')
+		)}</p>
 
-    <p>${_('Or you can go back to the {link_start}home page{link_end}.').format(link_start='<a href="/">', link_end='</a>')}</p>
+    <p>${Text(_('Or you can go back to the {link_start}home page{link_end}.')).format(
+           link_start=HTML('<a href="/">'), link_end=HTML('</a>'))}</p>
   </section>
 </section>


### PR DESCRIPTION
The largest changes here were around HTML escaping in the translations.
