### PR TITLE
Include raw program data on the detail page

### DIFF
--- a/lms/djangoapps/learner_dashboard/views.py
+++ b/lms/djangoapps/learner_dashboard/views.py
@@ -9,7 +9,7 @@ from django.http import Http404
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.credentials.utils import get_programs_credentials
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
-from openedx.core.djangoapps.programs.utils import ProgramProgressMeter, get_display_category
+from openedx.core.djangoapps.programs.utils import ProgramProgressMeter, get_programs, get_display_category
 from student.views import get_course_enrollments
 
 
@@ -50,13 +50,16 @@ def view_programs(request):
 
 @login_required
 @require_GET
-def program_details(request, program_id):  # pylint: disable=unused-argument
+def program_details(request, program_id):
     """View details about a specific program."""
     show_program_details = ProgramsApiConfig.current().show_program_details
     if not show_program_details:
         raise Http404
 
+    program_data = get_programs(request.user, program_id=program_id)
+
     context = {
+        'program_data': program_data,
         'nav_hidden': True,
         'disable_courseware_js': True,
         'uses_pattern_library': True

--- a/lms/templates/learner_dashboard/program_details.html
+++ b/lms/templates/learner_dashboard/program_details.html
@@ -13,7 +13,9 @@ from openedx.core.djangolib.js_utils import (
 
 <%block name="js_extra">
 <%static:require_module module_name="js/learner_dashboard/program_details_factory" class_name="ProgramDetailsFactory">
-ProgramDetailsFactory({});
+ProgramDetailsFactory({
+    programData: ${program_data | n, dump_js_escaped_json}
+});
 </%static:require_module>
 </%block>
 

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -10,7 +10,7 @@ from openedx.core.lib.edx_api_utils import get_edx_api_data
 log = logging.getLogger(__name__)
 
 
-def get_programs(user):
+def get_programs(user, program_id=None):
     """Given a user, get programs from the Programs service.
     Returned value is cached depending on user permissions. Staff users making requests
     against Programs will receive unpublished programs, while regular users will only receive
@@ -18,6 +18,9 @@ def get_programs(user):
 
     Arguments:
         user (User): The user to authenticate as when requesting programs.
+
+    Keyword Arguments:
+        program_id (int): Identifies a specific program for which to retrieve data.
 
     Returns:
         list of dict, representing programs returned by the Programs service.
@@ -27,7 +30,7 @@ def get_programs(user):
     # Bypass caching for staff users, who may be creating Programs and want
     # to see them displayed immediately.
     cache_key = programs_config.CACHE_KEY if programs_config.is_cache_enabled and not user.is_staff else None
-    return get_edx_api_data(programs_config, user, 'programs', cache_key=cache_key)
+    return get_edx_api_data(programs_config, user, 'programs', resource_id=program_id, cache_key=cache_key)
 
 
 def flatten_programs(programs, course_ids):


### PR DESCRIPTION
Uses the view's ID argument to retrieve and drop unmodified programs API data on the details page. Future work will supplement with CourseOverviews data. Part of ECOM-4415.

@schenedx @AlasdairSwan please review.
