### PR TITLE
AC-383 language menu events only when menu opens

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
@@ -130,7 +130,8 @@
             state.el.trigger('language_menu:hide');
             expect(Logger.log).toHaveBeenCalledWith('video_hide_cc_menu', {
                 id: 'id',
-                code: 'html5'
+                code: 'html5',
+                language: 'en'
             });
         });
 

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -105,7 +105,7 @@ define('video/09_events_plugin.js', [], function() {
         },
 
         onHideLanguageMenu: function () {
-            this.log('video_hide_cc_menu');
+            this.log('video_hide_cc_menu', { language: this.getCurrentLanguage() });
         },
 
         onShowCaptions: function () {
@@ -119,6 +119,11 @@ define('video/09_events_plugin.js', [], function() {
         getCurrentTime: function () {
             var player = this.state.videoPlayer;
             return player ? player.currentTime : 0;
+        },
+
+        getCurrentLanguage: function() {
+            var language = this.state.lang;
+            return language;
         },
 
         log: function (eventName, data) {

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -325,9 +325,6 @@
                 var button = this.languageChooserEl,
                     menu = button.parent().find('.menu');
 
-
-                this.state.el.trigger('language_menu:show');
-
                 button
                     .addClass('is-opened');
 
@@ -340,8 +337,6 @@
                 event.preventDefault();
 
                 var button = this.languageChooserEl;
-
-                this.state.el.trigger('language_menu:hide');
 
                 button
                     .removeClass('is-opened')
@@ -381,7 +376,13 @@
             onContainerMouseEnter: function (event) {
                 event.preventDefault();
                 $(event.currentTarget).find('.lang').addClass('is-opened');
-                this.state.el.trigger('language_menu:show');
+
+                // We only want to fire the analytics event if a menu is
+                // present instead of on the container hover, since it wraps
+                // the "CC" and "Transcript" buttons as well.
+                if ($(event.currentTarget).find('.lang').length) {
+                    this.state.el.trigger('language_menu:show');
+                }
             },
 
             /**
@@ -392,7 +393,13 @@
             onContainerMouseLeave: function (event) {
                 event.preventDefault();
                 $(event.currentTarget).find('.lang').removeClass('is-opened');
-                this.state.el.trigger('language_menu:hide');
+
+                // We only want to fire the analytics event if a menu is
+                // present instead of on the container hover, since it wraps
+                // the "CC" and "Transcript" buttons as well.
+                if ($(event.currentTarget).find('.lang').length) {
+                    this.state.el.trigger('language_menu:show');
+                }
             },
 
             /**


### PR DESCRIPTION
# [AC-383](https://openedx.atlassian.net/browse/AC-383)

When the video player UI tweaks were made, the language menu handler was moved to wrap the controls for closed-captions and the transcript. The event was emitted whenever a user hovered over any of the buttons in the container, whether or not a language menu was present.

This work cleans up the event emitter by emitting the event for the language menu only if a menu is available.
## Event proposals
- https://openedx.atlassian.net/wiki/display/AN/Video%3A+language+menu+events
## Sandboxes

https://clrux-ac-383.sandbox.edx.org
https://studio-clrux-ac-383.sandbox.edx.org
## Reviewers
- [x] @lamagnifica (Documentation)
- [x] @clytwynec (Team reviewer)

FYI @shnayder @stroilova @mulby 
