### PR TITLE
[PERF-274] Add NewRelic instrumentation to contentserver.

### DIFF
--- a/common/djangoapps/contentserver/admin.py
+++ b/common/djangoapps/contentserver/admin.py
@@ -4,7 +4,7 @@ that gets used when sending cachability headers back with request course assets.
 """
 from django.contrib import admin
 from config_models.admin import ConfigurationModelAdmin
-from .models import CourseAssetCacheTtlConfig
+from .models import CourseAssetCacheTtlConfig, CdnUserAgentsConfig
 
 
 class CourseAssetCacheTtlConfigAdmin(ConfigurationModelAdmin):
@@ -26,4 +26,24 @@ class CourseAssetCacheTtlConfigAdmin(ConfigurationModelAdmin):
         return self.list_display
 
 
+class CdnUserAgentsConfigAdmin(ConfigurationModelAdmin):
+    """
+    Basic configuration for CDN user agent whitelist.
+    """
+    list_display = [
+        'cdn_user_agents'
+    ]
+
+    def get_list_display(self, request):
+        """
+        Restore default list_display behavior.
+
+        ConfigurationModelAdmin overrides this, but in a way that doesn't
+        respect the ordering. This lets us customize it the usual Django admin
+        way.
+        """
+        return self.list_display
+
+
 admin.site.register(CourseAssetCacheTtlConfig, CourseAssetCacheTtlConfigAdmin)
+admin.site.register(CdnUserAgentsConfig, CdnUserAgentsConfigAdmin)

--- a/common/djangoapps/contentserver/migrations/0002_cdnuseragentsconfig.py
+++ b/common/djangoapps/contentserver/migrations/0002_cdnuseragentsconfig.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('contentserver', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CdnUserAgentsConfig',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
+                ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
+                ('cdn_user_agents', models.TextField(default=b'Amazon CloudFront', help_text=b'A newline-separated list of user agents that should be considered CDNs.')),
+                ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
+            ],
+        ),
+    ]

--- a/common/djangoapps/contentserver/models.py
+++ b/common/djangoapps/contentserver/models.py
@@ -2,7 +2,7 @@
 Models for contentserver
 """
 
-from django.db.models.fields import PositiveIntegerField
+from django.db.models.fields import PositiveIntegerField, TextField
 from config_models.models import ConfigurationModel
 
 
@@ -24,6 +24,29 @@ class CourseAssetCacheTtlConfig(ConfigurationModel):
 
     def __repr__(self):
         return '<CourseAssetCacheTtlConfig(cache_ttl={})>'.format(self.get_cache_ttl())
+
+    def __unicode__(self):
+        return unicode(repr(self))
+
+
+class CdnUserAgentsConfig(ConfigurationModel):
+    """Configuration for the user agents we expect to see from CDNs."""
+
+    class Meta(object):
+        app_label = 'contentserver'
+
+    cdn_user_agents = TextField(
+        default='Amazon CloudFront',
+        help_text="A newline-separated list of user agents that should be considered CDNs."
+    )
+
+    @classmethod
+    def get_cdn_user_agents(cls):
+        """Gets the list of CDN user agents, if present"""
+        return cls.current().cdn_user_agents
+
+    def __repr__(self):
+        return '<WhitelistedCdnConfig(cdn_user_agents={})>'.format(self.get_cdn_user_agents())
 
     def __unicode__(self):
         return unicode(repr(self))


### PR DESCRIPTION
This includes the course key/path for a given contentserver request, whether or not the asset is locked, cacheable, has been modified, etc.

This should give us some better insight as to what sort of requests are coming into the contentserver to figure out whether or use of a CDN in front of these assets is as efficient as effective as it could be.
