### PR TITLE
OSPR-1272 Upgrading xblock-lti-consumer to v1.0.7

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -89,7 +89,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
-git+https://github.com/edx/xblock-lti-consumer.git@v1.0.6#egg=xblock-lti-consumer==1.0.6
+git+https://github.com/edx/xblock-lti-consumer.git@v1.0.7#egg=xblock-lti-consumer==1.0.7
 git+https://github.com/edx/edx-proctoring.git@0.12.18#egg=edx-proctoring==0.12.18
 
 # Third Party XBlocks


### PR DESCRIPTION
Related JIRA tickets:
[LOC-78](https://openedx.atlassian.net/browse/LOC-78)
[OSPR-1272](https://openedx.atlassian.net/browse/OSPR-1272)

This change implements a transmission of registered user language settings to LTI tools being consumed through the `lti-consumer` XBlock.

Depends on edx/xblock-lti-consumer#16; that PR already contains internal testing to ensure that internationalization data is transmitted correctly.
