### PR TITLE
Added random seed to metadata that is sent to external grader

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -2819,6 +2819,7 @@ class CodeResponse(LoncapaResponse):
         student_info = {
             'anonymous_student_id': anonymous_student_id,
             'submission_time': qtime,
+            'random_seed': self.context['seed'],
         }
         contents.update({'student_info': json.dumps(student_info)})
 


### PR DESCRIPTION
I noticed that it was not possible to send the randomized variables in the grading payload. An easy way to replicate the randomized variables is to send the random_seed that was used along with the metadata. Is there any objection to adding that data here?
