### PR TITLE
MA-2552: create revoke_token endpoint for oauth

### DIFF
--- a/lms/djangoapps/oauth_dispatch/urls.py
+++ b/lms/djangoapps/oauth_dispatch/urls.py
@@ -13,6 +13,7 @@ urlpatterns = patterns(
     '',
     url(r'^authorize/?$', csrf_exempt(views.AuthorizationView.as_view()), name='authorize'),
     url(r'^access_token/?$', csrf_exempt(views.AccessTokenView.as_view()), name='access_token'),
+    url(r'^revoke_token/?$', csrf_exempt(views.RevokeTokenView.as_view()), name="revoke_token"),
 )
 
 if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):

--- a/lms/djangoapps/oauth_dispatch/views.py
+++ b/lms/djangoapps/oauth_dispatch/views.py
@@ -130,3 +130,10 @@ class AccessTokenExchangeView(_DispatchingView):
     """
     dop_view = auth_exchange_views.DOPAccessTokenExchangeView
     dot_view = auth_exchange_views.DOTAccessTokenExchangeView
+
+
+class RevokeTokenView(_DispatchingView):
+    """
+    Dispatch to the RevokeTokenView of django-oauth-toolkit
+    """
+    dot_view = dot_views.RevokeTokenView


### PR DESCRIPTION
### Description

[MA-2552](https://openedx.atlassian.net/browse/MA-2552)

Created a new oauth2 endpoint to invalidate all the tokens associated with the user's session.
This is only implemented for Django-Oauth-Toolkit clients.
Its a POST endpoint `oauth2/revoke_token` with post body requires `client_id`, `token` (where token is the value of refresh_token or access_token)
### Sandbox
- [x] https://jia-revoke-token.sandbox.edx.org/
### Testing
- [x] Unit
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @verdanmahmood 
- [x] Code review: @nasthagiri 
### Post-review
- [x] Squash commits
