### PR TITLE
Show message on progress page when user is in audit mode.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1446,6 +1446,22 @@ class ProgressPageTests(ModuleStoreTestCase):
         self.assertContains(resp, u'Download Your Certificate')
         self.assert_invalidate_certificate(generated_certificate)
 
+    def test_message_for_audit_mode(self):
+        """ Verify that message appears on progress page, if learner is enrolled
+         in audit mode.
+        """
+        user = UserFactory.create()
+        self.assertTrue(self.client.login(username=user.username, password='test'))
+        CourseEnrollmentFactory(user=user, course_id=self.course.id, mode=CourseMode.AUDIT)
+        response = self.client.get(
+            reverse('progress', args=[unicode(self.course.id)])
+        )
+
+        self.assertContains(
+            response,
+            u'You are enrolled in the audit track for this course. The audit track does not include a certificate.'
+        )
+
     def assert_invalidate_certificate(self, certificate):
         """ Dry method to mark certificate as invalid. And assert the response. """
         CertificateInvalidationFactory.create(

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -753,6 +753,7 @@ def _progress(request, course_key, student_id):
         'credit_course_requirements': _credit_course_requirements(course_key, student),
         'missing_required_verification': missing_required_verification,
         'certificate_invalidated': False,
+        'enrollment_mode': enrollment_mode,
     }
 
     if show_generate_cert_btn:

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -2,6 +2,7 @@
 <%namespace name='static' file='/static_content.html'/>
 <%def name="online_help_token()"><% return "progress" %></%def>
 <%!
+from course_modes.models import CourseMode
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from util.date_utils import get_time_display, DEFAULT_SHORT_DATE_FORMAT
@@ -47,9 +48,15 @@ from django.utils.http import urlquote_plus
           <header class="progress-certificates">
             <h1 class="progress-certificates-title">${_("Course Progress for Student '{username}' ({email})").format(username=student.username, email=student.email) | h}</h1>
           </header>
-
-          %if show_generate_cert_btn:
-          <div class="wrapper-msg wrapper-auto-cert">
+        <div class="wrapper-msg wrapper-auto-cert">
+          %if enrollment_mode == CourseMode.AUDIT:
+            <div class="auto-cert-message">
+              <div class="msg-content">
+                <h2 class="title">${_("Your enrollment: Audit track")}</h2>
+                <p class="copy">${_("You are enrolled in the audit track for this course. The audit track does not include a certificate.")}</p>
+              </div>
+            </div>
+          %elif show_generate_cert_btn:
             <div id="errors-info" class="errors-info"></div>
             %if passed:
             <div class="auto-cert-message" id="course-success">
@@ -105,8 +112,9 @@ from django.utils.http import urlquote_plus
               </div>
             </div>
             %endif
-          </div>
           %endif
+        </div>
+
 
           %if not course.disable_progress_graph:
             <div class="grade-detail-graph" id="grade-detail-graph" aria-hidden="true"></div>


### PR DESCRIPTION
[ECOM-4797](https://openedx.atlassian.net/browse/ECOM-4797)

Learner can't get certificate if he/she is enrolled in `audit` mode. Message added on learner's progress page.

Please review this @waheedahmed 

**Screenshot**
<img width="1128" alt="screen shot 2016-06-30 at 8 10 54 pm" src="https://cloud.githubusercontent.com/assets/4245618/16493556/5fd2b16e-3eff-11e6-8941-2c35964c4bb6.png">

**Verified on:**
https://tasawernawaz.sandbox.edx.org/
