### PR TITLE
Fix Django Templates to use lms-main-v1.css

### DIFF
--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -9,7 +9,7 @@
  <link rel="icon" type="image/x-icon" href="{% favicon_path %}" />
 
   {% stylesheet 'style-vendor' %}
-  {% stylesheet 'style-main' %}
+  {% stylesheet 'css/lms-main-v1.css' %}
 
   {% block main_vendor_js %}
   {% javascript 'main_vendor' %}


### PR DESCRIPTION
https://openedx.atlassian.net/browse/FEDX-149

I believe that this fix will resolve the issues with rendering CSS in Django templates (I had no idea we even had any!). I'm building a sandbox now.

@bjacobel @AlasdairSwan please review.

FYI @rlucioni 
