### PR TITLE
Fix errors in old Django templates / migrate to Mako

### DIFF
--- a/lms/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/lms/djangoapps/oauth_dispatch/tests/test_views.py
@@ -166,7 +166,7 @@ class TestAuthorizationView(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # check form is in context and form params are valid
-        context = response.context  # pylint: disable=no-member
+        context = response.context_data  # pylint: disable=no-member
         self.assertIn('form', context)
         self.assertIsNone(context['form']['authorize'].value())
 

--- a/lms/static/sass/views/_oauth2.scss
+++ b/lms/static/sass/views/_oauth2.scss
@@ -9,6 +9,7 @@
     @include span-columns(6);
     @include shift(3);
 
+    float: unset !important;  // fixes issues with oauth page and edx-theme footer
     line-height: 1.5em;
     padding: 50px 0;
 

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -42,8 +42,7 @@
 
   </div>
 
-    {% javascript 'application' %}
-    {% javascript 'module-js' %}
+    {% javascript 'base_application' %}
 
     {% render_block "js" %}
 </body>

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
-{% load sekizai_tags i18n microsite pipeline optional_include %}
+{% load sekizai_tags i18n microsite pipeline optional_include staticfiles %}
 {% load url from future %}
 <html lang="{{LANGUAGE_CODE}}">
 <head>
   <meta charset="UTF-8">
   {% block title %}<title>{% platform_name %}</title>{% endblock %}
 
- <link rel="icon" type="image/x-icon" href="{% favicon_path %}" />
+  <link rel="icon" type="image/x-icon" href="{% favicon_path %}" />
+
+  {% with "js/i18n/"|add:LANGUAGE_CODE|add:"/djangojs.js" as i18njs_path %}
+    <script type="text/javascript" src="{% static i18njs_path %}"></script>
+  {% endwith %}
 
   {% stylesheet 'style-vendor' %}
   {% stylesheet 'style-main-v1' %}

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -27,7 +27,7 @@
 </head>
 
 <body class="{% block bodyclass %}{% endblock %} lang_{{LANGUAGE_CODE}}">
-  <div class="window-wrap" dir="${static.dir_rtl()}">
+  <div class="window-wrap" dir="{{LANGUAGE_BIDI|yesno:'rtl,ltr'}}">
     <a class="nav-skip" href="#main">{% trans "Skip to main content" %}</a>
     {% with course=request.course %}
       {% include "header.html"|microsite_template_path %}

--- a/lms/templates/provider/authorize.html
+++ b/lms/templates/provider/authorize.html
@@ -1,59 +1,66 @@
-{% extends "main_django.html" %}
+## mako
 
-{% load scope i18n %}
+<%!
+from django.utils.translation import ugettext as _
+from provider.templatetags.scope import scopes
+from django.core.urlresolvers import reverse
+%>
 
-{% block bodyclass %}oauth2{% endblock %}
+<%inherit file="../main.html"/>
 
-{% block body %}
+<%block name="bodyclass">oauth2</%block>
+
+<%block name="body">
 <div class="authorization-confirmation">
-  {% if not error %}
+  % if not error:
   <p>
-  {% blocktrans with application_name=client.name %}
-    <strong>{{ application_name }}</strong> would like to access your data with the following permissions:
-  {% endblocktrans %}
+  ${_(
+    "<strong>{application_name}</strong> would like to access your data with the following permissions:"
+    .format(application_name=client.name)
+  )}
   </p>
   <ul>
-    {% for permission in oauth_data.scope|scopes %}
+    % for permission in scopes(oauth_data['scope']):
     <li>
-      {% if permission == "openid" %}
-        {% trans "Read your user ID" %}
-      {% elif permission == "profile" %}
-        {% trans "Read your user profile" %}
-      {% elif permission == "email" %}
-        {% trans "Read your email address" %}
-      {% elif permission == "course_staff" %}
-        {% trans "Read the list of courses in which you are a staff member." %}
-      {% elif permission == "course_instructor" %}
-        {% trans "Read the list of courses in which you are an instructor." %}
-      {% elif permission == "permissions" %}
-        {% trans "To see if you are a global staff user" %}
-      {% else %}
-        {% blocktrans %}Manage your data: {{ permission }}{% endblocktrans %}
-      {% endif %}
+      % if permission == "openid":
+        ${_("Read your user ID")}
+      % elif permission == "profile":
+        ${_("Read your user profile")}
+      % elif permission == "email":
+        ${_("Read your email address")}
+      % elif permission == "course_staff":
+        ${_("Read the list of courses in which you are a staff member.")}
+      % elif permission == "course_instructor":
+        ${_("Read the list of courses in which you are an instructor.")}
+      % elif permission == "permissions":
+        ${_("To see if you are a global staff user")}
+      % else:
+        ${_("Manage your data: {permission}".format(permission=permission))}
+      % endif
     </li>
-    {% endfor %}
+    % endfor
   </ul>
-  <form method="post" action="{% url "oauth2:authorize" %}">
-    {% csrf_token %}
-    {{ form.errors }}
-    {{ form.non_field_errors }}
+  <form method="post" action="${reverse('oauth2:authorize')}">
+    ${form.errors}
+    ${form.non_field_errors()}
     <fieldset>
       <div style="display: none;">
         <select type="select" name="scope" multiple="multiple">
-          {% for scope in oauth_data.scope|scopes %}
-          <option value="{{ scope }}" selected="selected">{{ scope }}</option>
-          {% endfor %}
+          % for scope in scopes(oauth_data['scope']):
+          <option value="${scope}" selected="selected">${scope}</option>
+          % endfor
         </select>
       </div>
       <input type="submit" class="btn login large danger" name="cancel" value="Cancel" />
       <input type="submit" class="btn login large primary" name="authorize" value="Authorize" />
     </fieldset>
+    <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}" />
   </form>
-  {% else %}
+  % else:
   <p class="error">
-    {{ error }}
-    {{ error_description }}
+    ${error}
+    ${error_description}
   </p>
-  {% endif %}
+  % endif
 </div>
-{% endblock %}
+</%block>

--- a/lms/templates/provider/authorize.html
+++ b/lms/templates/provider/authorize.html
@@ -14,10 +14,9 @@ from django.core.urlresolvers import reverse
 <div class="authorization-confirmation">
   % if not error:
   <p>
-  ${_(
-    "<strong>{application_name}</strong> would like to access your data with the following permissions:"
-    .format(application_name=client.name)
-  )}
+  ${_("<strong>{application_name}</strong> would like to access your data with the following permissions:".format(
+    application_name=client.name
+  ))}
   </p>
   <ul>
     % for permission in scopes(oauth_data['scope']):

--- a/lms/templates/provider/authorize.html
+++ b/lms/templates/provider/authorize.html
@@ -14,7 +14,7 @@ from django.core.urlresolvers import reverse
 <div class="authorization-confirmation">
   % if not error:
   <p>
-  ${_("<strong>{application_name}</strong> would like to access your data with the following permissions:".format(
+  ${_("\n    <strong>{application_name}</strong> would like to access your data with the following permissions:\n  ".format(
     application_name=client.name
   ))}
   </p>

--- a/lms/templates/provider/authorize.html
+++ b/lms/templates/provider/authorize.html
@@ -1,9 +1,12 @@
 ## mako
 
+<%page expression_filter="h"/>
+
 <%!
 from django.utils.translation import ugettext as _
 from provider.templatetags.scope import scopes
 from django.core.urlresolvers import reverse
+from openedx.core.djangolib.markup import Text, HTML
 %>
 
 <%inherit file="../main.html"/>
@@ -14,9 +17,11 @@ from django.core.urlresolvers import reverse
 <div class="authorization-confirmation">
   % if not error:
   <p>
-  ${_("\n    <strong>{application_name}</strong> would like to access your data with the following permissions:\n  ".format(
-    application_name=client.name
-  ))}
+  ${Text(_("{start_strong}{application_name}{end_strong} would like to access your data with the following permissions:")).format(
+    start_strong=HTML("<strong>"),
+    application_name=client.name,
+    end_strong=HTML("</strong>")
+  )}
   </p>
   <ul>
     % for permission in scopes(oauth_data['scope']):
@@ -34,7 +39,7 @@ from django.core.urlresolvers import reverse
       % elif permission == "permissions":
         ${_("To see if you are a global staff user")}
       % else:
-        ${_("Manage your data: {permission}".format(permission=permission))}
+        ${_("Manage your data: {permission}").format(permission=permission)}
       % endif
     </li>
     % endfor

--- a/lms/templates/registration/password_reset_complete.html
+++ b/lms/templates/registration/password_reset_complete.html
@@ -1,11 +1,14 @@
-{% extends "main_django.html" %}
-{% load i18n %}
+## mako
 
-{% block title %}
-<title>{% trans "Your Password Reset is Complete" %}</title>
-{% endblock %}
+<%! from django.utils.translation import ugettext as _ %>
 
-{% block bodyextra %}
+<%inherit file="../main.html"/>
+
+<%block name="title">
+    <title>${_("Your Password Reset is Complete")}</title>
+</%block>
+
+<%block name="bodyextra">
     <script type="text/javascript">
         $(function() {
             'use strict';
@@ -13,23 +16,24 @@
             $('body').addClass('js');
         });
     </script>
-{% endblock %}
+</%block>
 
-{% block bodyclass %}view-passwordreset{% endblock %}
+<%block name="bodyclass">view-passwordreset</%block>
 
-{% block body %}
+<%block name="body">
 <div id="password-reset-complete-container" class="login-register">
     <section id="password-reset-complete-anchor" class="form-type">
         <div id="password-reset-complete" class="form-wrapper">
             <div class="status submission-success" aria-live="polite">
-                <h4 class="message-title">{% trans "Password Reset Complete" %}</h4>
+                <h4 class="message-title">${_("Password Reset Complete")}</h4>
                 <ul class="message-copy">
-                {% blocktrans with link_start='<a href="/login">' link_end='</a>' %}
-                    Your password has been reset. {{ link_start }}Sign in to your account.{{ link_end }}
-                {% endblocktrans %}
+                ${_(
+                    "Your password has been reset. {start_link}Sign-in to your account.{end_link}"
+                    .format(start_link='<a href="/login">', end_link='</a>')
+                )}
                 </ul>
             </div>
         </div>
     </section>
 </div>
-{% endblock %}
+</%block>

--- a/lms/templates/registration/password_reset_complete.html
+++ b/lms/templates/registration/password_reset_complete.html
@@ -1,6 +1,11 @@
 ## mako
 
-<%! from django.utils.translation import ugettext as _ %>
+<%page expression_filter="h"/>
+
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import Text, HTML
+%>
 
 <%inherit file="../main.html"/>
 
@@ -27,9 +32,9 @@
             <div class="status submission-success" aria-live="polite">
                 <h4 class="message-title">${_("Password Reset Complete")}</h4>
                 <ul class="message-copy">
-                ${_(
-                    "Your password has been reset. {start_link}Sign-in to your account.{end_link}"
-                    .format(start_link='<a href="/login">', end_link='</a>')
+                ${Text(_("Your password has been reset. {start_link}Sign-in to your account.{end_link}")).format(
+                    start_link=HTML('<a href="/login">'),
+                    end_link=HTML('</a>')
                 )}
                 </ul>
             </div>

--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -1,72 +1,75 @@
-{% extends "main_django.html" %}
-{% load i18n %}
+## mako
 
-{% block title %}
-<title>
-{% blocktrans with platform_name=platform_name %}
-    Reset Your {{ platform_name }} Password
-{% endblocktrans %}
-</title>
-{% endblock %}
+<%! from django.utils.translation import ugettext as _ %>
 
-{% block bodyextra %}
-<script type="text/javascript" src="{{STATIC_URL}}js/student_account/password_reset.js"></script>
-{% endblock %}
+<%inherit file="../main.html"/>
 
-{% block bodyclass %}view-passwordreset{% endblock %}
+<%block name="title">
+    <title>${_("Reset Your {platform_name} Password".format(platform_name=platform_name))}</title>
+</%block>
 
-{% block body %}
+<%block name="bodyextra">
+    <script type="text/javascript" src="${STATIC_URL}js/student_account/password_reset.js"></script>
+</%block>
+
+<%block name="bodyclass">view-passwordreset</%block>
+
+<%block name="body">
 <div id="password-reset-confirm-container" class="login-register">
     <section id="password-reset-confirm-anchor" class="form-type">
         <div id="password-reset-confirm-form" class="form-wrapper" aria-live="polite">
-            <div class="status submission-error {% if not err_msg %} hidden {% endif %}">
-                <h4 class="message-title">{% trans "Error Resetting Password" %}</h4>
+            <div class="status submission-error ${'hidden' if err_msg is None else ''}">
+                <h4 class="message-title">${_("Error Resetting Password")}</h4>
                 <ul class="message-copy">
-                {% if err_msg %}
-                    <li>{{err_msg}}</li>
-                {% else %}
-                    <li>{% trans "You must enter and confirm your new password." %}</li>
-                    <li>{% trans "The text in both password fields must match." %}</li>
-                {% endif %}
+                % if err_msg:
+                    <li>${err_msg}</li>
+                % else:
+                    <li>${_("You must enter and confirm your new password.")}</li>
+                    <li>${_("The text in both password fields must match.")}</li>
+                % endif
                 </ul>
             </div>
-            {% if validlink %}
 
-            <form role="form" id="passwordreset-form" method="post" action="">{% csrf_token %}
+            % if validlink:
+            <form role="form" id="passwordreset-form" method="post" action="">
                 <div class="section-title lines">
                     <h2>
                         <span class="text">
-                        {% trans "Reset Your Password" %}
+                        ${_("Reset Your Password")}
                         </span>
                     </h2>
                 </div>
 
                 <p class="action-label" id="new_password_help_text">
-                    {% trans "Enter and confirm your new password." %}
+                    ${_("Enter and confirm your new password.")}
                 </p>
 
                 <div class="form-field new_password1-new_password1">
-                    <label for="new_password1">{% trans "New Password" %}</label>
+                    <label for="new_password1">${_("New Password")}</label>
                     <input id="new_password1" type="password" name="new_password1" aria-describedby="new_password_help_text" />
                 </div>
                 <div class="form-field new_password2-new_password2">
-                    <label for="new_password2">{% trans "Confirm Password" %}</label>
+                    <label for="new_password2">${_("Confirm Password")}</label>
                     <input id="new_password2" type="password" name="new_password2" />
                 </div>
 
-                <button type="submit" class="action action-primary action-update js-reset">{% trans "Reset My Password" %}</button>
+                <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">
+
+                <button type="submit" class="action action-primary action-update js-reset">${_("Reset My Password")}</button>
             </form>
-            {% else %}
+            % else:
             <div class="status submission-error">
-                <h4 class="message-title">{% trans "Invalid Password Reset Link" %}</h4>
+                <h4 class="message-title">${_("Invalid Password Reset Link")}</h4>
                 <ul class="message-copy">
-                {% blocktrans with start_link='<a href="/login">' end_link='</a>' %}
-                    This password reset link is invalid. It may have been used already. To reset your password, go to the {{ start_link }}sign-in{{ end_link }} page and select <strong>Forgot password</strong>.
-                {% endblocktrans %}
+                    ${_((
+                        "This password reset link is invalid. It may have been used already. To reset your password, "
+                        "go to the {start_link}sign-in{end_link} page and select <strong>Forgot password</strong>."
+                        ).format(start_link='<a href="/login">', end_link='</a>')
+                    )}
                 </ul>
             </div>
-            {% endif %}
+            % endif
         </div>
     </section>
 </div>
-{% endblock %}
+</%block>

--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -1,11 +1,16 @@
 ## mako
 
-<%! from django.utils.translation import ugettext as _ %>
+<%page expression_filter="h"/>
+
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import Text, HTML
+%>
 
 <%inherit file="../main.html"/>
 
 <%block name="title">
-    <title>${_("Reset Your {platform_name} Password".format(platform_name=platform_name))}</title>
+    <title>${_("Reset Your {platform_name} Password").format(platform_name=platform_name)}</title>
 </%block>
 
 <%block name="bodyextra">
@@ -18,7 +23,7 @@
 <div id="password-reset-confirm-container" class="login-register">
     <section id="password-reset-confirm-anchor" class="form-type">
         <div id="password-reset-confirm-form" class="form-wrapper" aria-live="polite">
-            <div class="status submission-error ${'hidden' if err_msg is None else ''}">
+            <div class="status submission-error ${'hidden' if not err_msg else ''}">
                 <h4 class="message-title">${_("Error Resetting Password")}</h4>
                 <ul class="message-copy">
                 % if err_msg:
@@ -61,11 +66,16 @@
             <div class="status submission-error">
                 <h4 class="message-title">${_("Invalid Password Reset Link")}</h4>
                 <ul class="message-copy">
-                    ${_((
+                    ${Text(_((
                         "This password reset link is invalid. It may have been used already. To reset your password, "
-                        "go to the {start_link}sign-in{end_link} page and select <strong>Forgot password</strong>."
-                        ).format(start_link='<a href="/login">', end_link='</a>')
-                    )}
+                        "go to the {start_link}sign-in{end_link} page and select {start_strong}Forgot password{end_strong}."
+                        ))).format(
+                            start_link=HTML('<a href="/login">'),
+                            end_link=HTML('</a>'),
+                            start_strong=HTML('<strong>'),
+                            end_strong=HTML('</strong>')
+                        )
+                    }
                 </ul>
             </div>
             % endif

--- a/lms/templates/support/refund.html
+++ b/lms/templates/support/refund.html
@@ -1,11 +1,18 @@
-{% extends "main_django.html" %}
-{% load i18n %}
-{% block title %}
+## mako
+
+<%!
+from django.utils.translation import ugettext as _
+from django.utils.html import escape
+%>
+
+<%inherit file="../main.html"/>
+
+<%block name="title">
 <title>
 Manual Refund
 </title>
-{% endblock %}
-{% block headextra %}
+</%block>
+<%block name="headextra">
 
 <style type="text/css">
 .errorlist,.messages {
@@ -18,56 +25,57 @@ strong {
     padding-right: 10px;
 }
 </style>
-{% endblock %}
+</%block>
 
 
-{% block body %}
+<%block name="body">
 <div class="content-wrapper" id="content">
     <div class="container about">
-        <h1>{% trans "Manual Refund" %}</h1>
-        {% if messages %}
+        <h1>${_("Manual Refund")}</h1>
+        % if messages:
         <ul class="messages">
-            {% for message in messages %}
-            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-            {% endfor %}
+            % for message in messages:
+                <li class="${message.tags if message.tags else ''}">${message}</li>
+            % endfor
         </ul>
-        {% endif %}
+        % endif
 
         <form method="POST" id="refund_form">
-            {% csrf_token %}
-            {{form.as_p}}
+            <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}" />
+            ${form.as_p()}
             <p>
-            <input type="button" value="Cancel" onclick="javascript:location=location"/> <input type="submit" value="{% if cert %}Refund{% else %}Confirm{% endif %}" />
+            <input type="button" value="Cancel" onclick="javascript:location=location"/> <input type="submit" value="${'Refund' if cert else 'Confirm'}" />
             </p>
         </form>
-        {% if cert %}
+        % if cert:
         <section class="content-wrapper">
             <h2>
-                {% trans "About to refund this order:" %}
+                ${_("About to refund this order:")}
             </h2>
             <p>
-                <strong>{% trans "Order Id:" %}</strong> {{cert.order.id}}
+                <strong>${_("Order Id:")}</strong> ${cert.order.id}
             </p>
             <p>
-                <strong>{% trans "Enrollment:" %}</strong> {{enrollment.course_id|escape}} {{enrollment.mode}} ({% if enrollment.is_active %}{% trans "enrolled" %}{% else %}{% trans "unenrolled" %}{% endif %})
+                <strong>${_("Enrollment:")}</strong> ${escape(enrollment.course_id)} ${enrollment.mode}
+                (${_("enrolled") if enrollment.is_active else _("unenrolled")})
             </p>
             <p>
-                <strong>{% trans "Cost:" %}</strong> {{cert.unit_cost}} {{cert.currency}}
+                <strong>${_("Cost:")}</strong> ${cert.unit_cost} ${cert.currency}
             </p>
             <p>
-                <strong>{% trans "CertificateItem Status:" %}</strong> {{cert.status}}
+                <strong>${_("CertificateItem Status:")}</strong> ${cert.status}
             </p>
             <p>
-                <strong>{% trans "Order Status:" %}</strong> {{cert.order.status}}
+                <strong>${_("Order Status:")}</strong> ${cert.order.status}
             </p>
             <p>
-                <strong>{% trans "Fulfilled Time:" %}</strong> {{cert.fulfilled_time}}
+                <strong>${_("Fulfilled Time:")}</strong> ${cert.fulfilled_time}
             </p>
             <p>
-                <strong>{% trans "Refund Request Time:" %}</strong> {{cert.refund_requested_time}}
+                <strong>${_("Refund Request Time:")}</strong> ${cert.refund_requested_time}
             </p>
         </section>
-        {% endif %}
+        % endif
     </div>
 </div>
-{% endblock %}
+</%block>

--- a/lms/templates/support/refund.html
+++ b/lms/templates/support/refund.html
@@ -1,5 +1,7 @@
 ## mako
 
+<%page expression_filter="h"/>
+
 <%!
 from django.utils.translation import ugettext as _
 from django.utils.html import escape

--- a/lms/templates/wiki/base.html
+++ b/lms/templates/wiki/base.html
@@ -6,7 +6,6 @@
 {% block bodyclass %}view-in-course view-wiki{% endblock %}
 
 {% block headextra %}
-  <script type="text/javascript" src="/i18n.js"></script>
   {% stylesheet 'course' %}
   {% stylesheet 'style-course-vendor' %}
   {% stylesheet 'style-course' %}


### PR DESCRIPTION
## [FEDX-150](https://openedx.atlassian.net/browse/FEDX-150)

Also refs [FEDX-156](https://openedx.atlassian.net/browse/FEDX-156), [FEDX-157](https://openedx.atlassian.net/browse/FEDX-157), [FEDX-158](https://openedx.atlassian.net/browse/FEDX-158), [FEDX-159](https://openedx.atlassian.net/browse/FEDX-159) and [TNL-4364](https://openedx.atlassian.net/browse/TNL4364)

Five pages existed on the site which used as a base template [`main_django.html`](https://github.com/edx/edx-platform/blob/master/lms/templates/main_django.html) instead of the standard Mako-ized `main.html`:
- OAuth client authorization, [`provider/authorize.html`](https://github.com/edx/edx-platform/tree/master/lms/templates/provider/authorize.html)
- Password reset confirmation form, [`registration/password_reset_confirm.html`](https://github.com/edx/edx-platform/tree/master/lms/templates/registration/password_reset_confirm.html)
- Password reset success view, [`registration/password_reset_complete.html`](https://github.com/edx/edx-platform/tree/master/lms/templates/registration/password_reset_complete.html)
- an (I think deprecated?) view for requesting and tracking the status of refunds, [`support/refund.html`](https://github.com/edx/edx-platform/tree/master/lms/templates/support/refund.html)
- Course wikis, [`wiki/base.html`](https://github.com/edx/edx-platform/tree/master/lms/templates/wiki/base.html) and child templates `create.html`, `edit.html`, and `history.html`

Basing these pages off a base Django template was done in part because some of them relied on Django-based packages or template tags that couldn't be easily migrated into Mako, and in part I think because people forgot a few of these pages existed. Over time, drift separated these two base templates, resulting in the following issues:
- the pages using the Django base template were excluded from Google Analytics and New Relic ([TNL-4364](https://openedx.atlassian.net/browse/TNL4364))
- these pages developed issues where requirejs could not load an internationalization library ([FEDX-150](https://openedx.atlassian.net/browse/FEDX-150))
- these pages handled CSS pipelining differently, resulting in the regression that caused this revert https://github.com/edx/edx-platform/pull/12089
- some sort of still-mysterious issue with the browser trying to load MomentJS and parse it as HTML

To resolve this, we first fixed a few issues with the base Django template, and then began the work of moving as many pages away from inheriting from it (by translating them to Mako) as we could. The first four pages were moved easily off of `main_django.html`, but after encountering difficulty migrating the wikis, we decided to leave that for a future effort. (After that is complete, `main_django.html` should be deleted.)
### Sandbox

[https://bjacobel-mako.sandbox.edx.org](https://bjacobel-mako.sandbox.edx.org)

Some of the pages to test are a little tricky to get to.
- [For the wiki](https://bjacobel-mako.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/wiki/edX.DemoX.Demo_Course/)
- For the password reset/confirm you'll have to sign up as a user on my sandbox with your real email and then go through the password reset process by clicking the link that's emailed to you. The emails from sandbox servers are _highly_ likely to get flagged as spam, so check there if you don't get one.
- For the OAuth page, [use this link](https://django-oauth-toolkit.herokuapp.com/consumer/?authorization_link=https%3A%2F%2Fbjacobel-mako.sandbox.edx.org%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dtest%26state%3Drandom_state_string%26scope%3Demail) and try varying the `scope` parameter in the URL to get different grant scopes, options are `openid, profile, email, course_staff, course_instructor, permissions`
- For the refund page [this link will get you to the request form](https://bjacobel-mako.sandbox.edx.org/support/refund). I don't actually know how to test that it works, though - I'm not familiar enough with the ecom ordering system. **Help appreciated to tag someone from the ECOM team on this PR for their help in testing this**. I've created a superuser on the sandbox with u/p `admin@example.com/edx` in order to create orders and certs.
### Testing
- [x] i18n
- [x] RTL
- [x] Data is properly encoded in HTML templates to avoid XSS
- [x] Unit, integration, acceptance tests as appropriate
- [x] Analytics
- [x] Performance
- ~~Database migrations are backwards-compatible~~ N/A
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
-  ~~Code Review: @cahrens~~ 
- [x] Code Review: @AlasdairSwan 
- [ ] Accessibility review

FYI: @awaisdar001 @adampalay @tobz 
### Post-review
- [ ] Squash commits
