### PR TITLE
Fix the About Me section on the learner profile page.

### DIFF
--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -60,7 +60,7 @@
                     HtmlUtils.HTML('<span class="fa fa-plus placeholder" aria-hidden="true"></span><span class="sr">'),
                     gettext("Placeholder"),
                     HtmlUtils.HTML('</span>')
-                )
+                ),
             },
 
             messages: {
@@ -98,8 +98,8 @@
                 return (this.modelValue() === true);
             },
 
-            title: function (text) {
-                return this.$('.u-field-title').text(text);
+            title: function (title) {
+                return HtmlUtils.setHtml(this.$('.u-field-title'), title);
             },
 
             getMessage: function(message_status) {
@@ -528,7 +528,8 @@
                     placeholderValue: this.options.placeholderValue
                 }));
                 this.delegateEvents();
-                this.title((this.modelValue() || this.mode === 'edit') ? this.options.title : this.indicators['plus'] + this.options.title);
+                this.title((this.modelValue() || this.mode === 'edit') ?
+                    this.options.title : HtmlUtils.joinHtml(this.indicators.plus, this.options.title));
 
                 if (this.editable === 'toggle') {
                     this.showCanEditMessage(this.mode === 'display');


### PR DESCRIPTION
@jcdyer 
@efischer19 

Because of my safe template PR, the learner profile page showed some HTML.
<img width="781" alt="screen shot 2016-07-11 at 11 01 54 am" src="https://cloud.githubusercontent.com/assets/14193378/16735479/2bd9329c-4757-11e6-9bd8-8fad8119628b.png">

This adds some additional safe template code and displays the About Me, as intended.
<img width="770" alt="screen shot 2016-07-11 at 11 02 43 am" src="https://cloud.githubusercontent.com/assets/14193378/16735509/4a57f320-4757-11e6-932d-b13ae3c5f669.png">
