### PR TITLE
Corrected RTL issues new forum post button

### DIFF
--- a/lms/static/sass/discussion/_mixins.scss
+++ b/lms/static/sass/discussion/_mixins.scss
@@ -1,18 +1,24 @@
 // discussion - mixins and extends
 // ====================
 
-@mixin blue-button {
-  @include linear-gradient(top, #6dccf1, #38a8e5);
+@mixin discussion-button() {
   display: block;
-  border: 1px solid #2d81ad;
+  border: 1px solid;
   border-radius: 3px;
-  padding: 0 ($baseline*0.75);
   height: 35px;
-  color: $white;
-  text-shadow: none;
-  font-size: 13px;
   line-height: 35px;
+  font-size: 13px;
+  white-space: nowrap;  // Prevent word-break in Arabic in Google Chrome
+  text-shadow: none;
+  padding: 0 ($baseline*0.75);
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.4) inset, 0 1px 1px rgba(0, 0, 0, .15);
+}
+
+@mixin blue-button {
+  @include discussion-button();
+  @include linear-gradient(top, #6dccf1, #38a8e5);
+  border-color: #2d81ad;
+  color: $white;
 
   &:hover, &:focus {
     @include linear-gradient(top, #4fbbe4, #2090d0);
@@ -21,17 +27,10 @@
 }
 
 @mixin white-button {
+  @include discussion-button();
   @include linear-gradient(top, $white, $gray-l5);
-  display: block;
-  border: 1px solid #aaa;
-  border-radius: 3px;
-  padding: 0 ($baseline*0.75);
-  height: 35px;
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.4) inset, 0 1px 1px rgba(0, 0, 0, .15);
+  border-color: #aaa;
   color: $dark-gray;
-  text-shadow: none;
-  font-size: 13px;
-  line-height: 35px;
 
   &:hover, &:focus {
     @include linear-gradient(top, $white, $gray-l6);
@@ -39,17 +38,10 @@
 }
 
 @mixin dark-grey-button {
-  display: block;
-  border: 1px solid #222;
-  border-radius: 3px;
-  padding: 0 ($baseline*0.75);
-  height: 35px;
-  background: -webkit-linear-gradient(top, #777, #555);
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.4) inset, 0 1px 1px rgba(0, 0, 0, .15);
+  @include discussion-button();
+  @include linear-gradient(top, #777, #555);
+  border-color: #222;
   color: $white;
-  text-shadow: none;
-  font-size: 13px;
-  line-height: 35px;
 
   &:hover, &:focus {
     background: -webkit-linear-gradient(top, #888, #666);


### PR DESCRIPTION
- Word break in Arabic on Google Chrome
- Refactored forum buttons

This is a bug we found in our fork (https://github.com/Edraak/edx-platform/pull/180), so I thought to open a PR for it here.

**Before:**
- ~~The icon is floated to left, like the LTR. It should be flipped.~~ The icon will be removed in #12538 so no need to fix it now.
- The [text is broken into two lines in Google Chrome](http://stackoverflow.com/questions/29078128/why-do-arabic-text-breaks-into-two-lines-sometimes).

![screen shot 2016-06-01 at 5 54 16 pm](https://cloud.githubusercontent.com/assets/645156/15714948/4f54c8a4-2825-11e6-8713-a2e44753825e.png)

**After:**
- All is fine

![screen shot 2016-06-01 at 5 54 26 pm](https://cloud.githubusercontent.com/assets/645156/15714959/590fe978-2825-11e6-8c33-186580a67f4d.png)
