### PR TITLE
Add a link to the developer's guide under Dogwood

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,15 @@
                     </div>
                   </a>
                 </li>
+                
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/">
+                    <h4 class="item-link__title">Open edX Developer's Guide</h4>
+                    <div class="item-link__copy">
+                      <p>For developers contributing to the edX platform.</p>
+                    </div>
+                  </a>
+                </li>
               </ul>
             </section>
             <section class="item-audience item-audience--release">


### PR DESCRIPTION
It's confusing that the developer's guide appears under Latest but not the Open edX release section of the docs landing page, particularly since Dogwood appears first. Let's add it above. It doesn't make sense for it to be versioned along with the Open edX release, so it just points to latest.
