### PR TITLE
WL-494 Put shopping cart bulk purchase behind a settings flag

### DIFF
--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -190,6 +190,7 @@ def show_cart(request):
         'form_html': form_html,
         'currency_symbol': settings.PAID_COURSE_REGISTRATION_CURRENCY[1],
         'currency': settings.PAID_COURSE_REGISTRATION_CURRENCY[0],
+        'enable_bulk_purchase': microsite.get_value('ENABLE_SHOPPING_CART_BULK_PURCHASE', True)
     }
     return render_to_response("shoppingcart/shopping_cart.html", context)
 

--- a/lms/templates/shoppingcart/shopping_cart.html
+++ b/lms/templates/shoppingcart/shopping_cart.html
@@ -101,6 +101,7 @@ from openedx.core.lib.courses import course_image_url
                   % endif
               </div>
               <div class="col-2">
+                % if enable_bulk_purchase:
                 <div class="numbers-row" aria-live="polite">
                   <label for="field_${item.id}">${_('Students:')}</label>
                   <div class="counter">
@@ -116,8 +117,9 @@ from openedx.core.lib.courses import course_image_url
                   </button>
                       <!--<a name="updateBtn" class="updateBtn hidden" id="updateBtn-${item.id}" href="#">update</a>-->
                   <span class="error-text hidden" id="students-${item.id}"></span>
-              </div>
                 </div>
+                % endif
+              </div>
 
               <div class="col-3">
                  <button href="#" class="btn-remove" data-item-id="${item.id}">


### PR DESCRIPTION
This enables us to hide the bulk purchase widget in the LMS shopping cart.
