### PR TITLE
AC-452 removing unnecessary and incorrect aria-label

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -759,7 +759,7 @@
                     self.subtitlesEl.find('.transcript-end')
                         .text(gettext('End of transcript. Skip to the start.'));
 
-                    self.container.find('.menu-container .control')
+                    self.container.find('.menu-container .language-menu')
                         .attr('aria-label', gettext('Language: Press the UP arrow key to enter the language menu then use UP and DOWN arrow keys to navigate language options. Press ENTER to change to the selected language.')); // jshint ignore:line
 
                     self.container.find('.menu-container .control .control-text')


### PR DESCRIPTION
# [AC-452](https://openedx.atlassian.net/browse/AC-452)

I found an `aria-label` on each of the language choice buttons in the video player that was added programmatically but aren't necessary. The intention was to add this label to the main language menu button, but the scope propagated to each `.control`. This went unnoticed until recently, but this work adjusts the scope to apply this label only to the main button that controls the menu.
## Sandbox

[Video with multiple languages](https://clrux-ac-452.sandbox.edx.org/courses/course-v1:edX+Justice101+2016_T2/courseware/C_01/lecture_01/)
## Reviewers
- [x] @clytwynec 
- [x] @cptvitamin 
