### PR TITLE
Upgrade to Django 1.8.12

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -32,7 +32,7 @@ django-method-override==0.1.0
 # We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
-django==1.8.11
+django==1.8.12
 djangorestframework-jwt==1.7.2
 djangorestframework-oauth==1.1.0
 edx-django-oauth2-provider==0.5.0


### PR DESCRIPTION
Upgrade to Django 1.8.12, which only contains some minor bugfixes:
https://docs.djangoproject.com/en/1.9/releases/1.8.12/

@nedbat @macdiesel @edx/devops PTAL.
