### PR TITLE
Firefox version must meet a minimum

### DIFF
--- a/pavelib/paver_tests/test_utils.py
+++ b/pavelib/paver_tests/test_utils.py
@@ -1,0 +1,43 @@
+"""
+Tests for pavelib/utils/test/utils
+"""
+
+from pavelib.utils.test.utils import check_firefox_version, MINIMUM_FIREFOX_VERSION
+import unittest
+from mock import patch
+
+
+class TestUtils(unittest.TestCase):
+    """
+    Test utils.py under pavelib/utils/test
+    """
+
+    @patch('subprocess.check_output')
+    def test_firefox_version_ok(self, _mock_subprocesss):
+        test_version = MINIMUM_FIREFOX_VERSION
+        _mock_subprocesss.return_value = "Mozilla Firefox {version}".format(
+            version=str(test_version)
+        )
+        # No exception should be raised
+        check_firefox_version()
+
+    @patch('subprocess.check_output')
+    def test_firefox_version_below_expected(self, _mock_subprocesss):
+        test_version = MINIMUM_FIREFOX_VERSION - 1
+        _mock_subprocesss.return_value = "Mozilla Firefox {version}".format(
+            version=test_version
+        )
+        with self.assertRaises(Exception):
+            check_firefox_version()
+
+    @patch('subprocess.check_output')
+    def test_firefox_version_not_detected(self, _mock_subprocesss):
+        _mock_subprocesss.return_value = "Mozilla Firefox"
+        with self.assertRaises(Exception):
+            check_firefox_version()
+
+    @patch('subprocess.check_output')
+    def test_firefox_version_bad(self, _mock_subprocesss):
+        _mock_subprocesss.return_value = "garbage"
+        with self.assertRaises(Exception):
+            check_firefox_version()

--- a/pavelib/utils/test/utils.py
+++ b/pavelib/utils/test/utils.py
@@ -4,10 +4,12 @@ Helper functions for test tasks
 from paver.easy import sh, task, cmdopts
 from pavelib.utils.envs import Env
 import os
+import re
 import subprocess
 
 MONGO_PORT_NUM = int(os.environ.get('EDXAPP_TEST_MONGO_PORT', '27017'))
 MONGO_HOST = os.environ.get('EDXAPP_TEST_MONGO_HOST', 'localhost')
+MINIMUM_FIREFOX_VERSION = 28.0
 
 __test__ = False  # do not collect
 
@@ -69,20 +71,25 @@ def check_firefox_version():
     """
     Check that firefox is the correct version.
     """
-    expected_firefox_ver = "Mozilla Firefox 28.0"
-    firefox_ver = subprocess.check_output("firefox --version", shell=True).strip()
+    expected_firefox_ver = "Mozilla Firefox " + str(MINIMUM_FIREFOX_VERSION)
+    firefox_ver_string = subprocess.check_output("firefox --version", shell=True).strip()
+    firefox_version_regex = re.compile(r"Mozilla Firefox (\d+.\d+)")
+    try:
+        firefox_ver = float(firefox_version_regex.search(firefox_ver_string).group(1))
+    except AttributeError:
+        firefox_ver = 0.0
     debian_location = 'https://s3.amazonaws.com/vagrant.testeng.edx.org/'
-    debian_package = 'firefox_28.0%2Bbuild2-0ubuntu0.12.04.1_amd64.deb'
+    debian_package = 'firefox-mozilla-build_42.0-0ubuntu1_amd64.deb'
     debian_path = '{location}{package}'.format(location=debian_location, package=debian_package)
 
-    if firefox_ver != expected_firefox_ver:
+    if firefox_ver < MINIMUM_FIREFOX_VERSION:
         raise Exception(
             'Required firefox version not found.\n'
             'Expected: {expected_version}; Actual: {actual_version}.\n\n'
             'As the vagrant user in devstack, run the following:\n\n'
-            '\t$ sudo wget -O /tmp/firefox_28.deb {debian_path}\n'
+            '\t$ sudo wget -O /tmp/firefox_42.deb {debian_path}\n'
             '\t$ sudo apt-get remove firefox\n\n'
-            '\t$ sudo gdebi -nq /tmp/firefox_28.deb\n\n'
+            '\t$ sudo gdebi -nq /tmp/firefox_42.deb\n\n'
             'Confirm the new version:\n'
             '\t$ firefox --version\n'
             '\t{expected_version}'.format(


### PR DESCRIPTION
This will be a backwards-compatible change, which will allow
developers that use older versions of firefox (e.g., 28) to
continue with development while also supporting a build system
and development that uses newer firefox versions (e.g., 42)
