### PR TITLE
Fixes jquery dependency causing require.storage.OptimizationError

### DIFF
--- a/lms/static/lms/js/require-config.js
+++ b/lms/static/lms/js/require-config.js
@@ -118,7 +118,6 @@
                 exports: "Date"
             },
             "jquery": {
-                deps: ["_jquery"],
                 exports: "jQuery"
             },
             "jquery-migrate": ['jquery'],


### PR DESCRIPTION
Fixes require.storage.OptimizationError when running `paver devstack lms --optimize`.

**Background:** Running `paver devstack lms --optimize` with `edx:dan-f/upgrade-jquery-to-2` produces:

```
    python manage.py lms --settings=test_static_optimized collectstatic --noinput > /dev/null
    WARNING:py.warnings:/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/require/helpers.py:4: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
      from django.utils.importlib import import_module

    Traceback (most recent call last):
      File "manage.py", line 116, in <module>
        execute_from_command_line([sys.argv[0]] + django_args)
      File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
      File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
      File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
        self.execute(*args, **cmd_options)
      File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
        output = self.handle(*args, **options)
      File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 168, in handle
    collected = self.collect()
      File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 114, in collect
        for original_path, processed_path, processed in processor:
      File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/require/storage.py", line 108, in post_process
        baseUrl = require_settings.REQUIRE_BASE_URL,
      File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/require/storage.py", line 52, in run_optimizer
        raise OptimizationError("Error while running r.js optimizer.")
    require.storage.OptimizationError: Error while running r.js optimizer.
```

I modified the installed `require.storage.run_optimizer` subprocess call to capture the error:

```
--- storage.py  2016-04-25 02:39:42.000000000 +0000
+++ /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/require/storage.py   2016-04-25 02:40:04.068084254 +0000
@@ -48,8 +48,10 @@
             in kwargs.items()
         )
         # Run the compiler in a subprocess.
-        if subprocess.call(compiler_args) != 0:
-            raise OptimizationError("Error while running r.js optimizer.")
+      p = subprocess.Popen(compiler_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      output, err = p.communicate()
+      if err != 0:
+          raise OptimizationError("Error while running r.js optimizer: %s" % output)

     def __enter__(self):
         return self
```

And it produced this, which lead to the changeset for this PR:

```
require.storage.OptimizationError: Error while running r.js optimizer: Error: ENOENT, no such file or directory '/tmp/tmpNXpUD4/_jquery.js'
In module tree:
    js/discovery/discovery_factory
      js/discovery/views/search_form

Error: Error: ENOENT, no such file or directory '/tmp/tmpNXpUD4/_jquery.js'
In module tree:
    js/discovery/discovery_factory
      js/discovery/views/search_form

    at Object.fs.openSync (fs.js:439:18)
```

**JIRA tickets**: Discovered issue when testing our XBlocks with the JQuery 2.2 upgrade in branch `dan-f/upgrade-jquery-to-2` ([OC-1504](https://tasks.opencraft.com/browse/OC-1504)).

**Sandbox URL**:  
- LMS: http://pr12195.sandbox.opencraft.com/ 
- Studio: http://studio.pr12195.sandbox.opencraft.com/

**Testing instructions**:

To verify error:
1. Set up devstack using edx-platform [edx:dan-f/upgrade-jquery-to-2](https://github.com/edx/edx-platform/pull/11665).
2. Run `paver devstack lms --optimize`.  Error shown as above. 

To test fix:
1. Checkout edx-platform branch [open-craft:jill/fedx-fix-require-js-optimize](https://github.com/open-craft/edx-platform/commit/8601b1d98f8cf0cc677e9a59bd1beeb0e007d99e).
2. Run `paver devstack lms --optimize`.  Should launch LMS without errors.

**Reviewers**
- [x] @smarnach 
- [x] @bjacobel 
