### PR TITLE
Allow multiple random cohorts.

### DIFF
--- a/lms/djangoapps/verified_track_content/models.py
+++ b/lms/djangoapps/verified_track_content/models.py
@@ -12,7 +12,7 @@ from courseware.courses import get_course_by_id
 
 from verified_track_content.tasks import sync_cohort_with_mode
 from openedx.core.djangoapps.course_groups.cohorts import (
-    get_course_cohorts, CourseCohort, is_course_cohorted, get_random_cohort, is_default_cohort
+    get_course_cohorts, CourseCohort, is_course_cohorted, get_random_cohort
 )
 
 import logging

--- a/lms/djangoapps/verified_track_content/models.py
+++ b/lms/djangoapps/verified_track_content/models.py
@@ -39,30 +39,24 @@ def move_to_verified_cohort(sender, instance, **kwargs):  # pylint: disable=unus
             course = get_course_by_id(course_key)
             existing_manual_cohorts = get_course_cohorts(course, CourseCohort.MANUAL)
             if any(cohort.name == verified_cohort_name for cohort in existing_manual_cohorts):
-                # Verify that a single random cohort exists in the course. Note that calling this method will create
-                # a "Default Group" random cohort if no random cohorts exist yet.
+                # Get a random cohort to use as the default cohort (for audit learners).
+                # Note that calling this method will create a "Default Group" random cohort if no random
+                # cohort yet exist.
                 random_cohort = get_random_cohort(course_key)
-                if not is_default_cohort(random_cohort):
-                    log.error(
-                        "Automatic verified cohorting enabled for course '%s', "
-                        "but course does not have exactly one default cohort for audit learners.",
-                        course_key
-                    )
-                else:
-                    args = {
-                        'course_id': unicode(course_key),
-                        'user_id': instance.user.id,
-                        'verified_cohort_name': verified_cohort_name,
-                        'default_cohort_name': random_cohort.name
-                    }
-                    # Do the update with a 3-second delay in hopes that the CourseEnrollment transaction has been
-                    # completed before the celery task runs. We want a reasonably short delay in case the learner
-                    # immediately goes to the courseware.
-                    sync_cohort_with_mode.apply_async(kwargs=args, countdown=3)
+                args = {
+                    'course_id': unicode(course_key),
+                    'user_id': instance.user.id,
+                    'verified_cohort_name': verified_cohort_name,
+                    'default_cohort_name': random_cohort.name
+                }
+                # Do the update with a 3-second delay in hopes that the CourseEnrollment transaction has been
+                # completed before the celery task runs. We want a reasonably short delay in case the learner
+                # immediately goes to the courseware.
+                sync_cohort_with_mode.apply_async(kwargs=args, countdown=3)
 
-                    # In case the transaction actually was not committed before the celery task runs,
-                    # run it again after 5 minutes. If the first completed successfully, this task will be a no-op.
-                    sync_cohort_with_mode.apply_async(kwargs=args, countdown=300)
+                # In case the transaction actually was not committed before the celery task runs,
+                # run it again after 5 minutes. If the first completed successfully, this task will be a no-op.
+                sync_cohort_with_mode.apply_async(kwargs=args, countdown=300)
             else:
                 log.error(
                     "Automatic verified cohorting enabled for course '%s', "

--- a/lms/djangoapps/verified_track_content/tests/test_forms.py
+++ b/lms/djangoapps/verified_track_content/tests/test_forms.py
@@ -1,8 +1,6 @@
 """
 Test for forms helpers.
 """
-from opaque_keys.edx.keys import CourseKey
-
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -430,7 +430,7 @@ def set_assignment_type(user_group, assignment_type):
     """
     course_cohort = user_group.cohort
 
-    if is_default_cohort(user_group) and course_cohort.assignment_type != assignment_type:
+    if is_last_random_cohort(user_group) and course_cohort.assignment_type != assignment_type:
         raise ValueError(_("There must be one cohort to which students can automatically be assigned."))
 
     course_cohort.assignment_type = assignment_type
@@ -445,9 +445,9 @@ def get_assignment_type(user_group):
     return course_cohort.assignment_type
 
 
-def is_default_cohort(user_group):
+def is_last_random_cohort(user_group):
     """
-    Check if a cohort is default.
+    Check if this cohort is the only random cohort in the course.
     """
     random_cohorts = CourseUserGroup.objects.filter(
         course_id=user_group.course_id,


### PR DESCRIPTION
## Continuation of [TNL-4355](https://openedx.atlassian.net/browse/TNL-4355)

Allow multiple random cohorts
### Sandbox
- [x] https://verifiedcohort.sandbox.edx.org

Notes: Demo course has feature fully enabled. You can enroll/upgrade to verified/and unenroll, and the cohorts should update accordingly (to see cohort assignments, go to https://verifiedcohort.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download as staff and click "List enrolled students' profile information".

The Demo course has 2 random cohorts and 2 manual cohorts configured. When in the audit track, a learner is randomly assigned to one of the 2 random cohorts (Audit 1 and Audit 2)-- both are linked to the Audit content group. When enrolling in the verified track, a learner is automatically moved to the manual cohort "Verified Learners". The "Stanford" manual cohort would be managed strictly by course staff.

The very first unit in the course has 1 HTML component visible to all, 1 visible only to Audit content group, and 1 visible only to Verified content group.

To view logs, grant yourself ssh access to the sandbox (http://jenkins.edx.org:8080/view/Ansible/job/ansible-grant-ssh-access/) , ssh to verifiedcohort.sandbox.edx.org, and look at these 2 logs:
sudo less /edx/var/log/lms/edx.log
sudo less /edx/var/log/supervisor/lms_default_1-stderr.log

To access the admin site (to enable automatic cohorting for a course):
1) Log in to the LMS as user "christina@example.com" with password "edx"
2) Go to this URL: https://verifiedcohort.sandbox.edx.org/admin/verified_track_content/verifiedtrackcohortedcourse/
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @dianakhuang 
- [x] Code review: @efischer19 
- [ ] Product review: @scottrish 
### Post-review
- [ ] Squash commits
