### PR TITLE
Fix reading view state for discussion thread listing (against feature branch)

### DIFF
--- a/lms/static/sass/discussion/elements/_navigation.scss
+++ b/lms/static/sass/discussion/elements/_navigation.scss
@@ -207,6 +207,7 @@
 .forum-nav-thread {
   border-bottom: 1px solid $forum-color-border;
   background-color: $forum-color-background;
+  margin-bottom: 0;
 
   &.is-unread {
     background: $forum-color-background;
@@ -226,18 +227,29 @@
 .forum-nav-thread-link {
   display: block;
   padding: ($baseline/4) ($baseline/2);
+  transition: none;
 
-  &.is-active {
-    background-color: $forum-color-background;
-    color: $base-font-color;
+  &.is-active,
+  &:hover {
+    color: $forum-color-background;
+    background-color: $forum-color-hover-thread;
+
+    .forum-nav-thread-labels > li {
+      border-color: $forum-color-background;
+      color: $forum-color-background;
+    }
 
     .forum-nav-thread-comments-count {
-      background-color: $gray-l4;
+      background-color: $forum-color-background;
       color: $base-font-color;
 
       &:after {
         border-right-color: $gray-l4;
       }
+    }
+
+    span.icon {
+      color: $forum-color-background;
     }
   }
 

--- a/lms/static/sass/discussion/elements/_navigation.scss
+++ b/lms/static/sass/discussion/elements/_navigation.scss
@@ -229,11 +229,18 @@
   padding: ($baseline/4) ($baseline/2);
   transition: none;
 
-  &.is-active,
   &:hover {
     color: $forum-color-background;
     background-color: $forum-color-hover-thread;
+  }
 
+  &.is-active {
+    color: $forum-color-background;
+    background-color: $forum-color-reading-thread;
+  }
+
+  &.is-active,
+  &:hover {
     .forum-nav-thread-labels > li {
       border-color: $forum-color-background;
       color: $forum-color-background;

--- a/lms/static/sass/discussion/utilities/_variables-v1.scss
+++ b/lms/static/sass/discussion/utilities/_variables-v1.scss
@@ -15,6 +15,7 @@ $forum-color-marked-answer: $green-d1 !default;
 $forum-color-border: $gray-l3 !default;
 $forum-color-error: $red !default;
 $forum-color-hover-thread: $gray-d3 !default;
+$forum-color-reading-thread: $gray-d3 !default;
 
 // post images
 $post-image-dimension: ($baseline*3) !default;  // image size  + margin

--- a/lms/static/sass/discussion/utilities/_variables-v1.scss
+++ b/lms/static/sass/discussion/utilities/_variables-v1.scss
@@ -14,6 +14,7 @@ $forum-color-community-ta: $green-d1 !default;
 $forum-color-marked-answer: $green-d1 !default;
 $forum-color-border: $gray-l3 !default;
 $forum-color-error: $red !default;
+$forum-color-hover-thread: $gray-d3 !default;
 
 // post images
 $post-image-dimension: ($baseline*3) !default;  // image size  + margin

--- a/lms/static/sass/discussion/utilities/_variables-v2.scss
+++ b/lms/static/sass/discussion/utilities/_variables-v2.scss
@@ -15,6 +15,7 @@ $forum-color-marked-answer: $green-d1 !default;
 $forum-color-border: palette(grayscale, base) !default;
 $forum-color-error: palette(error, base) !default;
 $forum-color-hover-thread: palette(grayscale, dark) !default;
+$forum-color-reading-thread: palette(grayscale, dark) !default;
 
 // post images
 $post-image-dimension: ($baseline*3) !default;  // image size  + margin

--- a/lms/static/sass/discussion/utilities/_variables-v2.scss
+++ b/lms/static/sass/discussion/utilities/_variables-v2.scss
@@ -14,6 +14,7 @@ $forum-color-community-ta: $green-d1 !default;
 $forum-color-marked-answer: $green-d1 !default;
 $forum-color-border: palette(grayscale, base) !default;
 $forum-color-error: palette(error, base) !default;
+$forum-color-hover-thread: palette(grayscale, dark) !default;
 
 // post images
 $post-image-dimension: ($baseline*3) !default;  // image size  + margin


### PR DESCRIPTION
### Description

[TNL-4556](https://openedx.atlassian.net/browse/TNL-4556)

Brings the read/active states on the discussion forums thread listings in line with [the comps](https://openedx.atlassian.net/secure/attachment/33818/Screen%20Shot%202016-05-19%20at%204.02.33%20PM.png).
### Sandbox
- [x] Build a sandbox for your branch and add a link here

https://bjacobel-active-thread.sandbox.edx.org
### Testing

N/A
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @dianakhuang 
- [ ] UX review: @chris-mike 
- [ ] Product review: @marcotuts 
### Post-review
- [ ] Squash commits
