### PR TITLE
Improved OAuth client credentials support

### DIFF
--- a/lms/djangoapps/oauth_dispatch/tests/test_client_credentials.py
+++ b/lms/djangoapps/oauth_dispatch/tests/test_client_credentials.py
@@ -1,0 +1,40 @@
+""" Tests for OAuth 2.0 client credentials support. """
+import json
+
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from edx_oauth2_provider.tests.factories import ClientFactory
+from provider.oauth2.models import AccessToken
+from student.tests.factories import UserFactory
+
+
+class ClientCredentialsTest(TestCase):
+    """ Tests validating the client credentials grant behavior. """
+
+    def setUp(self):
+        super(ClientCredentialsTest, self).setUp()
+
+        self.user = UserFactory()
+        self.oauth_client = ClientFactory(user=self.user)
+
+    def test_access_token(self):
+        """ Verify the client credentials grant can be used to obtain an access token whose default scopes allow access
+        to the user info endpoint.
+        """
+        data = {
+            'grant_type': 'client_credentials',
+            'client_id': self.oauth_client.client_id,
+            'client_secret': self.oauth_client.client_secret
+        }
+        response = self.client.post(reverse('oauth2:access_token'), data)
+        self.assertEqual(response.status_code, 200)
+
+        access_token = json.loads(response.content)['access_token']
+        expected = AccessToken.objects.filter(client=self.oauth_client, user=self.user).first().token
+        self.assertEqual(access_token, expected)
+
+        headers = {
+            'HTTP_AUTHORIZATION': 'Bearer ' + access_token
+        }
+        response = self.client.get(reverse('oauth2:user_info'), **headers)
+        self.assertEqual(response.status_code, 200)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -39,8 +39,8 @@ djangorestframework-oauth==1.1.0
 edx-ccx-keys==0.1.2
 edx-lint==0.4.3
 edx-management-commands==0.0.1
-edx-django-oauth2-provider==1.0.2
-edx-oauth2-provider==1.0.0
+edx-django-oauth2-provider==1.0.3
+edx-oauth2-provider==1.0.1
 edx-opaque-keys==0.2.1
 edx-organizations==0.4.0
 edx-rest-api-client==1.2.1


### PR DESCRIPTION
- Updated django-oauth2-provider libraries
- Added test ensuring issued access tokens have the basic scopes needed to get user info

ECOM-4197

Relies on https://github.com/edx/django-oauth2-provider/pull/32 and https://github.com/edx/edx-oauth2-provider/pull/39
