### PR TITLE
paver uninstall_python_packages

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -167,6 +167,7 @@ PACKAGES_TO_UNINSTALL = [
 ]
 
 
+@task
 def uninstall_python_packages():
     """
     Uninstall Python packages that need explicit uninstallation.


### PR DESCRIPTION
Allow paver users to run a command that uninstalls obsolete python packages without installing any packages.  This paves the way for devstack installs to be more robust against removed packages.

MA-2250

Please review @feanil @benpatterson 

FYI @edx/testeng @nedbat 
