### PR TITLE
Fix encoding of Django-called Mako files to be safe

### DIFF
--- a/common/djangoapps/edxmako/makoloader.py
+++ b/common/djangoapps/edxmako/makoloader.py
@@ -48,6 +48,8 @@ class MakoLoader(object):
                                 module_directory=self.module_directory,
                                 input_encoding='utf-8',
                                 output_encoding='utf-8',
+                                default_filters=['decode.utf8'],
+                                encoding_errors='replace',
                                 uri=template_name)
             return template, None
         else:

--- a/common/djangoapps/edxmako/template.py
+++ b/common/djangoapps/edxmako/template.py
@@ -19,8 +19,6 @@ from edxmako.middleware import get_template_request_context
 from edxmako.shortcuts import marketing_link
 from mako.template import Template as MakoTemplate
 
-DJANGO_VARIABLES = ['output_encoding', 'encoding_errors']
-
 # TODO: We should make this a Django Template subclass that simply has the MakoTemplate inside of it? (Intead of inheriting from MakoTemplate)
 
 
@@ -34,9 +32,7 @@ class Template(MakoTemplate):
     def __init__(self, *args, **kwargs):
         """Overrides base __init__ to provide django variable overrides"""
         if not kwargs.get('no_django', False):
-            overrides = {k: getattr(edxmako, k, None) for k in DJANGO_VARIABLES}
-            overrides['lookup'] = edxmako.LOOKUP['main']
-            kwargs.update(overrides)
+            kwargs['lookup'] = edxmako.LOOKUP['main']
         super(Template, self).__init__(*args, **kwargs)
 
     def render(self, context_instance):


### PR DESCRIPTION
The old code set the output-encoding to None, which means, I want
Unicode strings as output.  This made Mako pass markupsafe objects to
"unicode()", which applied all the escaping.  Then the result would be
given to Django, would would html-escape it again, resulting in
over-escaping.

By setting the output-encoding to utf8, we use filters.encode.utf8
instead, which is aware of Markupsafe, which avoids the over-escaping.

TNL-4365
