### PR TITLE
TNL-4317: Revert dump_html_escaped_json

### DIFF
--- a/openedx/core/djangolib/js_utils.py
+++ b/openedx/core/djangolib/js_utils.py
@@ -74,45 +74,6 @@ def dump_js_escaped_json(obj, cls=EdxJSONEncoder):
     return json_string
 
 
-def dump_html_escaped_json(obj, cls=EdxJSONEncoder):
-    """
-    JSON dumps and escapes objects that are safe to be embedded in HTML.
-
-    Use this for anything but strings (e.g. dicts, tuples, lists, bools, and
-    numbers).  For strings, just used the default html filter.
-
-    Usage:
-        Used as follows in a Mako template inside a HTML, like in
-        a data attribute::
-
-            data-obj='${obj | n, dump_html_escaped_json}'
-
-        If you must use the cls argument, then use as follows::
-
-            data-obj='${dump_html_escaped_json(obj, cls) | n}'
-
-        Use the "n" Mako filter above.  The default filter will include
-        html escaping in the future, and this ensures proper ordering of
-        these calls.
-
-        Ensure ascii in json.dumps (ensure_ascii=True) allows safe skipping of
-        Mako's default filter decode.utf8.
-
-    Arguments:
-        obj: The object soon to become an HTML escaped JSON string.  The object
-            can be anything but strings (e.g. dicts, tuples, lists, bools, and
-            numbers).
-        cls (class): The JSON encoder class (defaults to EdxJSONEncoder).
-
-    Returns:
-        (string) Escaped encoded JSON.
-
-    """
-    json_string = json.dumps(obj, ensure_ascii=True, cls=cls)
-    json_string = escape(json_string)
-    return json_string
-
-
 def js_escaped_string(string_for_js):
     """
     Mako filter that escapes text for use in a JavaScript string.

--- a/openedx/core/djangolib/tests/test_js_utils.py
+++ b/openedx/core/djangolib/tests/test_js_utils.py
@@ -10,7 +10,7 @@ import HTMLParser
 from mako.template import Template
 
 from openedx.core.djangolib.js_utils import (
-    dump_js_escaped_json, dump_html_escaped_json, js_escaped_string
+    dump_js_escaped_json, js_escaped_string
 )
 
 
@@ -68,38 +68,6 @@ class TestJSUtils(TestCase):
         escaped_json = dump_js_escaped_json(malicious_dict, cls=self.SampleJSONEncoder)
         self.assertEquals(expected_custom_escaped_json, escaped_json)
 
-    def test_dump_html_escaped_json_escapes_unsafe_html(self):
-        """
-        Test dump_html_escaped_json properly escapes &, <, and >.
-        """
-        malicious_dict = {"</script><script>alert('hello, ');</script>": "</script><script>alert('&world!');</script>"}
-        expected_escaped_json = (
-            "{&#34;&lt;/script&gt;&lt;script&gt;alert(&#39;hello, &#39;);&lt;/script&gt;&#34;: "
-            "&#34;&lt;/script&gt;&lt;script&gt;alert(&#39;&amp;world!&#39;);&lt;/script&gt;&#34;}"
-        )
-
-        escaped_json = dump_html_escaped_json(malicious_dict)
-        self.assertEquals(expected_escaped_json, escaped_json)
-
-    def test_dump_html_escaped_json_with_custom_encoder_escapes_unsafe_html(self):
-        """
-        Test dump_html_escaped_json first encodes with custom JSNOEncoder before escaping &, <, and >
-
-        The test encoder class should first perform the replacement of "<script>" with
-        "sample-encoder-was-here", and then should escape the remaining &, <, and >.
-
-        """
-        malicious_dict = {
-            "</script><script>alert('hello, ');</script>":
-            self.NoDefaultEncoding("</script><script>alert('&world!');</script>")
-        }
-        expected_custom_escaped_json = (
-            "{&#34;&lt;/script&gt;&lt;script&gt;alert(&#39;hello, &#39;);&lt;/script&gt;&#34;: "
-            "&#34;&lt;/script&gt;sample-encoder-was-herealert(&#39;&amp;world!&#39;);&lt;/script&gt;&#34;}"
-        )
-        escaped_json = dump_html_escaped_json(malicious_dict, cls=self.SampleJSONEncoder)
-        self.assertEquals(expected_custom_escaped_json, escaped_json)
-
     def test_js_escaped_string_escapes_unsafe_html(self):
         """
         Test js_escaped_string escapes &, <, and >, as well as returns a unicode type
@@ -139,17 +107,18 @@ class TestJSUtils(TestCase):
         template = Template(
             """
                 <%!
+                import json
                 from openedx.core.djangolib.js_utils import (
-                    dump_js_escaped_json, dump_html_escaped_json, js_escaped_string
+                    dump_js_escaped_json, js_escaped_string
                 )
                 %>
                 <body>
                     <div
-                        data-test-dict='${test_dict | n, dump_html_escaped_json}'
+                        data-test-dict='${json.dumps(test_dict)}'
                         data-test-string='${test_dict["test_string"]}'
-                        data-test-tuple='${test_dict["test_tuple"] | n, dump_html_escaped_json}'
-                        data-test-number='${test_dict["test_number"] | n, dump_html_escaped_json}'
-                        data-test-bool='${test_dict["test_bool"] | n, dump_html_escaped_json}'
+                        data-test-tuple='${json.dumps(test_dict["test_tuple"])}'
+                        data-test-number='${json.dumps(test_dict["test_number"])}'
+                        data-test-bool='${json.dumps(test_dict["test_bool"])}'
                     ></div>
 
                     <script>

--- a/scripts/safe_template_linter.py
+++ b/scripts/safe_template_linter.py
@@ -775,9 +775,6 @@ class MakoTemplateLinter(object):
                     results.violations.append(ExpressionRuleViolation(
                         Rules.mako_unwanted_html_filter, expression
                     ))
-            elif (len(filters) == 2) and (filters[0] == 'n') and (filters[1] == 'dump_html_escaped_json'):
-                # {x | n, dump_html_escaped_json} is valid
-                pass
             else:
                 results.violations.append(ExpressionRuleViolation(
                     Rules.mako_invalid_html_filter, expression

--- a/scripts/tests/test_safe_template_linter.py
+++ b/scripts/tests/test_safe_template_linter.py
@@ -125,7 +125,6 @@ class TestMakoTemplateLinter(TestCase):
             ${'{{unbalanced-nested'}
             ${x | n}
             ${x | h}
-            ${x | n, dump_html_escaped_json}
             ${x | n, dump_js_escaped_json}
         """)
 
@@ -247,7 +246,6 @@ class TestMakoTemplateLinter(TestCase):
                 ${'{{unbalanced-nested'}
                 ${x | n}
                 ${x | h}
-                ${x | n, dump_html_escaped_json}
                 ${x | n, dump_js_escaped_json}
                 "${x-with-quotes | n, js_escaped_string}"
             </script>
@@ -255,7 +253,7 @@ class TestMakoTemplateLinter(TestCase):
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 5)
+        self.assertEqual(len(results.violations), 4)
         self.assertEqual(results.violations[0].rule, Rules.mako_invalid_js_filter)
         self.assertEqual(results.violations[0].expression['expression'], "${x}")
         self.assertEqual(results.violations[1].rule, Rules.mako_unparsable_expression)
@@ -265,8 +263,6 @@ class TestMakoTemplateLinter(TestCase):
         self.assertEqual(results.violations[2].expression['expression'], "${x | n}")
         self.assertEqual(results.violations[3].rule, Rules.mako_invalid_js_filter)
         self.assertEqual(results.violations[3].expression['expression'], "${x | h}")
-        self.assertEqual(results.violations[4].rule, Rules.mako_invalid_js_filter)
-        self.assertEqual(results.violations[4].expression['expression'], "${x | n, dump_html_escaped_json}")
 
     def test_check_mako_expressions_in_require_js(self):
         """


### PR DESCRIPTION
The method `dump_html_escaped_json` is being dropped in favor of using json.dumps() in an html context.  We will be keeping `dump_js_escaped_json` for the JavaScript context.

@nedbat @efischer19: I'm just looking for one thumb on this simple PR as well.
