### PR TITLE
Fixed IntegrityError when making parallel enrollment requests for the same user / course

### DIFF
--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -8,12 +8,13 @@ from nose.plugins.attrib import attr
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.db import IntegrityError
 from course_modes.models import CourseMode
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from util.testing import UrlResetMixin
 from embargo.test_utils import restrict_course
-from student.tests.factories import UserFactory, CourseModeFactory
+from student.tests.factories import UserFactory, CourseModeFactory, CourseEnrollmentFactory
 from student.models import CourseEnrollment, CourseFullError
 from student.roles import (
     CourseInstructorRole,
@@ -281,3 +282,18 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
             params['email_opt_in'] = email_opt_in
 
         return self.client.post(reverse('change_enrollment'), params)
+
+    def test_get_or_create_integrity_error(self):
+        """Verify that get_or_create_enrollment handles IntegrityError."""
+
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
+
+        with patch.object(CourseEnrollment.objects, "get_or_create") as mock_get_or_create:
+            mock_get_or_create.side_effect = IntegrityError
+            enrollment = CourseEnrollment.get_or_create_enrollment(
+                self.user,
+                self.course.id
+            )
+
+        self.assertEqual(enrollment.user, self.user)
+        self.assertEqual(enrollment.course.id, self.course.id)


### PR DESCRIPTION
[ECOM-1730](https://openedx.atlassian.net/browse/ECOM-1730)

Updated method `get_or_create_enrollment` of model student for handling exception `IntegrityError` for concurrent enrollment requests from the same user.

This was previously fixed in [#9691](https://github.com/edx/edx-platform/pull/9691) but was probably mistakenly reverted in massive change [update Django to v1.8.5](https://github.com/edx/edx-platform/commit/6cb62f2697bcca1380854e139857678b2ddc35e0#diff-e2ffffdf6d67c9e0dee5bc10a67eb8bfL964) 

Please review this @jareerahsan @ahsan-ul-haq @awais786 @waheedahmed 
