### PR TITLE
Remove unnecessary VideoModule save_states.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/09_save_state_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_save_state_plugin.js
@@ -84,7 +84,12 @@ define('video/09_save_state_plugin.js', [], function() {
         },
 
         onYoutubeAvailability: function (event, youtubeIsAvailable) {
-            this.saveState(true, {youtube_is_available: youtubeIsAvailable});
+            // Compare what the client-side code has determined Youtube
+            // availability to be (true/false) vs. what the LMS recorded for
+            // this user. The LMS will assume YouTube is available by default.
+            if (youtubeIsAvailable !== this.state.config.recordedYoutubeIsAvailable) {
+                this.saveState(true, {youtube_is_available: youtubeIsAvailable});
+            }
         },
 
         saveState: function (async, data) {

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -332,7 +332,12 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
             ## There is no option in the "Advanced Editor" to set this option. However,
             ## this option will have an effect if changed to "True". The code on
             ## front-end exists.
-            'autohideHtml5': False
+            'autohideHtml5': False,
+
+            # This is the server's guess at whether youtube is available for
+            # this user, based on what was recorded the last time we saw the
+            # user, and defaulting to True.
+            'recordedYoutubeIsAvailable': self.youtube_is_available,
         }
 
         bumperize(self)

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -79,6 +79,7 @@ class TestVideoYouTube(TestVideo):
                     self.item_descriptor, 'transcript', 'available_translations'
                 ).rstrip('/?'),
                 "autohideHtml5": False,
+                "recordedYoutubeIsAvailable": True,
             })),
             'track': None,
             'transcript_download_format': 'srt',
@@ -157,6 +158,7 @@ class TestVideoNonYouTube(TestVideo):
                     self.item_descriptor, 'transcript', 'available_translations'
                 ).rstrip('/?'),
                 "autohideHtml5": False,
+                "recordedYoutubeIsAvailable": True,
             })),
             'track': None,
             'transcript_download_format': 'srt',
@@ -211,6 +213,7 @@ class TestGetHtmlMethod(BaseTestXmodule):
                 self.item_descriptor, 'transcript', 'available_translations'
             ).rstrip('/?'),
             "autohideHtml5": False,
+            "recordedYoutubeIsAvailable": True,
         })
 
     def test_get_html_track(self):
@@ -1379,6 +1382,7 @@ class TestVideoWithBumper(TestVideo):
                     self.item_descriptor, 'transcript', 'available_translations'
                 ).rstrip('/?'),
                 "autohideHtml5": False,
+                "recordedYoutubeIsAvailable": True,
             })),
             'track': None,
             'transcript_download_format': 'srt',


### PR DESCRIPTION
Before this commit, roughly half the save_state AJAX calls for the VideoModule were done at load time, in order to send information about YouTube availability (the value for which was almost always true).

This commit sends the value for wat the LMS already thinks YouTube availability is for this user, so that the AJAX callback is only used in the case where the client side sees something different.

[PERF-262]
