### PR TITLE
Upgrade pillow.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -67,7 +67,7 @@ oauthlib==0.7.2
 paramiko==1.9.0
 path.py==7.2
 piexif==1.0.2
-Pillow==2.7.0
+Pillow==3.1.1
 polib==1.0.3
 pycrypto>=2.6
 pygments==2.0.1


### PR DESCRIPTION
@edx/devops @macdiesel @nedbat @ormsbee -
Gemnasium reported a security problem in the Python Pillow package used to manipulate images:

https://gemnasium.com/edx/edx-platform/alerts

I took a few minutes to push a branch that upgraded the package - and it passed all tests. I see tests that do call into Pillow, so it seems the API hasn't changed significantly.

Questions:
- Are there any manual tests that should be done to further verify the Pillow upgrade?
- Should anyone else be tagged on this PR?
