### PR TITLE
Updated dashboard UI for empty list of courses and programs

### DIFF
--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -499,11 +499,11 @@ class DashboardTest(ModuleStoreTestCase):
         self.client.login(username="jack", password="test")
         response = self.client.get(reverse("dashboard"))
 
-        # "Find courses" is shown in the side panel
-        self.assertContains(response, "Find courses")
+        # "Explore courses" is shown in the side panel
+        self.assertContains(response, "Explore courses")
 
         # But other links are hidden in the navigation
-        self.assertNotContains(response, "How it Works")
+        self.assertNotContains(response, "How it works")
         self.assertNotContains(response, "Schools & Partners")
 
     def test_course_mode_info_with_honor_enrollment(self):

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -212,9 +212,79 @@
   }
 }
 
+.xseries-epmty-section{
+    @include float(left);
+    @include outer-container;
+    @include span-columns(9);
+}
+// CASE: empty dashboard
+    .empty-dashboard-message {
+      border: 3px solid $gray-l4;
+      background: $gray-l6;
+      padding: ($baseline*2) 0;
+      text-align: center;
+
+      p {
+        @include font-size(24);
+        color: $lighter-base-font-color;
+        margin-bottom: $baseline;
+        text-shadow: 0 1px rgba(255,255,255, 0.6);
+      }
+
+      a {
+        background-color: $blue;
+        border: 1px solid $blue;
+        box-shadow: 0 1px 8px 0 $shadow-l1;
+        @include box-sizing(border-box);
+        color: $white;
+        font-family: $sans-serif;
+        display: inline-block;
+        letter-spacing: 1px;
+        margin-top: ($baseline/4);
+        margin-left: ($baseline/4);
+        padding: 15px 20px;
+
+        &:hover, &:focus {
+          background: $blue-l2;
+          text-decoration: none;
+        }
+      }
+
+      .find-xseries-programs {
+        @extend %btn-pl-black-base;
+        .action-xseries-icon {
+          @include float(left);
+          display: inline;
+
+          @include margin-right($baseline*0.4);
+          background: url('#{$static-path}/images/icon-sm-xseries-white.png') no-repeat;
+          background-color: transparent;
+
+          width: ($baseline*1.1);
+          height: ($baseline*1.1);
+        }
+        &:hover,
+        &:focus {
+
+          .action-xseries-icon {
+            @include float(left);
+            display: inline;
+
+            @include margin-right($baseline*0.4);
+            background: url('#{$static-path}/images/icon-sm-xseries-black.png') no-repeat;
+            background-color: transparent;
+
+            width: ($baseline*1.1);
+            height: ($baseline*1.1);
+          }
+        }
+      }
+    }
+
 // +Dashboard - Course Listing
 // ====================
 .dashboard {
+
   .my-courses {
     @include float(left);
     margin: 0;
@@ -230,43 +300,6 @@
         @include padding-right($baseline/2);
       }
     }
-
-    // CASE: empty dashboard
-    .empty-dashboard-message {
-      padding: ($baseline*2) 0;
-      text-align: center;
-
-      p {
-        color: $lighter-base-font-color;
-        font-style: italic;
-        margin-bottom: $baseline;
-        text-shadow: 0 1px rgba(255,255,255, 0.6);
-      }
-
-      a {
-        background: rgb(240,240,240);
-        @include background-image($button-bg-image);
-        background-color: $button-bg-color;
-        border: 1px solid $border-color-2;
-        border-radius: 4px;
-        box-shadow: 0 1px 8px 0 $shadow-l1;
-        @include box-sizing(border-box);
-        color: $base-font-color;
-        font-family: $sans-serif;
-        display: inline-block;
-        letter-spacing: 1px;
-        @include margin-left($baseline/4);
-        padding: 5px 10px;
-        text-shadow: 0 1px rgba(255,255,255, 0.6);
-
-        &:hover, &:focus {
-          color: $link-color;
-          text-decoration: none;
-        }
-      }
-    }
-
-    // ====================
 
     // UI: course list
     .listing-courses {

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -103,12 +103,13 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
       </ul>
     % else:
       <section class="empty-dashboard-message">
-        <p>${_("Looks like you haven't enrolled in any courses yet.")}</p>
+        <p>${_("You are not enrolled in any courses yet.")}</p>
 
         % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
           <a href="${marketing_link('COURSES')}">
-            ${_("Find courses now!")}
+            ${_("Explore courses")}
           </a>
+
         %endif
       </section>
     % endif

--- a/lms/templates/learner_dashboard/programs.html
+++ b/lms/templates/learner_dashboard/programs.html
@@ -20,6 +20,17 @@ ProgramListFactory({
 <%block name="pagetitle">${_("Programs")}</%block>
 
 <div class="program-list-wrapper">
-    <div class="program-cards-container"></div>
+    % if not len(programs):
+        <div class="xseries-epmty-section">
+        <section class="empty-dashboard-message">
+            <p>${_("You are not enrolled in any XSeries Programs yet.")}</p>
+              <a class="find-xseries-programs" href="${xseries_url}"><i class="action-xseries-icon" aria-hidden="true"></i>
+                ${_("Explore XSeries Programs")}
+              </a>
+          </section>
+        </div>
+    % else:
+        <div class="program-cards-container"></div>
+    % endif
     <div class="sidebar"></div>
 </div>


### PR DESCRIPTION
ECOM-3201: Updated dashboard UI for empty list of courses and programs

Please review this @awais786 , @ahsan-ul-haq @waheedahmed @zubair-arbi 

**Dashboard Courses**
<img width="825" alt="screen shot 2016-04-13 at 3 19 26 pm" src="https://cloud.githubusercontent.com/assets/4245618/14490247/37eb68c8-018b-11e6-8775-c8c167bde67d.png">

**Dashboard Programs**
<img width="846" alt="screen shot 2016-04-13 at 3 19 10 pm" src="https://cloud.githubusercontent.com/assets/4245618/14490266/4a00e6b4-018b-11e6-861c-7a4a175f6fa6.png">
