### PR TITLE
Make sure csmhextended is on by default in devstacks

### DIFF
--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -186,10 +186,6 @@ PROFILE_IMAGE_BACKEND = {
     },
 }
 
-# Make sure we test with the extended history table
-FEATURES['ENABLE_CSMH_EXTENDED'] = True
-INSTALLED_APPS += ('coursewarehistoryextended',)
-
 BADGING_BACKEND = 'lms.djangoapps.badges.backends.tests.dummy_backend.DummyBackend'
 
 # Configure the LMS to use our stub eCommerce implementation

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -349,11 +349,8 @@ FEATURES = {
     # Show Language selector.
     'SHOW_LANGUAGE_SELECTOR': False,
 
-    # Write new CSM history to the extended table.
-    # This will eventually default to True and may be
-    # removed since all installs should have the separate
-    # extended history table.
-    'ENABLE_CSMH_EXTENDED': False,
+    # This may be removed when all installs have the separate extended history table.
+    'ENABLE_CSMH_EXTENDED': True,
 
     # Read from both the CSMH and CSMHE history tables.
     # This is the default, but can be disabled if all history

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -200,9 +200,9 @@ if os.environ.get('DISABLE_MIGRATIONS'):
     # to Django 1.9, which allows setting MIGRATION_MODULES to None in order to skip migrations.
     MIGRATION_MODULES = NoOpMigrationModules()
 
-# Make sure we test with the extended history table
-FEATURES['ENABLE_CSMH_EXTENDED'] = True
-INSTALLED_APPS += ('coursewarehistoryextended',)
+# The extended StudentModule history table
+if FEATURES.get('ENABLE_CSMH_EXTENDED'):
+    INSTALLED_APPS += ('coursewarehistoryextended',)
 
 CACHES = {
     # This is the cache used for most things.


### PR DESCRIPTION
This is already on in devstacks and other environments because of https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/defaults/main.yml#L172

This just brings edx-platform into line.

test.py inherits from common, so needs to conditionally modify installed_apps, bok_choy/devstack import aws, so get that conditional.
