### PR TITLE
Removing the focus outline for the main container in LMS

### DIFF
--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -47,6 +47,11 @@ body, h1, h2, h3, h4, h5, h6, p, label {
   font-family: $sans-serif;
 }
 
+// we want to hide the outline on the focusable <main> element
+main {
+    outline: none;
+}
+
 table {
   table-layout: fixed;
 }


### PR DESCRIPTION
# Adjusting styling for `main` element focus

Recently the "skip to main content" link available on every page was made more useful by sending its focus deeper within the LMS to more relevant content. This work entailed adding a `main` element to templates and making it focusable.

When an element is made focusable, it gets the normal focus ring, but in some cases this ring may not be visually appealing. This small piece of work hides the outline focus ring on the `main` element.

The drawback to this is that keyboard-only users may experience a slight pause when skipping to the main content because it will no longer appear to have received focus. The subsequent "Tab" should keep the flow going, clearing up any potential confusion.
## Reviewers
- [x] @cptvitamin 
