### PR TITLE
fix issue with pre-1900 course setting dates (TNL-4397)

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -52,6 +52,18 @@ class CourseSettingsEncoderTest(CourseTestCase):
         self.assertIsNone(jsondetails['effort'], "effort somehow initialized")
         self.assertIsNone(jsondetails['language'], "language somehow initialized")
 
+    def test_pre_1900_date(self):
+        """
+        Tests that the encoder can handle a pre-1900 date, since strftime
+        doesn't work for these dates.
+        """
+        details = CourseDetails.fetch(self.course.id)
+        pre_1900 = datetime.datetime(1564, 4, 23, 1, 1, 1, tzinfo=UTC())
+        details.enrollment_start = pre_1900
+        dumped_jsondetails = json.dumps(details, cls=CourseSettingsEncoder)
+        loaded_jsondetails = json.loads(dumped_jsondetails)
+        self.assertEqual(loaded_jsondetails['enrollment_start'], pre_1900.isoformat())
+
     def test_ooc_encoder(self):
         """
         Test the encoder out of its original constrained purpose to see if it functions for general use

--- a/common/lib/xmodule/xmodule/fields.py
+++ b/common/lib/xmodule/xmodule/fields.py
@@ -73,6 +73,10 @@ class Date(JSONField):
             return time.strftime('%Y-%m-%dT%H:%M:%SZ', value)
         elif isinstance(value, datetime.datetime):
             if value.tzinfo is None or value.utcoffset().total_seconds() == 0:
+                if value.year < 1900:
+                    # strftime doesn't work for pre-1900 dates, so use
+                    # isoformat instead
+                    return value.isoformat()
                 # isoformat adds +00:00 rather than Z
                 return value.strftime('%Y-%m-%dT%H:%M:%SZ')
             else:


### PR DESCRIPTION
This is meant to be a quick patch for [TNL-4397](https://openedx.atlassian.net/browse/TNL-4397). We'll also want to add front end validation eventually, but this should work for now to keep courses from being broken.
- [x] @efischer19 
- [x] @mushtaqak ,

May you please review?
