### PR TITLE
Don't hide spans within ui-btn-non class.

### DIFF
--- a/cms/templates/js/certificate-details.underscore
+++ b/cms/templates/js/certificate-details.underscore
@@ -64,7 +64,7 @@
             <button class="edit"><span class="icon fa fa-pencil" aria-hidden="true"></span> <%- gettext("Edit") %></button>
         </li>
         <li class="action action-delete wrapper-delete-button" data-tooltip="<%- gettext('Delete') %>">
-            <button class="delete action-icon"><span class="icon fa fa-trash-o" aria-hidden="true"></span><span><%- gettext("Delete") %></span></button>
+            <button class="delete action-icon" title="<%- gettext('Delete') %>"><span class="icon fa fa-trash-o" aria-hidden="true"></span></button>
         </li>
         <% } %>
     </ul>

--- a/cms/templates/js/content-group-details.underscore
+++ b/cms/templates/js/content-group-details.underscore
@@ -28,11 +28,11 @@
         </li>
         <% if (_.isEmpty(usage)) { %>
             <li class="action action-delete wrapper-delete-button" data-tooltip="<%- gettext('Delete') %>">
-                <button class="delete action-icon"><span class="icon fa fa-trash-o" aria-hidden="true"></span><span><%- gettext("Delete") %></span></button>
+                <button class="delete action-icon" title="<%- gettext('Delete') %>"><span class="icon fa fa-trash-o" aria-hidden="true"></span></button>
             </li>
         <% } else { %>
             <li class="action action-delete wrapper-delete-button" data-tooltip="<%- gettext('Cannot delete when in use by a unit') %>">
-                <button class="delete action-icon is-disabled" aria-disabled="true" disabled="disabled"><span class="icon fa fa-trash-o" aria-hidden="true"></span><span><%- gettext("Delete") %></span></button>
+                <button class="delete action-icon is-disabled" aria-disabled="true" disabled="disabled" title="<%- gettext('Delete') %>"><span class="icon fa fa-trash-o" aria-hidden="true"></span></button>
             </li>
         <% } %>
     </ul>

--- a/cms/templates/js/group-configuration-details.underscore
+++ b/cms/templates/js/group-configuration-details.underscore
@@ -46,11 +46,11 @@
         </li>
         <% if (_.isEmpty(usage)) { %>
             <li class="action action-delete wrapper-delete-button">
-                <button class="delete action-icon"><span class="icon fa fa-trash-o" aria-hidden="true"></span><span><%- gettext("Delete") %></span></button>
+                <button class="delete action-icon" title="<%- gettext('Delete') %>"><span class="icon fa fa-trash-o" aria-hidden="true"></span></button>
             </li>
         <% } else { %>
             <li class="action action-delete wrapper-delete-button" data-tooltip="<%- gettext('Cannot delete when in use by an experiment') %>">
-                <button class="delete action-icon is-disabled" aria-disabled="true" aria-hidden="true"><span class="icon fa fa-trash-o"></span><span><%- gettext("Delete") %></span></button>
+                <button class="delete action-icon is-disabled" aria-disabled="true" aria-hidden="true" title="<%- gettext('Delete') %>"><span class="icon fa fa-trash-o"></span></button>
             </li>
         <% } %>
     </ul>

--- a/cms/templates/js/show-textbook.underscore
+++ b/cms/templates/js/show-textbook.underscore
@@ -40,7 +40,7 @@
         <button class="edit"><%- gettext("Edit") %></button>
     </li>
     <li class="action action-delete">
-        <button class="delete action-icon"><span class="icon fa fa-trash-o" aria-hidden="true"></span><span><%- gettext("Delete") %></span></button>
+        <button class="delete action-icon" title="<%- gettext('Delete') %>"><span class="icon fa fa-trash-o" aria-hidden="true" ></span></button>
     </li>
 </ul>
 

--- a/common/static/sass/_mixins.scss
+++ b/common/static/sass/_mixins.scss
@@ -313,10 +313,6 @@
     background-color: $gray-l1;
     color: $white;
   }
-
-  span {
-    @extend %cont-text-sr;
-  }
 }
 
 // button with no button shell until hover for understated actions


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-4799

@clrux Could you please review this? @ssemenova and I did it together.

Sandbox examples (staff@example.com):
-  https://studio-span.sandbox.edx.org/textbooks/course-v1:DemoX+PERF101+course
- https://studio-span.sandbox.edx.org/course_team/course-v1:DemoX+PERF101+course
- https://studio-span.sandbox.edx.org/group_configurations/course-v1:DemoX+PERF101+course

Here is some additional context--
On stage:
![image](https://cloud.githubusercontent.com/assets/484484/16048949/ee2097c6-3223-11e6-946a-4301b642b91f.png)

With fix:
![image](https://cloud.githubusercontent.com/assets/484484/16048960/f85733ee-3223-11e6-9afc-476a3e074a9a.png)

Previously "Delete" beside the icon was hidden. To keep the behavior the same, we've added sr-only class to the text where this has been impacted. Otherwise, the spacing looks odd in some cases.

It's possible that we didn't find every impacted span, but the worse-case scenario is that text is shown where it was previously hidden. This is obviously less severe than icons and text both being hidden.
