### PR TITLE
TNL-4324: Enhance Mako linting

### DIFF
--- a/scripts/tests/test_safe_template_linter.py
+++ b/scripts/tests/test_safe_template_linter.py
@@ -46,9 +46,10 @@ class TestSafeTemplateLinter(TestCase):
         with mock.patch.object(MakoTemplateLinter, '_is_valid_directory', return_value=True):
             with mock.patch.object(JavaScriptLinter, '_is_valid_directory', return_value=True):
                 with mock.patch.object(UnderscoreTemplateLinter, '_is_valid_directory', return_value=True):
-                    _process_os_walk('scripts/tests/templates', template_linters, options, out)
+                    num_violations = _process_os_walk('scripts/tests/templates', template_linters, options, out)
 
         output = out.getvalue()
+        self.assertEqual(num_violations, 6)
         self.assertIsNotNone(re.search('test\.html.*mako-missing-default', output))
         self.assertIsNotNone(re.search('test\.coffee.*javascript-concat-html', output))
         self.assertIsNotNone(re.search('test\.coffee.*underscore-not-escaped', output))


### PR DESCRIPTION
## [TNL-4324](https://openedx.atlassian.net/browse/TNL-4324)

Enhance Mako linting:
- Lint JavaScript context for JavaScript violations
- Lint for Mako specific JavaScript rules
- Skip commented lines
- Change unicode to decode.utf8

Other enhancements:
- Count lint violations
### Testing
- [x] Data is properly encoded in HTML templates to avoid XSS
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @nedbat 
### Post-review
- [ ] Squash commits
