### PR TITLE
Allow the "Default Group" to be renamed (automatic cohorting)

### DIFF
--- a/lms/djangoapps/verified_track_content/tasks.py
+++ b/lms/djangoapps/verified_track_content/tasks.py
@@ -9,14 +9,14 @@ from celery.utils.log import get_task_logger
 from opaque_keys.edx.keys import CourseKey
 from student.models import CourseEnrollment, CourseMode
 from openedx.core.djangoapps.course_groups.cohorts import (
-    get_cohort_by_name, get_cohort, add_user_to_cohort, DEFAULT_COHORT_NAME
+    get_cohort_by_name, get_cohort, add_user_to_cohort
 )
 
 LOGGER = get_task_logger(__name__)
 
 
 @task()
-def sync_cohort_with_mode(course_id, user_id, verified_cohort_name):
+def sync_cohort_with_mode(course_id, user_id, verified_cohort_name, default_cohort_name):
     """
     If the learner's mode does not match their assigned cohort, move the learner into the correct cohort.
     It is assumed that this task is only initiated for courses that are using the
@@ -34,17 +34,20 @@ def sync_cohort_with_mode(course_id, user_id, verified_cohort_name):
 
     if enrollment.mode == CourseMode.VERIFIED and (current_cohort.id != verified_cohort.id):
         LOGGER.info(
-            "MOVING_TO_VERIFIED: Moving user '%s' to the verified cohort for course '%s'", user.username, course_id
+            "MOVING_TO_VERIFIED: Moving user '%s' to the verified cohort '%s' for course '%s'",
+            user.username, verified_cohort.name, course_id
         )
         add_user_to_cohort(verified_cohort, user.username)
     elif enrollment.mode != CourseMode.VERIFIED and current_cohort.id == verified_cohort.id:
+        default_cohort = get_cohort_by_name(course_key, default_cohort_name)
         LOGGER.info(
-            "MOVING_TO_DEFAULT: Moving user '%s' to the default cohort for course '%s'", user.username, course_id
+            "MOVING_TO_DEFAULT: Moving user '%s' to the default cohort '%s' for course '%s'",
+            user.username, default_cohort.name, course_id
         )
-        default_cohort = get_cohort_by_name(course_key, DEFAULT_COHORT_NAME)
         add_user_to_cohort(default_cohort, user.username)
     else:
         LOGGER.info(
-            "NO_ACTION_NECESSARY: No action necessary for user '%s' in course '%s' and enrollment mode '%s'",
-            user.username, course_id, enrollment.mode
+            "NO_ACTION_NECESSARY: No action necessary for user '%s' in course '%s' and enrollment mode '%s'. "
+            "The user is already in cohort '%s'.",
+            user.username, course_id, enrollment.mode, current_cohort.name
         )

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -82,11 +82,11 @@ def _cohort_membership_changed(sender, **kwargs):
 
 
 # A 'default cohort' is an auto-cohort that is automatically created for a course if no cohort with automatic
-# assignment have been specified. It is intended to be used in a cohorted-course for users who have yet to be assigned
-# to a cohort.
-# Translation Note: We are NOT translating this string since it is the constant identifier for the "default group"
-#                   and needed across product boundaries.
-DEFAULT_COHORT_NAME = "Default Group"
+# assignment have been specified. It is intended to be used in a cohorted course for users who have yet to be assigned
+# to a cohort, if the course staff have not explicitly created a cohort of type "RANDOM".
+# Note that course staff have the ability to change the name of this cohort after creation via the cohort
+# management UI in the instructor dashboard.
+DEFAULT_COHORT_NAME = _("Default Group")
 
 
 # tl;dr: global state is bad.  capa reseeds random every time a problem is loaded.  Even
@@ -196,14 +196,17 @@ def get_cohort(user, course_key, assign=True, use_cached=False):
     # Otherwise assign the user a cohort.
     membership = CohortMembership.objects.create(
         user=user,
-        course_user_group=_get_default_cohort(course_key)
+        course_user_group=get_random_cohort(course_key)
     )
     return request_cache.data.setdefault(cache_key, membership.course_user_group)
 
 
-def _get_default_cohort(course_key):
+def get_random_cohort(course_key):
     """
-    Helper method to get a default cohort for assignment in get_cohort
+    Helper method to get a cohort for random assignment.
+
+    If there are multiple cohorts of type RANDOM in the course, one of them will be randomly selected.
+    If there are no existing cohorts of type RANDOM in the course, one will be created.
     """
     course = courses.get_course(course_key)
     cohorts = get_course_cohorts(course, assignment_type=CourseCohort.RANDOM)


### PR DESCRIPTION
## [TNL-4355](https://openedx.atlassian.net/browse/TNL-4355)

Support a renamed default group when moving learners from verified to audit track.
### Sandbox
- [x] https://verifiedcohort.sandbox.edx.org

Notes: Demo course has feature fully enabled. You can enroll/upgrade to verified/and unenroll, and the cohorts should update accordingly (to see cohort assignments, go to https://verifiedcohort.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download as staff and click "List enrolled students' profile information".

The Test course also has the feature enabled.

The Performance course does not have the automatic cohorting feature enabled. The logs should never say anything about this course.

To view logs, grant yourself ssh access to the sandbox (http://jenkins.edx.org:8080/view/Ansible/job/ansible-grant-ssh-access/) , ssh to verifiedcohort.sandbox.edx.org, and look at these 2 logs:
sudo less /edx/var/log/lms/edx.log
sudo less /edx/var/log/supervisor/lms_default_1-stderr.log

To access the admin site (to enable automatic cohorting for a course):
1) Log in to the LMS as user "christina@edx.org" with password "edx"
2) Go to this URL: https://verifiedcohort.sandbox.edx.org/admin/verified_track_content/verifiedtrackcohortedcourse/
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [x] Code review: @efischer19 
- [ ] Product review: @scottrish 
### Post-review
- [x] Squash commits
