### PR TITLE
Upgrade edx-oauth2-provider to v1.1.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -43,7 +43,7 @@ edx-drf-extensions==0.5.1
 edx-lint==0.4.3
 edx-django-oauth2-provider==1.1.1
 edx-django-sites-extensions==2.0.1
-edx-oauth2-provider==1.1.1
+edx-oauth2-provider==1.1.2
 edx-opaque-keys==0.2.1
 edx-organizations==0.4.1
 edx-rest-api-client==1.2.1


### PR DESCRIPTION
@clintonb Is there anywhere else this needs to be bumped?

@adampalay 
After this merges, our side of the hotfix should be ready to go.
