### PR TITLE
Update version of XBlock repo.

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -752,11 +752,12 @@ class VideoExportTestCase(VideoDescriptorTestBase):
 
     def test_export_to_xml_invalid_characters_in_attributes(self):
         """
-        Test XML export will raise TypeError by lxml library if contains illegal characters.
+        Test XML export will *not* raise TypeError by lxml library if contains illegal characters.
+        The illegal characters in a String field are removed from the string instead.
         """
-        self.descriptor.display_name = '\x1e'
-        with self.assertRaises(ValueError):
-            self.descriptor.definition_to_xml(None)
+        self.descriptor.display_name = 'Display\x1eName'
+        xml = self.descriptor.definition_to_xml(None)
+        self.assertEqual(xml.get('display_name'), 'DisplayName')
 
     def test_export_to_xml_unicode_characters(self):
         """

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -70,7 +70,7 @@ git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 git+https://github.com/edx/pa11ycrawler.git@0.0.4#egg=pa11ycrawler==0.0.4
 
 # Our libraries:
-git+https://github.com/edx/XBlock.git@xblock-0.4.10#egg=XBlock==0.4.10
+git+https://github.com/edx/XBlock.git@xblock-0.4.11#egg=XBlock==0.4.11
 -e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2


### PR DESCRIPTION
Change XBlock repo hash and tests to reflect change in handling control characters in XBlock String fields.
https://openedx.atlassian.net/browse/PLAT-1031
The XBlock repo was changed in these PRs:
https://github.com/edx/XBlock/pull/351
https://github.com/edx/XBlock/pull/352
