### PR TITLE
Fix start url format for paver pa11ycrawler

### DIFF
--- a/pavelib/bok_choy.py
+++ b/pavelib/bok_choy.py
@@ -152,8 +152,8 @@ def pa11ycrawler(options):
     opts = parse_bokchoy_opts(options)
     opts['report_dir'] = Env.PA11YCRAWLER_REPORT_DIR
     opts['coveragerc'] = Env.PA11YCRAWLER_COVERAGERC
-    opts['should_fetch_course'] = getattr(options, 'should_fetch_course', None)
-    opts['course_key'] = getattr(options, 'course-key', None)
+    opts['should_fetch_course'] = getattr(options, 'should_fetch_course', not opts['fasttest'])
+    opts['course_key'] = getattr(options, 'course-key', "course-v1:edX+Test101+course")
     test_suite = Pa11yCrawler('a11y_crawler', **opts)
     test_suite.run()
 

--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -200,7 +200,7 @@ class TestPaverPa11yCrawlerCmd(unittest.TestCase):
             '--pa11y-reporter="1.0-json" '
             '--depth-limit=6 '
         ).format(
-            start_urls=start_urls,
+            start_urls=' '.join(start_urls),
             report_dir=report_dir,
         )
         return expected_statement

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -268,7 +268,7 @@ class Pa11yCrawler(BokChoyTestSuite):
 
     def __init__(self, *args, **kwargs):
         super(Pa11yCrawler, self).__init__(*args, **kwargs)
-        self.course_key = kwargs.get('course_key', "course-v1:edX+Test101+course")
+        self.course_key = kwargs.get('course_key')
         if self.imports_dir:
             # If imports_dir has been specified, assume the files are
             # already there -- no need to fetch them from github. This
@@ -279,7 +279,7 @@ class Pa11yCrawler(BokChoyTestSuite):
             # Otherwise, obey `--skip-fetch` command and use the default
             # test course.  Note that the fetch will also be skipped when
             # using `--fast`.
-            self.should_fetch_course = kwargs.get('should_fetch_course', not self.fasttest)
+            self.should_fetch_course = kwargs.get('should_fetch_course')
             self.imports_dir = path('test_root/courses/')
 
         self.pa11y_report_dir = os.path.join(self.report_dir, 'pa11ycrawler_reports')

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -360,7 +360,7 @@ class Pa11yCrawler(BokChoyTestSuite):
             '--pa11y-reporter="{reporter}" '
             '--depth-limit={depth} '
         ).format(
-            start_urls=self.start_urls,
+            start_urls=' '.join(self.start_urls),
             allowed_domains='localhost',
             report_dir=self.pa11y_report_dir,
             reporter="1.0-json",


### PR DESCRIPTION
@benpatterson @cpennington  Please review when you have a chance. (Next week is fine.)

I managed to mess these up somehow before merging PR https://github.com/edx/edx-platform/pull/12060.  They're straightforward changes.  Basically, two things--
- The default values for `course_key` and `should_fetch_course` needed to be set in a different location.
- The `start_urls` need to be joined in the command. I don't really know how this didn't end up in my final commit, since it was in an intermediate commit that I tested and squashed.
