### PR TITLE
If not certificates remove the container element from the DOM

### DIFF
--- a/common/test/acceptance/pages/lms/programs.py
+++ b/common/test/acceptance/pages/lms/programs.py
@@ -19,4 +19,4 @@ class ProgramListingPage(PageObject):
     @property
     def is_sidebar_present(self):
         """Check whether sidebar is present."""
-        return self.q(css='.sidebar').present and self.q(css='.certificates-list').present
+        return self.q(css='.sidebar').present

--- a/lms/static/js/learner_dashboard/views/certificate_view.js
+++ b/lms/static/js/learner_dashboard/views/certificate_view.js
@@ -25,6 +25,12 @@
 
                     if (certificatesData.length) {
                         this.$el.html(this.tpl(this.context));
+                    } else {
+                        /**
+                         *  If not rendering remove el because
+                         *  styles are applied to it
+                         */
+                        this.remove();
                     }
                 }
             });

--- a/lms/static/js/spec/learner_dashboard/certificate_view_spec.js
+++ b/lms/static/js/spec/learner_dashboard/certificate_view_spec.js
@@ -50,15 +50,13 @@ define([
             });
 
              it('should display no certificate box if certificates list is empty', function() {
-                var $certificate;
                 view.remove();
                 setFixtures('<div class="certificates-list"></div>');
                 view = new CertificateView({
                     context: {certificatesData: []}
                 });
                 view.render();
-                $certificate = view.$el.find('.certificate-link');
-                expect($certificate.length).toBe(0);
+                expect(view.$('.certificates-list').length).toBe(0);
             });
         });
     }


### PR DESCRIPTION
@schenedx @rlucioni a quick fix after I noticed that the move to the Pattern Library for the program listing page will show an empty certificates container element if none are present. This updates simply removes said element if there are no certificates to display.
