### PR TITLE
Fix date summaries with Unicode format issues.

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -111,7 +111,7 @@ class DateSummary(object):
         date_format = _(u"{relative} ago - {absolute}") if date_has_passed else _(u"in {relative} - {absolute}")
         return date_format.format(
             relative=relative_date,
-            absolute=self.date.strftime(self.date_format),
+            absolute=self.date.strftime(self.date_format.encode('utf-8')).decode('utf-8'),
         )
 
     @property
@@ -157,7 +157,9 @@ class TodaysDate(DateSummary):
 
     @property
     def title(self):
-        return _(u'Today is {date}').format(date=datetime.now(pytz.UTC).strftime(self.date_format))
+        return _(u'Today is {date}').format(
+            date=datetime.now(pytz.UTC).strftime(self.date_format.encode('utf-8')).decode('utf-8')
+        )
 
 
 class CourseStartDate(DateSummary):


### PR DESCRIPTION
FYI @bderusha 

This issue would show up when date formatting strings are translated with Unicode characters (like when testing with fake Esperanto translations). Python's `strftime` doesn't handle Unicode well, so this just encodes/decodes to get around that.
