### PR TITLE
AC-455 adding main to PDF books; styling chapters

### DIFF
--- a/lms/static/sass/course/_textbook.scss
+++ b/lms/static/sass/course/_textbook.scss
@@ -27,20 +27,15 @@ div.book-wrapper {
     border-right: none;
     width: 180px;
 
-    ul#booknav {
-      font-size: em(14);
-
-      .chapter-number {
-      }
+    #booknav {
+        list-style: none;
 
       .chapter {
-        float: left;
-        width: 87%;
         line-height: 1.4em;
       }
 
       .page-number {
-        float: right;
+        @include float(right);
         width: 12%;
         font-size: .8em;
         line-height: 2.1em;
@@ -59,7 +54,6 @@ div.book-wrapper {
           @include clearfix();
           padding: 0;
           color: $link-color;
-          cursor: pointer;
 
           &:hover, &:focus {
             background-color: transparent;
@@ -231,6 +225,3 @@ div.book-wrapper {
     }
   }
 }
-
-
-

--- a/lms/templates/static_htmlbook.html
+++ b/lms/templates/static_htmlbook.html
@@ -118,33 +118,34 @@ from openedx.core.djangolib.js_utils import (
 <%include file="/courseware/course_navigation.html" args="active_page='htmltextbook/{0}'.format(book_index)" />
 
     <div id="outerContainer">
-      <div id="mainContainer" class="book-wrapper">
+        <main id="main" aria-label="${_('Content')}" tabindex="-1">
+          <div id="mainContainer" class="book-wrapper">
 
-        %if 'chapters' in textbook:
-        <section aria-label="${_('Textbook Navigation')}" class="book-sidebar">
-          <ul id="booknav" class="treeview-booknav">
-            <%def name="print_entry(entry, index_value)">
-              <li id="htmlchapter-${index_value}">
-                <a class="chapter">
-                  ${entry.get('title')}
-                </a>
-              </li>
-            </%def>
+            %if 'chapters' in textbook:
+            <section aria-label="${_('Textbook Navigation')}" class="book-sidebar">
+              <ul id="booknav" class="treeview-booknav">
+                <%def name="print_entry(entry, index_value)">
+                  <li id="htmlchapter-${index_value}">
+                    <a class="chapter">
+                      ${entry.get('title')}
+                    </a>
+                  </li>
+                </%def>
 
-            %for (index, entry) in enumerate(textbook['chapters']):
-              ${HTML(print_entry(entry, index+1))}
-            % endfor
-          </ul>
-        </section>
-        %endif
+                %for (index, entry) in enumerate(textbook['chapters']):
+                  ${HTML(print_entry(entry, index+1))}
+                % endfor
+              </ul>
+            </section>
+            %endif
 
-        <section id="viewerContainer" class="book">
-          <section class="page">
-            <div id="bookpage" />
-          </section>
-        </section>
-		<span class="idU" style="display:none">${student.id}</span>
-		<span class="idDU" style="display:none">${student.username}</span>
-      </div>
+            <section id="viewerContainer" class="book">
+              <section class="page">
+                <div id="bookpage" />
+              </section>
+            </section>
+    		<span class="idU" style="display:none">${student.id}</span>
+    		<span class="idDU" style="display:none">${student.username}</span>
+          </div>
+      </main>
     </div>
-

--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -26,7 +26,8 @@ $(function(){
 });
 </script>
 
-<div class="book-wrapper">
+<main id="main" aria-label="${_('Content')}" tabindex="-1">
+    <div class="book-wrapper">
     %if 'chapters' in textbook:
     <section class="book-sidebar" aria-label="${_('Textbook Navigation')}">
         <ul id="booknav">
@@ -39,14 +40,15 @@ $(function(){
     </section>
     %endif
 
-<div class="book">
-<iframe
-  title="${current_chapter['title']|h}"
-  id="viewer-frame"
-  src="${request.path}?viewer=true${viewer_params}"
-  width="856"
-  height="1108"
-  frameborder="0"
-  seamless></iframe>
-</div>
-</div>
+    <div class="book">
+    <iframe
+    title="${current_chapter['title']|h}"
+    id="viewer-frame"
+    src="${request.path}?viewer=true${viewer_params}"
+    width="856"
+    height="1108"
+    frameborder="0"
+    seamless></iframe>
+    </div>
+    </div>
+</main>

--- a/lms/templates/staticbook.html
+++ b/lms/templates/staticbook.html
@@ -76,6 +76,7 @@ $("#open_close_accordion a").click(function(){
 <%include file="/courseware/course_navigation.html" args="active_page='textbook/{0}'.format(book_index)" />
 
 <section class="container">
+    <main id="main" aria-label="${_('Content')}" tabindex="-1">
   <div class="book-wrapper">
 
     <section aria-label="${_('Textbook Navigation')}" class="book-sidebar">
@@ -130,4 +131,5 @@ $("#open_close_accordion a").click(function(){
       </section>
     </section>
   </div>
+  </main>
 </section>


### PR DESCRIPTION
# [AC-455](https://openedx.atlassian.net/browse/AC-455)

This work adds a missing `main` element to the PDF/Book viewer templates. It also adjusts the styling of the chapter links resolving [TNL-4309](https://openedx.atlassian.net/browse/TNL-4309).
## Sandbox

https://clrux-ac-455.sandbox.edx.org/courses/course-v1:edX+Test101+course/pdfbook/2/
## Reviewers
- [x] @cahrens (TNL)
- [x] @jaakana (reporter)
