### PR TITLE
[WIP] Serve localfs instructor reports over HTTP

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2342,7 +2342,8 @@ GRADES_DOWNLOAD_ROUTING_KEY = HIGH_MEM_QUEUE
 GRADES_DOWNLOAD = {
     'STORAGE_TYPE': 'localfs',
     'BUCKET': 'edx-grades',
-    'ROOT_PATH': '/tmp/edx-s3/grades',
+    'ROOT_PATH': os.path.join(MEDIA_ROOT, 'grades/'),
+    'ROOT_URL': os.path.join(MEDIA_URL, 'grades/'),
 }
 
 FINANCIAL_REPORTS = {

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -7,7 +7,7 @@ from .aws import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 # Don't use S3 in devstack, fall back to filesystem
 del DEFAULT_FILE_STORAGE
-MEDIA_ROOT = "/edx/var/edxapp/uploads"
+MEDIA_ROOT = "/edx/var/edxapp/media"
 
 
 DEBUG = True


### PR DESCRIPTION
When using localfs to serve instructor reports, do it over HTTP, as
opposed to via "file://".  This allows for running devstack on
containers, and also for constrained production use (where the user is
guaranteed to hit the same web server on multiple requests).
