### PR TITLE
Bumping version of a11y custom ruleset

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "underscore.string": "~3.3.4"
   },
   "devDependencies": {
-    "edx-custom-a11y-rules": "0.1.1",
+    "edx-custom-a11y-rules": "0.1.2",
     "pa11y": "3.6.0",
     "pa11y-reporter-1.0-json": "1.0.2",
     "jasmine-core": "^2.4.1",


### PR DESCRIPTION
Dependency: https://github.com/edx/edx-custom-a11y-rules/pull/4 (Merged!)

Bumping the package.json version to pull in the recent additions to our custom a11y rules.
- [x] @benpatterson 

FYI @cptvitamin 
