### PR TITLE
Corrects duplicate main element wrapper on Wiki article template

### DIFF
--- a/lms/templates/wiki/article.html
+++ b/lms/templates/wiki/article.html
@@ -12,18 +12,16 @@
 
   <div class="article-wrapper">
 
-    <main id="main" aria-label="Content" tabindex="-1">
-        <article class="main-article" id="main-article">
-            {% if selected_tab != "edit" %}
-              <h1>{{ article.current_revision.title }}</h1>
+    <article class="main-article" id="main-article">
+        {% if selected_tab != "edit" %}
+          <h1>{{ article.current_revision.title }}</h1>
 
-            {% endif %}
+        {% endif %}
 
-            {% block wiki_contents_tab %}
-            {% wiki_render article %}
-            {% endblock %}
-        </article>
-    </main>
+        {% block wiki_contents_tab %}
+        {% wiki_render article %}
+        {% endblock %}
+    </article>
 
     <div class="article-functions">
       <ul class="nav nav-tabs">


### PR DESCRIPTION
# [AC-474](https://openedx.atlassian.net/browse/AC-474)

Bug fix for the duplicate `main` element on the Wiki article page that was causing the layout to break.

The "article" template extends the "wiki/base" template, which already had the `main` wrapper. The "article" template didn't need it. See screenshots of before/after below.
## Before

![screen shot 2016-05-17 at 3 22 21 pm](https://cloud.githubusercontent.com/assets/2112024/15336174/3f864e5e-1c43-11e6-899f-575eb979f4d3.png)

![screen shot 2016-05-17 at 3 28 25 pm](https://cloud.githubusercontent.com/assets/2112024/15336315/08d463f4-1c44-11e6-8da3-cc213de39a38.png)
## After

![screen shot 2016-05-17 at 3 19 16 pm](https://cloud.githubusercontent.com/assets/2112024/15336185/49bf21a2-1c43-11e6-8d56-a9ea9d975936.png)

![screen shot 2016-05-17 at 3 26 54 pm](https://cloud.githubusercontent.com/assets/2112024/15336276/d7c760b8-1c43-11e6-9cc6-2e55f729170f.png)
## Reviewer
- [x] @cahrens 
