### PR TITLE
Come up to a newer New Relic version.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -119,7 +119,7 @@ watchdog==0.8.3
 
 # Metrics gathering and monitoring
 dogapi==1.2.1
-newrelic==2.56.0.42
+newrelic==2.64.0.48
 
 # Used for documentation gathering
 sphinx==1.1.3


### PR DESCRIPTION
This supports a number of their new Error features.

@edx/devops 
