### PR TITLE
Bump opaque-keys version to 0.3.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -44,7 +44,7 @@ edx-lint==0.4.3
 edx-django-oauth2-provider==1.1.1
 edx-django-sites-extensions==2.0.1
 edx-oauth2-provider==1.1.3
-edx-opaque-keys==0.2.1
+edx-opaque-keys==0.3.2
 edx-organizations==0.4.1
 edx-rest-api-client==1.2.1
 edx-search==0.1.2


### PR DESCRIPTION
Just wanted to test out edx-platform with the latest version before we publish an update to opaque keys.
