### PR TITLE
MAYN-193 Use django_sites_extensions.middleware.RedirectMiddleware to enable redirects

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -787,6 +787,7 @@ INSTALLED_APPS = (
     # Standard apps
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.redirects',
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.messages',
@@ -912,6 +913,9 @@ INSTALLED_APPS = (
 
     # Tagging
     'cms.lib.xblock.tagging',
+
+    # Enables default site and redirects
+    'django_sites_extensions',
 )
 
 

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -289,7 +289,7 @@ class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         self.assertEqual(resp.status_code, 200)
 
     def test_num_queries_instructor_paced(self):
-        self.fetch_course_info_with_queries(self.instructor_paced_course, 20, 4)
+        self.fetch_course_info_with_queries(self.instructor_paced_course, 21, 4)
 
     def test_num_queries_self_paced(self):
-        self.fetch_course_info_with_queries(self.self_paced_course, 20, 4)
+        self.fetch_course_info_with_queries(self.self_paced_course, 21, 4)

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -372,8 +372,8 @@ class ViewsQueryCountTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSet
         return inner
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 3, 4, 26),
-        (ModuleStoreEnum.Type.split, 3, 13, 26),
+        (ModuleStoreEnum.Type.mongo, 3, 4, 29),
+        (ModuleStoreEnum.Type.split, 3, 13, 29),
     )
     @ddt.unpack
     @count_queries
@@ -381,8 +381,8 @@ class ViewsQueryCountTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSet
         self.create_thread_helper(mock_request)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 3, 3, 20),
-        (ModuleStoreEnum.Type.split, 3, 10, 20),
+        (ModuleStoreEnum.Type.mongo, 3, 3, 23),
+        (ModuleStoreEnum.Type.split, 3, 10, 23),
     )
     @ddt.unpack
     @count_queries

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1093,6 +1093,10 @@ MIDDLEWARE_CLASSES = (
     'microsite_configuration.middleware.MicrositeMiddleware',
     'django_comment_client.middleware.AjaxExceptionMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'django.contrib.sites.middleware.CurrentSiteMiddleware',
+
+    # Allows us to define redirects via Django admin
+    'django_sites_extensions.middleware.RedirectMiddleware',
 
     # Instead of SessionMiddleware, we use a more secure version
     # 'django.contrib.sessions.middleware.SessionMiddleware',
@@ -1823,6 +1827,7 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.humanize',
     'django.contrib.messages',
+    'django.contrib.redirects',
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.staticfiles',
@@ -2050,6 +2055,9 @@ INSTALLED_APPS = (
 
     # Needed whether or not enabled, due to migrations
     'badges',
+
+    # Enables default site and redirects
+    'django_sites_extensions',
 )
 
 # Migrations which are not in the standard module "migrations"
@@ -2888,9 +2896,6 @@ CREDENTIALS_GENERATION_ROUTING_KEY = HIGH_PRIORITY_QUEUE
 
 WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS = "request_cache.middleware.RequestCache"
 
-# Dafault site id to use in case there is no site that matches with the request headers.
-DEFAULT_SITE_ID = 1
-
 # API access management
 API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
 API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
@@ -2899,3 +2904,10 @@ AUTH_DOCUMENTATION_URL = 'http://edx.readthedocs.org/projects/edx-platform-api/e
 
 # Affiliate cookie tracking
 AFFILIATE_COOKIE_NAME = 'affiliate_id'
+
+############## Settings for RedirectMiddleware ###############
+
+# Setting this to None causes Redirect data to never expire
+# The cache is cleared when Redirect models are saved/deleted
+REDIRECT_CACHE_TIMEOUT = None  # The length of time we cache Redirect model data
+REDIRECT_CACHE_KEY_PREFIX = 'redirects'

--- a/openedx/core/djangoapps/bookmarks/tests/test_views.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_views.py
@@ -268,7 +268,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
         self.assertEqual(response.data['developer_message'], u'Parameter usage_id not provided.')
 
         # Send empty data dictionary.
-        with self.assertNumQueries(6):  # No queries for bookmark table.
+        with self.assertNumQueries(7):  # No queries for bookmark table.
             response = self.send_post(
                 client=self.client,
                 url=reverse('bookmarks'),

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -248,7 +248,7 @@ class TestAccountAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.different_client.login(username=self.different_user.username, password=self.test_password)
         self.create_mock_profile(self.user)
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(17):
             response = self.send_get(self.different_client)
         self._verify_full_shareable_account_response(response, account_privacy=ALL_USERS_VISIBILITY)
 
@@ -263,7 +263,7 @@ class TestAccountAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.different_client.login(username=self.different_user.username, password=self.test_password)
         self.create_mock_profile(self.user)
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(17):
             response = self.send_get(self.different_client)
         self._verify_private_account_response(response, account_privacy=PRIVATE_VISIBILITY)
 
@@ -337,12 +337,12 @@ class TestAccountAPI(CacheIsolationTestCase, UserAPITestCase):
             self.assertEqual(False, data["accomplishments_shared"])
 
         self.client.login(username=self.user.username, password=self.test_password)
-        verify_get_own_information(12)
+        verify_get_own_information(15)
 
         # Now make sure that the user can get the same information, even if not active
         self.user.is_active = False
         self.user.save()
-        verify_get_own_information(9)
+        verify_get_own_information(10)
 
     def test_get_account_empty_string(self):
         """
@@ -356,7 +356,7 @@ class TestAccountAPI(CacheIsolationTestCase, UserAPITestCase):
         legacy_profile.save()
 
         self.client.login(username=self.user.username, password=self.test_password)
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(15):
             response = self.send_get(self.client)
         for empty_field in ("level_of_education", "gender", "country", "bio"):
             self.assertIsNone(response.data[empty_field])

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -42,6 +42,7 @@ edx-ccx-keys==0.1.2
 edx-drf-extensions==0.5.1
 edx-lint==0.4.3
 edx-django-oauth2-provider==1.0.3
+edx-django-sites-extensions==2.0.1
 edx-oauth2-provider==1.0.1
 edx-opaque-keys==0.2.1
 edx-organizations==0.4.1


### PR DESCRIPTION
This adds support for allowing permanent redirects to be configured using the Django admin and enabling a default Site using the SITE_ID setting.

Related PR: https://github.com/edx/edx-django-sites-extensions/pull/6
