### PR TITLE
Fix false positives on javascript_contact_html.

### DIFF
--- a/scripts/tests/test_safe_template_linter.py
+++ b/scripts/tests/test_safe_template_linter.py
@@ -1079,7 +1079,17 @@ class TestJavaScriptLinter(TestLinter):
     @data(
         {'template': 'var m = "Plain text " + message + "plain text"', 'rule': None},
         {'template': 'var m = "檌檒濦 " + message + "plain text"', 'rule': None},
+        {
+            'template':
+                ("""$email_header.append($('<input>', type: "button", name: "copy-email-body-text","""
+                 """ value: gettext("Copy Email To Editor"), id: 'copy_email_' + email_id))"""),
+            'rule': None
+        },
         {'template': 'var m = "<p>" + message + "</p>"', 'rule': Rules.javascript_concat_html},
+        {
+            'template': r'var m = "<p>\"escaped quote\"" + message + "\"escaped quote\"</p>"',
+            'rule': Rules.javascript_concat_html
+        },
         {'template': '  // var m = "<p>" + commentedOutMessage + "</p>"', 'rule': None},
         {'template': 'var m = " <p> " + message + " </p> "', 'rule': Rules.javascript_concat_html},
         {'template': 'var m = " <p> " + message + " broken string', 'rule': Rules.javascript_concat_html},


### PR DESCRIPTION
## [TNL-4633](https://openedx.atlassian.net/browse/TNL-4633)

TNL-4633: Safe commit linter false positives in coffeescript

@efischer19: This should take care of your false positives.
### Testing
- [x] safecommit shows 0 violations
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @nedbat 
### Post-review
- [x] Squash commits
