### PR TITLE
[PERF-341] Don't rewrite XBlock resource URLs.

### DIFF
--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -13,6 +13,7 @@ from xmodule.contentstore.content import StaticContent
 from opaque_keys.edx.locator import AssetLocator
 
 log = logging.getLogger(__name__)
+XBLOCK_STATIC_RESOURCE_PREFIX = '/static/xblock'
 
 
 def _url_replace_regex(prefix):
@@ -109,6 +110,13 @@ def process_static_urls(text, replacement_function, data_dir=None):
         prefix = match.group('prefix')
         quote = match.group('quote')
         rest = match.group('rest')
+
+        # Don't rewrite XBlock resource links.  Probably wasn't a good idea that /static
+        # works for actual static assets and for magical course asset URLs....
+        full_url = prefix + rest
+        if full_url.startswith(XBLOCK_STATIC_RESOURCE_PREFIX):
+            return original
+
         return replacement_function(original, prefix, quote, rest)
 
     return re.sub(

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -196,6 +196,21 @@ def test_regex():
         assert_false(re.match(regex, s))
 
 
+@patch('static_replace.staticfiles_storage', autospec=True)
+@patch('static_replace.modulestore', autospec=True)
+def test_static_url_with_xblock_resource(mock_modulestore, mock_storage):
+    """
+    Make sure that for URLs with XBlock resource URL, which start with /static/,
+    we don't rewrite them.
+    """
+    mock_storage.exists.return_value = False
+    mock_modulestore.return_value = Mock(MongoModuleStore)
+
+    pre_text = 'EMBED src ="/static/xblock/resources/babys_first.lil_xblock/public/images/pacifier.png"'
+    post_text = pre_text
+    assert_equals(post_text, replace_static_urls(pre_text, DATA_DIRECTORY, COURSE_KEY))
+
+
 @ddt.ddt
 class CanonicalContentTest(SharedModuleStoreTestCase):
     """


### PR DESCRIPTION
For XBlocks that used their static/public resources in the rendered output -- for example, a link to a bundled image -- those URLs would be treated as course assets using the '/static/' prefix trick, and thus, rewritten.  These rewritten URLs don't work because they aren't course assets.

This fix simply ignores any URLs which have the XBlock resource prefix (/static/xblock) and continues on.
