### PR TITLE
Set the Email field length is 254 characters.

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -131,7 +131,7 @@ class AccountCreationForm(forms.Form):
         }
     )
     email = forms.EmailField(
-        max_length=75,  # Limit per RFCs is 254, but User's email field in django 1.4 only takes 75
+        max_length=254,  # Limit per RFCs is 254
         error_messages={
             "required": _EMAIL_INVALID_MSG,
             "invalid": _EMAIL_INVALID_MSG,

--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -388,8 +388,19 @@ class TestCreateAccountValidation(TestCase):
             assert_email_error("A properly formatted e-mail is required")
 
         # Too long
-        params["email"] = "this_email_address_has_76_characters_in_it_so_it_is_unacceptable@example.com"
-        assert_email_error("Email cannot be more than 75 characters long")
+        params["email"] = '{email}@example.com'.format(
+            email='this_email_address_has_254_characters_in_it_so_it_is_unacceptable' * 4
+        )
+
+        # Assert that we get error when email has more than 254 characters.
+        self.assertGreater(len(params['email']), 254)
+        assert_email_error("Email cannot be more than 254 characters long")
+
+        # Valid Email
+        params["email"] = "student@edx.com"
+        # Assert success on valid email
+        self.assertLess(len(params["email"]), 254)
+        self.assert_success(params)
 
         # Invalid
         params["email"] = "not_an_email_address"

--- a/common/djangoapps/student/tests/test_long_username_email.py
+++ b/common/djangoapps/student/tests/test_long_username_email.py
@@ -38,11 +38,14 @@ class TestLongUsernameEmail(TestCase):
 
     def test_long_email(self):
         """
-        Test email cannot be more than 75 characters long.
+        Test email cannot be more than 254 characters long.
         """
 
-        self.url_params['email'] = '{0}@bar.com'.format('foo_bar' * 15)
+        self.url_params['email'] = '{email}@bar.com'.format(email='foo_bar' * 36)
         response = self.client.post(self.url, self.url_params)
+
+        # Assert that we get error when email has more than 254 characters.
+        self.assertGreater(len(self.url_params['email']), 254)
 
         # Status code should be 400.
         self.assertEqual(response.status_code, 400)
@@ -50,5 +53,5 @@ class TestLongUsernameEmail(TestCase):
         obj = json.loads(response.content)
         self.assertEqual(
             obj['value'],
-            "Email cannot be more than 75 characters long",
+            "Email cannot be more than 254 characters long",
         )


### PR DESCRIPTION
## [PLAT-1004](https://openedx.atlassian.net/browse/PLAT-1004)

Email field length is too restrictive.Set the field length from `75 to 254`.
### Reviewers
- [x] @mushtaqak 
- [x] @aamir-khan 
