### PR TITLE
Make multiprocessing for unit tests disabled by default

### DIFF
--- a/pavelib/utils/test/suites/nose_suite.py
+++ b/pavelib/utils/test/suites/nose_suite.py
@@ -126,9 +126,8 @@ class SystemTestSuite(NoseTestSuite):
         self.randomize = kwargs.get('randomize', None)
 
         if self.processes is None:
-            # Use one process per core for LMS tests, and no multiprocessing
-            # otherwise.
-            self.processes = -1 if self.root == 'lms' else 0
+            # Unless specified, do not use multiprocessing.
+            self.processes = 0
 
         self.processes = int(self.processes)
 


### PR DESCRIPTION
while we investigate coverage reporting.

@benpatterson @cpennington 
