### PR TITLE
Convert Dates for User Time Zone

### DIFF
--- a/common/djangoapps/util/date_utils.py
+++ b/common/djangoapps/util/date_utils.py
@@ -5,7 +5,6 @@ Convenience methods for working with datetime objects
 from datetime import datetime, timedelta
 import re
 
-from django.utils.timezone import now
 from django.utils.translation import pgettext, ugettext
 from pytz import timezone, utc, UnknownTimeZoneError
 
@@ -61,15 +60,6 @@ def get_time_display(dtime, format_string=None, coerce_tz=None):
         return unicode(strftime_localized(dtime, format_string))
     except ValueError:
         return get_default_time_display(dtime)
-
-
-def get_formatted_time_zone(time_zone):
-    """
-    Returns a formatted time zone (e.g. 'Asia/Tokyo (JST +0900)') for user account settings time zone drop down
-    """
-    abbr = get_time_display(now(), '%Z', time_zone)
-    offset = get_time_display(now(), '%z', time_zone)
-    return "{name} ({abbr}, UTC{offset})".format(name=time_zone, abbr=abbr, offset=offset).replace("_", " ")
 
 
 def almost_same_datetime(dt1, dt2, allowed_delta=timedelta(minutes=1)):

--- a/common/lib/xmodule/xmodule/course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/course_metadata_utils.py
@@ -11,6 +11,7 @@ import dateutil.parser
 from math import exp
 
 from django.utils.timezone import UTC
+from openedx.core.lib.time_zone_utils import get_formatted_time_zone
 
 from .fields import Date
 
@@ -167,11 +168,11 @@ def course_start_date_is_default(start, advertised_start):
     return advertised_start is None and start == DEFAULT_START_DATE
 
 
-def _datetime_to_string(date_time, format_string, strftime_localized):
+def _datetime_to_string(date_time, time_zone, format_string, strftime_localized):
     """
     Formats the given datetime with the given function and format string.
 
-    Adds UTC to the resulting string if the format is DATE_TIME or TIME.
+    Adds time zone abbreviation to the resulting string if the format is DATE_TIME or TIME.
 
     Arguments:
         date_time (datetime): the datetime to be formatted
@@ -179,18 +180,20 @@ def _datetime_to_string(date_time, format_string, strftime_localized):
         strftime_localized ((datetime, str) -> str): a nm localized string
             formatting function
     """
-    # TODO: Is manually appending UTC really the right thing to do here? What if date_time isn't UTC?
-    result = strftime_localized(date_time, format_string)
+    result = strftime_localized(date_time.astimezone(time_zone), format_string)
     return (
-        result + u" UTC" if format_string in ['DATE_TIME', 'TIME', 'DAY_AND_TIME']
+        result + ' ' + get_formatted_time_zone(time_zone, **{'abbr': True}) if format_string in ['DATE_TIME', 'TIME', 'DAY_AND_TIME']
         else result
     )
+    # TODO: Change this back to above
+    # kwargs = {'abbr': True}
+    # return result + ' ' + get_formatted_time_zone(time_zone, **kwargs)
 
 
-def course_start_datetime_text(start_date, advertised_start, format_string, ugettext, strftime_localized):
+def course_start_datetime_text(start_date, advertised_start, time_zone, format_string, ugettext, strftime_localized):
     """
     Calculates text to be shown to user regarding a course's start
-    datetime in UTC.
+    datetime in specified time zone.
 
     Prefers .advertised_start, then falls back to .start.
 
@@ -210,12 +213,12 @@ def course_start_datetime_text(start_date, advertised_start, format_string, uget
             if parsed_advertised_start is not None:
                 # In the Django implementation of strftime_localized, if
                 # the year is <1900, _datetime_to_string will raise a ValueError.
-                return _datetime_to_string(parsed_advertised_start, format_string, strftime_localized)
+                return _datetime_to_string(parsed_advertised_start, time_zone, format_string, strftime_localized)
         except ValueError:
             pass
         return advertised_start.title()
     elif start_date != DEFAULT_START_DATE:
-        return _datetime_to_string(start_date, format_string, strftime_localized)
+        return _datetime_to_string(start_date, time_zone, format_string, strftime_localized)
     else:
         _ = ugettext
         # Translators: TBD stands for 'To Be Determined' and is used when a course
@@ -223,7 +226,7 @@ def course_start_datetime_text(start_date, advertised_start, format_string, uget
         return _('TBD')
 
 
-def course_end_datetime_text(end_date, format_string, strftime_localized):
+def course_end_datetime_text(end_date, time_zone, format_string, strftime_localized):
     """
     Returns a formatted string for a course's end date or datetime.
 
@@ -236,7 +239,7 @@ def course_end_datetime_text(end_date, format_string, strftime_localized):
             formatting function
     """
     return (
-        _datetime_to_string(end_date, format_string, strftime_localized) if end_date is not None
+        _datetime_to_string(end_date, time_zone, format_string, strftime_localized) if end_date is not None
         else ''
     )
 

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1269,15 +1269,16 @@ class CourseDescriptor(CourseFields, SequenceDescriptor, LicenseMixin):
         """Return the course_id for this course"""
         return self.location.course_key
 
-    def start_datetime_text(self, format_string="SHORT_DATE"):
+    def start_datetime_text(self, time_zone=UTC, format_string="SHORT_DATE"):
         """
-        Returns the desired text corresponding the course's start date and time in UTC.  Prefers .advertised_start,
-        then falls back to .start
+        Returns the desired text corresponding the course's start date and time in specified time zone, defaulted
+        to UTC. Prefers .advertised_start, then falls back to .start
         """
         i18n = self.runtime.service(self, "i18n")
         return course_metadata_utils.course_start_datetime_text(
             self.start,
             self.advertised_start,
+            time_zone,
             format_string,
             i18n.ugettext,
             i18n.strftime
@@ -1294,12 +1295,13 @@ class CourseDescriptor(CourseFields, SequenceDescriptor, LicenseMixin):
             self.advertised_start
         )
 
-    def end_datetime_text(self, format_string="SHORT_DATE"):
+    def end_datetime_text(self, time_zone=UTC, format_string="SHORT_DATE"):
         """
         Returns the end date or date_time for the course formatted as a string.
         """
         return course_metadata_utils.course_end_datetime_text(
             self.end,
+            time_zone,
             format_string,
             self.runtime.service(self, "i18n").strftime
         )

--- a/lms/djangoapps/ccx/models.py
+++ b/lms/djangoapps/ccx/models.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.utils.timezone import UTC
 
 from lazy import lazy
+from openedx.core.lib.time_zone_utils import get_formatted_time_zone
 from xmodule_django.models import CourseKeyField, LocationKeyField
 from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore.django import modulestore
@@ -81,34 +82,36 @@ class CustomCourseForEdX(models.Model):
 
         return datetime.now(UTC()) > self.due
 
-    def start_datetime_text(self, format_string="SHORT_DATE"):
+    def start_datetime_text(self, time_zone=UTC, format_string="SHORT_DATE"):
         """Returns the desired text representation of the CCX start datetime
 
-        The returned value is always expressed in UTC
+        The returned value is in specified time zone, defaulted to UTC.
         """
         i18n = self.course.runtime.service(self.course, "i18n")
         strftime = i18n.strftime
-        value = strftime(self.start, format_string)
+        value = strftime(self.start.astimezone(time_zone), format_string)
         if format_string == 'DATE_TIME':
-            value += u' UTC'
+            kwargs = {'abbr': True}
+            value += get_formatted_time_zone(time_zone, **kwargs)
         return value
 
-    def end_datetime_text(self, format_string="SHORT_DATE"):
+    def end_datetime_text(self, time_zone=UTC, format_string="SHORT_DATE"):
         """Returns the desired text representation of the CCX due datetime
 
         If the due date for the CCX is not set, the value returned is the empty
         string.
 
-        The returned value is always expressed in UTC
+        The returned value is in specified time zone, defaulted to UTC.
         """
         if self.due is None:
             return ''
 
         i18n = self.course.runtime.service(self.course, "i18n")
         strftime = i18n.strftime
-        value = strftime(self.due, format_string)
+        value = strftime(self.due.astimezone(time_zone), format_string)
         if format_string == 'DATE_TIME':
-            value += u' UTC'
+            kwargs = {'abbr': True}
+            value += get_formatted_time_zone(time_zone, **kwargs)
         return value
 
     @property

--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -12,11 +12,12 @@ from django.utils.translation import ugettext_lazy
 from django.utils.translation import to_locale, get_language
 from edxmako.shortcuts import render_to_string
 from lazy import lazy
-import pytz
+from pytz import utc
 
 from course_modes.models import CourseMode
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.verify_student.models import VerificationDeadline, SoftwareSecurePhotoVerification
+from openedx.core.lib.time_zone_utils import get_formatted_time_zone, get_user_time_zone
 from student.models import CourseEnrollment
 
 
@@ -64,6 +65,10 @@ class DateSummary(object):
         """The text of the link."""
         return ''
 
+    @property
+    def time_zone(self):
+        return get_user_time_zone(self.user)
+
     def __init__(self, course, user):
         self.course = course
         self.user = user
@@ -93,7 +98,7 @@ class DateSummary(object):
         if self.date is None:
             return ''
         locale = to_locale(get_language())
-        delta = self.date - datetime.now(pytz.UTC)
+        delta = self.date - datetime.now(utc)
         try:
             relative_date = format_timedelta(delta, locale=locale)
         # Babel doesn't have translations for Esperanto, so we get
@@ -111,7 +116,8 @@ class DateSummary(object):
         date_format = _(u"{relative} ago - {absolute}") if date_has_passed else _(u"in {relative} - {absolute}")
         return date_format.format(
             relative=relative_date,
-            absolute=self.date.strftime(self.date_format.encode('utf-8')).decode('utf-8'),
+            #TODO: normalize?
+            absolute=self.date.astimezone(self.time_zone).strftime(self.date_format.encode('utf-8')).decode('utf-8'),
         )
 
     @property
@@ -123,7 +129,7 @@ class DateSummary(object):
         future.
         """
         if self.date is not None:
-            return datetime.now(pytz.UTC) <= self.date
+            return datetime.now(utc) <= self.date
         return False
 
     def __repr__(self):
@@ -143,7 +149,8 @@ class TodaysDate(DateSummary):
 
     @property
     def date_format(self):
-        return u'%b %d, %Y (%H:%M {utc})'.format(utc=_('UTC'))
+        kwargs = {'abbr': True}
+        return u'%b %d, %Y (%H:%M {tz_abbr})'.format(tz_abbr=get_formatted_time_zone(self.time_zone, **kwargs))
 
     # The date is shown in the title, no need to display it again.
     def get_context(self):
@@ -153,12 +160,14 @@ class TodaysDate(DateSummary):
 
     @property
     def date(self):
-        return datetime.now(pytz.UTC)
+        return datetime.now(utc)
 
     @property
     def title(self):
         return _(u'Today is {date}').format(
-            date=datetime.now(pytz.UTC).strftime(self.date_format.encode('utf-8')).decode('utf-8')
+            date=self.time_zone.normalize(self.date).strftime(self.date_format.encode('utf-8')).decode('utf-8')
+            #TODO: Refactor to below?
+            #date=get_time_display(self.date, self.date_formate.encode('utf-8'),self.time_zone.zone)
         )
 
 
@@ -187,7 +196,7 @@ class CourseEndDate(DateSummary):
 
     @property
     def description(self):
-        if datetime.now(pytz.UTC) <= self.date:
+        if datetime.now(utc) <= self.date:
             mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
             if is_active and CourseMode.is_eligible_for_certificate(mode):
                 return _('To earn a certificate, you must complete all requirements before this date.')
@@ -332,7 +341,7 @@ class VerificationDeadlineDate(DateSummary):
         Return True if a verification deadline exists, and has already passed.
         """
         deadline = self.date
-        return deadline is not None and deadline <= datetime.now(pytz.UTC)
+        return deadline is not None and deadline <= datetime.now(utc)
 
     def must_retry(self):
         """Return True if the user must re-submit verification, False otherwise."""

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -26,6 +26,7 @@ from lang_pref import LANGUAGE_KEY
 from xblock.fragment import Fragment
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.lib.gating import api as gating_api
+from openedx.core.lib.time_zone_utils import get_user_time_zone
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from shoppingcart.models import CourseRegistrationCode
 from student.models import CourseEnrollment
@@ -506,6 +507,7 @@ def render_accordion(request, course, table_of_contents):
             ('course_id', unicode(course.id)),
             ('csrf', csrf(request)['csrf_token']),
             ('due_date_display_format', course.due_date_display_format),
+            ('time_zone', get_user_time_zone(request.user).zone),
         ] + TEMPLATE_IMPORTS.items()
     )
     return render_to_string('courseware/accordion.html', context)

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -31,7 +31,7 @@ from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.theming.helpers import is_request_in_themed_site, get_value as get_themed_value
 from openedx.core.djangoapps.user_api.accounts.api import request_password_change
 from openedx.core.djangoapps.user_api.errors import UserNotFound
-from openedx.core.djangoapps.user_api.models import UserPreference
+from openedx.core.lib.time_zone_utils import TIME_ZONE_CHOICES
 from openedx.core.lib.edx_api_utils import get_edx_api_data
 from student.models import UserProfile
 from student.views import (
@@ -449,7 +449,7 @@ def account_settings_context(request):
             }, 'preferred_language': {
                 'options': all_languages(),
             }, 'time_zone': {
-                'options': UserPreference.TIME_ZONE_CHOICES,
+                'options': TIME_ZONE_CHOICES,
                 'enabled': settings.FEATURES.get('ENABLE_TIME_ZONE_PREFERENCE'),
             }
         },

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -365,7 +365,7 @@ FEATURES = {
     'ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES': True,
 
     # WIP -- will be removed in Ticket #TNL-4750.
-    'ENABLE_TIME_ZONE_PREFERENCE': False,
+    'ENABLE_TIME_ZONE_PREFERENCE': True,
 }
 
 # Ignore static asset files on import which match this pattern

--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -36,7 +36,7 @@ else:
                 if section.get('due') is None:
                     due_date = ''
                 else:
-                    formatted_string = get_time_display(section['due'], due_date_display_format, coerce_tz=settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES)
+                    formatted_string = get_time_display(section['due'], due_date_display_format, coerce_tz=time_zone)
                     due_date = '' if len(formatted_string)==0 else _('due {date}').format(date=formatted_string)
                 %>
 

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -89,10 +89,10 @@ from openedx.core.djangolib.markup import HTML, Text
           % endif
         </section>
         <section aria-label="${_('Handout Navigation')}" class="handouts">
-          % if SelfPacedConfiguration.current().enable_course_home_improvements:
+          <!-- % if SelfPacedConfiguration.current().enable_course_home_improvements: -->
             <h1 class="handouts-header">${_("Important Course Dates")}</h1>
             ${HTML(get_course_date_summary(course, user))}
-          % endif
+          <!-- % endif -->
 
           <h1 class="handouts-header">${_(course.info_sidebar_name)}</h1>
           ${HTML(get_course_info_section(request, masquerade_user, course, 'handouts'))}

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -10,6 +10,7 @@ from course_modes.models import CourseMode
 from course_modes.helpers import enrollment_mode_display
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from openedx.core.djangolib.markup import HTML, Text
+from openedx.core.lib.time_zone_utils import get_user_time_zone
 from student.helpers import (
   VERIFY_STATUS_NEED_TO_VERIFY,
   VERIFY_STATUS_SUBMITTED,
@@ -103,16 +104,17 @@ from student.helpers import (
           <span class="info-university">${course_overview.display_org_with_default} - </span>
           <span class="info-course-id">${course_overview.display_number_with_default}</span>
           <span class="info-date-block" data-tooltip="Hi">
+          <% time_zone = get_user_time_zone(user) %>
           % if course_overview.has_ended():
-            ${_("Ended - {end_date}").format(end_date=course_overview.end_datetime_text("SHORT_DATE"))}
+            ${_("Ended - {end_date}").format(end_date=course_overview.end_datetime_text(time_zone, "SHORT_DATE"))}
           % elif course_overview.has_started():
-            ${_("Started - {start_date}").format(start_date=course_overview.start_datetime_text("SHORT_DATE"))}
+            ${_("Started - {start_date}").format(start_date=course_overview.start_datetime_text(time_zone, "SHORT_DATE"))}
           % elif course_overview.start_date_is_still_default: # Course start date TBD
             ${_("Coming Soon")}
           % elif course_overview.starts_within(days=5):   # hasn't started yet
-            ${_("Starts - {start_date}").format(start_date=course_overview.start_datetime_text("DAY_AND_TIME"))}
+            ${_("Starts - {start_date}").format(start_date=course_overview.start_datetime_text(time_zone, "DAY_AND_TIME"))}
           % else:   # hasn't started yet
-            ${_("Starts - {start_date}").format(start_date=course_overview.start_datetime_text("SHORT_DATE"))}
+            ${_("Starts - {start_date}").format(start_date=course_overview.start_datetime_text(time_zone, "SHORT_DATE"))}
           % endif
           </span>
         </div>

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -18,6 +18,7 @@ from opaque_keys.edx.keys import CourseKey
 from config_models.models import ConfigurationModel
 from lms.djangoapps import django_comment_client
 from openedx.core.djangoapps.models.course_details import CourseDetails
+from pytz import utc
 from static_replace.models import AssetBaseUrlConfig
 from util.date_utils import strftime_localized
 from xmodule import course_metadata_utils
@@ -359,14 +360,16 @@ class CourseOverview(TimeStampedModel):
 
         return course_metadata_utils.course_starts_within(self.start, days)
 
-    def start_datetime_text(self, format_string="SHORT_DATE"):
+    def start_datetime_text(self, time_zone=utc, format_string="SHORT_DATE"):
         """
-        Returns the desired text corresponding the course's start date and
-        time in UTC.  Prefers .advertised_start, then falls back to .start.
+        Returns the desired text corresponding to the course's start date and
+        time in the specified time zone, or utc if no time zone given.
+        Prefers .advertised_start, then falls back to .start.
         """
         return course_metadata_utils.course_start_datetime_text(
             self.start,
             self.advertised_start,
+            time_zone,
             format_string,
             ugettext,
             strftime_localized
@@ -383,12 +386,13 @@ class CourseOverview(TimeStampedModel):
             self.advertised_start,
         )
 
-    def end_datetime_text(self, format_string="SHORT_DATE"):
+    def end_datetime_text(self, time_zone=utc, format_string="SHORT_DATE"):
         """
         Returns the end date or datetime for the course formatted as a string.
         """
         return course_metadata_utils.course_end_datetime_text(
             self.end,
+            time_zone,
             format_string,
             strftime_localized
         )

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -8,9 +8,6 @@ from django.db.models.signals import post_delete, pre_save, post_save
 from django.dispatch import receiver
 from model_utils.models import TimeStampedModel
 
-from pytz import common_timezones
-from util.date_utils import get_formatted_time_zone
-
 from util.model_utils import get_changed_fields_dict, emit_setting_changed_event
 from xmodule_django.models import CourseKeyField
 
@@ -29,10 +26,6 @@ class UserPreference(models.Model):
     user = models.ForeignKey(User, db_index=True, related_name="preferences")
     key = models.CharField(max_length=255, db_index=True, validators=[RegexValidator(KEY_REGEX)])
     value = models.TextField()
-
-    TIME_ZONE_CHOICES = [
-        (tz, get_formatted_time_zone(tz)) for tz in common_timezones
-    ]
 
     class Meta(object):
         unique_together = ("user", "key")

--- a/openedx/core/lib/tests/test_time_zone_utils.py
+++ b/openedx/core/lib/tests/test_time_zone_utils.py
@@ -1,0 +1,95 @@
+"""Tests covering time zone utilities."""
+from django.test import TestCase
+
+from freezegun import freeze_time
+from student.tests.factories import UserFactory
+from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
+from openedx.core.lib.time_zone_utils import get_formatted_time_zone, get_user_time_zone
+from pytz import timezone, utc
+
+
+class TestTimeZoneUtils(TestCase):
+    def setUp(self):
+        """
+        Sets up user for testing with time zone utils.
+        """
+        super(TestTimeZoneUtils, self).setUp()
+
+        self.user = UserFactory.build()
+        self.user.save()
+
+    def test_get_user_time_zone(self):
+        """
+        Test to ensure get_user_time_zone() returns the correct time zone
+        or UTC if user has not specified time zone.
+        """
+        # User time zone should be UTC when no time zone has been chosen
+        user_tz = get_user_time_zone(self.user)
+        self.assertEqual(user_tz, utc)
+
+        # User time zone should change when user specifies time zone
+        set_user_preference(self.user, 'time_zone', 'Asia/Tokyo')
+        user_tz = get_user_time_zone(self.user)
+        self.assertEqual(user_tz, timezone('Asia/Tokyo'))
+
+    def _formatted_time_zone_helper(self, time_zone):
+        """
+        Helper function to return all info from get_formatted_time_zone()
+        """
+        tz = timezone(time_zone)
+        tz_str = get_formatted_time_zone(tz)
+
+        kwargs = {'abbr': True}
+        tz_abbr = get_formatted_time_zone(tz, **kwargs)
+
+        kwargs = {'offset': True}
+        tz_offset = get_formatted_time_zone(tz, **kwargs)
+
+        return {'str': tz_str, 'abbr': tz_abbr, 'offset': tz_offset}
+
+    def _assert_time_zone_info_equal(self, formatted_tz_info, expected_name, expected_abbr, expected_offset):
+        """
+        Asserts that all formatted_tz_info is equal to the expected inputs
+        """
+        self.assertEqual(formatted_tz_info['str'], '{name} ({abbr}, UTC{offset})'.format(name=expected_name,
+                                                                                         abbr=expected_abbr,
+                                                                                         offset=expected_offset)
+        )
+        self.assertEqual(formatted_tz_info['abbr'], expected_abbr)
+        self.assertEqual(formatted_tz_info['offset'], expected_offset)
+
+    @freeze_time("2015-02-09")
+    def test_formatted_time_zone_without_dst(self):
+        """
+        Test to ensure get_formatted_time_zone() returns full formatted string when no kwargs specified
+        and returns just abbreviation or offset when specified
+        """
+        tz_info = self._formatted_time_zone_helper('America/Los_Angeles')
+        self._assert_time_zone_info_equal(tz_info, 'America/Los Angeles', 'PST', '-0800')
+
+    @freeze_time("2015-04-02")
+    def test_formatted_time_zone_with_dst(self):
+        """
+        Test to ensure get_formatted_time_zone() returns modified abbreviations and
+        offsets during daylight savings time.
+        """
+        tz_info = self._formatted_time_zone_helper('America/Los_Angeles')
+        self._assert_time_zone_info_equal(tz_info, 'America/Los Angeles', 'PDT', '-0700')
+
+    @freeze_time("2015-11-01 08:59:00")
+    def test_formatted_time_zone_ambiguous_before(self):
+        """
+        Test to ensure get_formatted_time_zone() returns correct abbreviations and offsets
+        during ambiguous time periods (e.g. when DST is about to start/end) before the change
+        """
+        tz_info = self._formatted_time_zone_helper('America/Los_Angeles')
+        self._assert_time_zone_info_equal(tz_info, 'America/Los Angeles', 'PDT', '-0700')
+
+    @freeze_time("2015-11-01 09:00:00")
+    def test_formatted_time_zone_ambiguous_after(self):
+        """
+        Test to ensure get_formatted_time_zone() returns correct abbreviations and offsets
+        during ambiguous time periods (e.g. when DST is about to start/end) after the change
+        """
+        tz_info = self._formatted_time_zone_helper('America/Los_Angeles')
+        self._assert_time_zone_info_equal(tz_info, 'America/Los Angeles', 'PST', '-0800')

--- a/openedx/core/lib/time_zone_utils.py
+++ b/openedx/core/lib/time_zone_utils.py
@@ -1,0 +1,60 @@
+"""
+Utilities related to timezones
+"""
+from datetime import datetime, timedelta
+
+from pytz import common_timezones, timezone, utc
+
+
+def get_user_time_zone(user):
+    """
+    Returns pytz time zone object of the user's time zone if available or UTC time zone if unavailable
+    """
+    #TODO: exception for unknown timezones?
+    tz = user.preferences.model.get_value(user, "time_zone")
+    if tz is not None:
+        return timezone(tz)
+    return utc
+
+
+def _format_time_zone_string(time_zone, format_string):
+    """
+    Returns a string, specified by format string, of the current date/time of the time zone.
+
+    :param time_zone: Pytz time zone object
+    :param format_string: A list of format codes can be found at:
+            https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+    """
+    return datetime.now(utc).astimezone(time_zone).strftime(format_string)
+
+
+def _is_daylight_savings_time(time_zone):
+    """
+    Returns a bool whether or not a time zone is currently in Daylight Savings Time. Useful in determining
+    which time zone to show user (e.g. EST or EDT) during ambiguous time periods.
+
+    :param time_zone: Pytz time zone object
+    """
+    now = utc.localize(datetime.now())
+    return now.astimezone(time_zone).dst() != timedelta(0)
+
+
+def get_formatted_time_zone(time_zone, **kwargs):
+    """
+    Returns a formatted time zone (e.g. 'Asia/Tokyo (JST, UTC+0900)') by default or just time zone
+    abbreviation (e.g. JST) or utc offset (e.g. +0900), if specified
+
+    :param time_zone: Pytz time zone object
+    """
+    tz_abbr = _format_time_zone_string(time_zone, '%Z')
+    tz_offset = _format_time_zone_string(time_zone, '%z')
+    if 'abbr' in kwargs:
+        return tz_abbr
+    elif 'offset' in kwargs:
+        return tz_offset
+    return "{name} ({abbr}, UTC{offset})".format(name=time_zone, abbr=tz_abbr, offset=tz_offset).replace("_", " ")
+
+
+TIME_ZONE_CHOICES = [
+    (tz, get_formatted_time_zone(timezone(tz))) for tz in common_timezones
+]


### PR DESCRIPTION
Initial commit. Converts the dates in the platform with respect to the user's specified time zone, or displays in UTC if no time zone chosen. Tests are still WIP. Currently, only converts 1,3, and 4 in [TNL-4595](https://openedx.atlassian.net/browse/TNL-4595).
