### PR TITLE
Allow to create users with a password hash instead of a clear text password.

### DIFF
--- a/common/djangoapps/student/management/commands/create_user.py
+++ b/common/djangoapps/student/management/commands/create_user.py
@@ -116,8 +116,8 @@ class Command(TrackedCommand):
             reg.activate()
             reg.save()
             create_comments_service_user(user)
-        except (AccountValidationError, ValidationError) as e:
-            self.stderr.write(e.message)
+        except (AccountValidationError, ValidationError) as exception:
+            self.stderr.write(exception.message)
             user = User.objects.get(email=options['email'])
         if options['course']:
             CourseEnrollment.enroll(user, course, mode=options['mode'])


### PR DESCRIPTION
The management command `create_user` currently only supports passing in a clear text password.  This change introduces a flag to indicate that the password that is passed in is a Django password hash instead. This allows to import users from other Django apps, and to avoid having clear text passwords in e.g. Ansible variables.

To allow creating users with unusable passwords, I added switch `--disabled-password` in response to a suggestion on edx/configuration#3059.

This change also fixes a bug in handling users that already exist.  The old code catches `AccountValidationError` to deal with the case that the account already exists.  However, the current version of the form validation code will raise a Django `ValidationError` if the email address is already taken, but stil an `AccountValidationError` if the username is already taken, so I changed the code to catch both exceptions.

**JIRA tickets**: [OSPR-1281](https://openedx.atlassian.net/browse/OSPR-1281)

**Dependencies**: None

**Screenshots**: N/A

**Sandbox URL**: http://pr12519.sandbox.opencraft.com/ (SSH access can be granted on request)

**Testing instructions**:
1. In your devstack, run this command twice:
   
   ```
   ./manage.py lms --settings=devstack create_user -e joe@example.com -n "Joe Test" -p edx
   ```
   
   In the old version, this fails the second time.  In the version with this fix applied, it succeeds both times (exit code zero).
2. Create a user using a password hash
   
   ```
   ./manage.py lms --settings=devstack create_user -e jane@example.com -n "Jane Test" -p 'pbkdf2_sha256$20000$mRxYkenyBiH6$yIk8aZYmWisW2voX5qP+cAr+i7R/IrZoohGsRK2fy4E=' --password-hash
   ```
   
   Run the LMS and make sure the user can log in. (The password is `edx`; you can create your own hashes by using `django.contrib.auth.hashers.make_password()` in a Django shell.)
3. Create a user with unusable password
   
   ```
   ./manage.py lms --settings=devstack create_user -e jack@example.com -n "Jack Test" --disabled-password
   ```
   
   The user will be created, but won't be able to log in.

**Author notes and concerns**: N/A

**Reviewers**
- [x] OpenCraft internal reviewer jbzdak
- [ ] edX reviewer[s] TBD
