### PR TITLE
wait needed for notes pages.

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -872,18 +872,27 @@ class EdxNotesPageTest(EventsTestMixin, EdxNotesTestMixin):
 
         self._add_default_notes()
         self.notes_page.visit()
+        # visiting the page results in an ajax request to fetch the notes
+        self.notes_page.wait_for_ajax()
         note = self.notes_page.notes[0]
         assert_page(note, self.raw_note_list[4]['usage_id'], "Recent Activity")
 
         self.notes_page.visit().switch_to_tab("structure")
+        # visiting the page results in an ajax request to fetch the notes
+        self.notes_page.wait_for_ajax()
         note = self.notes_page.notes[1]
         assert_page(note, self.raw_note_list[2]['usage_id'], "Location in Course")
 
         self.notes_page.visit().switch_to_tab("tags")
+        # visiting the page results in an ajax request to fetch the notes
+        self.notes_page.wait_for_ajax()
         note = self.notes_page.notes[0]
         assert_page(note, self.raw_note_list[2]['usage_id'], "Tags")
 
         self.notes_page.visit().search("Fifth")
+        # visiting the page results in an ajax request to fetch the notes
+        self.notes_page.wait_for_ajax()
+
         note = self.notes_page.notes[0]
         assert_page(note, self.raw_note_list[4]['usage_id'], "Search Results")
 


### PR DESCRIPTION
The page load itself requires and ajax request. Without waiting for that
to complete, additional navigation results in a socket error.

Example failure from the stub service:

``` python
Traceback (most recent call last):
  File "/usr/lib/python2.7/SocketServer.py", line 295, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 321, in process_request
    self.finish_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.7/SocketServer.py", line 657, in __init__
    self.finish()
  File "/usr/lib/python2.7/SocketServer.py", line 716, in finish
    self.wfile.close()
  File "/usr/lib/python2.7/socket.py", line 283, in close
    self.flush()
  File "/usr/lib/python2.7/socket.py", line 307, in flush
    self._sock.sendall(view[write_offset:write_offset+buffer_size])
error: [Errno 32] Broken pipe
```
