### PR TITLE
[TNL-3960] Fix for thumbnail generation code crashing with SVG files

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_content.py
@@ -3,6 +3,7 @@
 import os
 import unittest
 import ddt
+from mock import Mock, patch
 from path import Path as path
 
 from xmodule.contentstore.content import StaticContent, StaticContentStream
@@ -58,6 +59,7 @@ class Content(object):
     def __init__(self, location, content_type):
         self.location = location
         self.content_type = content_type
+        self.data = None
 
 
 class FakeGridFsItem(object):
@@ -84,6 +86,17 @@ class FakeGridFsItem(object):
         return chunk
 
 
+class MockImage(Mock):
+    """
+    This class pretends to be PIL.Image for purposes of thumbnails testing.
+    """
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
 @ddt.ddt
 class ContentTest(unittest.TestCase):
     def test_thumbnail_none(self):
@@ -103,11 +116,43 @@ class ContentTest(unittest.TestCase):
     )
     @ddt.unpack
     def test_generate_thumbnail_image(self, original_filename, thumbnail_filename):
-        contentStore = ContentStore()
+        content_store = ContentStore()
         content = Content(AssetLocation(u'mitX', u'800', u'ignore_run', u'asset', original_filename), None)
-        (thumbnail_content, thumbnail_file_location) = contentStore.generate_thumbnail(content)
+        (thumbnail_content, thumbnail_file_location) = content_store.generate_thumbnail(content)
         self.assertIsNone(thumbnail_content)
-        self.assertEqual(AssetLocation(u'mitX', u'800', u'ignore_run', u'thumbnail', thumbnail_filename), thumbnail_file_location)
+        self.assertEqual(
+            AssetLocation(u'mitX', u'800', u'ignore_run', u'thumbnail', thumbnail_filename),
+            thumbnail_file_location
+        )
+
+    @patch('xmodule.contentstore.content.Image')
+    def test_image_is_closed_when_generating_thumbnail(self, image_class_mock):
+        # We used to keep the Image's file descriptor open when generating a thumbnail.
+        # It should be closed after being used.
+        mock_image = MockImage()
+        image_class_mock.open.return_value = mock_image
+
+        content_store = ContentStore()
+        content = Content(AssetLocation(u'mitX', u'800', u'ignore_run', u'asset', "monsters.jpg"), "image/jpeg")
+        content.data = 'mock data'
+        content_store.generate_thumbnail(content)
+        self.assertTrue(image_class_mock.open.called, "Image.open not called")
+        self.assertTrue(mock_image.close.called, "mock_image.close not called")
+
+    def test_store_svg_as_thumbnail(self):
+        # We had a bug that caused generate_thumbnail to attempt to pass SVG to PIL to generate a thumbnail.
+        # SVG files should be stored in original form for thumbnail purposes.
+        content_store = ContentStore()
+        content_store.save = Mock()
+        thumbnail_filename = u'test.svg'
+        content = Content(AssetLocation(u'mitX', u'800', u'ignore_run', u'asset', u'test.svg'), 'image/svg+xml')
+        content.data = 'mock svg file'
+        (thumbnail_content, thumbnail_file_location) = content_store.generate_thumbnail(content)
+        self.assertEqual(thumbnail_content.data.read(), b'mock svg file')
+        self.assertEqual(
+            AssetLocation(u'mitX', u'800', u'ignore_run', u'thumbnail', thumbnail_filename),
+            thumbnail_file_location
+        )
 
     def test_compute_location(self):
         # We had a bug that __ got converted into a single _. Make sure that substitution of INVALID_CHARS (like space)
@@ -115,7 +160,10 @@ class ContentTest(unittest.TestCase):
         asset_location = StaticContent.compute_location(
             SlashSeparatedCourseKey('mitX', '400', 'ignore'), 'subs__1eo_jXvZnE .srt.sjson'
         )
-        self.assertEqual(AssetLocation(u'mitX', u'400', u'ignore', u'asset', u'subs__1eo_jXvZnE_.srt.sjson', None), asset_location)
+        self.assertEqual(
+            AssetLocation(u'mitX', u'400', u'ignore', u'asset', u'subs__1eo_jXvZnE_.srt.sjson', None),
+            asset_location
+        )
 
     def test_get_location_from_path(self):
         asset_location = StaticContent.get_location_from_path(u'/c4x/a/b/asset/images_course_image.jpg')


### PR DESCRIPTION
**Background**: As reported in [TNL-3960](https://openedx.atlassian.net/browse/TNL-3960), adding an SVG file to assets results in a logged exception while generating a thumbnail. A user-visible side effect is that no thumbnail is shown next to the uploaded file.

**Studio Updates**: Assets view now shows thumbnails of uploaded SVG files.

**LMS Updates**: None.

**Testing**: Try uploading an SVG file in "Content -> Files & Uploads". A thumbnail should appear next to the file on the list.

**Concerns**: As [mentioned](https://openedx.atlassian.net/browse/TNL-3960?focusedCommentId=191419&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-191419) on JIRA, IE11 does not always display SVG files correctly, but that is not a regression. Also displaying many, large, or complex SVG files in the list could have a client-side performance penalty, but assuming reasonable uploads, it should not be an issue.

The screenshot below demonstrates thumbnails of SVG files now being displayed (MS Edge - right side), and the above-mentioned IE11 (left side) not displaying some thumbnails.

![screenshot from 2016-05-24 23-24-01](https://cloud.githubusercontent.com/assets/120114/15547169/e6a3f7ee-22a2-11e6-88d4-37a1cfce4ff1.png)
