### PR TITLE
Add a circle-R to the initial welcome message

### DIFF
--- a/common/test/acceptance/pages/lms/index.py
+++ b/common/test/acceptance/pages/lms/index.py
@@ -29,7 +29,7 @@ class IndexPage(PageObject):
         Returns a browser query object representing the video modal element
         """
         element = self.q(css=BANNER_SELECTOR)
-        return element.visible and element.text[0] == "Welcome to the Open edX platform!"
+        return element.visible and element.text[0].startswith("Welcome to the Open edX")
 
     @property
     def banner_element(self):

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -1,8 +1,11 @@
+<%page expression_filter="h"/>
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+
+from openedx.core.djangolib.markup import Text, HTML
 %>
 
 <main id="main" aria-label="Content" tabindex="-1">
@@ -12,11 +15,11 @@ from django.core.urlresolvers import reverse
           <div class="title">
             <div class="heading-group">
               % if homepage_overlay_html:
-                ${homepage_overlay_html}
+                ${homepage_overlay_html|n}
               % else:
-                  ## Translators: 'Open edX' is a brand, please keep this untranslated. See http://openedx.org for more information.
-                  <h1>${_("Welcome to the Open edX platform!")}</h1>
-                  ## Translators: 'Open edX' is a brand, please keep this untranslated. See http://openedx.org for more information.
+                  ## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See http://open.edx.org for more information.
+                  <h1>${Text(_(u"Welcome to the Open edX{registered_trademark} platform!")).format(registered_trademark=HTML("<sup style='font-size: 65%'>&reg;</sup>"))}</h1>
+                  ## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See http://open.edx.org for more information.
                   <p>${_("It works! This is the default homepage for this Open edX instance.")}</p>
               % endif
             </div>


### PR DESCRIPTION
Adds a cirlcle-R to the first prominent use of "Open edX":
<img width="828" alt="screen shot 2016-05-04 at 2 08 58 pm" src="https://cloud.githubusercontent.com/assets/23789/15024183/dd16d892-1201-11e6-8371-3fd71ee09c99.png">
