### PR TITLE
Fix CRI-57 Bug

### DIFF
--- a/lms/djangoapps/instructor_analytics/csvs.py
+++ b/lms/djangoapps/instructor_analytics/csvs.py
@@ -24,7 +24,9 @@ def create_csv_response(filename, header, datarows):
         quotechar='"',
         quoting=csv.QUOTE_ALL)
 
-    csvwriter.writerow(header)
+    encoded_header = [unicode(s).encode('utf-8') for s in header]
+    csvwriter.writerow(encoded_header)
+
     for datarow in datarows:
         encoded_row = [unicode(s).encode('utf-8') for s in datarow]
         csvwriter.writerow(encoded_row)


### PR DESCRIPTION
Fix error in instructor dashboard, data download section, when trying to download a csv with the issued certificates in a spanish (es-419) configured edx-platform deployment returns a UnicodeEncodeError: 'ascii' codec can't encode character u'\xf3' in position 16: ordinal not in range(128)
