### PR TITLE
ECOM-4334 Update learner  account menu

### DIFF
--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -174,6 +174,12 @@ class DashboardPage(PageObject):
         """
         self.q(css='.dropdown').first.click()
 
+    def click_username(self):
+        """
+        Click username.
+        """
+        self.q(css='.label-username').first.click()
+
     @property
     def username_dropdown_link_text(self):
         """

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -266,21 +266,17 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
 
     def test_dashboard_learner_profile_link(self):
         """
-        Scenario: Verify that my profile link is present on dashboard page and we can navigate to correct page.
+        Scenario: Verify that when user click on username it will leads to profile page.
 
         Given that I am a registered user.
         When I go to Dashboard page.
-        And I click on username dropdown.
-        Then I see Profile link in the dropdown menu.
-        When I click on Profile link.
+        And I click on username.
         Then I will be navigated to Profile page.
         """
         username, user_id = self.log_in_as_unique_user()
         dashboard_page = DashboardPage(self.browser)
         dashboard_page.visit()
-        dashboard_page.click_username_dropdown()
-        self.assertIn('Profile', dashboard_page.username_dropdown_link_text)
-        dashboard_page.click_my_profile_link()
+        dashboard_page.click_username()
         my_profile_page = LearnerProfilePage(self.browser, username)
         my_profile_page.wait_for_page()
 

--- a/lms/templates/user_dropdown.html
+++ b/lms/templates/user_dropdown.html
@@ -28,8 +28,6 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
         </button>
         <ul class="dropdown-menu list-divided is-hidden" id="${_("Usermenu")}" tabindex="-1">
             <%block name="navigation_dropdown_menu_links" >
-                <li class="dropdown-item item has-block-link"><a href="${reverse('dashboard')}" class="action">${_("Dashboard")}</a></li>
-                <li class="dropdown-item item has-block-link"><a href="${reverse('learner_profile', kwargs={'username': user.username})}" class="action">${_("Profile")}</a></li>
                 <li class="dropdown-item item has-block-link"><a href="${reverse('account_settings')}" class="action">${_("Account")}</a></li>
             </%block>
             <li class="dropdown-item item has-block-link"><a href="${reverse('logout')}" role="menuitem" class="action">${_("Sign Out")}</a></li>
@@ -38,19 +36,19 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
 % else:
     <ol class="user">
         <li class="primary">
-            <a href="${reverse('dashboard')}" class="user-link">
-                <span class="sr">${_("Dashboard for:")}</span>
+            <a href="${reverse('learner_profile', kwargs={'username': user.username})}" class="user-link">
+                <span class="sr">${_("Profile for:")}</span>
                 <%
                 username = user.username
                 profile_image_url = get_profile_image_urls_for_user(user)['medium']
                 %>
-                <img class="user-image-frame" src="${profile_image_url}" alt="${_('Profile image for {username}').format(username=username)}">
+                <img class="user-image-frame" src="${profile_image_url}" alt="">
                 <div class="label-username">${username}</div>
             </a>
         </li>
         <li class="primary">
-            <button class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span><span class="fa fa-sort-desc" aria-hidden="true"></span></button>
-            <ul class="dropdown-menu" aria-label="More Options" role="menu">
+            <button class="dropdown" aria-haspopup="true" aria-expanded="false" title=${_("Account settings menu")}><span class="fa fa-sort-desc" aria-hidden="true"></span></button>
+            <ul class="dropdown-menu" aria-label=${_("Account settings")} role="menu">
                 ${navigation_dropdown_menu_links()}
                 <li class="item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></li>
             </ul>


### PR DESCRIPTION
Learner account menu updated.
- `dashboard` and `profile` links removed from account menu.
- `photo / username` act as the profile link.

@ahsan-ul-haq @zubair-arbi @waheedahmed @zubair-arbi Please review this.

<img width="261" alt="screen shot 2016-05-05 at 2 39 22 pm" src="https://cloud.githubusercontent.com/assets/4245618/15040558/37134bdc-12cf-11e6-8f21-60ce989a4cbc.png">

You can verify here: https://theme-testing.sandbox.edx.org/
