### PR TITLE
Create a 4th shard for lms unit tests

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -8,6 +8,7 @@ import decimal
 import ddt
 import freezegun
 from mock import patch
+from nose.plugins.attrib import attr
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
@@ -25,9 +26,13 @@ from course_modes.models import CourseMode, Mode
 from openedx.core.djangoapps.theming.test_util import with_is_edx_domain
 
 
+@attr('shard_3')
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class CourseModeViewTest(UrlResetMixin, ModuleStoreTestCase):
+    """
+    Course Mode View tests
+    """
     @patch.dict(settings.FEATURES, {'MODE_CREATION_FOR_TESTING': True})
     def setUp(self):
         super(CourseModeViewTest, self).setUp('course_modes.urls')

--- a/common/djangoapps/embargo/tests/test_api.py
+++ b/common/djangoapps/embargo/tests/test_api.py
@@ -4,6 +4,7 @@ Tests for EmbargoMiddleware
 
 from contextlib import contextmanager
 import mock
+from nose.plugins.attrib import attr
 import unittest
 import pygeoip
 import ddt
@@ -37,6 +38,7 @@ from mock import patch
 MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {})
 
 
+@attr('shard_3')
 @ddt.ddt
 @override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')

--- a/common/djangoapps/embargo/tests/test_middleware.py
+++ b/common/djangoapps/embargo/tests/test_middleware.py
@@ -4,6 +4,7 @@ Tests for EmbargoMiddleware with CountryAccessRules
 
 import unittest
 from mock import patch
+from nose.plugins.attrib import attr
 import ddt
 
 from django.core.urlresolvers import reverse
@@ -20,6 +21,7 @@ from embargo.models import RestrictedCourse, IPFilter
 from embargo.test_utils import restrict_course
 
 
+@attr('shard_3')
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -9,6 +9,7 @@ import datetime
 import ddt
 from django.core.cache import cache
 from mock import patch
+from nose.plugins.attrib import attr
 from django.test import Client
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.urlresolvers import reverse
@@ -125,6 +126,7 @@ class EnrollmentTestMixin(object):
         self.assertEqual(actual_mode, expected_mode)
 
 
+@attr('shard_3')
 @override_settings(EDX_API_KEY="i am a key")
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')

--- a/common/djangoapps/external_auth/tests/test_shib.py
+++ b/common/djangoapps/external_auth/tests/test_shib.py
@@ -20,6 +20,7 @@ from external_auth.views import (
     shib_login, course_specific_login, course_specific_register, _flatten_to_ascii
 )
 from mock import patch
+from nose.plugins.attrib import attr
 from urllib import urlencode
 
 from student.views import create_account, change_enrollment
@@ -72,6 +73,7 @@ def gen_all_identities():
                     yield _build_identity_dict(mail, display_name, given_name, surname)
 
 
+@attr('shard_3')
 @ddt
 @override_settings(SESSION_ENGINE='django.contrib.sessions.backends.cache')
 class ShibSPTest(SharedModuleStoreTestCase):

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -4,6 +4,7 @@ Tests for student enrollment.
 import ddt
 import unittest
 from mock import patch
+from nose.plugins.attrib import attr
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -20,6 +21,7 @@ from student.roles import (
 )
 
 
+@attr('shard_3')
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):

--- a/common/djangoapps/student/tests/test_recent_enrollments.py
+++ b/common/djangoapps/student/tests/test_recent_enrollments.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from opaque_keys.edx import locator
 from pytz import UTC
+from nose.plugins.attrib import attr
 import unittest
 import ddt
 from shoppingcart.models import DonationConfiguration
@@ -19,6 +20,7 @@ from student.views import get_course_enrollments, _get_recently_enrolled_courses
 from common.test.utils import XssTestMixin
 
 
+@attr('shard_3')
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @ddt.ddt
 class TestRecentEnrollments(ModuleStoreTestCase, XssTestMixin):

--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import unittest
 import ddt
 from mock import patch
+from nose.plugins.attrib import attr
 from pytz import UTC
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -24,6 +25,7 @@ from lms.djangoapps.verify_student.models import VerificationDeadline, SoftwareS
 from util.testing import UrlResetMixin
 
 
+@attr('shard_3')
 @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @ddt.ddt

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -11,6 +11,7 @@ from urlparse import urljoin
 import pytz
 from markupsafe import escape
 from mock import Mock, patch
+from nose.plugins.attrib import attr
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from pyquery import PyQuery as pq
 
@@ -888,6 +889,7 @@ class AnonymousLookupTable(ModuleStoreTestCase):
 
 
 # TODO: Clean up these tests so that they use the ProgramsDataMixin.
+@attr('shard_3')
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @ddt.ddt
 class DashboardTestXSeriesPrograms(ModuleStoreTestCase, ProgramsApiConfigMixin):

--- a/common/djangoapps/track/views/tests/test_segmentio.py
+++ b/common/djangoapps/track/views/tests/test_segmentio.py
@@ -5,6 +5,7 @@ import json
 
 from ddt import ddt, data, unpack
 from mock import sentinel
+from nose.plugins.attrib import attr
 
 from django.contrib.auth.models import User
 from django.test.client import RequestFactory
@@ -36,6 +37,7 @@ def expect_failure_with_message(message):
     return test_decorator
 
 
+@attr('shard_3')
 @ddt
 @override_settings(
     TRACKING_SEGMENTIO_WEBHOOK_SECRET=SECRET,

--- a/lms/djangoapps/badges/api/tests.py
+++ b/lms/djangoapps/badges/api/tests.py
@@ -4,6 +4,7 @@ Tests for the badges API views.
 from ddt import ddt, data, unpack
 from django.conf import settings
 from django.test.utils import override_settings
+from nose.plugins.attrib import attr
 
 from badges.tests.factories import BadgeAssertionFactory, BadgeClassFactory, RandomBadgeClassFactory
 from openedx.core.lib.api.test_utils import ApiTestCase
@@ -151,6 +152,7 @@ class TestUserCourseBadgeAssertions(UserAssertionTestCase):
         self.check_assertion_structure(assertion, response['results'][0])
 
 
+@attr('shard_3')
 @ddt
 class TestUserBadgeAssertionsByClass(UserAssertionTestCase):
     """

--- a/lms/djangoapps/bulk_email/tests/test_tasks.py
+++ b/lms/djangoapps/bulk_email/tests/test_tasks.py
@@ -75,7 +75,7 @@ def my_update_subtask_status(entry_id, current_task_id, new_subtask_status):
         update_subtask_status(entry_id, current_task_id, new_subtask_status)
 
 
-@attr('shard_1')
+@attr('shard_3')
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class TestBulkEmailInstructorTask(InstructorTaskCourseTestCase):
     """Tests instructor task that send bulk email."""

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -30,7 +30,7 @@ from ccx_keys.locator import CCXLocator
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 
 
-@attr('shard_1')
+@attr('shard_3')
 @mock.patch.dict(
     'django.conf.settings.FEATURES',
     {

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -97,6 +97,7 @@ class CourseListViewTests(CourseApiViewTestMixin, ModuleStoreTestCase):
         self.assertListEqual(actual, expected)
 
 
+@attr('shard_3')
 @ddt.ddt
 class CourseRetrieveUpdateViewTests(CourseApiViewTestMixin, ModuleStoreTestCase):
     """ Tests for CourseRetrieveUpdateView. """

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_proctored_exam.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_proctored_exam.py
@@ -2,6 +2,7 @@
 Tests for ProctoredExamTransformer.
 """
 from mock import patch
+from nose.plugins.attrib import attr
 
 import ddt
 from edx_proctoring.api import (
@@ -19,6 +20,7 @@ from ..proctored_exam import ProctoredExamTransformer
 from ...api import get_course_blocks
 
 
+@attr('shard_3')
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PROCTORED_EXAMS': True})
 class ProctoredExamTransformerTestCase(CourseStructureTestCase):

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -125,7 +125,6 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
         self.assertEqual(result['pacing'], expected_pacing)
 
 
-@attr('shard_3')
 class TestCourseDetailSerializer(TestCourseSerializer):  # pylint: disable=test-inherits-tests
     """
     Test CourseDetailSerializer by rerunning all the tests

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 import ddt
+from nose.plugins.attrib import attr
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from rest_framework.test import APIRequestFactory
@@ -20,6 +21,7 @@ from ..serializers import CourseSerializer, CourseDetailSerializer
 from .mixins import CourseApiFactoryMixin
 
 
+@attr('shard_3')
 @ddt.ddt
 class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
     """
@@ -123,6 +125,7 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
         self.assertEqual(result['pacing'], expected_pacing)
 
 
+@attr('shard_3')
 class TestCourseDetailSerializer(TestCourseSerializer):  # pylint: disable=test-inherits-tests
     """
     Test CourseDetailSerializer by rerunning all the tests

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -5,6 +5,7 @@ from hashlib import md5
 
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory
+from nose.plugins.attrib import attr
 
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from .mixins import CourseApiFactoryMixin, TEST_PASSWORD
@@ -46,6 +47,7 @@ class CourseApiTestViewMixin(CourseApiFactoryMixin):
         return response
 
 
+@attr('shard_3')
 class CourseListViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase):
     """
     Test responses returned from CourseListView.

--- a/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
@@ -2,6 +2,7 @@
 Tests for SplitTestTransformer.
 """
 import ddt
+from nose.plugins.attrib import attr
 
 import openedx.core.djangoapps.user_api.course_tag.api as course_tag_api
 from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme
@@ -14,6 +15,7 @@ from ..user_partitions import UserPartitionTransformer, _get_user_partition_grou
 from .helpers import CourseStructureTestCase, create_location
 
 
+@attr('shard_3')
 @ddt.ddt
 class SplitTestTransformerTestCase(CourseStructureTestCase):
     """

--- a/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
@@ -5,12 +5,14 @@ import ddt
 from datetime import timedelta
 from django.utils.timezone import now
 from mock import patch
+from nose.plugins.attrib import attr
 
 from courseware.tests.factories import BetaTesterFactory
 from ..start_date import StartDateTransformer, DEFAULT_START_DATE
 from .helpers import BlockParentsMapTestCase, update_block
 
 
+@attr('shard_3')
 @ddt.ddt
 class StartDateTransformerTestCase(BlockParentsMapTestCase):
     """

--- a/lms/djangoapps/course_blocks/transformers/tests/test_user_partitions.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_user_partitions.py
@@ -4,6 +4,7 @@ Tests for UserPartitionTransformer.
 """
 from collections import namedtuple
 import ddt
+from nose.plugins.attrib import attr
 
 from openedx.core.djangoapps.course_groups.partition_scheme import CohortPartitionScheme
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory, config_course_cohorts
@@ -65,6 +66,7 @@ class UserPartitionTestMixin(object):
             self.partition_cohorts.append(partition_cohorts)
 
 
+@attr('shard_3')
 @ddt.ddt
 class UserPartitionTransformerTestCase(UserPartitionTestMixin, CourseStructureTestCase):
     """
@@ -212,6 +214,7 @@ class UserPartitionTransformerTestCase(UserPartitionTestMixin, CourseStructureTe
         )
 
 
+@attr('shard_3')
 @ddt.ddt
 class MergedGroupAccessTestData(UserPartitionTestMixin, CourseStructureTestCase):
     """

--- a/lms/djangoapps/course_blocks/transformers/tests/test_visibility.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_visibility.py
@@ -2,11 +2,13 @@
 Tests for VisibilityTransformer.
 """
 import ddt
+from nose.plugins.attrib import attr
 
 from ..visibility import VisibilityTransformer
 from .helpers import BlockParentsMapTestCase, update_block
 
 
+@attr('shard_3')
 @ddt.ddt
 class VisibilityTransformerTestCase(BlockParentsMapTestCase):
     """

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -676,6 +676,7 @@ class UserRoleTestCase(TestCase):
         )
 
 
+@attr('shard_3')
 @ddt.ddt
 class CourseOverviewAccessTestCase(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -38,7 +38,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
-@attr('shard_1')
+@attr('shard_2')
 @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True, 'MILESTONES_APP': True})
 class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTestCaseMixin):
     """

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -51,7 +51,7 @@ def resolve_attrs(test_method):
     return _wrapper
 
 
-@attr('shard_1')
+@attr('shard_2')
 @ddt.ddt
 class GroupAccessTestCase(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -316,7 +316,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
         return [s.earned for s in hw_section['scores']]
 
 
-@attr('shard_1')
+@attr('shard_3')
 class TestCourseGrader(TestSubmittingProblems):
     """
     Suite of tests for the course grader.

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -184,7 +184,7 @@ class TestJumpTo(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-@attr('shard_1')
+@attr('shard_2')
 @ddt.ddt
 class ViewsTestCase(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
+++ b/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
@@ -8,6 +8,8 @@ import StringIO
 import subprocess
 import unittest
 
+from nose.plugins.attrib import attr
+
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -34,6 +36,7 @@ FEATURES_WITH_SSL_AUTH = settings.FEATURES.copy()
 FEATURES_WITH_SSL_AUTH['AUTH_USE_CERTIFICATES'] = True
 
 
+@attr('shard_3')
 @override_settings(MONGODB_LOG=TEST_MONGODB_LOG)
 @unittest.skipUnless(settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'),
                      "ENABLE_SYSADMIN_DASHBOARD not set")

--- a/lms/djangoapps/discussion_api/tests/test_permissions.py
+++ b/lms/djangoapps/discussion_api/tests/test_permissions.py
@@ -4,6 +4,7 @@ Tests for discussion API permission logic
 import itertools
 
 import ddt
+from nose.plugins.attrib import attr
 
 from discussion_api.permissions import (
     can_delete,
@@ -64,6 +65,7 @@ class GetInitializableFieldsTest(ModuleStoreTestCase):
         self.assertEqual(actual, expected)
 
 
+@attr('shard_3')
 @ddt.ddt
 class GetEditableFieldsTest(ModuleStoreTestCase):
     """Tests for get_editable_fields"""

--- a/lms/djangoapps/discussion_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion_api/tests/test_serializers.py
@@ -7,6 +7,7 @@ from urlparse import urlparse
 import ddt
 import httpretty
 import mock
+from nose.plugins.attrib import attr
 
 from django.test.client import RequestFactory
 
@@ -132,6 +133,7 @@ class SerializerTestMixin(CommentsServiceMockMixin, UrlResetMixin):
         self.assertEqual(serialized["voted"], True)
 
 
+@attr('shard_3')
 @ddt.ddt
 class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTestCase):
     """Tests for ThreadSerializer serialization."""

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -8,6 +8,7 @@ from urlparse import urlparse
 import ddt
 import httpretty
 import mock
+from nose.plugins.attrib import attr
 from pytz import UTC
 
 from django.core.urlresolvers import reverse
@@ -225,6 +226,7 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 self.client.get(course_url)
 
 
+@attr('shard_3')
 @ddt.ddt
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -615,6 +617,7 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response_data, expected_response_data)
 
 
+@attr('shard_3')
 @ddt.ddt
 @httpretty.activate
 @disable_signal(api, 'thread_edited')
@@ -864,6 +867,7 @@ class ThreadViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
 
+@attr('shard_3')
 @ddt.ddt
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -200,6 +200,7 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
         self.assertEqual(len(utils.get_accessible_discussion_modules(course, self.user)), expected_discussion_modules)
 
 
+@attr('shard_3')
 class CachedDiscussionIdMapTestCase(ModuleStoreTestCase):
     """
     Tests that using the cache of discussion id mappings has the same behavior as searching through the course.

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -6,6 +6,7 @@ import ddt
 import json
 import jwt
 from mock import patch, MagicMock
+from nose.plugins.attrib import attr
 from unittest import skipUnless
 from datetime import datetime
 import urlparse
@@ -86,6 +87,7 @@ class TestProblem(object):
         return "original_get_html"
 
 
+@attr('shard_3')
 @skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
 class EdxNotesDecoratorTest(ModuleStoreTestCase):
     """
@@ -169,6 +171,7 @@ class EdxNotesDecoratorTest(ModuleStoreTestCase):
         self.assertEqual("original_get_html", self.problem.get_html())
 
 
+@attr('shard_3')
 @skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesHelpersTest(ModuleStoreTestCase):
@@ -941,6 +944,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         verify_url(previous_url, previous_api_url)
 
 
+@attr('shard_3')
 @skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesViewsTest(ModuleStoreTestCase):
@@ -1136,6 +1140,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 400)
 
 
+@attr('shard_3')
 @skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesPluginTest(ModuleStoreTestCase):

--- a/lms/djangoapps/gating/tests/test_api.py
+++ b/lms/djangoapps/gating/tests/test_api.py
@@ -2,6 +2,7 @@
 Unit tests for gating.signals module
 """
 from mock import patch
+from nose.plugins.attrib import attr
 from ddt import ddt, data, unpack
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -114,6 +115,7 @@ class TestGetXBlockParent(GatingTestCase):
         self.assertIsNone(result)
 
 
+@attr('shard_3')
 @ddt
 class TestEvaluatePrerequisite(GatingTestCase, MilestonesTestCaseMixin):
     """

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -4,6 +4,7 @@ Unit tests for instructor_dashboard.py.
 import ddt
 import datetime
 from mock import patch
+from nose.plugins.attrib import attr
 from pytz import UTC
 
 from django.conf import settings
@@ -42,6 +43,7 @@ def intercept_renderer(path, context):
     return response
 
 
+@attr('shard_3')
 @ddt.ddt
 class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssTestMixin):
     """

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -6,6 +6,7 @@ import datetime
 import json
 import pytz
 from mock import MagicMock, Mock, patch
+from nose.plugins.attrib import attr
 from django.core.urlresolvers import reverse
 from django.db.models import Q
 
@@ -31,6 +32,7 @@ from edx_proctoring.api import create_exam
 from edx_proctoring.models import ProctoredExamStudentAttempt
 
 
+@attr('shard_3')
 class TestAnalyticsBasic(ModuleStoreTestCase):
     """ Test basic analytics functions. """
 

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -2,6 +2,7 @@
 Test for LMS instructor background task queue management
 """
 from mock import patch, Mock, MagicMock
+from nose.plugins.attrib import attr
 from bulk_email.models import CourseEmail, SEND_TO_ALL
 from courseware.tests.factories import UserFactory
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -82,6 +83,7 @@ class InstructorTaskReportTest(InstructorTaskTestCase):
         self.assertEquals(set(task_ids), set())
 
 
+@attr('shard_3')
 class InstructorTaskModuleSubmitTest(InstructorTaskModuleTestCase):
     """Tests API methods that involve the submission of module-based background tasks."""
 
@@ -172,6 +174,7 @@ class InstructorTaskModuleSubmitTest(InstructorTaskModuleTestCase):
         self._test_submit_task(submit_delete_problem_state_for_all_students)
 
 
+@attr('shard_3')
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCase):
     """Tests API methods that involve the submission of course-based background tasks."""

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -8,6 +8,7 @@ paths actually work.
 import json
 import logging
 from mock import patch
+from nose.plugins.attrib import attr
 import textwrap
 
 from celery.states import SUCCESS, FAILURE
@@ -63,6 +64,7 @@ class TestIntegrationTask(InstructorTaskModuleTestCase):
         self.assertEqual(status['message'], expected_message)
 
 
+@attr('shard_3')
 class TestRescoringTask(TestIntegrationTask):
     """
     Integration-style tests for rescoring problems in a background task.

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -9,6 +9,7 @@ import json
 from uuid import uuid4
 
 from mock import Mock, MagicMock, patch
+from nose.plugins.attrib import attr
 
 from celery.states import SUCCESS, FAILURE
 from django.utils.translation import ugettext_noop
@@ -213,6 +214,7 @@ class TestInstructorTasks(InstructorTaskModuleTestCase):
         self.assertEquals(output['traceback'][-3:], "...")
 
 
+@attr('shard_3')
 class TestRescoreInstructorTask(TestInstructorTasks):
     """Tests problem-rescoring instructor task."""
 
@@ -315,6 +317,7 @@ class TestRescoreInstructorTask(TestInstructorTasks):
         self.assertGreater(output.get('duration_ms'), 0)
 
 
+@attr('shard_3')
 class TestResetAttemptsInstructorTask(TestInstructorTasks):
     """Tests instructor task that resets problem attempts."""
 
@@ -413,6 +416,7 @@ class TestResetAttemptsInstructorTask(TestInstructorTasks):
         self._test_reset_with_student(True)
 
 
+@attr('shard_3')
 class TestDeleteStateInstructorTask(TestInstructorTasks):
     """Tests instructor task that deletes problem state."""
 

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -16,6 +16,7 @@ import urllib
 import ddt
 from freezegun import freeze_time
 from mock import Mock, patch
+from nose.plugins.attrib import attr
 import tempfile
 from openedx.core.djangoapps.course_groups import cohorts
 import unicodecsv
@@ -666,6 +667,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
         ])
 
 
+@attr('shard_3')
 class TestProblemReportSplitTestContent(TestReportMixin, TestConditionalContent, InstructorTaskModuleTestCase):
     """
     Test the problem report on a course that has split tests.
@@ -1674,6 +1676,7 @@ class TestGradeReportEnrollmentAndCertificateInfo(TestReportMixin, InstructorTas
         self._verify_csv_data(user.username, expected_output)
 
 
+@attr('shard_3')
 @ddt.ddt
 @override_settings(CERT_QUEUE='test-queue')
 class TestCertificateGeneration(InstructorTaskModuleTestCase):

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -6,6 +6,7 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 from mock import patch, MagicMock
+from nose.plugins.attrib import attr
 
 from courseware.testutils import RenderXBlockTestMixin
 from lti_provider import views, models
@@ -157,6 +158,7 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
         self.assertEqual(consumer.instance_guid, u'consumer instance guid')
 
 
+@attr('shard_3')
 class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCase):
     """
     Tests for the rendering returned by lti_launch view.

--- a/lms/djangoapps/mobile_api/course_info/tests.py
+++ b/lms/djangoapps/mobile_api/course_info/tests.py
@@ -4,6 +4,7 @@ Tests for course_info
 
 import ddt
 from django.conf import settings
+from nose.plugins.attrib import attr
 
 from xmodule.html_module import CourseInfoModule
 from xmodule.modulestore import ModuleStoreEnum
@@ -16,6 +17,7 @@ from ..testutils import (
 )
 
 
+@attr('shard_3')
 @ddt.ddt
 class TestUpdates(MobileAPITestCase, MobileAuthTestMixin, MobileCourseAccessTestMixin, MilestonesTestCaseMixin):
     """
@@ -83,6 +85,7 @@ class TestUpdates(MobileAPITestCase, MobileAuthTestMixin, MobileCourseAccessTest
             self.assertIn("Update" + str(num), update_data['content'])
 
 
+@attr('shard_3')
 @ddt.ddt
 class TestHandouts(MobileAPITestCase, MobileAuthTestMixin, MobileCourseAccessTestMixin, MilestonesTestCaseMixin):
     """

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -50,6 +50,11 @@ from opaque_keys.edx.locator import CourseLocator
 @attr('shard_3')
 @ddt.ddt
 class OrderTest(ModuleStoreTestCase):
+    """
+    Test shopping cart orders (e.g., cart contains various items,
+    order is taken through various pieces of cart state, etc.)
+    """
+
     def setUp(self):
         super(OrderTest, self).setUp()
 

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -11,6 +11,7 @@ import smtplib
 from boto.exception import BotoServerError  # this is a super-class of SESError and catches connection errors
 
 from mock import patch, MagicMock
+from nose.plugins.attrib import attr
 import pytz
 import ddt
 from django.core import mail
@@ -46,6 +47,7 @@ from shoppingcart.exceptions import (
 from opaque_keys.edx.locator import CourseLocator
 
 
+@attr('shard_3')
 @ddt.ddt
 class OrderTest(ModuleStoreTestCase):
     def setUp(self):
@@ -477,6 +479,7 @@ class OrderItemTest(TestCase):
         self.assertEqual(item.get_list_price(), item.list_price)
 
 
+@attr('shard_3')
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PAID_COURSE_REGISTRATION': True})
 class PaidCourseRegistrationTest(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -69,6 +69,10 @@ postpay_mock = Mock()
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PAID_COURSE_REGISTRATION': True})
 @ddt.ddt
 class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
+    """
+    Test shopping cart view under various states
+    """
+
     @classmethod
     def setUpClass(cls):
         super(ShoppingCartViewsTests, cls).setUpClass()

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -22,6 +22,7 @@ from pytz import UTC
 from freezegun import freeze_time
 from datetime import datetime, timedelta
 from mock import patch, Mock
+from nose.plugins.attrib import attr
 import ddt
 
 from common.test.utils import XssTestMixin
@@ -64,6 +65,7 @@ render_mock = Mock(side_effect=mock_render_to_response)
 postpay_mock = Mock()
 
 
+@attr('shard_3')
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PAID_COURSE_REGISTRATION': True})
 @ddt.ddt
 class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -2,6 +2,7 @@
 """ Tests for student account views. """
 
 import re
+from nose.plugins.attrib import attr
 from unittest import skipUnless
 from urllib import urlencode
 
@@ -203,6 +204,7 @@ class StudentAccountUpdateTest(UrlResetMixin, TestCase):
         return self.client.post(path=reverse('password_change_request'), data=data)
 
 
+@attr('shard_3')
 @ddt.ddt
 class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleStoreTestCase):
     """ Tests for the student account views that update the user's account information. """

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -10,6 +10,7 @@ import re
 
 import ddt
 from django.core.urlresolvers import reverse
+from nose.plugins.attrib import attr
 from pytz import UTC
 
 from course_modes.models import CourseMode
@@ -40,6 +41,7 @@ class SupportViewTestCase(ModuleStoreTestCase):
         self.assertTrue(success, msg="Could not log in")
 
 
+@attr('shard_3')
 @ddt.ddt
 class SupportViewAccessTests(SupportViewTestCase):
     """

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -2,6 +2,7 @@
 Tests of the LMS XBlock Mixin
 """
 import ddt
+from nose.plugins.attrib import attr
 
 from xblock.validation import ValidationMessage
 from xmodule.modulestore import ModuleStoreEnum
@@ -151,6 +152,7 @@ class OpenAssessmentBlockMixinTestCase(ModuleStoreTestCase):
         self.assertTrue(self.open_assessment.has_score)
 
 
+@attr('shard_3')
 @ddt.ddt
 class XBlockGetParentTest(LmsXBlockMixinTestCase):
     """
@@ -243,6 +245,7 @@ def ddt_named(parent, child):
     return args
 
 
+@attr('shard_3')
 @ddt.ddt
 class XBlockMergedGroupAccessTest(LmsXBlockMixinTestCase):
     """

--- a/openedx/core/djangoapps/content/course_overviews/tests.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests.py
@@ -7,6 +7,7 @@ import ddt
 import itertools
 import math
 import mock
+from nose.plugins.attrib import attr
 import pytz
 
 from django.conf import settings
@@ -36,6 +37,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls
 from .models import CourseOverview, CourseOverviewImageSet, CourseOverviewImageConfig
 
 
+@attr('shard_3')
 @ddt.ddt
 class CourseOverviewTestCase(ModuleStoreTestCase):
     """
@@ -516,6 +518,7 @@ class CourseOverviewTestCase(ModuleStoreTestCase):
             )
 
 
+@attr('shard_3')
 @ddt.ddt
 class CourseOverviewImageSetTestCase(ModuleStoreTestCase):
     """

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -108,7 +108,10 @@ case "$TEST_SUITE" in
                 paver test_system -s lms --extra_args="--attr='shard_2' --with-flaky" --cov_args="-p"
                 ;;
             "3")
-                paver test_system -s lms --extra_args="--attr='shard_1=False,shard_2=False' --with-flaky" --cov_args="-p"
+                paver test_system -s lms --extra_args="--attr='shard_3' --with-flaky" --cov_args="-p"
+                ;;
+            "4")
+                paver test_system -s lms --extra_args="--attr='shard_1=False,shard_2=False,shard_3=False' --with-flaky" --cov_args="-p"
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a


### PR DESCRIPTION
Create a 4th shard for lms unit tests. 

This change flags explicit tests for shard 3, leaving those without any attr settings to fall into shard 4.
