### PR TITLE
Fix `bulk_change_enrollment` command to emit event

### DIFF
--- a/common/djangoapps/student/management/tests/test_bulk_change_enrollment.py
+++ b/common/djangoapps/student/management/tests/test_bulk_change_enrollment.py
@@ -2,9 +2,10 @@
 import ddt
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from mock import patch, call
 
 from student.tests.factories import UserFactory, CourseModeFactory, CourseEnrollmentFactory
-from student.models import CourseEnrollment
+from student.models import CourseEnrollment, EVENT_NAME_ENROLLMENT_MODE_CHANGED
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -18,9 +19,10 @@ class BulkChangeEnrollmentTests(SharedModuleStoreTestCase):
         self.course = CourseFactory.create()
         self.users = UserFactory.create_batch(5)
 
+    @patch('student.models.tracker')
     @ddt.data(('audit', 'honor'), ('honor', 'audit'))
     @ddt.unpack
-    def test_bulk_convert(self, from_mode, to_mode):
+    def test_bulk_convert(self, from_mode, to_mode, mock_tracker):
         """Verify that enrollments are changed correctly."""
         self._enroll_users(from_mode)
         CourseModeFactory(course_id=self.course.id, mode_slug=to_mode)
@@ -40,6 +42,16 @@ class BulkChangeEnrollmentTests(SharedModuleStoreTestCase):
         # raise CourseEnrollment.DoesNotExist
         for user in self.users:
             CourseEnrollment.objects.get(mode=to_mode, course_id=self.course.id, user=user)
+
+            # Confirm the analytics event was emitted.
+            mock_tracker.emit.assert_has_calls(  # pylint: disable=maybe-no-member
+                [
+                    call(
+                        EVENT_NAME_ENROLLMENT_MODE_CHANGED,
+                        {'course_id': unicode(self.course.id), 'user_id': user.id, 'mode': to_mode}
+                    ),
+                ]
+            )
 
     def test_without_commit(self):
         """Verify that nothing happens when the `commit` flag is not given."""


### PR DESCRIPTION
### Bulk_change_enrollment mgmt command does not emit tracking events

`bulk_change_enrollment` management command is not emitting tracking events. 

[ECOM-4775](https://openedx.atlassian.net/browse/ECOM-4775)
