### PR TITLE
Fix flaky cohort tests

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -315,6 +315,14 @@ class CohortManagementSection(PageObject):
         # There are 2 create buttons on the page. The second one is only present when no cohort yet exists
         # (in which case the first is not visible). Click on the last present create button.
         create_buttons.results[len(create_buttons.results) - 1].click()
+
+        # Both the edit and create forms have an element with id="cohort-name". Verify that the create form
+        # has been rendered.
+        self.wait_for(
+            lambda: "Add a New Cohort" in self.q(css=self._bounded_selector(".form-title")).text,
+            "Create cohort form is visible"
+        )
+
         textinput = self.q(css=self._bounded_selector("#cohort-name")).results[0]
         textinput.send_keys(cohort_name)
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-2257

This fix addresses this issue--
1) Cohort A is created. It has an input field for the name, and all is well.
2) Cohort B is created. Sometimes the input field returned is the one for Cohort A (before the re-rendering occurs, switching the form to the new cohort under creation), and thus "no longer attached to the DOM" error.

With this change, the two test points mentioned in TNL-2257 have passed > 100 times.

@dianakhuang and @jzoldak can you please review?
