### PR TITLE
Fixed celery task.

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -5,6 +5,7 @@ from celery.task import task
 from django.dispatch.dispatcher import receiver
 
 from certificates.models import CertificateGenerationCourseSetting
+from opaque_keys.edx.keys import CourseKey
 from xmodule.modulestore.django import SignalHandler, modulestore
 
 
@@ -14,12 +15,13 @@ def _listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable
     enable the self-generated certificates by default for self-paced
     courses.
     """
-    enable_self_generated_certs.delay(course_key)
+    enable_self_generated_certs.delay(unicode(course_key))
 
 
 @task()
 def enable_self_generated_certs(course_key):
     """Enable the self-generated certificates by default for self-paced courses."""
+    course_key = CourseKey.from_string(course_key)
     course = modulestore().get_course(course_key)
     is_enabled_for_course = CertificateGenerationCourseSetting.is_enabled_for_course(course_key)
     if course.self_paced and not is_enabled_for_course:


### PR DESCRIPTION
[ECOM-3437](https://openedx.atlassian.net/browse/ECOM-3437)

Celery task was returning this error `Response was: CourseLocator(u'edX', u'Test101', u'course', None, None) is not JSON serializable` if we pass it a `CourseKey` object.

Fixed by converting `CourseKey` into unicode.

**Related PR:** https://github.com/edx/edx-platform/pull/12210

**Sandbox:** https://ecom-3437.sandbox.edx.org
