### PR TITLE
Fix to remove mulitple page tags on mako templates

### DIFF
--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from urlparse import urljoin
 
 import pytz
+from markupsafe import escape
 from mock import Mock, patch
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from pyquery import PyQuery as pq
@@ -404,7 +405,7 @@ class DashboardTest(ModuleStoreTestCase):
         self.assertNotIn('Add Certificate to LinkedIn', response.content)
 
         response_url = 'http://www.linkedin.com/profile/add?_ed='
-        self.assertNotContains(response, response_url)
+        self.assertNotContains(response, escape(response_url))
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': False})
@@ -452,7 +453,7 @@ class DashboardTest(ModuleStoreTestCase):
             'pfCertificationUrl=www.edx.org&'
             'source=o'
         )
-        self.assertContains(response, expected_url)
+        self.assertContains(response, escape(expected_url))
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -1,5 +1,4 @@
-<%page expression_filter="h"/>
-<%page args="cert_status, course_overview, enrollment" />
+<%page expression_filter="h" args="cert_status, course_overview, enrollment" />
 
 <%!
 from django.utils.translation import ugettext as _

--- a/lms/templates/dashboard/_dashboard_xseries_info.html
+++ b/lms/templates/dashboard/_dashboard_xseries_info.html
@@ -1,5 +1,4 @@
-<%page expression_filter="h"/>
-<%page args="program_data, enrollment_mode, display_category" />
+<%page expression_filter="h" args="program_data, enrollment_mode, display_category" />
 <%!
     from django.utils.translation import ugettext as _
     from openedx.core.djangolib.markup import Text, HTML


### PR DESCRIPTION
This is an error introduced by the xss fix I did as of https://github.com/edx/edx-platform/pull/11894.
