### PR TITLE
turn on bok choy XSS checking

### DIFF
--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -18,7 +18,7 @@ class TestPaverBokChoyCmd(unittest.TestCase):
     Paver Bok Choy Command test cases
     """
 
-    def _expected_command(self, name, store=None, verify_xss=False):
+    def _expected_command(self, name, store=None, verify_xss=True):
         """
         Returns the command that is expected to be run for the given test spec
         and store.
@@ -101,11 +101,11 @@ class TestPaverBokChoyCmd(unittest.TestCase):
         self.assertEqual(suite.cmd, self._expected_command(name=name, verify_xss=True))
 
     def test_verify_xss_env_var(self):
-        self.env_var_override.set('VERIFY_XSS', 'True')
+        self.env_var_override.set('VERIFY_XSS', 'False')
         with self.env_var_override:
             suite = BokChoyTestSuite('')
             name = 'tests'
-            self.assertEqual(suite.cmd, self._expected_command(name=name, verify_xss=True))
+            self.assertEqual(suite.cmd, self._expected_command(name=name, verify_xss=False))
 
     def test_test_dir(self):
         test_dir = 'foo'

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -58,7 +58,7 @@ class BokChoyTestSuite(TestSuite):
         self.default_store = kwargs.get('default_store', None)
         self.verbosity = kwargs.get('verbosity', DEFAULT_VERBOSITY)
         self.num_processes = kwargs.get('num_processes', DEFAULT_NUM_PROCESSES)
-        self.verify_xss = kwargs.get('verify_xss', os.environ.get('VERIFY_XSS', False))
+        self.verify_xss = kwargs.get('verify_xss', os.environ.get('VERIFY_XSS', True))
         self.extra_args = kwargs.get('extra_args', '')
         self.har_dir = self.log_dir / 'hars'
         self.a11y_file = Env.BOK_CHOY_A11Y_CUSTOM_RULES_FILE


### PR DESCRIPTION
I am turning on XSS checking by default for all bok choy tests in the paver command.

Reviewers: @robrap @jzoldak 
