### PR TITLE
AC-472 removing outline from main

### DIFF
--- a/cms/static/sass/_base.scss
+++ b/cms/static/sass/_base.scss
@@ -36,6 +36,11 @@ body, input, button {
   font-family: 'Open Sans', sans-serif;
 }
 
+// we want to hide the outline on the focusable <main> element
+main {
+    outline: none;
+}
+
 a {
   @include transition(color $tmg-f2 ease-in-out 0s);
   text-decoration: none;


### PR DESCRIPTION
# [AC-472](https://openedx.atlassian.net/browse/AC-472)

This quick work removes the outline on `main` focus/click in Studio. This change was already implemented in LMS, but I didn't realize that the `main` addition also updated Studio.
## Sandbox

https://studio-clrux-ac-472.sandbox.edx.org
## Reviewers
- [x] @cahrens (reporter)
