### PR TITLE
asadiqbal08/WL-552 ID-Verification message is responsive in activate account page

### DIFF
--- a/lms/templates/verify_student/make_payment_step.underscore
+++ b/lms/templates/verify_student/make_payment_step.underscore
@@ -85,7 +85,7 @@
     <% } %>
 
     <% if ( courseModeSlug === 'no-id-professional') { %>
-    <div class="container register is-verified">
+    <div class="container register is-verified no-min-scale">
       <h3 class="title"><%- gettext( "ID-Verification is not required for this Professional Education course." ) %></h3>
       <p><%- gettext( "All professional education courses are fee-based, and require payment to complete the enrollment process." ) %></p>
     </div>


### PR DESCRIPTION
[WL-552](https://openedx.atlassian.net/browse/WL-552)
<img width="402" alt="screen shot 2016-07-11 at 5 44 16 pm" src="https://cloud.githubusercontent.com/assets/7334669/16731021/6f849b34-478f-11e6-9b54-0f6306780275.png">

@saleem-latif @mattdrayer FYI. 
