### PR TITLE
AC-444 Adding legacy event_type for language menu events

### DIFF
--- a/common/djangoapps/track/transformers.py
+++ b/common/djangoapps/track/transformers.py
@@ -374,6 +374,8 @@ class VideoEventTransformer(EventTransformer):
         u'edx.video.seeked': u'seek_video',
         u'edx.video.transcript.shown': u'show_transcript',
         u'edx.video.transcript.hidden': u'hide_transcript',
+        u'edx.video.language_menu.shown': u'video_show_cc_menu',
+        u'edx.video.language_menu.hidden': u'video_hide_cc_menu',
     }
 
     is_legacy_event = True

--- a/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
@@ -117,17 +117,17 @@
             });
         });
 
-        it('can emit "video_show_cc_menu" event', function () {
+        it('can emit "edx.video.language_menu.shown" event', function () {
             state.el.trigger('language_menu:show');
-            expect(Logger.log).toHaveBeenCalledWith('video_show_cc_menu', {
+            expect(Logger.log).toHaveBeenCalledWith('edx.video.language_menu.shown', {
                 id: 'id',
                 code: 'html5'
             });
         });
 
-        it('can emit "video_hide_cc_menu" event', function () {
+        it('can emit "edx.video.language_menu.hidden" event', function () {
             state.el.trigger('language_menu:hide');
-            expect(Logger.log).toHaveBeenCalledWith('video_hide_cc_menu', {
+            expect(Logger.log).toHaveBeenCalledWith('edx.video.language_menu.hidden', {
                 id: 'id',
                 code: 'html5',
                 language: 'en'

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -101,11 +101,11 @@ define('video/09_events_plugin.js', [], function() {
         },
 
         onShowLanguageMenu: function () {
-            this.log('video_show_cc_menu');
+            this.log('edx.video.language_menu.shown');
         },
 
         onHideLanguageMenu: function () {
-            this.log('video_hide_cc_menu', { language: this.getCurrentLanguage() });
+            this.log('edx.video.language_menu.hidden', { language: this.getCurrentLanguage() });
         },
 
         onShowCaptions: function () {

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -398,7 +398,7 @@
                 // present instead of on the container hover, since it wraps
                 // the "CC" and "Transcript" buttons as well.
                 if ($(event.currentTarget).find('.lang').length) {
-                    this.state.el.trigger('language_menu:show');
+                    this.state.el.trigger('language_menu:hide');
                 }
             },
 


### PR DESCRIPTION
# [AC-444](https://openedx.atlassian.net/browse/AC-444)

This work updates the video language menu event to include the new, namespaced `name` property, while providing backwards compatibility support for older/legacy `event_type` properties.

Documentation for these updates has already been updated in the [documentation repo](https://github.com/edx/edx-documentation/pull/988).
## Sandboxes

https://clrux-ac-444.sandbox.edx.org
https://studio-clrux-ac-444.sandbox.edx.org
## Reviewers
- [x] @mulby (Analytics/Eventing)
- [x] @lamagnifica (Documentation)
- [x] @clytwynec (Team reviewer)

FYI @stroilova 
