### PR TITLE
Christina/tnl 1619 xss

### DIFF
--- a/common/test/acceptance/pages/lms/video/video.py
+++ b/common/test/acceptance/pages/lms/video/video.py
@@ -842,6 +842,7 @@ class VideoPage(PageObject):
             return self.state != 'buffering'
 
         self._wait_for(_is_buffering_completed, 'Buffering completed after Seek.')
+        self.wait_for_position(seek_value)
 
     def reload_page(self):
         """

--- a/common/test/acceptance/tests/video/test_video_times.py
+++ b/common/test/acceptance/tests/video/test_video_times.py
@@ -1,9 +1,7 @@
 """
 Acceptance tests for Video Times(Start, End and Finish) functionality.
 """
-from flaky import flaky
 from .test_video_module import VideoBaseTest
-import unittest
 
 
 class VideoTimesTest(VideoBaseTest):
@@ -55,7 +53,6 @@ class VideoTimesTest(VideoBaseTest):
 
         self.assertIn(self.video.position, ('0:05', '0:06'))
 
-    @flaky  # TODO fix this, see TNL-1619
     def test_video_end_time_wo_default_start_time(self):
         """
         Scenario: End time works for Youtube video if starts playing from between.


### PR DESCRIPTION
@dianakhuang The video tests are no longer failing with VERIFY_XSS enabled and this change. I can't promise they won't EVER fail, but they didn't fail in the 16 times I ran the test. :)

The change was inspired by watching the tests run. I would sometimes see play begin before the video was actually at the seek point.

Thumbs-up and move on to enabling VERIFY_XSS?
