### PR TITLE
[bok-choy] Move wait_for_ajax to edxnotes page

### DIFF
--- a/common/test/acceptance/pages/lms/edxnotes.py
+++ b/common/test/acceptance/pages/lms/edxnotes.py
@@ -260,6 +260,8 @@ class EdxNotesPage(CoursePage, PaginatedUIMixin):
         self.current_view = self.MAPPING["recent"](self.browser)
 
     def is_browser_on_page(self):
+        # When visiting this page, an ajax request is made for the notes
+        self.wait_for_ajax()
         return self.q(css=".wrapper-student-notes .note-group").visible
 
     def switch_to_tab(self, tab_name):

--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -872,26 +872,18 @@ class EdxNotesPageTest(EventsTestMixin, EdxNotesTestMixin):
 
         self._add_default_notes()
         self.notes_page.visit()
-        # visiting the page results in an ajax request to fetch the notes
-        self.notes_page.wait_for_ajax()
         note = self.notes_page.notes[0]
         assert_page(note, self.raw_note_list[4]['usage_id'], "Recent Activity")
 
         self.notes_page.visit().switch_to_tab("structure")
-        # visiting the page results in an ajax request to fetch the notes
-        self.notes_page.wait_for_ajax()
         note = self.notes_page.notes[1]
         assert_page(note, self.raw_note_list[2]['usage_id'], "Location in Course")
 
         self.notes_page.visit().switch_to_tab("tags")
-        # visiting the page results in an ajax request to fetch the notes
-        self.notes_page.wait_for_ajax()
         note = self.notes_page.notes[0]
         assert_page(note, self.raw_note_list[2]['usage_id'], "Tags")
 
         self.notes_page.visit().search("Fifth")
-        # visiting the page results in an ajax request to fetch the notes
-        self.notes_page.wait_for_ajax()
 
         note = self.notes_page.notes[0]
         assert_page(note, self.raw_note_list[4]['usage_id'], "Search Results")


### PR DESCRIPTION
This solution will be more robust against changes or additions
to edx notes tests. It is the better pattern for us, after
discussion in #12222.
