### PR TITLE
Upgrade Pillow to 3.1.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -67,7 +67,7 @@ oauthlib==0.7.2
 paramiko==1.9.0
 path.py==7.2
 piexif==1.0.2
-Pillow==2.7.0
+Pillow==3.1.1
 polib==1.0.3
 pycrypto>=2.6
 pygments==2.0.1


### PR DESCRIPTION
upgrade to address vulnerability http://www.cvedetails.com/cve/CVE-2016-2533/ and others

@ormsbee @robrap @edx/devops FYI.
