### PR TITLE
TNL-4324: Add check for HTML entities

### DIFF
--- a/scripts/tests/test_safe_template_linter.py
+++ b/scripts/tests/test_safe_template_linter.py
@@ -255,6 +255,14 @@ class TestMakoTemplateLinter(TestCase):
             'expression': "${ HTML('<span></span>') + 'some other text' }",
             'rule': Rules.mako_html_alone
         },
+        {
+            'expression': "${'Rock &amp; Roll'}",
+            'rule': Rules.mako_html_entities
+        },
+        {
+            'expression': "${'Rock &#38; Roll'}",
+            'rule': Rules.mako_html_entities
+        },
     )
     def test_check_mako_with_text_and_html(self, data):
         """


### PR DESCRIPTION
## [TNL-4324](https://openedx.atlassian.net/browse/TNL-4324)

Add check for HTML entities

Sample output from the latest linter with the new rule:

```
cms/templates/settings_advanced.html: 96:59: mako-html-entities:             <li class="nav-item"><a href="${details_url}">${_("Details &amp; Schedule")}</a></li>
```
### Testing
- [x] Data is properly encoded in HTML templates to avoid XSS
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @nedbat 
### Post-review
- [x] Squash commits
