### PR TITLE
SOL-1738 Fix "Site matching query does not exist" stacktrace

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -786,6 +786,7 @@ SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 CMS_BASE = 'localhost:8001'
 
 # Site info
+SITE_ID = 1
 SITE_NAME = "example.com"
 HTTPS = 'on'
 ROOT_URLCONF = 'lms.urls'


### PR DESCRIPTION
This fixes a stacktrace which occurs when accessing the django admin login/logout views without a valid site configuration. This is a temporary rollback of work done to support multi-site theming until a more robust solution can be achieved.

@nedbat @cahrens @mattdrayer 
