### PR TITLE
Fix flakey TextbooksTest

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_textbooks.py
+++ b/common/test/acceptance/tests/studio/test_studio_textbooks.py
@@ -80,6 +80,7 @@ class TextbooksTest(StudioCourseTest):
         self.textbook_view_page.switch_to_pdf_frame(self)
         self.textbook_view_page.a11y_audit.config.set_rules({
             'ignore': [
+                'color-contrast',  # will always fail because pdf.js converts pdf to divs with transparent text
                 'html-lang',  # AC-504
                 'meta-viewport',  # AC-505
                 'skip-link',  # AC-506


### PR DESCRIPTION
### Description

[TNL-4806](https://openedx.atlassian.net/browse/TNL-4806)

In test_studio_textbooks.py, test_pdf_viewer_a11y was occasionally failing because of the color contrast rule. The flakiness stemmed from the switching to the pdf frame - the test waits for the iframe to load, switches to the iframe, then runs the a11y rules, but just because the iframe loaded doesn't necessarily mean the pdf itself has loaded. Because of the way the pdf viewer converts the pdf (turning text blocks into divs), the contents of the pdf were failing the test because the text in the example pdf was too small and light.

The fix includes waiting for an element in the pdf after the iframe has loaded and before the a11y tests are run, and then (because the color contrast rule fails because of the text size of the sample pdf), ignoring the color contrast rule. I could also change the pdf itself to have bigger text so we don't ignore the color contrast rule, but I think that might be a hard problem for someone to solve later down the line if they accidentally change the pdf file and suddenly the test is flakey again. That's also why I didn't make a new ticket for the color-contrast a11y rule like I did for the other ignored rules.
### Sandbox
- [ ] ssemenova.sandbox.edx.org (not necessary because I just changed the test, but it'll be up in about 30 minutes)
### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit shows 0 violations
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @cahrens 
- [ ] Code review: @clrux (I guess? I don't know who else should look at this)
### Post-review
- [ ] Squash commits
