### PR TITLE
Bumping bok-choy to pick up a11y changes

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -142,7 +142,7 @@ django_debug_toolbar==1.3.2
 
 # Used for testing
 before_after==0.1.3
-bok-choy==0.5.2
+bok-choy==0.5.3
 chrono==1.0.2
 coverage==4.0.2
 ddt==0.8.0


### PR DESCRIPTION
Dependency PR: https://github.com/edx/bok-choy/pull/157 (Merged)

This updates the platform to pick up the latest Bok Choy version which includes additional details for developers using the a11y tests.

I've included the "severity" detail (minor, critical, etc.) so developers are aware of the impact of their changes or failures.
## Reviewers
- [x] @benpatterson 
