### PR TITLE
Fix import order for HTML, Text.

### DIFF
--- a/cms/templates/404.html
+++ b/cms/templates/404.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="base.html" />
 <%block name="title">${_("Page Not Found")}</%block>

--- a/cms/templates/500.html
+++ b/cms/templates/500.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 from django.utils.translation import ugettext as _
 %>
 <%inherit file="base.html" />

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -4,7 +4,7 @@
 <%!
   from django.core.urlresolvers import reverse
   from django.utils.translation import ugettext as _
-  from openedx.core.djangolib.markup import Text, HTML
+  from openedx.core.djangolib.markup import HTML, Text
   from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
 %>
 <%block name="title">${_("Files & Uploads")}</%block>

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -15,7 +15,7 @@ from contentstore.views.helpers import xblock_studio_url, xblock_type_display_na
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%block name="title">${xblock.display_name_with_default} ${xblock_type_display_name(xblock)}</%block>

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from contentstore.utils import reverse_usage_url
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 <%block name="title">${_("Course Outline")}</%block>
 <%block name="bodyclass">is-signedin course view-outline</%block>

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%block name="title">${_("Group Configurations")}</%block>

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -2,7 +2,7 @@
 <%!
 from django.utils.translation import ugettext as _
 
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%inherit file="base.html" />

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -53,7 +53,7 @@ from class_dashboard.dashboard_data import get_section_display_name, get_array_s
 from .tools import get_units_with_due_date, title_or_url
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 
 log = logging.getLogger(__name__)
 

--- a/lms/templates/api_admin/status.html
+++ b/lms/templates/api_admin/status.html
@@ -5,7 +5,7 @@
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangoapps.api_admin.models import ApiAccessRequest
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <div id="api-access-wrapper">

--- a/lms/templates/api_admin/status.html
+++ b/lms/templates/api_admin/status.html
@@ -45,7 +45,7 @@ from openedx.core.djangolib.markup import HTML, Text
         <div class="api-form-container">
           <form id="api-form-fields" method="post" class="api-form">
             <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">
-            ${form.as_p() | n}
+            ${form.as_p() | n, decode.utf8}
             <input id="api-access-submit" type="submit" value="${_('Generate API client credentials')}"/>
           </form>
         </div>

--- a/lms/templates/ccx/enrollment.html
+++ b/lms/templates/ccx/enrollment.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <div class="batch-enrollment" style="float:left;width:50%">

--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -5,7 +5,7 @@
     from util.date_utils import get_time_display
     from django.utils.translation import ugettext as _
     from django.conf import settings
-    from openedx.core.djangolib.markup import Text, HTML
+    from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%def name="make_chapter(chapter)">

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext as _
 from courseware.courses import get_course_info_section, get_course_date_summary
 
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%block name="pagetitle">${_("{course_number} Course Info").format(course_number=course.display_number_with_default)}</%block>

--- a/lms/templates/courseware/welcome-back.html
+++ b/lms/templates/courseware/welcome-back.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <h2>${chapter_module.display_name_with_default}</h2>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -63,13 +63,13 @@ from openedx.core.djangolib.markup import HTML, Text
 <div class="dashboard-notifications" tabindex="-1">
     %if message:
         <section class="dashboard-banner">
-            ${message | n, unicode}
+            ${message | n, decode.utf8}
         </section>
     %endif
 
     %if enrollment_message:
         <section class="dashboard-banner">
-            ${enrollment_message | n, unicode}
+            ${enrollment_message | n,  decode.utf8}
         </section>
     %endif
 </div>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -8,7 +8,7 @@ from django.template import RequestContext
 import third_party_auth
 from third_party_auth import pipeline
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -2,7 +2,7 @@
 
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 from course_modes.models import CourseMode
 %>
 <%namespace name='static' file='../static_content.html'/>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse
 from course_modes.models import CourseMode
 from course_modes.helpers import enrollment_mode_display
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 from student.helpers import (
   VERIFY_STATUS_NEED_TO_VERIFY,
   VERIFY_STATUS_SUBMITTED,

--- a/lms/templates/dashboard/_dashboard_xseries_info.html
+++ b/lms/templates/dashboard/_dashboard_xseries_info.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h" args="program_data, enrollment_mode, display_category" />
 <%!
     from django.utils.translation import ugettext as _
-    from openedx.core.djangolib.markup import Text, HTML
+    from openedx.core.djangolib.markup import HTML, Text
 %>
 <%namespace name='static' file='../static_content.html'/>
     <div class="message message-status is-shown credit-message">

--- a/lms/templates/edxnotes/edxnotes.html
+++ b/lms/templates/edxnotes/edxnotes.html
@@ -5,7 +5,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from edxnotes.helpers import NoteJSONEncoder
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>
 

--- a/lms/templates/edxnotes/edxnotes.html
+++ b/lms/templates/edxnotes/edxnotes.html
@@ -113,7 +113,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
     <%static:require_module module_name="js/edxnotes/views/page_factory" class_name="NotesPageFactory">
         NotesPageFactory({
             disabledTabs: ${disabled_tabs | n, dump_js_escaped_json},
-            notes: ${dump_js_escaped_json(notes, NoteJSONEncoder) | n},
+            notes: ${dump_js_escaped_json(notes, NoteJSONEncoder) | n, decode.utf8},
             notesEndpoint: ${notes_endpoint | n, dump_js_escaped_json},
             pageSize: ${page_size | n, dump_js_escaped_json},
             debugMode: ${debug | n, dump_js_escaped_json}

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 from xmodule.tabs import CourseTabList
 %>
 

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -5,7 +5,7 @@
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <main id="main" aria-label="Content" tabindex="-1">

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -15,7 +15,7 @@ from openedx.core.djangolib.markup import HTML, Text
           <div class="title">
             <div class="heading-group">
               % if homepage_overlay_html:
-                ${homepage_overlay_html|n}
+                ${homepage_overlay_html | n, decode.utf8}
               % else:
                   ## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See http://open.edx.org for more information.
                   <h1>${Text(_(u"Welcome to the Open edX{registered_trademark} platform!")).format(registered_trademark=HTML("<sup style='font-size: 65%'>&reg;</sup>"))}</h1>

--- a/lms/templates/provider/authorize.html
+++ b/lms/templates/provider/authorize.html
@@ -6,7 +6,7 @@
 from django.utils.translation import ugettext as _
 from provider.templatetags.scope import scopes
 from django.core.urlresolvers import reverse
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%inherit file="../main.html"/>

--- a/lms/templates/registration/password_reset_complete.html
+++ b/lms/templates/registration/password_reset_complete.html
@@ -4,7 +4,7 @@
 
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%inherit file="../main.html"/>

--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -4,7 +4,7 @@
 
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%inherit file="../main.html"/>

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -2,7 +2,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />
 

--- a/lms/templates/static_templates/embargo.html
+++ b/lms/templates/static_templates/embargo.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />
 

--- a/lms/templates/static_templates/server-down.html
+++ b/lms/templates/static_templates/server-down.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />
 

--- a/lms/templates/static_templates/server-error.html
+++ b/lms/templates/static_templates/server-error.html
@@ -2,7 +2,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />
 

--- a/lms/templates/static_templates/server-overloaded.html
+++ b/lms/templates/static_templates/server-overloaded.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />
 

--- a/lms/templates/unsubscribe.html
+++ b/lms/templates/unsubscribe.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%!
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from django.conf import settings

--- a/lms/templates/verify_student/pay_and_verify.html
+++ b/lms/templates/verify_student/pay_and_verify.html
@@ -3,7 +3,7 @@
 import json
 from django.utils.translation import ugettext as _
 
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 from lms.djangoapps.verify_student.views import PayAndVerifyView
 %>
 <%namespace name='static' file='../static_content.html'/>

--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -23,7 +23,7 @@ def HTML(html):                                 # pylint: disable=invalid-name
         <%!
         from django.utils.translation import ugettext as _
 
-        from openedx.core.djangolib.markup import Text, HTML
+        from openedx.core.djangolib.markup import HTML, Text
         %>
         ${Text(_("Write & send {start}email{end}")).format(
             start=HTML("<a href='mailto:{}'>").format(user.email),

--- a/openedx/core/djangolib/tests/test_markup.py
+++ b/openedx/core/djangolib/tests/test_markup.py
@@ -10,7 +10,7 @@ import ddt
 from django.utils.translation import ugettext as _, ungettext
 from mako.template import Template
 
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 
 
 @attr('shard_2')
@@ -60,7 +60,7 @@ class FormatHtmlTest(unittest.TestCase):
                 <%!
                 from django.utils.translation import ugettext as _
 
-                from openedx.core.djangolib.markup import Text, HTML
+                from openedx.core.djangolib.markup import HTML, Text
                 %>
                 ${Text(_(u"A & {BC}")).format(BC=HTML("B & C"))}
             """,

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -10,7 +10,7 @@ from microsite_configuration import microsite
 from django.core.urlresolvers import reverse
 import json
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
-from openedx.core.djangolib.markup import Text, HTML
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -65,13 +65,13 @@ from openedx.core.djangolib.markup import HTML, Text
 <div class="dashboard-notifications" tabindex="-1">
     %if message:
         <section class="dashboard-banner">
-            ${message | n, unicode}
+            ${message | n, decode.utf8}
         </section>
     %endif
 
     %if enrollment_message:
         <section class="dashboard-banner">
-            ${enrollment_message | n, unicode}
+            ${enrollment_message | n, decode.utf8}
         </section>
     %endif
 </div>


### PR DESCRIPTION
I made this PR to attempt to avoid writing a Nit comment about this minor order issue on everyone's PR, assuming it was continuing to appear due to copy and paste.  Let me know if you want me to add a TNL ticket for this.

Most safe-commit violations found were minor and similar, so I corrected them.  I left those [violations found in help_modal.html](https://build.testeng.edx.org/job/edx-platform-quality-pr/18694/artifact/edx-platform/reports/safecommit/safecommit.report/*view*/) which will take some time.  How do you feel about making a separate ticket for that issue?
### Sandbox
- Let me know if you feel this is warranted.
### Testing
- [X] safecommit shows 0 violations (Exception: 6 violations in 1 file)
- [X] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [x] Code review: @andy-armstrong 
### Post-review
- [x] Squash commits
