### PR TITLE
Use the latest version of the transifex client

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -129,7 +129,7 @@ sphinx_rtd_theme==0.1.5
 
 # Used for Internationalization and localization
 Babel==1.3
-transifex-client==0.11b3
+transifex-client==0.12.1
 
 # Ip network support for Embargo feature
 ipaddr==2.1.11


### PR DESCRIPTION
I got an email from Transifex that said, "Yo dawg, we noticed you're using an old version of the client. Upgrade." (not quite like that, but basically).  This upgrades us to the latest version on PyPI. I made this week's release strings with the new version so it seems to work. ¯\_(ツ)_/¯
