### PR TITLE
Repair platform API documentation build

### DIFF
--- a/docs/en_us/platform_api/source/conf.py
+++ b/docs/en_us/platform_api/source/conf.py
@@ -154,6 +154,9 @@ MOCK_MODULES = [
     'provider',
     'provider.oauth2',
     'oauth2_provider',
+    'celery.signals',
+    'edx_rest_framework_extensions',
+    'edx_rest_framework_extensions.authentication',
 ]
 
 for mod_name in MOCK_MODULES:

--- a/docs/en_us/platform_api/source/user/accounts.rst
+++ b/docs/en_us/platform_api/source/user/accounts.rst
@@ -17,7 +17,7 @@ tasks.
 Get and Update a User's Account Information
 **********************************************
 
-.. autoclass:: user_api.accounts.views.AccountView
+.. autoclass:: user_api.accounts.views.AccountViewSet
 
 **Example response showing a user's account information**
 


### PR DESCRIPTION
## [DOC-2315](https://openedx.atlassian.net/browse/DOC-2315)

The platform API documentation build was broken by recent changes to the edx-platform repository. Sphinx was failing to import modules and one of the Python classes that we include for its docstring content was renamed. This PR adds Python modules to the list of modules we mock during the build and updates the autoclass class name.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @nedbat 
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica @catong @srpearce 
### Post-review
- [x] Squash commits
