### PR TITLE
TNL 4141

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -190,7 +190,7 @@ class LoncapaResponse(object):
 
         for prop in self.required_attributes:
             prop_value = xml.get(prop)
-            if prop_value and isinstance(prop_value, str):
+            if prop_value: # Stripping off the empty strings
                 prop_value = prop_value.strip()
             if not prop_value:
                 msg = "Error in problem specification: %s missing required attribute %s" % (

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -189,7 +189,10 @@ class LoncapaResponse(object):
             raise LoncapaProblemError(msg)
 
         for prop in self.required_attributes:
-            if not xml.get(prop):
+            prop_value = xml.get(prop)
+            if prop_value and isinstance(prop_value, str):
+                prop_value = prop_value.strip()
+            if not prop_value:
                 msg = "Error in problem specification: %s missing required attribute %s" % (
                     unicode(self), prop)
                 msg += "\nSee XML source line %s" % getattr(

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -946,12 +946,12 @@ class StringResponseTest(ResponseTest):  # pylint: disable=missing-docstring
         hint = correct_map.get_hint('1_2_1')
         self.assertEqual(hint, self._get_random_number_result(problem.seed))
 
-    def test_empty_answer_graded_as_incorrect(self):
+    def test_empty_answer_problem_creation_not_allowed(self):
         """
-        Tests that problem should be graded incorrect if blank space is chosen as answer
+        Tests that empty answer string is not allowed to create a problem
         """
-        problem = self.build_problem(answer=" ", case_sensitive=False, regexp=True)
-        self.assert_grade(problem, u" ", "incorrect")
+        with self.assertRaises(LoncapaProblemError):
+            self.build_problem(answer=" ", case_sensitive=False, regexp=True)
 
 
 class CodeResponseTest(ResponseTest):  # pylint: disable=missing-docstring


### PR DESCRIPTION
### Description

[TNL-4141](https://openedx.atlassian.net/browse/TNL-4141)

Problem was when we added a problem with
empty string as an answer it created the problem instead of throwing an excpetion

A test added to check that and exception is thrown when a problem is
being created with empty string as an answer.

A test is removed which used to test that problem should be graded incorrect if blank space is chosen as answer.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @ayub-khan
- [x] Code review: @Qubad786
- [ ] FYI: @adampalay 
### Post-review
- [ ] Squash commits
