### PR TITLE
Fix remove user from cert-exception list

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -831,6 +831,34 @@ class CertificatesTest(BaseInstructorDashboardTest):
         self.assertIn(self.user_name, self.certificates_section.last_certificate_exception.text)
         self.assertIn(notes, self.certificates_section.last_certificate_exception.text)
 
+    def test_remove_certificate_exception_on_page_reload(self):
+        """
+        Scenario: On the Certificates tab of the Instructor Dashboard, Instructor can remove added certificate
+        exceptions from the list.
+
+            Given that I am on the Certificates tab on the Instructor Dashboard
+            When I fill in student username and notes fields and click 'Add Exception' button
+            Then new certificate exception should be visible in certificate exceptions list
+
+            Revisit the page to make sure exceptions are synced.
+
+            Remove the user from the exception list should remove the user from the list.
+        """
+        notes = 'Test Notes'
+        # Add a student to Certificate exception list
+        self.certificates_section.add_certificate_exception(self.user_name, notes)
+        self.assertIn(self.user_name, self.certificates_section.last_certificate_exception.text)
+        self.assertIn(notes, self.certificates_section.last_certificate_exception.text)
+
+        # Verify that added exceptions are also synced with backend
+        # Revisit Page
+        self.certificates_section.refresh()
+
+        # Remove Certificate Exception
+        self.certificates_section.remove_first_certificate_exception()
+        self.assertNotIn(self.user_name, self.certificates_section.last_certificate_exception.text)
+        self.assertNotIn(notes, self.certificates_section.last_certificate_exception.text)
+
     def test_instructor_can_remove_certificate_exception(self):
         """
         Scenario: On the Certificates tab of the Instructor Dashboard, Instructor can remove  added certificate

--- a/lms/static/js/certificates/models/certificate_exception.js
+++ b/lms/static/js/certificates/models/certificate_exception.js
@@ -24,11 +24,9 @@
                     certificate_generated: '',
                     notes: ''
                 },
-
-               url: function() {
-                    return this.get('url');
+                initialize: function (attributes, options) {
+                    this.url = options.url;
                 },
-
                 validate: function(attrs){
                     if (!str.trim(attrs.user_name) && !str.trim(attrs.user_email)) {
                         return gettext('Student username/email field is required and can not be empty. ' +

--- a/lms/static/js/certificates/views/certificate_whitelist_editor.js
+++ b/lms/static/js/certificates/views/certificate_whitelist_editor.js
@@ -44,13 +44,17 @@
                         model = {user_name: user_name};
                     }
 
-                    var certificate_exception = new CertificateExceptionModel({
-                        url: this.collection.url,
-                        user_name: user_name,
-                        user_email: user_email,
-                        notes: notes,
-                        new: true
-                    });
+                    var certificate_exception = new CertificateExceptionModel(
+                        {
+                            user_name: user_name,
+                            user_email: user_email,
+                            notes: notes,
+                            new: true
+                        },
+                        {
+                            url: this.collection.url
+                        }
+                    );
                     var message = "";
 
                     if(this.collection.findWhere(model)){

--- a/lms/static/js/spec/instructor_dashboard/certificates_exception_spec.js
+++ b/lms/static/js/spec/instructor_dashboard/certificates_exception_spec.js
@@ -30,7 +30,7 @@ define([
 
             beforeEach(function() {
 
-                certificate_exception = new CertificateExceptionModel({user_name: 'test_user'});
+                certificate_exception = new CertificateExceptionModel({user_name: 'test_user'}, {url: 'test/url/'});
                 certificate_exception.set({
                     notes: "Test notes"
                 });


### PR DESCRIPTION
### Fix Remove user from exception list

User added in exception list, was not able to remove because `url` was missing. 
[ECOM-4650](https://openedx.atlassian.net/browse/ECOM-4650)
