### PR TITLE
Staff should be able to masquerade when previewing content.

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -742,7 +742,7 @@ def _has_access_to_course(user, access_level, course_key):
         debug("Deny: no user or anon user")
         return ACCESS_DENIED
 
-    if is_masquerading_as_student(user, course_key):
+    if not in_preview_mode() and is_masquerading_as_student(user, course_key):
         return ACCESS_DENIED
 
     if GlobalStaff().has_user(user):

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -278,6 +278,16 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         self.assertFalse(bool(access.has_access(self.student, 'staff', self.course, course_key=self.course.id)))
         self.assertFalse(bool(access.has_access(self.student, 'load', self.course, course_key=self.course.id)))
 
+        # User should be able to preview when masquerade.
+        with patch('courseware.access.is_masquerading_as_student') as mock_masquerade:
+            mock_masquerade.return_value = True
+            self.assertTrue(
+                bool(access.has_access(self.global_staff, 'staff', self.course, course_key=self.course.id))
+            )
+            self.assertFalse(
+                bool(access.has_access(self.student, 'staff', self.course, course_key=self.course.id))
+            )
+
     def test_has_access_to_course(self):
         self.assertFalse(access._has_access_to_course(
             None, 'staff', self.course.id


### PR DESCRIPTION
The purpose of this PR is to fix the masquerade functionality when staff is previewing content. This was broken after we enabled the preview content only for staff.

https://openedx.atlassian.net/browse/TNL-4291
