### PR TITLE
Fix certificate exception view.

### DIFF
--- a/lms/static/js/certificates/factories/certificate_whitelist_factory.js
+++ b/lms/static/js/certificates/factories/certificate_whitelist_factory.js
@@ -16,7 +16,7 @@
             return function(certificate_white_list_json, generate_certificate_exceptions_url,
                             certificate_exception_view_url, generate_bulk_certificate_exceptions_url){
 
-                var certificateWhiteList = new CertificateWhiteListCollection(JSON.parse(certificate_white_list_json), {
+                var certificateWhiteList = new CertificateWhiteListCollection(certificate_white_list_json, {
                     parse: true,
                     canBeEmpty: true,
                     url: certificate_exception_view_url,

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -7,7 +7,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 %>
 
 <%static:require_module module_name="js/certificates/factories/certificate_whitelist_factory" class_name="CertificateWhitelistFactory">
-        CertificateWhitelistFactory('${certificate_white_list | n, dump_js_escaped_json}', '${generate_certificate_exceptions_url | n, js_escaped_string}', '${certificate_exception_view_url | n, js_escaped_string}', '${generate_bulk_certificate_exceptions_url | n, js_escaped_string}');
+        CertificateWhitelistFactory(${certificate_white_list | n, dump_js_escaped_json}, '${generate_certificate_exceptions_url | n, js_escaped_string}', '${certificate_exception_view_url | n, js_escaped_string}', '${generate_bulk_certificate_exceptions_url | n, js_escaped_string}');
 </%static:require_module>
 
 <%static:require_module module_name="js/certificates/factories/certificate_invalidation_factory" class_name="CertificateInvalidationFactory">


### PR DESCRIPTION
Rendering Certificate exception view breaks when exception notes contains `\n` or `HTML` tags. 

`JSON.parse` fails if there is `\n` in the string. Using `dump_js_escaped_json` which returns an object which removes the need of using `JSON.parse` method. 

[ECOM-3910](https://openedx.atlassian.net/browse/ECOM-3910)
