### PR TITLE
Fail fast if the reset-test-db script fails

### DIFF
--- a/scripts/reset-test-db.sh
+++ b/scripts/reset-test-db.sh
@@ -22,6 +22,9 @@
 #
 ############################################################################
 
+# Fail fast
+set -e
+
 DB_CACHE_DIR="common/test/db_cache"
 
 declare -A databases


### PR DESCRIPTION
The bok choy tests fail to run in devstack with [this private settings file](https://github.com/edx/edx-platform/wiki/Developing-on-the-edX-Developer-Stack#making-the-local-servers-run-faster):
- The private settings file overrides `INSTALLED_APPS`, bypassing the value set in `lms/envs/bok_choy.py`
- This excludes `django_extensions` from the installed apps
- This means that the `reset_db` management command is no longer available
- This causes the `reset-test-db.sh` script to fail
- But the script ignores the failures and carries on anyway, causing much confusion

This pull request adds `set -e` to the `reset-test-db.sh` script, causing it to exit with an error if any of the commands it runs fail.
