### PR TITLE
Using NPM package for edx-custom-a11y-rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "underscore.string": "~3.3.4"
   },
   "devDependencies": {
-    "edx-custom-a11y-rules": "git+https://github.com/edx/edx-custom-a11y-rules.git#12d2cae4ffdbb45c5643819211e06c17d6200210",
+    "edx-custom-a11y-rules": "0.1.0",
     "pa11y": "3.6.0",
     "pa11y-reporter-1.0-json": "1.0.2",
     "jasmine-core": "^2.4.1",


### PR DESCRIPTION
@benpatterson @andy-armstrong 

This is the follow-up PR to https://github.com/edx/edx-platform/pull/12652 that formally updates the platform package.json to use the new NPM package for the edx-custom-a11y-rules. I've got it set to use the previous version (Christine's last update) as opposed to mine, until I can ignore the section failures until we can get them fixed.
