### PR TITLE
Bake in the contentserver version to course asset paths + reorganize code.

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -16,6 +16,7 @@ from contentstore.utils import reverse_course_url
 from xmodule.contentstore.django import contentstore
 from xmodule.modulestore.django import modulestore
 from xmodule.contentstore.content import StaticContent
+from contentserver.url import get_static_path_from_location, serialize_asset_key_with_slash
 from xmodule.exceptions import NotFoundError
 from contentstore.views.exception import AssetNotFoundException
 from django.core.exceptions import PermissionDenied
@@ -369,7 +370,7 @@ def _get_asset_json(display_name, content_type, date, location, thumbnail_locati
     """
     Helper method for formatting the asset information to send to client.
     """
-    asset_url = StaticContent.serialize_asset_key_with_slash(location)
+    asset_url = serialize_asset_key_with_slash(location)
     external_url = settings.LMS_BASE + asset_url
     return {
         'display_name': display_name,
@@ -377,8 +378,8 @@ def _get_asset_json(display_name, content_type, date, location, thumbnail_locati
         'date_added': get_default_time_display(date),
         'url': asset_url,
         'external_url': external_url,
-        'portable_url': StaticContent.get_static_path_from_location(location),
-        'thumbnail': StaticContent.serialize_asset_key_with_slash(thumbnail_location) if thumbnail_location else None,
+        'portable_url': get_static_path_from_location(location),
+        'thumbnail': serialize_asset_key_with_slash(thumbnail_location) if thumbnail_location else None,
         'locked': locked,
         # Needed for Backbone delete/update.
         'id': unicode(location)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -92,6 +92,7 @@ from util.organizations_helpers import (
 )
 from util.string_utils import _has_non_ascii_characters
 from xmodule.contentstore.content import StaticContent
+from contentserver.url import get_base_url_path_for_course_assets
 from xmodule.course_module import CourseFields
 from xmodule.course_module import DEFAULT_START_DATE
 from xmodule.error_module import ErrorDescriptor
@@ -892,7 +893,7 @@ def course_info_handler(request, course_key_string):
                     'context_course': course_module,
                     'updates_url': reverse_course_url('course_info_update_handler', course_key),
                     'handouts_locator': course_key.make_usage_key('course_info', 'handouts'),
-                    'base_asset_url': StaticContent.get_base_url_path_for_course_assets(course_module.id),
+                    'base_asset_url': get_base_url_path_for_course_assets(course_module.id),
                     'push_notification_enabled': push_notification_enabled()
                 }
             )

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -14,6 +14,7 @@ from contentstore.views import assets
 from contentstore.utils import reverse_course_url
 from xmodule.assetstore import AssetMetadata
 from xmodule.contentstore.content import StaticContent
+from contentserver.url import get_static_path_from_location, get_location_from_path
 from xmodule.contentstore.django import contentstore
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import ModuleStoreEnum
@@ -82,7 +83,7 @@ class BasicAssetsTestCase(AssetsTestCase):
 
         course_key = SlashSeparatedCourseKey('org', 'class', 'run')
         location = course_key.make_asset_key('asset', 'my_file_name.jpg')
-        path = StaticContent.get_static_path_from_location(location)
+        path = get_static_path_from_location(location)
         self.assertEquals(path, '/static/my_file_name.jpg')
 
     def test_pdf_asset(self):
@@ -379,7 +380,7 @@ class LockAssetTestCase(AssetsTestCase):
         """
         def verify_asset_locked_state(locked):
             """ Helper method to verify lock state in the contentstore """
-            asset_location = StaticContent.get_location_from_path('/c4x/edX/toy/asset/sample_static.html')
+            asset_location = get_location_from_path('/c4x/edX/toy/asset/sample_static.html')
             content = contentstore().find(asset_location)
             self.assertEqual(content.locked, locked)
 
@@ -465,7 +466,7 @@ class DeleteAssetTestCase(AssetsTestCase):
         response = self.client.post(self.url, {"name": "delete_image_thumb_test", "file": thumbnail_image_asset})
         self.assertEquals(response.status_code, 200)
         thumbnail_url = json.loads(response.content)['asset']['url']
-        thumbnail_location = StaticContent.get_location_from_path(thumbnail_url)
+        thumbnail_location = get_location_from_path(thumbnail_url)
 
         image_asset_location = AssetLocation.from_deprecated_string(uploaded_image_url)
         content = contentstore().find(image_asset_location)
@@ -491,7 +492,7 @@ class DeleteAssetTestCase(AssetsTestCase):
         """ Tests the sad path :( """
         test_url = reverse_course_url(
             'assets_handler', self.course.id, kwargs={'asset_key_string': unicode(self.uploaded_url)})
-        self.content.thumbnail_location = StaticContent.get_location_from_path('/c4x/edX/toy/asset/invalid')
+        self.content.thumbnail_location = get_location_from_path('/c4x/edX/toy/asset/invalid')
         contentstore().save(self.content)
         resp = self.client.delete(test_url, HTTP_ACCEPT="application/json")
         self.assertEquals(resp.status_code, 204)

--- a/common/djangoapps/contentserver/test/test_contentserver.py
+++ b/common/djangoapps/contentserver/test/test_contentserver.py
@@ -28,6 +28,8 @@ from contentserver.middleware import parse_range_header, HTTP_DATE_FORMAT, Stati
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory, AdminFactory
 
+from contentserver.url import get_location_from_path, add_version_to_asset_path
+
 log = logging.getLogger(__name__)
 
 TEST_DATA_CONTENTSTORE = copy.deepcopy(settings.CONTENTSTORE)
@@ -42,9 +44,9 @@ def get_versioned_asset_url(asset_path):
     Creates a versioned asset URL.
     """
     try:
-        locator = StaticContent.get_location_from_path(asset_path)
+        locator = get_location_from_path(asset_path)
         content = AssetManager.find(locator, as_stream=True)
-        return StaticContent.add_version_to_asset_path(asset_path, content.content_digest)
+        return add_version_to_asset_path(asset_path, content.content_digest)
     except (InvalidKeyError, ItemNotFoundError):
         pass
 
@@ -115,7 +117,7 @@ class ContentStoreToyCourseTest(SharedModuleStoreTestCase):
         Test that unlocked assets that are versioned, but have a nonexistent version,
         are sent back as a 301 redirect which tells the caller the correct URL.
         """
-        url_unlocked_versioned_old = StaticContent.add_version_to_asset_path(self.url_unlocked, FAKE_MD5_HASH)
+        url_unlocked_versioned_old = add_version_to_asset_path(self.url_unlocked, FAKE_MD5_HASH)
 
         self.client.logout()
         resp = self.client.get(url_unlocked_versioned_old)

--- a/common/djangoapps/contentserver/url.py
+++ b/common/djangoapps/contentserver/url.py
@@ -1,0 +1,222 @@
+import re
+
+from urlparse import urlparse, urlunparse, parse_qsl
+from urllib import urlencode, quote_plus
+from opaque_keys.edx.locator import AssetLocator
+from opaque_keys.edx.keys import CourseKey, AssetKey
+from opaque_keys import InvalidKeyError
+from xmodule.assetstore.assetmgr import AssetManager
+from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule.exceptions import NotFoundError
+from xmodule.contentstore.content import StaticContent
+from static_replace.constants import STATIC_RESOURCE_PREFIX
+
+from . import CONTENTSERVER_VERSION
+
+VERSIONED_ASSETS_PREFIX = '/assets/courseware'
+VERSIONED_ASSETS_PATTERN = r'/assets/courseware(/v[\d])?/([a-f0-9]{32})'
+ASSET_URL_RE = re.compile(r"""
+        /?c4x/
+        (?P<org>[^/]+)/
+        (?P<course>[^/]+)/
+        (?P<category>[^/]+)/
+        (?P<name>[^/]+)
+    """, re.VERBOSE | re.IGNORECASE)
+
+
+def is_versioned_asset_path(path):
+    """Determines whether the given asset path is versioned."""
+    return path.startswith(VERSIONED_ASSETS_PREFIX)
+
+
+def parse_versioned_asset_path(path):
+    """
+    Examines an asset path and breaks it apart if it is versioned,
+    returning both the asset digest and the unversioned asset path,
+    which will normally be an AssetKey.
+    """
+    asset_digest = None
+    asset_path = path
+    if is_versioned_asset_path(asset_path):
+        result = re.match(VERSIONED_ASSETS_PATTERN, asset_path)
+        if result is not None:
+            asset_digest = result.groups()[1]
+        asset_path = re.sub(VERSIONED_ASSETS_PATTERN, '', asset_path)
+
+    return (asset_digest, asset_path)
+
+
+def add_version_to_asset_path(path, version):
+    """
+    Adds a prefix to an asset path indicating the asset's version.
+    """
+
+    # Don't version an already-versioned path.
+    if is_versioned_asset_path(path):
+        return path
+
+    # TODO: this should just use some sort of join-these-url-components-smartly function from stdlib
+    return u"{}/v{}/{}{}".format(VERSIONED_ASSETS_PREFIX, CONTENTSERVER_VERSION, version, path)
+
+
+def get_asset_key_from_path(course_key, path):
+    """
+    Parses a path, extracting an asset key or creating one.
+
+    Args:
+        course_key: key to the course which owns this asset
+        path: the path to said content
+
+    Returns:
+        AssetKey: the asset key that represents the path
+    """
+
+    # Clean up the path, removing any static prefix and any leading slash.
+    if path.startswith(STATIC_RESOURCE_PREFIX):
+        path = path[len(STATIC_RESOURCE_PREFIX):]
+
+    path = path.lstrip('/')
+
+    try:
+        return AssetKey.from_string(path)
+    except InvalidKeyError:
+        # If we couldn't parse the path, just let compute_location figure it out.
+        # It's most likely a path like /image.png or something.
+        return StaticContent.compute_location(course_key, path)
+
+
+def is_excluded_asset_type(path, excluded_exts):
+    """
+    Check if this is an allowed file extension to serve.
+
+    Some files aren't served through the CDN in order to avoid same-origin policy/CORS-related issues.
+    """
+    return any(path.lower().endswith(excluded_ext.lower()) for excluded_ext in excluded_exts)
+
+
+def get_canonicalized_asset_path(course_key, path, base_url, excluded_exts, encode=True):
+    """
+    Returns a fully-qualified path to a piece of static content.
+
+    If a static asset CDN is configured, this path will include it.
+    Otherwise, the path will simply be relative.
+
+    Args:
+        course_key: key to the course which owns this asset
+        path: the path to said content
+
+    Returns:
+        string: fully-qualified path to asset
+    """
+
+    # Break down the input path.
+    _, _, relative_path, params, query_string, _ = urlparse(path)
+
+    # Convert our path to an asset key if it isn't one already.
+    asset_key = get_asset_key_from_path(course_key, relative_path)
+
+    # Check the status of the asset to see if this can be served via CDN aka publicly.
+    serve_from_cdn = False
+    content_digest = None
+    try:
+        content = AssetManager.find(asset_key, as_stream=True)
+        serve_from_cdn = not getattr(content, "locked", True)
+        content_digest = getattr(content, "content_digest", None)
+    except (ItemNotFoundError, NotFoundError):
+        # If we can't find the item, just treat it as if it's locked.
+        serve_from_cdn = False
+
+    # Do a generic check to see if anything about this asset disqualifies it from being CDN'd.
+    is_excluded = False
+    if is_excluded_asset_type(relative_path, excluded_exts):
+        serve_from_cdn = False
+        is_excluded = True
+
+    # Update any query parameter values that have asset paths in them. This is for assets that
+    # require their own after-the-fact values, like a Flash file that needs the path of a config
+    # file passed to it e.g. /static/visualization.swf?configFile=/static/visualization.xml
+    query_params = parse_qsl(query_string)
+    updated_query_params = []
+    for query_name, query_val in query_params:
+        if query_val.startswith(STATIC_RESOURCE_PREFIX):
+            new_val = get_canonicalized_asset_path(
+                course_key, query_val, base_url, excluded_exts, encode=False)
+            updated_query_params.append((query_name, new_val))
+        else:
+            # Make sure we're encoding Unicode strings down to their byte string
+            # representation so that `urlencode` can handle it.
+            updated_query_params.append((query_name, query_val.encode('utf-8')))
+
+    serialized_asset_key = serialize_asset_key_with_slash(asset_key)
+    base_url = base_url if serve_from_cdn else ''
+    asset_path = serialized_asset_key
+
+    # If the content has a digest (i.e. md5sum) value specified, create a versioned path to the asset using it.
+    if not is_excluded and content_digest:
+        asset_path = add_version_to_asset_path(serialized_asset_key, content_digest)
+
+    # Only encode this if told to.  Important so that we don't double encode
+    # when working with paths that are in query parameters.
+    asset_path = asset_path.encode('utf-8')
+    if encode:
+        asset_path = quote_plus(asset_path, '/:+@')
+
+    return urlunparse((None, base_url.encode('utf-8'), asset_path, params, urlencode(updated_query_params), None))
+
+
+def get_base_url_path_for_course_assets(course_key):
+    if course_key is None:
+        return None
+
+    assert isinstance(course_key, CourseKey)
+    placeholder_id = uuid.uuid4().hex
+    # create a dummy asset location with a fake but unique name. strip off the name, and return it
+    url_path = serialize_asset_key_with_slash(
+        course_key.make_asset_key('asset', placeholder_id).for_branch(None)
+    )
+    return url_path.replace(placeholder_id, '')
+
+
+def get_location_from_path(path):
+    """
+    Generate an AssetKey for the given path (old c4x/org/course/asset/name syntax)
+    """
+    try:
+        return AssetKey.from_string(path)
+    except InvalidKeyError:
+        # TODO - re-address this once LMS-11198 is tackled.
+        if path.startswith('/'):
+            # try stripping off the leading slash and try again
+            return AssetKey.from_string(path[1:])
+
+
+def serialize_asset_key_with_slash(asset_key):
+    """
+    Legacy code expects the serialized asset key to start w/ a slash; so, do that in one place
+    :param asset_key:
+    """
+    url = unicode(asset_key)
+    if not url.startswith('/'):
+        url = '/' + url  # TODO - re-address this once LMS-11198 is tackled.
+    return url
+
+
+def is_c4x_path(path_string):
+    """
+    Returns a boolean if a path is believed to be a c4x link based on the leading element
+    """
+    return ASSET_URL_RE.match(path_string) is not None
+
+
+def get_static_path_from_location(location):
+    """
+    This utility static method will take a location identifier and create a 'durable' /static/.. URL representation of it.
+    This link is 'durable' as it can maintain integrity across cloning of courseware across course-ids, e.g. reruns of
+    courses.
+    In the LMS/CMS, we have runtime link-rewriting, so at render time, this /static/... format will get translated into
+    the actual /c4x/... path which the client needs to reference static content
+    """
+    if location is not None:
+        return u"/static/{name}".format(name=location.name)
+    else:
+        return None

--- a/common/djangoapps/contentserver/url.py
+++ b/common/djangoapps/contentserver/url.py
@@ -1,9 +1,11 @@
+"""
+Helper functions to generate usable URLs from asset keys.
+"""
 import re
 import uuid
 
 from urlparse import urlparse, urlunparse, parse_qsl
 from urllib import urlencode, quote_plus
-from opaque_keys.edx.locator import AssetLocator
 from opaque_keys.edx.keys import CourseKey, AssetKey
 from opaque_keys import InvalidKeyError
 from xmodule.assetstore.assetmgr import AssetManager
@@ -165,6 +167,9 @@ def get_canonicalized_asset_path(course_key, path, base_url, excluded_exts, enco
 
 
 def get_base_url_path_for_course_assets(course_key):
+    """
+    Generates the base URL for an asset of a given course.
+    """
     if course_key is None:
         return None
 
@@ -193,7 +198,6 @@ def get_location_from_path(path):
 def serialize_asset_key_with_slash(asset_key):
     """
     Legacy code expects the serialized asset key to start w/ a slash; so, do that in one place
-    :param asset_key:
     """
     url = unicode(asset_key)
     if not url.startswith('/'):
@@ -210,13 +214,9 @@ def is_c4x_path(path_string):
 
 def get_static_path_from_location(location):
     """
-    This utility static method will take a location identifier and create a 'durable' /static/.. URL representation of it.
-    This link is 'durable' as it can maintain integrity across cloning of courseware across course-ids, e.g. reruns of
-    courses.
-    In the LMS/CMS, we have runtime link-rewriting, so at render time, this /static/... format will get translated into
-    the actual /c4x/... path which the client needs to reference static content
+    Generates the equivalent "static" version of an asset i.e. "/static/file.png"
     """
     if location is not None:
-        return u"/static/{name}".format(name=location.name)
+        return u"/static/{}".format(location.name)
     else:
         return None

--- a/common/djangoapps/contentserver/url.py
+++ b/common/djangoapps/contentserver/url.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 
 from urlparse import urlparse, urlunparse, parse_qsl
 from urllib import urlencode, quote_plus
@@ -9,7 +10,6 @@ from xmodule.assetstore.assetmgr import AssetManager
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.exceptions import NotFoundError
 from xmodule.contentstore.content import StaticContent
-from static_replace.constants import STATIC_RESOURCE_PREFIX
 
 from . import CONTENTSERVER_VERSION
 
@@ -72,8 +72,8 @@ def get_asset_key_from_path(course_key, path):
     """
 
     # Clean up the path, removing any static prefix and any leading slash.
-    if path.startswith(STATIC_RESOURCE_PREFIX):
-        path = path[len(STATIC_RESOURCE_PREFIX):]
+    if path.startswith('/static/'):
+        path = path[len('/static/'):]
 
     path = path.lstrip('/')
 

--- a/common/djangoapps/contentserver/url.py
+++ b/common/djangoapps/contentserver/url.py
@@ -138,7 +138,7 @@ def get_canonicalized_asset_path(course_key, path, base_url, excluded_exts, enco
     query_params = parse_qsl(query_string)
     updated_query_params = []
     for query_name, query_val in query_params:
-        if query_val.startswith(STATIC_RESOURCE_PREFIX):
+        if query_val.startswith('/static/'):
             new_val = get_canonicalized_asset_path(
                 course_key, query_val, base_url, excluded_exts, encode=False)
             updated_query_params.append((query_name, new_val))

--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -9,11 +9,12 @@ from static_replace.models import AssetBaseUrlConfig, AssetExcludedExtensionsCon
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.contentstore.content import StaticContent
-
 from opaque_keys.edx.locator import AssetLocator
+from contentserver.url import get_canonicalized_asset_path
+
+from .constants import XBLOCK_STATIC_RESOURCE_PREFIX, STATIC_RESOURCE_PREFIX
 
 log = logging.getLogger(__name__)
-XBLOCK_STATIC_RESOURCE_PREFIX = '/static/xblock'
 
 
 def _url_replace_regex(prefix):
@@ -189,7 +190,7 @@ def replace_static_urls(text, data_directory=None, course_id=None, static_asset_
                 # Mongo-backed database
                 base_url = AssetBaseUrlConfig.get_base_url()
                 excluded_exts = AssetExcludedExtensionsConfig.get_excluded_extensions()
-                url = StaticContent.get_canonicalized_asset_path(course_id, rest, base_url, excluded_exts)
+                url = get_canonicalized_asset_path(course_id, rest, base_url, excluded_exts)
 
                 if AssetLocator.CANONICAL_NAMESPACE in url:
                     url = url.replace('block@', 'block/', 1)

--- a/common/djangoapps/static_replace/constants.py
+++ b/common/djangoapps/static_replace/constants.py
@@ -1,0 +1,2 @@
+XBLOCK_STATIC_RESOURCE_PREFIX = '/static/xblock'
+STATIC_RESOURCE_PREFIX = '/static/'

--- a/common/djangoapps/static_replace/constants.py
+++ b/common/djangoapps/static_replace/constants.py
@@ -1,2 +1,5 @@
+"""
+Common constants.
+"""
 XBLOCK_STATIC_RESOURCE_PREFIX = '/static/xblock'
 STATIC_RESOURCE_PREFIX = '/static/'

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -117,7 +117,6 @@ def test_storage_url_not_exists(mock_storage):
 @patch('static_replace.AssetBaseUrlConfig.get_base_url')
 @patch('static_replace.AssetExcludedExtensionsConfig.get_excluded_extensions')
 def test_mongo_filestore(mock_get_excluded_extensions, mock_get_base_url, mock_modulestore):
-
     mock_modulestore.return_value = Mock(MongoModuleStore)
     mock_get_base_url.return_value = u''
     mock_get_excluded_extensions.return_value = ['foobar']

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -540,7 +540,7 @@ class CanonicalContentTest(SharedModuleStoreTestCase):
         )
 
         expected = encode_unicode_characters_in_url(expected)
-        expected = expected.replace('VMARK', 'v[\d]')
+        expected = expected.replace('VMARK', r'v[\d]')
         expected = expected.replace('HMARK', '[a-f0-9]{32}')
         expected = expected.replace('+', r'\+').replace('?', r'\?')
 
@@ -738,7 +738,7 @@ class CanonicalContentTest(SharedModuleStoreTestCase):
         )
 
         expected = encode_unicode_characters_in_url(expected)
-        expected = expected.replace('VMARK', 'v[\d]')
+        expected = expected.replace('VMARK', r'v[\d]')
         expected = expected.replace('HMARK', '[a-f0-9]{32}')
         expected = expected.replace('+', r'\+').replace('?', r'\?')
 

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -43,13 +43,12 @@ class StaticContent(object):
         return self.location.category == 'thumbnail'
 
     @staticmethod
-    def compute_location(course_key, path, revision=None, is_thumbnail=False):
+    def compute_location(course_key, path, is_thumbnail=False):
         """
         Constructs a location object for static content.
 
         - course_key: the course that this asset belongs to
         - path: is the name of the static asset
-        - revision: is the object's revision information
         - is_thumbnail: is whether or not we want the thumbnail version of this
             asset
         """
@@ -86,6 +85,9 @@ class StaticContent(object):
         return self.location
 
     def stream_data(self):
+        """
+        Streams the data of this content to the caller.
+        """
         return self._data
 
     @property
@@ -102,6 +104,9 @@ class StaticContentStream(StaticContent):
         self._stream = stream
 
     def stream_data(self):
+        """
+        Streams the data of this content to the caller.
+        """
         while True:
             chunk = self._stream.read(STREAM_DATA_CHUNK_SIZE)
             if len(chunk) == 0:

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -7,8 +7,6 @@ XASSET_LOCATION_TAG = 'c4x'
 XASSET_SRCREF_PREFIX = 'xasset:'
 XASSET_THUMBNAIL_TAIL_NAME = '.jpg'
 STREAM_DATA_CHUNK_SIZE = 1024
-VERSIONED_ASSETS_PREFIX = '/assets/courseware'
-VERSIONED_ASSETS_PATTERN = r'/assets/courseware/([a-f0-9]{32})'
 
 import os
 import logging
@@ -45,6 +43,23 @@ class StaticContent(object):
         return self.location.category == 'thumbnail'
 
     @staticmethod
+    def compute_location(course_key, path, revision=None, is_thumbnail=False):
+        """
+        Constructs a location object for static content.
+
+        - course_key: the course that this asset belongs to
+        - path: is the name of the static asset
+        - revision: is the object's revision information
+        - is_thumbnail: is whether or not we want the thumbnail version of this
+            asset
+        """
+        path = path.replace('/', '_')
+        return course_key.make_asset_key(
+            'asset' if not is_thumbnail else 'thumbnail',
+            AssetLocator.clean_keeping_underscores(path)
+        ).for_branch(None)
+
+    @staticmethod
     def generate_thumbnail_name(original_name, dimensions=None, extension=None):
         """
         - original_name: Name of the asset (typically its location.name)
@@ -67,237 +82,15 @@ class StaticContent(object):
             extension=extension,
         )
 
-    @staticmethod
-    def compute_location(course_key, path, revision=None, is_thumbnail=False):
-        """
-        Constructs a location object for static content.
-
-        - course_key: the course that this asset belongs to
-        - path: is the name of the static asset
-        - revision: is the object's revision information
-        - is_thumbnail: is whether or not we want the thumbnail version of this
-            asset
-        """
-        path = path.replace('/', '_')
-        return course_key.make_asset_key(
-            'asset' if not is_thumbnail else 'thumbnail',
-            AssetLocator.clean_keeping_underscores(path)
-        ).for_branch(None)
-
     def get_id(self):
         return self.location
+
+    def stream_data(self):
+        return self._data
 
     @property
     def data(self):
         return self._data
-
-    ASSET_URL_RE = re.compile(r"""
-        /?c4x/
-        (?P<org>[^/]+)/
-        (?P<course>[^/]+)/
-        (?P<category>[^/]+)/
-        (?P<name>[^/]+)
-    """, re.VERBOSE | re.IGNORECASE)
-
-    @staticmethod
-    def is_c4x_path(path_string):
-        """
-        Returns a boolean if a path is believed to be a c4x link based on the leading element
-        """
-        return StaticContent.ASSET_URL_RE.match(path_string) is not None
-
-    @staticmethod
-    def get_static_path_from_location(location):
-        """
-        This utility static method will take a location identifier and create a 'durable' /static/.. URL representation of it.
-        This link is 'durable' as it can maintain integrity across cloning of courseware across course-ids, e.g. reruns of
-        courses.
-        In the LMS/CMS, we have runtime link-rewriting, so at render time, this /static/... format will get translated into
-        the actual /c4x/... path which the client needs to reference static content
-        """
-        if location is not None:
-            return u"/static/{name}".format(name=location.name)
-        else:
-            return None
-
-    @staticmethod
-    def get_base_url_path_for_course_assets(course_key):
-        if course_key is None:
-            return None
-
-        assert isinstance(course_key, CourseKey)
-        placeholder_id = uuid.uuid4().hex
-        # create a dummy asset location with a fake but unique name. strip off the name, and return it
-        url_path = StaticContent.serialize_asset_key_with_slash(
-            course_key.make_asset_key('asset', placeholder_id).for_branch(None)
-        )
-        return url_path.replace(placeholder_id, '')
-
-    @staticmethod
-    def get_location_from_path(path):
-        """
-        Generate an AssetKey for the given path (old c4x/org/course/asset/name syntax)
-        """
-        try:
-            return AssetKey.from_string(path)
-        except InvalidKeyError:
-            # TODO - re-address this once LMS-11198 is tackled.
-            if path.startswith('/'):
-                # try stripping off the leading slash and try again
-                return AssetKey.from_string(path[1:])
-
-    @staticmethod
-    def is_versioned_asset_path(path):
-        """Determines whether the given asset path is versioned."""
-        return path.startswith(VERSIONED_ASSETS_PREFIX)
-
-    @staticmethod
-    def parse_versioned_asset_path(path):
-        """
-        Examines an asset path and breaks it apart if it is versioned,
-        returning both the asset digest and the unversioned asset path,
-        which will normally be an AssetKey.
-        """
-        asset_digest = None
-        asset_path = path
-        if StaticContent.is_versioned_asset_path(asset_path):
-            result = re.match(VERSIONED_ASSETS_PATTERN, asset_path)
-            if result is not None:
-                asset_digest = result.groups()[0]
-            asset_path = re.sub(VERSIONED_ASSETS_PATTERN, '', asset_path)
-
-        return (asset_digest, asset_path)
-
-    @staticmethod
-    def add_version_to_asset_path(path, version):
-        """
-        Adds a prefix to an asset path indicating the asset's version.
-        """
-
-        # Don't version an already-versioned path.
-        if StaticContent.is_versioned_asset_path(path):
-            return path
-
-        return VERSIONED_ASSETS_PREFIX + '/' + version + path
-
-    @staticmethod
-    def get_asset_key_from_path(course_key, path):
-        """
-        Parses a path, extracting an asset key or creating one.
-
-        Args:
-            course_key: key to the course which owns this asset
-            path: the path to said content
-
-        Returns:
-            AssetKey: the asset key that represents the path
-        """
-
-        # Clean up the path, removing any static prefix and any leading slash.
-        if path.startswith('/static/'):
-            path = path[len('/static/'):]
-
-        path = path.lstrip('/')
-
-        try:
-            return AssetKey.from_string(path)
-        except InvalidKeyError:
-            # If we couldn't parse the path, just let compute_location figure it out.
-            # It's most likely a path like /image.png or something.
-            return StaticContent.compute_location(course_key, path)
-
-    @staticmethod
-    def is_excluded_asset_type(path, excluded_exts):
-        """
-        Check if this is an allowed file extension to serve.
-
-        Some files aren't served through the CDN in order to avoid same-origin policy/CORS-related issues.
-        """
-        return any(path.lower().endswith(excluded_ext.lower()) for excluded_ext in excluded_exts)
-
-    @staticmethod
-    def get_canonicalized_asset_path(course_key, path, base_url, excluded_exts, encode=True):
-        """
-        Returns a fully-qualified path to a piece of static content.
-
-        If a static asset CDN is configured, this path will include it.
-        Otherwise, the path will simply be relative.
-
-        Args:
-            course_key: key to the course which owns this asset
-            path: the path to said content
-
-        Returns:
-            string: fully-qualified path to asset
-        """
-
-        # Break down the input path.
-        _, _, relative_path, params, query_string, _ = urlparse(path)
-
-        # Convert our path to an asset key if it isn't one already.
-        asset_key = StaticContent.get_asset_key_from_path(course_key, relative_path)
-
-        # Check the status of the asset to see if this can be served via CDN aka publicly.
-        serve_from_cdn = False
-        content_digest = None
-        try:
-            content = AssetManager.find(asset_key, as_stream=True)
-            serve_from_cdn = not getattr(content, "locked", True)
-            content_digest = getattr(content, "content_digest", None)
-        except (ItemNotFoundError, NotFoundError):
-            # If we can't find the item, just treat it as if it's locked.
-            serve_from_cdn = False
-
-        # Do a generic check to see if anything about this asset disqualifies it from being CDN'd.
-        is_excluded = False
-        if StaticContent.is_excluded_asset_type(relative_path, excluded_exts):
-            serve_from_cdn = False
-            is_excluded = True
-
-        # Update any query parameter values that have asset paths in them. This is for assets that
-        # require their own after-the-fact values, like a Flash file that needs the path of a config
-        # file passed to it e.g. /static/visualization.swf?configFile=/static/visualization.xml
-        query_params = parse_qsl(query_string)
-        updated_query_params = []
-        for query_name, query_val in query_params:
-            if query_val.startswith("/static/"):
-                new_val = StaticContent.get_canonicalized_asset_path(
-                    course_key, query_val, base_url, excluded_exts, encode=False)
-                updated_query_params.append((query_name, new_val))
-            else:
-                # Make sure we're encoding Unicode strings down to their byte string
-                # representation so that `urlencode` can handle it.
-                updated_query_params.append((query_name, query_val.encode('utf-8')))
-
-        serialized_asset_key = StaticContent.serialize_asset_key_with_slash(asset_key)
-        base_url = base_url if serve_from_cdn else ''
-        asset_path = serialized_asset_key
-
-        # If the content has a digest (i.e. md5sum) value specified, create a versioned path to the asset using it.
-        if not is_excluded and content_digest:
-            asset_path = StaticContent.add_version_to_asset_path(serialized_asset_key, content_digest)
-
-        # Only encode this if told to.  Important so that we don't double encode
-        # when working with paths that are in query parameters.
-        asset_path = asset_path.encode('utf-8')
-        if encode:
-            asset_path = quote_plus(asset_path, '/:+@')
-
-        return urlunparse((None, base_url.encode('utf-8'), asset_path, params, urlencode(updated_query_params), None))
-
-    def stream_data(self):
-        yield self._data
-
-    @staticmethod
-    def serialize_asset_key_with_slash(asset_key):
-        """
-        Legacy code expects the serialized asset key to start w/ a slash; so, do that in one place
-        :param asset_key:
-        """
-        url = unicode(asset_key)
-        if not url.startswith('/'):
-            url = '/' + url  # TODO - re-address this once LMS-11198 is tackled.
-        return url
 
 
 class StaticContentStream(StaticContent):

--- a/common/lib/xmodule/xmodule/contentstore/utils.py
+++ b/common/lib/xmodule/xmodule/contentstore/utils.py
@@ -1,4 +1,5 @@
 from xmodule.contentstore.content import StaticContent
+from contentserver.url import get_location_from_path
 from .django import contentstore
 
 
@@ -29,7 +30,7 @@ def restore_asset_from_trashcan(location):
     trash = contentstore('trashcan')
     store = contentstore()
 
-    loc = StaticContent.get_location_from_path(location)
+    loc = get_location_from_path(location)
     content = trash.find(loc)
 
     # ok, save the content into the courseware

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -13,6 +13,7 @@ import textwrap
 import dogstats_wrapper as dog_stats_api
 from xmodule.util.misc import escape_html_characters
 from xmodule.contentstore.content import StaticContent
+from contentserver.url import get_base_url_path_for_course_assets
 from xmodule.editing_module import EditingDescriptor
 from xmodule.edxnotes_utils import edxnotes
 from xmodule.html_checker import check_html
@@ -175,7 +176,7 @@ class HtmlDescriptor(HtmlBlock, XmlDescriptor, EditingDescriptor):  # pylint: di
         # Add some specific HTML rendering context when editing HTML modules where we pass
         # the root /c4x/ url for assets. This allows client-side substitutions to occur.
         _context.update({
-            'base_asset_url': StaticContent.get_base_url_path_for_course_assets(self.location.course_key),
+            'base_asset_url': get_base_url_path_for_course_assets(self.location.course_key),
             'enable_latex_compiler': self.use_latex_compiler,
             'editor': self.editor
         })

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -36,6 +36,7 @@ from xmodule.x_module import XModuleDescriptor, XModuleMixin
 from opaque_keys.edx.keys import UsageKey
 from xblock.fields import Scope, Reference, ReferenceList, ReferenceValueDict
 from xmodule.contentstore.content import StaticContent
+from contentserver.url import is_c4x_path, get_location_from_path, get_static_path_from_location
 from .inheritance import own_metadata
 from xmodule.errortracker import make_error_tracker
 from .store_utilities import rewrite_nonportable_content_links
@@ -516,9 +517,10 @@ class CourseImportManager(ImportManager):
         """
         for entry in course.pdf_textbooks:
             for chapter in entry.get('chapters', []):
-                if StaticContent.is_c4x_path(chapter.get('url', '')):
-                    asset_key = StaticContent.get_location_from_path(chapter['url'])
-                    chapter['url'] = StaticContent.get_static_path_from_location(asset_key)
+                if is_c4x_path(chapter.get('url', '')):
+                    asset_key = get_location_from_path(chapter['url'])
+                    chapter['url'] = get_static_path_from_location(asset_key)
+
 
         # Original wiki_slugs had value location.course. To make them unique this was changed to 'org.course.name'.
         # If we are importing into a course with a different course_id and wiki_slug is equal to either of these default

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -521,7 +521,6 @@ class CourseImportManager(ImportManager):
                     asset_key = get_location_from_path(chapter['url'])
                     chapter['url'] = get_static_path_from_location(asset_key)
 
-
         # Original wiki_slugs had value location.course. To make them unique this was changed to 'org.course.name'.
         # If we are importing into a course with a different course_id and wiki_slug is equal to either of these default
         # values then remap it so that the wiki does not point to the old wiki.

--- a/common/lib/xmodule/xmodule/tests/test_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_content.py
@@ -7,6 +7,7 @@ from mock import Mock, patch
 from path import Path as path
 
 from xmodule.contentstore.content import StaticContent, StaticContentStream
+from contentserver.url import get_location_from_path
 from xmodule.contentstore.content import ContentStore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey, AssetLocation
 from xmodule.static_content import _write_js, _list_descriptors
@@ -166,7 +167,7 @@ class ContentTest(unittest.TestCase):
         )
 
     def test_get_location_from_path(self):
-        asset_location = StaticContent.get_location_from_path(u'/c4x/a/b/asset/images_course_image.jpg')
+        asset_location = get_location_from_path(u'/c4x/a/b/asset/images_course_image.jpg')
         self.assertEqual(
             AssetLocation(u'a', u'b', None, u'asset', u'images_course_image.jpg', None),
             asset_location

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -36,6 +36,7 @@ from xmodule.raw_module import EmptyDataRawDescriptor
 from xmodule.xml_module import is_pointer_tag, name_to_pathname, deserialize_field
 from xmodule.exceptions import NotFoundError
 from xmodule.contentstore.content import StaticContent
+from contentserver.url import serialize_asset_key_with_slash, get_location_from_path
 
 from .transcripts_utils import VideoTranscriptsMixin, Transcript, get_html5_ids
 from .video_utils import create_youtube_string, get_poster, rewrite_video_url, format_xml_exception_message
@@ -759,10 +760,10 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
         course_id = getattr(id_generator, 'target_course_id', None)
         # Update the handout location with current course_id
         if 'handout' in field_data.keys() and course_id:
-            handout_location = StaticContent.get_location_from_path(field_data['handout'])
+            handout_location = get_location_from_path(field_data['handout'])
             if isinstance(handout_location, AssetLocator):
                 handout_new_location = StaticContent.compute_location(course_id, handout_location.path)
-                field_data['handout'] = StaticContent.serialize_asset_key_with_slash(handout_new_location)
+                field_data['handout'] = serialize_asset_key_with_slash(handout_new_location)
 
         # For backwards compatibility: Add `source` if XML doesn't have `download_video`
         # attribute.

--- a/openedx/core/djangoapps/content/course_overviews/tests.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests.py
@@ -22,6 +22,7 @@ from static_replace.models import AssetBaseUrlConfig
 from xmodule.assetstore.assetmgr import AssetManager
 from xmodule.contentstore.django import contentstore
 from xmodule.contentstore.content import StaticContent
+from contentserver.url import get_location_from_path
 from xmodule.course_metadata_utils import DEFAULT_START_DATE
 from xmodule.course_module import (
     CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
@@ -663,6 +664,8 @@ class CourseOverviewImageSetTestCase(ModuleStoreTestCase):
                 expected_path_start = "/asset-v1:"
 
             for url in overview.image_urls.values():
+                print expected_path_start
+                print url
                 self.assertTrue(url.startswith(expected_path_start))
 
             # Now enable the CDN...
@@ -797,7 +800,7 @@ class CourseOverviewImageSetTestCase(ModuleStoreTestCase):
 
             # Now make sure our thumbnails are of the sizes we expect...
             for image_url, expected_size in [(image_urls['small'], config.small), (image_urls['large'], config.large)]:
-                image_key = StaticContent.get_location_from_path(image_url)
+                image_key = get_location_from_path(image_url)
                 image_content = AssetManager.find(image_key)
                 image = Image.open(StringIO(image_content.data))
                 self.assertEqual(image.size, expected_size)
@@ -849,7 +852,7 @@ class CourseOverviewImageSetTestCase(ModuleStoreTestCase):
         image_urls = course_overview.image_urls
 
         for image_url, target in [(image_urls['small'], config.small), (image_urls['large'], config.large)]:
-            image_key = StaticContent.get_location_from_path(image_url)
+            image_key = get_location_from_path(image_url)
             image_content = AssetManager.find(image_key)
             image = Image.open(StringIO(image_content.data))
 

--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -29,7 +29,7 @@ def course_image_url(course, image_key='course_image'):
         url = settings.STATIC_URL + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
     else:
         loc = StaticContent.compute_location(course.id, getattr(course, image_key))
-        url = StaticContent.serialize_asset_key_with_slash(loc)
+        url = unicode(loc)
 
     return url
 
@@ -44,4 +44,4 @@ def create_course_image_thumbnail(course, dimensions):
 
     _content, thumb_loc = contentstore().generate_thumbnail(course_image, dimensions=dimensions)
 
-    return StaticContent.serialize_asset_key_with_slash(thumb_loc)
+    return unicode(thumb_loc)

--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -8,6 +8,7 @@ from xmodule.contentstore.content import StaticContent
 from xmodule.contentstore.django import contentstore
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import ModuleStoreEnum
+from contentserver.url import serialize_asset_key_with_slash
 
 
 def course_image_url(course, image_key='course_image'):
@@ -29,7 +30,7 @@ def course_image_url(course, image_key='course_image'):
         url = settings.STATIC_URL + settings.DEFAULT_COURSE_ABOUT_IMAGE_URL
     else:
         loc = StaticContent.compute_location(course.id, getattr(course, image_key))
-        url = unicode(loc)
+        url = serialize_asset_key_with_slash(loc)
 
     return url
 


### PR DESCRIPTION
This PR is two-header:
- bake in the `CONTENTSERVER_VERSION` into courseware asset URLs so that code changes can trigger client-side refreshes, providing a way to avoid chicken-egg problems like CloudFront sending old assets with in-the-past expiration dates
- move a lot of the code for generating canonicalized asset paths into the contentserver, since it's the area of code that actually understands those paths
