### PR TITLE
mattdrayer/add-bulk-sku-default-none: Fix MySQL insert error

### DIFF
--- a/common/djangoapps/course_modes/migrations/0007_coursemode_bulk_sku.py
+++ b/common/djangoapps/course_modes/migrations/0007_coursemode_bulk_sku.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='coursemode',
             name='bulk_sku',
-            field=models.CharField(help_text='This is the bulk SKU (stock keeping unit) of this mode in the external ecommerce service.', max_length=255, null=True, verbose_name=b'Bulk SKU', blank=True),
+            field=models.CharField(default=None, max_length=255, blank=True, help_text='This is the bulk SKU (stock keeping unit) of this mode in the external ecommerce service.', null=True, verbose_name=b'Bulk SKU'),
         ),
     ]

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -102,6 +102,7 @@ class CourseMode(models.Model):
         max_length=255,
         null=True,
         blank=True,
+        default=None,  # Need this in order to set DEFAULT NULL on the database column
         verbose_name="Bulk SKU",
         help_text=_(
             u"This is the bulk SKU (stock keeping unit) of this mode in the external ecommerce service."


### PR DESCRIPTION
@douglashall @mjfrey -- Figured out what was causing the Otto course publishing error that was observed earlier.  It's a corner case in this particular instance, but we should fix it before the 'bulk_sku' column is created in stage/prod which would then require a MySQL-level fix.

It took a while to understand what the problem was and why it was happening.  The solution ended up being a pretty simple thing -- apparently something that is easily and often overlooked.

After we merge the change I'll add it to the patch and rebuild the edx-platform AMIs.
