### PR TITLE
Fix branding api get_logo_url return value

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -376,9 +376,9 @@ def get_logo_url():
     # let's use that
     image_url = microsite.get_value('logo_image_url')
     if image_url:
-        return '{static_url}{image_url}'.format(
-            static_url=settings.STATIC_URL,
-            image_url=image_url
+        return _absolute_url_staticfile(
+            is_secure=True,
+            name=image_url
         )
 
     # otherwise, use the legacy means to configure this

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -1,0 +1,23 @@
+# encoding: utf-8
+"""Tests of Branding API """
+
+from django.test import TestCase
+
+import mock
+from branding.api import get_logo_url
+
+
+class TestHeader(TestCase):
+    """Test API end-point for retrieving the header. """
+
+    def test_cdn_urls_for_logo(self):
+        # Ordinarily, we'd use `override_settings()` to override STATIC_URL,
+        # which is what the staticfiles storage backend is using to construct the URL.
+        # Unfortunately, other parts of the system are caching this value on module
+        # load, which can cause other tests to fail.  To ensure that this change
+        # doesn't affect other tests, we patch the `url()` method directly instead.
+        cdn_url = "http://cdn.example.com/static/image.png"
+        with mock.patch('branding.api.staticfiles_storage.url', return_value=cdn_url):
+            logo_url = get_logo_url()
+
+        self.assertEqual(logo_url, cdn_url)


### PR DESCRIPTION
@mattdrayer , @jcdyer 

This PR fixes the logo hash issue for logos added via branding API.
