### PR TITLE
Switch to using the standard edxapp-migrate-(lms|cms) tools

### DIFF
--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -155,7 +155,8 @@ class TestPaverServerTasks(PaverTestCase):
         """
         settings = options.get("settings", "devstack")
         call_task("pavelib.servers.update_db", options=options)
-        db_command = "python manage.py {server} --settings={settings} migrate --traceback --pythonpath=."
+        # pylint: disable=line-too-long
+        db_command = "NO_EDXAPP_SUDO=1 EDX_PLATFORM_SETTINGS_OVERRIDE={settings} /edx/bin/edxapp-migrate-{server} --traceback --pythonpath=. "
         self.assertEquals(
             self.task_messages,
             [

--- a/pavelib/servers.py
+++ b/pavelib/servers.py
@@ -239,12 +239,16 @@ def run_all_servers(options):
 ])
 def update_db(options):
     """
-    Runs syncdb and then migrate.
+    Migrates the lms and cms across all databases
     """
     settings = getattr(options, 'settings', DEFAULT_SETTINGS)
     fake = "--fake-initial" if getattr(options, 'fake_initial', False) else ""
     for system in ('lms', 'cms'):
-        sh(django_cmd(system, settings, 'migrate', fake, '--traceback', '--pythonpath=.'))
+        # pylint: disable=line-too-long
+        sh("NO_EDXAPP_SUDO=1 EDX_PLATFORM_SETTINGS_OVERRIDE={settings} /edx/bin/edxapp-migrate-{system} --traceback --pythonpath=. {fake}".format(
+            settings=settings,
+            system=system,
+            fake=fake))
 
 
 @task


### PR DESCRIPTION
edxapp-migrate-lms figures out at system build time what databases
it needs to migrate (just default, or default + student_module_history).
This avoids paver needing to be clever about figuring out if a user has
enabled the split CSMHE databases flag and permits this to merge early
and safely.

We can the CSMHE flag on from configuration at the same time we enable
all of the database config and ensure that the new database is created.
Until a devstack is provisioned using that version of configuration,
it'll continue to have and migrate with 1 database.  This allows us to
control deployment.
