### PR TITLE
Add option to bypass course home

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -752,6 +752,17 @@ class CourseFields(object):
         scope=Scope.settings
     )
 
+    bypass_home = Boolean(
+        display_name=_("Bypass Course Home"),
+        help=_(
+            "Bypass the course home tab when students arrive from the dashboard, "
+            "sending them directly to course content."
+        ),
+        default=False,
+        scope=Scope.settings,
+        deprecated=True
+    )
+
     enable_subsection_gating = Boolean(
         display_name=_("Enable Subsection Prerequisites"),
         help=_(

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -365,6 +365,16 @@ class SelfPacedTestCase(unittest.TestCase):
         self.assertFalse(self.course.self_paced)
 
 
+class BypassHomeTestCase(unittest.TestCase):
+    """Tests for setting which allows course home to be bypassed."""
+    def setUp(self):
+        super(BypassHomeTestCase, self).setUp()
+        self.course = get_dummy_course('2012-12-02T12:00')
+
+    def test_default(self):
+        self.assertFalse(self.course.bypass_home)
+
+
 class CourseDescriptorTestCase(unittest.TestCase):
     """
     Tests for a select few functions from CourseDescriptor.

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -694,6 +694,10 @@ def course_info(request, course_id):
         if request.user.is_authenticated() and survey.utils.must_answer_survey(course, user):
             return redirect(reverse('course_survey', args=[unicode(course.id)]))
 
+        is_from_dashboard = reverse('dashboard') in request.META.get('HTTP_REFERER', [])
+        if course.bypass_home and is_from_dashboard:
+            return redirect(reverse('courseware', args=[course_id]))
+
         studio_url = get_studio_url(course, 'course_info')
 
         # link to where the student should go to enroll in the course:


### PR DESCRIPTION
Exposes an advanced setting in Studio allowing course teams to bypass the home tab when students arrive from the dashboard, sending them directly to course content. ECOM-3961.

@jimabramson @schenedx please review. The new setting is marked as deprecated at @marcotuts' request to avoid encouraging other course teams to use this option.
