### PR TITLE
WL-541 Add recipient key to Zendesk ticket creation API request payload

### DIFF
--- a/common/djangoapps/util/tests/test_submit_feedback.py
+++ b/common/djangoapps/util/tests/test_submit_feedback.py
@@ -165,6 +165,7 @@ class SubmitFeedbackTest(TestCase):
             mock.call.create_ticket(
                 {
                     "ticket": {
+                        "recipient": "registration@example.com",
                         "requester": {"name": "Test User", "email": "test@edx.org"},
                         "subject": "a subject",
                         "comment": {"body": "some details"},
@@ -208,6 +209,7 @@ class SubmitFeedbackTest(TestCase):
             mock.call.create_ticket(
                 {
                     "ticket": {
+                        "recipient": "no-reply@fakeuniversity.com",
                         "requester": {"name": "Test User", "email": "test@edx.org"},
                         "subject": "a subject",
                         "comment": {"body": "some details"},
@@ -259,6 +261,7 @@ class SubmitFeedbackTest(TestCase):
             mock.call.create_ticket(
                 {
                     "ticket": {
+                        "recipient": "registration@example.com",
                         "requester": {"name": "Test User", "email": "test@edx.org"},
                         "subject": "a subject",
                         "comment": {"body": "some details"},


### PR DESCRIPTION
This change will make it easier for the edX support team to reply to support tickets created via the contact form on WL sites and have the from email address of those replies come from the appropriate WL support address.
