### PR TITLE
AC-400 removing tabindex from bookmark

### DIFF
--- a/lms/templates/bookmarks/bookmarks-list.underscore
+++ b/lms/templates/bookmarks/bookmarks-list.underscore
@@ -27,7 +27,7 @@
 
 <% } else {%>
 
-    <div class="bookmarks-empty" tabindex="0">
+    <div class="bookmarks-empty">
         <div class="bookmarks-empty-header">
             <i class="icon fa fa-bookmark-o bookmarks-empty-header-icon" aria-hidden="true"></i>
             <%= gettext("You have not bookmarked any courseware pages yet.") %>


### PR DESCRIPTION
# [AC-400](https://openedx.atlassian.net/browse/AC-400)

This work is part of the SSB Bart review and removes the `tabindex` from the empty Bookmarks container.
## Reviewers
- [x] @cptvitamin 
- [x] @clytwynec 
