### PR TITLE
mattdrayer/wl-466: Use LMS Courses API on checkout receipt page

### DIFF
--- a/lms/static/js/commerce/views/receipt_view.js
+++ b/lms/static/js/commerce/views/receipt_view.js
@@ -164,7 +164,7 @@ var edx = edx || {};
          * @return {object} JQuery Promise.
          */
         getCourseData: function (courseId) {
-            var courseDetailUrl = '/api/course_structure/v0/courses/%s/';
+            var courseDetailUrl = '/api/courses/v1/courses/%s/';
             return $.ajax({
                 url: _.sprintf(courseDetailUrl, courseId),
                 type: 'GET',


### PR DESCRIPTION
The checkout receipt page currently uses the deprecated LMS Course Structure API (/api/course_structure/v0/courses) and it's causing the "Thank you!" message to display the course key instead of the course name.  I'm not sure how long it has been doing this.  The fix is to use the LMS Course Info API (/api/courses/v1/courses).  Sandbox testing shows the correct course name being inserted into the thank you message.
