### PR TITLE
Change BlockStructure logging from DEBUG to INFO

### DIFF
--- a/openedx/core/lib/block_structure/cache.py
+++ b/openedx/core/lib/block_structure/cache.py
@@ -48,7 +48,7 @@ class BlockStructureCache(object):
             self._encode_root_cache_key(block_structure.root_block_usage_key),
             zp_data_to_cache
         )
-        logger.debug(
+        logger.info(
             "Wrote BlockStructure %s to cache, size: %s",
             block_structure.root_block_usage_key,
             len(zp_data_to_cache),
@@ -77,13 +77,13 @@ class BlockStructureCache(object):
         # Find root_block_usage_key in the cache.
         zp_data_from_cache = self._cache.get(self._encode_root_cache_key(root_block_usage_key))
         if not zp_data_from_cache:
-            logger.debug(
+            logger.info(
                 "Did not find BlockStructure %r in the cache.",
                 root_block_usage_key,
             )
             return None
         else:
-            logger.debug(
+            logger.info(
                 "Read BlockStructure %r from cache, size: %s",
                 root_block_usage_key,
                 len(zp_data_from_cache),
@@ -109,7 +109,7 @@ class BlockStructureCache(object):
                 the cache.
         """
         self._cache.delete(self._encode_root_cache_key(root_block_usage_key))
-        logger.debug(
+        logger.info(
             "Deleted BlockStructure %r from the cache.",
             root_block_usage_key,
         )

--- a/openedx/core/lib/block_structure/transformers.py
+++ b/openedx/core/lib/block_structure/transformers.py
@@ -99,7 +99,7 @@ class BlockStructureTransformers(object):
                 outdated_transformers.append(transformer)
 
         if outdated_transformers:
-            logger.debug(
+            logger.info(
                 "Collected Block Structure data for the following transformers is outdated: '%s'.",
                 [(transformer.name(), transformer.VERSION) for transformer in outdated_transformers],
             )


### PR DESCRIPTION
Changing the logging level for `BlockStructure` log messages from `DEBUG` to `INFO` so we can have a better idea of whether the information is being properly cached in production. 
