### PR TITLE
Allow migrations to run if CCX is enabled

### DIFF
--- a/lms/djangoapps/ccx/migrations/0003_add_master_course_staff_in_ccx.py
+++ b/lms/djangoapps/ccx/migrations/0003_add_master_course_staff_in_ccx.py
@@ -64,6 +64,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ('ccx', '0001_initial'),
         ('ccx', '0002_customcourseforedx_structure_json'),
+        ('course_overviews','0010_auto_20160329_2317'), # because we use course overview and are in the same release as that table is modified
     ]
 
     operations = [


### PR DESCRIPTION
Without this, when CCX runs 0003 it'll invoke course_overviews while
loading a course, but that table has a model change, and the migration
has not run yet.  This ensures the course_overviews migration happens
first.

@peter-fogg @edx/devops @pdpinch @giocalitri @clintonb 

This would not have been seen in normal devstack work because CCX is not enabled by default there. 
