### PR TITLE
 DOC-2216: Modify message text when Adv Settings saved

### DIFF
--- a/cms/static/js/views/settings/advanced.js
+++ b/cms/static/js/views/settings/advanced.js
@@ -109,7 +109,7 @@ var AdvancedView = ValidatingView.extend({
             success : function() {
                 self.render();
                 var title = gettext("Your policy changes have been saved.");
-                var message = gettext("Please note that validation of your policy key and value pairs is not currently in place yet. If you are having difficulties, please review your policy pairs.");
+                var message = gettext("No validation is performed on policy keys or value pairs. If you are having difficulties, check your formatting.");  // jshint ignore:line
                 self.showSavedBar(title, message);
                 analytics.track('Saved Advanced Settings', {
                     'course': course_location_analytics


### PR DESCRIPTION
- DOC-2216 (https://openedx.atlassian.net/browse/DOC-2216)
  Change the wording in the Advanced Settings/Save message to make it clearer there's no validation.
## Sandbox
- [x] https://studio-catong.sandbox.edx.org/settings/advanced/course-v1:edX+Test101+course
## Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Docs review (required for UI strings/error messages) @lamagnifica

FYI: Tag anyone who might be interested in this PR here.
## Post-review
- [x] Squash commits
