### PR TITLE
remove usage of minifed Underscore.string

### DIFF
--- a/common/static/karma_common.conf.js
+++ b/common/static/karma_common.conf.js
@@ -38,7 +38,7 @@ var libraryFiles = [
     {pattern: 'js/vendor/jquery.truncate.js', included: true},
     {pattern: 'js/vendor/mustache.js', included: true},
     {pattern: 'common/js/vendor/underscore.js', included: true},
-    {pattern: 'js/vendor/underscore.string.min.js', included: true},
+    {pattern: 'common/js/vendor/underscore.string.js', included: true},
     {pattern: 'js/vendor/backbone-min.js', included: true},
     {pattern: 'js/vendor/jquery.timeago.js', included: true},
     {pattern: 'js/vendor/URI.min.js', included: true},

--- a/common/static/karma_common_requirejs.conf.js
+++ b/common/static/karma_common_requirejs.conf.js
@@ -36,7 +36,7 @@ var libraryFiles = [
     {pattern: 'js/vendor/jquery.simulate.js', included: false},
     {pattern: 'js/vendor/jquery.truncate.js', included: false},
     {pattern: 'common/js/vendor/underscore.js', included: false},
-    {pattern: 'js/vendor/underscore.string.min.js', included: false},
+    {pattern: 'common/js/vendor/underscore.string.js', included: false},
     {pattern: 'js/vendor/backbone-min.js', included: false},
     {pattern: 'js/vendor/backbone.paginator.min.js', included: false},
     {pattern: 'js/vendor/jquery.timeago.js', included: false},

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1251,7 +1251,6 @@ base_vendor_js = [
     'js/vendor/url.min.js',
     'common/js/vendor/underscore.js',
     'common/js/vendor/underscore.string.js',
-    'js/vendor/underscore.string.min.js',
     'common/js/vendor/picturefill.min.js',
 
     # Make some edX UI Toolkit utilities available in the global "edx" namespace

--- a/lms/static/karma_lms.conf.js
+++ b/lms/static/karma_lms.conf.js
@@ -60,7 +60,7 @@ var libraryFiles = [
     {pattern: 'xmodule_js/src/xmodule.js', included: false},
     {pattern: 'xmodule_js/common_static/js/src/**/*.js', included: false},
     {pattern: 'xmodule_js/common_static/common/js/vendor/underscore.js', included: false},
-    {pattern: 'xmodule_js/common_static/js/vendor/underscore.string.min.js', included: false},
+    {pattern: 'xmodule_js/common_static/common/js/vendor/underscore.string.js', included: false},
     {pattern: 'xmodule_js/common_static/js/vendor/backbone-min.js', included: false},
     {pattern: 'xmodule_js/common_static/js/vendor/backbone.paginator.min.js', included: false},
     {pattern: 'xmodule_js/common_static/js/vendor/edxnotes/annotator-full.min.js', included: false},
@@ -151,4 +151,3 @@ module.exports = function (config) {
 
     config.set(_.extend(commonConfig, localConfig));
 };
-


### PR DESCRIPTION
## [FEDX-171](https://openedx.atlassian.net/browse/FEDX-171)

We removed `underscore.string.min.js` a few weeks ago, somehow it came back.
### Sandbox
- [x] Build a sandbox for your branch and add a link here

[https://bjacobel-uds-remove.sandbox.edx.org](https://bjacobel-uds-remove.sandbox.edx.org)
### Testing
- [ ] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
### Post-review
- [ ] Squash commits
