### PR TITLE
Clytwynec/ac 367

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ jscover.log
 jscover.log.*
 .tddium*
 common/test/data/test_unicode/static/
+test_root/courses/
 django-pyfs
 
 ### Installation artifacts

--- a/common/djangoapps/student/tests/test_auto_auth.py
+++ b/common/djangoapps/student/tests/test_auto_auth.py
@@ -219,6 +219,17 @@ class AutoAuthEnabledTestCase(UrlResetMixin, TestCase):
 
         self.assertTrue(response.url.endswith(url_pattern))  # pylint: disable=no-member
 
+    def test_redirect_to_specified(self):
+        # Create user and redirect to specified url
+        url_pattern = '/u/test#about_me'
+        response = self._auto_auth({
+            'username': 'test',
+            'redirect_to': url_pattern,
+            'staff': 'true',
+        }, status_code=302)
+
+        self.assertTrue(response.url.endswith(url_pattern))  # pylint: disable=no-member
+
     def _auto_auth(self, params=None, status_code=None, **kwargs):
         """
         Make a request to the auto-auth end-point and check

--- a/common/test/acceptance/.pa11ycrawlercoveragerc
+++ b/common/test/acceptance/.pa11ycrawlercoveragerc
@@ -1,0 +1,40 @@
+[run]
+data_file = reports/pa11ycrawler/.coverage
+
+source =
+    lms
+    cms
+    common/djangoapps
+    common/lib
+    openedx/core/djangoapps
+    **/mako_lms/
+    **/mako_cms/
+
+omit =
+    lms/envs/*
+    cms/envs/*
+    common/djangoapps/terrain/*
+    common/djangoapps/*/migrations/*
+    openedx/core/djangoapps/*/migrations/*
+    */test*
+    */management/*
+    */urls*
+    */wsgi*
+    lms/djangoapps/*/migrations/*
+    cms/djangoapps/*/migrations/*
+
+parallel = True
+
+[report]
+ignore_errors = True
+include =
+    **/views/*.py
+    **/views.py
+
+
+[html]
+title = pa11ycrawler Coverage Report
+directory = reports/pa11ycrawler/cover
+
+[xml]
+output = reports/pa11ycrawler/coverage.xml

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "devDependencies": {
     "jshint": "^2.7.0",
     "edx-custom-a11y-rules": "edx/edx-custom-a11y-rules",
+    "pa11y": "3.6.0",
+    "pa11y-reporter-1.0-json": "1.0.2",
     "plato": "1.2.2"
   }
 }

--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -8,7 +8,7 @@ import unittest
 from mock import patch, call
 from test.test_support import EnvironmentVarGuard
 from paver.easy import BuildFailure
-from pavelib.utils.test.suites import BokChoyTestSuite, A11yCrawler
+from pavelib.utils.test.suites import BokChoyTestSuite, Pa11yCrawler
 
 REPO_DIR = os.getcwd()
 
@@ -171,7 +171,7 @@ class TestPaverBokChoyCmd(unittest.TestCase):
             BokChoyTestSuite.verbosity_processes_string(suite)
 
 
-class TestPaverPa11ycrawlerCmd(unittest.TestCase):
+class TestPaverPa11yCrawlerCmd(unittest.TestCase):
 
     """
     Paver pa11ycrawler command test cases.  Most of the functionality is
@@ -179,7 +179,7 @@ class TestPaverPa11ycrawlerCmd(unittest.TestCase):
     """
 
     def setUp(self):
-        super(TestPaverPa11ycrawlerCmd, self).setUp()
+        super(TestPaverPa11yCrawlerCmd, self).setUp()
 
         # Mock shell commands
         mock_sh = patch('pavelib.utils.test.suites.bokchoy_suite.sh')
@@ -188,41 +188,32 @@ class TestPaverPa11ycrawlerCmd(unittest.TestCase):
         # Cleanup mocks
         self.addCleanup(mock_sh.stop)
 
-    def _expected_command(self, report_dir):
+    def _expected_command(self, report_dir, start_urls):
         """
         Returns the expected command to run pa11ycrawler.
         """
-        cms_start_url = (
-            "http://localhost:8031/auto_auth?redirect=true&course_id=course-v1"
-            "%3AedX%2BTest101%2Bcourse&staff=true"
-        )
-
-        lms_start_url = (
-            "http://localhost:8003/auto_auth?redirect=true&course_id=course-v1"
-            "%3AedX%2BTest101%2Bcourse&staff=true"
-        )
-
         expected_statement = (
-            'pa11ycrawler run "{cms_start_url}" "{lms_start_url}" '
+            'pa11ycrawler run {start_urls} '
             '--pa11ycrawler-allowed-domains=localhost '
             '--pa11ycrawler-reports-dir={report_dir} '
             '--pa11ycrawler-deny-url-matcher=logout '
             '--pa11y-reporter="1.0-json" '
             '--depth-limit=6 '
         ).format(
-            cms_start_url=cms_start_url,
-            lms_start_url=lms_start_url,
+            start_urls=start_urls,
             report_dir=report_dir,
         )
         return expected_statement
 
     def test_default(self):
-        suite = A11yCrawler('')
+        suite = Pa11yCrawler('')
         self.assertEqual(
-            suite.cmd, self._expected_command(suite.pa11y_report_dir))
+            suite.cmd,
+            self._expected_command(suite.pa11y_report_dir, suite.start_urls)
+        )
 
     def test_get_test_course(self):
-        suite = A11yCrawler('')
+        suite = Pa11yCrawler('')
         suite.get_test_course()
         self._mock_sh.assert_has_calls([
             call(
@@ -232,7 +223,7 @@ class TestPaverPa11ycrawlerCmd(unittest.TestCase):
         ])
 
     def test_generate_html_reports(self):
-        suite = A11yCrawler('')
+        suite = Pa11yCrawler('')
         suite.generate_html_reports()
         self._mock_sh.assert_has_calls([
             call(

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -37,6 +37,9 @@ class Env(object):
         "lib" / "custom_a11y_rules.js"
     )
 
+    PA11YCRAWLER_REPORT_DIR = REPORT_DIR / "pa11ycrawler"
+    PA11YCRAWLER_COVERAGERC = BOK_CHOY_DIR / ".pa11ycrawlercoveragerc"
+
     # If set, put reports for run in "unique" directories.
     # The main purpose of this is to ensure that the reports can be 'slurped'
     # in the main jenkins flow job without overwriting the reports from other

--- a/pavelib/utils/test/suites/__init__.py
+++ b/pavelib/utils/test/suites/__init__.py
@@ -6,4 +6,4 @@ from .nose_suite import NoseTestSuite, SystemTestSuite, LibTestSuite
 from .python_suite import PythonTestSuite
 from .js_suite import JsTestSuite
 from .acceptance_suite import AcceptanceTestSuite
-from .bokchoy_suite import BokChoyTestSuite, A11yCrawler
+from .bokchoy_suite import BokChoyTestSuite, Pa11yCrawler

--- a/pavelib/utils/test/suites/__init__.py
+++ b/pavelib/utils/test/suites/__init__.py
@@ -6,4 +6,4 @@ from .nose_suite import NoseTestSuite, SystemTestSuite, LibTestSuite
 from .python_suite import PythonTestSuite
 from .js_suite import JsTestSuite
 from .acceptance_suite import AcceptanceTestSuite
-from .bokchoy_suite import BokChoyTestSuite
+from .bokchoy_suite import BokChoyTestSuite, A11yCrawler

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -2,9 +2,11 @@
 Class used for defining and running Bok Choy acceptance test suite
 """
 from time import sleep
+from urllib import urlencode
 
 from common.test.acceptance.fixtures.course import CourseFixture, FixtureError
 
+from path import Path as path
 from paver.easy import sh, BuildFailure
 from pavelib.utils.test.suites.suite import TestSuite
 from pavelib.utils.envs import Env
@@ -162,6 +164,26 @@ class BokChoyTestSuite(TestSuite):
         # load data in db_fixtures
         self.load_data()
 
+        # load courses if self.imports_dir is set
+        self.load_courses()
+
+        # Ensure the test servers are available
+        msg = colorize('green', "Confirming servers are running...")
+        print msg
+        bokchoy_utils.start_servers(self.default_store, self.coveragerc)
+
+    def load_courses(self):
+        """
+        Loads courses from self.imports_dir.
+
+        Note: self.imports_dir is the directory that contains the directories
+        that have courses in them. For example, if the course is located in
+        `test_root/courses/test-example-course/`, self.imports_dir should be
+        `test_root/courses/`.
+        """
+        msg = colorize('green', "Importing courses from {}...".format(self.imports_dir))
+        print msg
+
         if self.imports_dir:
             sh(
                 "DEFAULT_STORE={default_store}"
@@ -170,11 +192,6 @@ class BokChoyTestSuite(TestSuite):
                     import_dir=self.imports_dir
                 )
             )
-
-        # Ensure the test servers are available
-        msg = colorize('green', "Confirming servers are running...")
-        print msg
-        bokchoy_utils.start_servers(self.default_store, self.coveragerc)
 
     def load_data(self):
         """
@@ -241,3 +258,88 @@ class BokChoyTestSuite(TestSuite):
 
         cmd = (" ").join(cmd)
         return cmd
+
+
+class A11yCrawler(BokChoyTestSuite):
+    """
+    Sets up test environment with mega-course loaded, and runs pa11ycralwer
+    against it.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(A11yCrawler, self).__init__(*args, **kwargs)
+
+        self.pa11y_report_dir = os.path.join(self.report_dir, 'pa11ycrawler_reports')
+        self.imports_dir = path('test_root/courses/')
+        self.tar_gz_file = "https://github.com/edx/demo-test-course/archive/master.tar.gz"
+
+    def __enter__(self):
+        self.get_test_course()
+        super(A11yCrawler, self).__enter__()
+
+    def get_test_course(self):
+        """
+        Fetches the test course.
+        """
+        self.imports_dir.makedirs_p()
+        zipped_course = self.imports_dir + 'demo_course.tar.gz'
+
+        msg = colorize('green', "Fetching the test course from github...")
+        print msg
+
+        sh(
+            'wget {tar_gz_file} -O {zipped_course}'.format(
+                tar_gz_file=self.tar_gz_file,
+                zipped_course=zipped_course,
+            )
+        )
+
+        msg = colorize('green', "Uncompressing the test course...")
+        print msg
+
+        sh(
+            'tar zxf {zipped_course} -C {courses_dir}'.format(
+                zipped_course=zipped_course,
+                courses_dir=self.imports_dir,
+            )
+        )
+
+    def generate_html_reports(self):
+        """
+        Runs pa11ycrawler json-to-html
+        """
+        cmd_str = (
+            'pa11ycrawler json-to-html --pa11ycrawler-reports-dir={report_dir}'
+        ).format(report_dir=self.pa11y_report_dir)
+
+        sh(cmd_str)
+
+    @property
+    def cmd(self):
+        """
+        Runs pa11ycrawler as staff user against the test course.
+        """
+        params = urlencode({
+            "redirect": 'true',
+            "staff": 'true',
+            "course_id": "course-v1:edX+Test101+course",
+        })
+        cms_start_url = 'http://localhost:8031/auto_auth?{}'.format(params)
+        lms_start_url = 'http://localhost:8003/auto_auth?{}'.format(params)
+        cmd_str = (
+            'pa11ycrawler run "{cms_start_url}" "{lms_start_url}" '
+            '--pa11ycrawler-allowed-domains={allowed_domains} '
+            '--pa11ycrawler-reports-dir={report_dir} '
+            '--pa11ycrawler-deny-url-matcher={dont_go_here} '
+            '--pa11y-reporter="{reporter}" '
+            '--depth-limit={depth} '
+        ).format(
+            cms_start_url=cms_start_url,
+            lms_start_url=lms_start_url,
+            allowed_domains='localhost',
+            report_dir=self.pa11y_report_dir,
+            reporter="1.0-json",
+            dont_go_here="logout",
+            depth="6",
+        )
+        return cmd_str

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -67,6 +67,7 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 
 # Used for testing
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
+git+https://github.com/edx/pa11ycrawler.git@0.0.1#egg=pa11ycrawler
 
 # Our libraries:
 git+https://github.com/edx/XBlock.git@xblock-0.4.7#egg=XBlock==0.4.7

--- a/scripts/accessibility-crawler.sh
+++ b/scripts/accessibility-crawler.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Setting up for accessibility tests..."
+source scripts/jenkins-common.sh
+
+echo "Running pa11ycrawler against test course..."
+paver pa11ycrawler
+
+echo "Generating coverage report..."
+paver pa11ycrawler_coverage


### PR DESCRIPTION
## Overview

The initial work for implementing an accessibility crawler has been merged (See: https://github.com/edx/pa11ycrawler/releases/tag/0.0.1).  This PR is a followup to script running the crawler against the "mega test course" that was created during a hackathon.  To do this, I've built on top of the existing Bok Choy test setup because it already had the features needed (e.g. importing a course from a directory) and used settings required to be able to crawl the course.

This PR introduces a new `paver pa11ycrawler` command that fetches the test course, installs it, and runs the crawler against it.   Additionally, there is a `paver pa11ycrawler_coverage` command that combines the coverage reports from the servers used during the test run.

I've also included `scripts/accessibility-crawler.sh` as a starting point.  I'll be working more on that piece in my next task.

@benpatterson @cpennington  Please review.
