### PR TITLE
Update migration to add a dependency.

### DIFF
--- a/lms/djangoapps/ccx/migrations/0003_add_master_course_staff_in_ccx.py
+++ b/lms/djangoapps/ccx/migrations/0003_add_master_course_staff_in_ccx.py
@@ -65,6 +65,7 @@ class Migration(migrations.Migration):
         ('ccx', '0001_initial'),
         ('ccx', '0002_customcourseforedx_structure_json'),
         ('course_overviews','0010_auto_20160329_2317'), # because we use course overview and are in the same release as that table is modified
+        ('verified_track_content','0001_initial'), # because we use enrollement code and are in the same release as an enrollement related table is created 
     ]
 
     operations = [


### PR DESCRIPTION
Because this migration depends on enrollment code and enrollment added a new table.
