### PR TITLE
Decreased the flakiness of upload_tar function

### DIFF
--- a/common/test/acceptance/pages/studio/import_export.py
+++ b/common/test/acceptance/pages/studio/import_export.py
@@ -178,7 +178,15 @@ class ImportMixin(object):
         asset_file_path = self.file_path(tarball_filename)
         # Make the upload elements visible to the WebDriver.
         self.browser.execute_script('$(".file-name-block").show();$(".file-input").show()')
+        # Upload the file.
         self.q(css='input[type="file"]')[0].send_keys(asset_file_path)
+        # Upload the same file again. Reason behind this is to decrease the
+        # probability or fraction of times the failure occur. Please be
+        # noted this doesn't eradicate the root cause of the error, it
+        # just decreases to failure rate to minimal.
+        # Jira ticket reference: TNL-4191.
+        self.q(css='input[type="file"]')[0].send_keys(asset_file_path)
+        # Some of the tests need these lines to pass so don't remove them.
         self._wait_for_button()
         click_css(self, '.submit-button', require_notification=False)
 

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -182,7 +182,6 @@ class ImportTestMixin(object):
         """
         return []
 
-    @flaky      # TODO, fix this: TNL-4191
     def test_upload(self):
         """
         Scenario: I want to upload a course or library for import.


### PR DESCRIPTION
This is the final pull request after trying couple of different approaches to find and eliminate the flakiness linked with some tests using upload_tarball. Unfortunately, I was unable to find the exact cause of the error but changes proposed in this PR is going to reduce the flakiness. Solution was simply upload the same file twice to reduce the probability of failure. I works fine as at my end failure rate reduced to 2 or 3 percent.
There are two bokchoy tests on which I directly worked on studio/test_import_export.py:ImportTestMixin.test_upload and studio/test_import_export.py:ImportTestMixin.test_bad_filename_error. test_upload was marked flaky which was removed after my changes. [Here is the link](https://dl.dropboxusercontent.com/u/51282027/Screen%20Shot%202016-04-01%20at%206.29.46%20PM.png) of screenshot where we can see the test passed 50 times without flaky decorator.  The test test_bad_filename_error [also passed 50 times](https://dl.dropboxusercontent.com/u/51282027/Screen%20Shot%202016-04-01%20at%206.16.41%20PM.png). 

As suggested by ben, I will also update the ticket on Jira once I get go ahead for this PR.

Please review @raeeschachar @benpatterson @jzoldak 
