### PR TITLE
AC-473 fixing width of closed captions in fullscreen

### DIFF
--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -744,6 +744,13 @@
       }
     }
   }
+  
+  &.video-fullscreen {
+      
+      .closed-captions {
+          width: 60%;
+      }
+  }
 
   .subtitles {
     @include float(left);

--- a/common/lib/xmodule/xmodule/js/src/video/04_video_full_screen.js
+++ b/common/lib/xmodule/xmodule/js/src/video/04_video_full_screen.js
@@ -133,7 +133,8 @@ define('video/04_video_full_screen.js', [], function () {
     }
 
     function exit() {
-        var fullScreenClassNameEl = this.el.add(document.documentElement);
+        var fullScreenClassNameEl = this.el.add(document.documentElement),
+            closedCaptionsEl = this.el.find('.closed-captions');
 
         this.videoFullScreen.fullScreenState = this.isFullScreen = false;
         fullScreenClassNameEl.removeClass('video-fullscreen');
@@ -146,10 +147,16 @@ define('video/04_video_full_screen.js', [], function () {
                     .text(gettext('Fill browser'));
 
         this.el.trigger('fullscreen', [this.isFullScreen]);
+
+        $(closedCaptionsEl).css({
+            'top': '70%',
+            'left': '5%'
+        });
     }
 
     function enter() {
-        var fullScreenClassNameEl = this.el.add(document.documentElement);
+        var fullScreenClassNameEl = this.el.add(document.documentElement),
+            closedCaptionsEl = this.el.find('.closed-captions');
 
         this.scrollPos = $(window).scrollTop();
         $(window).scrollTop(0);
@@ -163,6 +170,11 @@ define('video/04_video_full_screen.js', [], function () {
                     .text(gettext('Exit full browser'));
 
         this.el.trigger('fullscreen', [this.isFullScreen]);
+
+        $(closedCaptionsEl).css({
+            'top': '70%',
+            'left': '5%'
+        });
     }
 
     /** Toggle fullscreen mode. */


### PR DESCRIPTION
# [AC-473](https://openedx.atlassian.net/browse/AC-473)

This relatively small update addresses an issue where the closed captions would overlap the side-transcript upon video resize (going to/from fullscreen). It also includes a tweak to the fullscreen code to re-position the closed captions when going to/from fullscreen. Depending on where one dragged the captions would render them offscreen when going from fullscreen to normal size. The code will position them in their default placement with each toggle.

The original JIRA ticket has a screenshot of the original issue.
## Sandbox

https://clrux-ac-473.sandbox.edx.org
## Reviewers
- [x] @adampalay 
- [x] @muzaffaryousaf 
