### PR TITLE
Hotfix 2016-05-11

### DIFF
--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -42,26 +42,6 @@ var CourseDetails = Backbone.Model.extend({
             newattrs, ["start_date", "end_date", "enrollment_start", "enrollment_end"]
         );
 
-        if (newattrs.title.length > 50) {
-            errors.title = gettext("The title field must be limited to 50 characters.");
-        }
-
-        if (newattrs.subtitle.length > 150) {
-            errors.subtitle = gettext("The subtitle field must be limited to 150 characters.");
-        }
-
-        if (newattrs.duration.length > 50) {
-            errors.duration = gettext("The duration field must be limited to 50 characters.");
-        }
-
-        if (newattrs.short_description.length > 150) {
-            errors.short_description = gettext("The short description field must be limited to 150 characters.");
-        }
-
-        if (newattrs.description.length > 1000) {
-            errors.description = gettext("The description field must be limited to 1000 characters.");
-        }
-
         if (newattrs.start_date === null) {
             errors.start_date = gettext("The course must have an assigned start date.");
         }


### PR DESCRIPTION
This fixes SOL-1797. We previously added some character limit validation to the course short description field in Studio, but there was existing data for some courses that violated the added validation rule. This was preventing the Schedule & Detail page from being saved in those courses.
