### PR TITLE
quiet some noisy logs

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1067,8 +1067,11 @@ class CapaMixin(CapaFields):
             self.set_last_submission_time()
 
         except (StudentInputError, ResponseError, LoncapaProblemError) as inst:
-            log.warning("StudentInputError in capa_module:problem_check",
-                        exc_info=True)
+            if self.runtime.DEBUG:
+                log.warning(
+                    "StudentInputError in capa_module:problem_check",
+                    exc_info=True
+                )
 
             # Save the user's state before failing
             self.set_state_from_lcp()

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -98,8 +98,8 @@ class CapaModule(CapaMixin, XModule):
         try:
             result = handlers[dispatch](data)
 
-        except NotFoundError as err:
-            log.exception(
+        except NotFoundError:
+            log.info(
                 "Unable to find data when dispatching %s to %s for user %s",
                 dispatch,
                 self.scope_ids.usage_id,

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1244,7 +1244,7 @@ class CourseDescriptor(CourseFields, SequenceDescriptor, LicenseMixin):
                     raise ValueError
             return ret
         except (TypeError, ValueError):
-            log.exception(
+            log.info(
                 "Error parsing discussion_blackouts %s for course %s",
                 self.discussion_blackouts,
                 self.id


### PR DESCRIPTION
I was looking through the kinds of error logs we get on prod, and I thought a bunch of them could be downgraded to `info`

Reviews?
- [x] @jibsheet
- [x] @ormsbee 
