### PR TITLE
AC-518 updates `button-name` todo; needs TinyMCE work

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -95,7 +95,7 @@ class BulkEmailTest(BaseInstructorDashboardTest):
         ])
         self.send_email_page.a11y_audit.config.set_rules({
             "ignore": [
-                'button-name',  # TODO: AC-491
+                'button-name',  # TinyMCE button is missing accessible text
                 'color-contrast',  # TODO: AC-491
             ]
         })


### PR DESCRIPTION
# AC-518

This addresses ignored a11y checks for `button-name`.
## Sandbox

https://clrux-ac-518.sandbox.edx.org
## Special notes

There is one remaining ignore that's specific to a TinyMCE button (the caret/dropdown button). We don't want to edit vendor files so I've left this ignore in place.
## Reviewers
- [x] @cptvitamin 
- [x] @bjacobel
- [x] @cahrens, @andy-armstrong, or other TNL
