### PR TITLE
MA-2496: DiscussionAPI - added feature flag for requested_fields

### DIFF
--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -4,6 +4,7 @@ Discussion API internal interface
 from collections import defaultdict
 from urllib import urlencode
 from urlparse import urlunparse
+from django.conf import settings
 
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
@@ -412,7 +413,9 @@ def _include_profile_image(requested_fields):
     """
     Returns True if requested_fields list has 'profile_image' entity else False
     """
-    return requested_fields and 'profile_image' in requested_fields
+    return (settings.FEATURES["DISCUSSION_API_REQUESTED_FIELDS_PARAM"] and
+            requested_fields and
+            'profile_image' in requested_fields)
 
 
 def _serialize_discussion_entities(request, context, discussion_entities, requested_fields, discussion_entity_type):

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -631,6 +631,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
             }
         )
 
+    @mock.patch.dict("django.conf.settings.FEATURES", {"DISCUSSION_API_REQUESTED_FIELDS_PARAM": True})
     def test_profile_image_requested_field(self):
         """
         Tests thread has user profile image details if called in requested_fields
@@ -1288,6 +1289,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
             }
         )
 
+    @mock.patch.dict("django.conf.settings.FEATURES", {"DISCUSSION_API_REQUESTED_FIELDS_PARAM": True})
     def test_profile_image_requested_field(self):
         """
         Tests all comments retrieved have user profile image details if called in requested_fields
@@ -1328,6 +1330,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
             response_users = response_comment['users']
             self.assertEqual(expected_profile_data, response_users[response_comment['author']])
 
+    @mock.patch.dict("django.conf.settings.FEATURES", {"DISCUSSION_API_REQUESTED_FIELDS_PARAM": True})
     def test_profile_image_requested_field_endorsed_comments(self):
         """
         Tests all comments have user profile image details for both author and endorser
@@ -1685,6 +1688,7 @@ class ThreadViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase,
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 404)
 
+    @mock.patch.dict("django.conf.settings.FEATURES", {"DISCUSSION_API_REQUESTED_FIELDS_PARAM": True})
     def test_profile_image_requested_field(self):
         """
         Tests thread has user profile image details if called in requested_fields
@@ -1802,6 +1806,7 @@ class CommentViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase
             {"developer_message": "Page not found (No results on this page)."}
         )
 
+    @mock.patch.dict("django.conf.settings.FEATURES", {"DISCUSSION_API_REQUESTED_FIELDS_PARAM": True})
     def test_profile_image_requested_field(self):
         """
         Tests all comments retrieved have user profile image details if called in requested_fields

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -363,6 +363,11 @@ FEATURES = {
     # lives in the Extended table, saving the frontend from
     # making multiple queries.
     'ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES': True,
+
+    # Enable "requested_fields" additional optional parameter for GET endpoints in discussion mobile APIs.
+    # TODO: This is temporary feature flag and should be removed once we are comfotable with the performance of APIs
+    # with the addition of 'requested_fields=profile_image'.
+    'DISCUSSION_API_REQUESTED_FIELDS_PARAM': False,
 }
 
 # Ignore static asset files on import which match this pattern


### PR DESCRIPTION
### Description

[MA-2496](https://openedx.atlassian.net/browse/MA-2496)

Added a feature flag for "requested_fields" query param for discussion GET APIs. For Reference,
https://openedx.atlassian.net/browse/MA-2476. 
MA-2476 is under progress and I need to do a more investigation on the results of performance testing. Hence introduced feature flag.
### Sandbox
- [ ] Build a sandbox for your branch and add a link here
### Testing
- [x] Unit
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @verdanmahmood 
- [ ] Code review: @robrap 
### Post-review
- [ ] Squash commits
