### PR TITLE
Load jquery-ui by default in LMS suite.

### DIFF
--- a/lms/static/karma_lms.conf.js
+++ b/lms/static/karma_lms.conf.js
@@ -34,7 +34,7 @@ var libraryFiles = [
     {pattern: 'js/RequireJS-namespace-undefine.js', included: false},
     {pattern: 'xmodule_js/common_static/js/vendor/requirejs/text.js', included: false},
     {pattern: 'xmodule_js/common_static/js/vendor/jquery.min.js', included: true},
-    {pattern: 'xmodule_js/common_static/js/vendor/jquery-ui.min.js', included: false},
+    {pattern: 'xmodule_js/common_static/js/vendor/jquery-ui.min.js', included: true},
     {pattern: 'xmodule_js/common_static/js/vendor/jquery.simulate.js', included: false},
     {pattern: 'xmodule_js/common_static/js/vendor/jquery.cookie.js', included: false},
     {pattern: 'xmodule_js/common_static/js/vendor/jquery.timeago.js', included: false},


### PR DESCRIPTION
Saw the following error on the LMS suite. `ecommerce.js` does not use requirejs so we need to load `jquery-ui` by default. It works most of the time right now because other files are requiring `jquery-ui` but depending on the time it may not be there for `ecommerce.js`.

```
15:49:28 Firefox 28.0.0 (Ubuntu 0.0.0) ERROR LOG: 'There is no timestamp for //cdn.mathjax.org/mathjax/2.6-latest/MathJax.js!'
15:49:28 Firefox 28.0.0 (Ubuntu 0.0.0) ERROR: 'There is no timestamp for //cdn.mathjax.org/mathjax/2.6-latest/MathJax.js!'
15:49:29 Firefox 28.0.0 (Ubuntu 0.0.0) ERROR
15:49:29   TypeError: $(...).datepicker is not a function
15:49:29   at /home/jenkins/workspace/edx-platform-js-master/edx-platform/lms/static/js/instructor_dashboard/ecommerce.js:9
15:49:29 Firefox 28.0.0 (Ubuntu 0.0.0) ERROR
15:49:29   TypeError: $(...).datepicker is not a function
15:49:29   at /home/jenkins/workspace/edx-platform-js-master/edx-platform/lms/static/js/instructor_dashboard/ecommerce.js:9
```
