### PR TITLE
WIP: Create XBlock Cache Service

### DIFF
--- a/common/djangoapps/request_cache/__init__.py
+++ b/common/djangoapps/request_cache/__init__.py
@@ -77,8 +77,9 @@ class RequestPlusRemoteCache(BaseCache):
     """
     This Django cache backend implements two layers of caching.
 
-    Layer 1 is a threadlocal dictionary that is tied to the life of a given
-    request.
+    The first layer is a threadlocal dictionary that is tied to the life of a
+    given request. The second layer is another named Django cache -- e.g. the
+    "default" entry in settings.CACHES, typically backed by memcached.
 
     Some baseline rules:
 
@@ -90,8 +91,12 @@ class RequestPlusRemoteCache(BaseCache):
     2. Timeouts are ignored for the purposes of the in-memory request cache, but
        do apply to the backing remote cache. One consequence of this is that
        sending an explicit timeout of 0 in `set` or `add` will cause that item
-       to only be cached across the duration of the request and never make it
-       out to the backing remote cache.
+       to only be cached across the duration of the request and will not cause
+       a write to the remote cache.
+
+    3. If you're in a situation where key generation performance is actually a
+       concern (many thousands of lookups), then just use the request cache
+       directly instead of this hybrid.
     """
     def __init__(self, name, params):
         try:

--- a/common/djangoapps/request_cache/__init__.py
+++ b/common/djangoapps/request_cache/__init__.py
@@ -8,6 +8,8 @@ is installed in order to clear the cache after each request.
 import logging
 from urlparse import urlparse
 
+from django.core.cache import caches
+from django.core.cache.backends.base import BaseCache
 from django.conf import settings
 from django.test.client import RequestFactory
 
@@ -69,3 +71,147 @@ def get_request_or_stub():
 
     else:
         return request
+
+
+class RequestPlusRemoteCache(BaseCache):
+    """
+    This Django cache backend implements two layers of caching.
+
+    Layer 1 is a threadlocal dictionary that is tied to the life of a given
+    request.
+
+    Some baseline rules:
+
+    1. Treat it as a global namespace, like any other cache. The per-request
+       local cache is only going to live for the lifetime of one request, but
+       the backing cache is going to something like Memcached, where key
+       collision is possible.
+
+    2. Timeouts are ignored for the purposes of the in-memory request cache, but
+       do apply to the backing remote cache. One consequence of this is that
+       sending an explicit timeout of 0 in `set` or `add` will cause that item
+       to only be cached across the duration of the request and never make it
+       out to the backing remote cache.
+    """
+    def __init__(self, name, params):
+        try:
+            super(RequestPlusRemoteCache, self).__init__(params)
+            self._remote_cache = caches[params['REMOTE_CACHE_NAME']]
+        except Exception:
+            log.exception(
+                "DjangoRequestCache %s could not load backing remote cache.",
+                name
+            )
+            raise
+
+        # This is a threadlocal that will get wiped out for each request.
+        self._local_dict = get_cache("DjangoRequestCache")
+
+    def add(self, key, value, timeout=0, version=None):
+        """
+        Set a value in the cache if the key does not already exist. If
+        timeout is given, that timeout will be used for the key; otherwise
+        the timeout will default to 0, and the (key, value) will only be stored
+        in the local in-memory request cache, not the backing remote cache.
+
+        Returns True if the value was stored, False otherwise.
+        """
+        local_key = self.make_key(key, version)
+        if local_key in self._local_dict:
+            return False
+
+        self._local_dict[local_key] = value
+        if timeout != 0:
+            self._remote_cache.add(key, value, timeout=timeout, version=version)
+
+        return True
+
+    def get(self, key, default=None, version=None):
+        """
+        Fetch a given key from the cache. If the key does not exist, return
+        default, which itself defaults to None.
+        """
+        # Simple case: It's already in our local memory...
+        local_key = self.make_key(key, version)
+        if local_key in self._local_dict:
+            return self._local_dict[local_key]
+
+        # Now try looking it up in our backing cache...
+        external_value = self._remote_cache.get(key, default=default, version=None)
+
+        # This might be None, but we store it anyway to prevent repeated requests
+        # to the same non-existent key during the course of the request.
+        self._local_dict[local_key] = external_value
+
+        return external_value
+
+    def set(self, key, value, timeout=0, version=None):
+        """
+        Set a value in the cache. If timeout is given, that timeout will be used
+        for the key when storing in the remote cache; otherwise the timeout will
+        default to 0, and the (key, value) will only be stored in the local
+        in-memory request cache.
+
+        For example::
+
+            # This will only be stored in the local request cache, and should
+            # be used for items where there are potentially many, many keys.
+            dj_req_cache.set('has_access:user1243:block3048', True, 0)
+
+            # This value will be stored in both the local request cache and the
+        """
+        local_key = self.make_key(key, version)
+        self._local_dict[local_key] = value
+        if timeout != 0:
+            self._remote_cache.set(key, value, timeout=timeout, version=version)
+
+    def delete(self, key, version=None):
+        """
+        Delete a key from the cache, failing silently.
+
+        Note that this *will* flow through to the backing remote cache.
+        """
+        local_key = self.make_key(key, version)
+        if local_key in self._local_:
+            del self._local_dict[local_key]
+        self._remote_cache.delete(key, version=version)
+
+    def get_many(self, keys, version=None):
+        mapping = {}
+
+        # First get all the keys that exist locally.
+        for key in keys:
+            local_key = self.make_key(key)
+            if local_key in self._local_dict:
+                mapping[key] = self._local_dict[local_key]
+
+        # Now check the external cache for everything that we didn't find
+        remaining_keys = set(keys) - set(mapping)
+        external_mapping = self._remote_cache.get_many(remaining_keys, version=version)
+
+        # Update both the mapping that we're returning as well as our local cache
+        mapping.update(external_mapping)
+        self._local_dict.update({
+            self.make_key(key): value for key, value in external_mapping.items()
+        })
+
+        return mapping
+
+    def set_many(self, data, timeout=0, version=None):
+        self._local_dict.update({
+            self.make_key(key): value for key, value in data.items()
+        })
+        self._remote_cache.set_many(data, timeout=timeout, version=version)
+
+    def delete_many(self, keys, version=None):
+        for key in keys:
+            del self._local_dict[self.make_key(key)]
+        self._remote_cache.delete_many(keys)
+
+    def clear(self):
+        self._local_dict.clear()
+        self._remote_cache.clear()
+
+    def close(self, **kwargs):
+        self._local_dict.clear()
+        self._remote_cache.close()

--- a/common/djangoapps/request_cache/tests.py
+++ b/common/djangoapps/request_cache/tests.py
@@ -18,3 +18,9 @@ class TestRequestCache(TestCase):
         stub = get_request_or_stub()
         expected_url = "http://{site_name}/foobar".format(site_name=settings.SITE_NAME)
         self.assertEqual(stub.build_absolute_uri("foobar"), expected_url)
+
+
+class TestDjangoRequestCache(TestCase):
+
+    pass
+

--- a/common/lib/xmodule/xmodule/discussion_module.py
+++ b/common/lib/xmodule/xmodule/discussion_module.py
@@ -73,7 +73,6 @@ class DiscussionModule(DiscussionFields, XModule):
     js_module_name = "InlineDiscussion"
 
     def get_html(self):
-        course = self.get_course()
         user = None
         user_service = self.runtime.service(self, 'user')
         if user_service:
@@ -90,7 +89,6 @@ class DiscussionModule(DiscussionFields, XModule):
             can_create_thread = False
         context = {
             'discussion_id': self.discussion_id,
-            'course': course,
             'can_create_comment': json.dumps(can_create_comment),
             'can_create_subcomment': json.dumps(can_create_subcomment),
             'can_create_thread': can_create_thread,
@@ -110,10 +108,14 @@ class DiscussionModule(DiscussionFields, XModule):
         cache_key = (user, course_id, permission)
         cached_answer = cache.get(cache_key)
         if cached_answer is not None:
+            print "Cache hit: {}, {}".format(cache_key, cached_answer)
             return cached_answer
 
         has_perm = any(role.has_permission(permission) for role in user.roles.filter(course_id=course_id))
-        cache.set(cache_key, has_perm, 0)
+
+        # Only cache for the duration of this single request
+        cache.set(cache_key, has_perm, timeout=0)
+        print "Cache set {}, {}".format(cache_key, has_perm)
 
         return has_perm
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -201,6 +201,13 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
+# Create a request cache if one is not already specified.
+if 'request' not in CACHES:
+    CACHES['request'] = {
+        'BACKEND': 'request_cache.RequestPlusRemoteCache',
+        'REMOTE_CACHE_NAME': 'default',
+    }
+
 # Email overrides
 DEFAULT_FROM_EMAIL = ENV_TOKENS.get('DEFAULT_FROM_EMAIL', DEFAULT_FROM_EMAIL)
 DEFAULT_FEEDBACK_EMAIL = ENV_TOKENS.get('DEFAULT_FEEDBACK_EMAIL', DEFAULT_FEEDBACK_EMAIL)

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -233,6 +233,12 @@ CACHES = {
     'course_structure_cache': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
     },
+
+    ##### ADD REQUEST CACHE HERE
+    'request': {
+        'BACKEND': 'request_cache.RequestPlusRemoteCache',
+        'REMOTE_CACHE_NAME': 'default',
+    }
 }
 
 # Dummy secret key for dev


### PR DESCRIPTION
While doing performance work, there have been multiple occasions where I've really wanted XBlocks to be able to cache data. This is especially true for situations where leaf XBlocks are recomputing the same thing over and over again while rendering a single sequence, because they lack any ability to share that computation with each other.
# Use Case: DiscussionModule

A concrete example of this is the DiscussionModule, which provides inline forum functionality in the courseware. When rendering a full SequenceModule in the courseware index view, each instance of a DiscussionModule:
1. Does three database calls to check for user permissions that apply at the course level (create_comment, create_sub_comment, create_thread).
2. Does a check against blackout settings, for which it needs to inspect the root course node.
3. Renders an expensive template with dozens of includes, where the only difference between them is the discussion_id.

In larger sequences, this can result in dozens of database calls. Profiling runs have shown that sequences using inline discussions spend as much as a quarter of their overall server-side processing time on instances of the DiscussionModule doing these three things.
# API

My basic idea is to have a cache runtime service that you could access from inside an XBlock like:

```
cache = self.runtime.service(self, 'cache').get_cache("discussion")
```

This would allow you to get a named cache from the service. The namespacing here is just a matter of convention, and is not intended to serve as a security measure. It would typically be the tag that the XBlock is using.

Once you have a cache object, you can call get(), get_many(), set(), set_many(), delete(), and delete_many() with the same signatures as Django offers in its low level caching framework.

```
get(key, default=None, version=None)
get_many(keys, version=None)

set(key, value, timeout=0, version=None)
set_many(kv_dict, timeout=0, version=None)

delete(key, version=None)
delete_many(keys, version=None)
```

The big difference from Django would be how the timeout value is treated. Django's cache has a default timeout values of 5 minutes unless specified otherwise in the call or in the cache configuration. To Django, a timeout of 0 means "don't cache this at all".

For this runtime service, I'm proposing that the timeout defaults to 0, and that this means "cache this only for the duration of this request". Like Django, a timeout of None would keep the same meaning of "cache this forever" and any positive integer would indicate an expiration time in seconds.
# Implementation

Note: All names up for debate.

The bulk of the implementation of this would be in RequestPlusRemoteCache, a new kind of Django cache backend that could be used anywhere in the platform. This would be a two layer cache that uses the request cache middleware for an in-memory first layer, and has a second layer that can point to any other named Django cache. We always check the in-memory layer first, and write to the remote cache only if timeout != 0.

A version of this idea that's floated around has been to have a cache that can string together an arbitrary number of caches instead of special casing local request + a remote cache. I didn't do this because:
1. The in-memory request cache really is different because of how cheap it is to access. It means that we can treat timeout=0 in a special way for the in-memory cache, and also allows us to make optimizations like never asking the remote cache twice for the same non-existent value in the course of a single request.
2. I couldn't think of a real use case where having an arbitrary number of caches gave a benefit over a request + one remote cache model, and figured this would be simpler overall.

The actual cache object that the XBlock gets from the runtime service is a thin wrapper around RequestPlusRemoteCache that exists only to wrap keys in a namespace.
# Status

It's not a complete implementation, just enough to prove it works and demonstrate the shape of the API. I'm not working against an active deadline to merge this, and will leave it there for a couple of weeks for comments (I'm actually on vacation next week, so please forgive me if I'm slow to respond). I'd appreciate any feedback. :-)
