### PR TITLE
AC-448 removing tabindex from canvas elements

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/capa/schematic.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/schematic.js
@@ -2147,7 +2147,7 @@ schematic = (function() {
 	    this.bg_image.height = this.height;
 
 	    if (!this.diagram_only) {
-		this.canvas.tabIndex = 1; // so we get keystrokes
+        this.canvas.tabIndex = 0; // so we get keystrokes
 		this.canvas.style.borderStyle = 'solid';
 		this.canvas.style.borderWidth = '1px';
 		this.canvas.style.borderColor = grid_style;


### PR DESCRIPTION
# [AC-448](https://openedx.atlassian.net/browse/AC-448)

This removes the `tabindex` from the canvas elements in the Circuit Schematic Builder module.
## Reviewers
- [x] @cptvitamin 
- [x] @clytwynec 
