### PR TITLE
TNL-4444 correcting fullscreen transcript skip links

### DIFF
--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -787,6 +787,15 @@
         &:empty {
           margin-bottom: 0;
         }
+        
+        &.spacing:last-of-type {
+            position: relative;
+            
+            .transcript-end {
+                position: absolute;
+                bottom: 0;
+            }
+        }
       }
     }
   }

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -107,12 +107,8 @@
 
                 var template = [
                     '<div class="subtitles" role="region" id="transcript-' + this.state.id + '">',
-                        '<a href="#transcript-end-' + this.state.id + '"',
-                        'id="transcript-start-' + this.state.id + '" class="transcript-start"></a>',
                         '<h3 id="transcript-label-' + this.state.id + '" class="transcript-title sr"></h3>',
                         '<ol id="transcript-captions" class="subtitles-menu"></ol>',
-                        '<a href="#transcript-start-' + this.state.id + '"',
-                        'id="transcript-end-' + this.state.id + '" class="transcript-end">\</a>',
                     '</div>'
                 ].join('');
 
@@ -785,14 +781,12 @@
 
                 this.subtitlesMenuEl
                     .prepend(
-                        $('<li class="spacing">')
+                        $('<li class="spacing"><a href="#transcript-end-' + this.state.id + '" id="transcript-start-' + this.state.id + '" class="transcript-start"></a>') // jshint ignore: line
                             .height(this.topSpacingHeight())
-                            .attr('tabindex', -1)
                     )
                     .append(
-                        $('<li class="spacing">')
+                        $('<li class="spacing"><a href="#transcript-start-' + this.state.id + '" id="transcript-end-' + this.state.id + '" class="transcript-end"></a>') // jshint ignore: line
                             .height(this.bottomSpacingHeight())
-                            .attr('tabindex', -1)
                     );
             },
 


### PR DESCRIPTION
# [TNL-4444](https://openedx.atlassian.net/browse/TNL-4444)

This adjusts the markup of the side transcript, moving the skip links from standalone anchors inside the first and last list items, which addresses the overlapping text when in fullscreen mode.

The reason for the issue was that the links were placed outside of the list and therefore didn't have any dimension or weren't aware of the dimension of the list items. The bottom skip link was overlapping with text in the transcript.

I've moved the skip links into the empty "spacer" list items so they understand the dimension of the transcript. I've also removed the inability to focus on these items.
## Sandbox

https://clrux-tnl-4444.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/
## Reviewers
- [x] @adampalay 
- [x] @cptvitamin 
