### PR TITLE
Got rid of aria-disabled states 

### DIFF
--- a/cms/templates/js/content-group-details.underscore
+++ b/cms/templates/js/content-group-details.underscore
@@ -32,7 +32,7 @@
             </li>
         <% } else { %>
             <li class="action action-delete wrapper-delete-button" data-tooltip="<%- gettext('Cannot delete when in use by a unit') %>">
-                <button class="delete action-icon is-disabled" aria-disabled="true" disabled="disabled" title="<%- gettext('Delete') %>"><span class="icon fa fa-trash-o" aria-hidden="true"></span></button>
+                <button class="delete action-icon is-disabled" disabled="disabled" title="<%- gettext('Delete') %>"><span class="icon fa fa-trash-o" aria-hidden="true"></span></button>
             </li>
         <% } %>
     </ul>

--- a/cms/templates/js/group-configuration-details.underscore
+++ b/cms/templates/js/group-configuration-details.underscore
@@ -50,7 +50,7 @@
             </li>
         <% } else { %>
             <li class="action action-delete wrapper-delete-button" data-tooltip="<%- gettext('Cannot delete when in use by an experiment') %>">
-                <button class="delete action-icon is-disabled" aria-disabled="true" aria-hidden="true" title="<%- gettext('Delete') %>"><span class="icon fa fa-trash-o"></span></button>
+                <button class="delete action-icon is-disabled" disabled="disabled" title="<%- gettext('Delete') %>"><span class="icon fa fa-trash-o" aria-hidden="true"></span></button>
             </li>
         <% } %>
     </ul>


### PR DESCRIPTION
### Description

[TNL-4805](https://openedx.atlassian.net/browse/TNL-4805)

Removed aria-disabled in a few places, based on [this PR](https://github.com/edx/edx-platform/pull/12747)
### Sandbox
- [ ] ssemenovadisabledstates.sandbox.edx.org
### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit shows 0 violations
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @clrux 
- [x] Code review: @cahrens 
### Post-review
- [ ] Squash commits
