### PR TITLE
TNL-4324: Enhance linter for HTML() and Text()

### DIFF
--- a/scripts/tests/test_safe_template_linter.py
+++ b/scripts/tests/test_safe_template_linter.py
@@ -109,7 +109,14 @@ class TestMakoTemplateLinter(TestCase):
         if data['violations'] > 0:
             self.assertEqual(results.violations[0].rule, data['rule'])
 
-    def test_check_mako_expressions_in_html(self):
+    @data(
+        {'expression': '${x}', 'rule': None},
+        {'expression': '${{unbalanced}', 'rule': Rules.mako_unparseable_expression},
+        {'expression': '${x | n}', 'rule': Rules.mako_invalid_html_filter},
+        {'expression': '${x | h}', 'rule': Rules.mako_unwanted_html_filter},
+        {'expression': '${x | n, dump_js_escaped_json}', 'rule': Rules.mako_invalid_html_filter},
+    )
+    def test_check_mako_expressions_in_html(self, data):
         """
         Test _check_mako_file_is_safe in html context provides appropriate violations
         """
@@ -118,25 +125,12 @@ class TestMakoTemplateLinter(TestCase):
 
         mako_template = textwrap.dedent("""
             <%page expression_filter="h"/>
-            ${x}
-            ${'{{unbalanced-nested'}
-            ${x | n}
-            ${x | h}
-            ${x | n, dump_js_escaped_json}
-        """)
+            {expression}
+        """.format(expression=data['expression']))
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 4)
-        self.assertEqual(results.violations[0].rule, Rules.mako_unparsable_expression)
-        start_index = results.violations[0].expression['start_index']
-        self.assertEqual(mako_template[start_index:start_index + 24], "${'{{unbalanced-nested'}")
-        self.assertEqual(results.violations[1].rule, Rules.mako_invalid_html_filter)
-        self.assertEqual(results.violations[1].expression['expression'], "${x | n}")
-        self.assertEqual(results.violations[2].rule, Rules.mako_unwanted_html_filter)
-        self.assertEqual(results.violations[2].expression['expression'], "${x | h}")
-        self.assertEqual(results.violations[3].rule, Rules.mako_invalid_html_filter)
-        self.assertEqual(results.violations[3].expression['expression'], "${x | n, dump_js_escaped_json}")
+        self._validate_data_rule(data, results)
 
     def test_check_mako_expression_display_name(self):
         """
@@ -155,6 +149,87 @@ class TestMakoTemplateLinter(TestCase):
 
         self.assertEqual(len(results.violations), 1)
         self.assertEqual(results.violations[0].rule, Rules.mako_deprecated_display_name)
+
+    @data(
+        {
+            'expression':
+                textwrap.dedent("""
+                    ${"Mixed {span_start}text{span_end}".format(
+                        span_start=HTML("<span>"),
+                        span_end=HTML("</span>"),
+                    )}
+                """),
+            'rule': Rules.mako_html_requires_text
+        },
+        {
+            'expression':
+                textwrap.dedent("""
+                    ${Text("Mixed {span_start}text{span_end}").format(
+                        span_start=HTML("<span>"),
+                        span_end=HTML("</span>"),
+                    )}
+                """),
+            'rule': None
+        },
+        {
+            'expression':
+                textwrap.dedent("""
+                    ${"Mixed {span_start}{text}{span_end}".format(
+                        span_start=HTML("<span>"),
+                        text=Text("This should still break."),
+                        span_end=HTML("</span>"),
+                    )}
+                """),
+            'rule': Rules.mako_html_requires_text
+        },
+        {
+            'expression':
+                textwrap.dedent("""
+                    ${Text("Mixed {link_start}text{link_end}".format(
+                        link_start=HTML("<a href='{}'>").format(url),
+                        link_end=HTML("</a>"),
+                    ))}
+                """),
+            'rule': Rules.mako_close_before_format
+        },
+        {
+            'expression':
+                textwrap.dedent("""
+                    ${Text("Mixed {link_start}text{link_end}").format(
+                        link_start=HTML("<a href='{}'>".format(url)),
+                        link_end=HTML("</a>"),
+                    )}
+                """),
+            'rule': Rules.mako_close_before_format
+        },
+        {
+            'expression': """${ Text("text") }""",
+            'rule': Rules.mako_text_redundant
+        },
+        {
+            'expression': """${ HTML("<span></span>") }""",
+            'rule': None
+        },
+        {
+            'expression': """${ HTML("<span></span>") + "some other text" }""",
+            'rule': Rules.mako_html_alone
+        },
+    )
+    def test_check_mako_with_text_and_html(self, data):
+        """
+        Test _check_mako_file_is_safe tests for proper use of Text() and Html().
+        """
+        linter = MakoTemplateLinter()
+        results = FileResults('')
+
+        mako_template = textwrap.dedent("""
+            <%page expression_filter="h"/>
+            {expression}
+        """.format(expression=data['expression']))
+
+        linter._check_mako_file_is_safe(mako_template, results)
+
+        self._validate_data_rule(data, results)
 
     def test_check_mako_expression_default_disabled(self):
         """
@@ -228,7 +303,14 @@ class TestMakoTemplateLinter(TestCase):
         self.assertEqual(len(results.violations), 1)
         self.assertEqual(results.violations[0].rule, Rules.mako_missing_default)
 
-    def test_check_mako_expressions_in_javascript(self):
+    @data(
+        {'expression': '${x}', 'rule': Rules.mako_invalid_js_filter},
+        {'expression': '${{unbalanced}', 'rule': Rules.mako_unparseable_expression},
+        {'expression': '${x | n}', 'rule': Rules.mako_invalid_js_filter},
+        {'expression': '${x | h}', 'rule': Rules.mako_invalid_js_filter},
+        {'expression': '${x | n, dump_js_escaped_json}', 'rule': None},
+    )
+    def test_check_mako_expressions_in_javascript(self, data):
         """
         Test _check_mako_file_is_safe in JavaScript script context provides
         appropriate violations
@@ -239,29 +321,19 @@ class TestMakoTemplateLinter(TestCase):
         mako_template = textwrap.dedent("""
             <%page expression_filter="h"/>
             <script>
-                ${x}
-                ${'{{unbalanced-nested'}
-                ${x | n}
-                ${x | h}
-                ${x | n, dump_js_escaped_json}
-                "${x-with-quotes | n, js_escaped_string}"
+                {expression}
             </script>
-        """)
+        """.format(expression=data['expression']))
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 4)
-        self.assertEqual(results.violations[0].rule, Rules.mako_invalid_js_filter)
-        self.assertEqual(results.violations[0].expression['expression'], "${x}")
-        self.assertEqual(results.violations[1].rule, Rules.mako_unparsable_expression)
-        start_index = results.violations[1].expression['start_index']
-        self.assertEqual(mako_template[start_index:start_index + 24], "${'{{unbalanced-nested'}")
-        self.assertEqual(results.violations[2].rule, Rules.mako_invalid_js_filter)
-        self.assertEqual(results.violations[2].expression['expression'], "${x | n}")
-        self.assertEqual(results.violations[3].rule, Rules.mako_invalid_js_filter)
-        self.assertEqual(results.violations[3].expression['expression'], "${x | h}")
+        self._validate_data_rule(data, results)
 
-    def test_check_mako_expressions_in_require_js(self):
+    @data(
+        {'expression': '${x}', 'rule': Rules.mako_invalid_js_filter},
+        {'expression': '${x | n, js_escaped_string}', 'rule': None},
+    )
+    def test_check_mako_expressions_in_require_js(self, data):
         """
         Test _check_mako_file_is_safe in JavaScript require context provides
         appropriate violations
@@ -271,17 +343,14 @@ class TestMakoTemplateLinter(TestCase):
 
         mako_template = textwrap.dedent("""
             <%page expression_filter="h"/>
-            <%static:require_module module_name="${x}" class_name="TestFactory">
-                ${x}
-                ${x | n, js_escaped_string}
+            <%static:require_module module_name="${{x}}" class_name="TestFactory">
+                {expression}
             </%static:require_module>
-        """)
+        """.format(expression=data['expression']))
 
         linter._check_mako_file_is_safe(mako_template, results)
 
-        self.assertEqual(len(results.violations), 1)
-        self.assertEqual(results.violations[0].rule, Rules.mako_invalid_js_filter)
-        self.assertEqual(results.violations[0].expression['expression'], "${x}")
+        self._validate_data_rule(data, results)
 
     @data(
         {'media_type': 'text/javascript', 'expected_violations': 0},
@@ -339,7 +408,20 @@ class TestMakoTemplateLinter(TestCase):
         self.assertEqual(results.violations[3].rule, Rules.mako_invalid_js_filter)
         self.assertEqual(results.violations[4].rule, Rules.mako_unwanted_html_filter)
 
-    def test_expression_detailed_results(self):
+    @data(
+        {'template': "\n${x | n}", 'parseable': True},
+        {
+            'template': textwrap.dedent(
+                """
+                    <div>${(
+                        'tabbed-multi-line-expression'
+                    ) | n}</div>
+                """),
+            'parseable': True
+        },
+        {'template': "${{unparseable}", 'parseable': False},
+    )
+    def test_expression_detailed_results(self, data):
         """
         Test _check_mako_file_is_safe provides detailed results, including line
         numbers, columns, and line
@@ -347,86 +429,115 @@ class TestMakoTemplateLinter(TestCase):
         linter = MakoTemplateLinter()
         results = FileResults('')
 
-        mako_template = textwrap.dedent("""
-            ${x | n}
-                <div>${(
-                    'tabbed-multi-line-expression'
-                ) | n}</div>
-            ${'{{unbalanced-nested' | n}
-        """)
+        linter._check_mako_file_is_safe(data['template'], results)
 
-        linter._check_mako_file_is_safe(mako_template, results)
-
-        self.assertEqual(len(results.violations), 4)
+        self.assertEqual(len(results.violations), 2)
         self.assertEqual(results.violations[0].rule, Rules.mako_missing_default)
 
-        self.assertEqual(results.violations[1].start_line, 2)
-        self.assertEqual(results.violations[1].start_column, 1)
-        self.assertEqual(results.violations[1].end_line, 2)
-        self.assertEqual(results.violations[1].end_column, 8)
-        self.assertEqual(len(results.violations[1].lines), 1)
-        self.assertEqual(results.violations[1].lines[0], "${x | n}")
+        violation = results.violations[1]
+        lines = list(data['template'].splitlines())
+        self.assertTrue("${" in lines[violation.start_line - 1])
+        self.assertTrue(lines[violation.start_line - 1].startswith("${", violation.start_column - 1))
+        if data['parseable']:
+            self.assertTrue("}" in lines[violation.end_line - 1])
+            self.assertTrue(lines[violation.end_line - 1].startswith("}", violation.end_column - 1))
+        else:
+            self.assertEqual(violation.start_line, violation.end_line)
+            self.assertEqual(violation.end_column, "?")
+        self.assertEqual(len(violation.lines), violation.end_line - violation.start_line + 1)
+        for line_index in range(0, len(violation.lines)):
+            self.assertEqual(violation.lines[line_index], lines[line_index + violation.start_line - 1])
 
-        self.assertEqual(results.violations[2].start_line, 3)
-        self.assertEqual(results.violations[2].start_column, 10)
-        self.assertEqual(results.violations[2].end_line, 5)
-        self.assertEqual(results.violations[2].end_column, 10)
-        self.assertEqual(len(results.violations[2].lines), 3)
-        self.assertEqual(results.violations[2].lines[0], "    <div>${(")
-        self.assertEqual(
-            results.violations[2].lines[1],
-            "        'tabbed-multi-line-expression'"
-        )
-        self.assertEqual(results.violations[2].lines[2], "    ) | n}</div>")
-
-        self.assertEqual(results.violations[3].start_line, 6)
-        self.assertEqual(results.violations[3].start_column, 1)
-        self.assertEqual(results.violations[3].end_line, 6)
-        self.assertEqual(results.violations[3].end_column, "?")
-        self.assertEqual(len(results.violations[3].lines), 1)
-        self.assertEqual(
-            results.violations[3].lines[0],
-            "${'{{unbalanced-nested' | n}"
-        )
-
-    def test_find_mako_expressions(self):
+    @data(
+        {'template': "${x}"},
+        {'template': "\n ${x}"},
+        {'template': "${x} "},
+        {'template': "${{test-balanced-delims}} "},
+        {'template': "${'{unbalanced in string'}"},
+        {'template': "${'unbalanced in string}'}"},
+        {'template': "${(\n    'tabbed-multi-line-expression'\n  )}"},
+    )
+    def test_find_mako_expressions(self, data):
         """
-        Test _find_mako_expressions finds appropriate expressions
+        Test _find_mako_expressions for parseable expressions
         """
         linter = MakoTemplateLinter()
 
-        mako_template = textwrap.dedent("""
-            ${x}
-                ${tabbed-x}
-                ${(
-                    'tabbed-multi-line-expression'
-                )}
-            ${'{{unbalanced-nested'}
-            ${'{{nested}}'}
-                <div>no expression</div>
-        """)
+        expressions = linter._find_mako_expressions(data['template'])
 
-        expressions = linter._find_mako_expressions(mako_template)
+        self.assertEqual(len(expressions), 1)
+        start_index = expressions[0]['start_index']
+        end_index = expressions[0]['end_index']
+        self.assertEqual(data['template'][start_index:end_index + 1], data['template'].strip())
+        self.assertEqual(expressions[0]['expression'], data['template'].strip())
 
-        self.assertEqual(len(expressions), 5)
-        self._validate_expression(mako_template, expressions[0], '${x}')
-        self._validate_expression(mako_template, expressions[1], '${tabbed-x}')
-        self._validate_expression(mako_template, expressions[2], "${(\n        'tabbed-multi-line-expression'\n    )}")
+    @data(
+        {'template': " ${{unparseable} ${}", 'start_index': 1},
+        {'template': " ${'unparseable} ${}", 'start_index': 1},
+    )
+    def test_find_mako_expressions(self, data):
+        """
+        Test _find_mako_expressions for unparseable expressions
+        """
+        linter = MakoTemplateLinter()
 
-        # won't parse unbalanced nested {}'s
-        unbalanced_expression = "${'{{unbalanced-nested'}"
-        self.assertEqual(expressions[3]['end_index'], -1)
-        start_index = expressions[3]['start_index']
-        self.assertEqual(mako_template[start_index:start_index + len(unbalanced_expression)], unbalanced_expression)
-        self.assertEqual(expressions[3]['expression'], None)
+        expressions = linter._find_mako_expressions(data['template'])
+        self.assertTrue(2 <= len(expressions))
+        self.assertEqual(expressions[0]['start_index'], data['start_index'])
+        self.assertIsNone(expressions[0]['expression'])
 
-        self._validate_expression(mako_template, expressions[4], "${'{{nested}}'}")
+    @data(
+        {'template': """${""}""", 'start_index': 0, 'end_index': 5, 'expected_index': 2},
+        {'template': """${''}""", 'start_index': 0, 'end_index': 5, 'expected_index': 2},
+        {'template': """${"''"}""", 'start_index': 0, 'end_index': 7, 'expected_index': 2},
+        {'template': """${'""'}""", 'start_index': 0, 'end_index': 7, 'expected_index': 2},
+        {'template': """${'""'}""", 'start_index': 3, 'end_index': 7, 'expected_index': 3},
+        {'template': """${'""'}""", 'start_index': 0, 'end_index': 1, 'expected_index': -1},
+    )
+    def test_find_string_start(self, data):
+        """
+        Test _find_string_start helper
+        """
+        linter = MakoTemplateLinter()
 
-    def _validate_expression(self, template_string, expression, expected_expression):
-        start_index = expression['start_index']
-        end_index = expression['end_index']
-        self.assertEqual(template_string[start_index:end_index + 1], expected_expression)
-        self.assertEqual(expression['expression'], expected_expression)
+        string_start_index = linter._find_string_start(data['template'], data['start_index'], data['end_index'])
+
+        self.assertEqual(string_start_index, data['expected_index'])
+
+    @data(
+        {
+            'template': '${""}',
+            'result': {'start_index': 2, 'end_index': 4, 'quote_length': 1}
+        },
+        {
+            'template': "${'Hello'}",
+            'result': {'start_index': 2, 'end_index': 9, 'quote_length': 1}
+        },
+        {
+            'template': '${""" triple """}',
+            'result': {'start_index': 2, 'end_index': 16, 'quote_length': 3}
+        },
+        {
+            'template': r""" ${" \" \\"} """,
+            'result': {'start_index': 3, 'end_index': 11, 'quote_length': 1}
+        },
+    )
+    def test_parse_string(self, data):
+        """
+        Test _parse_string helper
+        """
+        linter = MakoTemplateLinter()
+
+        result = linter._parse_string(data['template'], data['result']['start_index'])
+
+        self.assertDictEqual(result, data['result'])
+
+    def _validate_data_rule(self, data, results):
+        if data['rule'] is None:
+            self.assertEqual(len(results.violations), 0)
+        else:
+            self.assertEqual(len(results.violations), 1)
+            self.assertEqual(results.violations[0].rule, data['rule'])
 
 
 @ddt


### PR DESCRIPTION
## [TNL-4324](https://openedx.atlassian.net/browse/TNL-4324)

Completed some enhancements to the linter for HTML() and Text() method rules.

Details follow:
- Add capability to run linter on file or directory
- Add rule for HTML() requiring Text()
- Add rule for HTML() and Text() being closed before format()
- Add rule for Text() unnecessary without HTML()
- Enhance expression parsing
- Refactor lone HTML() into Python files
- Clean up unit tests
### Testing
- [X] Data is properly encoded in HTML templates to avoid XSS
- [X] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @nedbat 

FYI: @douglashall 
### Post-review
- [x] Squash commits
