### PR TITLE
Display correct timezone on timestamp for question submission

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -269,3 +269,4 @@ Florian Haas <florian@hastexo.com>
 Leonardo Quiñonez <leonardo.quinonez@edunext.co>
 Dmitry Viskov <dmitry.viskov@webenterprise.ru>
 Brian Jacobel <bjacobel@edx.org>
+Sigberto Alarcon <salarcon@stanford.edu>

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -11,6 +11,7 @@ import unittest
 from datetime import datetime, timedelta
 from HTMLParser import HTMLParser
 from nose.plugins.attrib import attr
+from freezegun import freeze_time
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -18,6 +19,7 @@ from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseBadRequest
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.test.client import Client
 from django.test.utils import override_settings
 from mock import MagicMock, patch, create_autospec, Mock
 from opaque_keys.edx.locations import Location, SlashSeparatedCourseKey
@@ -613,6 +615,39 @@ class ViewsTestCase(ModuleStoreTestCase):
         self.assertIn(json.dumps({'field_a': 'x', 'field_b': 'y'}, sort_keys=True, indent=2), response_content)
         self.assertIn("Score: 3.0 / 3.0", response_content)
         self.assertIn('#4', response_content)
+
+    @ddt.data(('America/New_York', -5),  # UTC - 5
+              ('Asia/Pyongyang', 9),  # UTC + 9
+              ('Europe/London', 0),  # UTC
+              ('Canada/Yukon', -8),  # UTC - 8
+              ('Europe/Moscow', 4))  # UTC + 3 + 1 for daylight savings
+    @ddt.unpack
+    @freeze_time('2012-01-01')
+    def test_submission_history_timezone(self, timezone, hour_diff):
+        with (override_settings(TIME_ZONE=timezone)):
+            course = CourseFactory.create()
+            course_key = course.id
+            client = Client()
+            admin = AdminFactory.create()
+            client.login(username=admin.username, password='test')
+            state_client = DjangoXBlockUserStateClient(admin)
+            usage_key = course_key.make_usage_key('problem', 'test-history')
+            state_client.set(
+                username=admin.username,
+                block_key=usage_key,
+                state={'field_a': 'x', 'field_b': 'y'}
+            )
+            url = reverse('submission_history', kwargs={
+                'course_id': unicode(course_key),
+                'student_username': admin.username,
+                'location': unicode(usage_key),
+            })
+            response = client.get(url)
+            response_content = HTMLParser().unescape(response.content)
+            expected_time = datetime.now() + timedelta(hours=hour_diff)
+            expected_tz = expected_time.strftime('%Z')
+            self.assertIn(expected_tz, response_content)
+            self.assertIn(str(expected_time), response_content)
 
     def _email_opt_in_checkbox(self, response, org_name_string=None):
         """Check if the email opt-in checkbox appears in the response content."""

--- a/lms/templates/courseware/submission_history.html
+++ b/lms/templates/courseware/submission_history.html
@@ -1,11 +1,13 @@
 <%page expression_filter="h"/>
-<% import json  %>
+<% import json, pytz  %>
 <h3>${username} > ${course_id} > ${location}</h3>
 
 % for i, (entry, score) in enumerate(zip(history_entries, scores)):
 <hr/>
 <div>
-<b>#${len(history_entries) - i}</b>: ${entry.updated} UTC</br>
+    <% timedate = entry.updated.astimezone(pytz.timezone(settings.TIME_ZONE))%>
+    <% timedate_str = timedate.strftime('%Y-%m-%d %H:%M:%S %Z') %>
+<b>#${len(history_entries) - i}</b>: ${timedate_str}</br>
 Score: ${score.grade} / ${score.max_grade}
 <pre>
 ${json.dumps(entry.state, indent=2, sort_keys=True)}


### PR DESCRIPTION
The view for submission history used to grab the timezone from the database (UTC) and
appended the TIME_ZONE variable after, which could be any time zone and thus caused a discrepancy. With this update, the submission time is pulled from the database, but the time is adjusted to the user's time zone and the latter is displayed. A new unittest checks this functionality.
