### PR TITLE
AC-342 sending skip links to single main, relevant

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -54,7 +54,7 @@ from openedx.core.djangolib.js_utils import (
   <body class="${static.dir_rtl()} <%block name='bodyclass'></%block> lang_${LANGUAGE_CODE}">
     <%block name="view_notes"></%block>
 
-    <a class="nav-skip" href="#content">${_("Skip to main content")}</a>
+    <a class="nav-skip" href="#main">${_("Skip to main content")}</a>
 
     <script type="text/javascript">
       window.baseUrl = "${settings.STATIC_URL | n, js_escaped_string}";
@@ -72,9 +72,11 @@ from openedx.core.djangolib.js_utils import (
       <%block name="page_alert"></%block>
       </div>
 
-      <div id="content" tabindex="-1">
-      <%block name="content"></%block>
-      </div>
+      <main id="main" aria-label="Content" tabindex="-1">
+          <div id="content">
+          <%block name="content"></%block>
+          </div>
+      </main>
 
       % if user.is_authenticated():
         <%include file="widgets/sock.html" args="online_help_token=online_help_token" />

--- a/cms/templates/course-create-rerun.html
+++ b/cms/templates/course-create-rerun.html
@@ -22,7 +22,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 </%block>
 
 <%block name="content">
-<div id="content" tabindex="-1">
+<div id="content">
   <div class="wrapper-mast wrapper">
     <header class="mast mast-wizard has-actions">
       <h1 class="page-header">

--- a/lms/static/js/fixtures/edxnotes/edxnotes.html
+++ b/lms/static/js/fixtures/edxnotes/edxnotes.html
@@ -1,7 +1,7 @@
 <section class="container">
   <div class="wrapper-student-notes">
     <div class="student-notes">
-
+    <main id="main" aria-label="Content" tabindex="-1">
       <div class="title-search-container">
         <div class="wrapper-title">
           <h1 class="page-title">
@@ -42,7 +42,7 @@
           <span class="copy">Loading</span>
         </div>
       </section>
-
+    </main>
     </div>
   </div>
 </section>

--- a/lms/templates/ccx/coach_dashboard.html
+++ b/lms/templates/ccx/coach_dashboard.html
@@ -10,7 +10,6 @@ from openedx.core.djangolib.js_utils import (
 %>
 
 <%block name="pagetitle">${_("CCX Coach Dashboard")}</%block>
-<%block name="nav_skip">#ccx-coach-dashboard-content</%block>
 
 <%block name="headextra">
   <%static:css group='style-course-vendor'/>
@@ -23,66 +22,68 @@ from openedx.core.djangolib.js_utils import (
 
 <section class="container">
   <div class="instructor-dashboard-wrapper-2">
-    <section class="instructor-dashboard-content-2" id="ccx-coach-dashboard-content">
-      <h1>${_("CCX Coach Dashboard")}</h1>
+        <main id="main" aria-label="Content" tabindex="-1">
+        <section class="instructor-dashboard-content-2" id="ccx-coach-dashboard-content">
+          <h1>${_("CCX Coach Dashboard")}</h1>
 
-      %if not ccx:
-        % if messages:
-          <ul class="messages">
-            % for message in messages:
-              % if message.tags:
-                <li class="${message.tags}">${message}</li>
-              % else:
-                <li>${message}</li>
-              % endif
-            % endfor
+          %if not ccx:
+            % if messages:
+              <ul class="messages">
+                % for message in messages:
+                  % if message.tags:
+                    <li class="${message.tags}">${message}</li>
+                  % else:
+                    <li>${message}</li>
+                  % endif
+                % endfor
+              </ul>
+            % endif
+            <section>
+              <p class="request-response-error" id="ccx-create-message"></p>
+              <form action="${create_ccx_url}" class="ccx-form" method="POST" onsubmit="return validateForm(this)">
+                <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
+                <div class="field">
+                  <label class="sr" for="ccx_name">${_('Name your CCX')}</label>
+                  <input name="name" id="ccx_name" placeholder="${_('Name your CCX')}"/><br/>
+                </div>
+                <div class="field">
+                  <button id="create-ccx" type="submit">${_('Create a new Custom Course for edX')}</button>
+                </div>
+              </form>
+            </section>
+          %endif
+
+          %if ccx:
+          <ul class="instructor-nav">
+            <li class="nav-item">
+              <a href="#" data-section="membership">${_("Enrollment")}</a>
+            </li>
+            <li class="nav-item">
+              <a href="#" data-section="schedule">${_("Schedule")}</a>
+            </li>
+            <li class="nav-item">
+              <a href="#" data-section="student_admin">${_("Student Admin")}</a>
+            </li>
+            <li class="nav-item">
+              <a href="#" data-section="grading_policy">${_("Grading Policy")}</a>
+            </li>
           </ul>
-        % endif
-        <section>
-          <p class="request-response-error" id="ccx-create-message"></p>
-          <form action="${create_ccx_url}" class="ccx-form" method="POST" onsubmit="return validateForm(this)">
-            <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
-            <div class="field">
-              <label class="sr" for="ccx_name">${_('Name your CCX')}</label>
-              <input name="name" id="ccx_name" placeholder="${_('Name your CCX')}"/><br/>
-            </div>
-            <div class="field">
-              <button id="create-ccx" type="submit">${_('Create a new Custom Course for edX')}</button>
-            </div>
-          </form>
-        </section>
-      %endif
+          <section id="membership" class="idash-section">
+            <%include file="enrollment.html" args="" />
+          </section>
+          <section id="schedule" class="idash-section">
+            <%include file="schedule.html" args="" />
+          </section>
+          <section id="student_admin" class="idash-section">
+            <%include file="student_admin.html" args="" />
+          </section>
+          <section id="grading_policy" class="idash-section">
+            <%include file="grading_policy.html" args="" />
+          </section>
+          %endif
 
-      %if ccx:
-      <ul class="instructor-nav">
-        <li class="nav-item">
-          <a href="#" data-section="membership">${_("Enrollment")}</a>
-        </li>
-        <li class="nav-item">
-          <a href="#" data-section="schedule">${_("Schedule")}</a>
-        </li>
-        <li class="nav-item">
-          <a href="#" data-section="student_admin">${_("Student Admin")}</a>
-        </li>
-        <li class="nav-item">
-          <a href="#" data-section="grading_policy">${_("Grading Policy")}</a>
-        </li>
-      </ul>
-      <section id="membership" class="idash-section">
-        <%include file="enrollment.html" args="" />
       </section>
-      <section id="schedule" class="idash-section">
-        <%include file="schedule.html" args="" />
-      </section>
-      <section id="student_admin" class="idash-section">
-        <%include file="student_admin.html" args="" />
-      </section>
-      <section id="grading_policy" class="idash-section">
-        <%include file="grading_policy.html" args="" />
-      </section>
-      %endif
-
-    </section>
+        </main>
   </div>
 </section>
 

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -28,48 +28,50 @@
 
 <%block name="pagetitle">${_("Courses")}</%block>
 
-<section class="find-courses">
-  <section class="courses-container">
-    % if course_discovery_enabled:
-    <div id="discovery-form" role="search" aria-label="course" class="wrapper-search-context">
-      <div id="discovery-message" class="search-status-label"></div>
-      <form class="wrapper-search-input">
-        <label for="discovery-input" class="sr">${_('Search for a course')}</label>
-        <input id="discovery-input" class="discovery-input" placeholder="${_('Search for a course')}" type="text"/>
-        <button type="submit" class="button postfix discovery-submit" aria-label="${_('Search')}">
-          <i class="icon fa fa-search" aria-hidden="true"></i>
-          <div aria-live="polite" aria-relevant="all">
-            <div id="loading-indicator" class="loading-spinner hidden">
-              <i class="icon fa fa-spinner fa-spin"></i>
-              <span class="sr">${_('Loading')}</span>
-            </div>
-          </div>
-        </button>
-      </form>
-    </div>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="find-courses">
+      <section class="courses-container">
+        % if course_discovery_enabled:
+        <div id="discovery-form" role="search" aria-label="course" class="wrapper-search-context">
+          <div id="discovery-message" class="search-status-label"></div>
+          <form class="wrapper-search-input">
+            <label for="discovery-input" class="sr">${_('Search for a course')}</label>
+            <input id="discovery-input" class="discovery-input" placeholder="${_('Search for a course')}" type="text"/>
+            <button type="submit" class="button postfix discovery-submit" aria-label="${_('Search')}">
+              <i class="icon fa fa-search" aria-hidden="true"></i>
+              <div aria-live="polite" aria-relevant="all">
+                <div id="loading-indicator" class="loading-spinner hidden">
+                  <i class="icon fa fa-spinner fa-spin"></i>
+                  <span class="sr">${_('Loading')}</span>
+                </div>
+              </div>
+            </button>
+          </form>
+        </div>
 
-    <div id="filter-bar" class="filters hide-phone is-collapsed">
-    </div>
-    % endif
+        <div id="filter-bar" class="filters hide-phone is-collapsed">
+        </div>
+        % endif
 
-    <div class="courses${'' if course_discovery_enabled else ' no-course-discovery'}" role="region" aria-label="${_('List of Courses')}">
-      <ul class="courses-listing">
-        %for course in courses:
-        <li class="courses-listing-item">
-          <%include file="../course.html" args="course=course" />
-        </li>
-        %endfor
-      </ul>
-    </div>
+        <div class="courses${'' if course_discovery_enabled else ' no-course-discovery'}" role="region" aria-label="${_('List of Courses')}">
+          <ul class="courses-listing">
+            %for course in courses:
+            <li class="courses-listing-item">
+              <%include file="../course.html" args="course=course" />
+            </li>
+            %endfor
+          </ul>
+        </div>
 
 
-    % if course_discovery_enabled:
-    <aside aria-label="${_('Refine Your Search')}" class="search-facets phone-menu">
-      <h2 class="header-search-facets">${_('Refine Your Search')}</h2>
-      <section class="search-facets-lists">
+        % if course_discovery_enabled:
+        <aside aria-label="${_('Refine Your Search')}" class="search-facets phone-menu">
+          <h2 class="header-search-facets">${_('Refine Your Search')}</h2>
+          <section class="search-facets-lists">
+          </section>
+        </aside>
+        % endif
+
       </section>
-    </aside>
-    % endif
-
-  </section>
-</section>
+    </section>
+</main>

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -37,8 +37,6 @@ ${static.get_page_title_breadcrumbs(course_name())}
 <%static:css group='style-student-notes'/>
 % endif
 
-<%block name="nav_skip">${"#content" if section_title else "#content"}</%block>
-
 <%include file="../discussion/_js_head_dependencies.html" />
   ${fragment.head_html()}
 </%block>

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -57,8 +57,6 @@ ${static.get_page_title_breadcrumbs(course_name())}
 <%static:css group='style-student-notes'/>
 % endif
 
-<%block name="nav_skip">${"#content" if section_title else "#content"}</%block>
-
 <%include file="../discussion/_js_head_dependencies.html" />
   ${fragment.head_html()}
 </%block>
@@ -170,7 +168,8 @@ ${fragment.foot_html()}
 
     </div>
 % endif
-    <section class="course-content" id="course-content" role="main" aria-label="Content">
+    <section class="course-content" id="course-content">
+        <main id="main" aria-label="Content" tabindex="-1">
         % if getattr(course, 'entrance_exam_enabled') and \
            getattr(course, 'entrance_exam_minimum_score_pct') and \
            entrance_exam_current_score is not UNDEFINED:
@@ -199,9 +198,10 @@ ${fragment.foot_html()}
                 )}
             </p>
             % endif
-      % endif
+        % endif
 
-      ${fragment.body_html()}
+          ${fragment.body_html()}
+        </main>
     </section>
 
     <section class="courseware-results-wrapper">

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -52,57 +52,60 @@ from openedx.core.djangolib.markup import Text, HTML
 </%block>
 
 <%block name="bodyclass">view-in-course view-course-info ${course.css_class or ''}</%block>
-<section class="container">
-  <div class="home">
-    <div class="page-header-main">
-        <h1 class="page-title">${_("Welcome to {org}'s {course_name}!").format(org=course.display_org_with_default, course_name=course.display_number_with_default)}</h1>
-        <h2 class="page-subtitle">${course.display_name_with_default}</h2>
-    </div>
-    % if last_accessed_courseware_url:
-      <div class="page-header-secondary">
-          <a href="${last_accessed_courseware_url}" class="last-accessed-link">${_("Resume Course")}</a>
-      </div>
-    % endif
-  </div>
-  <div class="info-wrapper">
-    % if user.is_authenticated():
-    <section class="updates">
-      % if studio_url is not None and masquerade and masquerade.role == 'staff':
-      <div class="wrap-instructor-info studio-view">
-        <a class="instructor-info-action" href="${studio_url}">
-          ${_("View Updates in Studio")}
-        </a>
-      </div>
-      % endif
 
-      <h1>${_("Course Updates and News")}</h1>
-      ${HTML(get_course_info_section(request, masquerade_user, course, 'updates'))}
-
-      ## CourseTalk widget
-      % if show_coursetalk_widget:
-      <div class="coursetalk-write-reviews">
-        <div id="ct-custom-read-review-widget" data-provider="${platform_key}" data-course="${course_review_key}"></div>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container">
+      <div class="home">
+        <div class="page-header-main">
+            <h1 class="page-title">${_("Welcome to {org}'s {course_name}!").format(org=course.display_org_with_default, course_name=course.display_number_with_default)}</h1>
+            <h2 class="page-subtitle">${course.display_name_with_default}</h2>
+        </div>
+        % if last_accessed_courseware_url:
+          <div class="page-header-secondary">
+              <a href="${last_accessed_courseware_url}" class="last-accessed-link">${_("Resume Course")}</a>
+          </div>
+        % endif
       </div>
-      % endif
-    </section>
-    <section aria-label="${_('Handout Navigation')}" class="handouts">
-      % if SelfPacedConfiguration.current().enable_course_home_improvements:
-        <h1 class="handouts-header">${_("Important Course Dates")}</h1>
-        ${HTML(get_course_date_summary(course, user))}
-      % endif
+      <div class="info-wrapper">
+        % if user.is_authenticated():
+        <section class="updates">
+          % if studio_url is not None and masquerade and masquerade.role == 'staff':
+          <div class="wrap-instructor-info studio-view">
+            <a class="instructor-info-action" href="${studio_url}">
+              ${_("View Updates in Studio")}
+            </a>
+          </div>
+          % endif
 
-      <h1 class="handouts-header">${_(course.info_sidebar_name)}</h1>
-      ${HTML(get_course_info_section(request, masquerade_user, course, 'handouts'))}
+          <h1>${_("Course Updates and News")}</h1>
+          ${HTML(get_course_info_section(request, masquerade_user, course, 'updates'))}
+
+          ## CourseTalk widget
+          % if show_coursetalk_widget:
+          <div class="coursetalk-write-reviews">
+            <div id="ct-custom-read-review-widget" data-provider="${platform_key}" data-course="${course_review_key}"></div>
+          </div>
+          % endif
+        </section>
+        <section aria-label="${_('Handout Navigation')}" class="handouts">
+          % if SelfPacedConfiguration.current().enable_course_home_improvements:
+            <h1 class="handouts-header">${_("Important Course Dates")}</h1>
+            ${HTML(get_course_date_summary(course, user))}
+          % endif
+
+          <h1 class="handouts-header">${_(course.info_sidebar_name)}</h1>
+          ${HTML(get_course_info_section(request, masquerade_user, course, 'handouts'))}
+        </section>
+        % else:
+        <section class="updates">
+          <h1 class="handouts-header">${_("Course Updates and News")}</h1>
+          ${HTML(get_course_info_section(request, masquerade_user, course, 'guest_updates'))}
+        </section>
+        <section aria-label="${_('Handout Navigation')}" class="handouts">
+          <h1 class="handouts-header">${_("Course Handouts")}</h1>
+          ${HTML(get_course_info_section(request, masquerade_user, course, 'guest_handouts'))}
+        </section>
+        % endif
+      </div>
     </section>
-    % else:
-    <section class="updates">
-      <h1 class="handouts-header">${_("Course Updates and News")}</h1>
-      ${HTML(get_course_info_section(request, masquerade_user, course, 'guest_updates'))}
-    </section>
-    <section aria-label="${_('Handout Navigation')}" class="handouts">
-      <h1 class="handouts-header">${_("Course Handouts")}</h1>
-      ${HTML(get_course_info_section(request, masquerade_user, course, 'guest_handouts'))}
-    </section>
-    % endif
-  </div>
-</section>
+</main>

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -18,7 +18,6 @@ from django.utils.http import urlquote_plus
 <%namespace name="progress_graph" file="/courseware/progress_graph.js"/>
 
 <%block name="pagetitle">${_("{course_number} Progress").format(course_number=course.display_number_with_default) | h}</%block>
-<%block name="nav_skip">#content</%block>
 
 <%block name="js_extra">
 <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js') | h}"></script>
@@ -37,188 +36,189 @@ from django.utils.http import urlquote_plus
 <div class="container">
   <div class="profile-wrapper">
 
-    <div class="course-info" id="course-info-progress" aria-label="${_('Course Progress')}">
-      % if staff_access and studio_url is not None:
-        <div class="wrap-instructor-info">
-          <a class="instructor-info-action studio-view" href="${studio_url | h}">${_("View Grading in studio")}</a>
-        </div>
-      % endif
-
-      <header class="progress-certificates">
-        <h1 class="progress-certificates-title">${_("Course Progress for Student '{username}' ({email})").format(username=student.username, email=student.email) | h}</h1>
-      </header>
-
-      %if show_generate_cert_btn:
-      <div class="wrapper-msg wrapper-auto-cert">
-        <div id="errors-info" class="errors-info"></div>
-        %if passed:
-        <div class="auto-cert-message" id="course-success">
-          <div class="has-actions">
-              <% post_url = reverse('generate_user_cert', args=[unicode(course.id)]) %>
-              % if is_downloadable:
-              <div class="msg-content">
-                <h2 class="title">${_("Your certificate is available")}</h2>
-                <p class="copy">
-                  ${_("You can keep working for a higher grade, or request your certificate now.")}
-                </p>
-              </div>
-              <div class="msg-actions">
-                %if show_cert_web_view and cert_web_view_url:
-                <a class="btn" href="${cert_web_view_url | h}" target="_blank" title="${_('View certificate in a new browser window or tab.')}">
-                  ${_("View Certificate")}
-                </a>
-                %elif download_url:
-                <a class="btn" href="${download_url | h}" target="_blank" title="${_('PDF will open in a new browser window or tab.')}">
-                  ${_("Download Your Certificate")}
-                </a>
-                %endif
-              </div>
-              %elif is_generating:
-              <div class="msg-content">
-                ## Translators: This message appears to users when the system is processessing course certificates, which can take a few hours.
-                <h2 class="title">${_("We're working on it...")}</h2>
-                <p class="copy">${_("We're creating your certificate. You can keep working in your courses and a link to it will appear here and on your Dashboard when it is ready.")}</p>
-              </div>
-              <div class="msg-actions"></div>
-              %else:
-              <div class="msg-content">
-                <h2 class="title">${_("Congratulations, you qualified for a certificate!")}</h2>
-                <p class="copy">${_("You can keep working for a higher grade, or request your certificate now.")}</p>
-              </div>
-              <div class="msg-actions">
-                <button class="btn generate_certs" data-endpoint="${post_url | h}" id="btn_generate_cert">${_('Request Certificate')}</button>
-              </div>
-              %endif
-          </div>
-        </div>
-        %endif
-      </div>
-      %endif
-
-      %if not course.disable_progress_graph:
-        <div class="grade-detail-graph" id="grade-detail-graph" aria-hidden="true"></div>
-      %endif
-
-      % if credit_course_requirements:
-        <section class="credit-eligibility">
-            <div class="credit-eligibility-container">
-                <div class="eligibility-heading">
-                    <h2>${_("Requirements for Course Credit")}</h2>
-                </div>
-                %if credit_course_requirements['eligibility_status'] == 'not_eligible':
-                    <span class="eligibility_msg">${_("{student_name}, you are no longer eligible for credit in this course.").format(student_name=student.profile.name) | h}</span>
-                %elif credit_course_requirements['eligibility_status'] == 'eligible':
-                    <span class="eligibility_msg">${_("{student_name}, you have met the requirements for credit in this course.").format(student_name=student.profile.name) | h}
-                        ${_("{a_start}Go to your dashboard{a_end} to purchase course credit.").format(
-		             a_start=u"<a href={url}>".format(url=reverse('dashboard')),
-			     a_end="</a>"
-		      )}
-                    </span>
-                %elif credit_course_requirements['eligibility_status'] == 'partial_eligible':
-                    <span>${_("{student_name}, you have not yet met the requirements for credit.").format(student_name=student.profile.name) | h}</span>
-                %endif
-                <a href="${settings.CREDIT_HELP_LINK_URL | h}" class="credit-help"><i class="fa fa-question"></i><span class="sr">${_("Information about course credit requirements")}</span></a><br>
-                <div class="requirement-container" data-eligible="${credit_course_requirements['eligibility_status'] | h}">
-                %for requirement in credit_course_requirements['requirements']:
-                    <div class="requirement">
-                        <div class="requirement-name">
-                            ${_(requirement['display_name']) | h}
-                            %if requirement['namespace'] == 'grade':
-                                <span>${int(requirement['criteria']['min_grade'] * 100) | h}%</span>
-                            %endif
-                        </div>
-                        <div class="requirement-status">
-                            %if requirement['status']:
-                                %if requirement['status'] == 'submitted':
-                                    <span class="requirement-submitted">${_("Verification Submitted")}</span>
-                                %elif requirement['status'] == 'failed':
-                                    <i class="fa fa-times" aria-hidden="true"></i>
-                                    <span>${_("Verification Failed" )}</span>
-                                %elif requirement['status'] == 'declined':
-                                    <i class="fa fa-times" aria-hidden="true"></i>
-                                    <span>${_("Verification Declined" )}</span>
-                                %elif requirement['status'] == 'satisfied':
-                                    <i class="fa fa-check" aria-hidden="true"></i>
-                                    <span>${_("Completed by")} ${get_time_display(requirement['status_date'], DEFAULT_SHORT_DATE_FORMAT, settings.TIME_ZONE)}</span>
-                                %endif
-                            %else:
-                                <span class="not-achieve">${_("Upcoming")}</span>
-                            %endif
-                        </div>
-                    </div>
-                %endfor
-                 </div>
-                <button class="detail-collapse" aria-live="polite"><i class="fa fa-caret-up" aria-hidden="true"></i>
-                    <span class="requirement-detail">${_("Less")}</span>
-                </button>
+    <main id="main" aria-label="Content" tabindex="-1">
+        <div class="course-info" id="course-info-progress" aria-label="${_('Course Progress')}">
+          % if staff_access and studio_url is not None:
+            <div class="wrap-instructor-info">
+              <a class="instructor-info-action studio-view" href="${studio_url | h}">${_("View Grading in studio")}</a>
             </div>
-        </section>
-      %endif
+          % endif
 
-      <div class="chapters">
-        %for chapter in courseware_summary:
-        %if not chapter['display_name'] == "hidden":
-        <section>
-          <h2>${ chapter['display_name'] | h}</h2>
+          <header class="progress-certificates">
+            <h1 class="progress-certificates-title">${_("Course Progress for Student '{username}' ({email})").format(username=student.username, email=student.email) | h}</h1>
+          </header>
 
-          <div class="sections">
-            %for section in chapter['sections']:
-            <div>
-              <%
-              earned = section['section_total'].earned
-              total = section['section_total'].possible
-              percentageString = "{0:.0%}".format( float(earned)/total) if earned > 0 and total > 0 else ""
-              %>
-
-              <h3><a href="${reverse('courseware_section', kwargs=dict(course_id=course.id.to_deprecated_string(), chapter=chapter['url_name'], section=section['url_name'])) | h}">
-                ${ section['display_name'] | h}
-                %if total > 0 or earned > 0:
-                  <span class="sr">
-                    ${_("{earned} of {total} possible points").format(earned='{:.3n}'.format(float(earned)), total='{:.3n}'.format(float(total))) | h}
-                  </span>
-                %endif
-                </a>
-                %if total > 0 or earned > 0:
-                  <span> ${"({0:.3n}/{1:.3n}) {2}".format( float(earned), float(total), percentageString ) | h}</span>
-                %endif
-              </h3>
-              <p>
-                ${section['format'] | h}
-
-                %if section.get('due') is not None:
-                  <%
-                      formatted_string = get_time_display(section['due'], course.due_date_display_format, coerce_tz=settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES)
-                      due_date = '' if len(formatted_string)==0 else _(u'due {date}').format(date=formatted_string)
-                  %>
-                  <em>
-                  ${due_date | h}
-                  </em>
-                %endif
-              </p>
-
-              <div class="scores">
-                %if len(section['scores']) > 0:
-                  <h3> ${ _("Problem Scores: ") if section['graded'] else _("Practice Scores: ")} </h3>
-                  <ol>
-                    %for score in section['scores']:
-                    <li>${"{0:.3n}/{1:.3n}".format(float(score.earned),float(score.possible)) | h}</li>
-                    %endfor
-                  </ol>
-                %else:
-                  <h3 class="no-scores"> ${_("No problem scores in this section")} </h3>
-                %endif
+          %if show_generate_cert_btn:
+          <div class="wrapper-msg wrapper-auto-cert">
+            <div id="errors-info" class="errors-info"></div>
+            %if passed:
+            <div class="auto-cert-message" id="course-success">
+              <div class="has-actions">
+                  <% post_url = reverse('generate_user_cert', args=[unicode(course.id)]) %>
+                  % if is_downloadable:
+                  <div class="msg-content">
+                    <h2 class="title">${_("Your certificate is available")}</h2>
+                    <p class="copy">
+                      ${_("You can keep working for a higher grade, or request your certificate now.")}
+                    </p>
+                  </div>
+                  <div class="msg-actions">
+                    %if show_cert_web_view and cert_web_view_url:
+                    <a class="btn" href="${cert_web_view_url | h}" target="_blank" title="${_('View certificate in a new browser window or tab.')}">
+                      ${_("View Certificate")}
+                    </a>
+                    %elif download_url:
+                    <a class="btn" href="${download_url | h}" target="_blank" title="${_('PDF will open in a new browser window or tab.')}">
+                      ${_("Download Your Certificate")}
+                    </a>
+                    %endif
+                  </div>
+                  %elif is_generating:
+                  <div class="msg-content">
+                    ## Translators: This message appears to users when the system is processessing course certificates, which can take a few hours.
+                    <h2 class="title">${_("We're working on it...")}</h2>
+                    <p class="copy">${_("We're creating your certificate. You can keep working in your courses and a link to it will appear here and on your Dashboard when it is ready.")}</p>
+                  </div>
+                  <div class="msg-actions"></div>
+                  %else:
+                  <div class="msg-content">
+                    <h2 class="title">${_("Congratulations, you qualified for a certificate!")}</h2>
+                    <p class="copy">${_("You can keep working for a higher grade, or request your certificate now.")}</p>
+                  </div>
+                  <div class="msg-actions">
+                    <button class="btn generate_certs" data-endpoint="${post_url | h}" id="btn_generate_cert">${_('Request Certificate')}</button>
+                  </div>
+                  %endif
               </div>
+            </div>
+            %endif
+          </div>
+          %endif
+
+          %if not course.disable_progress_graph:
+            <div class="grade-detail-graph" id="grade-detail-graph" aria-hidden="true"></div>
+          %endif
+
+          % if credit_course_requirements:
+            <section class="credit-eligibility">
+                <div class="credit-eligibility-container">
+                    <div class="eligibility-heading">
+                        <h2>${_("Requirements for Course Credit")}</h2>
+                    </div>
+                    %if credit_course_requirements['eligibility_status'] == 'not_eligible':
+                        <span class="eligibility_msg">${_("{student_name}, you are no longer eligible for credit in this course.").format(student_name=student.profile.name) | h}</span>
+                    %elif credit_course_requirements['eligibility_status'] == 'eligible':
+                        <span class="eligibility_msg">${_("{student_name}, you have met the requirements for credit in this course.").format(student_name=student.profile.name) | h}
+                            ${_("{a_start}Go to your dashboard{a_end} to purchase course credit.").format(
+    		             a_start=u"<a href={url}>".format(url=reverse('dashboard')),
+    			     a_end="</a>"
+    		      )}
+                        </span>
+                    %elif credit_course_requirements['eligibility_status'] == 'partial_eligible':
+                        <span>${_("{student_name}, you have not yet met the requirements for credit.").format(student_name=student.profile.name) | h}</span>
+                    %endif
+                    <a href="${settings.CREDIT_HELP_LINK_URL | h}" class="credit-help"><i class="fa fa-question"></i><span class="sr">${_("Information about course credit requirements")}</span></a><br>
+                    <div class="requirement-container" data-eligible="${credit_course_requirements['eligibility_status'] | h}">
+                    %for requirement in credit_course_requirements['requirements']:
+                        <div class="requirement">
+                            <div class="requirement-name">
+                                ${_(requirement['display_name']) | h}
+                                %if requirement['namespace'] == 'grade':
+                                    <span>${int(requirement['criteria']['min_grade'] * 100) | h}%</span>
+                                %endif
+                            </div>
+                            <div class="requirement-status">
+                                %if requirement['status']:
+                                    %if requirement['status'] == 'submitted':
+                                        <span class="requirement-submitted">${_("Verification Submitted")}</span>
+                                    %elif requirement['status'] == 'failed':
+                                        <i class="fa fa-times" aria-hidden="true"></i>
+                                        <span>${_("Verification Failed" )}</span>
+                                    %elif requirement['status'] == 'declined':
+                                        <i class="fa fa-times" aria-hidden="true"></i>
+                                        <span>${_("Verification Declined" )}</span>
+                                    %elif requirement['status'] == 'satisfied':
+                                        <i class="fa fa-check" aria-hidden="true"></i>
+                                        <span>${_("Completed by")} ${get_time_display(requirement['status_date'], DEFAULT_SHORT_DATE_FORMAT, settings.TIME_ZONE)}</span>
+                                    %endif
+                                %else:
+                                    <span class="not-achieve">${_("Upcoming")}</span>
+                                %endif
+                            </div>
+                        </div>
+                    %endfor
+                     </div>
+                    <button class="detail-collapse" aria-live="polite"><i class="fa fa-caret-up" aria-hidden="true"></i>
+                        <span class="requirement-detail">${_("Less")}</span>
+                    </button>
+                </div>
+            </section>
+          %endif
+
+          <div class="chapters">
+            %for chapter in courseware_summary:
+            %if not chapter['display_name'] == "hidden":
+            <section>
+              <h2>${ chapter['display_name'] | h}</h2>
+
+              <div class="sections">
+                %for section in chapter['sections']:
+                <div>
+                  <%
+                  earned = section['section_total'].earned
+                  total = section['section_total'].possible
+                  percentageString = "{0:.0%}".format( float(earned)/total) if earned > 0 and total > 0 else ""
+                  %>
+
+                  <h3><a href="${reverse('courseware_section', kwargs=dict(course_id=course.id.to_deprecated_string(), chapter=chapter['url_name'], section=section['url_name'])) | h}">
+                    ${ section['display_name'] | h}
+                    %if total > 0 or earned > 0:
+                      <span class="sr">
+                        ${_("{earned} of {total} possible points").format(earned='{:.3n}'.format(float(earned)), total='{:.3n}'.format(float(total))) | h}
+                      </span>
+                    %endif
+                    </a>
+                    %if total > 0 or earned > 0:
+                      <span> ${"({0:.3n}/{1:.3n}) {2}".format( float(earned), float(total), percentageString ) | h}</span>
+                    %endif
+                  </h3>
+                  <p>
+                    ${section['format'] | h}
+
+                    %if section.get('due') is not None:
+                      <%
+                          formatted_string = get_time_display(section['due'], course.due_date_display_format, coerce_tz=settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES)
+                          due_date = '' if len(formatted_string)==0 else _(u'due {date}').format(date=formatted_string)
+                      %>
+                      <em>
+                      ${due_date | h}
+                      </em>
+                    %endif
+                  </p>
+
+                  <div class="scores">
+                    %if len(section['scores']) > 0:
+                      <h3> ${ _("Problem Scores: ") if section['graded'] else _("Practice Scores: ")} </h3>
+                      <ol>
+                        %for score in section['scores']:
+                        <li>${"{0:.3n}/{1:.3n}".format(float(score.earned),float(score.possible)) | h}</li>
+                        %endfor
+                      </ol>
+                    %else:
+                      <h3 class="no-scores"> ${_("No problem scores in this section")} </h3>
+                    %endif
+                  </div>
 
 
-            </div> <!--End section-->
+                </div> <!--End section-->
+                %endfor
+              </div> <!--End sections-->
+            </section> <!--End chapter-->
+            %endif
             %endfor
-          </div> <!--End sections-->
-        </section> <!--End chapter-->
-        %endif
-        %endfor
-      </div> <!--End chapters-->
+          </div> <!--End chapters-->
 
-    </div>
+        </div>
+    </main>
   </div>
 </div>
-

--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -16,8 +16,10 @@
 
 <%include file="/courseware/course_navigation.html" args="active_page='static_tab_{0}'.format(tab['url_slug'])" />
 
-<section class="container">
-  <div class="static_tab_wrapper">
-    ${tab_contents}
-  </div>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container">
+      <div class="static_tab_wrapper">
+        ${tab_contents}
+      </div>
+    </section>
+</main>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -19,7 +19,6 @@ from openedx.core.djangolib.markup import Text, HTML
 
 <%block name="pagetitle">${_("Dashboard")}</%block>
 <%block name="bodyclass">view-dashboard is-authenticated</%block>
-<%block name="nav_skip">#my-courses</%block>
 
 <%block name="header_extras">
 % for template_name in ["donation"]:
@@ -75,120 +74,122 @@ from openedx.core.djangolib.markup import Text, HTML
     %endif
 </div>
 
-<section class="container dashboard" id="dashboard-main">
-  <section class="my-courses" id="my-courses" role="main" tabindex="-1">
-    <header class="wrapper-header-courses">
-      <h2 class="header-courses">${_("My Courses")}</h2>
-    </header>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container dashboard" id="dashboard-main">
+      <section class="my-courses" id="my-courses">
+        <header class="wrapper-header-courses">
+          <h2 class="header-courses">${_("My Courses")}</h2>
+        </header>
 
 
-    % if len(course_enrollments) > 0:
-      <ul class="listing-courses">
-      <% share_settings = getattr(settings, 'SOCIAL_SHARING_SETTINGS', {}) %>
-      % for dashboard_index, enrollment in enumerate(course_enrollments):
-        <% show_courseware_link = (enrollment.course_id in show_courseware_links_for) %>
-        <% cert_status = cert_statuses.get(enrollment.course_id) %>
-        <% can_unenroll = (not cert_status) or cert_status.get('can_unenroll') %>
-        <% credit_status = credit_statuses.get(enrollment.course_id) %>
-        <% show_email_settings = (enrollment.course_id in show_email_settings_for) %>
-        <% course_mode_info = all_course_modes.get(enrollment.course_id) %>
-        <% show_refund_option = (enrollment.course_id in show_refund_option_for) %>
-        <% is_paid_course = (enrollment.course_id in enrolled_courses_either_paid) %>
-        <% is_course_blocked = (enrollment.course_id in block_courses) %>
-        <% course_verification_status = verification_status_by_course.get(enrollment.course_id, {}) %>
-        <% course_requirements = courses_requirements_not_met.get(enrollment.course_id) %>
-        <% course_program_info = course_programs.get(unicode(enrollment.course_id)) %>
-        <%include file = 'dashboard/_dashboard_course_listing.html' args="course_overview=enrollment.course_overview, enrollment=enrollment, show_courseware_link=show_courseware_link, cert_status=cert_status, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, show_refund_option=show_refund_option, is_paid_course=is_paid_course, is_course_blocked=is_course_blocked, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, course_program_info=course_program_info" />
-      % endfor
-
-      </ul>
-    % else:
-      <section class="empty-dashboard-message">
-        <p>${_("You are not enrolled in any courses yet.")}</p>
-
-        % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
-          <a href="${marketing_link('COURSES')}">
-            ${_("Explore courses")}
-          </a>
-
-        %endif
-      </section>
-    % endif
-
-    % if staff_access and len(errored_courses) > 0:
-      <div id="course-errors">
-        <h2>${_("Course-loading errors")}</h2>
-
-      % for course_dir, errors in errored_courses.items():
-         <h3>${course_dir}</h3>
-             <ul>
-           % for (msg, err) in errors:
-               <li>${msg}
-                 <ul><li><pre>${err}</pre></li></ul>
-               </li>
-           % endfor
-             </ul>
-      % endfor
-      </div>
-    % endif
-  </section>
-
-  % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
-    <div id="dashboard-search-bar" class="search-bar dashboard-search-bar" role="search" aria-label="Dashboard">
-      <form>
-        <label for="dashboard-search-input">${_('Search Your Courses')}</label>
-        <div class="search-field-wrapper">
-          <input id="dashboard-search-input" type="text" class="search-field"/>
-          <button type="submit" class="search-button" aria-label="${_('Search')}">
-            <i class="icon fa fa-search" aria-hidden="true"></i>
-          </button>
-          <button type="button" class="cancel-button" aria-label="${_('Clear search')}">
-            <i class="icon fa fa-remove" aria-hidden="true"></i>
-          </button>
-        </div>
-      </form>
-    </div>
-  % endif
-
-  % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
-    <section id="dashboard-search-results" class="search-results dashboard-search-results"></section>
-  % endif
-
-  <section class="profile-sidebar" id="profile-sidebar" role="region" aria-label="Account Status Info">
-    <header class="profile">
-      <h2 class="account-status-title sr">${_("Account Status Info")}: </h2>
-    </header>
-    <section class="user-info">
-      <ul>
-
-        % if len(order_history_list):
-        <li class="order-history">
-          <span class="title">${_("Order History")}</span>
-          % for order_history_item in order_history_list:
-            <span><a href="${order_history_item['receipt_url']}" target="_blank" class="edit-name">${order_history_item['order_date']}</a></span>
+        % if len(course_enrollments) > 0:
+          <ul class="listing-courses">
+          <% share_settings = getattr(settings, 'SOCIAL_SHARING_SETTINGS', {}) %>
+          % for dashboard_index, enrollment in enumerate(course_enrollments):
+            <% show_courseware_link = (enrollment.course_id in show_courseware_links_for) %>
+            <% cert_status = cert_statuses.get(enrollment.course_id) %>
+            <% can_unenroll = (not cert_status) or cert_status.get('can_unenroll') %>
+            <% credit_status = credit_statuses.get(enrollment.course_id) %>
+            <% show_email_settings = (enrollment.course_id in show_email_settings_for) %>
+            <% course_mode_info = all_course_modes.get(enrollment.course_id) %>
+            <% show_refund_option = (enrollment.course_id in show_refund_option_for) %>
+            <% is_paid_course = (enrollment.course_id in enrolled_courses_either_paid) %>
+            <% is_course_blocked = (enrollment.course_id in block_courses) %>
+            <% course_verification_status = verification_status_by_course.get(enrollment.course_id, {}) %>
+            <% course_requirements = courses_requirements_not_met.get(enrollment.course_id) %>
+            <% course_program_info = course_programs.get(unicode(enrollment.course_id)) %>
+            <%include file = 'dashboard/_dashboard_course_listing.html' args="course_overview=enrollment.course_overview, enrollment=enrollment, show_courseware_link=show_courseware_link, cert_status=cert_status, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, show_refund_option=show_refund_option, is_paid_course=is_paid_course, is_course_blocked=is_course_blocked, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, course_program_info=course_program_info" />
           % endfor
-        </li>
+
+          </ul>
+        % else:
+          <section class="empty-dashboard-message">
+            <p>${_("You are not enrolled in any courses yet.")}</p>
+
+            % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
+              <a href="${marketing_link('COURSES')}">
+                ${_("Explore courses")}
+              </a>
+
+            %endif
+          </section>
         % endif
 
-        <%include file="${static.get_template_path('dashboard/_dashboard_status_verification.html')}" />
+        % if staff_access and len(errored_courses) > 0:
+          <div id="course-errors">
+            <h2>${_("Course-loading errors")}</h2>
 
-      </ul>
+          % for course_dir, errors in errored_courses.items():
+             <h3>${course_dir}</h3>
+                 <ul>
+               % for (msg, err) in errors:
+                   <li>${msg}
+                     <ul><li><pre>${err}</pre></li></ul>
+                   </li>
+               % endfor
+                 </ul>
+          % endfor
+          </div>
+        % endif
+      </section>
+
+      % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
+        <div id="dashboard-search-bar" class="search-bar dashboard-search-bar" role="search" aria-label="Dashboard">
+          <form>
+            <label for="dashboard-search-input">${_('Search Your Courses')}</label>
+            <div class="search-field-wrapper">
+              <input id="dashboard-search-input" type="text" class="search-field"/>
+              <button type="submit" class="search-button" aria-label="${_('Search')}">
+                <i class="icon fa fa-search" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="cancel-button" aria-label="${_('Clear search')}">
+                <i class="icon fa fa-remove" aria-hidden="true"></i>
+              </button>
+            </div>
+          </form>
+        </div>
+      % endif
+
+      % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
+        <section id="dashboard-search-results" class="search-results dashboard-search-results"></section>
+      % endif
+
+      <section class="profile-sidebar" id="profile-sidebar" role="region" aria-label="Account Status Info">
+        <header class="profile">
+          <h2 class="account-status-title sr">${_("Account Status Info")}: </h2>
+        </header>
+        <section class="user-info">
+          <ul>
+
+            % if len(order_history_list):
+            <li class="order-history">
+              <span class="title">${_("Order History")}</span>
+              % for order_history_item in order_history_list:
+                <span><a href="${order_history_item['receipt_url']}" target="_blank" class="edit-name">${order_history_item['order_date']}</a></span>
+              % endfor
+            </li>
+            % endif
+
+            <%include file="${static.get_template_path('dashboard/_dashboard_status_verification.html')}" />
+
+          </ul>
+        </section>
+      </section>
+      % if xseries_credentials:
+        <div class="wrapper-xseries-certificates">
+          <p class="title">${_("XSeries Program Certificates")}</p>
+          <p class="copy">${_("You have received a certificate for the following XSeries programs:")}</p>
+          <ul>
+          % for xseries_credential in xseries_credentials:
+            <li>
+              <a class="copy" href="${xseries_credential['credential_url']}">${xseries_credential['display_name']}</a>
+            </li>
+          % endfor
+          </ul>
+        </div>
+      % endif
     </section>
-  </section>
-  % if xseries_credentials:
-    <div class="wrapper-xseries-certificates">
-      <p class="title">${_("XSeries Program Certificates")}</p>
-      <p class="copy">${_("You have received a certificate for the following XSeries programs:")}</p>
-      <ul>
-      % for xseries_credential in xseries_credentials:
-        <li>
-          <a class="copy" href="${xseries_credential['credential_url']}">${xseries_credential['display_name']}</a>
-        </li>
-      % endfor
-      </ul>
-    </div>
-  % endif
-</section>
+</main>
 
 <section id="email-settings-modal" class="modal" aria-hidden="true">
   <div class="inner-wrapper" role="dialog" aria-labelledby="email-settings-title">

--- a/lms/templates/discussion/index.html
+++ b/lms/templates/discussion/index.html
@@ -8,7 +8,6 @@ from django.core.urlresolvers import reverse
 
 <%block name="bodyclass">discussion</%block>
 <%block name="pagetitle">${_("Discussion - {course_number}").format(course_number=course.display_number_with_default) | h}</%block>
-<%block name="nav_skip">#discussion-container</%block>
 
 <%block name="headextra">
 <%static:css group='style-course-vendor'/>
@@ -39,13 +38,14 @@ from django.core.urlresolvers import reverse
          data-sort-preference="${sort_preference | h}"
          data-flag-moderator="${flag_moderator | h}"
          data-user-cohort-id="${user_cohort | h}"
-         data-course-settings="${course_settings | h}"
-         tabindex="-1">
+         data-course-settings="${course_settings | h}">
     <div class="discussion-body">
         <div class="forum-nav" role="complementary" aria-label="${_("Discussion thread list")}"></div>
-        <div class="discussion-column" role="main" aria-label="Discussion" id="discussion-column">
-          <article class="new-post-article" style="display: none" tabindex="-1" aria-label="${_("New topic form")}"></article>
-          <div class="forum-content"></div>
+        <div class="discussion-column" id="discussion-column">
+            <main id="main" aria-label="Content" tabindex="-1">
+                <article class="new-post-article" style="display: none" tabindex="-1" aria-label="${_("New topic form")}"></article>
+                <div class="forum-content"></div>
+            </main>
         </div>
     </div>
 </section>

--- a/lms/templates/edxnotes/edxnotes.html
+++ b/lms/templates/edxnotes/edxnotes.html
@@ -20,7 +20,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 <section class="container">
   <div class="wrapper-student-notes">
     <div class="student-notes">
-
+    <main id="main" aria-label="Content" tabindex="-1">
       <div class="title-search-container">
         <div class="wrapper-title">
           <h1 class="page-title">
@@ -93,7 +93,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         </section>
         % endif
       </section>
-
+    </main>
     </div>
   </div>
 </section>

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -5,48 +5,50 @@ from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 %>
 
-<section class="home">
-  <header>
-    <div class="outer-wrapper">
-      <div class="title">
-        <div class="heading-group">
-          % if homepage_overlay_html:
-            ${homepage_overlay_html}
-          % else:
-              ## Translators: 'Open edX' is a brand, please keep this untranslated. See http://openedx.org for more information.
-              <h1>${_("Welcome to Open edX!")}</h1>
-              ## Translators: 'Open edX' is a brand, please keep this untranslated. See http://openedx.org for more information.
-              <p>${_("It works! This is the default homepage for this Open edX instance.")}</p>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="home">
+      <header>
+        <div class="outer-wrapper">
+          <div class="title">
+            <div class="heading-group">
+              % if homepage_overlay_html:
+                ${homepage_overlay_html}
+              % else:
+                  ## Translators: 'Open edX' is a brand, please keep this untranslated. See http://openedx.org for more information.
+                  <h1>${_("Welcome to Open edX!")}</h1>
+                  ## Translators: 'Open edX' is a brand, please keep this untranslated. See http://openedx.org for more information.
+                  <p>${_("It works! This is the default homepage for this Open edX instance.")}</p>
+              % endif
+            </div>
+            % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+              <div class="course-search">
+                <form method="get" action="/courses">
+                  <label><span class="sr">${_("Search for a course")}</span>
+                    <input class="search-input" name="search_query" type="text" placeholder="${_("Search for a course")}"></input>
+                  </label>
+                  <button class="search-button" type="submit">
+                    <i class="icon fa fa-search" aria-hidden="true"></i><span class="sr">${_("Search")}</span>
+                  </button>
+                </form>
+              </div>
+            % endif
+
+          </div>
+
+          % if show_homepage_promo_video:
+            <a href="#video-modal" class="media" rel="leanModal">
+              <div class="hero">
+                <div class="play-intro"></div>
+              </div>
+            </a>
           % endif
         </div>
-        % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
-          <div class="course-search">
-            <form method="get" action="/courses">
-              <label><span class="sr">${_("Search for a course")}</span>
-                <input class="search-input" name="search_query" type="text" placeholder="${_("Search for a course")}"></input>
-              </label>
-              <button class="search-button" type="submit">
-                <i class="icon fa fa-search" aria-hidden="true"></i><span class="sr">${_("Search")}</span>
-              </button>
-            </form>
-          </div>
-        % endif
 
-      </div>
+      </header>
+      <%include file="${courses_list}" />
 
-      % if show_homepage_promo_video:
-        <a href="#video-modal" class="media" rel="leanModal">
-          <div class="hero">
-            <div class="play-intro"></div>
-          </div>
-        </a>
-      % endif
-    </div>
-
-  </header>
-  <%include file="${courses_list}" />
-
-</section>
+    </section>
+</main>
 
 % if show_homepage_promo_video:
   <section id="video-modal" class="modal home-page-video-modal video-modal">

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -20,7 +20,6 @@ from django.core.urlresolvers import reverse
 ## 6. And tests go in lms/djangoapps/instructor/tests/
 
 <%block name="pagetitle">${_("Instructor Dashboard")}</%block>
-<%block name="nav_skip">#content</%block>
 
 <%block name="headextra">
   <%static:css group='style-course-vendor'/>
@@ -86,41 +85,42 @@ from django.core.urlresolvers import reverse
 
 <section class="container">
   <div class="instructor-dashboard-wrapper-2">
-    <section class="instructor-dashboard-content-2" id="instructor-dashboard-content">
-      <div class="wrap-instructor-info studio-view">
-        %if studio_url:
-        <a class="instructor-info-action" href="${studio_url}">${_("View Course in Studio")}</a>
-        %endif
-      </div>
+        <main id="main" aria-label="Content" tabindex="-1">
+        <section class="instructor-dashboard-content-2" id="instructor-dashboard-content">
+          <div class="wrap-instructor-info studio-view">
+            %if studio_url:
+            <a class="instructor-info-action" href="${studio_url}">${_("View Course in Studio")}</a>
+            %endif
+          </div>
 
-    <h1>${_("Instructor Dashboard")}</h1>
+        <h1>${_("Instructor Dashboard")}</h1>
 
-      %if analytics_dashboard_message:
-        <div class="wrapper-msg urgency-low is-shown">
-            <p>${analytics_dashboard_message}</p>
-        </div>
-      %endif
+          %if analytics_dashboard_message:
+            <div class="wrapper-msg urgency-low is-shown">
+                <p>${analytics_dashboard_message}</p>
+            </div>
+          %endif
 
-    ## links which are tied to idash-sections below.
-    ## the links are activated and handled in instructor_dashboard.coffee
-    ## when the javascript loads, it clicks on the first section
-    <ul class="instructor-nav">
-      % for section_data in sections:
-        ## This is necessary so we don't scrape 'section_display_name' as a string.
-        <% dname = section_data['section_display_name'] %>
-        <li class="nav-item"><a href="" data-section="${ section_data['section_key'] }">${_(dname)}</a></li>
-      % endfor
-    </ul>
+        ## links which are tied to idash-sections below.
+        ## the links are activated and handled in instructor_dashboard.coffee
+        ## when the javascript loads, it clicks on the first section
+        <ul class="instructor-nav">
+          % for section_data in sections:
+            ## This is necessary so we don't scrape 'section_display_name' as a string.
+            <% dname = section_data['section_display_name'] %>
+            <li class="nav-item"><a href="" data-section="${ section_data['section_key'] }">${_(dname)}</a></li>
+          % endfor
+        </ul>
 
-    ## each section corresponds to a section_data sub-dictionary provided by the view
-    ## to keep this short, sections can be pulled out into their own files
+        ## each section corresponds to a section_data sub-dictionary provided by the view
+        ## to keep this short, sections can be pulled out into their own files
 
-    % for section_data in sections:
-      <section id="${ section_data['section_key'] }" class="idash-section">
-        <%include file="${ section_data['section_key'] }.html" args="section_data=section_data" />
-      </section>
-      % endfor
-    </section>
+        % for section_data in sections:
+          <section id="${ section_data['section_key'] }" class="idash-section">
+            <%include file="${ section_data['section_key'] }.html" args="section_data=section_data" />
+          </section>
+          % endfor
+        </section>
+        </main>
   </div>
 </section>
-

--- a/lms/templates/learner_dashboard/programs.html
+++ b/lms/templates/learner_dashboard/programs.html
@@ -18,8 +18,9 @@ ProgramListFactory({
 </%block>
 
 <%block name="pagetitle">${_("Programs")}</%block>
-
-<div class="program-list-wrapper">
-    <div class="program-cards-container"></div>
-    <div class="sidebar"></div>
-</div>
+<main id="main" aria-label="Content" tabindex="-1">
+    <div class="program-list-wrapper">
+        <div class="program-cards-container"></div>
+        <div class="sidebar"></div>
+    </div>
+</main>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -120,13 +120,13 @@ from pipeline_mako import render_require_js_path_overrides
 % if not disable_window_wrap:
   <div class="window-wrap" dir="${static.dir_rtl()}">
 % endif
-    <a class="nav-skip" href="<%block name="nav_skip">#content</%block>">${_("Skip to main content")}</a>
+    <a class="nav-skip" href="#main">${_("Skip to main content")}</a>
 
     % if not disable_header:
         <%include file="${static.get_template_path('header.html')}" />
     % endif
 
-    <div role="main" class="content-wrapper" id="content" tabindex="-1">
+    <div class="content-wrapper" id="content">
       ${self.body()}
       <%block name="bodyextra"/>
     </div>

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -24,11 +24,11 @@
 
 <body class="{% block bodyclass %}{% endblock %} lang_{{LANGUAGE_CODE}}">
   <div class="window-wrap" dir="${static.dir_rtl()}">
-    <a class="nav-skip" href="{% block nav_skip %}#content{% endblock %}">{% trans "Skip to main content" %}</a>
+    <a class="nav-skip" href="#main">{% trans "Skip to main content" %}</a>
     {% with course=request.course %}
       {% include "header.html"|microsite_template_path %}
     {% endwith %}
-    <div role="main" class="content-wrapper" id="content" tabindex="-1">
+    <div class="content-wrapper" id="content">
       {% block body %}{% endblock %}
       {% block bodyextra %}{% endblock %}
     </div>

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -8,11 +8,13 @@ from openedx.core.djangolib.markup import Text, HTML
 
 <%block name="pagetitle">${_("Page Not Found")}</%block>
 
-<section class="outside-app">
-<h1>${_("Page not found")}</h1>
-<p>${Text(_('The page that you were looking for was not found. Go back to the {link_start}homepage{link_end} or let us know about any pages that may have been moved at {email}.')).format(
-    link_start=HTML('<a href="/">'),
-    link_end=HTML('</a>'),
-    email=HTML('<a href="mailto:{email}">{email}</a>').format(email=Text(static.get_tech_support_email_address()))
-  )}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="outside-app">
+    <h1>${_("Page not found")}</h1>
+    <p>${Text(_('The page that you were looking for was not found. Go back to the {link_start}homepage{link_end} or let us know about any pages that may have been moved at {email}.')).format(
+        link_start=HTML('<a href="/">'),
+        link_end=HTML('</a>'),
+        email=HTML('<a href="mailto:{email}">{email}</a>').format(email=Text(static.get_tech_support_email_address()))
+      )}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/about.html
+++ b/lms/templates/static_templates/about.html
@@ -4,7 +4,9 @@
 
 <%block name="pagetitle">${_("About")}</%block>
 
-<section class="container about">
-<h1>${_("About")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+        <h1>${_("About")}</h1>
+        <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/blog.html
+++ b/lms/templates/static_templates/blog.html
@@ -4,7 +4,9 @@
 
 <%block name="pagetitle">${_("Blog")}</%block>
 
-<section class="container about">
-    <h1>${_("Blog")}</h1>
-    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+        <h1>${_("Blog")}</h1>
+        <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -4,7 +4,9 @@
 
 <%block name="pagetitle">${_("Contact")}</%block>
 
-<section class="container about">
-<h1>${_("Contact")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+        <h1>${_("Contact")}</h1>
+        <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/donate.html
+++ b/lms/templates/static_templates/donate.html
@@ -4,7 +4,9 @@
 
 <%block name="pagetitle">${_("Donate")}</%block>
 
-<section class="container about">
-    <h1>${_("Donate")}</h1>
-    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+        <h1>${_("Donate")}</h1>
+        <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/embargo.html
+++ b/lms/templates/static_templates/embargo.html
@@ -7,14 +7,16 @@ from openedx.core.djangolib.markup import Text, HTML
 
 <%block name="pagetitle">${_("This Course Unavailable In Your Country")}</%block>
 
-<section class="outside-app">
-<p>
-${Text(_("Our system indicates that you are trying to access this {platform_name} "
-    "course from a country or region currently subject to U.S. economic and trade "
-    "sanctions. Unfortunately, at this time {platform_name} must comply with "
-    "export controls, and we cannot allow you to access this course."
-  )).format(
-    platform_name=Text(settings.PLATFORM_NAME),
-  )}
-</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="outside-app">
+    <p>
+    ${Text(_("Our system indicates that you are trying to access this {platform_name} "
+        "course from a country or region currently subject to U.S. economic and trade "
+        "sanctions. Unfortunately, at this time {platform_name} must comply with "
+        "export controls, and we cannot allow you to access this course."
+      )).format(
+        platform_name=Text(settings.PLATFORM_NAME),
+      )}
+    </p>
+    </section>
+</main>

--- a/lms/templates/static_templates/faq.html
+++ b/lms/templates/static_templates/faq.html
@@ -4,7 +4,9 @@
 
 <%block name="pagetitle">${_("FAQ")}</%block>
 
-<section class="container about">
-<h1>${_("FAQ")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+    <h1>${_("FAQ")}</h1>
+    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/help.html
+++ b/lms/templates/static_templates/help.html
@@ -4,7 +4,9 @@
 
 <%block name="pagetitle">${_("Help")}</%block>
 
-<section class="container about">
-<h1>${_("Help")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+    <h1>${_("Help")}</h1>
+    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/honor.html
+++ b/lms/templates/static_templates/honor.html
@@ -4,7 +4,9 @@
 
 <%block name="pagetitle">${_("Honor Code")}</%block>
 
-<section class="container about">
-<h1>${_("Honor Code")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+    <h1>${_("Honor Code")}</h1>
+    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/jobs.html
+++ b/lms/templates/static_templates/jobs.html
@@ -4,7 +4,9 @@
 
 <%block name="pagetitle">${_("Jobs")}</%block>
 
-<section class="container about">
-<h1>${_("Jobs")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+    <h1>${_("Jobs")}</h1>
+    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/media-kit.html
+++ b/lms/templates/static_templates/media-kit.html
@@ -4,7 +4,9 @@
 
 <%block name="pagetitle">${_("Media Kit")}</%block>
 
-<section class="container about">
-<h1>${_("Media Kit")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Cntent" tabindex="-1">
+    <section class="container about">
+    <h1>${_("Media Kit")}</h1>
+    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/news.html
+++ b/lms/templates/static_templates/news.html
@@ -5,7 +5,9 @@
 
 <%block name="pagetitle">${_("In the Press")}</%block>
 
-<section class="container about">
-<h1>${_("In the Press")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+    <h1>${_("In the Press")}</h1>
+    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/press.html
+++ b/lms/templates/static_templates/press.html
@@ -5,7 +5,9 @@
 
 <%block name="pagetitle">${_("In the Press")}</%block>
 
-<section class="container about">
-<h1>${_("In the Press")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+    <h1>${_("In the Press")}</h1>
+    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/privacy.html
+++ b/lms/templates/static_templates/privacy.html
@@ -5,7 +5,9 @@
 
 <%block name="pagetitle">${_("Privacy Policy")}</%block>
 
-<section class="container about">
-<h1>${_("Privacy Policy")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+    <h1>${_("Privacy Policy")}</h1>
+    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/server-down.html
+++ b/lms/templates/static_templates/server-down.html
@@ -1,19 +1,21 @@
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _ 
+from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import Text, HTML
 %>
 <%inherit file="../main.html" />
 
-<section class="outside-app">
-  <h1>
-    ${Text(_("Currently the {platform_name} servers are down")).format(
-        platform_name=HTML(u"<em>{}</em>").format(Text(settings.PLATFORM_NAME))
-    )}
-  </h1>
-  <p>
-    ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
-    "Please email us at {tech_support_email} to report any problems or downtime.")).format(
-        tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(Text(settings.TECH_SUPPORT_EMAIL))
-    )}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="outside-app">
+      <h1>
+        ${Text(_("Currently the {platform_name} servers are down")).format(
+            platform_name=HTML(u"<em>{}</em>").format(Text(settings.PLATFORM_NAME))
+        )}
+      </h1>
+      <p>
+        ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
+        "Please email us at {tech_support_email} to report any problems or downtime.")).format(
+            tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(Text(settings.TECH_SUPPORT_EMAIL))
+        )}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/server-error.html
+++ b/lms/templates/static_templates/server-error.html
@@ -6,17 +6,19 @@ from openedx.core.djangolib.markup import Text, HTML
 %>
 <%inherit file="../main.html" />
 
-<section class="outside-app">
-  <h1>
-    ${Text(_(u"There has been a 500 error on the {platform_name} servers")).format(
-        platform_name=HTML("<em>{platform_name}</em>").format(platform_name=Text(static.get_platform_name()))
-    )}
-  </h1>
-  <p>
-    ${Text(_('Please wait a few seconds and then reload the page. If the problem persists, please email us at {email}.')).format(
-        email=HTML('<a href="mailto:{email}">{email}</a>').format(
-            email=Text(static.get_tech_support_email_address())
-        )
-    )}
-  </p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="outside-app">
+      <h1>
+        ${Text(_(u"There has been a 500 error on the {platform_name} servers")).format(
+            platform_name=HTML("<em>{platform_name}</em>").format(platform_name=Text(static.get_platform_name()))
+        )}
+      </h1>
+      <p>
+        ${Text(_('Please wait a few seconds and then reload the page. If the problem persists, please email us at {email}.')).format(
+            email=HTML('<a href="mailto:{email}">{email}</a>').format(
+                email=Text(static.get_tech_support_email_address())
+            )
+        )}
+      </p>
+    </section>
+</main>

--- a/lms/templates/static_templates/server-overloaded.html
+++ b/lms/templates/static_templates/server-overloaded.html
@@ -5,16 +5,18 @@ from openedx.core.djangolib.markup import Text, HTML
 %>
 <%inherit file="../main.html" />
 
-<section class="outside-app">
-  <h1>
-    ${Text(_("Currently the {platform_name} servers are overloaded")).format(
-        platform_name=HTML("<em>{}</em>").format(platform_name=Text(settings.PLATFORM_NAME))
-    )}
-  </h1>
-  <p>
-    ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
-    "Please email us at {tech_support_email} to report any problems or downtime.")).format(
-        tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(tech_support_email=Text(settings.TECH_SUPPORT_EMAIL))
-    )}
-  </p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="outside-app">
+      <h1>
+        ${Text(_("Currently the {platform_name} servers are overloaded")).format(
+            platform_name=HTML("<em>{}</em>").format(platform_name=Text(settings.PLATFORM_NAME))
+        )}
+      </h1>
+      <p>
+        ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
+        "Please email us at {tech_support_email} to report any problems or downtime.")).format(
+            tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(tech_support_email=Text(settings.TECH_SUPPORT_EMAIL))
+        )}
+      </p>
+    </section>
+</main>

--- a/lms/templates/static_templates/tos.html
+++ b/lms/templates/static_templates/tos.html
@@ -4,7 +4,9 @@
 
 <%block name="pagetitle">${_("Terms of Service")}</%block>
 
-<section class="container about">
-<h1>${_("Terms of Service")}</h1>
-<p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
-</section>
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="container about">
+    <h1>${_("Terms of Service")}</h1>
+    <p>${_("This page left intentionally blank. It is not used by edx.org but is left here for possible use by installations of Open edX.")}</p>
+    </section>
+</main>

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -16,7 +16,6 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 <%namespace name='static' file='/static_content.html'/>
 
 <%block name="pagetitle">${_("Account Settings")}</%block>
-<%block name="nav_skip">#content</%block>
 
 % if duplicate_provider:
     <section>
@@ -37,7 +36,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
     var platformName = '${ static.get_platform_name() | n, js_escaped_string }';
 
     AccountSettingsFactory(
-        fieldsData, 
+        fieldsData,
         authData,
         '${ user_accounts_api_url | n, js_escaped_string }',
         '${ user_preferences_api_url | n, js_escaped_string }',

--- a/lms/templates/student_account/account_settings.underscore
+++ b/lms/templates/student_account/account_settings.underscore
@@ -1,3 +1,4 @@
+<main id="main" aria-label="Content" tabindex="-1">
 <div class="account-settings-container">
     <div class="wrapper-header">
         <h2 class="header-title"><%- gettext("Account Settings") %></h2>
@@ -22,3 +23,4 @@
         <% }); %>
     </div>
 </div>
+</main>

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -33,5 +33,7 @@
 </%block>
 
 <div class="section-bkg-wrapper">
-    <div id="login-and-registration-container" class="login-register" />
+    <main id="main" aria-label="Content" tabindex="-1">
+        <div id="login-and-registration-container" class="login-register" />
+    </main>
 </div>

--- a/lms/templates/student_profile/learner_profile.html
+++ b/lms/templates/student_profile/learner_profile.html
@@ -9,16 +9,17 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json
 %>
 
 <%block name="pagetitle">${_("Learner Profile")}</%block>
-<%block name="nav_skip">#content</%block>
 
 <%block name="bodyclass">view-profile</%block>
 
 <div class="message-banner" aria-live="polite"></div>
-<div class="wrapper-profile">
-    <div class="ui-loading-indicator">
-        <p><span class="spin"><i class="icon fa fa-refresh" aria-hidden="true"></i></span> <span class="copy">${_("Loading")}</span></p>
+<main id="main" aria-label="Content" tabindex="-1">
+    <div class="wrapper-profile">
+        <div class="ui-loading-indicator">
+            <p><span class="spin"><i class="icon fa fa-refresh" aria-hidden="true"></i></span> <span class="copy">${_("Loading")}</span></p>
+        </div>
     </div>
-</div>
+</main>
 <%block name="headextra">
     <%static:css group='style-course'/>
 </%block>

--- a/lms/templates/wiki/article.html
+++ b/lms/templates/wiki/article.html
@@ -7,22 +7,23 @@
 {% block wiki_breadcrumbs %}
 {% include "wiki/includes/breadcrumbs.html" %}
 {% endblock %}
-{% block nav_skip %}#main-article{% endblock %}
 
 {% block wiki_contents %}
 
   <div class="article-wrapper">
 
-    <article class="main-article" id="main-article" tabindex="-1">
-        {% if selected_tab != "edit" %}
-          <h1>{{ article.current_revision.title }}</h1>
+    <main id="main" aria-label="Content" tabindex="-1">
+        <article class="main-article" id="main-article">
+            {% if selected_tab != "edit" %}
+              <h1>{{ article.current_revision.title }}</h1>
 
-        {% endif %}
+            {% endif %}
 
-        {% block wiki_contents_tab %}
-        {% wiki_render article %}
-        {% endblock %}
-    </article>
+            {% block wiki_contents_tab %}
+            {% wiki_render article %}
+            {% endblock %}
+        </article>
+    </main>
 
     <div class="article-functions">
       <ul class="nav nav-tabs">

--- a/lms/templates/wiki/base.html
+++ b/lms/templates/wiki/base.html
@@ -47,8 +47,6 @@
 
 {% endblock %}
 
-{% block nav_skip %}#wiki-content{% endblock %}
-
 {% block body %}
   {% if request.course %}
   {% with course=request.course %}
@@ -56,6 +54,7 @@
   {% endwith %}
   {% endif %}
 
+<main id="main" aria-label="Content" tabindex="-1">
   <section class="container wiki {{ selected_tab }}" id="wiki-content">
     <div class="wiki-wrapper">
       {% block wiki_body %}
@@ -77,5 +76,6 @@
     </div>
 
   </section>
+</main>
 
 {% endblock %}

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -20,7 +20,6 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 
 <%block name="pagetitle">${_("Dashboard")}</%block>
 <%block name="bodyclass">view-dashboard is-authenticated</%block>
-<%block name="nav_skip">#my-courses</%block>
 
 <%block name="header_extras">
 % for template_name in ["donation"]:
@@ -77,7 +76,8 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 </div>
 
 <section class="container dashboard" id="dashboard-main">
-  <section class="my-courses" id="my-courses" role="main" aria-label="Content" tabindex="-1">
+<main id="main" aria-label="Content" tabindex="-1">
+  <section class="my-courses" id="my-courses">
     <header class="wrapper-header-courses">
       <h2 class="header-courses">${_("My Courses")}</h2>
     </header>
@@ -132,6 +132,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
       </div>
     % endif
   </section>
+</main>
 
   % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
     <div id="dashboard-search-bar" class="search-bar dashboard-search-bar" role="search" aria-label="Dashboard">


### PR DESCRIPTION
# [AC-342](https://openedx.atlassian.net/browse/AC-342)

This work cleans up LMS templates by eliminating all but one `main` container that surrounds the main content of the page. Furthermore it alters the skip links to target that container, sending the user deeper into the page making the skip links more relevant.
## Sandbox

https://clrux-ac-342.sandbox.edx.org
https://studio-clrux-ac-342.sandbox.org
## Reviewers
- [x] @cptvitamin 
- [x] @efischer19 or @dianakhuang 
