### PR TITLE
TNL-4321: Add Jenkins support for Safe Templates Linter

### DIFF
--- a/pavelib/paver_tests/test_safelint.py
+++ b/pavelib/paver_tests/test_safelint.py
@@ -1,0 +1,62 @@
+"""
+Tests for paver quality tasks
+"""
+from mock import patch
+
+import pavelib.quality
+from paver.easy import call_task
+
+from .utils import PaverTestCase
+
+
+class PaverSafeLintTest(PaverTestCase):
+    """
+    Test run_safelint with a mocked environment in order to pass in opts
+    """
+
+    def setUp(self):
+        super(PaverSafeLintTest, self).setUp()
+        self.reset_task_messages()
+
+    @patch.object(pavelib.quality, '_write_metric')
+    @patch.object(pavelib.quality, '_prepare_report_dir')
+    @patch.object(pavelib.quality, '_get_count_from_last_line')
+    def test_safelint_violation_number_not_found(self, _mock_count, _mock_report_dir, _mock_write_metric):
+        """
+        run_safelint encounters an error parsing the safelint output log
+        """
+        _mock_count.return_value = None
+        with self.assertRaises(SystemExit):
+            call_task('pavelib.quality.run_safelint')
+
+    @patch.object(pavelib.quality, '_write_metric')
+    @patch.object(pavelib.quality, '_prepare_report_dir')
+    @patch.object(pavelib.quality, '_get_count_from_last_line')
+    def test_safelint_vanilla(self, _mock_count, _mock_report_dir, _mock_write_metric):
+        """
+        run_safelint finds violations, but a limit was not set
+        """
+        _mock_count.return_value = 1
+        call_task('pavelib.quality.run_safelint')
+
+    @patch.object(pavelib.quality, '_write_metric')
+    @patch.object(pavelib.quality, '_prepare_report_dir')
+    @patch.object(pavelib.quality, '_get_count_from_last_line')
+    def test_safelint_too_many_violations(self, _mock_count, _mock_report_dir, _mock_write_metric):
+        """
+        run_safelint finds more violations than are allowed
+        """
+        _mock_count.return_value = 4
+        with self.assertRaises(SystemExit):
+            call_task('pavelib.quality.run_safelint', options={"limit": "3"})
+
+    @patch.object(pavelib.quality, '_write_metric')
+    @patch.object(pavelib.quality, '_prepare_report_dir')
+    @patch.object(pavelib.quality, '_get_count_from_last_line')
+    def test_safelint_under_limit(self, _mock_count, _mock_report_dir, _mock_write_metric):
+        """
+        run_safelint finds fewer violations than are allowed
+        """
+        _mock_count.return_value = 4
+        # No System Exit is expected
+        call_task('pavelib.quality.run_safelint', options={"limit": "5"})

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -13,6 +13,7 @@ set -e
 # Violations thresholds for failing the build
 export PYLINT_THRESHOLD=4175
 export JSHINT_THRESHOLD=9080
+export SAFELINT_THRESHOLD=2550
 
 doCheckVars() {
     if [ -n "$CIRCLECI" ] ; then

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -84,7 +84,10 @@ case "$TEST_SUITE" in
         paver run_jshint -l $JSHINT_THRESHOLD > jshint.log || { cat jshint.log; EXIT=1; }
         echo "Running code complexity report (python)."
         paver run_complexity > reports/code_complexity.log || echo "Unable to calculate code complexity. Ignoring error."
+        echo "Running safe template linter report."
+        paver run_safelint -l $SAFELINT_THRESHOLD > safelint.log || { cat safelint.log; EXIT=1; }
         # Run quality task. Pass in the 'fail-under' percentage to diff-quality
+        echo "Running diff quality."
         paver run_quality -p 100 || EXIT=1
 
         # Need to create an empty test result so the post-build


### PR DESCRIPTION
Adding Jenkins support for Safe Templates Linter.

The linter was added with a threshold.  I ran into issues with diff-quality that need to be discussed.

I'll add more comments/questions inline.

FYI: @jzoldak @benpatterson 

TODO:
- [x] Rebase and update threshold accordingly.
