### PR TITLE
Fixed progress page grade requirements text.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_credit_requirements.py
+++ b/lms/djangoapps/courseware/tests/test_credit_requirements.py
@@ -119,8 +119,8 @@ class ProgressPageCreditRequirementsTest(SharedModuleStoreTestCase):
             response,
             "{}, you have met the requirements for credit in this course.".format(self.USER_FULL_NAME)
         )
-        self.assertContains(response, "Completed {date}".format(date=self._now_formatted_date()))
-        self.assertContains(response, "95%")
+        self.assertContains(response, "Completed by {date}".format(date=self._now_formatted_date()))
+        self.assertNotContains(response, "95%")
 
     def test_credit_requirements_not_eligible(self):
         # Mark the user as having failed both requirements

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -139,11 +139,7 @@ from django.utils.http import urlquote_plus
                                     <span>${_("Verification Declined" )}</span>
                                 %elif requirement['status'] == 'satisfied':
                                     <i class="fa fa-check" aria-hidden="true"></i>
-                                    % if requirement['namespace'] == 'grade' and 'final_grade' in requirement['reason']:
-                                    <span>${int(requirement['reason']['final_grade'] * 100) | h}%</span>
-                                    % else:
-                                    <span>${_("Completed")} ${get_time_display(requirement['status_date'], DEFAULT_SHORT_DATE_FORMAT, settings.TIME_ZONE)}</span>
-                                    % endif
+                                    <span>${_("Completed by")} ${get_time_display(requirement['status_date'], DEFAULT_SHORT_DATE_FORMAT, settings.TIME_ZONE)}</span>
                                 %endif
                             %else:
                                 <span class="not-achieve">${_("Upcoming")}</span>


### PR DESCRIPTION
[ECOM-3127](https://openedx.atlassian.net/browse/ECOM-3127)

Updated text in the credit requirements. This should read: `Completed by /date/` instead of showing the grade.

<img width="795" alt="screen shot 2016-03-31 at 11 29 36 am" src="https://cloud.githubusercontent.com/assets/2851134/14275169/2db28d8a-fb2f-11e5-9656-bcacf1e401b1.png">
