### PR TITLE
Added scopes claim to JWT access tokens

### DIFF
--- a/lms/djangoapps/oauth_dispatch/tests/mixins.py
+++ b/lms/djangoapps/oauth_dispatch/tests/mixins.py
@@ -34,6 +34,7 @@ class AccessTokenMixin(object):
             'aud': audience,
             'iss': issuer,
             'preferred_username': user.username,
+            'scopes': scopes,
         }
 
         if 'email' in scopes:

--- a/lms/djangoapps/oauth_dispatch/tests/test_client_credentials.py
+++ b/lms/djangoapps/oauth_dispatch/tests/test_client_credentials.py
@@ -1,4 +1,6 @@
 """ Tests for OAuth 2.0 client credentials support. """
+from __future__ import unicode_literals
+
 import json
 
 from django.core.urlresolvers import reverse
@@ -52,7 +54,7 @@ class ClientCredentialsTest(mixins.AccessTokenMixin, TestCase):
             redirect_uri=DUMMY_REDIRECT_URL,
             client_id='dot-app-client-id',
         )
-        scopes = ('read', 'write', 'email')
+        scopes = ['read', 'write', 'email']
         data = {
             'grant_type': 'client_credentials',
             'client_id': application.client_id,

--- a/lms/djangoapps/oauth_dispatch/views.py
+++ b/lms/djangoapps/oauth_dispatch/views.py
@@ -130,6 +130,7 @@ class AccessTokenView(_DispatchingView):
             'exp': now + expires_in,
             'iat': now,
             'preferred_username': user.username,
+            'scopes': scopes,
         }
 
         for scope in scopes:


### PR DESCRIPTION
This will allow API servers to limit access based on scopes.
