### PR TITLE
Updated to check and ensure the progress Detail is a string before lo…

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -86,38 +86,38 @@ describe 'Problem', ->
     it 'bind the show button', ->
       expect($('div.action button.show')).toHandleWith 'click', @problem.show
 
+
   describe 'renderProgressState', ->
     beforeEach ->
       @problem = new Problem($('.xblock-student_view'))
       #@renderProgressState = @problem.renderProgressState
 
+    testProgessData = (problem, status, detail, expected_progress_after_render) ->
+      problem.el.data('progress_status', status)
+      problem.el.data('progress_detail', detail)
+      expect(problem.$('.problem-progress').html()).toEqual ""
+      problem.renderProgressState()
+      expect(problem.$('.problem-progress').html()).toEqual expected_progress_after_render
+
     describe 'with a status of "none"', ->
       it 'reports the number of points possible', ->
-        @problem.el.data('progress_status', 'none')
-        @problem.el.data('progress_detail', '0/1')
-        @problem.renderProgressState()
-        expect(@problem.$('.problem-progress').html()).toEqual "(1 point possible)"
+        testProgessData(@problem, 'none', '0/1', "(1 point possible)")
 
       it 'displays the number of points possible when rendering happens with the content', ->
-        @problem.el.data('progress_status', 'none')
-        @problem.el.data('progress_detail', '0/2')
-        expect(@problem.$('.problem-progress').html()).toEqual ""
-        @problem.render(problem_content_default)
-        expect(@problem.$('.problem-progress').html()).toEqual "(2 points possible)"
+        testProgessData(@problem, 'none', '0/2', "(2 points possible)")
 
     describe 'with any other valid status', ->
+
       it 'reports the current score', ->
-        @problem.el.data('progress_status', 'foo')
-        @problem.el.data('progress_detail', '1/1')
-        @problem.renderProgressState()
-        expect(@problem.$('.problem-progress').html()).toEqual "(1/1 point)"
+        testProgessData(@problem, 'foo', '1/1', "(1/1 point)")
 
       it 'shows current score when rendering happens with the content', ->
-        @problem.el.data('progress_status', 'test status')
-        @problem.el.data('progress_detail', '2/2')
-        expect(@problem.$('.problem-progress').html()).toEqual ""
-        @problem.render(problem_content_default)
-        expect(@problem.$('.problem-progress').html()).toEqual "(2/2 points)"
+        testProgessData(@problem, 'test status', '2/2', "(2/2 points)")
+
+    describe 'with valid status and string containing an integer like "0" for detail', ->
+      # These tests are to address a failure specific to Chrome 51 and 52 +
+      it 'shows no score possible for the detail', ->
+        testProgessData(@problem, 'foo', '0', "")
 
   describe 'render', ->
     beforeEach ->

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -66,8 +66,8 @@ class @Problem
     detail = @el.data('progress_detail')
     status = @el.data('progress_status')
 
-    # Render 'x/y point(s)' if student has attempted question
-    if status != 'none' and detail? and detail.indexOf('/') > 0
+    # Render 'x/y point(s)' if student has attempted question 
+    if status != 'none' and detail? and (jQuery.type(detail) == "string") and detail.indexOf('/') > 0
         a = detail.split('/')
         earned = parseFloat(a[0])
         possible = parseFloat(a[1])
@@ -77,7 +77,7 @@ class @Problem
         progress = interpolate(progress_template, {'earned': earned, 'possible': possible}, true)
 
     # Render 'x point(s) possible' if student has not yet attempted question
-    if status == 'none' and detail? and detail.indexOf('/') > 0
+    if status == 'none' and detail? and (jQuery.type(detail) == "string") and detail.indexOf('/') > 0
         a = detail.split('/')
         possible = parseFloat(a[1])
         `// Translators: %(num_points)s is the number of points possible (examples: 1, 3, 10). There will always be at least 1 point possible.`


### PR DESCRIPTION
…oking for the index of /

TNL-4723
### Description

[TNL-4723](https://openedx.atlassian.net/browse/TNL-4723)

Added a check to ensure that detail was a String before looking for the index of "/".  The issue was that when a "0" was returned for progress_detail the data() method would make a "best guss" on the type and return an integer 0. This would then cause the indexOf("/") method to throw an exception.
### Sandbox
- [x] Testing URL: https://studio-staubina.sandbox.edx.org 
- To test I would create a Blank Common Problem and a Blank Advanced Problem. While doing this observe the Chrome Dev Console and No "detail.indexOf is not a function" errors should be shown.
### Testing
- [x] Unit, integration, acceptance tests as appropriate

I ran the following unit tests on the dev stack with 0 failures
    paver test_js_run -s lms
    paver test_js_run -s lms-coffee
    paver test_js_run -s cms
    paver test_js_run -s xmodule
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @alisan617 

FYI for @muzaffaryousaf @ssemenova 
### Post-review
- [x] Squash commits
