### PR TITLE
Fix broken import due to merging oauth changes to master

### DIFF
--- a/lms/djangoapps/learner_dashboard/tests/test_programs.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_programs.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.test import override_settings
-from oauth2_provider.tests.factories import ClientFactory
+from edx_oauth2_provider.tests.factories import ClientFactory
 from opaque_keys.edx import locator
 from provider.constants import CONFIDENTIAL
 


### PR DESCRIPTION
@benpatterson @sanfordstudent 
There was an import of a library whose name had changed (oauth2_provider -> edx_oauth2_provider).  There's a new oauth2_provider library, which has a couple imports, but no other attempts to import from the old one by the old name.  

I was able to replicate the error message from [jenkins](https://build.testeng.edx.org/job/edx-platform-python-unittests-master/2997/testReport/junit/nose.failure/Failure/runTest/) locally, and then fix it with this patch.
