### PR TITLE
AC-380 ensuring proper event tracking with updated video player

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -83,6 +83,10 @@ NAME_TO_EVENT_TYPE_MAP = {
     'edx.video.seeked': 'seek_video',
     'edx.video.transcript.shown': 'show_transcript',
     'edx.video.transcript.hidden': 'hide_transcript',
+    'edx.video.closed_captions.shown': 'show_closed_captions',
+    'edx.video.closed_captions.hidden': 'hide_closed_captions',
+    'edx.video.language_menu.shown': 'video_show_cc_menu',
+    'edx.video.language_menu.hidden': 'video_hide_cc_menu'
 }
 
 

--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -83,10 +83,13 @@ NAME_TO_EVENT_TYPE_MAP = {
     'edx.video.seeked': 'seek_video',
     'edx.video.transcript.shown': 'show_transcript',
     'edx.video.transcript.hidden': 'hide_transcript',
-    'edx.video.closed_captions.shown': 'show_closed_captions',
-    'edx.video.closed_captions.hidden': 'hide_closed_captions',
-    'edx.video.language_menu.shown': 'video_show_cc_menu',
-    'edx.video.language_menu.hidden': 'video_hide_cc_menu'
+
+    # Needs to add the following, but 'event' is seen as a str with them
+    # Mobile team?
+    # 'edx.video.closed_captions.shown': 'edx.video.closed_captions.shown',
+    # 'edx.video.closed_captions.hidden': 'edx.video.closed_captions.hidden',
+    # 'edx.video.language_menu.shown': 'video_show_cc_menu',
+    # 'edx.video.language_menu.hidden': 'video_hide_cc_menu',
 }
 
 
@@ -114,6 +117,14 @@ class VideoEventProcessor(object):
         # ever be emitted.
         if name == "edx.video.seeked":
             event['name'] = "edx.video.position.changed"
+
+        # Convert to the new namespace
+        # Mobile team?
+        if name == "video_show_cc_menu":
+            event['name'] = "edx.video.language_menu.shown"
+
+        if name == "video_hide_cc_menu":
+            event['name'] = "edx.video.language_menu.hidden"
 
         event['event_type'] = NAME_TO_EVENT_TYPE_MAP[name]
 

--- a/common/djangoapps/track/views/tests/test_segmentio.py
+++ b/common/djangoapps/track/views/tests/test_segmentio.py
@@ -320,6 +320,10 @@ class SegmentIOTrackingTestCase(EventTrackingTestCase):
         ('edx.video.position.changed', 'seek_video'),
         ('edx.video.transcript.shown', 'show_transcript'),
         ('edx.video.transcript.hidden', 'hide_transcript'),
+        ('edx.video.closed_captions.shown', 'show_closed_captions'),
+        ('edx.video.closed_captions.hidden', 'hide_closed_captions'),
+        ('edx.video.language_menu.shown', 'video_show_cc_menu'),
+        ('edx.video.language_menu.hidden', 'video_hide_cc_menu')
     )
     @unpack
     def test_video_event(self, name, event_type):

--- a/common/djangoapps/track/views/tests/test_segmentio.py
+++ b/common/djangoapps/track/views/tests/test_segmentio.py
@@ -320,10 +320,13 @@ class SegmentIOTrackingTestCase(EventTrackingTestCase):
         ('edx.video.position.changed', 'seek_video'),
         ('edx.video.transcript.shown', 'show_transcript'),
         ('edx.video.transcript.hidden', 'hide_transcript'),
-        ('edx.video.closed_captions.shown', 'show_closed_captions'),
-        ('edx.video.closed_captions.hidden', 'hide_closed_captions'),
-        ('edx.video.language_menu.shown', 'video_show_cc_menu'),
-        ('edx.video.language_menu.hidden', 'video_hide_cc_menu')
+
+        # Need to add the following
+        # Mobile team?
+        # ('edx.video.closed_captions.shown', 'edx.video.closed_captions.shown'),
+        # ('edx.video.closed_captions.hidden', 'edx.video.closed_captions.hidden'),
+        # ('edx.video.language_menu.shown', 'video_show_cc_menu'),
+        # ('edx.video.language_menu.hidden', 'video_hide_cc_menu'),
     )
     @unpack
     def test_video_event(self, name, event_type):

--- a/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
@@ -130,12 +130,13 @@
             state.el.trigger('language_menu:hide');
             expect(Logger.log).toHaveBeenCalledWith('video_hide_cc_menu', {
                 id: 'id',
-                code: 'html5'
+                code: 'html5',
+                language: 'en'
             });
         });
 
         it('can emit "show_transcript" event', function () {
-            state.el.trigger('captions:show');
+            state.el.trigger('transcript:show');
             expect(Logger.log).toHaveBeenCalledWith('show_transcript', {
                 id: 'id',
                 code: 'html5',
@@ -144,8 +145,26 @@
         });
 
         it('can emit "hide_transcript" event', function () {
-            state.el.trigger('captions:hide');
+            state.el.trigger('transcript:hide');
             expect(Logger.log).toHaveBeenCalledWith('hide_transcript', {
+                id: 'id',
+                code: 'html5',
+                current_time: 10
+            });
+        });
+
+        it('can emit "show_closed_captions" event', function () {
+            state.el.trigger('captions:show');
+            expect(Logger.log).toHaveBeenCalledWith('show_closed_captions', {
+                id: 'id',
+                code: 'html5',
+                current_time: 10
+            });
+        });
+
+        it('can emit "hide_closed_captions" event', function () {
+            state.el.trigger('captions:hide');
+            expect(Logger.log).toHaveBeenCalledWith('hide_closed_captions', {
                 id: 'id',
                 code: 'html5',
                 current_time: 10
@@ -167,6 +186,8 @@
                 'speedchange': plugin.onSpeedChange,
                 'language_menu:show': plugin.onShowLanguageMenu,
                 'language_menu:hide': plugin.onHideLanguageMenu,
+                'transcript:show': plugin.onShowTranscript,
+                'transcript:hide': plugin.onHideTranscript,
                 'captions:show': plugin.onShowCaptions,
                 'captions:hide': plugin.onHideCaptions,
                 'destroy': plugin.destroy

--- a/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
@@ -153,18 +153,18 @@
             });
         });
 
-        it('can emit "show_closed_captions" event', function () {
+        it('can emit "edx.video.closed_captions.shown" event', function () {
             state.el.trigger('captions:show');
-            expect(Logger.log).toHaveBeenCalledWith('show_closed_captions', {
+            expect(Logger.log).toHaveBeenCalledWith('edx.video.closed_captions.shown', {
                 id: 'id',
                 code: 'html5',
                 current_time: 10
             });
         });
 
-        it('can emit "hide_closed_captions" event', function () {
+        it('can emit "edx.video.closed_captions.hidden" event', function () {
             state.el.trigger('captions:hide');
-            expect(Logger.log).toHaveBeenCalledWith('hide_closed_captions', {
+            expect(Logger.log).toHaveBeenCalledWith('edx.video.closed_captions.hidden', {
                 id: 'id',
                 code: 'html5',
                 current_time: 10

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -17,7 +17,8 @@ define('video/09_events_plugin.js', [], function() {
 
         _.bindAll(this, 'onReady', 'onPlay', 'onPause', 'onEnded', 'onSeek',
             'onSpeedChange', 'onShowLanguageMenu', 'onHideLanguageMenu', 'onSkip',
-            'onShowCaptions', 'onHideCaptions', 'destroy');
+            'onShowCaptions', 'onHideCaptions', 'onShowTranscript', 'onHideTranscript',
+            'destroy');
         this.state = state;
         this.options = _.extend({}, options);
         this.state.videoEventsPlugin = this;
@@ -103,11 +104,11 @@ define('video/09_events_plugin.js', [], function() {
         },
 
         onShowLanguageMenu: function () {
-            this.log('video_show_language_menu');
+            this.log('video_show_cc_menu');
         },
 
         onHideLanguageMenu: function () {
-            this.log('video_hide_language_menu');
+            this.log('video_hide_cc_menu', { language: this.getCurrentLanguage() });
         },
 
         onShowCaptions: function () {
@@ -118,7 +119,7 @@ define('video/09_events_plugin.js', [], function() {
             this.log('hide_closed_captions', {current_time: this.getCurrentTime()});
         },
 
-        onShowTransscript: function () {
+        onShowTranscript: function () {
             this.log('show_transcript', {current_time: this.getCurrentTime()});
         },
 
@@ -129,6 +130,11 @@ define('video/09_events_plugin.js', [], function() {
         getCurrentTime: function () {
             var player = this.state.videoPlayer;
             return player ? player.currentTime : 0;
+        },
+
+        getCurrentLanguage: function() {
+            var language = this.state.lang;
+            return language;
         },
 
         log: function (eventName, data) {

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -103,19 +103,19 @@ define('video/09_events_plugin.js', [], function() {
         },
 
         onShowLanguageMenu: function () {
-            this.log('video_show_cc_menu');
+            this.log('video_show_language_menu');
         },
 
         onHideLanguageMenu: function () {
-            this.log('video_hide_cc_menu');
+            this.log('video_hide_language_menu');
         },
 
         onShowCaptions: function () {
-            this.log('show_captions', {current_time: this.getCurrentTime()});
+            this.log('show_closed_captions', {current_time: this.getCurrentTime()});
         },
 
         onHideCaptions: function () {
-            this.log('hide_captions', {current_time: this.getCurrentTime()});
+            this.log('hide_closed_captions', {current_time: this.getCurrentTime()});
         },
 
         onShowTransscript: function () {

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -112,11 +112,11 @@ define('video/09_events_plugin.js', [], function() {
         },
 
         onShowCaptions: function () {
-            this.log('show_closed_captions', {current_time: this.getCurrentTime()});
+            this.log("edx.video.closed_captions.shown");
         },
 
         onHideCaptions: function () {
-            this.log('hide_closed_captions', {current_time: this.getCurrentTime()});
+            this.log("edx.video.closed_captions.hidden");
         },
 
         onShowTranscript: function () {

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -45,6 +45,8 @@ define('video/09_events_plugin.js', [], function() {
                 'speedchange': this.onSpeedChange,
                 'language_menu:show': this.onShowLanguageMenu,
                 'language_menu:hide': this.onHideLanguageMenu,
+                'transcript:show': this.onShowTranscript,
+                'transcript:hide': this.onHideTranscript,
                 'captions:show': this.onShowCaptions,
                 'captions:hide': this.onHideCaptions,
                 'destroy': this.destroy
@@ -109,10 +111,18 @@ define('video/09_events_plugin.js', [], function() {
         },
 
         onShowCaptions: function () {
-            this.log('show_transcript', {current_time: this.getCurrentTime()});
+            this.log('show_captions', {current_time: this.getCurrentTime()});
         },
 
         onHideCaptions: function () {
+            this.log('hide_captions', {current_time: this.getCurrentTime()});
+        },
+
+        onShowTransscript: function () {
+            this.log('show_transcript', {current_time: this.getCurrentTime()});
+        },
+
+        onHideTranscript: function () {
             this.log('hide_transcript', {current_time: this.getCurrentTime()});
         },
 

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -325,9 +325,6 @@
                 var button = this.languageChooserEl,
                     menu = button.parent().find('.menu');
 
-
-                this.state.el.trigger('language_menu:show');
-
                 button
                     .addClass('is-opened');
 
@@ -340,8 +337,6 @@
                 event.preventDefault();
 
                 var button = this.languageChooserEl;
-
-                this.state.el.trigger('language_menu:hide');
 
                 button
                     .removeClass('is-opened')
@@ -381,6 +376,10 @@
             onContainerMouseEnter: function (event) {
                 event.preventDefault();
                 $(event.currentTarget).find('.lang').addClass('is-opened');
+
+                // We only want to fire the analytics event if a menu is
+                // present instead of on the container hover, since it wraps
+                // the "CC" and "Transcript" buttons as well.
                 if ($(event.currentTarget).find('.lang').length) {
                     this.state.el.trigger('language_menu:show');
                 }
@@ -394,6 +393,10 @@
             onContainerMouseLeave: function (event) {
                 event.preventDefault();
                 $(event.currentTarget).find('.lang').removeClass('is-opened');
+
+                // We only want to fire the analytics event if a menu is
+                // present instead of on the container hover, since it wraps
+                // the "CC" and "Transcript" buttons as well.
                 if ($(event.currentTarget).find('.lang').length) {
                     this.state.el.trigger('language_menu:hide');
                 }
@@ -669,7 +672,6 @@
                 });
 
                 this.languageChooserEl.append(menu);
-                // event: video_show_cc_menu, video_hide_cc_menu
 
                 menu.on('click', '.control-lang', function (e) {
                     var el = $(e.currentTarget).parent(),
@@ -1122,6 +1124,9 @@
                     .find('.control-text')
                         .text(gettext('Hide closed captions'));
 
+                // trigger an analytics event
+                this.state.el.trigger('captions:show');
+
                 if (this.subtitlesEl.find('.current').text()) {
                     this.captionDisplayEl
                         .text(this.subtitlesEl.find('.current').text());
@@ -1142,6 +1147,9 @@
                     .removeClass('is-active')
                     .find('.control-text')
                         .text(gettext('Turn on closed captioning'));
+
+                // trigger an analytics event
+                this.state.el.trigger('captions:hide');
             },
 
             updateCaptioningCookie: function(method) {
@@ -1189,7 +1197,7 @@
                     state.el.addClass('closed');
                     text = gettext('Turn on transcripts');
                     if (trigger_event) {
-                        this.state.el.trigger('captions:hide');
+                        this.state.el.trigger('transcript:hide');
                     }
 
                     transcriptControlEl
@@ -1202,7 +1210,7 @@
                     this.scrollCaption();
                     text = gettext('Turn off transcripts');
                     if (trigger_event) {
-                        this.state.el.trigger('captions:show');
+                        this.state.el.trigger('transcript:show');
                     }
 
                     transcriptControlEl

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -381,7 +381,9 @@
             onContainerMouseEnter: function (event) {
                 event.preventDefault();
                 $(event.currentTarget).find('.lang').addClass('is-opened');
-                this.state.el.trigger('language_menu:show');
+                if ($(event.currentTarget).find('.lang').length) {
+                    this.state.el.trigger('language_menu:show');
+                }
             },
 
             /**
@@ -392,7 +394,9 @@
             onContainerMouseLeave: function (event) {
                 event.preventDefault();
                 $(event.currentTarget).find('.lang').removeClass('is-opened');
-                this.state.el.trigger('language_menu:hide');
+                if ($(event.currentTarget).find('.lang').length) {
+                    this.state.el.trigger('language_menu:hide');
+                }
             },
 
             /**
@@ -665,6 +669,7 @@
                 });
 
                 this.languageChooserEl.append(menu);
+                // event: video_show_cc_menu, video_hide_cc_menu
 
                 menu.on('click', '.control-lang', function (e) {
                     var el = $(e.currentTarget).parent(),


### PR DESCRIPTION
# [AC-380](https://openedx.atlassian.net/browse/AC-380)

After video player skin updates were completed several months ago, analytics eventing needed to be updated to match the new controls and markup structure. The first part of this work was to see which events were still present and working. The second was to ensure only the language menu event was triggered when a language menu was present and made visible. Then I made sure that the transcript event was specific to the transcript. Finally I added a new event for closed captioning, which was added in the recent video work.
## Overview of (modified) events
- **Language menu** triggered with `video_show_cc_menu` and `video_hide_cc_menu` now only triggers when more than one language is available and the menu is opened or closed respectively.
- **Transcript** triggered with `show_transcript` and `hide_transcript` is triggered when the vertically scrolling transcript to the side of the video is shown or hidden.
- **(NEW!) Closed-captions** triggered with `show_closed_captions` and `hide_closed_captions` is a new event for showing and hiding the floating closed-captions.
## Event proposals
- https://openedx.atlassian.net/wiki/display/AN/Video%3A+closed-captioning+events
- https://openedx.atlassian.net/wiki/display/AN/Video%3A+language+menu+events
## Sandboxes

https://clrux-ac-380.sandbox.edx.org
https://studio-clrux-ac-380.sandbox.edx.org
## Reviewers
- [ ] @stroilova 
- [x] @lamagnifica 
- [x] @clytwynec 

FYI @shnayder 
