### PR TITLE
WL-461 Always include the course price in the course_about template context

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -510,8 +510,7 @@ def course_about(request, course_id):
         ecommerce_bulk_checkout_link = ''
         professional_mode = None
         ecomm_service = EcommerceService()
-        _is_ecomm_service_enabled = ecomm_service.is_enabled(request.user)
-        if _is_ecomm_service_enabled and (
+        if ecomm_service.is_enabled(request.user) and (
                 CourseMode.PROFESSIONAL in modes or CourseMode.NO_ID_PROFESSIONAL_MODE in modes
         ):
             professional_mode = modes.get(CourseMode.PROFESSIONAL, '') or \
@@ -520,15 +519,11 @@ def course_about(request, course_id):
             if professional_mode.bulk_sku:
                 ecommerce_bulk_checkout_link = ecomm_service.checkout_page_url(professional_mode.bulk_sku)
 
-        # We need to look up the price from the CourseMode only when the EcommerceService is enabled OR
-        # the legacy shoppingcart ecommerce implementation is enabled.
-        registration_price = 0
-        if _is_ecomm_service_enabled or _is_shopping_cart_enabled:
-            registration_price = CourseMode.min_course_price_for_currency(
-                course_key,
-                settings.PAID_COURSE_REGISTRATION_CURRENCY[0]
-            )
-
+        # Find the minimum price for the course across all course modes
+        registration_price = CourseMode.min_course_price_for_currency(
+            course_key,
+            settings.PAID_COURSE_REGISTRATION_CURRENCY[0]
+        )
         course_price = get_cosmetic_display_price(course, registration_price)
         can_add_course_to_cart = _is_shopping_cart_enabled and registration_price
 


### PR DESCRIPTION
This is a followup PR to https://github.com/edx/edx-platform/pull/12436 since that first approach did not work. You need to have a logged in user to determine if the ecommerce service is enabled, so the course price was still displaying as "Free" when an anonymous user visited the course details page. This change will include the course price in the course_about template context regardless of any flags being set.

@mattdrayer @mjfrey @vkaracic 
