### PR TITLE
Only coach can access ccx dashboard

### DIFF
--- a/lms/djangoapps/ccx/plugins.py
+++ b/lms/djangoapps/ccx/plugins.py
@@ -28,9 +28,7 @@ class CcxCourseTab(CourseTab):
         if not settings.FEATURES.get('CUSTOM_COURSES_EDX', False) or not course.enable_ccx:
             # If ccx is not enable do not show ccx coach tab.
             return False
-        if has_access(user, 'staff', course) or has_access(user, 'instructor', course):
-            # if user is staff or instructor then he can always see ccx coach tab.
-            return True
+
         # check if user has coach access.
         role = CourseCcxCoachRole(course.id)
         return role.has_user(user)

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -88,24 +88,18 @@ def coach_dashboard(view):
             course_key = ccx.course_id
 
         course = get_course_by_id(course_key, depth=None)
-        is_staff = has_access(request.user, 'staff', course)
-        is_instructor = has_access(request.user, 'instructor', course)
+        role = CourseCcxCoachRole(course_key)
 
-        if is_staff or is_instructor:
-            # if user is staff or instructor then he can view ccx coach dashboard.
-            return view(request, course, ccx)
-        else:
-            role = CourseCcxCoachRole(course_key)
-            if not role.has_user(request.user):
-                return HttpResponseForbidden(_('You must be a CCX Coach to access this view.'))
+        if not role.has_user(request.user):
+            return HttpResponseForbidden(_('You must be a CCX Coach to access this view.'))
 
-            # if there is a ccx, we must validate that it is the ccx for this coach
-            if ccx is not None:
-                coach_ccx = get_ccx_by_ccx_id(course, request.user, ccx.id)
-                if coach_ccx is None:
-                    return HttpResponseForbidden(
-                        _('You must be the coach for this ccx to access this view')
-                    )
+        # if there is a ccx, we must validate that it is the ccx for this coach
+        if ccx is not None:
+            coach_ccx = get_ccx_by_ccx_id(course, request.user, ccx.id)
+            if coach_ccx is None:
+                return HttpResponseForbidden(
+                    _('You must be the coach for this ccx to access this view')
+                )
 
         return view(request, course, ccx)
     return wrapper


### PR DESCRIPTION
### Background

fixes https://github.com/mitocw/edx-platform/issues/248 and https://github.com/mitocw/edx-platform/issues/249
### What is done in this PR

**Studio Updates:** None.
**LMS Updates:** 
- Hid create ccx tab for staff, Now user can only see this tab if he is coach of ccx course.
- Remove automatically addition of staff as ccx coach on visiting coach dashboard.

@pdpinch @aliceriot  @giocalitri 
