### PR TITLE
Dumpdata unmanaged model

### DIFF
--- a/scripts/reset-test-db.sh
+++ b/scripts/reset-test-db.sh
@@ -92,7 +92,7 @@ else
 
         # Dump the schema and data to the cache
         echo "Using the dumpdata command to save the $db fixture data to the filesystem."
-        ./manage.py lms --settings bok_choy dumpdata --database $db > $DB_CACHE_DIR/bok_choy_data_$db.json
+        ./manage.py lms --settings bok_choy dumpdata --exclude api_admin.Catalog --database $db > $DB_CACHE_DIR/bok_choy_data_$db.json
         echo "Saving the schema of the $dh bok_choy DB to the filesystem."
         mysqldump -u root --no-data --skip-comments --skip-dump-date "${databases[$db]}" > $DB_CACHE_DIR/bok_choy_schema_$db.sql
 


### PR DESCRIPTION
While attempting to reset test databases for https://github.com/edx/edx-platform/pull/12376, I ran into an issue with the `dumpdata` command in `reset-test-db.sh`.

The error message was `CommandError: Unable to serialize database: (1146, "Table 'edxtest.api_admin_catalog' doesn't exist")`; a full stack trace can be seen here https://gist.github.com/efischer19/f1f5f0f3b91295d1a41ec8d2a8eb2115.

Fix was found on [StackOverflow](http://stackoverflow.com/questions/18313703/dumpdata-with-unmanaged-models). The issue was that https://github.com/edx/edx-platform/pull/12372/files#diff-d7cdd902d9a3d119aa70b98956aac3c4 added an unmanaged model, which must be explicitly excluded from `dumpdata`.

I doubt this approach of excluding individual files will be what we want to merge into master, but I wanted to highlight the issue and workaround.

@peter-fogg @edx/testeng - LMK if you want me to file a ticket or anything for this. A quick git grep indicates this model is the only unmanaged one we have currently in edx-platform.
