### PR TITLE
Revert "TNL 4141"

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -189,10 +189,7 @@ class LoncapaResponse(object):
             raise LoncapaProblemError(msg)
 
         for prop in self.required_attributes:
-            prop_value = xml.get(prop)
-            if prop_value: # Stripping off the empty strings
-                prop_value = prop_value.strip()
-            if not prop_value:
+            if not xml.get(prop):
                 msg = "Error in problem specification: %s missing required attribute %s" % (
                     unicode(self), prop)
                 msg += "\nSee XML source line %s" % getattr(

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -946,12 +946,12 @@ class StringResponseTest(ResponseTest):  # pylint: disable=missing-docstring
         hint = correct_map.get_hint('1_2_1')
         self.assertEqual(hint, self._get_random_number_result(problem.seed))
 
-    def test_empty_answer_problem_creation_not_allowed(self):
+    def test_empty_answer_graded_as_incorrect(self):
         """
-        Tests that empty answer string is not allowed to create a problem
+        Tests that problem should be graded incorrect if blank space is chosen as answer
         """
-        with self.assertRaises(LoncapaProblemError):
-            self.build_problem(answer=" ", case_sensitive=False, regexp=True)
+        problem = self.build_problem(answer=" ", case_sensitive=False, regexp=True)
+        self.assert_grade(problem, u" ", "incorrect")
 
 
 class CodeResponseTest(ResponseTest):  # pylint: disable=missing-docstring


### PR DESCRIPTION
Reverts edx/edx-platform#12833

This broke master with a pep8 violation:
./common/lib/capa/capa/responsetypes.py:193:27: E261 at least two spaces before inline comment
