### PR TITLE
Always clear when copying static assets

### DIFF
--- a/cms/startup.py
+++ b/cms/startup.py
@@ -11,7 +11,8 @@ from openedx.core.lib.django_startup import autostartup
 import django
 from monkey_patch import (
     third_party_auth,
-    django_db_models_options
+    django_db_models_options,
+    collectstatic
 )
 from openedx.core.lib.xblock_utils import xblock_local_resource_url
 
@@ -27,6 +28,7 @@ def run():
     """
     third_party_auth.patch()
     django_db_models_options.patch()
+    collectstatic.patch()
 
     # Comprehensive theming needs to be set up before django startup,
     # because modifying django template paths after startup has no effect.

--- a/common/djangoapps/monkey_patch/collectstatic.py
+++ b/common/djangoapps/monkey_patch/collectstatic.py
@@ -1,0 +1,29 @@
+"""
+Monkey patch implementation to not throw errors when directories don't exist
+Currently in 1.9.5 but not 1.8
+https://github.com/django/django/pull/4262/files
+https://code.djangoproject.com/ticket/23986
+"""
+
+from django.contrib.staticfiles.management.commands.collectstatic import Command
+
+
+def patch():
+    """
+    Monkey-patch the static files management command
+    """
+    def create_collectstatic_wrapper(wrapped_func):
+        # pylint: disable=missing-docstring
+        wrapped_func = wrapped_func.__func__
+
+        def _clear_dir(self, path, **kwargs):
+            # Django has a bug when you collecstatic --clean and directories don't exist
+            # This happens if those files are gitignored, and cleaning really shouldn't die
+            # when the directory it wants to remove is already gone.
+            if not self.storage.exists(path):
+                return
+            else:
+                return wrapped_func(self, path, **kwargs)
+        return _clear_dir
+
+    Command.clear_dir = create_collectstatic_wrapper(Command.clear_dir)

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -14,7 +14,8 @@ import logging
 import analytics
 from monkey_patch import (
     third_party_auth,
-    django_db_models_options
+    django_db_models_options,
+    collectstatic
 )
 
 import xmodule.x_module
@@ -32,6 +33,7 @@ def run():
     """
     third_party_auth.patch()
     django_db_models_options.patch()
+    collectstatic.patch()
 
     # To override the settings before executing the autostartup() for python-social-auth
     if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -379,7 +379,7 @@ def collect_assets(systems, settings):
     `settings` is the Django settings module to use.
     """
     for sys in systems:
-        sh(django_cmd(sys, settings, "collectstatic --clear --noinput"))
+        sh(django_cmd(sys, settings, "collectstatic --clear --noinput -v 0"))
         print("\t\tFinished collecting {} assets.".format(sys))
 
 

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -379,7 +379,7 @@ def collect_assets(systems, settings):
     `settings` is the Django settings module to use.
     """
     for sys in systems:
-        sh(django_cmd(sys, settings, "collectstatic --noinput > /dev/null"))
+        sh(django_cmd(sys, settings, "collectstatic --clear --noinput"))
         print("\t\tFinished collecting {} assets.".format(sys))
 
 

--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -28,7 +28,7 @@ EXPECTED_PREPROCESS_ASSETS_COMMAND = (
     u" {system}/static/sass/*.scss {system}/static/themed_sass"
 )
 EXPECTED_COLLECT_STATIC_COMMAND = (
-    u"python manage.py {system} --settings={asset_settings} collectstatic --clear --noinput"
+    u"python manage.py {system} --settings={asset_settings} collectstatic --clear --noinput -v 0"
 )
 EXPECTED_CELERY_COMMAND = (
     u"python manage.py lms --settings={settings} celery worker --beat --loglevel=INFO --pythonpath=."

--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -28,7 +28,7 @@ EXPECTED_PREPROCESS_ASSETS_COMMAND = (
     u" {system}/static/sass/*.scss {system}/static/themed_sass"
 )
 EXPECTED_COLLECT_STATIC_COMMAND = (
-    u"python manage.py {system} --settings={asset_settings} collectstatic --noinput > /dev/null"
+    u"python manage.py {system} --settings={asset_settings} collectstatic --clear --noinput"
 )
 EXPECTED_CELERY_COMMAND = (
     u"python manage.py lms --settings={settings} celery worker --beat --loglevel=INFO --pythonpath=."


### PR DESCRIPTION
Reintroduce the first commit of https://github.com/edx/edx-platform/pull/12074 but instead of using .gitkeep, it backports this fix from django 1.9.5 https://code.djangoproject.com/ticket/23986.

I no longer see the dirty workspace issues on devstacks, and when building sandboxes, I discovered that they were setting EDXAPP_COMPREHENSIVE_THEME_DIR incorrectly, so clean was being too aggressive and cleaning too many things.  We will need to update sandbox configurations to set the dir correctly and the theme itself and ensure it doesn't cause CI breakage before merging.
