### PR TITLE
Adjust program detail page URL routing

### DIFF
--- a/common/test/acceptance/pages/lms/programs.py
+++ b/common/test/acceptance/pages/lms/programs.py
@@ -24,7 +24,7 @@ class ProgramListingPage(PageObject):
 
 class ProgramDetailsPage(PageObject):
     """Program details page."""
-    url = BASE_URL + '/dashboard/programs/123'
+    url = BASE_URL + '/dashboard/programs/123/program-name/'
 
     def is_browser_on_page(self):
         return self.q(css='.js-program-details-wrapper').present

--- a/lms/djangoapps/learner_dashboard/urls.py
+++ b/lms/djangoapps/learner_dashboard/urls.py
@@ -1,11 +1,11 @@
-"""
-Learner's Dashboard urls
-"""
-
+"""Learner dashboard URL routing configuration"""
 from django.conf.urls import url
+
 from . import views
 
+
 urlpatterns = [
-    url(r'^programs/(?P<program_uuid>[0-9a-f-]+)/$', views.program_details, name='program_details_view'),
     url(r'^programs/$', views.view_programs, name='program_listing_view'),
+    # Matches paths like 'programs/123/' and 'programs/123/foo/', but not 'programs/123/foo/bar/'.
+    url(r'^programs/(?P<program_id>\d+)/[\w\-]*/?$', views.program_details, name='program_details_view'),
 ]

--- a/lms/djangoapps/learner_dashboard/views.py
+++ b/lms/djangoapps/learner_dashboard/views.py
@@ -1,4 +1,4 @@
-"""New learner dashboard views."""
+"""Learner dashboard views"""
 from urlparse import urljoin
 
 from django.conf import settings
@@ -50,8 +50,8 @@ def view_programs(request):
 
 @login_required
 @require_GET
-def program_details(request, program_uuid):  # pylint: disable=unused-argument
-    """View programs in which the user is engaged."""
+def program_details(request, program_id):  # pylint: disable=unused-argument
+    """View details about a specific program."""
     show_program_details = ProgramsApiConfig.current().show_program_details
     if not show_program_details:
         raise Http404


### PR DESCRIPTION
The new URL pattern expects a program ID and allows a program name to be included, if desired. It will match paths like 'programs/123/' and 'programs/123/foo/', but not 'programs/123/foo/bar/'. The given ID is passed to the view, where it will be used to retrieve program data. Part of ECOM-4415.

@schenedx @AlasdairSwan please review.
