### PR TITLE
TNL-4324: Add check for strings that should be wrapped with HTML()

### DIFF
--- a/scripts/safe_template_linter.py
+++ b/scripts/safe_template_linter.py
@@ -874,8 +874,8 @@ class MakoTemplateLinter(object):
 
         filters = filters_match.group()[1:-1].replace(" ", "").split(",")
         if (len(filters) == 2) and (filters[0] == 'n') and (filters[1] == 'unicode'):
-                # {x | n, unicode} is valid in any context
-                pass
+            # {x | n, unicode} is valid in any context
+            pass
         elif context == 'html':
             if (len(filters) == 1) and (filters[0] == 'h'):
                 if has_page_default:
@@ -1053,7 +1053,14 @@ class MakoTemplateLinter(object):
         open_char_index = template.find(open_char, start_index, close_char_index)
         parse_string = ParseString(template, start_index, close_char_index)
 
+        valid_index_list = [close_char_index]
+        if 0 <= open_char_index:
+            valid_index_list.append(open_char_index)
         if 0 <= parse_string.start_index:
+            valid_index_list.append(parse_string.start_index)
+        min_valid_index = min(valid_index_list)
+
+        if parse_string.start_index == min_valid_index:
             strings.append(parse_string)
             if parse_string.end_index < 0:
                 return unparseable_result
@@ -1063,7 +1070,7 @@ class MakoTemplateLinter(object):
                     num_open_chars=num_open_chars, strings=strings
                 )
 
-        if 0 <= open_char_index < close_char_index:
+        if open_char_index == min_valid_index:
             if start_delim is not None:
                 # if we find another starting delim, consider this unparseable
                 start_delim_index = template.find(start_delim, start_index, close_char_index)

--- a/scripts/safe_template_linter.py
+++ b/scripts/safe_template_linter.py
@@ -548,14 +548,12 @@ class ParseString(object):
             The start index of the first single or double quote, or -1 if
             no quote was found.
         """
-        double_quote_index = template.find('"', start_index, end_index)
-        single_quote_index = template.find("'", start_index, end_index)
-        if 0 <= single_quote_index or 0 <= double_quote_index:
-            if 0 <= single_quote_index and 0 <= double_quote_index:
-                return min(single_quote_index, double_quote_index)
-            else:
-                return max(single_quote_index, double_quote_index)
-        return -1
+        quote_regex = re.compile(r"""['"]""")
+        start_match = quote_regex.search(template, start_index, end_index)
+        if start_match is None:
+            return -1
+        else:
+            return start_match.start()
 
     def _parse_string(self, template, start_index):
         """
@@ -801,7 +799,7 @@ class MakoTemplateLinter(object):
                 close_paren_index = self._find_closing_char_index(
                     None, "(", ")", expression_inner, start_index=len('HTML('), num_open_chars=0, strings=[]
                 )['close_char_index']
-                # check that the close paren is at the end of the expression.
+                # check that the close paren is at the end of the stripped expression.
                 if close_paren_index != len(expression_inner) - 1:
                     results.violations.append(ExpressionRuleViolation(
                         Rules.mako_html_alone, expression

--- a/scripts/tests/test_safe_template_linter.py
+++ b/scripts/tests/test_safe_template_linter.py
@@ -248,6 +248,10 @@ class TestMakoTemplateLinter(TestCase):
             'rule': None
         },
         {
+            'expression': "${HTML(render_entry(map['entries'], child))}",
+            'rule': None
+        },
+        {
             'expression': "${ HTML('<span></span>') + 'some other text' }",
             'rule': Rules.mako_html_alone
         },

--- a/scripts/tests/test_safe_template_linter.py
+++ b/scripts/tests/test_safe_template_linter.py
@@ -214,7 +214,29 @@ class TestMakoTemplateLinter(TestCase):
             'rule': Rules.mako_wrap_html
         },
         {
+            'expression':
+                textwrap.dedent("""
+                    ${Text(_("String with multiple lines "
+                        "{link_start}unenroll{link_end} "
+                        "and final line")).format(
+                            link_start=HTML(
+                                '<a id="link__over_multiple_lines" '
+                                'data-course-id="{course_id}" '
+                                'href="#test-modal">'
+                            ).format(
+                                course_id=course_overview.id
+                            ),
+                            link_end=HTML('</a>'),
+                    )}
+                """),
+            'rule': None
+        },
+        {
             'expression': "${'<span></span>'}",
+            'rule': Rules.mako_wrap_html
+        },
+        {
+            'expression': "${'Embedded HTML <strong></strong>'}",
             'rule': Rules.mako_wrap_html
         },
         {
@@ -529,7 +551,6 @@ class TestMakoTemplateLinter(TestCase):
         Test _parse_string helper
         """
         linter = MakoTemplateLinter()
-
 
         parse_string = ParseString(data['template'], data['result']['start_index'], len(data['template']))
         string_dict = {


### PR DESCRIPTION
## [TNL-4324](https://openedx.atlassian.net/browse/TNL-4324)

Also include the following:
- new rule for strings that should be wrapped with HTML()
- allow expressions to use "| n, unicode"
- refactor string parsing into separate class
- switch end_index to be the index following the expression

Sample output from the latest linter with the new rule:

```
lms/templates/shoppingcart/shopping_cart.html: 177:25: mako-wrap-html:                         ${_('After this purchase is complete, {username} will be enrolled in this course.').format(username=u'<br/><b>{username}</b>'.format(username=order.user.username))}
```
### Testing
- [x] Data is properly encoded in HTML templates to avoid XSS
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @nedbat 
### Post-review
- [ ] Squash commits
