### PR TITLE
fix for instructor image revert issue

### DIFF
--- a/cms/static/js/views/instructor_info.js
+++ b/cms/static/js/views/instructor_info.js
@@ -48,6 +48,7 @@ define([  // jshint ignore:line
                 this.$el.find('img').load(function() {
                     $(this).show();
                 });
+                this.justRendered = true;
             },
 
             removeInstructor: function(event) {

--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -320,8 +320,13 @@ var DetailsView = ValidatingView.extend({
     updateImagePreview: function(imagePathInputElement, previewSelector) {
         // Wait to set the image src until the user stops typing
         clearTimeout(this.imageTimer);
+        var that = this;
+        that.instructor_info_view.justRendered = false;
+
         this.imageTimer = setTimeout(function() {
-            $(previewSelector).attr('src', $(imagePathInputElement).val());
+            if (!that.instructor_info_view.justRendered) {
+                $(previewSelector).attr('src', $(imagePathInputElement).val());
+            }
         }, 1000);
     },
     removeVideo: function(event) {


### PR DESCRIPTION
Fix for : "When admin change the asset path of Instructor image and press cancel button, instructor image does not revert to original image."
