### PR TITLE
branch out at assert based on chrome and firefox

### DIFF
--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -1220,12 +1220,22 @@ class DragAndDropTest(VideoBaseTest):
 
         captions_start = captions.location
         action.drag_and_drop_by_offset(captions, 0, -15).perform()
+
         captions_end = captions.location
-        self.assertEqual(
-            captions_end.get('y') + 15,
-            captions_start.get('y'),
-            'Closed captions did not get dragged.'
-        )
+        # We have to branch here due to unexpected behaviour of chrome.
+        # Chrome sets the y offset of element to 834 instead of 650
+        if self.browser.name == 'chrome':
+            self.assertEqual(
+                captions_end.get('y') - 168,
+                captions_start.get('y'),
+                'Closed captions did not get dragged.'
+            )
+        else:
+            self.assertEqual(
+                captions_end.get('y') + 15,
+                captions_start.get('y'),
+                'Closed captions did not get dragged.'
+            )
 
 
 @attr('a11y')


### PR DESCRIPTION
We have to branch here due to unexpected behaviour of chrome.Chrome sets of y offset of element to 834 instead of 650.

Original error can [be seen here](https://build.testeng.edx.org/view/All/job/edx-platform-bok-choy-custom/601/testReport/common.test.acceptance.tests.video.test_video_module/DragAndDropTest/test_if_captions_are_draggable/) 
