### PR TITLE
Use cached data to find completed programs on LMS

### DIFF
--- a/lms/djangoapps/learner_dashboard/tests/test_programs.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_programs.py
@@ -56,8 +56,6 @@ class TestProgramListing(
     def _create_course_and_enroll(self, student, org, course, run):
         """
         Creates a course and associated enrollment.
-
-        TODO: Use CourseEnrollmentFactory to avoid course creation.
         """
         course_location = locator.CourseLocator(org, course, run)
         course = CourseFactory.create(

--- a/lms/djangoapps/learner_dashboard/views.py
+++ b/lms/djangoapps/learner_dashboard/views.py
@@ -11,7 +11,6 @@ from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.credentials.utils import get_programs_credentials
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.programs import utils
-from student.views import get_course_enrollments
 
 
 @login_required
@@ -22,8 +21,7 @@ def view_programs(request):
     if not show_program_listing:
         raise Http404
 
-    enrollments = list(get_course_enrollments(request.user, None, []))
-    meter = utils.ProgramProgressMeter(request.user, enrollments)
+    meter = utils.ProgramProgressMeter(request.user)
     programs = meter.engaged_programs
 
     # TODO: Pull 'xseries' string from configuration model.


### PR DESCRIPTION
These changes improve the performance of the LMS' program certification task. They also reduce strain on the programs service, especially when attempting to award program certificates to large numbers of students. ECOM-4490.

This will be accompanied by a programs PR deprecating the completion endpoint on that end. I'll look into getting this on a sandbox for additional testing.

@schenedx please review. @mikedikan FYI. I'll be looking for your reviews on PRs like this in the future. When you have a moment, let's chat about what's going on here.
