### PR TITLE
TNL-4236 – Check for video transcripts before using it

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -741,6 +741,15 @@ class VideoExportTestCase(VideoDescriptorTestBase):
         expected = '<video url_name="SampleProblem" download_video="false"/>\n'
         self.assertEquals(expected, etree.tostring(xml, pretty_print=True))
 
+    def test_export_to_xml_with_transcripts_as_none(self):
+        """
+        Test XML export with transcripts being overridden to None.
+        """
+        self.descriptor.transcripts = None
+        xml = self.descriptor.definition_to_xml(None)
+        expected = '<video url_name="SampleProblem" download_video="false"/>\n'
+        self.assertEquals(expected, etree.tostring(xml, pretty_print=True))
+
 
 class VideoDescriptorIndexingTestCase(unittest.TestCase):
     """

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -573,12 +573,13 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
             ele.set('src', self.handout)
             xml.append(ele)
 
-        # sorting for easy testing of resulting xml
-        for transcript_language in sorted(self.transcripts.keys()):
-            ele = etree.Element('transcript')
-            ele.set('language', transcript_language)
-            ele.set('src', self.transcripts[transcript_language])
-            xml.append(ele)
+        if self.transcripts is not None:
+            # sorting for easy testing of resulting xml
+            for transcript_language in sorted(self.transcripts.keys()):
+                ele = etree.Element('transcript')
+                ele.set('language', transcript_language)
+                ele.set('src', self.transcripts[transcript_language])
+                xml.append(ele)
 
         if self.edx_video_id and edxval_api:
             try:


### PR DESCRIPTION
[TNL-4236](https://openedx.atlassian.net/browse/TNL-4236)
## Background

In video module, `self.transcripts` field was expected to be a dictionary while converting video module to corresponding xml. In a course, `self.transcripts` was overridden to `None` and `definition_to_xml` module (who was responsible for xml conversion of video module) was crashing thereby staff was unable to get this course exported. 
## Fix

I've added extra check on `self.transcripts` in `definition_to_xml` module, test for the corresponding fix has been added as well.
## Review
- [x] @Shrhawk 
- [x] @mushtaqak 

FYI @adampalay 

Thanks!
