### PR TITLE
AC-398 putting edx.org social media links in list, updating styles

### DIFF
--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -83,6 +83,15 @@ footer#footer-edx-v3 {
       width: 100%;
     }
   }
+  
+  .social-media-links,
+  .mobile-app-links {
+      @extend %ui-no-list;
+      
+      .list-item {
+          display: inline-block;
+      }
+  }
 
   .mobile-app-links {
     @include clearfix();

--- a/themes/edx.org/lms/templates/footer.html
+++ b/themes/edx.org/lms/templates/footer.html
@@ -52,22 +52,26 @@
       </div>
 
       <div class="external-links">
-        <div class="social-media-links">
-          % for link in footer['social_links']:
-          <a href="${link['url']}" class="sm-link external" title="${link['title']}" rel="noreferrer">
-            <span class="icon fa ${link['icon-class']}" aria-hidden="true"></span>
-            <span class="sr">${link['action']}</span>
-          </a>
-          % endfor
-        </div>
+        <ul class="social-media-links">
+            % for link in footer['social_links']:
+            <li class="list-item">
+                <a href="${link['url']}" class="sm-link external" title="${link['title']}" rel="noreferrer">
+                    <span class="icon fa ${link['icon-class']}" aria-hidden="true"></span>
+                    <span class="sr">${link['action']}</span>
+                </a>
+            </li>
+            % endfor
+        </ul>
 
-        <div class="mobile-app-links">
-          % for link in footer['mobile_links']:
-          <a href="${link['url']}" class="app-link external">
-            <img alt="${link['title']}" src="${link['image']}">
-          </a>
-          % endfor
-        </div>
+        <ul class="mobile-app-links">
+            % for link in footer['mobile_links']:
+            <li class="list-item">
+                <a href="${link['url']}" class="app-link external">
+                    <img alt="${link['title']}" src="${link['image']}">
+                </a>
+            </li>
+            % endfor
+        </ul>
       </div>
     </div>
 </footer>
@@ -91,4 +95,3 @@
 % if footer_js_url:
   <script type="text/javascript" src="${footer_js_url}"></script>
 % endif
-


### PR DESCRIPTION
# [AC-398](https://openedx.atlassian.net/browse/AC-398)

The social media links in the footer of the edx.org theme (not Open EdX) needed to be in a list. This updates the markup in the footer template and adjusts the styles accordingly.
## Sandbox

https://clrux-ac-398.sandbox.edx.org
## Reviewers
- [x] @cptvitamin 
- [x] @AlasdairSwan?
