### PR TITLE
Fixes to #12266

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -104,7 +104,11 @@ source, template_path = Loader(engine).load_template_source(path)
   <script type="text/javascript">
     (function (require) {
       % if settings.REQUIRE_DEBUG:
-        require_module(module_name, class_name);
+          (function (require) {
+              require(['${module_name | n, js_escaped_string}'], function (${class_name | n, decode.utf8}) {
+                  ${caller.body() | n, decode.utf8}
+              });
+          }).call(this, require || RequireJS.require);
       % else:
         ## The "raw" parameter is specified to avoid the URL from being further maninpulated by
         ## static_replace calls (as woudl happen if require_module is used within courseware).


### PR DESCRIPTION
## [ECOM-4672](https://openedx.atlassian.net/browse/ECOM-4672).

Fixed approach with calling `require_module` from `require_module_async`  - didn't quite work in Mako the way I thought it did

[bjacobel-requirejs-sync.sandbox.edx.org](https://bjacobel-requirejs-sync.sandbox.edx.org)

specifically, https://bjacobel-requirejs-sync.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-certificates
## Review
- [x] @andy-armstrong (sorry, know you're on the way to OpenedX, let me know if you don't think you'll be able to get to this)
- [x] @tobz 
## FYI

@adampalay @awais786 @awaisdar001 @adampalay 
