### PR TITLE
Hotfix: Invalidate, don't update, Block structure cache in CMS

### DIFF
--- a/openedx/core/djangoapps/content/course_structures/tasks.py
+++ b/openedx/core/djangoapps/content/course_structures/tasks.py
@@ -97,7 +97,7 @@ def update_course_structure(course_key):
         structure_model.discussion_id_map_json = discussion_id_map_json
         structure_model.save()
 
-    # TODO (TNL-4630) For temporary hotfix to update the block_structure cache.
+    # TODO (TNL-4630) For temporary hotfix to delete the block_structure cache.
     # Should be moved to proper location.
     from django.core.cache import cache
     from openedx.core.lib.block_structure.manager import BlockStructureManager
@@ -105,4 +105,4 @@ def update_course_structure(course_key):
     store = modulestore()
     course_usage_key = store.make_course_usage_key(course_key)
     block_structure_manager = BlockStructureManager(course_usage_key, store, cache)
-    block_structure_manager.update_collected()
+    block_structure_manager.clear()


### PR DESCRIPTION
This hotfix changes the handling of the Course Publish signal for the BlockStructure cache.
- Instead of automatically updating the cache on course publish, it simply invalidates the cache on course publish.

**Rationale for Hotfix:**
- Shortly after the release, the following error was found in NewRelic: 

```
File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/course_structures/tasks.py", line 108, in update_course_structure
File "/edx/app/edxapp/edx-platform/openedx/core/lib/block_structure/manager.py", line 106, in update_collected
...
File "/edx/app/edxapp/edx-platform/lms/djangoapps/course_api/blocks/transformers/blocks_api.py", line 49, in collect
File "/edx/app/edxapp/edx-platform/lms/djangoapps/course_api/blocks/transformers/student_view.py", line 62, in collect
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/video_module.py", line 904, in student_view_data
...
exceptions:NotImplementedError: edX Studio doesn't support third-party xblock handler urls
```
- This indicates that there are Block Transformers that expect their `collect` method to be called within the context of the LMS.  However, the Course Publish signal is sent only within CMS.
- Long-term, we need a cross-process signalling mechanism to ensure the signal is sent by CMS and processed in LMS.

**Reviewers:** @feanil @ormsbee @bderusha 
