### PR TITLE
Add skip_clean option to pa11ycrawler

### DIFF
--- a/pavelib/bok_choy.py
+++ b/pavelib/bok_choy.py
@@ -19,6 +19,7 @@ __test__ = False  # do not collect
 BOKCHOY_OPTS = [
     ('test_spec=', 't', 'Specific test to run'),
     ('fasttest', 'a', 'Skip some setup'),
+    ('skip_clean', 'C', 'Skip cleaning repository before running tests'),
     ('serversonly', 'r', 'Prepare suite and leave servers running'),
     ('testsonly', 'o', 'Assume servers are running and execute tests only'),
     ('extra_args=', 'e', 'adds as extra args to the test command'),

--- a/scripts/accessibility-tests.sh
+++ b/scripts/accessibility-tests.sh
@@ -24,7 +24,7 @@ paver a11y_coverage
 if [ "$RUN_PA11YCRAWLER" = "1" ]
 then
     echo "Running pa11ycrawler against test course..."
-    paver pa11ycrawler --fasttest --fetch-course --with-html
+    paver pa11ycrawler --fasttest --skip_clean --fetch-course --with-html
 
     echo "Generating coverage report..."
     paver pa11ycrawler_coverage


### PR DESCRIPTION
@jzoldak @benpatterson This adds the `--skip_clean` option to the pa11ycrawler command in `accessibility-tests.sh` so that the results from `paver test_a11y` aren't cleaned up before the end of the script.  Please review.
