### PR TITLE
Enable Azure AD third party auth provider by default

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/test_azuread.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_azuread.py
@@ -1,0 +1,46 @@
+"""Integration tests for Azure Active Directory / Microsoft Account provider."""
+
+from third_party_auth.tests.specs import base
+
+
+# pylint: disable=test-inherits-tests
+class AzureADOauth2IntegrationTest(base.Oauth2IntegrationTest):
+    """Integration tests for Azure Active Directory / Microsoft Account provider."""
+
+    def setUp(self):
+        super(AzureADOauth2IntegrationTest, self).setUp()
+        self.provider = self.configure_azure_ad_provider(
+            enabled=True,
+            key='azure_ad_oauth2_key',
+            secret='azure_ad_oauth2_secret',
+        )
+
+    TOKEN_RESPONSE_DATA = {
+        'exp': 1234590302,
+        'nbf': 1234586402,
+        'iat': 1234586402,
+        'expires_on': '1234590302',
+        'ver': '1.0',
+        'access_token': 'access_token_value',
+        'expires_in': '3599',
+        'id_token': 'id_token_value',
+        'token_type': 'Bearer',
+        'refresh_token': 'REFRESH1234567890',
+        'iss': 'https://sts.windows.net/abcdefgh-1234-5678-900a-0aa0a00aa0aa/',
+        'ipaddr': '123.123.123.123',
+    }
+    USER_RESPONSE_DATA = {
+        'oid': 'abcdefgh-1234-5678-900a-0aa0a00aa0aa',
+        'aud': 'abcdefgh-1234-5678-900a-0aa0a00aa0aa',
+        'tid': 'abcdefgh-1234-5678-900a-0aa0a00aa0aa',
+        'amr': ['pwd'],
+        'unique_name': 'email_value@example.com',
+        'upn': 'email_value@example.com',
+        'family_name': 'family_name_value',
+        'name': 'name_value',
+        'given_name': 'given_name_value',
+        'sub': 'aBC_ab12345678h94CSgP1lTYJCHATGQDAcfg8jSOck',
+    }
+
+    def get_username(self):
+        return self.get_response_data().get('name')

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -113,6 +113,16 @@ class ThirdPartyAuthTestMixin(object):
         return cls.configure_oauth_provider(**kwargs)
 
     @classmethod
+    def configure_azure_ad_provider(cls, **kwargs):
+        """ Update the settings for the Azure AD third party auth provider/backend """
+        kwargs.setdefault("name", "Azure AD")
+        kwargs.setdefault("backend_name", "azuread-oauth2")
+        kwargs.setdefault("icon_class", "fa-azuread")
+        kwargs.setdefault("key", "test")
+        kwargs.setdefault("secret", "test")
+        return cls.configure_oauth_provider(**kwargs)
+
+    @classmethod
     def configure_twitter_provider(cls, **kwargs):
         """ Update the settings for the Twitter third party auth provider/backend """
         kwargs.setdefault("name", "Twitter")

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -576,6 +576,7 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
             'social.backends.google.GoogleOAuth2',
             'social.backends.linkedin.LinkedinOAuth2',
             'social.backends.facebook.FacebookOAuth2',
+            'social.backends.azuread.AzureADOAuth2',
             'third_party_auth.saml.SAMLAuthBackend',
             'third_party_auth.lti.LTIAuthBackend',
         ]) + list(AUTHENTICATION_BACKENDS)

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -265,6 +265,7 @@ AUTHENTICATION_BACKENDS = (
     'social.backends.google.GoogleOAuth2',
     'social.backends.linkedin.LinkedinOAuth2',
     'social.backends.facebook.FacebookOAuth2',
+    'social.backends.azuread.AzureADOAuth2',
     'social.backends.twitter.TwitterOAuth',
     'third_party_auth.dummy.DummyBackend',
     'third_party_auth.saml.SAMLAuthBackend',


### PR DESCRIPTION
This is a simple PR to add the "Azure AD" (Active Directory) OAuth2 third party auth provider to the default provider whitelist.

The provider code was contributed to the python-social-auth project by Microsoft last year.

The result of this PR is that Open edX instances which wish to use an Active Directory based login provider can do so without needing to customize the `THIRD_PARTY_AUTH_BACKENDS` ansible variable / edxapp env configuration setting.

**Sandbox**
http://pr11984.sandbox.opencraft.com/login

**Test Instructions**
1. Open http://pr11984.sandbox.opencraft.com/login in an incognito window
2. Sign in using the email address "test1@opencraftssotest.onmicrosoft.com" and the password you can get privately from Braden (other types of accounts may not be able to login as this is not yet enabled as a "multi tenant" Azure AD app)

**Settings**

``` yaml
EDXAPP_ENABLE_THIRD_PARTY_AUTH: true
EDXAPP_FEATURES:
    ENABLE_COMBINED_LOGIN_REGISTRATION: true
    ENABLE_THIRD_PARTY_AUTH: true
disable_edx_services: true
```
