### PR TITLE
Remove flaky decorator TNL-4683

### DIFF
--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -303,7 +303,6 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
         self.verify_profile_page_is_private(profile_page)
         self.verify_profile_page_view_event(username, user_id, visibility=self.PRIVACY_PRIVATE)
 
-    @flaky  # TODO fix this, see TNL-4683
     def test_fields_on_my_public_profile(self):
         """
         Scenario: Verify that desired fields are shown when looking at her own public profile.


### PR DESCRIPTION
When checking editable_fields, if language_proficiency is checked
before bio, bio is sometimes not properly selected. Changing the order
of the fields seems to fix the issue.

I was able to replicate the strange click behavior intermittently on my sandbox. Selecting the language proficiencies area, then the bio area repeatedly will occasionally result in de-focusing the former without selecting the latter. This is very easy to do if you select the `padding` area instead of the inner `div`.

![screen shot 2016-06-03 at 3 34 36 pm](https://cloud.githubusercontent.com/assets/7373924/15790709/d0d8642c-29a0-11e6-8421-11c7dae5777a.png)

I suspect this has to do with the slightly different behavior of `field-text-area` (see https://github.com/edx/edx-platform/blob/master/common/test/acceptance/pages/lms/fields.py#L123, note that for `bio`, we must click the inner `'.u-field-bio > .wrapper-u-field'` to properly select the field).

FYI @sanfordstudent @jcdyer - I'm going to 20x run this test on jenkins multiple times to ensure the fix actually works before removing the `flaky` decorator for review and merging.
