### PR TITLE
Bump safe template linter thresholds to fix failing builds

### DIFF
--- a/scripts/safelint_thresholds.json
+++ b/scripts/safelint_thresholds.json
@@ -1,13 +1,13 @@
 {
     "rules": {
-        "javascript-concat-html": 205,
+        "javascript-concat-html": 213,
         "javascript-escape": 7,
         "javascript-interpolate": 49,
-        "javascript-jquery-append": 104,
-        "javascript-jquery-html": 275,
+        "javascript-jquery-append": 111,
+        "javascript-jquery-html": 279,
         "javascript-jquery-insert-into-target": 27,
-        "javascript-jquery-insertion": 26,
-        "javascript-jquery-prepend": 11,
+        "javascript-jquery-insertion": 29,
+        "javascript-jquery-prepend": 13,
         "mako-html-entities": 0,
         "mako-invalid-html-filter": 27,
         "mako-invalid-js-filter": 207,
@@ -28,5 +28,5 @@
         "python-wrap-html": 264,
         "underscore-not-escaped": 658
     },
-    "total": 2232
+    "total": 2245
 }


### PR DESCRIPTION
Looks like a revert commit that was included in patch-2016-06-23 caused our safe template violations to jump back up. Bumping up the threshold numbers to fix the issue for now.

See https://build.testeng.edx.org/job/edx-platform-quality-pr/20542/console for an example failing build.
See https://github.com/edx/edx-platform/commit/a628c523038a0be5fede2dd6335c0632f3d8eabf for the revert commit.

@robrap @jzoldak @jmbowman 
