### PR TITLE
fix staff-modal unusable size

### DIFF
--- a/common/static/js/vendor/jquery.leanModal.js
+++ b/common/static/js/vendor/jquery.leanModal.js
@@ -41,8 +41,7 @@
                         "position": "fixed",
                         "opacity": 0,
                         "z-index": 11000,
-                        "left": 50 + "%",
-                        "margin-left": -(modal_width / 2) + "px",
+                        "left": 10 + "%",
                         "top": o.top + "px"
                     });
                     $(modal_id).fadeTo(200, 1);


### PR DESCRIPTION
fixing this bug https://openedx.atlassian.net/browse/TNL-4388 . 
 inline css is coming out of lean-modal jquery modal plugin for dialog windows. The fix consists of changing wrong values.
@andy-armstrong 
