### PR TITLE
Add VAL "Duplicate" status

### DIFF
--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -44,6 +44,9 @@ class StatusDisplayStrings(object):
     _COMPLETE = ugettext_noop("Ready")
     # Translators: This is the status for a video that the servers have failed to process
     _FAILED = ugettext_noop("Failed")
+    # Translators: This is the status for a video which has failed
+    # due to being flagged as a duplicate by an external or internal CMS
+    _DUPLICATE = ugettext_noop("Failed Duplicate")
     # Translators: This is the status for a video for which an invalid
     # processing token was provided in the course settings
     _INVALID_TOKEN = ugettext_noop("Invalid Token")
@@ -61,6 +64,7 @@ class StatusDisplayStrings(object):
         "file_complete": _COMPLETE,
         "file_corrupt": _FAILED,
         "pipeline_error": _FAILED,
+        "duplicate": _DUPLICATE,
         "invalid_token": _INVALID_TOKEN,
         "imported": _IMPORTED,
     }
@@ -311,9 +315,9 @@ def videos_post(course, request):
         edx_video_id = unicode(uuid4())
         key = storage_service_key(bucket, file_name=edx_video_id)
         for metadata_name, value in [
-            ("course_video_upload_token", course_video_upload_token),
-            ("client_video_id", file_name),
-            ("course_key", unicode(course.id)),
+                ("course_video_upload_token", course_video_upload_token),
+                ("client_video_id", file_name),
+                ("course_key", unicode(course.id)),
         ]:
             key.set_metadata(metadata_name, value)
         upload_url = key.generate_url(


### PR DESCRIPTION
Added duplicate video failed status for VAL. Common use case for external CMS failures.
