### PR TITLE
asadiqbal08/WL-388: Add ModuleI18nService for Descriptor System

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -22,6 +22,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from mock import Mock
 from opaque_keys.edx.locator import CourseKey, LibraryLocator
 from openedx.core.djangoapps.content.course_structures.tests import SignalDisconnectTestMixin
+from xblock_django.user_service import DjangoXBlockUserService
 
 
 class LibraryTestCase(ModuleStoreTestCase):
@@ -83,9 +84,8 @@ class LibraryTestCase(ModuleStoreTestCase):
         of a LibraryContent block
         """
         if 'user' not in lib_content_block.runtime._services:  # pylint: disable=protected-access
-            mocked_user_service = Mock(user_id=self.user.id)
-            mocked_user_service.get_current_user.return_value = XBlockUser(is_current_user=True)
-            lib_content_block.runtime._services['user'] = mocked_user_service  # pylint: disable=protected-access
+            user_service = DjangoXBlockUserService(self.user)
+            lib_content_block.runtime._services['user'] = user_service  # pylint: disable=protected-access
 
         handler_url = reverse_usage_url(
             'component_handler',

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -204,7 +204,7 @@ def create_modulestore_instance(
         xblock_field_data_wrappers=xblock_field_data_wrappers,
         disabled_xblock_types=disabled_xblock_types,
         doc_store_config=doc_store_config,
-        i18n_service=i18n_service or ModuleI18nService(),
+        i18n_service=i18n_service or ModuleI18nService,
         fs_service=fs_service or xblock.reference.plugins.FSService(),
         user_service=user_service or xb_user_service,
         signal_handler=signal_handler or SignalHandler(class_),
@@ -274,7 +274,8 @@ class ModuleI18nService(object):
         """
         self.translator = django.utils.translation
         if block:
-            xblock_resource = block.unmixed_class.__module__
+            xblock_class = getattr(block, 'unmixed_class', block.__class__)
+            xblock_resource = xblock_class.__module__
             xblock_locale_dir = '/translations'
             xblock_locale_path = resource_filename(xblock_resource, xblock_locale_dir)
             xblock_domain = 'text'

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1494,6 +1494,28 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):
         # A stub publish method that doesn't emit any events from XModuleDescriptors.
         pass
 
+    def service(self, block, service_name):
+        """
+        Runtime-specific override for the XBlock service manager.  If a service is not currently
+        instantiated and is declared as a critical requirement, an attempt is made to load the
+        module.
+
+        Arguments:
+            block (an XBlock): this block's class will be examined for service
+                decorators.
+            service_name (string): the name of the service requested.
+
+        Returns:
+            An object implementing the requested service, or None.
+        """
+        # getting the service from parent module. making sure of block service declarations.
+        service = super(DescriptorSystem, self).service(block=block, service_name=service_name)
+        # Passing the block to service if it is callable e.g. ModuleI18nService. It is the responsibility of calling
+        # service to handle the passing argument.
+        if callable(service):
+            return service(block)
+        return service
+
 
 new_contract('DescriptorSystem', DescriptorSystem)
 


### PR DESCRIPTION
@mattdrayer @cpennington 
Today I was working on a XBlock Translation and I was seeing that xblock runtime in `studio_view` is utilizing the `DescriptorSystem` instead of `ModuleSystem` due to that Modulei18nService in django.py was not loading when we click on `Edit` button in XBlock e.g. drag and drop , poll etc etc 
in simple words I was getting the hit to [self._descriptor_system.service](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/x_module.py#L1883)

Please share your thoughts on this PR, May be I am missing something as `x_module.py` has a lot of logics to understand ...
