### PR TITLE
Revert "Remove ThemingAware storage mixins and ComprehensiveThemeFind…

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -520,6 +520,7 @@ STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
 # List of finder classes that know how to find static files in various locations.
 # Note: the pipeline finder is included to be able to discover optimized files
 STATICFILES_FINDERS = [
+    'openedx.core.djangoapps.theming.finders.ComprehensiveThemeFinder',
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -41,6 +41,7 @@ STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
 STATICFILES_FINDERS = [
+    'openedx.core.djangoapps.theming.finders.ComprehensiveThemeFinder',
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1178,6 +1178,7 @@ STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
 # List of finder classes that know how to find static files in various locations.
 # Note: the pipeline finder is included to be able to discover optimized files
 STATICFILES_FINDERS = [
+    'openedx.core.djangoapps.theming.finders.ComprehensiveThemeFinder',
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -99,6 +99,7 @@ STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
 STATICFILES_FINDERS = [
+    'openedx.core.djangoapps.theming.finders.ComprehensiveThemeFinder',
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]

--- a/openedx/core/storage.py
+++ b/openedx/core/storage.py
@@ -4,9 +4,11 @@ Django storage backends for Open edX.
 from django.contrib.staticfiles.storage import StaticFilesStorage, CachedFilesMixin
 from pipeline.storage import PipelineMixin, NonPackagingMixin
 from require.storage import OptimizedFilesMixin
+from openedx.core.djangoapps.theming.storage import ComprehensiveThemingAwareMixin
 
 
 class ProductionStorage(
+        ComprehensiveThemingAwareMixin,
         OptimizedFilesMixin,
         PipelineMixin,
         CachedFilesMixin,
@@ -20,6 +22,7 @@ class ProductionStorage(
 
 
 class DevelopmentStorage(
+        ComprehensiveThemingAwareMixin,
         NonPackagingMixin,
         PipelineMixin,
         StaticFilesStorage


### PR DESCRIPTION
Revert "Remove ThemingAware storage mixins and ComprehensiveThemeFinder."

This reverts commit 266f593d2d00a0c35bf7af67a0be1326505b40be, aka PR #11319.

We were experiencing issues with static asset compilation and originally thought the issue was due to the rather large #11885 change set.  However, after reverting that PR we continued to observe issues with image and stylesheet selection, which led us back to this commit.  So it has taken a couple days to track down what we think is the cause and we are hopeful that we have figured out what is going on.

@rlucioni @douglashall @saleem-latif @mtyaka FYI
