### PR TITLE
Fix discussion bundling in Studio

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -620,7 +620,7 @@ PIPELINE_JS = {
         'source_filenames': (
             rooted_glob(COMMON_ROOT / 'static/', 'xmodule/descriptors/js/*.js') +
             rooted_glob(COMMON_ROOT / 'static/', 'xmodule/modules/js/*.js') +
-            rooted_glob(COMMON_ROOT / 'static/', 'coffee/src/discussion/*.js')
+            rooted_glob(COMMON_ROOT / 'static/', 'common/js/discussion/*.js')
         ),
         'output_filename': 'js/cms-modules.js',
         'test_order': 1

--- a/scripts/safelint_thresholds.json
+++ b/scripts/safelint_thresholds.json
@@ -1,13 +1,13 @@
 {
     "rules": {
-        "javascript-concat-html": 205,
+        "javascript-concat-html": 213,
         "javascript-escape": 7,
         "javascript-interpolate": 49,
-        "javascript-jquery-append": 104,
-        "javascript-jquery-html": 275,
+        "javascript-jquery-append": 111,
+        "javascript-jquery-html": 279,
         "javascript-jquery-insert-into-target": 27,
-        "javascript-jquery-insertion": 26,
-        "javascript-jquery-prepend": 11,
+        "javascript-jquery-insertion": 29,
+        "javascript-jquery-prepend": 13,
         "mako-html-entities": 0,
         "mako-invalid-html-filter": 27,
         "mako-invalid-js-filter": 207,
@@ -28,5 +28,5 @@
         "python-wrap-html": 264,
         "underscore-not-escaped": 658
     },
-    "total": 2232
+    "total": 2245
 }


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-4863

This change fixes a bug with how Studio bundles the discussion module code that was introduced by the migration from CoffeeScript. It turns out that it didn't actually stop Studio from being able to edit the discussion component, but this fix stops an error being logged to the console.

@bjacobel @cahrens please review.

FYI @e-kolpakov @jmbowman @jibsheet 
