### PR TITLE
Disable `Generate Exception Certificate button

### DIFF
--- a/lms/static/js/certificates/factories/certificate_whitelist_factory.js
+++ b/lms/static/js/certificates/factories/certificate_whitelist_factory.js
@@ -14,7 +14,8 @@
         function($, CertificateWhiteListListView, CertificateExceptionModel, CertificateWhiteListEditorView ,
                  CertificateWhiteListCollection, CertificateBulkWhiteList){
             return function(certificate_white_list_json, generate_certificate_exceptions_url,
-                            certificate_exception_view_url, generate_bulk_certificate_exceptions_url){
+                            certificate_exception_view_url, generate_bulk_certificate_exceptions_url,
+                            active_certificate){
 
                 var certificateWhiteList = new CertificateWhiteListCollection(certificate_white_list_json, {
                     parse: true,
@@ -30,7 +31,8 @@
 
                 new CertificateWhiteListListView({
                     collection: certificateWhiteList,
-                    certificateWhiteListEditorView: certificateWhiteListEditorView
+                    certificateWhiteListEditorView: certificateWhiteListEditorView,
+                    active_certificate: active_certificate
                 }).render();
 
                 new CertificateBulkWhiteList({

--- a/lms/static/js/certificates/views/certificate_whitelist.js
+++ b/lms/static/js/certificates/views/certificate_whitelist.js
@@ -25,6 +25,7 @@
 
                 initialize: function(options){
                     this.certificateWhiteListEditorView = options.certificateWhiteListEditorView;
+                    this.active_certificate = options.active_certificate;
                     // Re-render the view when an item is added to the collection
                     this.listenTo(this.collection, 'change add remove', this.render);
                 },
@@ -32,7 +33,7 @@
                 render: function(){
                     var template = this.loadTemplate('certificate-white-list');
                     this.$el.html(template({certificates: this.collection.models}));
-                    if (this.collection.isEmpty()) {
+                    if (!this.active_certificate || this.collection.isEmpty()){
                         this.$("#generate-exception-certificates").addClass("is-disabled");
                     }
                     else {

--- a/lms/static/js/spec/instructor_dashboard/certificates_exception_spec.js
+++ b/lms/static/js/spec/instructor_dashboard/certificates_exception_spec.js
@@ -182,7 +182,7 @@ define([
                 setFixtures("<script type='text/template' id='certificate-white-list-tpl'>" + fixture + "</script>" +
                     "<div class='white-listed-students' id='white-listed-students'></div>");
 
-                var certificate_white_list = new CertificateWhiteListCollection(certificates_exceptions_json, {
+                this.certificate_white_list = new CertificateWhiteListCollection(certificates_exceptions_json, {
                     parse: true,
                     canBeEmpty: true,
                     url: certificate_exception_url,
@@ -190,12 +190,31 @@ define([
 
                 });
 
-                view = new CertificateWhiteListView({collection: certificate_white_list});
+                view = new CertificateWhiteListView({
+                    collection: this.certificate_white_list,
+                    active_certificate: true
+                });
                 view.render();
             });
 
             it("verifies view is initialized and rendered successfully", function() {
                 expect(view).not.toBe(undefined);
+                expect(view.$el.find('table tbody tr').length).toBe(2);
+            });
+
+            it("verifies that Generate Exception Certificate button is disabled", function() {
+                expect(view.$el.find('table tbody tr').length).toBe(2);
+                expect(view.$el.find('#generate-exception-certificates').first()).not.toHaveClass('is-disabled');
+
+                // Render the view with active_certificate set to false.
+                view = new CertificateWhiteListView({
+                    collection: this.certificate_white_list,
+                    active_certificate: false
+                });
+                view.render();
+
+                // Verify that `Generate Exception Certificate` is disabled even when Collection is not empty.
+                expect(view.$el.find('#generate-exception-certificates').first()).toHaveClass('is-disabled');
                 expect(view.$el.find('table tbody tr').length).toBe(2);
             });
 

--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -7,7 +7,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 %>
 
 <%static:require_module module_name="js/certificates/factories/certificate_whitelist_factory" class_name="CertificateWhitelistFactory">
-        CertificateWhitelistFactory(${certificate_white_list | n, dump_js_escaped_json}, '${generate_certificate_exceptions_url | n, js_escaped_string}', '${certificate_exception_view_url | n, js_escaped_string}', '${generate_bulk_certificate_exceptions_url | n, js_escaped_string}');
+        CertificateWhitelistFactory(${certificate_white_list | n, dump_js_escaped_json}, '${generate_certificate_exceptions_url | n, js_escaped_string}', '${certificate_exception_view_url | n, js_escaped_string}', '${generate_bulk_certificate_exceptions_url | n, js_escaped_string}', ${bool(section_data['active_certificate']) | n, dump_js_escaped_json});
 </%static:require_module>
 
 <%static:require_module module_name="js/certificates/factories/certificate_invalidation_factory" class_name="CertificateInvalidationFactory">


### PR DESCRIPTION
## Possible to generate certificates through white-list even if certificates aren't active for a course

You shouldn't be able to generate certificates for a user web certificate configuration is deactivated. 

[ECOM-4202](https://openedx.atlassian.net/browse/ECOM-4202)
