### PR TITLE
WL-461 Include course price in course_about template context

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -489,16 +489,11 @@ def course_about(request, course_id):
         )
 
         # Note: this is a flow for payment for course registration, not the Verified Certificate flow.
-        registration_price = 0
         in_cart = False
         reg_then_add_to_cart_link = ""
 
         _is_shopping_cart_enabled = is_shopping_cart_enabled()
         if _is_shopping_cart_enabled:
-            registration_price = CourseMode.min_course_price_for_currency(
-                course_key,
-                settings.PAID_COURSE_REGISTRATION_CURRENCY[0]
-            )
             if request.user.is_authenticated():
                 cart = shoppingcart.models.Order.get_cart_for_user(request.user)
                 in_cart = shoppingcart.models.PaidCourseRegistration.contained_in_order(cart, course_key) or \
@@ -515,7 +510,8 @@ def course_about(request, course_id):
         ecommerce_bulk_checkout_link = ''
         professional_mode = None
         ecomm_service = EcommerceService()
-        if ecomm_service.is_enabled(request.user) and (
+        _is_ecomm_service_enabled = ecomm_service.is_enabled(request.user)
+        if _is_ecomm_service_enabled and (
                 CourseMode.PROFESSIONAL in modes or CourseMode.NO_ID_PROFESSIONAL_MODE in modes
         ):
             professional_mode = modes.get(CourseMode.PROFESSIONAL, '') or \
@@ -523,6 +519,16 @@ def course_about(request, course_id):
             ecommerce_checkout_link = ecomm_service.checkout_page_url(professional_mode.sku)
             if professional_mode.bulk_sku:
                 ecommerce_bulk_checkout_link = ecomm_service.checkout_page_url(professional_mode.bulk_sku)
+
+        # We need to look up the price from the CourseMode only when the EcommerceService is enabled OR
+        # the legacy shoppingcart ecommerce implementation is enabled.
+        registration_price = 0
+        if _is_ecomm_service_enabled or _is_shopping_cart_enabled:
+            registration_price = CourseMode.min_course_price_for_currency(
+                course_key,
+                settings.PAID_COURSE_REGISTRATION_CURRENCY[0]
+            )
+
         course_price = get_cosmetic_display_price(course, registration_price)
         can_add_course_to_cart = _is_shopping_cart_enabled and registration_price
 


### PR DESCRIPTION
We need to include the course price in the course_about template context if either the ecommerce service is enabled or shoppingcart is enabled. Currently, if you set ENABLE_SHOPPING_CART to false (which you need to do in order to checkout via Otto), the course price will display as "Free" on the course details page.

Sandbox URL: https://mitprofessionalx.sandbox.edx.org/courses/course-v1:MITProfessionalX+IOTx+2016_T1/about

@mattdrayer @mjfrey @vkaracic 
