### PR TITLE
mattdrayer/rc/2016-05-17: Check for "code" on receipt line item attribute

### DIFF
--- a/lms/static/js/commerce/views/receipt_view.js
+++ b/lms/static/js/commerce/views/receipt_view.js
@@ -253,7 +253,13 @@ var edx = edx || {};
                 for (var i = 0; i < length; i++) {
                     var line = order.lines[i],
                         attributeValues = _.find(line.product.attribute_values, function (attribute) {
-                            return attribute.name === 'course_key'
+                            // If the attribute has a 'code' property, compare its value, otherwise compare 'name'
+                            var value_to_match = 'course_key';
+                            if (attribute.code) {
+                                return attribute.code === value_to_match;
+                            } else {
+                                return attribute.name === value_to_match;
+                            }
                         });
 
                     // This method assumes that all items in the order are related to a single course.


### PR DESCRIPTION
@vkaracic -- here is the LMS-side of the fix for the receipt page "We have received your payment for null." issue.

@doctoryes, FYI.

Update:  The Otto-side of the fix can be viewed here: https://github.com/edx/ecommerce/pull/719/commits/ab81b557bfb66cdb0f9ca241b4dacee7b3daf8c2
