### PR TITLE
ECOM-3673 Update the course end date description text to remove the reference to certificates

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -182,7 +182,11 @@ class CourseEndDate(DateSummary):
     @property
     def description(self):
         if datetime.now(pytz.UTC) <= self.date:
-            return _('To earn a certificate, you must complete all requirements before this date.')
+            mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
+            if is_active and CourseMode.is_eligible_for_certificate(mode):
+                return _('To earn a certificate, you must complete all requirements before this date.')
+            else:
+                return _('After this date, course content will be archived.')
         return _('This course is archived, which means you can review course content but it is no longer active.')
 
     @property

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -173,12 +173,20 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
 
     ## CourseEndDate
 
-    def test_course_end_date_during_course(self):
+    def test_course_end_date_for_certificate_eligible_mode(self):
         self.setup_course_and_user(days_till_start=-1)
         block = CourseEndDate(self.course, self.user)
         self.assertEqual(
             block.description,
             'To earn a certificate, you must complete all requirements before this date.'
+        )
+
+    def test_course_end_date_for_non_certificate_eligible_mode(self):
+        self.setup_course_and_user(days_till_start=-1, enrollment_mode=CourseMode.AUDIT)
+        block = CourseEndDate(self.course, self.user)
+        self.assertEqual(
+            block.description,
+            'After this date, course content will be archived.'
         )
 
     def test_course_end_date_after_course(self):


### PR DESCRIPTION
Tested:
Make sure the audit course have the end_date description changed
