### PR TITLE
Updated ALLOWED_HOSTS post 1.8 upgrade

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -128,7 +128,6 @@ LMS_BASE = ENV_TOKENS.get('LMS_BASE')
 SITE_NAME = ENV_TOKENS['SITE_NAME']
 
 ALLOWED_HOSTS = [
-    # TODO: bbeggs remove this before prod, temp fix to get load testing running
     "*",
     ENV_TOKENS.get('CMS_BASE')
 ]

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -176,7 +176,6 @@ for feature, value in ENV_FEATURES.items():
 CMS_BASE = ENV_TOKENS.get('CMS_BASE', 'studio.edx.org')
 
 ALLOWED_HOSTS = [
-    # TODO: bbeggs remove this before prod, temp fix to get load testing running
     "*",
     ENV_TOKENS.get('LMS_BASE'),
     FEATURES['PREVIEW_LMS_BASE'],


### PR DESCRIPTION
@edx/devops @symbolist @nedbat @doctoryes 

During the Django 1.8 upgrade we updated the ALLOED_HOSTS to include `*` at the head of it's list in envs/aws.py. 

I would like to open the conversation so we can decide what this should be set to. I think that the \* should remain and we should handle locking this down via configuration/ansible in the places it makes sense.

Thoughts? Concerns?
