### PR TITLE
Uses previous commit hash to prevent failures on master

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "underscore.string": "~3.3.4"
   },
   "devDependencies": {
-    "edx-custom-a11y-rules": "edx/edx-custom-a11y-rules",
+    "edx-custom-a11y-rules": "git+https://github.com/edx/edx-custom-a11y-rules.git#12d2cae4ffdbb45c5643819211e06c17d6200210",
     "pa11y": "3.6.0",
     "pa11y-reporter-1.0-json": "1.0.2",
     "jasmine-core": "^2.4.1",


### PR DESCRIPTION
@benpatterson @andy-armstrong 

When I merged the update to the `edx-custom-a11y-rules` it inadvertently caused all PRs to `edx-platform` master branch to fail because it is triggering checks for the new Section rules.

I've worked with Andy to publish our custom rules package to NPMJS.org so we can manage updates with a version, rather than from master, as it's being used now.

This is a quick-fix PR to use the previous commit hash. I will create another PR with the version update instead.
