### PR TITLE
Account registration and activation text string revisions

### DIFF
--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -235,7 +235,7 @@ class AuthTestCase(ContentStoreTestCase):
 
         # check the the HTML has links to the right login page. Note that this is merely a content
         # check and thus could be fragile should the wording change on this page
-        expected = 'You can now <a href="' + reverse('login') + '">login</a>.'
+        expected = 'You can now <a href="' + reverse('login') + '">sign in</a>.'
         self.assertIn(expected, resp.content)
 
     def test_private_pages_auth(self):

--- a/cms/templates/registration/activation_complete.html
+++ b/cms/templates/registration/activation_complete.html
@@ -25,7 +25,7 @@ from django.core.urlresolvers import reverse
       %if user_logged_in:
         ${_("Visit your {link_start}dashboard{link_end} to see your courses.").format(link_start='<a href="/">', link_end='</a>')}
       %else:
-        ${_("You can now {link_start}login{link_end}.").format(link_start='<a href="{url}">'.format(url=reverse('login')), link_end='</a>')}
+        ${_("You can now {link_start}sign in{link_end}.").format(link_start='<a href="{url}">'.format(url=reverse('login')), link_end='</a>')}
       %endif
     </p>
   </section>

--- a/cms/templates/registration/reg_complete.html
+++ b/cms/templates/registration/reg_complete.html
@@ -1,3 +1,3 @@
 <%! from django.utils.translation import ugettext as _ %>
 <h1>Check your email</h1>
-<p>${_("An activation link has been sent to {email}, along with instructions for activating your account.").format(email=email)}</p>
+<p>${_("We've sent an email message to {email} with instructions for activating your account.").format(email=email)}</p>

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -75,10 +75,10 @@ class ActivationEmailTests(TestCase):
     # Text fragments we expect in the body of an email
     # sent from an OpenEdX installation.
     OPENEDX_FRAGMENTS = [
-        "Thank you for signing up for {platform}.".format(platform=settings.PLATFORM_NAME),
+        "Thank you for creating an account with {platform}!".format(platform=settings.PLATFORM_NAME),
         "http://edx.org/activate/",
         (
-            "if you require assistance, check the help section of the "
+            "Check the help section of the "
             "{platform} website".format(platform=settings.PLATFORM_NAME)
         )
     ]
@@ -86,10 +86,10 @@ class ActivationEmailTests(TestCase):
     # Text fragments we expect in the body of an email
     # sent from an EdX-controlled domain.
     EDX_DOMAIN_FRAGMENTS = [
-        "Thank you for signing up for {platform}".format(platform=settings.PLATFORM_NAME),
+        "Thank you for creating an account with {platform}!".format(platform=settings.PLATFORM_NAME),
         "http://edx.org/activate/",
         "https://www.edx.org/contact-us",
-        "This email was automatically sent by edx.org"
+        "This email message was automatically sent by edx.org"
     ]
 
     def setUp(self):

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -126,7 +126,7 @@ class LoginTest(CacheIsolationTestCase):
         # Should now be unable to login
         response, mock_audit_log = self._login_response('test@edx.org', 'test_password')
         self._assert_response(response, success=False,
-                              value="This account has not been activated")
+                              value="Before you sign in, you need to activate your account")
         self._assert_audit_log(mock_audit_log, 'warning', [u'Login failed', u'Account not active for user'])
 
     @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
@@ -138,7 +138,7 @@ class LoginTest(CacheIsolationTestCase):
         # Should now be unable to login
         response, mock_audit_log = self._login_response('test@edx.org', 'test_password')
         self._assert_response(response, success=False,
-                              value="This account has not been activated")
+                              value="Before you sign in, you need to activate your account")
         self._assert_audit_log(mock_audit_log, 'warning', [u'Login failed', u'Account not active for user'])
         self._assert_not_in_audit_log(mock_audit_log, 'warning', [u'test'])
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1316,8 +1316,8 @@ def login_user(request, error=""):  # pylint: disable=too-many-statements,unused
         AUDIT_LOG.warning(u"Login failed - Account not active for user {0}, resending activation".format(username))
 
     reactivation_email_for_user(user)
-    not_activated_msg = _("This account has not been activated. We have sent another activation "
-                          "message. Please check your email for the activation instructions.")
+    not_activated_msg = _("Before you sign in, you need to activate your account. We have sent you an "
+                          "email message with instructions for activating your account.")
     return JsonResponse({
         "success": False,
         "value": not_activated_msg,

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -361,7 +361,7 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         self.assertEqual(200, response.status_code)  # Yes, it's a 200 even though it's a failure.
         payload = json.loads(response.content)
         self.assertFalse(payload.get('success'))
-        self.assertIn('This account has not been activated', payload.get('value'))
+        self.assertIn('Before you sign in, you need to activate your account', payload.get('value'))
 
     def assert_json_failure_response_is_missing_social_auth(self, response):
         """Asserts failure on /login for missing social auth looks right."""

--- a/lms/templates/emails/activation_email.txt
+++ b/lms/templates/emails/activation_email.txt
@@ -1,12 +1,13 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from openedx.core.djangoapps.theming.helpers import get_value as get_themed_value %>
-${_("Thank you for signing up for {platform_name}.").format(
+${_("Thank you for creating an account with {platform_name}!").format(
     platform_name=get_themed_value('PLATFORM_NAME', settings.PLATFORM_NAME)
 )}
 
-${_("Change your life and start learning today by activating your "
-    "{platform_name} account. Click on the link below or copy and "
-    "paste it into your browser's address bar.").format(
+${_("There's just one more step before you can enroll in a course: "
+    "you need to activate your {platform_name} account. To activate "
+    "your account, click the following link. If that doesn't work, "
+    "copy and paste the link into your browser's address bar.").format(
         platform_name=get_themed_value('PLATFORM_NAME', settings.PLATFORM_NAME)
     )}
 
@@ -15,7 +16,7 @@ ${_("Change your life and start learning today by activating your "
 % else:
   http://${ site }/activate/${ key }
 % endif
-${_("If you didn't request this, you don't need to do anything; you won't "
-      "receive any more email from us. Please do not reply to this e-mail; "
-      "if you require assistance, check the help section of the "
+${_("If you didn't create an account, you don't need to do anything; you "
+      "won't receive any more email from us. If you need assistance, please "
+      "do not reply to this email message. Check the help section of the "
       "{platform_name} website.").format(platform_name=get_themed_value('PLATFORM_NAME', settings.PLATFORM_NAME))}

--- a/lms/templates/login-sidebar.html
+++ b/lms/templates/login-sidebar.html
@@ -1,5 +1,5 @@
-<%! 
-from django.utils.translation import ugettext as _ 
+<%!
+from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 %>
 
@@ -22,7 +22,7 @@ from django.core.urlresolvers import reverse
   ## Disable help unless the FAQ marketing link is enabled
   % if settings.MKTG_URL_LINK_MAP.get('FAQ'):
     <h3>${_("Need Help?")}</h3>
-    <p>${_("Looking for help in logging in or with your {platform_name} account?").format(platform_name=platform_name)}
+    <p>${_("Looking for help signing in or with your {platform_name} account?").format(platform_name=platform_name)}
     <a href="${marketing_link('FAQ')}">
         ${_("View our help section for answers to commonly asked questions.")}
     </a></p>

--- a/lms/templates/register-sidebar.html
+++ b/lms/templates/register-sidebar.html
@@ -33,16 +33,16 @@ from django.core.urlresolvers import reverse
 
 <div class="cta cta-nextsteps">
   <h3>${_("Next Steps")}</h3>
-    <p>${_("As part of joining {platform_name}, you will receive an activation email.  You must click on the activation link to complete the process.  Don't see the email?  Check your spam folder and mark {platform_name} emails as 'not spam'.  At {platform_name}, we communicate mostly through email.").format(platform_name=platform_name)}</p>
+    <p>${_("As part of joining {platform_name}, you will receive an email message with instructions for activating your account. Don't see the email? Check your spam folder and mark {platform_name} emails as 'not spam'. At {platform_name}, we communicate mostly through email.").format(platform_name=platform_name)}</p>
 </div>
 
 % if settings.MKTG_URL_LINK_MAP.get('FAQ'):
   <div class="cta cta-help">
     <h3>${_("Need Help?")}</h3>
-    <p>${_("Need help in registering with {platform_name}?").format(platform_name=platform_name)}
+    <p>${_("Need help registering with {platform_name}?").format(platform_name=platform_name)}
       <a href="${marketing_link('FAQ')}">
           ${_("View our FAQs for answers to commonly asked questions.")}
       </a>
-      ${_("Once registered, most questions can be answered in the course specific discussion forums or through the FAQs.")}</p>
+      ${_("You can find the answers to most of your questions in our list of FAQs. After you enroll in a course, you can also find answers in the course discussions.")}</p>
   </div>
 % endif

--- a/lms/templates/registration/activate_account_notice.html
+++ b/lms/templates/registration/activate_account_notice.html
@@ -6,12 +6,16 @@ from openedx.core.djangolib.markup import HTML, Text
 <div class="wrapper-msg urgency-high">
     <div class="msg">
         <div class="msg-content">
-            <h2 class="title">${_("Thanks for Registering!")}</h2>
+            <h2 class="title">${_("You're almost there!")}</h2>
             <div class="copy">
                 <p class='activation-message'>${Text(_(
-                        "You've successfully created an account on {platform_name}. We've sent an account "
-                        "activation message to {email_start}{email}{email_end}. To activate your account and start enrolling in "
-                        "courses, click the link in the message."
+                        "There's just one more step: Before you "
+                        "enroll in a course, you need to activate "
+                        "your account. We've sent an email message to "
+                        "{email_start}{email}{email_end} with "
+                        "instructions for activating your account. If "
+                        "you don't receive this message, check your "
+                        "spam folder."
                         )).format(email_start=HTML("<strong>"),
                                   email_end=HTML("</strong>"),
                                   email=email,

--- a/lms/templates/registration/activation_complete.html
+++ b/lms/templates/registration/activation_complete.html
@@ -11,9 +11,9 @@ from openedx.core.djangolib.markup import HTML, Text
 
   <section class="message">
     %if not already_active:
-      <h1 class="valid">${_("Activation Complete!")}</h1>
+      <h1 class="valid">${_("Account Activated")}</h1>
     %else:
-      <h1>${_("Account already active!")}</h1>
+      <h1>${_("Account already active")}</h1>
     %endif
     <hr class="horizontal-divider">
 
@@ -28,7 +28,7 @@ from openedx.core.djangolib.markup import HTML, Text
         ${Text(_("Visit your {link_start}dashboard{link_end} to see your courses.")).format(
             link_start=HTML('<a href="{url}">').format(url=reverse('dashboard')), link_end=HTML('</a>'))}
       %else:
-        ${Text(_("You can now {link_start}log in{link_end}.")).format(
+        ${Text(_("You can now {link_start}sign in{link_end}.")).format(
             link_start=HTML('<a href="{url}">').format(url=reverse('signin_user')), link_end=HTML('</a>'))}
       %endif
     </p>

--- a/lms/templates/registration/activation_invalid.html
+++ b/lms/templates/registration/activation_invalid.html
@@ -13,16 +13,15 @@ from openedx.core.djangolib.markup import HTML, Text
     <h1 class="invalid">${_("Activation Invalid")}</h1>
     <hr class="horizontal-divider">
 
-    <p>${Text(_('Something went wrong. Check to make sure the URL you went to was '
-                'correct -- e-mail programs will sometimes split it into two '
-                'lines. If you still have issues, e-mail us to let us know what happened '
-                'at {email_start}{email}{email_end}.')).format(
+    <p>${Text(_("Something went wrong. Email programs sometimes split URLs "
+                "into two lines, so make sure the URL you're using is " "formatted correctly. If you still have issues, send us "
+                "an email message at " "{email_start}{email}{email_end}.")).format(
 		    email_start=HTML('<a href="mailto:{}">').format(settings.BUGS_EMAIL),
 		    email=settings.BUGS_EMAIL,
 		    email_end=HTML('</a>')
 		)}</p>
 
-    <p>${Text(_('Or you can go back to the {link_start}home page{link_end}.')).format(
+    <p>${Text(_('Return to the {link_start}home page{link_end}.')).format(
            link_start=HTML('<a href="/">'), link_end=HTML('</a>'))}</p>
   </section>
 </section>

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1472,7 +1472,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
         self.assertEqual(sent_email.to, [self.EMAIL])
         self.assertEqual(sent_email.subject, "Activate Your edX Account")
         self.assertIn(
-            u"activating your {platform} account".format(platform=settings.PLATFORM_NAME),
+            u"you need to activate your {platform} account".format(platform=settings.PLATFORM_NAME),
             sent_email.body
         )
 

--- a/themes/edx.org/lms/templates/emails/activation_email.txt
+++ b/themes/edx.org/lms/templates/emails/activation_email.txt
@@ -1,9 +1,9 @@
 <%! from django.utils.translation import ugettext as _ %>
-${_("Thank you for signing up for {platform_name}.").format(platform_name=settings.PLATFORM_NAME)}
-
-${_("Change your life and start learning today by activating your "
-    "{platform_name} account. Click on the link below or copy and "
-    "paste it into your browser's address bar.").format(
+${_("Thank you for creating an account with {platform_name}!").format(platform_name=settings.PLATFORM_NAME)}
+"There’s just one more step before you can enroll in a course: "
+    "You need to activate your {platform_name} account. To activate "
+    "your account, click the following link. If that doesn't work, "
+    "copy and paste the link into your browser's address bar.").format(
       platform_name=settings.PLATFORM_NAME
     )}
 
@@ -13,12 +13,12 @@ ${_("Change your life and start learning today by activating your "
   http://${ site }/activate/${ key }
 % endif
 
-${_("After you activate your account, you can sign up for "
-    "and take any of the hundreds of courses {platform_name} offers."
+${_("After you activate your account, you can take "
+    "any of the hundreds of courses {platform_name} "
+    "offers. You will receive occasional email "
+    "messages from {platform_name} about new courses "
+    "or other information."
   ).format(platform_name=settings.PLATFORM_NAME)}
-
-${_("Once you have activated your account, edX will send you email "
-    "from time to time about new courses or other information.")}
 
 ${_("If you need help, please use our web form at "
     "{contact_us_url}, email {info_email_address}, "
@@ -35,8 +35,9 @@ ${_("We hope you enjoy learning with {platform_name}!").format(
 
 ${_("The {platform_name} Team").format(platform_name=settings.PLATFORM_NAME)}
 
-${_("This email was automatically sent by {site_name} because someone "
-      "attempted to create an {platform_name} account using this email address."
+${_("This email message was automatically sent by {site_name} because "
+     "someone attempted to create an account on {platform_name} using "
+     "this email address."
     ).format(
       site_name=settings.SITE_NAME,
       platform_name=settings.PLATFORM_NAME


### PR DESCRIPTION
## [DOC-2361](https://openedx.atlassian.net/browse/DOC-2361)

This PR updates several UI text strings to clarify the user registration and account activation workflow per user feedback. (For background, see DOC-2361.)
### Reviewers
- [x] Subject matter expert: @edx/ecommerce  
- [ ] Subject matter expert: @jsubramanian or @(laurenholliday - her GH username doesn't seem to be listed)
