### PR TITLE
Hotfix for tabs

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -140,16 +140,7 @@
                                 url: 'my-teams',
                                 view: this.myTeamsView
                             }, {
-                                title: HtmlUtils.interpolateHtml(
-                                    // Translators: sr_start and sr_end surround text meant only for screen readers.
-                                    // The whole string will be shown to users as "Browse teams" if they are using a
-                                    // screenreader, and "Browse" otherwise.
-                                    gettext('Browse {sr_start} teams {sr_end}'),
-                                    {
-                                        sr_start: HtmlUtils.HTML('<span class="sr">'),
-                                        sr_end: HtmlUtils.HTML('</span>')
-                                    }
-                                ),
+                                title: gettext('Browse'),
                                 url: 'browse',
                                 view: this.topicsView
                             }],


### PR DESCRIPTION
This removes additional context from the "Browse" teams tab until I can properly safely render the HTML portion, or 'sr' text.

I wanted to get it in before others who've made branches from master, pick up the irregularity.

Future work will take place that renders additional HTML (in the form of 'sr' spans) within a tab title.
