### PR TITLE
Feature/update learner dashboard

### DIFF
--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -174,6 +174,12 @@ class DashboardPage(PageObject):
         """
         self.q(css='.dropdown').first.click()
 
+    def click_username(self):
+        """
+        Click username.
+        """
+        self.q(css='.label-username').first.click()
+
     @property
     def username_dropdown_link_text(self):
         """

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -266,21 +266,17 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
 
     def test_dashboard_learner_profile_link(self):
         """
-        Scenario: Verify that my profile link is present on dashboard page and we can navigate to correct page.
+        Scenario: Verify that when user click on username it will leads to profile page.
 
         Given that I am a registered user.
         When I go to Dashboard page.
-        And I click on username dropdown.
-        Then I see Profile link in the dropdown menu.
-        When I click on Profile link.
+        And I click on username.
         Then I will be navigated to Profile page.
         """
         username, user_id = self.log_in_as_unique_user()
         dashboard_page = DashboardPage(self.browser)
         dashboard_page.visit()
-        dashboard_page.click_username_dropdown()
-        self.assertIn('Profile', dashboard_page.username_dropdown_link_text)
-        dashboard_page.click_my_profile_link()
+        dashboard_page.click_username()
         my_profile_page = LearnerProfilePage(self.browser, username)
         my_profile_page.wait_for_page()
 

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -36,6 +36,7 @@ from third_party_auth import pipeline
 from third_party_auth.decorators import xframe_allow_whitelisted
 from util.bad_request_rate_limiter import BadRequestRateLimiter
 
+from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.theming.helpers import is_request_in_themed_site, get_value as get_themed_value
 from openedx.core.djangoapps.user_api.accounts.api import request_password_change
 from openedx.core.djangoapps.user_api.errors import UserNotFound
@@ -394,6 +395,7 @@ def account_settings_context(request):
         'user_accounts_api_url': reverse("accounts_api", kwargs={'username': user.username}),
         'user_preferences_api_url': reverse('preferences_api', kwargs={'username': user.username}),
         'disable_courseware_js': True,
+        'show_program_listing': ProgramsApiConfig.current().show_program_listing,
     }
 
     if third_party_auth.is_enabled():

--- a/lms/djangoapps/student_profile/test/test_views.py
+++ b/lms/djangoapps/student_profile/test/test_views.py
@@ -6,13 +6,13 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 
-from util.testing import UrlResetMixin
+from openedx.core.djangoapps.programs.tests.mixins import ProgramsApiConfigMixin
 from student.tests.factories import UserFactory
-
 from student_profile.views import learner_profile_context
+from util.testing import UrlResetMixin
 
 
-class LearnerProfileViewTest(UrlResetMixin, TestCase):
+class LearnerProfileViewTest(UrlResetMixin, TestCase, ProgramsApiConfigMixin):
     """ Tests for the student profile view. """
 
     USERNAME = "username"
@@ -101,3 +101,23 @@ class LearnerProfileViewTest(UrlResetMixin, TestCase):
         profile_path = reverse('learner_profile', kwargs={'username': "no_such_user"})
         response = self.client.get(path=profile_path)
         self.assertEqual(404, response.status_code)
+
+    def test_header_with_programs_listing_enabled(self):
+        """
+        Verify that tabs header will be shown while program listing is enabled.
+        """
+        self.create_programs_config(program_listing_enabled=True)
+        profile_path = reverse('learner_profile', kwargs={'username': self.USERNAME})
+        response = self.client.get(path=profile_path)
+
+        self.assertContains(response, '<li class="tab-nav-item">')
+
+    def test_header_with_programs_listing_disabled(self):
+        """
+        Verify that nav header will be shown while program listing is disabled.
+        """
+        self.create_programs_config(program_listing_enabled=False)
+        profile_path = reverse('learner_profile', kwargs={'username': self.USERNAME})
+        response = self.client.get(path=profile_path)
+
+        self.assertContains(response, '<li class="item nav-global-01">')

--- a/lms/djangoapps/student_profile/views.py
+++ b/lms/djangoapps/student_profile/views.py
@@ -12,6 +12,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from badges.utils import badges_enabled
 from edxmako.shortcuts import render_to_response, marketing_link
 from microsite_configuration import microsite
+from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.user_api.accounts.api import get_account_settings
 from openedx.core.djangoapps.user_api.errors import UserNotFound, UserNotAuthorized
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
@@ -95,6 +96,7 @@ def learner_profile_context(request, profile_username, user_is_staff):
             'platform_name': microsite.get_value('platform_name', settings.PLATFORM_NAME),
         },
         'disable_courseware_js': True,
+        'show_program_listing': ProgramsApiConfig.current().show_program_listing,
     }
 
     if badges_enabled():

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -49,13 +49,21 @@ site_status_msg = get_site_status_msg(course_id)
 </%block>
   <header id="global-navigation" class="header-global ${"slim" if course else ""}" >
     <nav class="wrapper-header" aria-label="${_('Global')}">
-    <h1 class="logo">
-      <a href="${marketing_link('ROOT')}">
-        <%block name="navigation_logo">
-            <img src="${static.url(branding_api.get_logo_url())}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
-        </%block>
-      </a>
-    </h1>
+      <h1 class="logo">
+
+      <%block name="navigation_logo">
+        % if user.is_authenticated():
+          <a href="${reverse('dashboard')}">
+            <img src="${static.url(branding_api.get_logo_url())}" alt=${_("Your Dashboard")}/>
+          </a>
+        % else:
+          <a href="${marketing_link('ROOT')}">
+            <img src="${static.url(branding_api.get_logo_url())}"
+                 alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
+          </a>
+        % endif
+      </%block>
+      </h1>
 
     % if course:
       <h2 class="course-header"><span class="provider">${course.display_org_with_default}:</span>

--- a/lms/templates/user_dropdown.html
+++ b/lms/templates/user_dropdown.html
@@ -28,8 +28,6 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
         </button>
         <ul class="dropdown-menu list-divided is-hidden" id="${_("Usermenu")}" tabindex="-1">
             <%block name="navigation_dropdown_menu_links" >
-                <li class="dropdown-item item has-block-link"><a href="${reverse('dashboard')}" class="action">${_("Dashboard")}</a></li>
-                <li class="dropdown-item item has-block-link"><a href="${reverse('learner_profile', kwargs={'username': user.username})}" class="action">${_("Profile")}</a></li>
                 <li class="dropdown-item item has-block-link"><a href="${reverse('account_settings')}" class="action">${_("Account")}</a></li>
             </%block>
             <li class="dropdown-item item has-block-link"><a href="${reverse('logout')}" role="menuitem" class="action">${_("Sign Out")}</a></li>
@@ -38,19 +36,19 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
 % else:
     <ol class="user">
         <li class="primary">
-            <a href="${reverse('dashboard')}" class="user-link">
-                <span class="sr">${_("Dashboard for:")}</span>
+            <a href="${reverse('learner_profile', kwargs={'username': user.username})}" class="user-link">
+                <span class="sr">${_("Profile for:")}</span>
                 <%
                 username = user.username
                 profile_image_url = get_profile_image_urls_for_user(user)['medium']
                 %>
-                <img class="user-image-frame" src="${profile_image_url}" alt="${_('Profile image for {username}').format(username=username)}">
+                <img class="user-image-frame" src="${profile_image_url}" alt="">
                 <div class="label-username">${username}</div>
             </a>
         </li>
         <li class="primary">
-            <button class="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span><span class="fa fa-sort-desc" aria-hidden="true"></span></button>
-            <ul class="dropdown-menu" aria-label="More Options" role="menu">
+            <button class="dropdown" aria-haspopup="true" aria-expanded="false" title=${_("Account settings menu")}><span class="fa fa-sort-desc" aria-hidden="true"></span></button>
+            <ul class="dropdown-menu" aria-label=${_("Account settings")} role="menu">
                 ${navigation_dropdown_menu_links()}
                 <li class="item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></li>
             </ul>

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -51,11 +51,18 @@ site_status_msg = get_site_status_msg(course_id)
 % endif
   <div class="${"rwd" if responsive else ""} wrapper-header nav-container">
     <h1 class="logo" itemscope="" itemtype="http://schema.org/Organization">
-      <a href="${marketing_link('ROOT')}" itemprop="url">
-        <%block name="navigation_logo">
-            <img src="${static.url("images/logo.png")}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}" itemprop="logo" />
-        </%block>
-      </a>
+      <%block name="navigation_logo">
+        % if user.is_authenticated():
+          <a href="${reverse('dashboard')}">
+            <img src="${static.url("images/logo.png")}" alt=${_("Your Dashboard")}/>
+          </a>
+        % else:
+          <a href="${marketing_link('ROOT')}" itemprop="url">
+            <img src="${static.url("images/logo.png")}" itemprop="logo"
+                 alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
+          </a>
+        % endif
+      </%block>
     </h1>
 
     % if course and not disable_courseware_header:
@@ -69,10 +76,20 @@ site_status_msg = get_site_status_msg(course_id)
 
     % if user.is_authenticated():
       % if not course or disable_courseware_header:
-        % if not nav_hidden or show_program_listing:
           <nav aria-label="Main" class="nav-main">
             <ul class="left list-inline nav-global authenticated">
-              % if not nav_hidden:
+              % if show_program_listing:
+                <li class="tab-nav-item">
+                  <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}">
+                    ${_("Courses")}
+                  </a>
+                </li>
+                <li class="tab-nav-item">
+                  <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}">
+                    ${_("Programs")}
+                  </a>
+                </li>
+              % elif not nav_hidden:
                 <%block name="navigation_global_links_authenticated">
                   <li class="item nav-global-01">
                     <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
@@ -85,21 +102,8 @@ site_status_msg = get_site_status_msg(course_id)
                   </li>
                 </%block>
               % endif
-              % if show_program_listing:
-                <li class="tab-nav-item">
-                  <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}">
-                    ${_("Courses")}
-                  </a>
-                </li>
-                <li class="tab-nav-item">
-                  <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}">
-                    ${_("Programs")}
-                  </a>
-                </li>
-              % endif
             </ul>
           </nav>
-        % endif
       % endif
 
       <%include file="user_dropdown.html"/>


### PR DESCRIPTION
Learner dashboard is updated.

**Sandbox:** http://tasawernawaz.sandbox.edx.org/
1.  [ECOM-4334](https://openedx.atlassian.net/browse/ECOM-4334): Update learner account menu.
   - PR: #12383 
   - `dashboard` and `profile` links removed from account menu.
   - `photo / username` act as the profile link.
2. [ECOM-4397](https://openedx.atlassian.net/browse/ECOM-4397): Header updated for Account settings and Profile pages.
   - PR: #12469 
   - Header will show tabs for `programs` and `courses` if `show_programs_listing` is `true`.
3. [ECOM-4399](https://openedx.atlassian.net/browse/ECOM-4399): Update edX Logo post-login link
   - PR: #12507 
   - If user is logged in logo will leads to dashboard instead of the main `edx.org` pre-login site.
   - `alt` text of logo image is updated.

FYI: @zubair-arbi @ahsan-ul-haq @waheedahmed @awais786 @schenedx @AlasdairSwan @marcotuts 
