### PR TITLE
Moving main element up higher to not conflict with chart

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -33,10 +33,9 @@ from django.utils.http import urlquote_plus
 
 <%include file="/courseware/course_navigation.html" args="active_page='progress'" />
 
-<div class="container">
-  <div class="profile-wrapper">
-
-    <main id="main" aria-label="Content" tabindex="-1">
+<main id="main" aria-label="Content" tabindex="-1">
+    <div class="container">
+      <div class="profile-wrapper">
         <div class="course-info" id="course-info-progress" aria-label="${_('Course Progress')}">
           % if staff_access and studio_url is not None:
             <div class="wrap-instructor-info">
@@ -219,6 +218,6 @@ from django.utils.http import urlquote_plus
           </div> <!--End chapters-->
 
         </div>
-    </main>
-  </div>
-</div>
+      </div>
+    </div>
+</main>


### PR DESCRIPTION
I can't explain why this works.

For some reason having the `main` element lower in the structure causes the chart JS not to determine the correct width, which is applied inline. On stage (without `main`), the widths were calculated at 1180px which gave the labels room to shift to the left. With the `main` element where it was previously, the widths were calculated at like 986px or something like that. Strange, considering there are no styles - widths or dimension otherwise - on the `main` element.

This fix solves the problem and allows us to continue to use the `main` element.

We may want to spend some time cleaning up the LMS styles. The rules pretty strict in some cases, requiring certain markup. For example, `.container>div` assumes there's a `div` element immediately following the `.container` element. Having the `main` there broke the styles, which may have been partly causing the issue. I was hesitant to change that style though, not knowing what else it might impact.
- [x] @clintonb 
- [ ] @andy-armstrong 
