### PR TITLE
0 processes if debugging python tests

### DIFF
--- a/docs/en_us/internal/testing.rst
+++ b/docs/en_us/internal/testing.rst
@@ -211,7 +211,7 @@ To run a single test format the command like this.
 The ``lms`` suite of tests runs concurrently, and with randomized order, by default.
 You can override these by using ``--no-randomize`` to disable randomization,
 and ``--processes=N`` to control how many tests will run concurrently (``0`` will
-disable concurrency). For example:
+disable concurrency, and is required to break when debugging). For example:
 
 ::
     # This will run all tests in the order that they appear in their files, serially


### PR DESCRIPTION
@cpennington @jzoldak 

Continuation of our discussion on https://github.com/edx/edx-platform/pull/12527/files#r66834026. I wasn't aware of this when trying to investigate why breakpoints weren't working, and the documentation didn't mention it.

If there's a better way to phrase this, feel free to suggest it.
