### PR TITLE
Removing nav_skip block from template

### DIFF
--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -3,7 +3,6 @@
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
 <%block name="pagetitle">${_('{course_number} Textbook').format(course_number=course.display_number_with_default) | h}</%block>
-<%block name="nav_skip">#viewer-frame</%block>
 <%block name="headextra">
 <%static:css group='style-course-vendor'/>
 <%static:css group='style-course'/>


### PR DESCRIPTION
Quick fix that removes a block from a template. Relates to [TNL-4482](https://openedx.atlassian.net/browse/TNL-4482).
- [x] @clintonb 
