### PR TITLE
AC-519 removing list from ignored a11y check

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -96,7 +96,6 @@ class BulkEmailTest(BaseInstructorDashboardTest):
         self.send_email_page.a11y_audit.config.set_rules({
             "ignore": [
                 'button-name',  # TODO: AC-491
-                'list',  # TODO: AC-491,
                 'color-contrast',  # TODO: AC-491
             ]
         })


### PR DESCRIPTION
This test is no longer triggering failures.

FYI @cptvitamin 
