### PR TITLE
Add back and fix missing discussion Jasmine tests

### DIFF
--- a/common/static/common/js/discussion/discussion.js
+++ b/common/static/common/js/discussion/discussion.js
@@ -82,10 +82,10 @@
             Discussion.prototype.retrieveAnotherPage = function(mode, options, sort_options, error) {
                 var data, url,
                     self = this;
-                if (options === null) {
+                if (!options) {
                     options = {};
                 }
-                if (sort_options === null) {
+                if (!sort_options) {
                     sort_options = {};
                 }
                 data = {

--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -30,7 +30,7 @@
 
         DiscussionUtil.isStaff = function(userId) {
             var staff;
-            if (userId === null) {
+            if (_.isUndefined(userId)) {
                 userId = this.user ? this.user.id : void 0;
             }
             staff = _.union(this.roleIds.Moderator, this.roleIds.Administrator);
@@ -39,7 +39,7 @@
 
         DiscussionUtil.isTA = function(userId) {
             var ta;
-            if (userId === null) {
+            if (_.isUndefined(userId)) {
                 userId = this.user ? this.user.id : void 0;
             }
             ta = _.union(this.roleIds['Community TA']);

--- a/common/static/karma_common.conf.js
+++ b/common/static/karma_common.conf.js
@@ -41,7 +41,9 @@ var options = {
 
         {pattern: 'js/vendor/jasmine-imagediff.js', included: true},
         {pattern: 'common/js/spec_helpers/jasmine-extensions.js', included: true},
-        {pattern: 'common/js/spec_helpers/jasmine-waituntil.js', included: true}
+        {pattern: 'common/js/spec_helpers/jasmine-waituntil.js', included: true},
+        {pattern: 'common/js/spec_helpers/discussion_spec_helper.js', included: true},
+        {pattern: 'common/js/spec/discussion/view/discussion_view_spec_helper.js', included: true}
     ],
 
     libraryFiles: [
@@ -53,6 +55,7 @@ var options = {
         {pattern: 'coffee/src/**/*.js', included: true},
         {pattern: 'common/js/xblock/core.js', included: true},
         {pattern: 'common/js/xblock/runtime.v1.js', included: true},
+        {pattern: 'common/js/discussion/**/*.js', included: true},
         {pattern: 'js/capa/src/**/*.js', included: true},
         {pattern: 'js/src/**/*.js', included: true}
     ],
@@ -60,6 +63,7 @@ var options = {
     specFiles: [
         {pattern: 'coffee/spec/**/*.js', included: true},
         {pattern: 'common/js/spec/xblock/*.js', included: true},
+        {pattern: 'common/js/spec/discussion/**/*spec.js', included: true},
         {pattern: 'js/**/*spec.js', included: true}
     ],
 


### PR DESCRIPTION
This change puts back the missing discussion Jasmine tests that got lost in the CoffeeScript conversion. It also fixes a couple of places in the code where CoffeeScript was using `==` to perform comparisons, and then in the upgrade they were changed to `===`. Unfortunately that behavior is different for undefined values, which compare true with `== null` but false with `=== null`.

@bjacobel @e-kolpakov please review.

FYI @dianakhuang @benpatterson 
