### PR TITLE
Add configurable name for verified track cohort.

### DIFF
--- a/lms/djangoapps/verified_track_content/migrations/0002_verifiedtrackcohortedcourse_verified_cohort_name.py
+++ b/lms/djangoapps/verified_track_content/migrations/0002_verifiedtrackcohortedcourse_verified_cohort_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('verified_track_content', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='verifiedtrackcohortedcourse',
+            name='verified_cohort_name',
+            field=models.CharField(default=b'Verified Learners', max_length=100),
+        ),
+    ]

--- a/lms/djangoapps/verified_track_content/models.py
+++ b/lms/djangoapps/verified_track_content/models.py
@@ -10,7 +10,7 @@ from xmodule_django.models import CourseKeyField
 from student.models import CourseEnrollment
 from courseware.courses import get_course_by_id
 
-from verified_track_content.tasks import sync_cohort_with_mode, VERIFIED_COHORT_NAME
+from verified_track_content.tasks import sync_cohort_with_mode
 from openedx.core.djangoapps.course_groups.cohorts import (
     get_course_cohorts, CourseCohort, is_course_cohorted
 )
@@ -18,6 +18,8 @@ from openedx.core.djangoapps.course_groups.cohorts import (
 import logging
 
 log = logging.getLogger(__name__)
+
+DEFAULT_VERIFIED_COHORT_NAME = "Verified Learners"
 
 
 @receiver(post_save, sender=CourseEnrollment)
@@ -28,14 +30,19 @@ def move_to_verified_cohort(sender, instance, **kwargs):  # pylint: disable=unus
     """
     course_key = instance.course_id
     verified_cohort_enabled = VerifiedTrackCohortedCourse.is_verified_track_cohort_enabled(course_key)
+    verified_cohort_name = VerifiedTrackCohortedCourse.verified_cohort_name_for_course(course_key)
 
     if verified_cohort_enabled and (instance.mode != instance._old_mode):  # pylint: disable=protected-access
         if not is_course_cohorted(course_key):
             log.error("Automatic verified cohorting enabled for course '%s', but course is not cohorted", course_key)
         else:
             existing_cohorts = get_course_cohorts(get_course_by_id(course_key), CourseCohort.MANUAL)
-            if any(cohort.name == VERIFIED_COHORT_NAME for cohort in existing_cohorts):
-                args = {'course_id': unicode(course_key), 'user_id': instance.user.id}
+            if any(cohort.name == verified_cohort_name for cohort in existing_cohorts):
+                args = {
+                    'course_id': unicode(course_key),
+                    'user_id': instance.user.id,
+                    'verified_cohort_name': verified_cohort_name
+                }
                 # Do the update with a 3-second delay in hopes that the CourseEnrollment transaction has been
                 # completed before the celery task runs. We want a reasonably short delay in case the learner
                 # immediately goes to the courseware.
@@ -46,8 +53,9 @@ def move_to_verified_cohort(sender, instance, **kwargs):  # pylint: disable=unus
                 sync_cohort_with_mode.apply_async(kwargs=args, countdown=300)
             else:
                 log.error(
-                    "Automatic verified cohorting enabled for course '%s', but course does not have a verified cohort",
-                    course_key
+                    "Automatic verified cohorting enabled for course '%s', but cohort named '%s' does not exist.",
+                    course_key,
+                    verified_cohort_name,
                 )
 
 
@@ -72,10 +80,30 @@ class VerifiedTrackCohortedCourse(models.Model):
         help_text=ugettext_lazy(u"The course key for the course we would like to be auto-cohorted.")
     )
 
+    verified_cohort_name = models.CharField(max_length=100, default=DEFAULT_VERIFIED_COHORT_NAME)
+
     enabled = models.BooleanField()
 
     def __unicode__(self):
         return u"Course: {}, enabled: {}".format(unicode(self.course_key), self.enabled)
+
+    @classmethod
+    def verified_cohort_name_for_course(cls, course_key):
+        """
+        Returns the given cohort name for the specific course.
+
+        Args:
+            course_key (CourseKey): a course key representing the course we want the verified cohort name for
+
+        Returns:
+            The cohort name if the course key has one associated to it. None otherwise.
+
+        """
+        try:
+            config = cls.objects.get(course_key=course_key)
+            return config.verified_cohort_name
+        except cls.DoesNotExist:
+            return None
 
     @classmethod
     def is_verified_track_cohort_enabled(cls, course_key):

--- a/lms/djangoapps/verified_track_content/tasks.py
+++ b/lms/djangoapps/verified_track_content/tasks.py
@@ -12,12 +12,11 @@ from openedx.core.djangoapps.course_groups.cohorts import (
     get_cohort_by_name, get_cohort, add_user_to_cohort, DEFAULT_COHORT_NAME
 )
 
-VERIFIED_COHORT_NAME = "verified"
 LOGGER = get_task_logger(__name__)
 
 
 @task()
-def sync_cohort_with_mode(course_id, user_id):
+def sync_cohort_with_mode(course_id, user_id, verified_cohort_name):
     """
     If the learner's mode does not match their assigned cohort, move the learner into the correct cohort.
     It is assumed that this task is only initiated for courses that are using the
@@ -31,7 +30,7 @@ def sync_cohort_with_mode(course_id, user_id):
     # Note that this will enroll the user in the default cohort on initial enrollment.
     # That's good because it will force creation of the default cohort if necessary.
     current_cohort = get_cohort(user, course_key)
-    verified_cohort = get_cohort_by_name(course_key, VERIFIED_COHORT_NAME)
+    verified_cohort = get_cohort_by_name(course_key, verified_cohort_name)
 
     if enrollment.mode == CourseMode.VERIFIED and (current_cohort.id != verified_cohort.id):
         LOGGER.info(

--- a/lms/djangoapps/verified_track_content/tests/test_forms.py
+++ b/lms/djangoapps/verified_track_content/tests/test_forms.py
@@ -23,12 +23,14 @@ class TestVerifiedTrackCourseForm(SharedModuleStoreTestCase):
         cls.course = CourseFactory.create()
 
     def test_form_validation_success(self):
-        form_data = {'course_key': unicode(self.course.id), 'enabled': True}
+        form_data = {
+            'course_key': unicode(self.course.id), 'verified_cohort_name': 'Verified Learners', 'enabled': True
+        }
         form = VerifiedTrackCourseForm(data=form_data)
         self.assertTrue(form.is_valid())
 
     def test_form_validation_failure(self):
-        form_data = {'course_key': self.FAKE_COURSE, 'enabled': True}
+        form_data = {'course_key': self.FAKE_COURSE, 'verified_cohort_name': 'Verified Learners', 'enabled': True}
         form = VerifiedTrackCourseForm(data=form_data)
         self.assertFalse(form.is_valid())
         self.assertEqual(
@@ -36,7 +38,7 @@ class TestVerifiedTrackCourseForm(SharedModuleStoreTestCase):
             ['COURSE NOT FOUND.  Please check that the course ID is valid.']
         )
 
-        form_data = {'course_key': self.BAD_COURSE_KEY, 'enabled': True}
+        form_data = {'course_key': self.BAD_COURSE_KEY, 'verified_cohort_name': 'Verified Learners', 'enabled': True}
         form = VerifiedTrackCourseForm(data=form_data)
         self.assertFalse(form.is_valid())
         self.assertEqual(


### PR DESCRIPTION
## [TNL-4293](https://openedx.atlassian.net/browse/TNL-4293)

Modify verified track configuration to allow for different cohort names. It defaults to the existing `VERIFIED_COHORT_NAME` if one is not specified.
### Sandbox
- [ ] https://dianakhuang.sandbox.edx.org - demo course is set up for verified cohorts
### Testing
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Database migrations are backwards-compatible
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @efischer19 
- [ ] Code review: @cahrens 

FYI: @maxrothman (database migration)
### Post-review
- [ ] Squash commits
