### PR TITLE
Derive list of programs in which a user is engaged

### DIFF
--- a/lms/djangoapps/learner_dashboard/views.py
+++ b/lms/djangoapps/learner_dashboard/views.py
@@ -1,8 +1,4 @@
-"""
-Handles requests for views, returning page frame
-"""
-
-import logging
+"""New learner dashboard views."""
 from urlparse import urljoin
 
 from django.conf import settings
@@ -11,39 +7,30 @@ from django.views.decorators.http import require_GET
 from django.http import Http404
 
 from edxmako.shortcuts import render_to_response
-from openedx.core.djangoapps.programs.utils import get_user_enrolled_programs
+from openedx.core.djangoapps.programs.utils import get_engaged_programs
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from student.views import get_course_enrollments
-
-
-log = logging.getLogger(__name__)
-
-
-def _get_xseries_url():
-    '''Create the xseries advertising link url'''
-    xseries_url = None
-    if ProgramsApiConfig.current().show_xseries_ad:
-        xseries_url = urljoin(settings.MKTG_URLS.get('ROOT'), 'xseries')
-    return xseries_url
 
 
 @login_required
 @require_GET
 def view_programs(request):
-    '''
-    This is the view to see all the programs the learner has been enrolled in
-    '''
+    """View programs in which the user is engaged."""
     if not ProgramsApiConfig.current().is_student_dashboard_enabled:
-        raise Http404("learner dashboard not enabled")
+        raise Http404
 
-    course_enrollments = list(get_course_enrollments(request.user, None, []))
+    enrollments = list(get_course_enrollments(request.user, None, []))
+    programs = get_engaged_programs(request.user, enrollments)
 
-    programs = get_user_enrolled_programs(
-        request.user,
-        [enrollment.course_id for enrollment in course_enrollments]
-    )
+    # TODO: Pull 'xseries' string from configuration model.
+    marketing_root = urljoin(settings.MKTG_URLS.get('ROOT'), 'xseries').strip('/')
+    for program in programs:
+        program['marketing_url'] = '{root}/{slug}'.format(
+            root=marketing_root,
+            slug=program['marketing_slug']
+        )
 
     return render_to_response('learner_dashboard/programs.html', {
         'programs': programs,
-        'xseries_url': _get_xseries_url()
+        'xseries_url': marketing_root if ProgramsApiConfig.current().show_xseries_ad else None
     })

--- a/openedx/core/djangoapps/credentials/tests/test_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_utils.py
@@ -94,7 +94,7 @@ class TestCredentialsRetrieval(ProgramsApiConfigMixin, CredentialsApiConfigMixin
         self.mock_credentials_api(self.user, reset_url=False)
 
         actual = get_user_program_credentials(self.user)
-        expected = self.PROGRAMS_API_RESPONSE['results']
+        expected = self.PROGRAMS_API_RESPONSE['results'][:2]
         expected[0]['credential_url'] = self.PROGRAMS_CREDENTIALS_DATA[0]['certificate_url']
         expected[1]['credential_url'] = self.PROGRAMS_CREDENTIALS_DATA[1]['certificate_url']
 

--- a/openedx/core/djangoapps/programs/tests/mixins.py
+++ b/openedx/core/djangoapps/programs/tests/mixins.py
@@ -36,6 +36,7 @@ class ProgramsDataMixin(object):
     PROGRAM_NAMES = [
         'Test Program A',
         'Test Program B',
+        'Test Program C',
     ]
 
     COURSE_KEYS = [
@@ -49,6 +50,7 @@ class ProgramsDataMixin(object):
         'organization-b/course-d/winter',
     ]
 
+    # TODO: Use factory-boy.
     PROGRAMS_API_RESPONSE = {
         'results': [
             {
@@ -170,6 +172,41 @@ class ProgramsDataMixin(object):
                                 'start_date': '2015-11-05T07:39:02.791741Z',
                                 'run_key': 'fall'
                             },
+                            {
+                                'course_key': COURSE_KEYS[7],
+                                'mode_slug': 'verified',
+                                'sku': '',
+                                'start_date': '2015-11-05T07:39:02.791741Z',
+                                'run_key': 'winter'
+                            }
+                        ]
+                    }
+                ],
+                'created': '2015-10-26T19:59:03.064000Z',
+                'modified': '2015-10-26T19:59:18.536000Z'
+            },
+            {
+                'id': 3,
+                'name': PROGRAM_NAMES[2],
+                'subtitle': 'A third program used for testing purposes',
+                'category': 'xseries',
+                'status': 'unpublished',
+                'marketing_slug': '{}_test_url'.format(PROGRAM_NAMES[2].replace(' ', '_')),
+                'organizations': [
+                    {
+                        'display_name': 'Test Organization B',
+                        'key': 'organization-b'
+                    }
+                ],
+                'course_codes': [
+                    {
+                        'display_name': 'Test Course D',
+                        'key': 'course-d',
+                        'organization': {
+                            'display_name': 'Test Organization B',
+                            'key': 'organization-b'
+                        },
+                        'run_modes': [
                             {
                                 'course_key': COURSE_KEYS[7],
                                 'mode_slug': 'verified',


### PR DESCRIPTION
@schenedx @jimabramson this adds a refined helper method which can be used to derive a list of programs in which the given user is engaged, sorted by most recent enrollment. I've separated XSeries-specific concerns from this method and concentrated them in the view.

Note that the base of this PR is @schenedx's feature branch, not master.
