### PR TITLE
AC-490 using latest a11y checks and ignoring section test

### DIFF
--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -208,6 +208,7 @@ class DiscussionHomePageTest(UniqueCourseTest):
     def test_page_accessibility(self):
         self.page.a11y_audit.config.set_rules({
             "ignore": [
+                'section',  # TODO: wcag2aa
                 'color-contrast',  # TNL-4635
                 'link-href',  # TNL-4636
                 'icon-aria-hidden',  # TNL-4637
@@ -347,6 +348,7 @@ class DiscussionTabMultipleThreadTest(BaseDiscussionTestCase):
     def test_page_accessibility(self):
         self.thread_page_1.a11y_audit.config.set_rules({
             "ignore": [
+                'section',  # TODO: wcag2aa
                 'aria-valid-attr-value',  # TNL-4638
                 'color-contrast',  # TNL-4639
                 'link-href',  # TNL-4640
@@ -358,6 +360,7 @@ class DiscussionTabMultipleThreadTest(BaseDiscussionTestCase):
 
         self.thread_page_2.a11y_audit.config.set_rules({
             "ignore": [
+                'section',  # TODO: wcag2aa
                 'aria-valid-attr-value',  # TNL-4638
                 'color-contrast',  # TNL-4639
                 'link-href',  # TNL-4640
@@ -421,6 +424,7 @@ class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
         page = self.setup_openclosed_thread_page()
         page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'aria-valid-attr-value',  # TNL-4643
                 'color-contrast',  # TNL-4644
                 'link-href',  # TNL-4640
@@ -432,6 +436,7 @@ class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
         page = self.setup_openclosed_thread_page(True)
         page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'aria-valid-attr-value',  # TNL-4643
                 'color-contrast',  # TNL-4644
                 'link-href',  # TNL-4640
@@ -720,6 +725,7 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
         page = self.create_single_thread_page("response_edit_test_thread")
         page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'aria-valid-attr-value',  # TNL-4638
                 'color-contrast',  # TNL-4644
                 'link-href',  # TNL-4640
@@ -821,6 +827,7 @@ class DiscussionCommentEditTest(BaseDiscussionTestCase):
         page.visit()
         page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'aria-valid-attr-value',  # TNL-4643
                 'color-contrast',  # TNL-4644
                 'link-href',  # TNL-4640
@@ -1195,6 +1202,7 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
     def test_page_accessibility(self):
         self.page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'color-contrast',  # TNL-4639
                 'link-href',  # TNL-4640
                 'icon-aria-hidden',  # TNL-4641

--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -459,6 +459,7 @@ class AccountSettingsA11yTest(AccountSettingsTestMixin, WebAppTest):
         self.visit_account_settings_page()
         self.account_settings_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'link-href',  # TODO: AC-233
             ],
         })

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -778,7 +778,7 @@ class LearnerProfileA11yTest(LearnerProfileTestMixin, WebAppTest):
 
         profile_page.a11y_audit.config.set_rules({
             "ignore": [
-                'skip-link',  # TODO: AC-179
+                'section',  # TODO: wcag2aa
                 'link-href',  # TODO: AC-231
             ],
         })
@@ -806,6 +806,7 @@ class LearnerProfileA11yTest(LearnerProfileTestMixin, WebAppTest):
 
         profile_page.a11y_audit.config.set_rules({
             "ignore": [
+                'section',  # TODO: wcag2aa
                 'link-href',  # TODO: AC-231
             ],
         })
@@ -822,7 +823,7 @@ class LearnerProfileA11yTest(LearnerProfileTestMixin, WebAppTest):
 
         profile_page.a11y_audit.config.set_rules({
             "ignore": [
-                'skip-link',  # TODO: AC-179
+                'section',  # TODO: wcag2aa
                 'link-href',  # TODO: AC-231
             ],
         })

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -1347,4 +1347,9 @@ class CourseInfoA11yTest(UniqueCourseTest):
 
     def test_course_home_a11y(self):
         self.course_info_page.visit()
+        self.course_info_page.a11y_audit.config.set_rules({
+            "ignore": [
+                'section',  # TODO: wcag2aa
+            ]
+        })
         self.course_info_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -619,6 +619,11 @@ class CoursewareMultipleVerticalsTest(UniqueCourseTest, EventsTestMixin):
         # Set the scope to the sequence navigation
         self.courseware_page.a11y_audit.config.set_scope(
             include=['div.sequence-nav'])
+        self.courseware_page.a11y_audit.config.set_rules({
+            "ignore": [
+                'section',  # TODO: wcag2aa
+            ],
+        })
         self.courseware_page.a11y_audit.check_for_accessibility_errors()
 
 

--- a/common/test/acceptance/tests/lms/test_lms_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard.py
@@ -232,4 +232,9 @@ class LmsDashboardA11yTest(BaseLmsDashboardTest):
         """
         course_listings = self.dashboard_page.get_course_listings()
         self.assertEqual(len(course_listings), 1)
+        self.dashboard_page.a11y_audit.config.set_rules({
+            "ignore": [
+                'section',  # TODO: wcag2aa
+            ]
+        })
         self.dashboard_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -245,6 +245,19 @@ class ProblemTypeTestMixin(object):
         self.problem_page.a11y_audit.config.set_scope(
             include=['div#seq_content'])
 
+        self.problem_page.a11y_audit.config.set_rules({
+            "ignore": [
+                'aria-allowed-attr',  # TODO: wcag2aa
+                'aria-valid-attr',  # TODO: wcag2aa
+                'aria-roles',  # TODO: wcag2aa
+                'checkboxgroup',  # TODO: wcag2aa
+                'radiogroup',  # TODO: wcag2aa
+                'color-contrast',  # TODO: wcag2aa
+                'section',  # TODO: wcag2aa
+                'label',  # TODO: wcag2aa
+            ]
+        })
+
         # Run the accessibility audit.
         self.problem_page.a11y_audit.check_for_accessibility_errors()
 
@@ -285,11 +298,6 @@ class AnnotationProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         Additional setup for AnnotationProblemTypeTest
         """
         super(AnnotationProblemTypeTest, self).setUp(*args, **kwargs)
-        self.problem_page.a11y_audit.config.set_rules({
-            'ignore': [
-                'label',  # TODO: AC-293
-            ]
-        })
 
     def answer_problem(self, correct):
         """
@@ -327,6 +335,7 @@ class CheckboxProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         super(CheckboxProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'aria-allowed-attr',  # TODO: AC-251
                 'aria-valid-attr',  # TODO: AC-251
                 'aria-roles',  # TODO: AC-251
@@ -372,6 +381,7 @@ class MultipleChoiceProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         super(MultipleChoiceProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'aria-valid-attr',  # TODO: AC-251
                 'radiogroup',  # TODO: AC-251
             ]
@@ -415,6 +425,7 @@ class RadioProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         super(RadioProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'aria-valid-attr',  # TODO: AC-292
                 'radiogroup',  # TODO: AC-292
             ]
@@ -452,6 +463,7 @@ class DropDownProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         super(DropDownProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'label',  # TODO: AC-291
             ]
         })
@@ -494,6 +506,7 @@ class StringProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         super(StringProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'label',  # TODO: AC-290
             ]
         })
@@ -535,6 +548,7 @@ class NumericalProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         super(NumericalProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'label',  # TODO: AC-289
             ]
         })
@@ -578,6 +592,7 @@ class FormulaProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         super(FormulaProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'label',  # TODO: AC-288
             ]
         })
@@ -628,6 +643,7 @@ class ScriptProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         super(ScriptProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'label',  # TODO: AC-287
             ]
         })
@@ -677,6 +693,7 @@ class CodeProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         super(CodeProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'color-contrast',  # TODO: AC-286
                 'label',  # TODO: AC-286
             ]
@@ -785,6 +802,7 @@ class RadioTextProblemTypeTest(ChoiceTextProbelmTypeTestBase, ProblemTypeTestMix
         super(RadioTextProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'label',  # TODO: AC-285
                 'radiogroup',  # TODO: AC-285
             ]
@@ -817,6 +835,7 @@ class CheckboxTextProblemTypeTest(ChoiceTextProbelmTypeTestBase, ProblemTypeTest
         super(CheckboxTextProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'label',  # TODO: AC-284
                 'checkboxgroup',  # TODO: AC-284
             ]
@@ -880,6 +899,7 @@ class SymbolicProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         super(SymbolicProblemTypeTest, self).setUp(*args, **kwargs)
         self.problem_page.a11y_audit.config.set_rules({
             'ignore': [
+                'section',  # TODO: wcag2aa
                 'label',  # TODO: AC-294
             ]
         })

--- a/common/test/acceptance/tests/lms/test_programs.py
+++ b/common/test/acceptance/tests/lms/test_programs.py
@@ -123,6 +123,11 @@ class ProgramListingPageA11yTest(ProgramPageBase):
         self.assertTrue(self.listing_page.is_sidebar_present)
         self.assertFalse(self.listing_page.are_cards_present)
 
+        self.listing_page.a11y_audit.config.set_rules({
+            "ignore": [
+                'section',  # TODO: wcag2aa
+            ]
+        })
         self.listing_page.a11y_audit.check_for_accessibility_errors()
 
     def test_cards_a11y(self):
@@ -133,6 +138,11 @@ class ProgramListingPageA11yTest(ProgramPageBase):
         self.assertTrue(self.listing_page.is_sidebar_present)
         self.assertTrue(self.listing_page.are_cards_present)
 
+        self.listing_page.a11y_audit.config.set_rules({
+            "ignore": [
+                'section',  # TODO: wcag2aa
+            ]
+        })
         self.listing_page.a11y_audit.check_for_accessibility_errors()
 
 
@@ -152,4 +162,9 @@ class ProgramDetailsPageA11yTest(ProgramPageBase):
         self.auth()
         self.details_page.visit()
 
+        self.details_page.a11y_audit.config.set_rules({
+            "ignore": [
+                'section',  # TODO: wcag2aa
+            ]
+        })
         self.details_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -656,6 +656,7 @@ class StudioLibraryA11yTest(StudioLibraryTest):
         # we will ignore this error in the test until we fix them.
         lib_page.a11y_audit.config.set_rules({
             "ignore": [
+                'section',  # TODO: wcag2aa
                 'color-contrast',  # TODO: AC-225
                 'link-href',  # TODO: AC-226
                 'nav-aria-label',  # TODO: AC-227

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -503,6 +503,7 @@ class StudioSettingsA11yTest(StudioCourseTest):
         # we will ignore this error in the test until we fix them.
         self.settings_page.a11y_audit.config.set_rules({
             "ignore": [
+                'section',  # TODO: wcag2aa
                 'color-contrast',  # TODO: AC-225
                 'link-href',  # TODO: AC-226
                 'nav-aria-label',  # TODO: AC-227
@@ -579,6 +580,11 @@ class StudioSubsectionSettingsA11yTest(StudioCourseTest):
         self.course_outline.a11y_audit.config.set_scope(
             include=['section.edit-settings-timed-examination']
         )
+        self.course_outline.a11y_audit.config.set_rules({
+            "ignore": [
+                'section',  # TODO: wcag2aa
+            ]
+        })
         self.course_outline.a11y_audit.check_for_accessibility_errors()
 
 

--- a/common/test/acceptance/tests/video/test_studio_video_module.py
+++ b/common/test/acceptance/tests/video/test_studio_video_module.py
@@ -358,4 +358,9 @@ class CMSVideoA11yTest(CMSVideoBaseTest):
         self.outline.a11y_audit.config.set_scope(
             include=["div.video"]
         )
+        self.outline.a11y_audit.config.set_rules({
+            "ignore": [
+                'section',  # TODO: wcag2aa
+            ]
+        })
         self.outline.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -1272,4 +1272,9 @@ class LMSVideoModuleA11yTest(VideoBaseTest):
         self.video.a11y_audit.config.set_scope(
             include=["div.video"]
         )
+        self.video.a11y_audit.config.set_rules({
+            "ignore": [
+                'section',  # TODO: wcag2aa
+            ]
+        })
         self.video.a11y_audit.check_for_accessibility_errors()

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "underscore.string": "~3.3.4"
   },
   "devDependencies": {
-    "edx-custom-a11y-rules": "git+https://github.com/edx/edx-custom-a11y-rules.git#12d2cae4ffdbb45c5643819211e06c17d6200210",
+    "edx-custom-a11y-rules": "0.1.1",
     "pa11y": "3.6.0",
     "pa11y-reporter-1.0-json": "1.0.2",
     "jasmine-core": "^2.4.1",


### PR DESCRIPTION
# [AC-490](https://openedx.atlassian.net/browse/AC-490)

This work is a subtask for AC-414 and addresses a bunch of master a11y failures due to additional tests added to our edx-custom-a11y-rules repository last week. I'm temporarily ignoring them (marked with a TODO: wcag2aa) and using the latest version from NPM that includes the new checks.

This should allow the section tests to be available in platform while not preventing folks from merging.

We should address all `wcag2aa` marked items before 2 Oct 2016. Additional JIRA tickets should be filed when ignoring certain rules.

@andy-armstrong 
@cptvitamin 

Mark, I'm seeing a lot of ignore rules, mainly from TNL. While I understand the need to postpone certain a11y fixes that might be out of scope of a PR, we should solidify a plan/flow with teams for getting all of those ignored rules addressed. Anytime a team ignores a rule, a JIRA ticket should be created to get it fixed.
