### PR TITLE
Bump problem-builder on edx.org to edx-release 2.0.4

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@v2.0.3#egg=xblock-problem-builder==2.0.3
+git+https://github.com/open-craft/problem-builder.git@v2.0.4#egg=xblock-problem-builder==2.0.4
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
This bumps the problem-builder XBlock version to fix [**TNL-4901**](https://openedx.atlassian.net/browse/TNL-4901).

The only change included is https://github.com/open-craft/problem-builder/pull/117

Sandbox: http://pr12992.sandbox.opencraft.hosting/ and http://studio-pr12992.sandbox.opencraft.hosting/

---

**Settings**

``` yaml
EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/open-craft/problem-builder.git@v2.0.4#egg=xblock-problem-builder==2.0.4
```
