### PR TITLE
mattdrayer/WL-493: Enable bulk purchase via Otto for unauthenticated users

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -94,7 +94,8 @@ class CourseModeViewTest(UrlResetMixin, ModuleStoreTestCase):
         url = reverse('course_modes_choose', args=[unicode(self.course.id)])
         response = self.client.get(url)
         # Check whether we were correctly redirected
-        start_flow_url = reverse('verify_student_start_flow', args=[unicode(self.course.id)])
+        purchase_workflow = "?purchase_workflow=single"
+        start_flow_url = reverse('verify_student_start_flow', args=[unicode(self.course.id)]) + purchase_workflow
         self.assertRedirects(response, start_flow_url)
 
     def test_no_id_redirect_otto(self):
@@ -194,7 +195,8 @@ class CourseModeViewTest(UrlResetMixin, ModuleStoreTestCase):
 
         # Since the only available track is professional ed, expect that
         # we're redirected immediately to the start of the payment flow.
-        start_flow_url = reverse('verify_student_start_flow', args=[unicode(self.course.id)])
+        purchase_workflow = "?purchase_workflow=single"
+        start_flow_url = reverse('verify_student_start_flow', args=[unicode(self.course.id)]) + purchase_workflow
         self.assertRedirects(response, start_flow_url)
 
         # Now enroll in the course

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -88,12 +88,15 @@ class ChooseModeView(View):
         # If there are both modes, default to non-id-professional.
         has_enrolled_professional = (CourseMode.is_professional_slug(enrollment_mode) and is_active)
         if CourseMode.has_professional_mode(modes) and not has_enrolled_professional:
-            redirect_url = reverse('verify_student_start_flow', kwargs={'course_id': unicode(course_key)})
+            purchase_workflow = request.GET.get("purchase_workflow", "single")
+            verify_url = reverse('verify_student_start_flow', kwargs={'course_id': unicode(course_key)})
+            redirect_url = "{url}?purchase_workflow={workflow}".format(url=verify_url, workflow=purchase_workflow)
             if ecommerce_service.is_enabled(request.user):
                 professional_mode = modes.get(CourseMode.NO_ID_PROFESSIONAL_MODE) or modes.get(CourseMode.PROFESSIONAL)
-                if professional_mode.sku:
+                if purchase_workflow == "single" and professional_mode.sku:
                     redirect_url = ecommerce_service.checkout_page_url(professional_mode.sku)
-
+                if purchase_workflow == "bulk" and professional_mode.bulk_sku:
+                    redirect_url = ecommerce_service.checkout_page_url(professional_mode.bulk_sku)
             return redirect(redirect_url)
 
         # If there isn't a verified mode available, then there's nothing

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -200,7 +200,7 @@ def auth_pipeline_urls(auth_entry, redirect_url=None):
 
 # Query string parameters that can be passed to the "finish_auth" view to manage
 # things like auto-enrollment.
-POST_AUTH_PARAMS = ('course_id', 'enrollment_action', 'course_mode', 'email_opt_in')
+POST_AUTH_PARAMS = ('course_id', 'enrollment_action', 'course_mode', 'email_opt_in', 'purchase_workflow')
 
 
 def get_next_url_for_login_page(request):

--- a/lms/djangoapps/verify_student/tests/test_integration.py
+++ b/lms/djangoapps/verify_student/tests/test_integration.py
@@ -32,7 +32,7 @@ class TestProfEdVerification(ModuleStoreTestCase):
             min_price=self.MIN_PRICE,
             suggested_prices=''
         )
-
+        purchase_workflow = "?purchase_workflow=single"
         self.urls = {
             'course_modes_choose': reverse(
                 'course_modes_choose',
@@ -42,7 +42,7 @@ class TestProfEdVerification(ModuleStoreTestCase):
             'verify_student_start_flow': reverse(
                 'verify_student_start_flow',
                 args=[unicode(self.course_key)]
-            ),
+            ) + purchase_workflow,
         }
 
     def test_start_flow(self):

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -334,6 +334,10 @@ class PayAndVerifyView(View):
         # Redirect the user to a more appropriate page if the
         # messaging won't make sense based on the user's
         # enrollment / payment / verification status.
+        sku_to_use = relevant_course_mode.sku
+        purchase_workflow = request.GET.get('purchase_workflow', 'single')
+        if purchase_workflow == 'bulk' and relevant_course_mode.bulk_sku:
+            sku_to_use = relevant_course_mode.bulk_sku
         redirect_response = self._redirect_if_necessary(
             message,
             already_verified,
@@ -342,7 +346,7 @@ class PayAndVerifyView(View):
             course_key,
             user_is_trying_to_pay,
             request.user,
-            relevant_course_mode.sku
+            sku_to_use
         )
         if redirect_response is not None:
             return redirect_response

--- a/lms/static/js/student_account/views/FinishAuthView.js
+++ b/lms/static/js/student_account/views/FinishAuthView.js
@@ -51,7 +51,8 @@
                     enrollmentAction: $.url( '?enrollment_action' ),
                     courseId: $.url( '?course_id' ),
                     courseMode: $.url( '?course_mode' ),
-                    emailOptIn: $.url( '?email_opt_in' )
+                    emailOptIn: $.url( '?email_opt_in' ),
+                    purchaseWorkflow: $.url( '?purchase_workflow' )
                 };
                 for (var key in queryParams) {
                     if (queryParams[key]) {
@@ -63,6 +64,7 @@
                 this.courseMode = queryParams.courseMode;
                 this.emailOptIn = queryParams.emailOptIn;
                 this.nextUrl = this.urls.defaultNextUrl;
+                this.purchaseWorkflow = queryParams.purchaseWorkflow;
                 if (queryParams.next) {
                     // Ensure that the next URL is internal for security reasons
                     if ( ! window.isExternal( queryParams.next ) ) {


### PR DESCRIPTION
It seems the bulk purchasing workflow was going directly to Otto and not passing through the user activation check.  This PR corrects that issue, and also appears to resolve the issue reported in WL-491 as well -- although I need to double-check this.

I don't have a stable sandbox at the moment that can be used to validate this branch -- I will build one tomorrow.

Also see the related PR https://github.com/edx/edx-microsite/pull/282
