### PR TITLE
Hide Verification Upgrade Deadline when user have paid

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -398,7 +398,7 @@ class CourseMode(models.Model):
 
     @classmethod
     def has_verified_mode(cls, course_mode_dict):
-        """Check whether the modes for a course allow a student to pursue a verfied certificate.
+        """Check whether the modes for a course allow a student to pursue a verified certificate.
 
         Args:
             course_mode_dict (dictionary mapping course mode slugs to Modes)

--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -217,6 +217,27 @@ class VerifiedUpgradeDeadlineDate(DateSummary):
             return ecommerce_service.checkout_page_url(course_mode.sku)
         return reverse('verify_student_upgrade_and_verify', args=(self.course.id,))
 
+    @property
+    def is_enabled(self):
+        """
+        Whether or not this summary block should be shown.
+
+        By default, the summary is only shown if it has date and the date is in the
+        future and the user's enrollment is in upsell modes
+        """
+        is_enabled = super(VerifiedUpgradeDeadlineDate, self).is_enabled
+        if not is_enabled:
+            return False
+
+        enrollment_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
+
+        # Return `true` if user is not enrolled in course
+        if enrollment_mode is None and is_active is None:
+            return True
+
+        # Show the summary if user enrollment is in which allow user to upsell
+        return is_active and enrollment_mode in CourseMode.UPSELL_TO_VERIFIED_MODES
+
     @lazy
     def date(self):
         try:

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -42,7 +42,9 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
             days_till_start=1,
             days_till_end=14,
             days_till_upgrade_deadline=4,
+            enroll_user=True,
             enrollment_mode=CourseMode.VERIFIED,
+            course_min_price=100,
             days_till_verification_deadline=14,
             verification_status=None,
             sku=None
@@ -64,11 +66,13 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
                 course_id=self.course.id,
                 mode_slug=enrollment_mode,
                 expiration_datetime=now + timedelta(days=days_till_upgrade_deadline),
+                min_price=course_min_price,
                 sku=sku
             )
+
+        if enroll_user:
+            enrollment_mode = enrollment_mode or CourseMode.DEFAULT_MODE_SLUG
             CourseEnrollmentFactory.create(course_id=self.course.id, user=self.user, mode=enrollment_mode)
-        else:
-            CourseEnrollmentFactory.create(course_id=self.course.id, user=self.user)
 
         if days_till_verification_deadline is not None:
             VerificationDeadline.objects.create(
@@ -95,21 +99,36 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         self.assertEqual(set(type(b) for b in blocks), set(expected_blocks))
 
     @ddt.data(
-        # Before course starts
-        ({}, (CourseEndDate, CourseStartDate, TodaysDate, VerificationDeadlineDate, VerifiedUpgradeDeadlineDate)),
-        # After course end
+        # Verified enrollment with no photo-verification before course start
+        ({}, (CourseEndDate, CourseStartDate, TodaysDate, VerificationDeadlineDate)),
+        # Verified enrollment with `approved` photo-verification after course end
         ({'days_till_start': -10,
           'days_till_end': -5,
           'days_till_upgrade_deadline': -6,
           'days_till_verification_deadline': -5,
           'verification_status': 'approved'},
          (TodaysDate, CourseEndDate)),
-        # No course end date
+        # Verified enrollment with `expired` photo-verification during course run
+        ({'days_till_start': -10,
+          'verification_status': 'expired'},
+         (TodaysDate, CourseEndDate, VerificationDeadlineDate)),
+        # Verified enrollment with `approved` photo-verification during course run
+        ({'days_till_start': -10,
+          'verification_status': 'approved'},
+         (TodaysDate, CourseEndDate)),
+        # Audit enrollment and non-upsell course.
+        ({'days_till_start': -10,
+          'days_till_upgrade_deadline': None,
+          'days_till_verification_deadline': None,
+          'course_min_price': 0,
+          'enrollment_mode': CourseMode.AUDIT},
+         (TodaysDate, CourseEndDate)),
+        # Verified enrollment with *NO* course end date
         ({'days_till_end': None},
-         (CourseStartDate, TodaysDate, VerificationDeadlineDate, VerifiedUpgradeDeadlineDate)),
-        # During course run
+         (CourseStartDate, TodaysDate, VerificationDeadlineDate)),
+        # Verified enrollment with no photo-verification during course run
         ({'days_till_start': -1},
-         (TodaysDate, CourseEndDate, VerificationDeadlineDate, VerifiedUpgradeDeadlineDate)),
+         (TodaysDate, CourseEndDate, VerificationDeadlineDate)),
         # Verification approved
         ({'days_till_start': -10,
           'days_till_upgrade_deadline': -1,
@@ -117,13 +136,26 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
           'verification_status': 'approved'},
          (TodaysDate, CourseEndDate)),
         # After upgrade deadline
-        ({'days_till_start': -10, 'days_till_upgrade_deadline': -1},
+        ({'days_till_start': -10,
+          'days_till_upgrade_deadline': -1},
          (TodaysDate, CourseEndDate, VerificationDeadlineDate)),
         # After verification deadline
         ({'days_till_start': -10,
           'days_till_upgrade_deadline': -2,
           'days_till_verification_deadline': -1},
-         (TodaysDate, CourseEndDate, VerificationDeadlineDate))
+         (TodaysDate, CourseEndDate, VerificationDeadlineDate)),
+        # Un-enrolled user before course start
+        ({'enroll_user': False},
+         (CourseStartDate, TodaysDate, CourseEndDate, VerifiedUpgradeDeadlineDate)),
+        # Un-enrolled user during course run
+        ({'days_till_start': -1,
+          'enroll_user': False},
+         (TodaysDate, CourseEndDate, VerifiedUpgradeDeadlineDate)),
+        # Un-enrolled user after course end.
+        ({'enroll_user': False,
+          'days_till_start': -10,
+          'days_till_end': -5},
+         (TodaysDate, CourseEndDate, VerifiedUpgradeDeadlineDate)),
     )
     @ddt.unpack
     def test_enabled_block_types(self, course_options, expected_blocks):


### PR DESCRIPTION
Student pays to upgrade to the verified track. Student is then should not prompted to pay again on the course info page.

[ECOM-3976](https://openedx.atlassian.net/browse/ECOM-3976)
