### PR TITLE
MA-333 Added ability to refresh uploaded videos

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -276,3 +276,4 @@ Kevin Kim <kkim@edx.org>
 Albert St. Aubin Jr. <astaubin@edx.org>
 Casey Litton <caseylitton@gmail.com>
 Jhony Avella <jhony.avella@edunext.co>
+Tanmay Mohapatra <tanmaykm@gmail.com>

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -336,7 +336,7 @@ def videos_post(course, request):
             "courses": [course.id]
         })
 
-        resp_files.append({"file_name": file_name, "upload_url": upload_url})
+        resp_files.append({"file_name": file_name, "upload_url": upload_url, "edx_video_id": edx_video_id})
 
     return JsonResponse({"files": resp_files}, status=200)
 

--- a/cms/static/js/models/active_video_upload.js
+++ b/cms/static/js/models/active_video_upload.js
@@ -19,6 +19,7 @@ define(
         var ActiveVideoUpload = Backbone.Model.extend(
             {
                 defaults: {
+                    videoId: null,
                     status: statusStrings.STATUS_QUEUED,
                     progress: 0
                 }


### PR DESCRIPTION
This adds ability to refresh the list of uploaded videos without refreshing the whole page.

~~Added a refresh button that when clicked:~~
An event is triggered on each successful upload that:
- fetches a fresh list of uploaded files from the server
- updates `PreviousVideoUploadListView`
- removes the successfully completed uploads from `ActiveVideoUploadListView`
- retains the ongoing or failed uploads in `ActiveVideoUploadListView` so that they can be monitored/retried

~~The view can also be refreshed without user action, but I felt it may be less surprising to have a button instead.~~

Sandbox
- [ Sandbox](https://video-auto-refresh.sandbox.edx.org/)
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @muzaffaryousaf
- [x] Code review: @mushtaqak 
- [x] Accessibility review: @cptvitamin 
- [x] Product review: @marcotuts  or @sstack22 

cc: @antoviaque 
