### PR TITLE
Add finished() metric for login and registration.

### DIFF
--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -13,6 +13,14 @@
     <%static:require_module module_name="js/student_account/logistration_factory" class_name="LogistrationFactory">
         var options = ${data | n, dump_js_escaped_json};
         LogistrationFactory(options);
+        if ('newrelic' in window) {
+            newrelic.finished();
+            // Because of a New Relic bug, the finished() event doesn't show up
+            // in Insights, so we have to make a new PageAction that is basically
+            // the same thing. We still want newrelic.finished() for session
+            // traces though.
+            newrelic.addPageAction('xfinished');
+        }
     </%static:require_module>
 </%block>
 


### PR DESCRIPTION
Call New Relic's finished() event marker to measure when the login and registration pages actually become usable. This is important because the pageLoad event can be distorted by analytics and marketing tools that trigger after the page looks complete to the user.

Note: The "xfinished" PageAction is there to work around a New Relic bug where "finished" events weren't making it into Insights. The reason we have both is because finished() _does_ still show up in session traces.

[PERF-298]

@tobz, @benpatterson: Got a workaround, verified the measurements on my sandbox against browser filmstrip measurements.
