### PR TITLE
Use unminified picturefill in development

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1257,7 +1257,7 @@ base_vendor_js = [
     'js/vendor/url.min.js',
     'common/js/vendor/underscore.js',
     'common/js/vendor/underscore.string.js',
-    'common/js/vendor/picturefill.min.js',
+    'common/js/vendor/picturefill.js',
 
     # Make some edX UI Toolkit utilities available in the global "edx" namespace
     'edx-ui-toolkit/js/utils/global-loader.js',

--- a/lms/static/js/spec/main.js
+++ b/lms/static/js/spec/main.js
@@ -67,7 +67,7 @@
             '_split': 'js/split',
             'mathjax_delay_renderer': 'coffee/src/mathjax_delay_renderer',
             'MathJaxProcessor': 'coffee/src/customwmd',
-            'picturefill': 'common/js/vendor/picturefill.min',
+            'picturefill': 'common/js/vendor/picturefill',
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly',
             'modernizr': 'xmodule_js/common_static/edx-pattern-library/js/modernizr-custom',
             'afontgarde': 'xmodule_js/common_static/edx-pattern-library/js/afontgarde',

--- a/lms/static/js_test.yml
+++ b/lms/static/js_test.yml
@@ -68,7 +68,7 @@ lib_paths:
     - xmodule_js/common_static/js/vendor/slick.core.js
     - xmodule_js/common_static/js/vendor/slick.grid.js
     - xmodule_js/common_static/js/vendor/jquery.event.drag-2.2.js
-    - xmodule_js/common_static/common/js/vendor/picturefill.min.js
+    - xmodule_js/common_static/common/js/vendor/picturefill.js
 
 # Paths to source JavaScript files
 src_paths:

--- a/lms/static/lms/js/require-config.js
+++ b/lms/static/lms/js/require-config.js
@@ -100,7 +100,7 @@
             "handlebars": "js/vendor/ova/catch/js/handlebars-1.1.2",
             "tinymce": "js/vendor/tinymce/js/tinymce/tinymce.full.min",
             "jquery.tinymce": "js/vendor/tinymce/js/tinymce/jquery.tinymce.min",
-            "picturefill": "common/js/vendor/picturefill.min"
+            "picturefill": "common/js/vendor/picturefill"
             // end of files needed by OVA
         },
         shim: {

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -47,7 +47,7 @@ SASS_LOAD_PATHS = [
 NPM_INSTALLED_LIBRARIES = [
     'underscore/underscore.js',
     'underscore.string/dist/underscore.string.js',
-    'picturefill/dist/picturefill.min.js',
+    'picturefill/dist/picturefill.js',
     'backbone/backbone-min.js',
 ]
 


### PR DESCRIPTION
## [FEDX-172](https://openedx.atlassian.net/browse/FEDX-172)

Use unminified version of Picturefill and other libraries installed from NPM - this gives us better debugging and error messages in development and our pipeline will handle minimizing them for production.
### Sandbox
- [x] Build a sandbox for your branch and add a link here

[https://programlisting.sandbox.edx.org/dashboard/programs/](https://programlisting.sandbox.edx.org/dashboard/programs/)
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 

cc @schenedx, can you manually review the components depending on Picturefill? Not sure where they are?
### Post-review
- [ ] Squash commits
