### PR TITLE
HULL-22 Get platform name via microsite configuration for forgot password page

### DIFF
--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -77,7 +77,7 @@ class LoginSessionView(APIView):
         # Translators: These instructions appear on the login form, immediately
         # below a field meant to hold the user's email address.
         email_instructions = _("The email address you used to register with {platform_name}").format(
-            platform_name=settings.PLATFORM_NAME
+            platform_name=get_themed_value('PLATFORM_NAME', settings.PLATFORM_NAME)
         )
 
         form_desc.add_field(


### PR DESCRIPTION
We need to be able to override the PLATFORM_NAME setting via MICROSITE_CONFIGURATION on the forgot password page.

@mattdrayer @mjfrey 
