### PR TITLE
HTML-encode string values in keyword substitution.

### DIFF
--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -12,6 +12,7 @@ file and check it in at the same time as your model changes. To do that,
 
 """
 import logging
+import markupsafe
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
@@ -176,7 +177,7 @@ class CourseEmailTemplate(models.Model):
         which is rendered using format() with the provided `context` dict.
 
         Any keywords encoded in the form %%KEYWORD%% found in the message
-        body are subtituted with user data before the body is inserted into
+        body are substituted with user data before the body is inserted into
         the template.
 
         Output is returned as a unicode string.  It is not encoded as utf-8.
@@ -215,6 +216,10 @@ class CourseEmailTemplate(models.Model):
         Convert HTML text body (`htmltext`) into HTML email message using the
         stored HTML template and the provided `context` dict.
         """
+        # HTML-escape string values in the context (used for keyword substitution).
+        for key, value in context.iteritems():
+            if isinstance(value, basestring):
+                context[key] = markupsafe.escape(value)
         return CourseEmailTemplate._render(self.html_template, htmltext, context)
 
 


### PR DESCRIPTION
## [TNL-4193](https://openedx.atlassian.net/browse/TNL-4193)

Escapes context fields used in bulk email keyword substitution (for HTML messages).
### Sandbox
- [ ] Bulk email is not enabled by default on sandboxes. I have tested with and without this change on my devstack-- if anyone really wants to test on a sandbox, let me know and I will figure out how to enable bulk email.
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [x] Code review: @robrap 
### Post-review
- [x] Squash commits
