### PR TITLE
Hide PDFJS Print and Download toolbar buttons

### DIFF
--- a/common/static/css/vendor/pdfjs/viewer.css
+++ b/common/static/css/vendor/pdfjs/viewer.css
@@ -1988,3 +1988,13 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
     display: none;
   }
 }
+
+.toolbarButton#openFile,
+.toolbarButton#print,
+.toolbarButton#download,
+.secondaryToolbarButton#secondaryOpenFile,
+.secondaryToolbarButton#secondaryPrint,
+.secondaryToolbarButton#secondaryDownload,
+.horizontalToolbarSeparator.visibleLargeView {
+    display: none;
+}


### PR DESCRIPTION
We've been looking at our diff to see if there's anything we can remove/push up to make our merges easier and we found this css change we made a while ago.

Most instructors don't want to make it too easy for people to download the PDFs uploaded onto edX platform, so we hid the buttons.

![screen shot 2016-05-06 at 11 08 39 am](https://cloud.githubusercontent.com/assets/3364609/15082205/60fa6136-137b-11e6-9072-0ba179c30edc.png)
