### PR TITLE
EdX problem grade report doesn't order problems as shown in course

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -836,7 +836,7 @@ def _order_problems(blocks):
         an OrderedDict that maps a problem id to its headers in the final report.
     """
     problems = OrderedDict()
-    assignments = dict()
+    assignments = OrderedDict()
     # First, sort out all the blocks into their correct assignments and all the
     # assignments into their correct types.
     for block in blocks:

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -330,3 +330,13 @@ class TestReportMixin(object):
                 self.assertEqual(csv_rows, expected_rows)
             else:
                 self.assertItemsEqual(csv_rows, expected_rows)
+
+    def get_csv_row_with_headers(self):
+        """
+        Helper function to return list with the column names from the CSV file (the first row)
+        """
+        report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
+        report_csv_filename = report_store.links_for(self.course.id)[0][0]
+        with open(report_store.path_to(self.course.id, report_csv_filename)) as csv_file:
+            rows = unicodecsv.reader(csv_file, encoding='utf-8')
+            return rows.next()


### PR DESCRIPTION
The problem Grade Report (from the Data Downloads page) must show the problems in the order they occur within the course.
