### PR TITLE
Use latest python-saml

### DIFF
--- a/requirements/edx/post.txt
+++ b/requirements/edx/post.txt
@@ -9,4 +9,4 @@
 # trying to compile lxml as a dependency causes setuptools to go into an
 # infinite loop and run out of memory. Because why would you trust a
 # dependency management tool to manage dependencies for you?
-python-saml==2.1.3
+python-saml==2.1.6


### PR DESCRIPTION
This PR back-ports security fix already released as part of `named-release/dogwood.3`, more details are discussed on SEC-109 issue. 
### Background information

Python saml versions prior to 2.1.6 were susceptible to signature wrapping attacks, threat model is that if an attacker has valid credentials (for any user), he can can produce SAML message with credentials for any other user, and this message passes `python-saml` validation. 

I didn't prepare a sandbox for this PR, as this change is already live in `named-release/dogwood.3`. However if the reviewers think that we need a sandbox to be extra sure that `python-saml==2.1.6` is compatible with current master, I'll be happy to provide one. 
- [ ] _Upstream reviewer_: @nedbat 
- [ ] _Upstream reviewer_: @e0d 
