### PR TITLE
Overriding display table-cell on instructor dashboard

### DIFF
--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -140,6 +140,7 @@
 // ====================
 .instructor-dashboard-content-2 {
   @extend .content;
+  display: block; // override the table-cell display set in .content
   width: 100%;
   padding: 40px;
 


### PR DESCRIPTION
This fixes an issue that was causing the contents to overflow a box due to an incorrectly set table-cell display style. This sets it to block, which overrides the extend.

**Note that we should not use `display: table-cell` for non-table layouts as it may cause screen readers to switch browsing modes. We should ultimately update the Sass extend but that is a bigger story.**
- [x] @clintonb 
