### PR TITLE
Move disabling of XBlocks to new XBlockConfiguration model

### DIFF
--- a/common/djangoapps/xblock_django/models.py
+++ b/common/djangoapps/xblock_django/models.py
@@ -42,16 +42,6 @@ class XBlockDisableConfig(ConfigurationModel):
         return block_type in config.disabled_blocks.split()
 
     @classmethod
-    def disabled_block_types(cls):
-        """ Return list of disabled xblock types. """
-
-        config = cls.current()
-        if not config.enabled:
-            return ()
-
-        return config.disabled_blocks.split()
-
-    @classmethod
     def disabled_create_block_types(cls):
         """ Return list of deprecated XBlock types. Merges types in settings file and field. """
 

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -185,6 +185,25 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
                     self.mappings[course_key] = store
             self.modulestores.append(store)
 
+    @property
+    def disabled_xblock_types(self):
+        """
+        Returns the list of disabled xblock types.
+        """
+        return None if not hasattr(self, "_disabled_xblock_types") else self._disabled_xblock_types
+
+    @disabled_xblock_types.setter
+    def disabled_xblock_types(self, value):
+        """
+        Sets the list of disabled xblock types, and propagates down
+        to child modulestores if available.
+        """
+        self._disabled_xblock_types = value  # pylint: disable=attribute-defined-outside-init
+
+        if hasattr(self, 'modulestores'):
+            for store in self.modulestores:
+                store.disabled_xblock_types = value
+
     def _clean_locator_for_mapping(self, locator):
         """
         In order for mapping to work, the locator must be minimal--no version, no branch--

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -340,9 +340,6 @@ FEATURES = {
     # Enable OpenBadge support. See the BADGR_* settings later in this file.
     'ENABLE_OPENBADGES': False,
 
-    # The block types to disable need to be specified in "x block disable config" in django admin.
-    'ENABLE_DISABLING_XBLOCK_TYPES': True,
-
     # Enable LTI Provider feature.
     'ENABLE_LTI_PROVIDER': False,
 


### PR DESCRIPTION
### Description

[TNL-4668](https://openedx.atlassian.net/browse/TNL-4668)

Moves disabling of XBlocks to new XBlockConfiguration model. The old model and associated code/tests will be deleted in a future story.
### Sandbox
- [x] config.sandbox.edx.org
  You can log in as "admin" with password "edx" to access the admin table https://config.sandbox.edx.org/admin/xblock_django/xblockconfiguration/
  You can then enable and disable XBlocks and verify that the appear/disappear in the LMS! Lots of fun.
### Testing
- [x] safecommit shows 0 violations
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @ehteshamkafeel
- [x] Code review: @efischer19 (since you have been kind enough to review other related PRs!)
### Devops assistance

FYI @jibsheet (substitute for @maxrothman ). I don't think this has any DevOps impact, but just giving a heads-up. I will create a DevOps ticket at the end for all the old settings values to be deleted from the configuration repo.

Note though that I shouldn't merge this PR until https://openedx.atlassian.net/browse/DEVOPS-4427 is complete.

FYI: @ssemenova @cpennington 
### Post-review
- [x] Squash commits
