### PR TITLE
Further theme support for ECOMMERCE_* settings

### DIFF
--- a/lms/djangoapps/commerce/tests/test_utils.py
+++ b/lms/djangoapps/commerce/tests/test_utils.py
@@ -54,8 +54,14 @@ class EcommerceServiceTests(TestCase):
 
     @patch('openedx.core.djangoapps.theming.helpers.is_request_in_themed_site')
     def test_is_enabled_for_microsites(self, is_microsite):
-        """Verify that is_enabled() returns False if used for a microsite."""
+        """Verify that is_enabled() returns True when ecomm checkout is enabled for microsite """
         is_microsite.return_value = True
+        is_enabled = EcommerceService().is_enabled(self.user)
+        self.assertTrue(is_enabled)
+
+        config = CommerceConfiguration.current()
+        config.checkout_on_ecommerce_service = False
+        config.save()
         is_not_enabled = EcommerceService().is_enabled(self.user)
         self.assertFalse(is_not_enabled)
 

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -46,8 +46,7 @@ class EcommerceService(object):
 
     def is_enabled(self, user):
         """ Check if the user is activated, if the service is enabled and that the site is not a microsite. """
-        return (user.is_active and self.config.checkout_on_ecommerce_service and not
-                helpers.is_request_in_themed_site())
+        return user.is_active and self.config.checkout_on_ecommerce_service
 
     def payment_page_url(self):
         """ Return the URL for the checkout page.

--- a/openedx/core/djangoapps/commerce/utils.py
+++ b/openedx/core/djangoapps/commerce/utils.py
@@ -3,6 +3,8 @@ from django.conf import settings
 from edx_rest_api_client.client import EdxRestApiClient
 from eventtracking import tracker
 
+from openedx.core.djangoapps.theming.helpers import get_value
+
 ECOMMERCE_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
@@ -23,14 +25,17 @@ def is_commerce_service_configured():
     Return a Boolean indicating whether or not configuration is present to use
     the external commerce service.
     """
-    return bool(settings.ECOMMERCE_API_URL and settings.ECOMMERCE_API_SIGNING_KEY)
+    return bool(
+        get_value('ECOMMERCE_API_URL', settings.ECOMMERCE_API_URL) and
+        get_value('ECOMMERCE_API_SIGNING_KEY', settings.ECOMMERCE_API_SIGNING_KEY)
+    )
 
 
 def ecommerce_api_client(user):
     """ Returns an E-Commerce API client setup with authentication for the specified user. """
     return EdxRestApiClient(
-        settings.ECOMMERCE_API_URL,
-        settings.ECOMMERCE_API_SIGNING_KEY,
+        get_value('ECOMMERCE_API_URL', settings.ECOMMERCE_API_URL),
+        get_value('ECOMMERCE_API_SIGNING_KEY', settings.ECOMMERCE_API_SIGNING_KEY),
         user.username,
         user.profile.name if hasattr(user, 'profile') else None,
         user.email,


### PR DESCRIPTION
**Description:** Expands https://github.com/edx/edx-platform/pull/11954 to support checkout on Otto for themed sites/microsites and allows themed site/microsite config to override ECOMMERCE_API_URL and ECOMMERCE_API_SIGNING_KEY
