### PR TITLE
Use the correct JWT key when authenticating against the course catalog API.

### DIFF
--- a/openedx/core/djangoapps/api_admin/admin.py
+++ b/openedx/core/djangoapps/api_admin/admin.py
@@ -1,5 +1,7 @@
 """Admin views for API managment."""
 from django.contrib import admin
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext as _
 
 from config_models.admin import ConfigurationModelAdmin
 from openedx.core.djangoapps.api_admin.models import ApiAccessRequest, ApiAccessConfig
@@ -14,5 +16,22 @@ class ApiAccessRequestAdmin(admin.ModelAdmin):
     raw_id_fields = ('user',)
     readonly_fields = ('user', 'website', 'reason', 'company_name', 'company_address', 'contacted', )
     exclude = ('site',)
+
+    def get_fieldsets(self, request, obj=None):
+        return (
+            (None, {
+                'fields': (
+                    'user', 'website', 'reason', 'company_name', 'company_address',
+                )
+            },),
+            ('Status', {
+                'description': _(
+                    'Once you have approved this request, go to {catalog_admin_url} to set up a catalog for this user.'
+                ).format(
+                    catalog_admin_url='<a href="{0}">{0}</a>'.format(reverse('api_admin:catalog-search'))
+                ),
+                'fields': ('status',),
+            }),
+        )
 
 admin.site.register(ApiAccessConfig, ConfigurationModelAdmin)

--- a/openedx/core/djangoapps/api_admin/utils.py
+++ b/openedx/core/djangoapps/api_admin/utils.py
@@ -1,5 +1,8 @@
 """ Course Discovery API Service. """
+from django.conf import settings
+
 from edx_rest_api_client.client import EdxRestApiClient
+from openedx.core.djangoapps.theming import helpers
 from openedx.core.lib.token_utils import get_id_token
 from provider.oauth2.models import Client
 
@@ -9,7 +12,8 @@ CLIENT_NAME = 'course-discovery'
 def course_discovery_api_client(user):
     """ Returns a Course Discovery API client setup with authentication for the specified user. """
     course_discovery_client = Client.objects.get(name=CLIENT_NAME)
+    secret_key = helpers.get_value('JWT_AUTH', settings.JWT_AUTH)['JWT_SECRET_KEY']
     return EdxRestApiClient(
         course_discovery_client.url,
-        jwt=get_id_token(user, CLIENT_NAME)
+        jwt=get_id_token(user, CLIENT_NAME, secret_key=secret_key)
     )

--- a/openedx/core/lib/token_utils.py
+++ b/openedx/core/lib/token_utils.py
@@ -11,7 +11,7 @@ from provider.oauth2.models import Client
 from student.models import UserProfile, anonymous_id_for_user
 
 
-def get_id_token(user, client_name):
+def get_id_token(user, client_name, secret_key=None):
     """Construct a JWT for use with the named client.
 
     The JWT is signed with the named client's secret, and includes the following claims:
@@ -31,6 +31,8 @@ def get_id_token(user, client_name):
     Arguments:
         user (User): User for which to generate the JWT.
         client_name (unicode): Name of the OAuth2 Client for which the token is intended.
+        secret_key (str): Optional secret key for signing the JWT. Defaults to the configured client secret
+            if not provided.
 
     Returns:
         str: the JWT
@@ -64,7 +66,10 @@ def get_id_token(user, client_name):
         'sub': anonymous_id_for_user(user, None),
     }
 
-    return jwt.encode(payload, client.client_secret)
+    if secret_key is None:
+        secret_key = client.client_secret
+
+    return jwt.encode(payload, secret_key)
 
 
 def get_asymmetric_token(user, client_id):


### PR DESCRIPTION
# [ECOM-4441](https://openedx.atlassian.net/browse/ECOM-4441)

@bderusha @clintonb 
