### PR TITLE
Remove improper scss syntax.

### DIFF
--- a/lms/static/sass/views/_shoppingcart.scss
+++ b/lms/static/sass/views/_shoppingcart.scss
@@ -896,7 +896,6 @@ $light-border: 1px solid $gray-l5;
     padding: $baseline;
 
     h2 {
-      @xtend %t-title5;
       @extend %t-strong;
       margin-bottom: 0;
       color: $dark-gray1;


### PR DESCRIPTION
This was a typo that was missed, and is not resulting in any styling.

Removing it is a no-op.

The original committer does not work in this code anymore, and
it is old enough such that changing it would be more disruptive.
