### PR TITLE
Update developer links to point directly to Confluence pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,9 @@ install edX:
    existing Ubuntu 12.04 server.
 
 .. _configuration repo: https://github.com/edx/configuration
-.. _edX Developer Stack: https://github.com/edx/configuration/wiki/edX-Developer-Stack
-.. _edX Full Stack: https://github.com/edx/configuration/wiki/edX-Full-Stack
-.. _edX Ubuntu 12.04 64-bit Installation: https://github.com/edx/configuration/wiki/edX-Ubuntu-12.04-64-bit-Installation
+.. _edX Developer Stack: https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Devstack
+.. _edX Full Stack: https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Fullstack
+.. _edX Ubuntu 12.04 64-bit Installation: https://openedx.atlassian.net/wiki/display/OpenOPS/Native+Open+edX+Ubuntu+12.04+64+bit+Installation
 
 
 License


### PR DESCRIPTION
Hello!

I can't quite tell, but it looks like this is the proper way to update the README doc (as opposed to https://github.com/edx/edx-documentation#contribute-to-edx-documentation), but apologies if this is the wrong path.

The current links point to deprecated pages, so it takes two clicks to get to the pages for developers finding the README and looking for install instructions.  This updates it to link directly to the Confluence pages.

@catong From the JIRA board, looks like you'd best be able to help review?  Thanks!
