### PR TITLE
WL-494 MAYN-285 Hotfix Release Candidate 2016-06-03

### DIFF
--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -337,7 +337,7 @@ def submit_calculate_students_features_csv(request, course_key, features):
     """
     task_type = 'profile_info_csv'
     task_class = calculate_students_features_csv
-    task_input = {'features': features}
+    task_input = features
     task_key = ""
 
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -996,7 +996,7 @@ def upload_students_csv(_xmodule_instance_args, _entry_id, course_id, task_input
     task_progress.update_task_state(extra_meta=current_step)
 
     # compute the student features table and format it
-    query_features = task_input.get('features')
+    query_features = task_input
     student_data = enrolled_students_features(course_id, query_features)
     header, rows = format_dictlist(student_data, query_features)
 

--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -190,6 +190,7 @@ def show_cart(request):
         'form_html': form_html,
         'currency_symbol': settings.PAID_COURSE_REGISTRATION_CURRENCY[1],
         'currency': settings.PAID_COURSE_REGISTRATION_CURRENCY[0],
+        'enable_bulk_purchase': microsite.get_value('ENABLE_SHOPPING_CART_BULK_PURCHASE', True)
     }
     return render_to_response("shoppingcart/shopping_cart.html", context)
 

--- a/lms/templates/shoppingcart/shopping_cart.html
+++ b/lms/templates/shoppingcart/shopping_cart.html
@@ -101,6 +101,7 @@ from openedx.core.lib.courses import course_image_url
                   % endif
               </div>
               <div class="col-2">
+                % if enable_bulk_purchase:
                 <div class="numbers-row" aria-live="polite">
                   <label for="field_${item.id}">${_('Students:')}</label>
                   <div class="counter">
@@ -116,8 +117,9 @@ from openedx.core.lib.courses import course_image_url
                   </button>
                       <!--<a name="updateBtn" class="updateBtn hidden" id="updateBtn-${item.id}" href="#">update</a>-->
                   <span class="error-text hidden" id="students-${item.id}"></span>
-              </div>
                 </div>
+                % endif
+              </div>
 
               <div class="col-3">
                  <button href="#" class="btn-remove" data-item-id="${item.id}">


### PR DESCRIPTION
WL-494 Put shopping cart bulk purchase behind a settings flag

We were seeing some issues with the LMS shopping cart JS code after the recent JQuery upgrade. This change will allow us to mitigate those issues by hiding the bulk purchase widget on the LMS shopping cart page until we can switch over to Otto as the ecommerce engine for WL sites.

MAYN-285 Fix student profile data download for courses with extended profile fields

Extended profile fields can be configured for certain courses which was causing the student profile data download on the Instructor Dashboard to fail due to a limit on the size of input parameters to asynchronous jobs which are used to create the instructor dashboard data downloads. This refactors the code which produces the profile data download removing the need to pass the list of profile fields to include in the data download as an input parameter to the asynchronous job.

@mattdrayer @adampalay 
