### PR TITLE
Bump DnDv2 to v2.0.6

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -95,4 +95,4 @@ git+https://github.com/edx/edx-proctoring.git@0.12.17#egg=edx-proctoring==0.12.1
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 -e git+https://github.com/open-craft/xblock-poll@e7a6c95c300e95c51e42bfd1eba70489c05a6527#egg=xblock-poll
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.5#egg=xblock-drag-and-drop-v2==2.0.5
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.6#egg=xblock-drag-and-drop-v2==2.0.6


### PR DESCRIPTION
This includes these changes over the previous version: 
- https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/67
- https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/68 (version bump)

**JIRA tickets**: [SOL-1770](https://openedx.atlassian.net/browse/SOL-1770), [OC-1575](https://tasks.opencraft.com/browse/OC-1575)

**Sandboxes**:
LMS: http://pr12340.sandbox.opencraft.com
Studio: http://studio.pr12340.sandbox.opencraft.com

You can see a working example course by signing in as `staff` to: http://pr12340.sandbox.opencraft.com/courses/course-v1:OpenCraft+XBlock101x+now/info

**Reviewers**
- [x] @bradenmacdonald 
- [x] @itsjeyd 

---

**Settings**

``` yaml
configuration_version: 365d57b991e8c39d6cb02fb8cdd06352277b8816
```
