### PR TITLE
Upgraded xblock-lti-consumer to 1.0.5

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -90,7 +90,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/edx-proctoring.git@0.12.15#egg=edx-proctoring==0.12.15
-git+https://github.com/edx/xblock-lti-consumer.git@v1.0.4#egg=xblock-lti-consumer==1.0.4
+git+https://github.com/edx/xblock-lti-consumer.git@v1.0.5#egg=xblock-lti-consumer==1.0.5
 
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga


### PR DESCRIPTION
Cherry-picked commit which missed the RC.

Original PR: https://github.com/edx/edx-platform/pull/12078
xblock-lti-consumer version diff: https://github.com/edx/xblock-lti-consumer/compare/v1.0.4...v1.0.5
