### PR TITLE
AC-396 updating courseware nav to display correctly on high contrast displays

### DIFF
--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -32,11 +32,11 @@
         @include border-left(1px solid $gray-d3);
       }
 
-      a {
+      a,
+      a:visited {
         @include padding(($baseline/2), ($baseline*0.75), 13px, ($baseline*0.75));
         @extend %t-title7;
         @extend %t-regular;
-        border-bottom: 3px solid transparent;
         color: $gray-d1;
         display: block;
         text-align: center;
@@ -45,19 +45,17 @@
         &:hover,
         &:focus {
           color: $blue;
-          border-color: $blue;
+          border-bottom: 4px solid $blue;
         }
 
         &.active {
-          border-bottom: 3px solid $gray-d4;
+          border-bottom: 4px solid $blue;
           background-color: transparent;
-          color: $gray-d4;
-          font-weight: $font-bold;
-          font-size: em(18);
+          color: $blue;
 
           &:hover,
           &:focus {
-            color: $gray-d4;
+            color: $blue;
           }
         }
       }

--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -12,7 +12,7 @@
     @extend %inner-wrapper;
   }
 
-  ol.course-tabs {
+  .course-tabs {
     @include border-top-radius(4px);
     @include clearfix();
     padding: ($baseline*0.75) 0 ($baseline*0.75) 0;
@@ -41,18 +41,19 @@
         display: block;
         text-align: center;
         text-decoration: none;
-        // text-shadow: 0 1px 0 rgba(0, 0, 0, .4);
 
         &:hover,
         &:focus {
           color: $blue;
-          border-bottom: 3px solid $blue;
+          border-color: $blue;
         }
 
         &.active {
           border-bottom: 3px solid $gray-d4;
           background-color: transparent;
           color: $gray-d4;
+          font-weight: $font-bold;
+          font-size: em(18);
 
           &:hover,
           &:focus {


### PR DESCRIPTION
# [AC-396](https://openedx.atlassian.net/browse/AC-396)

This work adjusts the styling of the courseware navigation bar so that the active/selected link is clearly distinguishable from the non-active links even in high contrast mode. See the JIRA ticket for more details on the original issue.

The solution I decided to go with - with input from UX - is the removal of a transparent bottom border on all tabs, but we'll keep the bottom-border of the active/selected tab. I've also made the active tab bold for definitive recognition.
## Visual result

![screen shot 2016-05-12 at 3 08 46 pm](https://cloud.githubusercontent.com/assets/2112024/15227058/7b21f696-1853-11e6-9a1e-3bdc83ecc072.png)

![img_20160512_154552](https://cloud.githubusercontent.com/assets/2112024/15228226/1c86ca98-1859-11e6-8daf-e081eb245072.jpg)

_Note that the visited link style is the same as the normal link, but high contrast mode applies its own styling._
## Sandbox

https://clrux-ac-396.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/
## Reviewers
- [x] @roderickmorales 
- [x] @cptvitamin 
