### PR TITLE
Load requirejs bundles synchronously

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -78,23 +78,14 @@ source, template_path = Loader(engine).load_template_source(path)
 %>${source | n, decode.utf8}</%def>
 
 <%def name="require_module(module_name, class_name)">
+    % if not settings.REQUIRE_DEBUG:
+      <script type="text/javascript" src="${staticfiles_storage.url(module_name + '.js') + '?raw'}"></script>
+    % endif
     <script type="text/javascript">
         (function (require) {
-            % if settings.REQUIRE_DEBUG:
-                require(['${module_name | n, js_escaped_string}'], function (${class_name | n, decode.utf8}) {
-                    ${caller.body() | n, decode.utf8}
-                });
-            % else:
-                ## The "raw" parameter is specified to avoid the URL from being further maninpulated by
-                ## static_replace calls (as woudl happen if require_module is used within courseware).
-                ## Without specifying "raw", a call to static_replace would result in the MD5 hash being
-                ## being appended more than once, causing the import to fail in production environments.
-                require(['${staticfiles_storage.url(module_name + ".js") + "?raw" | n, js_escaped_string}'], function () {
-                    require(['${module_name | n, js_escaped_string}'], function (${class_name | n, decode.utf8}) {
-                        ${caller.body() | n, decode.utf8}
-                    });
-                });
-            % endif
+            require(['${module_name | n, js_escaped_string}'], function (${class_name | n, decode.utf8}) {
+                ${caller.body() | n, decode.utf8}
+            });
         }).call(this, require || RequireJS.require);
     </script>
 </%def>

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -78,6 +78,11 @@ source, template_path = Loader(engine).load_template_source(path)
 %>${source | n, decode.utf8}</%def>
 
 <%def name="require_module(module_name, class_name)">
+    <%doc>
+      Loads Javascript onto your page synchronously.
+      Uses RequireJS in development and a plain script tag in production.
+      Use this form of require_module for all new code.
+    </%doc>
     % if not settings.REQUIRE_DEBUG:
       <script type="text/javascript" src="${staticfiles_storage.url(module_name + '.js') + '?raw'}"></script>
     % endif
@@ -91,6 +96,11 @@ source, template_path = Loader(engine).load_template_source(path)
 </%def>
 
 <%def name="require_module_async(module_name, class_name)">
+  <%doc>
+    Legacy mode of require_module that operates asynchronously, required for certain edge cases
+    (notably where Javascript is required outside of a <%block name="js_extra" or "headextra").
+    Do not use for any new code; instead create a factory and use require_module above.
+  </%doc>
   <script type="text/javascript">
     (function (require) {
       % if settings.REQUIRE_DEBUG:

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -90,6 +90,28 @@ source, template_path = Loader(engine).load_template_source(path)
     </script>
 </%def>
 
+<%def name="require_module_async(module_name, class_name)">
+  <script type="text/javascript">
+    (function (require) {
+      % if settings.REQUIRE_DEBUG:
+        require(['${module_name | n, js_escaped_string}'], function (${class_name | n, decode.utf8}) {
+          ${caller.body() | n, decode.utf8}
+        });
+      % else:
+        ## The "raw" parameter is specified to avoid the URL from being further maninpulated by
+        ## static_replace calls (as woudl happen if require_module is used within courseware).
+        ## Without specifying "raw", a call to static_replace would result in the MD5 hash being
+        ## being appended more than once, causing the import to fail in production environments.
+        require(['${staticfiles_storage.url(module_name + ".js") + "?raw" | n, js_escaped_string}'], function () {
+          require(['${module_name | n, js_escaped_string}'], function (${class_name | n, decode.utf8}) {
+            ${caller.body() | n, decode.utf8}
+          });
+        });
+      % endif
+    }).call(this, require || RequireJS.require);
+  </script>
+</%def>
+
 <%def name="optional_include_mako(file, is_theming_enabled=False)"><%
 # http://stackoverflow.com/q/21219531
 if is_theming_enabled:

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -94,9 +94,7 @@ source, template_path = Loader(engine).load_template_source(path)
   <script type="text/javascript">
     (function (require) {
       % if settings.REQUIRE_DEBUG:
-        require(['${module_name | n, js_escaped_string}'], function (${class_name | n, decode.utf8}) {
-          ${caller.body() | n, decode.utf8}
-        });
+        require_module(module_name, class_name);
       % else:
         ## The "raw" parameter is specified to avoid the URL from being further maninpulated by
         ## static_replace calls (as woudl happen if require_module is used within courseware).

--- a/common/templates/edxnotes_wrapper.html
+++ b/common/templates/edxnotes_wrapper.html
@@ -1,17 +1,23 @@
+<%namespace name='static' file='/static_content.html'/>
+<%page expression_filter="h"/>
+
 <%!
 import json
 from django.utils.translation import ugettext as _
 from student.models import anonymous_id_for_user
+from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
 %>
-<%namespace name='static' file='/static_content.html'/>
+
 <%
     if user:
         params.update({'user': anonymous_id_for_user(user, None)})
 %>
+
 <div id="edx-notes-wrapper-${uid}" class="edx-notes-wrapper">
-    <div class="edx-notes-wrapper-content">${content}</div>
+    <div class="edx-notes-wrapper-content">${content | n, decode.utf8 }</div>
 </div>
+
 <%static:require_module_async module_name="js/edxnotes/views/notes_visibility_factory" class_name="NotesVisibilityFactory">
-    var element = document.getElementById('edx-notes-wrapper-${uid}');
-    NotesVisibilityFactory.VisibilityDecorator.factory(element, ${json.dumps(params)}, ${edxnotes_visibility});
+    var element = document.getElementById('edx-notes-wrapper-${uid | n, js_escaped_string}');
+    NotesVisibilityFactory.VisibilityDecorator.factory(element, ${params | n, dump_js_escaped_json}, ${edxnotes_visibility | n, decode.utf8});
 </%static:require_module_async>

--- a/common/templates/edxnotes_wrapper.html
+++ b/common/templates/edxnotes_wrapper.html
@@ -11,7 +11,7 @@ from student.models import anonymous_id_for_user
 <div id="edx-notes-wrapper-${uid}" class="edx-notes-wrapper">
     <div class="edx-notes-wrapper-content">${content}</div>
 </div>
-<%static:require_module module_name="js/edxnotes/views/notes_visibility_factory" class_name="NotesVisibilityFactory">
+<%static:require_module_async module_name="js/edxnotes/views/notes_visibility_factory" class_name="NotesVisibilityFactory">
     var element = document.getElementById('edx-notes-wrapper-${uid}');
     NotesVisibilityFactory.VisibilityDecorator.factory(element, ${json.dumps(params)}, ${edxnotes_visibility});
-</%static:require_module>
+</%static:require_module_async>

--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -84,7 +84,7 @@ else:
 
 
 % if toc:
-    <%static:require_module module_name="js/courseware/accordion_events" class_name="AccordionEvents">
+    <%static:require_module_async module_name="js/courseware/accordion_events" class_name="AccordionEvents">
         AccordionEvents();
-    </%static:require_module>
+    </%static:require_module_async>
 % endif

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -106,7 +106,7 @@ include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
         "masqueradeUsername" : masquerade_user_name if masquerade_user_name is not UNDEFINED else None,
     }
     %>
-    <%static:require_module module_name="lms/js/preview/preview_factory" class_name="PreviewFactory">
+    <%static:require_module_async module_name="lms/js/preview/preview_factory" class_name="PreviewFactory">
         PreviewFactory(${preview_options | n, dump_js_escaped_json});
-    </%static:require_module>
+    </%static:require_module_async>
 % endif

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -38,12 +38,12 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <%include file="/courseware/course_navigation.html" args="active_page='info'" />
 
-<%static:require_module module_name="js/courseware/toggle_element_visibility" class_name="ToggleElementVisibility">
+<%static:require_module_async module_name="js/courseware/toggle_element_visibility" class_name="ToggleElementVisibility">
         ToggleElementVisibility();
-</%static:require_module>
-<%static:require_module module_name="js/courseware/course_home_events" class_name="CourseHomeEvents">
+</%static:require_module_async>
+<%static:require_module_async module_name="js/courseware/course_home_events" class_name="CourseHomeEvents">
         CourseHomeEvents();
-</%static:require_module>
+</%static:require_module_async>
 
 <%block name="js_extra">
   ## CourseTalk widget js script

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -22,9 +22,9 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
   </button>
 </div>
 
-<%static:require_module module_name="js/edxnotes/views/notes_visibility_factory" class_name="NotesVisibilityFactory">
+<%static:require_module_async module_name="js/edxnotes/views/notes_visibility_factory" class_name="NotesVisibilityFactory">
     NotesVisibilityFactory.ToggleVisibilityView(
         ${edxnotes_visibility | n, dump_js_escaped_json},
         '${edxnotes_visibility_url | n, js_escaped_string}'
     );
-</%static:require_module>
+</%static:require_module_async>

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -6,13 +6,13 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>
 
-<%static:require_module module_name="js/certificates/factories/certificate_whitelist_factory" class_name="CertificateWhitelistFactory">
+<%static:require_module_async module_name="js/certificates/factories/certificate_whitelist_factory" class_name="CertificateWhitelistFactory">
         CertificateWhitelistFactory(${certificate_white_list | n, dump_js_escaped_json}, '${generate_certificate_exceptions_url | n, js_escaped_string}', '${certificate_exception_view_url | n, js_escaped_string}', '${generate_bulk_certificate_exceptions_url | n, js_escaped_string}', ${bool(section_data['active_certificate']) | n, dump_js_escaped_json});
-</%static:require_module>
+</%static:require_module_async>
 
-<%static:require_module module_name="js/certificates/factories/certificate_invalidation_factory" class_name="CertificateInvalidationFactory">
+<%static:require_module_async module_name="js/certificates/factories/certificate_invalidation_factory" class_name="CertificateInvalidationFactory">
         CertificateInvalidationFactory('${certificate_invalidations | n, dump_js_escaped_json}', '${certificate_invalidation_view_url | n, js_escaped_string}');
-</%static:require_module>
+</%static:require_module_async>
 
 <div class="certificates-wrapper">
 

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -4,14 +4,15 @@
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
+from openedx.core.djangolib.markup import HTML
 %>
 
 <%static:require_module_async module_name="js/certificates/factories/certificate_whitelist_factory" class_name="CertificateWhitelistFactory">
-        CertificateWhitelistFactory(${certificate_white_list | n, dump_js_escaped_json}, '${generate_certificate_exceptions_url | n, js_escaped_string}', '${certificate_exception_view_url | n, js_escaped_string}', '${generate_bulk_certificate_exceptions_url | n, js_escaped_string}', ${bool(section_data['active_certificate']) | n, dump_js_escaped_json});
+    CertificateWhitelistFactory(${certificate_white_list | n, dump_js_escaped_json}, '${generate_certificate_exceptions_url | n, js_escaped_string}', '${certificate_exception_view_url | n, js_escaped_string}', '${generate_bulk_certificate_exceptions_url | n, js_escaped_string}', ${bool(section_data['active_certificate']) | n, dump_js_escaped_json});
 </%static:require_module_async>
 
 <%static:require_module_async module_name="js/certificates/factories/certificate_invalidation_factory" class_name="CertificateInvalidationFactory">
-        CertificateInvalidationFactory('${certificate_invalidations | n, dump_js_escaped_json}', '${certificate_invalidation_view_url | n, js_escaped_string}');
+    CertificateInvalidationFactory('${certificate_invalidations | n, dump_js_escaped_json}', '${certificate_invalidation_view_url | n, js_escaped_string}');
 </%static:require_module_async>
 
 <div class="certificates-wrapper">
@@ -85,7 +86,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
                     <input type="button" id="disabled-btn-start-generating-certificates" class="is-disabled" aria-disabled="true" value="${_('Generate Certificates')}"/>
                 % else:
                     <p class="under-heading">
-                        ${_("When you are ready to generate certificates for your course, click Generate Certificates. You do not need to do this<br/>if you have set the certificate mode to on-demand generation.")}
+                        ${HTML(_("When you are ready to generate certificates for your course, click Generate Certificates. You do not need to do this<br/>if you have set the certificate mode to on-demand generation."))}
                     </p>
                     <input type="button" class="btn-blue" id="btn-start-generating-certificates" value="${_('Generate Certificates')}" data-endpoint="${section_data['urls']['start_certificate_generation']}"/>
                 %endif
@@ -112,7 +113,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         <h2>${_("Regenerate Certificates")}</h2>
         <form id="certificate-regenerating-form" method="post" action="${section_data['urls']['start_certificate_regeneration']}">
             <p class="under-heading">
-                ${_('To regenerate certificates for your course, choose the learners who will receive regenerated certificates and click <br/> Regenerate Certificates.')}
+                ${HTML(_('To regenerate certificates for your course, choose the learners who will receive regenerated certificates and click <br/> Regenerate Certificates.'))}
             </p>
 
                 <label style="display: inline" for="certificate_status_${section_data['status'].downloadable}">

--- a/scripts/safe_template_linter.py
+++ b/scripts/safe_template_linter.py
@@ -2376,8 +2376,8 @@ class MakoTemplateLinter(BaseLinter):
             r"""
                 <script.*?> |  # script tag start
                 </script> |  # script tag end
-                <%static:require_module.*?> |  # require js script tag start
-                </%static:require_module> | # require js script tag end
+                <%static:require_module(_async)?.*?> |  # require js script tag start (optionally the _async version)
+                </%static:require_module(_async)?> | # require js script tag end (optionally the _async version)
                 <%block[ ]*name=['"]requirejs['"]\w*> |  # require js tag start
                 </%block>  # require js tag end
             """,


### PR DESCRIPTION
## [FEDX-163](https://openedx.atlassian.net/browse/FEDX-163)

Alter requirejs behavior to load all libraries synchronously in production. This prevents situations where UI is loaded but is non-functional because the JS it depends on is still loading.
### Sandbox
- [x] Build a sandbox for your branch and add a link here

[bjacobel-requirejs-sync.sandbox.edx.org](https://bjacobel-requirejs-sync.sandbox.edx.org)
### Testing
- [x] i18n
- [x] RTL
- [x] Data is properly encoded in HTML templates to avoid XSS
- ~~Unit, integration, acceptance tests as appropriate~~
- [x] Analytics
- [x] Performance
- ~~Database migrations are backwards-compatible~~
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @tobz

FYI: @ormsbee 
### Post-review
- [ ] Squash commits
