### PR TITLE
Add a third fixed case where images could overflow (refs #12735)

### DIFF
--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -134,10 +134,6 @@ body.discussion {
         border-radius: 3px;
       }
     }
-
-    img {
-      max-width: 100%;
-    }
   }
 
   .discussion-response .response-body {
@@ -205,5 +201,12 @@ body.view-in-course .discussion-article {
     &:hover, &:focus {
       border-color: #222;
     }
+  }
+}
+
+.thread-wrapper,
+.forum-new-post-form {
+  img {
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
[TNL-4839](https://openedx.atlassian.net/browse/TNL-4839)
#12735 fixed two cases where images could overflow the discussions layout, but missed the third case: images that were in the preview editor. This fixes all three.

Sandbox: https://bjacobel-dsc-image-overflow.sandbox.edx.org (coming online)

Reviewers:
- [x] @andy-armstrong 
- [x] @mdinino 

FYI @raeeschachar 
