### PR TITLE
Bump UI Toolkit version to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "backbone": "~1.3.2",
     "coffee-script": "1.6.1",
     "edx-pattern-library": "0.13.0",
-    "edx-ui-toolkit": "1.3.0",
+    "edx-ui-toolkit": "1.4.1",
     "jquery": "~2.2.0",
     "jquery-migrate": "^1.4.1",
     "jquery.scrollto": "~2.1.2",


### PR DESCRIPTION
Required for the breadcrumbs work I will be doing later this week. Also should fix issues we are seeing with NPM this morning.
- [x] @benpatterson 
- [x] @AlasdairSwan (my +1 for the 1.4.1 release)
