### PR TITLE
SOL-1777 Allow content gating to work with library_content blocks

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -839,7 +839,7 @@ def _calculate_score_for_modules(user_id, course, modules):
 
     # Iterate over all of the exam modules to get score percentage of user for each of them
     module_percentages = []
-    ignore_categories = ['course', 'chapter', 'sequential', 'vertical', 'randomize']
+    ignore_categories = ['course', 'chapter', 'sequential', 'vertical', 'randomize', 'library_content']
     for index, module in enumerate(modules):
         if module.category not in ignore_categories and (module.graded or module.has_score):
             module_score = scores_client.get(locations[index])

--- a/lms/djangoapps/courseware/tests/test_grades.py
+++ b/lms/djangoapps/courseware/tests/test_grades.py
@@ -366,13 +366,19 @@ class TestGetModuleScore(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
         cls.seq1 = ItemFactory.create(
             parent=cls.chapter,
             category='sequential',
-            display_name="Test Sequential",
+            display_name="Test Sequential 1",
             graded=True
         )
         cls.seq2 = ItemFactory.create(
             parent=cls.chapter,
             category='sequential',
-            display_name="Test Sequential",
+            display_name="Test Sequential 2",
+            graded=True
+        )
+        cls.seq3 = ItemFactory.create(
+            parent=cls.chapter,
+            category='sequential',
+            display_name="Test Sequential 3",
             graded=True
         )
         cls.vert1 = ItemFactory.create(
@@ -385,10 +391,20 @@ class TestGetModuleScore(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
             category='vertical',
             display_name='Test Vertical 2'
         )
+        cls.vert3 = ItemFactory.create(
+            parent=cls.seq3,
+            category='vertical',
+            display_name='Test Vertical 3'
+        )
         cls.randomize = ItemFactory.create(
             parent=cls.vert2,
             category='randomize',
             display_name='Test Randomize'
+        )
+        cls.library_content = ItemFactory.create(
+            parent=cls.vert3,
+            category='library_content',
+            display_name='Test Library Content'
         )
         problem_xml = MultipleChoiceResponseXMLFactory().build_xml(
             question_text='The correct answer is Choice 3',
@@ -417,6 +433,19 @@ class TestGetModuleScore(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
             parent=cls.randomize,
             category="problem",
             display_name="Test Problem 4",
+            data=problem_xml
+        )
+
+        cls.problem5 = ItemFactory.create(
+            parent=cls.library_content,
+            category="problem",
+            display_name="Test Problem 5",
+            data=problem_xml
+        )
+        cls.problem6 = ItemFactory.create(
+            parent=cls.library_content,
+            category="problem",
+            display_name="Test Problem 6",
             data=problem_xml
         )
 
@@ -483,6 +512,16 @@ class TestGetModuleScore(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
         answer_problem(self.course, self.request, self.problem4)
 
         score = get_module_score(self.request.user, self.course, self.seq2)
+        self.assertEqual(score, 1.0)
+
+    def test_get_module_score_with_library_content(self):
+        """
+        Test test_get_module_score_with_library_content
+        """
+        answer_problem(self.course, self.request, self.problem5)
+        answer_problem(self.course, self.request, self.problem6)
+
+        score = get_module_score(self.request.user, self.course, self.seq3)
         self.assertEqual(score, 1.0)
 
 


### PR DESCRIPTION
This fixes an issue with prerequisite subsections that contain a randomized library content block. The grade of the library_content block was being included when calculating the total grade for the subsection. Since the library_content block itself had a grade of 0 it was causing an inaccurate total grade calculation.
