### PR TITLE
removes text value from span that is intended only to receive focus

### DIFF
--- a/lms/static/js/edxnotes/plugins/accessibility.js
+++ b/lms/static/js/edxnotes/plugins/accessibility.js
@@ -48,8 +48,7 @@ define(['jquery', 'underscore', 'annotator_1.2.9'], function ($, _, Annotator) {
         addFocusGrabber: function () {
             this.focusGrabber = $('<span />', {
                 'class': 'sr edx-notes-focus-grabber',
-                'tabindex': '-1',
-                'text': gettext('Focus grabber')
+                'tabindex': '-1'
             });
             this.annotator.wrapper.before(this.focusGrabber);
         },

--- a/lms/static/js/edxnotes/plugins/accessibility.js
+++ b/lms/static/js/edxnotes/plugins/accessibility.js
@@ -47,7 +47,7 @@ define(['jquery', 'underscore', 'annotator_1.2.9'], function ($, _, Annotator) {
 
         addFocusGrabber: function () {
             this.focusGrabber = $('<span />', {
-                'class': 'sr edx-notes-focus-grabber',
+                'class': 'edx-notes-focus-grabber',
                 'tabindex': '-1'
             });
             this.annotator.wrapper.before(this.focusGrabber);


### PR DESCRIPTION
When Student Notes are enabled, screen reader users report their screen reader saying "Focus grabber".  Upon further investigation, a span with a tabindex of -1 was found, the purpose of which was to receive focus from a script to properly manage focus.  This use case is legitimate.  However, the span should not contain any text content.  I believe this was just a misunderstanding on the author's part.
