### PR TITLE
Screenreader added to the button "Upgrade to Verified" in LMS Dashboard.

### DIFF
--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -1155,5 +1155,5 @@ class DashboardTestXSeriesPrograms(ModuleStoreTestCase, ProgramsApiConfigMixin):
         self.assertContains(response, 'XSeries Program Course', count)
         self.assertContains(response, 'XSeries Program: Interested in more courses in this subject?', count)
         self.assertContains(response, 'This course is 1 of 3 courses in the', count)
-        self.assertContains(response, self.program_name, count)
+        self.assertContains(response, self.program_name, count * 2)
         self.assertContains(response, 'View XSeries Details', count)

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -358,6 +358,7 @@ from student.helpers import (
                       <i class="action-upgrade-icon"></i>
                     <span class="wrapper-copy">
                       <span class="copy" id="upgrade-to-verified">${_("Upgrade to Verified")}</span>
+                        <span class="sr">&nbsp;${_(course_overview.display_name_with_default)}</span>
                     </span>
                   </a>
                 </div>

--- a/lms/templates/dashboard/_dashboard_xseries_info.html
+++ b/lms/templates/dashboard/_dashboard_xseries_info.html
@@ -28,6 +28,7 @@
             %>
             <a class="btn ${xseries_btn_class}" href="${program_data['program_marketing_url']}" target="_blank"
                data-program-id="${program_data['program_id']}" >
+                <span class="sr">${program_data['display_name']}</span>
                 <i class="action-xseries-icon" aria-hidden="true"></i>
                 ${_("View {category} Details").format(category=display_category)}
             </a>


### PR DESCRIPTION
[ECOM-4269](https://openedx.atlassian.net/browse/ECOM-4269)
[ECOM-4270](https://openedx.atlassian.net/browse/ECOM-4270)
### Description:

On the dashboard page, if you are enrolled in multiple courses there will be multiple links to "Upgrade to Verified" or "View XSeries Details" on the page. To a visual user, it is apparent based on the layout which of these links is associated with which course. To a screenreader user, which may be browsing by links they would not be able to determine where the link will go based on that text alone. 
