### PR TITLE
Fix program details a11y test

### DIFF
--- a/common/test/acceptance/tests/lms/test_programs.py
+++ b/common/test/acceptance/tests/lms/test_programs.py
@@ -1,6 +1,4 @@
 """Acceptance tests for LMS-hosted Programs pages"""
-from unittest import skip
-
 from nose.plugins.attrib import attr
 
 from ...fixtures.programs import ProgramsFixture, ProgramsConfigMixin
@@ -139,7 +137,6 @@ class ProgramListingPageA11yTest(ProgramPageBase):
 
 
 @attr('a11y')
-@skip('The tested page is currently disabled. This test will be re-enabled once a11y failures are resolved.')
 class ProgramDetailsPageA11yTest(ProgramPageBase):
     """Test program details page accessibility."""
     def setUp(self):

--- a/lms/static/js/spec/learner_dashboard/course_card_view_spec.js
+++ b/lms/static/js/spec/learner_dashboard/course_card_view_spec.js
@@ -61,7 +61,7 @@ define([
                 expect(view.$('.header-img').attr('src')).toEqual(context.run_modes[0].course_image_url);
                 expect(view.$('.course-details .course-title-link').text().trim()).toEqual(context.display_name);
                 expect(view.$('.course-details .course-title-link').attr('href')).toEqual(
-                    context.run_modes[0].marketing_url);
+                    context.run_modes[0].course_url);
                 expect(view.$('.course-details .course-text .course-key').html()).toEqual(context.key);
                 expect(view.$('.course-details .course-text .run-period').html())
                     .toEqual(context.run_modes[0].start_date + ' - ' + context.run_modes[0].end_date);
@@ -71,7 +71,7 @@ define([
                 expect(view.$('.header-img').attr('src')).toEqual(context.run_modes[0].course_image_url);
                 expect(view.$('.course-details .course-title-link').text().trim()).toEqual(context.display_name);
                 expect(view.$('.course-details .course-title-link').attr('href')).toEqual(
-                    context.run_modes[0].marketing_url);
+                    context.run_modes[0].course_url);
                 expect(view.$('.course-details .course-text .course-key').html()).toEqual(context.key);
                 expect(view.$('.course-details .course-text .run-period').html()).not.toBeDefined();
             });

--- a/lms/templates/learner_dashboard/course_card.underscore
+++ b/lms/templates/learner_dashboard/course_card.underscore
@@ -1,6 +1,6 @@
 <div class="grid-container grid-manual">
     <div class="course-meta-container col-12 md-col-8 sm-col-12">
-        <a href="<%- marketing_url %>" class="course-image-link">
+        <a href="<%- course_url %>" class="course-image-link">
             <img
                 class="header-img"
                 src="<%- course_image_url %>"
@@ -8,7 +8,7 @@
         </a>
         <div class="course-details">
             <h3 class="course-title">
-                <a href="<%- marketing_url %>" class="course-title-link">
+                <a href="<%- course_url %>" class="course-title-link">
                     <%- display_name %>
                 </a>
             </h3>

--- a/lms/templates/learner_dashboard/program_header_view.underscore
+++ b/lms/templates/learner_dashboard/program_header_view.underscore
@@ -5,7 +5,7 @@
 </picture>
 <h2 class="hd-2 title"><%- name %></h2>
 <p class="subtitle"><%- subtitle %></p>
-<a href="" class="breadcrumb"><%- gettext('Programs') %></a>
+<a href="/dashboard/programs" class="breadcrumb"><%- gettext('Programs') %></a>
 <span><%- StringUtils.interpolate(
     gettext('{category}\'s program'),
     {category: category}


### PR DESCRIPTION
@schenedx @AlasdairSwan please review. Empty hrefs are an a11y violation, so I'm substituting the `course_url` (which we have) for the `marketing_url` (which we don't have), for now. I'm also hardcoding the program listing page URL. We can replace it with a URL passed by the server later; I just don't want to mix that up with this fix.
