### PR TITLE
Escape HTML that may be returned by misbehaving logistration APIs

### DIFF
--- a/lms/static/js/spec/student_account/password_reset_spec.js
+++ b/lms/static/js/spec/student_account/password_reset_spec.js
@@ -142,6 +142,23 @@
                 // Expect that the error is hidden
                 expect(view.$errors).toHaveClass('hidden');
             });
+
+            it('escapes HTML returned by a server 500', function() {
+                var errorString = "<b>unexpected error</b><script>alert('escape me');</script>";
+                createPasswordResetView(this);
+                submitEmail(true);
+
+                // Simulate a non-JSON error from the LMS servers
+                AjaxHelpers.respondWithTextError(
+                    requests,
+                    500,
+                    errorString
+                );
+
+                // Expect that an error is displayed and escaped
+                expect(view.$errors).not.toHaveClass('hidden');
+                expect($(".message-copy", view.$errors).text()).toEqual("<li>" + errorString + "</li>");
+            });
         });
     });
 }).call(this, define || RequireJS.define);

--- a/lms/static/js/student_account/views/FormView.js
+++ b/lms/static/js/student_account/views/FormView.js
@@ -4,9 +4,10 @@
             'jquery',
             'underscore',
             'backbone',
-            'common/js/utils/edx.utils.validate'
+            'common/js/utils/edx.utils.validate',
+            'edx-ui-toolkit/js/utils/html-utils'
         ],
-        function($, _, Backbone, EdxUtilsValidate) {
+        function($, _, Backbone, EdxUtilsValidate, HtmlUtils) {
 
         return Backbone.View.extend({
             tagName: 'form',
@@ -200,7 +201,7 @@
                     html.push( errors[i] );
                 }
 
-                $msg.html( html.join('') );
+                $msg.html(HtmlUtils.ensureHtml(html.join('')).text);
 
                 this.element.show( this.$errors );
 
@@ -214,7 +215,7 @@
             },
 
             /* Allows extended views to add non-form attributes
-             * to the data before saving it to model 
+             * to the data before saving it to model
              */
             setExtraData: function( data ) {
                 return data;


### PR DESCRIPTION
## [TNL-4684](https://openedx.atlassian.net/browse/TNL-4684)

Addresses the frontend component of the bug reported above - when a backend error occurs in the `/account/password` endpoint and the server returns the full 500 page in response to a request (which should ideally not happen, but did this morning), the forgot password page will attempt to render all returned HTML inside its error field. This has the visual effects seen [here](https://i.bjacobel.com/20160531-kw833.png), as well as the potential for unintended code execution (in this case, re-loading the entire RequireJS bundle).

This change escapes all error strings returned from the server before displaying them on the forgot password page.
### Sandbox
- [x] Build a sandbox for your branch and add a link here

[bjacobel-forgot-pwd-html.sandbox.edx.org](https://bjacobel-forgot-pwd-html.sandbox.edx.org)
### Testing
- [ ] i18n
- [ ] RTL
- [x] safecommit shows 0 violations
- [x] Unit, integration, acceptance tests as appropriate
- [x] Analytics
- [x] Performance
- [x] Database migrations are backwards-compatible
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @andy-armstrong 
- [ ] Code review: @AlasdairSwan 

FYI: @robrap @cahrens @mushtaqak @aqdasrehman 
### Post-review
- [ ] Squash commits
