### PR TITLE
update pa11ycrawler version

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -67,7 +67,7 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 
 # Used for testing
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
-git+https://github.com/edx/pa11ycrawler.git@0.0.2#egg=pa11ycrawler
+git+https://github.com/edx/pa11ycrawler.git@cad2c741510b432b95eaa8af0f8e920a38933f8a#egg=pa11ycrawler
 
 # Our libraries:
 git+https://github.com/edx/XBlock.git@xblock-0.4.10#egg=XBlock==0.4.10


### PR DESCRIPTION
@benpatterson @jzoldak  Please review. This updates the version of pa11ycrawler to the commit after https://github.com/edx/pa11ycrawler/pull/6.   I want to run it on the specific commit for a bit before updating the version again officially.
