### PR TITLE
Remove LMS_ROOT / static from cms/common.py

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -483,7 +483,6 @@ STATIC_ROOT = ENV_ROOT / "staticfiles" / EDX_PLATFORM_REVISION
 STATICFILES_DIRS = [
     COMMON_ROOT / "static",
     PROJECT_ROOT / "static",
-    LMS_ROOT / "static",
 
     # This is how you would use the textbook images locally
     # ("book", ENV_ROOT / "book_images"),


### PR DESCRIPTION
This has been around for a long time [1].
It probably shouldn't be there,
but we don't know what implicit dependencies may exist.

We've encountered issues on our fork where staticfile compilation steps fail
when the CMS is unable to find "missing" LMS files.
In our case, Stanford Theming is enabled for LMS but not CMS.
Depending on the context in which the CMS assets are compiled, 
the theme files may not (not should they need to) exist.

@andy-armstrong Suggests spinning up a sandbox for further testing.

Some of this has been discussed F2F,
so please let me know if I can provide additional information/context.

[1] https://github.com/edx/edx-platform/commit/d97921e6e2938c30b1a1d4698fc0f21e49412a82
