### PR TITLE
Update Bok Choy to 0.5.1 release.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -136,7 +136,7 @@ django_debug_toolbar==1.3.2
 
 # Used for testing
 before_after==0.1.3
-bok-choy==0.5.0
+bok-choy==0.5.1
 chrono==1.0.2
 coverage==4.0.2
 ddt==0.8.0


### PR DESCRIPTION
This change in version is needed for https://openedx.atlassian.net/browse/TNL-4295.

I verified that with this version of bok choy, we get only the expected remaining XSS test failures (with VERIFY_XSS set to true). https://build.testeng.edx.org/view/edx-platform-specific-tests/job/edx-platform-bok-choy-custom/305/#showFailuresLink

@jzoldak Can I get a thumb from you? I assume one is all that is needed.
