### PR TITLE
AC-385 adding events for closed captions

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
@@ -135,7 +135,7 @@
         });
 
         it('can emit "show_transcript" event', function () {
-            state.el.trigger('captions:show');
+            state.el.trigger('transcript:show');
             expect(Logger.log).toHaveBeenCalledWith('show_transcript', {
                 id: 'id',
                 code: 'html5',
@@ -144,8 +144,26 @@
         });
 
         it('can emit "hide_transcript" event', function () {
-            state.el.trigger('captions:hide');
+            state.el.trigger('transcript:hide');
             expect(Logger.log).toHaveBeenCalledWith('hide_transcript', {
+                id: 'id',
+                code: 'html5',
+                current_time: 10
+            });
+        });
+
+        it('can emit "edx.video.closed_captions.shown" event', function () {
+            state.el.trigger('captions:show');
+            expect(Logger.log).toHaveBeenCalledWith('edx.video.closed_captions.shown', {
+                id: 'id',
+                code: 'html5',
+                current_time: 10
+            });
+        });
+
+        it('can emit "edx.video.closed_captions.hidden" event', function () {
+            state.el.trigger('captions:hide');
+            expect(Logger.log).toHaveBeenCalledWith('edx.video.closed_captions.hidden', {
                 id: 'id',
                 code: 'html5',
                 current_time: 10
@@ -167,6 +185,8 @@
                 'speedchange': plugin.onSpeedChange,
                 'language_menu:show': plugin.onShowLanguageMenu,
                 'language_menu:hide': plugin.onHideLanguageMenu,
+                'transcript:show': plugin.onShowTranscript,
+                'transcript:hide': plugin.onHideTranscript,
                 'captions:show': plugin.onShowCaptions,
                 'captions:hide': plugin.onHideCaptions,
                 'destroy': plugin.destroy

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -17,7 +17,9 @@ define('video/09_events_plugin.js', [], function() {
 
         _.bindAll(this, 'onReady', 'onPlay', 'onPause', 'onEnded', 'onSeek',
             'onSpeedChange', 'onShowLanguageMenu', 'onHideLanguageMenu', 'onSkip',
-            'onShowCaptions', 'onHideCaptions', 'destroy');
+            'onShowTranscript', 'onHideTranscript', 'onShowCaptions', 'onHideCaptions',
+            'destroy');
+
         this.state = state;
         this.options = _.extend({}, options);
         this.state.videoEventsPlugin = this;
@@ -45,6 +47,8 @@ define('video/09_events_plugin.js', [], function() {
                 'speedchange': this.onSpeedChange,
                 'language_menu:show': this.onShowLanguageMenu,
                 'language_menu:hide': this.onHideLanguageMenu,
+                'transcript:show': this.onShowTranscript,
+                'transcript:hide': this.onHideTranscript,
                 'captions:show': this.onShowCaptions,
                 'captions:hide': this.onHideCaptions,
                 'destroy': this.destroy
@@ -108,12 +112,20 @@ define('video/09_events_plugin.js', [], function() {
             this.log('video_hide_cc_menu', { language: this.getCurrentLanguage() });
         },
 
-        onShowCaptions: function () {
+        onShowTranscript: function () {
             this.log('show_transcript', {current_time: this.getCurrentTime()});
         },
 
-        onHideCaptions: function () {
+        onHideTranscript: function () {
             this.log('hide_transcript', {current_time: this.getCurrentTime()});
+        },
+
+        onShowCaptions: function () {
+            this.log('edx.video.closed_captions.shown', {current_time: this.getCurrentTime()});
+        },
+
+        onHideCaptions: function () {
+            this.log('edx.video.closed_captions.hidden', {current_time: this.getCurrentTime()});
         },
 
         getCurrentTime: function () {

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -1131,6 +1131,8 @@
                     this.captionDisplayEl
                         .text(gettext('(Caption will be displayed when you start playing the video.)'));
                 }
+                
+                this.state.el.trigger('captions:show');
             },
 
             hideClosedCaptions: function() {
@@ -1144,6 +1146,8 @@
                     .removeClass('is-active')
                     .find('.control-text')
                         .text(gettext('Turn on closed captioning'));
+
+                this.state.el.trigger('captions:hide');
             },
 
             updateCaptioningCookie: function(method) {
@@ -1191,7 +1195,7 @@
                     state.el.addClass('closed');
                     text = gettext('Turn on transcripts');
                     if (trigger_event) {
-                        this.state.el.trigger('captions:hide');
+                        this.state.el.trigger('transcript:hide');
                     }
 
                     transcriptControlEl
@@ -1204,7 +1208,7 @@
                     this.scrollCaption();
                     text = gettext('Turn off transcripts');
                     if (trigger_event) {
-                        this.state.el.trigger('captions:show');
+                        this.state.el.trigger('transcript:show');
                     }
 
                     transcriptControlEl


### PR DESCRIPTION
# [AC-385](https://openedx.atlassian.net/browse/AC-385)

During the recent video player UI updates, a new control to toggle closed captions was added, but no event was added for analytics. This work adds an event emission when toggling closed captions.
## Event proposals
- https://openedx.atlassian.net/wiki/display/AN/Video%3A+closed-captioning+events
## Sandboxes

https://clrux-ac-385.sandbox.edx.org
https://studio-clrux-ac-385.sandbox.edx.org
## Reviewers
- [x] @mulby (Analytics/Eventing)
- [x] @lamagnifica (Documentation)
- [x] @clytwynec (Team reviewer)

FYI @shnayder @stroilova 
