### PR TITLE
ECOM-4399 Update edX Logo post-login link

### DIFF
--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -49,13 +49,21 @@ site_status_msg = get_site_status_msg(course_id)
 </%block>
   <header id="global-navigation" class="header-global ${"slim" if course else ""}" >
     <nav class="wrapper-header" aria-label="${_('Global')}">
-    <h1 class="logo">
-      <a href="${marketing_link('ROOT')}">
-        <%block name="navigation_logo">
-            <img src="${static.url(branding_api.get_logo_url())}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
-        </%block>
-      </a>
-    </h1>
+      <h1 class="logo">
+
+      <%block name="navigation_logo">
+        % if user.is_authenticated():
+          <a href="${reverse('dashboard')}">
+            <img src="${static.url(branding_api.get_logo_url())}" alt=${_("Your Dashboard")}/>
+          </a>
+        % else:
+          <a href="${marketing_link('ROOT')}">
+            <img src="${static.url(branding_api.get_logo_url())}"
+                 alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
+          </a>
+        % endif
+      </%block>
+      </h1>
 
     % if course:
       <h2 class="course-header"><span class="provider">${course.display_org_with_default}:</span>

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -51,11 +51,18 @@ site_status_msg = get_site_status_msg(course_id)
 % endif
   <div class="${"rwd" if responsive else ""} wrapper-header nav-container">
     <h1 class="logo" itemscope="" itemtype="http://schema.org/Organization">
-      <a href="${marketing_link('ROOT')}" itemprop="url">
-        <%block name="navigation_logo">
-            <img src="${static.url("images/logo.png")}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}" itemprop="logo" />
-        </%block>
-      </a>
+      <%block name="navigation_logo">
+        % if user.is_authenticated():
+          <a href="${reverse('dashboard')}">
+            <img src="${static.url("images/logo.png")}" alt=${_("Your Dashboard")}/>
+          </a>
+        % else:
+          <a href="${marketing_link('ROOT')}" itemprop="url">
+            <img src="${static.url("images/logo.png")}" itemprop="logo"
+                 alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
+          </a>
+        % endif
+      </%block>
     </h1>
 
     % if course and not disable_courseware_header:


### PR DESCRIPTION
[ECOM-4399](https://openedx.atlassian.net/browse/ECOM-4399)
- If user is logged in logo will leads to dashboard instead of the main edx.org pre-login site.
- `alt` text is updated.

Please review @zubair-arbi @awais786 @ahsan-ul-haq @waheedahmed 

Sandbox: https://tasawernawaz.sandbox.edx.org/
