### PR TITLE
Hotfix for BlockStructure data not invalidating upon Course Publish

### DIFF
--- a/openedx/core/djangoapps/content/course_structures/tasks.py
+++ b/openedx/core/djangoapps/content/course_structures/tasks.py
@@ -96,3 +96,13 @@ def update_course_structure(course_key):
         structure_model.structure_json = structure_json
         structure_model.discussion_id_map_json = discussion_id_map_json
         structure_model.save()
+
+    # TODO (TNL-4630) For temporary hotfix to update the block_structure cache.
+    # Should be moved to proper location.
+    from django.core.cache import cache
+    from openedx.core.lib.block_structure.manager import BlockStructureManager
+
+    store = modulestore()
+    course_usage_key = store.make_course_usage_key(course_key)
+    block_structure_manager = BlockStructureManager(course_usage_key, store, cache)
+    block_structure_manager.update_collected()

--- a/openedx/core/lib/block_structure/cache.py
+++ b/openedx/core/lib/block_structure/cache.py
@@ -45,13 +45,13 @@ class BlockStructureCache(object):
         )
         zp_data_to_cache = zpickle(data_to_cache)
 
-        # Set the timeout value for the cache to None. This caches the
-        # value forever. The expectation is that the caller will delete
-        # the cached value once it is outdated.
+        # Set the timeout value for the cache to 1 day as a fail-safe
+        # in case the signal to invalidate the cache doesn't come through.
+        timeout_in_seconds = 60 * 60 * 24
         self._cache.set(
             self._encode_root_cache_key(block_structure.root_block_usage_key),
             zp_data_to_cache,
-            timeout=None,
+            timeout=timeout_in_seconds,
         )
 
         logger.info(

--- a/openedx/core/lib/block_structure/tests/test_cache.py
+++ b/openedx/core/lib/block_structure/tests/test_cache.py
@@ -36,7 +36,7 @@ class TestBlockStructureCache(ChildrenMapTestMixin, TestCase):
 
         self.add_transformers()
         self.block_structure_cache.add(self.block_structure)
-        self.assertEquals(self.mock_cache.timeout_from_last_call, None)
+        self.assertEquals(self.mock_cache.timeout_from_last_call, 60 * 60 * 24)
 
         cached_value = self.block_structure_cache.get(self.block_structure.root_block_usage_key)
         self.assertIsNotNone(cached_value)


### PR DESCRIPTION
Hotfix for https://openedx.atlassian.net/browse/TNL-4630.

This PR is a very short-term fix for the issue.  
We won't close out the ticket until the longer-term fix is implemented.
