### PR TITLE
Make karma logs cleaner

### DIFF
--- a/common/static/common/js/jasmine_stack_trace.js
+++ b/common/static/common/js/jasmine_stack_trace.js
@@ -1,0 +1,28 @@
+/* This file overrides ExceptionFormatter of jasmine before it's initialization in karma-jasmine's
+ boot.js. It's important because ExceptionFormatter returns a constructor function. Once the method has been
+ initialized we can't override the ExceptionFormatter as Jasmine then uses the stored reference to the function */
+(function () {
+    /* globals jasmineRequire */
+    'use strict';
+
+    var OldExceptionFormatter = jasmineRequire.ExceptionFormatter(),
+        oldExceptionFormatter = new OldExceptionFormatter(),
+        MAX_STACK_TRACE_LINES = 10;
+
+    jasmineRequire.ExceptionFormatter = function () {
+        function ExceptionFormatter() {
+            this.message = oldExceptionFormatter.message;
+            this.stack = function (error) {
+                var errorMsg = null;
+
+                if (error) {
+                    errorMsg = error.stack.split('\n').slice(0, MAX_STACK_TRACE_LINES).join('\n');
+                }
+
+                return errorMsg;
+            };
+        }
+
+        return ExceptionFormatter;
+    };
+}());

--- a/common/static/common/js/karma.common.conf.js
+++ b/common/static/common/js/karma.common.conf.js
@@ -84,7 +84,7 @@ function junitNameFormatter(browser, result) {
  * @return {String}
  */
 function junitClassNameFormatter(browser) {
-    return "Javascript." + browser.name.split(" ")[0];
+    return 'Javascript.' + browser.name.split(' ')[0];
 }
 
 
@@ -227,6 +227,7 @@ var getBaseConfig = function (config, useRequireJs) {
         var files = [
             'node_modules/jquery/dist/jquery.js',
             'node_modules/jasmine-core/lib/jasmine-core/jasmine.js',
+            'common/static/common/js/jasmine_stack_trace.js',
             'node_modules/karma-jasmine/lib/boot.js',
             'node_modules/karma-jasmine/lib/adapter.js',
             'node_modules/jasmine-jquery/lib/jasmine-jquery.js'
@@ -292,6 +293,12 @@ var getBaseConfig = function (config, useRequireJs) {
         // karma-reporter
         reporters: reporters(config),
 
+        // Spec Reporter configuration
+        specReporter: {
+            maxLogLines: 5,
+            showSpecTiming: true
+        },
+
 
         coverageReporter: coverageSettings(config),
 
@@ -330,7 +337,11 @@ var getBaseConfig = function (config, useRequireJs) {
         // how many browser should be started simultaneous
         concurrency: Infinity,
 
-        browserNoActivityTimeout: 50000
+        browserNoActivityTimeout: 50000,
+
+        client: {
+            captureConsole: false
+        }
     };
 };
 


### PR DESCRIPTION
This PR includes changes to make karma terminal logs cleaner, it does so by 
1. limit the stack trace to 10 lines
2. prevent browser log to display on console output

The problem was that Firefox doesn't limit the stack trace nor provides any flag to limit it V8 on the other hand provides `Error.stackTraceLimit` to be set to get the desired level of trace. Firefox's `Error` doesn't provide any customization. These changes pick the first 10 lines of stack trace thus removing the noise from browser as well as from console. Earlier the problem was also there when using Firefox for debugging.

The console output has been decreased from 3,254 KB to 1554 KB.
## Related Story

https://openedx.atlassian.net/browse/TNL-4700
## Post-review
- [x] Squash commits into discrete sets of changes with descriptive commit messages.
## Reviewers
- [x] @andy-armstrong
- [x] @bjacobel 

If you've been tagged for review, please check your corresponding box once you've given the :+1:.

@muzaffaryousaf FYI
