### PR TITLE
Math inputs _and_ adaptive hints are sized/positioned correctly

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -749,14 +749,12 @@ div.problem {
 // ====================
 .problem {
   .capa_inputtype.textline, .inputtype.formulaequationinput {
-    display: inline-block;
 
     input {
       @include box-sizing(border-box);
       border: 2px solid $gray-l4;
       border-radius: 3px;
       min-width: 160px;
-      width: calc(100% - 45px);
       height: 46px;
     }
 
@@ -813,6 +811,14 @@ div.problem {
       .status {
         @include status-icon($gray-l4, "\f128");
       }
+    }
+  }
+
+  .inputtype.formulaequationinput {
+    display: inline-block;
+
+    input {
+      width: calc(100% - 45px);
     }
   }
 }


### PR DESCRIPTION
## [FEDX-167](https://openedx.atlassian.net/browse/FEDX-167)

Fixes a regression introduced in #11847 where Adaptive Hints were misaligned. Also preserves the intent of #11847 - math inputs work correctly here too.
### Sandbox
- [x] Should be coming up soon, I'll create a course with both a math expression input and an adaptive hint and link them both directly here

[Math expression input on sandbox here](https://bjacobel-fedx-167.sandbox.edx.org/xblock/block-v1:org+num+run+type@problem+block@b0e8897114ec45d7b93b984565769959)
[Adaptive hint on sandbox here](https://bjacobel-fedx-167.sandbox.edx.org/courses/course-v1:org+num+run/courseware/958dccbcb7244cc3aa1e100aa797dc48/0522047083ae4ecaada69d6ce9389271/1?activate_block_id=block-v1%3Aorg%2Bnum%2Brun%2Btype%40vertical%2Bblock%40bedb887c0f0542cc987c1b8a12222d4e)
### Testing
- ~~i18n~~ N/A
- ~~RTL~~ N/A
- ~~Data is properly encoded in HTML templates to avoid XSS~~ N/A
- [ ] Unit, integration, acceptance tests as appropriate (?)
- ~~Analytics~~ N/A
- ~~Performance~~ N/A
- ~~Database migrations are backwards-compatible~~ N/A
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @andy-armstrong 
- [ ] @mushtaqak 
- [x] @awaisdar001 

FYI, @adampalay, @cpennington 
### Post-review
- [x] Squash commits
