### PR TITLE
Stripping auth querystring from S3 URLs

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -274,6 +274,10 @@ AWS_SECRET_ACCESS_KEY = AUTH_TOKENS["AWS_SECRET_ACCESS_KEY"]
 if AWS_SECRET_ACCESS_KEY == "":
     AWS_SECRET_ACCESS_KEY = None
 
+# Disabling querystring auth instructs Boto to exclude the querystring parameters (e.g. signature, access key) it
+# normally appends to every returned URL.
+AWS_QUERYSTRING_AUTH = AUTH_TOKENS.get('AWS_QUERYSTRING_AUTH', True)
+
 if AUTH_TOKENS.get('DEFAULT_FILE_STORAGE'):
     DEFAULT_FILE_STORAGE = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
 elif AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -442,6 +442,10 @@ if AWS_SECRET_ACCESS_KEY == "":
 
 AWS_STORAGE_BUCKET_NAME = AUTH_TOKENS.get('AWS_STORAGE_BUCKET_NAME', 'edxuploads')
 
+# Disabling querystring auth instructs Boto to exclude the querystring parameters (e.g. signature, access key) it
+# normally appends to every returned URL.
+AWS_QUERYSTRING_AUTH = AUTH_TOKENS.get('AWS_QUERYSTRING_AUTH', True)
+
 if AUTH_TOKENS.get('DEFAULT_FILE_STORAGE'):
     DEFAULT_FILE_STORAGE = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
 elif AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -8,7 +8,7 @@ beautifulsoup4==4.1.3
 beautifulsoup==3.2.1
 bleach==1.4
 html5lib==0.999
-boto==2.32.1
+boto==2.39.0
 celery==3.1.18
 cssselect==0.9.1
 dealer==2.0.4
@@ -28,7 +28,7 @@ django-sekizai==0.8.2
 django-ses==0.7.0
 django-simple-history==1.6.3
 django-statici18n==1.1.5
-django-storages-redux==1.3
+django-storages==1.4.1
 django-method-override==0.1.0
 # We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
 #djangorestframework>=3.1,<3.2


### PR DESCRIPTION
We use S3 for a number of uploads. Boto, by default, includes a auth querystring on the returned URLs. Since these uploads are public, there is no need for this querystring. Additionally, the long length URLs cause problems when API consumers need to store the URLs. This commit resolves this problem by removing the auth querystring.
- Updated to latest versions of boto and django-storages-redux packages
- Added AWS_QUERYSTRING_AUTH setting to remove the querystring values

ECOM-4081
