### PR TITLE
Mocking some modules that were missing during platform API doc builds.

### DIFF
--- a/docs/en_us/platform_api/source/conf.py
+++ b/docs/en_us/platform_api/source/conf.py
@@ -151,6 +151,9 @@ MOCK_MODULES = [
     'xmodule.assetstore.assetmgr.AssetManager',
     'xmodule.contentstore.django',
     'piexif',
+    'provider',
+    'provider.oauth2',
+    'oauth2_provider',
 ]
 
 for mod_name in MOCK_MODULES:


### PR DESCRIPTION
This PR adds three Python modules to the list of modules that we need to mock in order to let Sphinx build the platform API doc. The doc build was failing, these additions allow it to succeed.
### Reviewers
- [ ] Sanity check: @nedbat 
- [ ] Sanity check: @lamagnifica @catong @srpearce  
