### PR TITLE
Fix order history page if order doesn't have any product

### DIFF
--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -595,6 +595,29 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, TestCase, ProgramsApiConf
 
         self.assertEqual(order_detail, [])
 
+    def test_order_history_with_no_product(self):
+        response = {
+            'results': [
+                factories.OrderFactory(
+                    lines=[
+                        factories.OrderLineFactory(
+                            product=None
+                        ),
+                        factories.OrderLineFactory(
+                            product=factories.ProductFactory(attribute_values=[factories.ProductAttributeFactory(
+                                name='certificate_type',
+                                value='verified'
+                            )])
+                        )
+                    ]
+                )
+            ]
+        }
+        with mock_get_orders(response=response):
+            order_detail = get_user_orders(self.user)
+
+        self.assertEqual(len(order_detail), 1)
+
 
 @override_settings(SITE_NAME=settings.MICROSITE_LOGISTRATION_HOSTNAME)
 class MicrositeLogistrationTests(TestCase):


### PR DESCRIPTION
While verifying changes for https://github.com/edx/edx-platform/pull/12543 on stage it has been observed that account setting page is broken if product is `Null` in order history lines. So the fix for that has been implemented in this PR. 
