### PR TITLE
Changed refund log level to warning.

### DIFF
--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -1883,7 +1883,7 @@ class CertificateItem(OrderItem):
         try:
             target_cert = target_certs[0]
         except IndexError:
-            log.error(
+            log.warning(
                 u"Matching CertificateItem not found while trying to refund. User %s, Course %s",
                 course_enrollment.user,
                 course_enrollment.course_id,


### PR DESCRIPTION
[ECOM-2378](https://openedx.atlassian.net/browse/ECOM-2378)

If an order is present in Oscar but not shoppingcart, the LMS logs a message at the ERROR level. However, these log messages don't correspond to something breaking in the system.

Level changed to WARNING.
