### PR TITLE
Updated requirements for `paver run_quality`

### DIFF
--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -5,14 +5,14 @@
 #   * @edx/devops to check system requirements
 
 # Use a modern setuptools instead of distribute
-setuptools==18.0.1
+setuptools==20.9.0
 
 # Numpy and scipy can't be installed in the same pip run.
 # Install numpy before other things to help resolve the problem.
 numpy==1.6.2
 
 # Needed to make sure that options in base.txt are allowed
-pip==7.1.2
+pip==8.1.1
 
 # Needed for meliae
 Cython==0.21.2


### PR DESCRIPTION
`paver run_quality` does not work any more with `setuptools==18.0.1` and requires at least `18.5`.

The error I get is
http://pastebin.com/PMQ2FUNM

I also updated `pip` to the latest version currently available.
