### PR TITLE
Header updated for Account settings and Profile pages

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -36,6 +36,7 @@ from third_party_auth import pipeline
 from third_party_auth.decorators import xframe_allow_whitelisted
 from util.bad_request_rate_limiter import BadRequestRateLimiter
 
+from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.theming.helpers import is_request_in_themed_site, get_value as get_themed_value
 from openedx.core.djangoapps.user_api.accounts.api import request_password_change
 from openedx.core.djangoapps.user_api.errors import UserNotFound
@@ -394,6 +395,7 @@ def account_settings_context(request):
         'user_accounts_api_url': reverse("accounts_api", kwargs={'username': user.username}),
         'user_preferences_api_url': reverse('preferences_api', kwargs={'username': user.username}),
         'disable_courseware_js': True,
+        'show_program_listing': ProgramsApiConfig.current().show_program_listing,
     }
 
     if third_party_auth.is_enabled():

--- a/lms/djangoapps/student_profile/test/test_views.py
+++ b/lms/djangoapps/student_profile/test/test_views.py
@@ -6,13 +6,13 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 
-from util.testing import UrlResetMixin
+from openedx.core.djangoapps.programs.tests.mixins import ProgramsApiConfigMixin
 from student.tests.factories import UserFactory
-
 from student_profile.views import learner_profile_context
+from util.testing import UrlResetMixin
 
 
-class LearnerProfileViewTest(UrlResetMixin, TestCase):
+class LearnerProfileViewTest(UrlResetMixin, TestCase, ProgramsApiConfigMixin):
     """ Tests for the student profile view. """
 
     USERNAME = "username"
@@ -101,3 +101,23 @@ class LearnerProfileViewTest(UrlResetMixin, TestCase):
         profile_path = reverse('learner_profile', kwargs={'username': "no_such_user"})
         response = self.client.get(path=profile_path)
         self.assertEqual(404, response.status_code)
+
+    def test_header_with_programs_listing_enabled(self):
+        """
+        Verify that tabs header will be shown while program listing is enabled.
+        """
+        self.create_programs_config(program_listing_enabled=True)
+        profile_path = reverse('learner_profile', kwargs={'username': self.USERNAME})
+        response = self.client.get(path=profile_path)
+
+        self.assertContains(response, '<li class="tab-nav-item">')
+
+    def test_header_with_programs_listing_disabled(self):
+        """
+        Verify that nav header will be shown while program listing is disabled.
+        """
+        self.create_programs_config(program_listing_enabled=False)
+        profile_path = reverse('learner_profile', kwargs={'username': self.USERNAME})
+        response = self.client.get(path=profile_path)
+
+        self.assertContains(response, '<li class="item nav-global-01">')

--- a/lms/djangoapps/student_profile/views.py
+++ b/lms/djangoapps/student_profile/views.py
@@ -12,6 +12,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from badges.utils import badges_enabled
 from edxmako.shortcuts import render_to_response, marketing_link
 from microsite_configuration import microsite
+from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.user_api.accounts.api import get_account_settings
 from openedx.core.djangoapps.user_api.errors import UserNotFound, UserNotAuthorized
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
@@ -95,6 +96,7 @@ def learner_profile_context(request, profile_username, user_is_staff):
             'platform_name': microsite.get_value('platform_name', settings.PLATFORM_NAME),
         },
         'disable_courseware_js': True,
+        'show_program_listing': ProgramsApiConfig.current().show_program_listing,
     }
 
     if badges_enabled():

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -69,10 +69,10 @@ site_status_msg = get_site_status_msg(course_id)
 
     % if user.is_authenticated():
       % if not course or disable_courseware_header:
-        % if not nav_hidden or show_program_listing:
+        % if not nav_hidden:
           <nav aria-label="Main" class="nav-main">
             <ul class="left list-inline nav-global authenticated">
-              % if not nav_hidden:
+              % if not show_program_listing:
                 <%block name="navigation_global_links_authenticated">
                   <li class="item nav-global-01">
                     <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
@@ -84,8 +84,7 @@ site_status_msg = get_site_status_msg(course_id)
                     <a href="${marketing_link('SCHOOLS')}">${_("Schools & Partners")}</a>
                   </li>
                 </%block>
-              % endif
-              % if show_program_listing:
+              % else:
                 <li class="tab-nav-item">
                   <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}">
                     ${_("Courses")}


### PR DESCRIPTION
[ECOM-4397](https://openedx.atlassian.net/browse/ECOM-4397)

Header is updated which is now consistent across `dashboard`, `account settings`, and `profile` pages.

**Sandbox:** https://tasawernawaz.sandbox.edx.org/

**Screenshot:**
<img width="1314" alt="screen shot 2016-05-16 at 3 52 40 pm" src="https://cloud.githubusercontent.com/assets/4245618/15287721/456968d0-1b7e-11e6-93c6-e74ac41391cd.png">

Please review @zubair-arbi @ahsan-ul-haq @awais786 @waheedahmed 
