### PR TITLE
Make program details date formatting consistent with course dashboard

### DIFF
--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -27,6 +27,7 @@ from openedx.core.djangoapps.programs.tests import factories
 from openedx.core.djangoapps.programs.tests.mixins import ProgramsApiConfigMixin, ProgramsDataMixin
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
+from util.date_utils import strftime_localized
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -675,7 +676,6 @@ class TestProgramProgressMeter(ProgramsApiConfigMixin, TestCase):
 class TestSupplementProgramData(ProgramsApiConfigMixin, ModuleStoreTestCase):
     """Tests of the utility function used to supplement program data."""
     password = 'test'
-    human_friendly_format = '%x'
     maxDiff = None
 
     def setUp(self):
@@ -707,8 +707,8 @@ class TestSupplementProgramData(ProgramsApiConfigMixin, ModuleStoreTestCase):
                 course_key=unicode(self.course.id),  # pylint: disable=no-member
                 course_url=reverse('course_root', args=[self.course.id]),  # pylint: disable=no-member
                 course_image_url=course_overview.course_image_url,
-                start_date=self.course.start.strftime(self.human_friendly_format),
-                end_date=self.course.end.strftime(self.human_friendly_format),
+                start_date=strftime_localized(self.course.start, 'SHORT_DATE'),
+                end_date=strftime_localized(self.course.end, 'SHORT_DATE'),
                 is_course_ended=self.course.end < timezone.now(),
                 is_enrolled=False,
                 is_enrollment_open=True,
@@ -746,14 +746,13 @@ class TestSupplementProgramData(ProgramsApiConfigMixin, ModuleStoreTestCase):
         data = utils.supplement_program_data(self.program, self.user)
 
         if is_enrollment_open:
-            self._assert_supplemented(
-                data,
-                is_enrollment_open=is_enrollment_open)
+            self._assert_supplemented(data, is_enrollment_open=is_enrollment_open)
         else:
             self._assert_supplemented(
                 data,
                 is_enrollment_open=is_enrollment_open,
-                enrollment_open_date=self.course.enrollment_start.strftime(self.human_friendly_format))
+                enrollment_open_date=strftime_localized(self.course.enrollment_start, 'SHORT_DATE')
+            )
 
     @ddt.data(True, False)
     @mock.patch(UTILS_MODULE + '.certificate_api.certificate_downloadable_status')

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -15,6 +15,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.lib.edx_api_utils import get_edx_api_data
 from student.models import CourseEnrollment
+from util.date_utils import strftime_localized
 from util.organizations_helpers import get_organization_by_short_name
 from xmodule.course_metadata_utils import DEFAULT_START_DATE
 
@@ -343,11 +344,10 @@ def supplement_program_data(program_data, user):
             run_mode['course_url'] = reverse('course_root', args=[course_key])
             run_mode['course_image_url'] = course_overview.course_image_url
 
-            human_friendly_format = '%x'
-            start_date = course_overview.start or DEFAULT_START_DATE
+            run_mode['start_date'] = course_overview.start_datetime_text()
+            run_mode['end_date'] = course_overview.end_datetime_text()
+
             end_date = course_overview.end or datetime.datetime.max.replace(tzinfo=pytz.UTC)
-            run_mode['start_date'] = start_date.strftime(human_friendly_format)
-            run_mode['end_date'] = end_date.strftime(human_friendly_format)
             run_mode['is_course_ended'] = end_date < timezone.now()
 
             run_mode['is_enrolled'] = CourseEnrollment.is_enrolled(user, course_key)
@@ -358,7 +358,7 @@ def supplement_program_data(program_data, user):
             run_mode['is_enrollment_open'] = is_enrollment_open
             if not is_enrollment_open:
                 # Only render this enrollment open date if the enrollment open is in the future
-                run_mode['enrollment_open_date'] = enrollment_start.strftime(human_friendly_format)
+                run_mode['enrollment_open_date'] = strftime_localized(enrollment_start, 'SHORT_DATE')
 
             # TODO: Currently unavailable on LMS.
             run_mode['marketing_url'] = ''


### PR DESCRIPTION
Here's what the dates look like now:
![](https://i.imgur.com/Pvf4MCx.png)

@schenedx @mikedikan @roderickmorales
