### PR TITLE
Fixed course not found against ccx issue on migration 0003

### DIFF
--- a/lms/djangoapps/ccx/migrations/0003_add_master_course_staff_in_ccx.py
+++ b/lms/djangoapps/ccx/migrations/0003_add_master_course_staff_in_ccx.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import logging
+
 from ccx_keys.locator import CCXLocator
 from courseware.courses import get_course_by_id
 from django.db import migrations
+from django.http import Http404
 
 from lms.djangoapps.ccx.utils import (
     add_master_course_staff_to_ccx,
     remove_master_course_staff_from_ccx,
 )
+
+log = logging.getLogger("edx.ccx")
 
 
 def add_master_course_staff_to_ccx_for_existing_ccx(apps, schema_editor):
@@ -23,16 +28,24 @@ def add_master_course_staff_to_ccx_for_existing_ccx(apps, schema_editor):
     CustomCourseForEdX = apps.get_model("ccx", "CustomCourseForEdX")
     list_ccx = CustomCourseForEdX.objects.all()
     for ccx in list_ccx:
-        if ccx.course_id.deprecated:
-            # prevent migration for deprecated course ids.
+        if not ccx.course_id or ccx.course_id.deprecated:
+            # prevent migration for deprecated course ids or invalid ids.
             continue
         ccx_locator = CCXLocator.from_course_locator(ccx.course_id, unicode(ccx.id))
-        add_master_course_staff_to_ccx(
-            get_course_by_id(ccx.course_id),
-            ccx_locator,
-            ccx.display_name,
-            send_email=False
-        )
+        try:
+            course = get_course_by_id(ccx.course_id)
+            add_master_course_staff_to_ccx(
+                course,
+                ccx_locator,
+                ccx.display_name,
+                send_email=False
+            )
+        except Http404:
+            log.warning(
+                "Unable to add instructors and staff of master course %s to ccx %s.",
+                ccx.course_id,
+                ccx_locator
+            )
 
 
 def remove_master_course_staff_from_ccx_for_existing_ccx(apps, schema_editor):
@@ -47,17 +60,24 @@ def remove_master_course_staff_from_ccx_for_existing_ccx(apps, schema_editor):
     CustomCourseForEdX = apps.get_model("ccx", "CustomCourseForEdX")
     list_ccx = CustomCourseForEdX.objects.all()
     for ccx in list_ccx:
-        if ccx.course_id.deprecated:
-            # prevent migration for deprecated course ids.
+        if not ccx.course_id or ccx.course_id.deprecated:
+            # prevent migration for deprecated course ids or invalid ids.
             continue
         ccx_locator = CCXLocator.from_course_locator(ccx.course_id, unicode(ccx.id))
-        remove_master_course_staff_from_ccx(
-            get_course_by_id(ccx.course_id),
-            ccx_locator,
-            ccx.display_name,
-            send_email=False
-        )
-
+        try:
+            course = get_course_by_id(ccx.course_id)
+            remove_master_course_staff_from_ccx(
+                course,
+                ccx_locator,
+                ccx.display_name,
+                send_email=False
+            )
+        except Http404:
+            log.warning(
+                "Unable to remove instructors and staff of master course %s from ccx %s.",
+                ccx.course_id,
+                ccx_locator
+            )
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
### Background

Fixed exception https://gist.github.com/feanil/9682bf681ad415b6e20f4b29810fb044 which was raise from  migration in https://github.com/edx/edx-platform/pull/11787
### What is done in this PR

**Studio Updates:** None.
**LMS Updates:**  Fixed exception mentioned above which appears when ccx migration 0003 tries to get course against ccx data attribute `ccx.course_id` and gets `Http404` exception instead.

@pdpinch 
