### PR TITLE
Fix overflowing images in forum posts/responses

### DIFF
--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -134,6 +134,10 @@ body.discussion {
         border-radius: 3px;
       }
     }
+
+    img {
+      max-width: 100%;
+    }
   }
 
   .discussion-response .response-body {


### PR DESCRIPTION
### Description

[TNL-4778](https://openedx.atlassian.net/browse/TNL-4778)

Set a maximum width on images appearing in discussion posts and responses.

Before:
![](https://i.bjacobel.com/20160613-970bn.png)

After:
![](https://i.bjacobel.com/20160613-zmms7.png)
### Sandbox
- [x] Build a sandbox for your branch and add a link here

https://bjacobel-dsc-image-overflow.sandbox.edx.org
### Testing

N/A visual testing only
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @cahrens 
- [x] @dianakhuang

FYI: @cahrens
### Post-review
- [ ] Squash commits
