### PR TITLE
SUST-40 – Eliminate unwanted problem_get ajax requests flooding the LMS.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -399,6 +399,7 @@ class CapaMixin(CapaFields):
             'ajax_url': self.runtime.ajax_url,
             'progress_status': Progress.to_js_status_str(progress),
             'progress_detail': Progress.to_js_detail_str(progress),
+            'content': self.get_problem_html(encapsulate=False)
         })
 
     def check_button_name(self):

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -399,7 +399,7 @@ class CapaMixin(CapaFields):
             'ajax_url': self.runtime.ajax_url,
             'progress_status': Progress.to_js_status_str(progress),
             'progress_detail': Progress.to_js_detail_str(progress),
-            'content': self.get_problem_html(encapsulate=False)
+            'content': self.get_problem_html(encapsulate=False),
         })
 
     def check_button_name(self):
@@ -1423,6 +1423,7 @@ class CapaMixin(CapaFields):
         return {
             'success': True,
             'msg': msg,
+            'html': self.get_problem_html(encapsulate=False),
         }
 
     def reset_problem(self, _data):

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -5,6 +5,7 @@ class @Problem
     @id = @el.data('problem-id')
     @element_id = @el.attr('id')
     @url = @el.data('url')
+    @content = @el.data('content')
 
     # has_timed_out and has_response are used to ensure that are used to
     # ensure that we wait a minimum of ~ 1s before transitioning the check
@@ -12,7 +13,7 @@ class @Problem
     @has_timed_out = false
     @has_response = false
 
-    @render()
+    @render(@content)
 
   $: (selector) ->
     $(selector, @el)

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -317,6 +317,7 @@ class @Problem
       switch response.success
         when 'incorrect', 'correct'
           window.SR.readElts($(response.contents).find('.status'))
+          @el.trigger('contentChanged', [@id, response.contents])
           @render(response.contents)
           @updateProgress response
           if @el.hasClass 'showed'
@@ -332,6 +333,7 @@ class @Problem
   reset_internal: =>
     Logger.log 'problem_reset', @answers
     $.postWithPrefix "#{@url}/problem_reset", id: @id, (response) =>
+        @el.trigger('contentChanged', [@id, response.html])
         @render(response.html)
         @updateProgress response
 
@@ -420,6 +422,8 @@ class @Problem
     Logger.log 'problem_save', @answers
     $.postWithPrefix "#{@url}/problem_save", @answers, (response) =>
       saveMessage = response.msg
+      if response.success
+        @el.trigger('contentChanged', [@id, response.html])
       @gentle_alert saveMessage
       @updateProgress response
 

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -30,6 +30,13 @@ class ProblemPage(PageObject):
         return self.q(css="div.problem p").text
 
     @property
+    def problem_content(self):
+        """
+        Return the content of the problem
+        """
+        return self.q(css="div.problems-wrapper").text[0]
+
+    @property
     def message_text(self):
         """
         Return the "message" text of the question of the problem.
@@ -103,9 +110,23 @@ class ProblemPage(PageObject):
 
     def click_check(self):
         """
-        Click the Check button!
+        Click the Check button.
         """
         self.q(css='div.problem button.check').click()
+        self.wait_for_ajax()
+
+    def click_save(self):
+        """
+        Click the Save button.
+        """
+        self.q(css='div.problem button.save').click()
+        self.wait_for_ajax()
+
+    def click_reset(self):
+        """
+        Click the Reset button.
+        """
+        self.q(css='div.problem button.reset').click()
         self.wait_for_ajax()
 
     def wait_for_status_icon(self):
@@ -113,6 +134,17 @@ class ProblemPage(PageObject):
         wait for status icon
         """
         self.wait_for_element_visibility('div.problem section.inputtype div .status', 'wait for status icon')
+
+    def wait_for_expected_status(self, status_selector, message):
+        """
+        Waits for the expected status indicator.
+
+        Args:
+            status_selector(str): status selector string.
+            message(str): description of promise, to be logged.
+        """
+        msg = "Wait for status to be {}".format(message)
+        self.wait_for_element_visibility(status_selector, msg)
 
     def click_hint(self):
         """

--- a/lms/templates/problem_ajax.html
+++ b/lms/templates/problem_ajax.html
@@ -1,1 +1,1 @@
-<div id="problem_${element_id}" class="problems-wrapper" data-problem-id="${id}" data-url="${ajax_url}" data-progress_status="${progress_status}" data-progress_detail="${progress_detail}"></div>
+<div id="problem_${element_id}" class="problems-wrapper" data-problem-id="${id}" data-url="${ajax_url}" data-progress_status="${progress_status}" data-progress_detail="${progress_detail}" data-content="${content | h}"></div>


### PR DESCRIPTION
[SUST-40](https://openedx.atlassian.net/browse/SUST-40)

Motivation is to eliminate `problem_get` AJAX requests that are being made for getting the problem's content every time on initial load and switching sequences in LMS courseware.

This PR is followup work of @ormsbee 's [commit](https://github.com/edx/edx-platform/commit/9984bbc29ab6b7092b787ba5cf35580dd4a58cec) that was reverted due to regression.

**Issue with previous PR:**
Learners were facing outdated problem state on sequence switching, like If a problem's content gets updated in the result of an AJAX call (i.e. on check, save or reset click) then we navigate to next sequence, on coming back to same previous sequence results in outdated problem content state. 

**Addressing of this PR:**
With this PR, `ContentChanged` event is being fired on actions (Check/Save/Reset) to keep track of updated problems in `UpdatedProblems` – that's local to `Sequence` module. On coming back to same sequence, while putting sequence contents in container, only those problems that are found in `UpdatedProblems` are going to be updated for current active sequence position. Acceptance tests verifying the corresponding changes have been added.

**Sandbox**
https://sust40.sandbox.edx.org

**Reviewers**
Please check the box right before your name once you've given 👍  
- [x]  @adampalay
- [x]  @andy-armstrong 
