### PR TITLE
Exclude deleted files from safe template linting

### DIFF
--- a/scripts/safe-commit-linter.sh
+++ b/scripts/safe-commit-linter.sh
@@ -67,7 +67,7 @@ fi
 
 merge_base_command="git merge-base $current_branch_hash $MAIN_COMMIT"
 merge_base=$(${merge_base_command})
-diff_command="git diff --name-only --diff-filter=ACM $current_branch_hash $merge_base"
+diff_command="git diff --name-only --diff-filter=ACM $merge_base $current_branch_hash"
 diff_files=$(${diff_command})
 
 if [ "$diff_files" = "" ]; then


### PR DESCRIPTION
I ran into a problem with the safe linter where it was failing trying to run against files that I deleted in my commit. @robrap helped me to diagnose that the diff command had the source and target branches reverted, so it was excluding adds rather than deletes.

You can see the failure on this PR currently: https://github.com/edx/edx-platform/pull/11491

@robrap @nedbat please review.
