### PR TITLE
Upgrade django-wiki to 0.0.9.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -47,7 +47,7 @@
 
 # Third-party:
 git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline==1.5.3
-git+https://github.com/edx/django-wiki.git@v0.0.8#egg=django-wiki==0.0.8
+git+https://github.com/edx/django-wiki.git@v0.0.9#egg=django-wiki==0.0.9
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
The new version fixes a problem where wiki fails with a 500 error when combined org/course name/course run fields are longer than 50 characters.

This depends on https://github.com/edx/django-wiki/pull/22. ~~I will update this PR to point to the edx/django-wiki fork once that PR is merged. I'm using the open-craft fork for now for testing purposes.~~

**JIRA tickets**: https://openedx.atlassian.net/browse/OSPR-1339

**Dependencies**: https://github.com/edx/django-wiki/pull/22

**Sandbox LMS URL**: http://pr12978.sandbox.opencraft.hosting/
**Sandbox Studio URL**: http://studio-pr12978.sandbox.opencraft.hosting/

**Testing instructions**:
1. Before installing this patch, go to Studio and create a new course with long organization, course number, and course run fields (concatenated together should be longer than 50 characters)
2. Go to the wiki page in the LMS. The wiki will raise a 500 error.
3. Install this patch and run the migration.
4. Restart edxapp, go to the wiki page in the LMS. The wiki will work properly (although the layout will look a bit broken due to the ridiculously long name).

**Reviewers**
- [x] @haikuginger 
- [x] edX reviewer[s]
