### PR TITLE
Honor verification required setting for professional courses in the receipt view

### DIFF
--- a/lms/static/js/spec/commerce/receipt_view_spec.js
+++ b/lms/static/js/spec/commerce/receipt_view_spec.js
@@ -8,6 +8,7 @@ define([
         'use strict';
         describe('edx.commerce.ReceiptView', function() {
             var data, courseResponseData, providerResponseData, mockRequests, mockRender, createReceiptView,
+                createProduct, createLine, createOrderResponse, doCheckVerification, doCheckVerificationNagRendered,
                 userResponseData;
 
             createReceiptView = function() {
@@ -19,17 +20,23 @@ define([
                 AjaxHelpers.respondWithJson(requests, responseData);
             };
 
-            mockRender = function(useEcommerceOrderNumber, isVerified) {
-                var requests, view, orderUrlFormat;
+            mockRender = function(useEcommerceOrderNumber, isVerified, requestInThemedSite) {
+                var requests, view, orderUrlFormat,
+                    actualRequestInThemedSite = requestInThemedSite;
+                if (typeof actualRequestInThemedSite === 'undefined') {
+                    actualRequestInThemedSite = 'False';
+                }
                 requests = AjaxHelpers.requests(this);
-                $('#receipt-container').data('verified', isVerified);
+                $('#receipt-container').data({
+                    verified: isVerified,
+                    'is-request-in-themed-site': actualRequestInThemedSite
+                });
                 view = createReceiptView();
                 view.useEcommerceApi = true;
                 if (useEcommerceOrderNumber) {
                     view.ecommerceOrderNumber = 'EDX-123456';
                     orderUrlFormat = '/api/commerce/v1/orders/EDX-123456/';
-                }
-                else {
+                } else {
                     view.ecommerceBasketId = 'EDX-123456';
                     orderUrlFormat = '/api/commerce/v0/baskets/EDX-123456/order/';
                 }
@@ -53,6 +60,107 @@ define([
                 return view;
             };
 
+            createProduct = function(attributes) {
+                var actualAttributes = attributes;
+                if (typeof actualAttributes === 'undefined') {
+                    actualAttributes = [
+                        {
+                            name: 'certificate_type',
+                            value: 'verified'
+                        },
+                        {
+                            name: 'course_key',
+                            code: 'course_key',
+                            value: 'course-v1:edx+dummy+2015_T3'
+                        },
+                        {
+                            name: 'credit_provider',
+                            value: 'edx'
+                        }
+                    ];
+                }
+
+                return {
+                    attribute_values: actualAttributes,
+                    stockrecords: [
+                        {
+                            price_currency: 'USD',
+                            product: 123,
+                            partner_sku: '1234ABC',
+                            partner: 1,
+                            price_excl_tax: '10.00',
+                            id: 123
+                        }
+                    ],
+                    product_class: 'Seat',
+                    title: 'Dummy title',
+                    url: 'https://ecom.edx.org/api/v2/products/123/',
+                    price: '10.00',
+                    expires: null,
+                    is_available_to_buy: true,
+                    id: 123,
+                    structure: 'child'
+                };
+            };
+
+            createLine = function(product) {
+                var actualProduct = product;
+                if (typeof actualProduct === 'undefined') {
+                    actualProduct = createProduct();
+                }
+                return {
+                    status: 'Open',
+                    unit_price_excl_tax: '10.00',
+                    product: actualProduct,
+                    line_price_excl_tax: '10.00',
+                    description: 'dummy description',
+                    title: 'dummy title',
+                    quantity: 1
+                };
+            };
+
+            createOrderResponse = function(lines) {
+                var actualLines = lines;
+                if (typeof actualLines === 'undefined') {
+                    actualLines = [createLine()];
+                }
+                return {
+                    status: 'Open',
+                    billed_to: {
+                        city: 'dummy city',
+                        first_name: 'john',
+                        last_name: 'doe',
+                        country: 'AL',
+                        line2: 'line2',
+                        line1: 'line1',
+                        state: '',
+                        postcode: '12345'
+                    },
+                    lines: actualLines,
+                    number: 'EDX-123456',
+                    date_placed: '2016-01-01T01:01:01Z',
+                    currency: 'USD',
+                    total_excl_tax: '10.00'
+                };
+            };
+
+            doCheckVerification = function(attributes, expected) {
+                var view = createReceiptView(),
+                    product = createProduct(attributes);
+                expect(view.requiresVerification(product)).toBe(expected);
+            };
+
+            doCheckVerificationNagRendered = function(attributes, userVerified, expected, requestInThemedSite) {
+                var view;
+                data = createOrderResponse([createLine(createProduct(attributes))]);
+                view = mockRender(true, userVerified, requestInThemedSite);
+                if (expected) {
+                    expect(view.$('.nav-wizard.is-ready').text()).toContain('Want to confirm your identity later');
+                } else {
+                    expect(view.$('.nav-wizard.is-ready').text()).toContain('Go to Dashboard');
+                }
+            };
+
             beforeEach(function() {
                 var receiptFixture, providerFixture;
                 // Stub analytics tracking
@@ -63,97 +171,38 @@ define([
                 receiptFixture = readFixtures('templates/commerce/receipt.underscore');
                 providerFixture = readFixtures('templates/commerce/provider.underscore');
                 appendSetFixtures(
-                    '<script id=\"receipt-tpl\" type=\"text/template\" >' + receiptFixture + '</script>' +
-                    '<script id=\"provider-tpl\" type=\"text/template\" >' + providerFixture + '</script>'
+                    '<script id="receipt-tpl" type="text/template" >' + receiptFixture + '</script>' +
+                    '<script id="provider-tpl" type="text/template" >' + providerFixture + '</script>'
                 );
 
-                data = {
-                    'status': 'Open',
-                    'billed_to': {
-                        'city': 'dummy city',
-                        'first_name': 'john',
-                        'last_name': 'doe',
-                        'country': 'AL',
-                        'line2': 'line2',
-                        'line1': 'line1',
-                        'state': '',
-                        'postcode': '12345'
-                    },
-                    'lines': [
-                        {
-                            'status': 'Open',
-                            'unit_price_excl_tax': '10.00',
-                            'product': {
-                                'attribute_values': [
-                                    {
-                                        'name': 'certificate_type',
-                                        'value': 'verified'
-                                    },
-                                    {
-                                        'name': 'course_key',
-                                        'code': 'course_key',
-                                        'value': 'course-v1:edx+dummy+2015_T3'
-                                    },
-                                    {
-                                        'name': 'credit_provider',
-                                        'value': 'edx'
-                                    }
-                                ],
-                                'stockrecords': [
-                                    {
-                                        'price_currency': 'USD',
-                                        'product': 123,
-                                        'partner_sku': '1234ABC',
-                                        'partner': 1,
-                                        'price_excl_tax': '10.00',
-                                        'id': 123
-                                    }
-                                ],
-                                'product_class': 'Seat',
-                                'title': 'Dummy title',
-                                'url': 'https://ecom.edx.org/api/v2/products/123/',
-                                'price': '10.00',
-                                'expires': null,
-                                'is_available_to_buy': true,
-                                'id': 123,
-                                'structure': 'child'
-                            },
-                            'line_price_excl_tax': '10.00',
-                            'description': 'dummy description',
-                            'title': 'dummy title',
-                            'quantity': 1
-                        }
-                    ],
-                    'number': 'EDX-123456',
-                    'date_placed': '2016-01-01T01:01:01Z',
-                    'currency': 'USD',
-                    'total_excl_tax': '10.00'
-                };
+                data = createOrderResponse();
+
                 providerResponseData = {
-                    'id': 'edx',
-                    'display_name': 'edX',
-                    'url': 'http://www.edx.org',
-                    'status_url': 'http://www.edx.org/status',
-                    'description': 'Nothing',
-                    'enable_integration': false,
-                    'fulfillment_instructions': '',
-                    'thumbnail_url': 'http://edx.org/thumbnail.png'
+                    id: 'edx',
+                    display_name: 'edX',
+                    url: 'http://www.edx.org',
+                    status_url: 'http://www.edx.org/status',
+                    description: 'Nothing',
+                    enable_integration: false,
+                    fulfillment_instructions: '',
+                    thumbnail_url: 'http://edx.org/thumbnail.png'
                 };
+
                 courseResponseData = {
-                    'id': 'course-v1:edx+dummy+2015_T3',
-                    'name': 'receipt test',
-                    'category': 'course',
-                    'org': 'edx',
-                    'run': '2015_T2',
-                    'course': 'CS420',
-                    'uri': 'http://test.com/api/courses/v1/courses/course-v1:edx+dummy+2015_T3/',
-                    'image_url': '/test.jpg',
-                    'start': '2030-01-01T00:00:00Z',
-                    'end': null
+                    id: 'course-v1:edx+dummy+2015_T3',
+                    name: 'receipt test',
+                    category: 'course',
+                    org: 'edx',
+                    run: '2015_T2',
+                    course: 'CS420',
+                    uri: 'http://test.com/api/courses/v1/courses/course-v1:edx+dummy+2015_T3/',
+                    image_url: '/test.jpg',
+                    start: '2030-01-01T00:00:00Z',
+                    end: null
                 };
                 userResponseData = {
-                    'username': 'user-1',
-                    'name': 'full name'
+                    username: 'user-1',
+                    name: 'full name'
                 };
             });
 
@@ -193,6 +242,96 @@ define([
 
                 view = mockRender(false, 'True');
                 expect(view.$('.course_name_placeholder').text()).toContain('receipt test');
+            });
+
+            it('requiresVerification returns true if product requires verification', function() {
+                var expected = true,
+                    attributes = [
+                        {name: 'certificate_type', value: 'professional'},
+                        {name: 'course_key', value: 'course-v1:OC+OC+2'},
+                        {name: 'id_verification_required', value: true}
+                    ];
+                doCheckVerification(attributes, expected, 'False');
+            });
+
+            it('requiresVerification returns true if product requires verification, different order', function() {
+                var expected = true,
+                    attributes = [
+                        {name: 'certificate_type', value: 'professional'},
+                        {name: 'id_verification_required', value: true},
+                        {name: 'course_key', value: 'course-v1:OC+OC+2'}
+                    ];
+                doCheckVerification(attributes, expected, 'False');
+            });
+
+            it('requiresVerification defaults to true', function() {
+                var expected = true,
+                    attributes = [
+                        {name: 'certificate_type', value: 'professional'},
+                        {name: 'course_key', value: 'course-v1:OC+OC+2'}
+                    ];
+                doCheckVerification(attributes, expected, 'False');
+            });
+
+            it('requiresVerification returns false for courses not requiring verification', function() {
+                var expected = false,
+                    attributes = [
+                        {name: 'certificate_type', value: 'professional'},
+                        {name: 'id_verification_required', value: false},
+                        {name: 'course_key', value: 'course-v1:OC+OC+2'}
+                    ];
+                doCheckVerification(attributes, expected, 'False');
+            });
+
+            it('receipt view verification nag for not verified users in a verified course', function() {
+                var attributes = [
+                    {name: 'certificate_type', value: 'professional'},
+                    {name: 'id_verification_required', value: true},
+                    {name: 'course_key', value: 'course-v1:edx+dummy+2015_T3'},
+                    {name: 'credit_provider', value: 'edx'}
+                ];
+                doCheckVerificationNagRendered(attributes, 'False', true, 'False');
+            });
+
+            it("receipt view doesn't show verification nag for a verified user in a verified course", function() {
+                var attributes = [
+                    {name: 'certificate_type', value: 'professional'},
+                    {name: 'id_verification_required', value: true},
+                    {name: 'course_key', value: 'course-v1:edx+dummy+2015_T3'},
+                    {name: 'credit_provider', value: 'edx'}
+                ];
+                doCheckVerificationNagRendered(attributes, 'True', false, 'False');
+            });
+
+            it("receipt view doesn't show verification for a unverified user in a not verified course", function() {
+                var attributes = [
+                    {name: 'certificate_type', value: 'professional'},
+                    {name: 'id_verification_required', value: false},
+                    {name: 'course_key', value: 'course-v1:edx+dummy+2015_T3'},
+                    {name: 'credit_provider', value: 'edx'}
+                ];
+                doCheckVerificationNagRendered(attributes, 'False', false, 'False');
+            });
+
+            it("receipt view doesn't show verification nag for a verified user in a not verified course", function() {
+                var attributes = [
+                    {name: 'certificate_type', value: 'professional'},
+                    {name: 'id_verification_required', value: false},
+                    {name: 'course_key', value: 'course-v1:edx+dummy+2015_T3'},
+                    {name: 'credit_provider', value: 'edx'}
+                ];
+                doCheckVerificationNagRendered(attributes, 'True', false, 'False');
+            });
+
+            it("receipt view doesn't show verification nag for a not verified user in a verified" +
+               ' course on themed site', function() {
+                var attributes = [
+                    {name: 'certificate_type', value: 'professional'},
+                    {name: 'id_verification_required', value: true},
+                    {name: 'course_key', value: 'course-v1:edx+dummy+2015_T3'},
+                    {name: 'credit_provider', value: 'edx'}
+                ];
+                doCheckVerificationNagRendered(attributes, 'False', false, 'True');
             });
         });
     }


### PR DESCRIPTION
**Background**

When creating a profesional course in CAT (`/courses` view ecommerce) administrator is given option to either enable or disable "Verification" feature for that course. This setting is honored on the LMS `/dashboard` view, however it is not honored on the `/receipt` view. 

Only LMS is affected by this change. 

**Sandbox URL**: http://pr12470.sandbox.opencraft.com/

**Partner information**: 3rd party-hosted open edX instance

**Reviewers**
- [x] @mtyaka 
- [ ] @clintonb
## Testing instructions

**On sandbox**

Login as a {{verified@example.com}} user and see following two receipts: 
- A receipt for course that does not require verification: http://pr12470.sandbox.opencraft.com/commerce/checkout/receipt/?orderNum=EDX-100007
- A receipt for course that requires verification: http://pr12470.sandbox.opencraft.com/commerce/checkout/receipt/?orderNum=EDX-100008

**On Devstack** 
Prepare the enviorment: 
1. Install devstack using recent master
2.  Setup a payment processor, paypal seems to be the easier one to set up. See setting-up PayPal for some hints
3. Create two new courses in Studio, name one of them "Professional with Verification Required" and another one "Professional no verification". 
4. Start e-commerce and go to `localhost:8002/courses`, and add two courses, first one with Verification second one without it. 

Reproduce the issue: 
1. Register to the platform with a new user, and buy for both courses. 
2. Observe that on Receipt for both courses you are asked to confirm your identity. 

![selection_001](https://cloud.githubusercontent.com/assets/112872/15285920/845883c4-1b5a-11e6-9db1-8980d51cdd69.png)

Verify the fix: 
1. Check out this branch. 
2. Go to the receipt pages for both courses, and observe that course with enabled verification still
   asks user to verify: 
   ![selection_002](https://cloud.githubusercontent.com/assets/112872/15285983/dff0c9ee-1b5a-11e6-851e-c10708e7a86b.png)
3. However for course with verification disabled user can go straight to the dashboard
   ![selection_003](https://cloud.githubusercontent.com/assets/112872/15285989/ec3cdc6a-1b5a-11e6-9dc5-5281bbece0d6.png)
### Setting up PayPal

To configure paypal [add section from this gist](https://gist.github.com/jbzdak/e5761f9f5ac05fee8624d0f966e98961) to `ecommerce/settings/private.py`. And `client_id` and `client_secret`. 

I also had problems releated to PayPal forcing TLS 1.2 for all urls (including Sandbox), if you'll get errors citing: 'sslv3 alert handshake failure', you'll need to update `lib-ssl-*`, `openssl-*` (and probably `*curl*`) in your devstack. 

---

**Settings**

``` yaml
SANDBOX_ENABLE_ECOMMERCE: True
```
