### PR TITLE
Update BlockStructure version number

### DIFF
--- a/openedx/core/lib/block_structure/block_structure.py
+++ b/openedx/core/lib/block_structure/block_structure.py
@@ -395,6 +395,12 @@ class BlockStructureBlockData(BlockStructure):
     Subclass of BlockStructure that is responsible for managing block
     and transformer data.
     """
+    # The latest version of the data structure of this class. Incrementally
+    # update this value whenever the data structure changes. Dependent storage
+    # layers can then use this value when serializing/deserializing block
+    # structures, and invalidating any previously cached/stored data.
+    VERSION = 1
+
     def __init__(self, root_block_usage_key):
         super(BlockStructureBlockData, self).__init__(root_block_usage_key)
 

--- a/openedx/core/lib/block_structure/cache.py
+++ b/openedx/core/lib/block_structure/cache.py
@@ -6,7 +6,7 @@ from logging import getLogger
 
 from openedx.core.lib.cache_utils import zpickle, zunpickle
 
-from .block_structure import BlockStructureModulestoreData
+from .block_structure import BlockStructureModulestoreData, BlockStructureBlockData
 
 
 logger = getLogger(__name__)  # pylint: disable=C0103
@@ -126,4 +126,7 @@ class BlockStructureCache(object):
         Returns the cache key to use for storing the block structure
         for the given root_block_usage_key.
         """
-        return "root.key." + unicode(root_block_usage_key)
+        return "v{version}.root.key.{root_usage_key}".format(
+            version=unicode(BlockStructureBlockData.VERSION),
+            root_usage_key=unicode(root_block_usage_key),
+        )

--- a/openedx/core/lib/block_structure/tests/test_manager.py
+++ b/openedx/core/lib/block_structure/tests/test_manager.py
@@ -4,6 +4,7 @@ Tests for manager.py
 from nose.plugins.attrib import attr
 from unittest import TestCase
 
+from ..block_structure import BlockStructureBlockData
 from ..exceptions import UsageKeyNotInBlockStructure
 from ..manager import BlockStructureManager
 from ..transformers import BlockStructureTransformers
@@ -151,6 +152,12 @@ class TestBlockStructureManager(TestCase, ChildrenMapTestMixin):
     def test_get_collected_outdated_data(self):
         self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
         TestTransformer1.VERSION += 1
+        self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
+        self.assertEquals(TestTransformer1.collect_call_count, 2)
+
+    def test_get_collected_version_update(self):
+        self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
+        BlockStructureBlockData.VERSION += 1
         self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
         self.assertEquals(TestTransformer1.collect_call_count, 2)
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-4865

Without this change, we get 500 errors when the server tries to deserialize cached data using a previously formatted data structure.

Reviewers: 2 of @efischer19 @sanfordstudent @jcdyer 
FYI @jmbowman @giocalitri 
