### PR TITLE
truncate email from addresses if >320 chars when encoded (TNL-4264)

### DIFF
--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -339,8 +339,8 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
         __, encoded_unexpected_from_addr = forbid_multi_line_headers(
             "from", unexpected_from_addr, 'utf-8'
         )
-        self.assertGreater(len(encoded_unexpected_from_addr), 320)
-        self.assertGreater(320, len(unexpected_from_addr))
+        self.assertEqual(len(encoded_unexpected_from_addr), 748)
+        self.assertEqual(len(unexpected_from_addr), 261)
 
         self.login_as_user(instructor)
         send_mail_url = reverse('send_email', kwargs={'course_id': unicode(course.id)})


### PR DESCRIPTION
In https://github.com/edx/edx-platform/pull/11865, I didn't realize that the from address that had to be fewer than 320 characters was the encoded one, not the original unicode one. This updates the functionality to check for the length of an encoded from address.
- [x] @dianakhuang 
- [x] @symbolist 
  Another look, please?
