### PR TITLE
removing redundant fields from outline.selected event

### DIFF
--- a/lms/static/js/courseware/accordion_events.js
+++ b/lms/static/js/courseware/accordion_events.js
@@ -7,8 +7,6 @@
                 Logger.log(
                     "edx.ui.lms.outline.selected",
                     {
-                        name: "edx.ui.lms.outline.selected",
-                        event_type: "edx.ui.lms.outline.selected",
                         current_url: window.location.href,
                         target_url: event.currentTarget.href,
                         target_name: $(this).find("p.accordion-display-name").text(),


### PR DESCRIPTION
Reviewers: @jcdyer @nasthagiri 

These fields are logged automatically as top level fields. It was redundant to log them as part of the event object as well.

Per feedback from @stroilova 
