### PR TITLE
Show location in the settings xblock.

### DIFF
--- a/cms/static/js/views/metadata.js
+++ b/cms/static/js/views/metadata.js
@@ -20,7 +20,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
                 courseKey = self.$el.closest('[data-course-key]').data('course-key');
 
             this.template = this.loadTemplate('metadata-editor');
-            this.$el.html(this.template({numEntries: this.collection.length}));
+            this.$el.html(this.template({numEntries: this.collection.length, locator: locator}));
 
             this.collection.each(
                 function (model) {

--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -599,7 +599,7 @@
       }
     }
 
-    .wrapper-comp-setting {
+    .wrapper-comp-setting, .wrapper-comp-setting-text {
       min-width: 300px;
       top: 0;
       vertical-align: top;
@@ -701,6 +701,11 @@
       font-color: $gray-l6;
       min-width: ($baseline*10);
       vertical-align: top;
+    }
+
+    .setting-text {
+      display: inline;
+      white-space: nowrap;
     }
 
 

--- a/cms/templates/js/metadata-editor.underscore
+++ b/cms/templates/js/metadata-editor.underscore
@@ -3,4 +3,10 @@
     <li class="field comp-setting-entry metadata_entry">
     </li>
     <% }) %>
+    <li class="field comp-setting-entry metadata_entry">
+        <div class="wrapper-comp-setting-text">
+            <label class="label setting-label"><%- gettext("Location ID") %></label>
+            <span class="setting-text"><%- locator %></span>
+        </div>
+    </li>
 </ul>

--- a/cms/templates/js/metadata-editor.underscore
+++ b/cms/templates/js/metadata-editor.underscore
@@ -5,7 +5,7 @@
     <% }) %>
     <li class="field comp-setting-entry metadata_entry">
         <div class="wrapper-comp-setting-text">
-            <label class="label setting-label"><%- gettext("Location ID") %></label>
+            <label class="label setting-label"><%- gettext("Component Location ID") %></label>
             <span class="setting-text"><%- locator %></span>
         </div>
     </li>


### PR DESCRIPTION
Background: 
Review of xblock location is enabled. Field "display_block_location" is added to course settings; this is a field visibility of xblock location depends on. This functionality is an important part of [Conditional Mode](https://github.com/edx/edx-platform/pull/11710) editing 

Studio Updates: 
The next file is modified: common/lib/xmodule/xmodule/course_module.py, common/lib/xmodule/xmodule/x_module.py.
The new tests are added common/test/acceptance/tests/studio/test_studio_container.py, common/lib/xmodule/xmodule/tests/test_course_module.py. 
For new functionality, the next tests are corrected: common/lib/xmodule/xmodule/tests/test_editing_module.py, common/lib/xmodule/xmodule/tests/test_split_test_module.py, common/lib/xmodule/xmodule/tests/test_xml_module.py, common/test/acceptance/pages/studio/settings_advanced.py, lms/djangoapps/courseware/tests/test_video_mongo.py.

LMS Updates: None

![img 1](https://dl.dropboxusercontent.com/u/28163465/location_2.png)

![img 2](https://dl.dropboxusercontent.com/u/28163465/location_1.png)
