### PR TITLE
Adding i18n info for developers

### DIFF
--- a/docs/en_us/internal/testing.rst
+++ b/docs/en_us/internal/testing.rst
@@ -70,6 +70,12 @@ UI Acceptance Tests
    write end-user acceptance tests directly in Python, using the
    framework to maximize reliability and maintainability.
 
+Internationalization
+~~~~~~~~~~~~~~~~~~~~
+
+-  Any new text that is added should be internationalized and translated.
+
+
 Test Locations
 --------------
 
@@ -609,6 +615,41 @@ During acceptance test execution, Django log files are written to
 ``test_root/log/cms_acceptance.log``.
 
 **Note**: The acceptance tests can *not* currently run in parallel.
+
+
+Testing internationalization with dummy translations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any text you add to the platform should be internationalized. To generate
+translations for your new strings, run the following command.
+
+::
+
+    paver i18n_dummy
+
+This command generates dummy translations for each dummy language in the
+platform and puts the dummy strings in the appropriate language files.
+You can then preview the dummy languages on your local machine and also in
+your sandbox, if and when you create one.
+
+The dummy language files that are generated during this process can be
+found in the following locations.
+
+::
+
+    conf/locale/{LANG_CODE}
+
+There are a few JavaScript files that are generated from this process. You
+can find those in the following locations.
+
+::
+
+    lms/static/js/i18n/{LANG_CODE}
+    cms/static/js/i18n/{LANG_CODE}
+
+Do not commit the ``.po``, ``.mo``, ``.js`` files that are generated
+in the above locations during the dummy translation process!
+
 
 Debugging Acceptance Tests on Vagrant
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I recently spent way too much time trying to figure out why local i18n wasn't working for newly added strings, only to learn there was no documentation on this new process. I decided to include testing i18n to the testing guide so everything is in one place. If this should reside elsewhere, I'm open to locations.
## Reviewers
- [x] @dianakhuang 
- [x] @catong 
- [x] @benpatterson 
