### PR TITLE
Fixed 500 error in case of user's profile not found when login/logout with CAS.

### DIFF
--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -478,9 +478,10 @@ def cas_login(request, next_page=None, required=False):
 
     if request.user.is_authenticated():
         user = request.user
-        if not UserProfile.objects.filter(user=user):
-            user_profile = UserProfile(name=user.username, user=user)
-            user_profile.save()
+        UserProfile.objects.get_or_create(
+            user=user,
+            defaults={'name': user.username}
+        )
 
     return ret
 

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1799,7 +1799,12 @@ def enforce_single_login(sender, request, user, signal, **kwargs):    # pylint: 
         else:
             key = None
         if user:
-            user.profile.set_login_session(key)
+            user_profile, __ = UserProfile.objects.get_or_create(
+                user=user,
+                defaults={'name': user.username}
+            )
+            if user_profile:
+                user.profile.set_login_session(key)
 
 
 class DashboardConfiguration(ConfigurationModel):

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -273,6 +273,48 @@ class LoginTest(TestCase):
         self.assertEqual(response.status_code, 302)
 
     @patch.dict("django.conf.settings.FEATURES", {'PREVENT_CONCURRENT_LOGINS': True})
+    def test_single_session_with_no_user_profile(self):
+        """
+        Assert that user login with cas (Central Authentication Service) is
+        redirect to dashboard in case of lms or upload_transcripts in case of
+        cms
+        """
+        user = UserFactory.build(username='tester', email='tester@edx.org')
+        user.set_password('test_password')
+        user.save()
+
+        # Assert that no profile is created.
+        self.assertFalse(hasattr(user, 'profile'))
+
+        creds = {'email': 'tester@edx.org', 'password': 'test_password'}
+        client1 = Client()
+        client2 = Client()
+
+        response = client1.post(self.url, creds)
+        self._assert_response(response, success=True)
+
+        # Reload the user from the database
+        user = User.objects.get(pk=user.pk)
+
+        # Assert that profile is created.
+        self.assertTrue(hasattr(user, 'profile'))
+
+        # second login should log out the first
+        response = client2.post(self.url, creds)
+        self._assert_response(response, success=True)
+
+        try:
+            # this test can be run with either lms or studio settings
+            # since studio does not have a dashboard url, we should
+            # look for another url that is login_required, in that case
+            url = reverse('dashboard')
+        except NoReverseMatch:
+            url = reverse('upload_transcripts')
+        response = client1.get(url)
+        # client1 will be logged out
+        self.assertEqual(response.status_code, 302)
+
+    @patch.dict("django.conf.settings.FEATURES", {'PREVENT_CONCURRENT_LOGINS': True})
     def test_single_session_with_url_not_having_login_required_decorator(self):
         # accessing logout url as it does not have login-required decorator it will avoid redirect
         # and go inside the enforce_single_login


### PR DESCRIPTION
### Background

fixes  https://github.com/mitocw/edx-platform/issues/102
### What is done in this PR

**Studio Updates:** None.
**LMS Updates:** None.
**Common Updates:**  Fixed issue where `enforce_single_login` was throwing exception in case profile is not created.

There was an [exception](https://gist.github.com/pdpinch/bd2e626df27a0ccad194#file-gistfile1-txt-L16) because of user's profile was not created on the time of login int edX platform using cas for first time.

@pdpinch @bdero 
