### PR TITLE
Fix TNL-4392

### DIFF
--- a/common/static/common/js/spec/discussion/view/thread_response_show_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/thread_response_show_view_spec.js
@@ -16,6 +16,7 @@
                 body: "this is a comment",
                 created_at: "2013-04-03T20:08:39Z",
                 endorsed: false,
+                endorsement: {},
                 abuse_flaggers: [],
                 votes: {
                     up_count: 42
@@ -132,7 +133,12 @@
             this.view.$(".action-answer").click();
             expect(this.view.$(".posted-details").text()).toMatch("marked as answer");
             this.view.$(".action-answer").click();
-            return expect(this.view.$(".posted-details").text()).not.toMatch("marked as answer");
+            expect(this.view.$(".posted-details").text()).not.toMatch("marked as answer");
+
+            // Previously the endorsement state would revert after a page load due to a bug in the template
+            this.view.render();
+            expect(this.view.$(".posted-details").text()).not.toMatch("marked as answer");
+
         });
         it("allows a moderator to mark an answer in a question thread", function() {
             var endorseButton;

--- a/common/static/common/templates/discussion/thread-response-show.underscore
+++ b/common/static/common/templates/discussion/thread-response-show.underscore
@@ -3,7 +3,7 @@
     <%= author_display %>
     <p class="posted-details">
         <span class="timeago" title="<%= created_at %>"><%= created_at %></span>
-        <% if (obj.endorsement) { %>
+        <% if (obj.endorsement && obj.endorsed) { %>
             -
             <%
             var fmt = null;


### PR DESCRIPTION
### Description

[TNL-4392](https://openedx.atlassian.net/browse/TNL-4392)

Fixes issue where discussion responses that were marked as answer ("endorsed") then un-marked as answer would retain the "marked as answer" text after the page was reloaded.
### Sandbox
- [x] Build a sandbox for your branch and add a link here

https://bjacobel-endorsed.sandbox.edx.org
### Testing
- ~~i18n~~ N/A
- ~~RTL~~ N/A
- [x] safecommit shows 0 violations
- [x] Unit, integration, acceptance tests as appropriate
- ~~Analytics~~ N/A
- ~~Performance~~ N/A
- ~~Database migrations are backwards-compatible~~ N/A
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @dianakhuang 
- [ ] Code review: @robrap 
- [x] Code review: @andy-armstrong 
- [ ] Product review: @marcotuts 

~~FYI: @andy-armstrong (not marking you as reviewer because you'll be out next week)~~
### Post-review
- [ ] Squash commits
