### PR TITLE
Benp douglashall/sol 1776/harden

### DIFF
--- a/common/test/acceptance/pages/studio/settings.py
+++ b/common/test/acceptance/pages/studio/settings.py
@@ -37,6 +37,20 @@ class SettingsPage(CoursePage):
         if hasattr(self, 'wait_for_js'):
             self.wait_for_js()  # pylint: disable=no-member
 
+    def wait_for_jquery_value(self, jquery_element, value):
+        """
+        Use jQuery to obtain the element's value.
+        This is useful for when jQuery performs functions towards the
+        end of the page load. (In other words, waiting for jquery to
+        load is not enough; we need to also query values that it has
+        injected onto the page to ensure it's done.)
+        """
+        self.wait_for(
+            lambda: self.browser.execute_script(
+                "return $('{ele}').val();".format(ele=jquery_element)) == '{val}'.format(val=value),
+            'wait for jQuery to finish loading data on page.'
+        )
+
     def refresh_and_wait_for_load(self):
         """
         Refresh the page and wait for all resources to load.

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -582,7 +582,13 @@ class StudioSettingsImageUploadTest(StudioCourseTest):
         super(StudioSettingsImageUploadTest, self).setUp()
         self.settings_page = SettingsPage(self.browser, self.course_info['org'], self.course_info['number'],
                                           self.course_info['run'])
+        # from nose.tools import set_trace; set_trace()
         self.settings_page.visit()
+
+        # Ensure jquery is loaded before running a jQuery
+        self.settings_page.wait_for_ajax()
+        # This text appears towards the end of the work that jQuery is performing on the page
+        self.settings_page.wait_for_jquery_value('input#course-name:text', 'test_run')
 
     @flaky(max_runs=20, min_passes=20)
     def test_upload_course_card_image(self):


### PR DESCRIPTION
Use jquery to perform a query. 

I found in local testing that the element's data:
- was one of the last things to appear on the page
- was not query-able from CSS selectors (the value is empty on the DOM)

Hence: use jquery to wait for that element's value to appear
