### PR TITLE
AC-530 fixing link-href ignores in the platform

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -4,6 +4,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from pipeline_mako import compressed_css, compressed_js
 from django.utils.translation import get_language_bidi
 from mako.exceptions import TemplateLookupException
+from edxmako.shortcuts import marketing_link
 
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangoapps.site_configuration.helpers import (
@@ -18,6 +19,11 @@ from openedx.core.djangoapps.theming.helpers import (
 from certificates.api import get_asset_url_by_slug
 from lang_pref.api import released_languages
 %>
+
+<%def name="marketing_link(name)"><%
+    link = marketing_link(name)
+    return "/" if link == "#" else link
+%></%def>
 
 <%def name='url(file, raw=False)'><%
 try:

--- a/common/djangoapps/terrain/ui_helpers.py
+++ b/common/djangoapps/terrain/ui_helpers.py
@@ -537,6 +537,14 @@ def click_link(partial_text, index=0):
 
 
 @world.absorb
+def click_button(data_attr, index=0):
+    xpath = '//button[text()="{button_text}"]'.format(
+        button_text=data_attr
+    )
+    world.browser.find_by_xpath(xpath)[index].click()
+
+
+@world.absorb
 def click_link_by_text(text, index=0):
     retry_on_exception(lambda: world.browser.find_link_by_text(text)[index].click())
 

--- a/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
@@ -94,15 +94,15 @@
                     <ol class="video-speeds"></ol>
                   </div>
                   <div class="volume">
-                    <a href="#"></a>
+                    <button type="button"></button>
                     <div class="volume-slider-container">
                       <div class="volume-slider"></div>
                     </div>
                   </div>
-                  <a href="#" class="add-fullscreen" title="Fill browser">Fill Browser</a>
-                  <a href="#" class="quality-control is-hidden" title="HD">HD</a>
+                  <button type="button" class="add-fullscreen" title="Fill browser">Fill Browser</button>
+                  <button type="button" class="quality-control is-hidden" title="HD">HD</button>
                   <div class="lang menu-container">
-                    <a href="#" class="hide-subtitles" title="Turn off captions" role="button" aria-disabled="false">Captions</a>
+                    <button type="button" class="hide-subtitles" title="Turn off captions" role="button" aria-disabled="false">Captions</button>
                   </div>
                 </div>
               </div>

--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -23,7 +23,7 @@ class InstructorDashboardPage(CoursePage):
         """
         Selects the membership tab and returns the MembershipSection
         """
-        self.q(css='[data-section=membership]').first.click()
+        self.q(css='[data-section="membership"]').first.click()
         membership_section = MembershipPage(self.browser)
         membership_section.wait_for_page()
         return membership_section
@@ -32,7 +32,7 @@ class InstructorDashboardPage(CoursePage):
         """
         Selects the cohort management tab and returns the CohortManagementSection
         """
-        self.q(css='[data-section=cohort_management]').first.click()
+        self.q(css='[data-section="cohort_management"]').first.click()
         cohort_management_section = CohortManagementSection(self.browser)
         # The first time cohort management is selected, an ajax call is made.
         cohort_management_section.wait_for_ajax()
@@ -43,7 +43,7 @@ class InstructorDashboardPage(CoursePage):
         """
         Selects the data download tab and returns a DataDownloadPage.
         """
-        self.q(css='[data-section=data_download]').first.click()
+        self.q(css='[data-section="data_download"]').first.click()
         data_download_section = DataDownloadPage(self.browser)
         data_download_section.wait_for_page()
         return data_download_section
@@ -52,7 +52,7 @@ class InstructorDashboardPage(CoursePage):
         """
         Selects the student admin tab and returns the MembershipSection
         """
-        self.q(css='[data-section=student_admin]').first.click()
+        self.q(css='[data-section="student_admin"]').first.click()
         student_admin_section = StudentAdminPage(self.browser)
         student_admin_section.wait_for_page()
         return student_admin_section
@@ -61,7 +61,7 @@ class InstructorDashboardPage(CoursePage):
         """
         Selects the certificates tab and returns the CertificatesSection
         """
-        self.q(css='[data-section=certificates]').first.click()
+        self.q(css='[data-section="certificates"]').first.click()
         certificates_section = CertificatesPage(self.browser)
         certificates_section.wait_for_page()
         return certificates_section
@@ -70,7 +70,7 @@ class InstructorDashboardPage(CoursePage):
         """
         Selects the timed exam tab and returns the Special Exams Section
         """
-        self.q(css='[data-section=special_exams]').first.click()
+        self.q(css='[data-section="special_exams"]').first.click()
         timed_exam_section = SpecialExamsPage(self.browser)
         timed_exam_section.wait_for_page()
         return timed_exam_section
@@ -79,7 +79,7 @@ class InstructorDashboardPage(CoursePage):
         """
         Selects the email tab and returns the bulk email section
         """
-        self.q(css='[data-section=send_email]').first.click()
+        self.q(css='[data-section="send_email"]').first.click()
         email_section = BulkEmailPage(self.browser)
         email_section.wait_for_page()
         return email_section
@@ -386,7 +386,6 @@ class CohortManagementSection(PageObject):
             lambda: "Add a New Cohort" in self.q(css=self._bounded_selector(".form-title")).text,
             "Create cohort form is visible"
         )
-
         textinput = self.q(css=self._bounded_selector("#cohort-name")).results[0]
         textinput.send_keys(cohort_name)
 
@@ -509,7 +508,7 @@ class CohortManagementSection(PageObject):
         """
         Selects the settings tab for the cohort currently being edited.
         """
-        self.q(css=self._bounded_selector(".cohort-management-settings li.tab-settings>a")).first.click()
+        self.q(css=self._bounded_selector(".cohort-management-settings li.tab-settings>.toggle-button")).first.click()
 
     # pylint: disable=redefined-builtin
     def get_cohort_settings_messages(self, type="confirmation", wait_for_messages=True):
@@ -585,7 +584,7 @@ class CohortManagementSection(PageObject):
         """
         Click on the link to the Data Download Page.
         """
-        self.q(css=self._bounded_selector("a.link-cross-reference[data-section=data_download]")).first.click()
+        self.q(css=self._bounded_selector('[data-section="data_download"]')).first.click()
 
     def upload_cohort_file(self, filename):
         """
@@ -627,7 +626,7 @@ class CohortManagementSection(PageObject):
         Shows the discussion topics.
         """
         self.q(css=self._bounded_selector(".toggle-cohort-management-discussions")).first.click()
-        self.wait_for_element_visibility("#cohort-management-discussion-topics", "Waiting for discussions to appear")
+        self.wait_for_element_visibility("#cohort-discussions-management", "Waiting for discussions to appear")
 
     def discussion_topics_visible(self):
         """

--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -271,7 +271,7 @@ class CombinedLoginAndRegisterPage(PageObject):
         login_form = self.current_form
 
         # Click the password reset link on the login page
-        self.q(css="a.forgot-password").click()
+        self.q(css=".forgot-password").click()
 
         # Wait for the password reset form to load
         EmptyPromise(

--- a/common/test/acceptance/pages/lms/staff_view.py
+++ b/common/test/acceptance/pages/lms/staff_view.py
@@ -88,7 +88,7 @@ class StaffDebugPage(PageObject):
         """
         if user:
             self.q(css='input[id^=sd_fu_]').first.fill(user)
-        self.q(css='section.staff-modal a.staff-debug-reset').click()
+        self.q(css='.staff-modal .staff-debug-reset').click()
 
     def delete_state(self, user=None):
         """
@@ -96,7 +96,7 @@ class StaffDebugPage(PageObject):
         """
         if user:
             self.q(css='input[id^=sd_fu_]').fill(user)
-        self.q(css='section.staff-modal a.staff-debug-sdelete').click()
+        self.q(css='.staff-modal .staff-debug-sdelete').click()
 
     def rescore(self, user=None):
         """
@@ -105,7 +105,7 @@ class StaffDebugPage(PageObject):
         """
         if user:
             self.q(css='input[id^=sd_fu_]').first.fill(user)
-        self.q(css='section.staff-modal a.staff-debug-rescore').click()
+        self.q(css='.staff-modal .staff-debug-rescore').click()
 
     @property
     def idash_msg(self):

--- a/common/test/acceptance/tests/discussion/test_cohort_management.py
+++ b/common/test/acceptance/tests/discussion/test_cohort_management.py
@@ -689,6 +689,13 @@ class CohortConfigurationTest(EventsTestMixin, UniqueCourseTest, CohortTestMixin
         messages = self.cohort_management_page.get_csv_messages()
         self.assertEquals(expected_message, messages[0])
 
+    @attr('a11y')
+    def test_cohorts_management_a11y(self):
+        """
+        Run accessibility audit for cohort management.
+        """
+        self.cohort_management_page.a11y_audit.check_for_accessibility_errors()
+
 
 @attr(shard=6)
 class CohortDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
@@ -1149,7 +1156,8 @@ class CohortContentGroupAssociationTest(UniqueCourseTest, CohortTestMixin):
         self.cohort_management_page.add_cohort(new_cohort, content_group=cohort_group)
         # After adding the cohort, it should automatically be selected
         EmptyPromise(
-            lambda: new_cohort == self.cohort_management_page.get_selected_cohort(), "Waiting for new cohort to appear"
+            lambda: new_cohort == self.cohort_management_page.get_selected_cohort(),
+            "Waiting for new cohort to appear"
         ).fulfill()
         self.assertEqual(cohort_group, self.cohort_management_page.get_cohort_associated_content_group())
 

--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -508,9 +508,4 @@ class AccountSettingsA11yTest(AccountSettingsTestMixin, WebAppTest):
         """
         self.log_in_as_unique_user()
         self.visit_account_settings_page()
-        self.account_settings_page.a11y_audit.config.set_rules({
-            'ignore': [
-                'link-href',  # TODO: AC-233
-            ],
-        })
         self.account_settings_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -58,11 +58,6 @@ class LMSInstructorDashboardA11yTest(BaseInstructorDashboardTest):
         self.instructor_dashboard_page = self.visit_instructor_dashboard()
 
     def test_instructor_dashboard_a11y(self):
-        self.instructor_dashboard_page.a11y_audit.config.set_rules({
-            "ignore": [
-                'link-href',  # TODO: AC-491
-            ]
-        })
         self.instructor_dashboard_page.a11y_audit.check_for_accessibility_errors()
 
 

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -186,7 +186,6 @@ class StaffDebugTest(CourseWithoutContentGroupsTest):
         """
         staff_page = self._goto_staff_page()
         staff_page.answer_problem()
-
         staff_debug_page = staff_page.open_staff_debug_info()
         staff_debug_page.delete_state('INVALIDUSER')
         msg = staff_debug_page.idash_msg[0]
@@ -382,6 +381,24 @@ class CourseWithContentGroupsTest(StaffViewTest):
         # Masquerade as student in beta cohort:
         course_page.set_staff_view_mode_specific_student(student_b_username)
         verify_expected_problem_visibility(self, course_page, [self.beta_text, self.everyone_text])
+
+    @attr('a11y')
+    def test_course_page(self):
+        """
+        Run accessibility audit for course staff pages.
+        """
+        course_page = self._goto_staff_page()
+        course_page.a11y_audit.config.set_rules({
+            'ignore': [
+                'aria-allowed-attr',  # TODO: AC-559
+                'aria-roles',  # TODO: AC-559,
+                'aria-valid-attr',  # TODO: AC-559
+                'color-contrast',  # TODO: AC-559
+                'link-href',  # TODO: AC-559
+                'section',  # TODO: AC-559
+            ]
+        })
+        course_page.a11y_audit.check_for_accessibility_errors()
 
 
 def verify_expected_problem_visibility(test, courseware_page, expected_problems):

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -656,8 +656,8 @@ class StudioLibraryA11yTest(StudioLibraryTest):
         # we will ignore this error in the test until we fix them.
         lib_page.a11y_audit.config.set_rules({
             "ignore": [
-                'link-href',  # TODO: AC-226
                 'icon-aria-hidden',  # TODO: AC-229
+                'link-href',  # TODO: AC-564
             ],
         })
 

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -504,7 +504,7 @@ class StudioSettingsA11yTest(StudioCourseTest):
         # we will ignore this error in the test until we fix them.
         self.settings_page.a11y_audit.config.set_rules({
             "ignore": [
-                'link-href',  # TODO: AC-226
+                'link-href',  # TODO: AC-557
                 'icon-aria-hidden',  # TODO: AC-229
             ],
         })

--- a/common/test/acceptance/tests/studio/test_studio_textbooks.py
+++ b/common/test/acceptance/tests/studio/test_studio_textbooks.py
@@ -61,7 +61,6 @@ class TextbooksTest(StudioCourseTest):
         self.textbook_view_page.a11y_audit.config.set_rules({
             'ignore': [
                 'skip-link',  # AC-501
-                'link-href',  # AC-502
                 'section'  # AC-503
             ],
         })
@@ -77,13 +76,17 @@ class TextbooksTest(StudioCourseTest):
         self.textbook_view_page.visit()
 
         self.textbook_view_page.switch_to_pdf_frame(self)
+        self.textbook_view_page.a11y_audit.config.set_scope({
+            'exclude': [
+                '#viewer',  # PDF viewer (vendor file)
+            ]
+        })
         self.textbook_view_page.a11y_audit.config.set_rules({
             'ignore': [
                 'color-contrast',  # will always fail because pdf.js converts pdf to divs with transparent text
                 'html-lang',  # AC-504
                 'meta-viewport',  # AC-505
                 'skip-link',  # AC-506
-                'link-href',  # AC-507
             ],
         })
         self.textbook_view_page.a11y_audit.check_for_accessibility_errors()

--- a/lms/djangoapps/courseware/features/courseware_common.py
+++ b/lms/djangoapps/courseware/features/courseware_common.py
@@ -15,6 +15,11 @@ def i_click_on_the_tab(step, tab_text):
     world.click_link(tab_text)
 
 
+@step('I click the "([^"]*)" button$')
+def i_click_on_the_button(step, data_attr):
+    world.click_button(data_attr)
+
+
 @step('I click on the "([^"]*)" link$')
 def i_click_on_the_link(step, link_text):
     world.click_link(link_text)

--- a/lms/djangoapps/courseware/features/lti.feature
+++ b/lms/djangoapps/courseware/features/lti.feature
@@ -51,7 +51,7 @@ Feature: LMS.LTI component
   Then I see text "Problem Scores: 5/10"
   And I see graph with total progress "5%"
   Then I click on the "Instructor" tab
-  And I click on the "Student Admin" tab
+  And I click the "Student Admin" button
   And I click on the "View Gradebook" link
   And I see in the gradebook table that "HW" is "50"
   And I see in the gradebook table that "Total" is "5"
@@ -90,7 +90,7 @@ Feature: LMS.LTI component
   Then I see text "Problem Scores: 8/10"
   And I see graph with total progress "8%"
   Then I click on the "Instructor" tab
-  And I click on the "Student Admin" tab
+  And I click the "Student Admin" button
   And I click on the "View Gradebook" link
   And I see in the gradebook table that "HW" is "80"
   And I see in the gradebook table that "Total" is "8"
@@ -116,7 +116,7 @@ Feature: LMS.LTI component
   Then I see text "Problem Scores: 0/10"
   And I see graph with total progress "0%"
   Then I click on the "Instructor" tab
-  And I click on the "Student Admin" tab
+  And I click the "Student Admin" button
   And I click on the "View Gradebook" link
   And I see in the gradebook table that "HW" is "0"
   And I see in the gradebook table that "Total" is "0"

--- a/lms/djangoapps/instructor/features/common.py
+++ b/lms/djangoapps/instructor/features/common.py
@@ -76,7 +76,7 @@ def go_to_section(section_name):
     # course_info, membership, student_admin, data_download, analytics, send_email
     world.visit(u'/courses/{}'.format(world.course_key))
     world.css_click(u'a[href="/courses/{}/instructor"]'.format(world.course_key))
-    world.css_click('a[data-section="{0}"]'.format(section_name))
+    world.css_click('[data-section="{0}"]'.format(section_name))
 
 
 @step(u'I click "([^"]*)"')

--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -29,7 +29,7 @@ class TestECommerceDashboardViews(SharedModuleStoreTestCase):
 
         # URL for instructor dash
         cls.url = reverse('instructor_dashboard', kwargs={'course_id': cls.course.id.to_deprecated_string()})
-        cls.e_commerce_link = '<a href="" data-section="e-commerce">E-Commerce</a>'
+        cls.e_commerce_link = '<button type="button" class="btn-link" data-section="e-commerce">E-Commerce</button>'
 
     def setUp(self):
         super(TestECommerceDashboardViews, self).setUp()

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -31,7 +31,7 @@ class TestNewInstructorDashboardEmailViewMongoBacked(SharedModuleStoreTestCase):
         # URL for instructor dash
         cls.url = reverse('instructor_dashboard', kwargs={'course_id': cls.course.id.to_deprecated_string()})
         # URL for email view
-        cls.email_link = '<a href="" data-section="send_email">Email</a>'
+        cls.email_link = '<button type="button" class="btn-link" data-section="send_email">Email</button>'
 
     def setUp(self):
         super(TestNewInstructorDashboardEmailViewMongoBacked, self).setUp()
@@ -126,7 +126,7 @@ class TestNewInstructorDashboardEmailViewXMLBacked(SharedModuleStoreTestCase):
         # URL for instructor dash
         cls.url = reverse('instructor_dashboard', kwargs={'course_id': cls.course_key.to_deprecated_string()})
         # URL for email view
-        cls.email_link = '<a href="" data-section="send_email">Email</a>'
+        cls.email_link = '<button type="button" class="btn-link" data-section="send_email">Email</button>'
 
     def setUp(self):
         super(TestNewInstructorDashboardEmailViewXMLBacked, self).setUp()
@@ -138,7 +138,7 @@ class TestNewInstructorDashboardEmailViewXMLBacked(SharedModuleStoreTestCase):
         # URL for instructor dash
         self.url = reverse('instructor_dashboard', kwargs={'course_id': self.course_key.to_deprecated_string()})
         # URL for email view
-        self.email_link = '<a href="" data-section="send_email">Email</a>'
+        self.email_link = '<button type="button" class="btn-link" data-section="send_email">Email</button>'
 
     def tearDown(self):
         super(TestNewInstructorDashboardEmailViewXMLBacked, self).tearDown()

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -27,7 +27,8 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
 
         # URL for instructor dash
         cls.url = reverse('instructor_dashboard', kwargs={'course_id': cls.course.id.to_deprecated_string()})
-        cls.proctoring_link = '<a href="" data-section="special_exams">Special Exams</a>'
+        button = '<button type="button" class="btn-link" data-section="special_exams">Special Exams</button>'
+        cls.proctoring_link = button
 
     def setUp(self):
         super(TestProctoringDashboardViews, self).setUp()

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -207,7 +207,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         Test analytics dashboard message is shown
         """
         response = self.client.get(self.url)
-        analytics_section = '<li class="nav-item"><a href="" data-section="instructor_analytics">Analytics</a></li>'
+        analytics_section = '<li class="nav-item"><button type="button" class="btn-link" data-section="instructor_analytics">Analytics</button></li>'  # pylint: disable=line-too-long
         self.assertIn(analytics_section, response.content)
 
         # link to dashboard shown

--- a/lms/static/coffee/src/instructor_dashboard/instructor_dashboard.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/instructor_dashboard.coffee
@@ -91,7 +91,7 @@ $ =>
 # handles hiding and showing sections
 setup_instructor_dashboard = (idash_content) =>
   # clickable section titles
-  $links = idash_content.find(".#{CSS_INSTRUCTOR_NAV}").find('a')
+  $links = idash_content.find(".#{CSS_INSTRUCTOR_NAV}").find('.btn-link')
 
   # attach link click handlers
   $links.each (i, link) ->
@@ -100,6 +100,7 @@ setup_instructor_dashboard = (idash_content) =>
 
       # deactivate all link & section styles
       idash_content.find(".#{CSS_INSTRUCTOR_NAV} li").children().removeClass CSS_ACTIVE_SECTION
+      idash_content.find(".#{CSS_INSTRUCTOR_NAV} li").children().attr('aria-pressed', 'false')
       idash_content.find(".#{CSS_IDASH_SECTION}").removeClass CSS_ACTIVE_SECTION
 
       # discover section paired to link
@@ -108,6 +109,7 @@ setup_instructor_dashboard = (idash_content) =>
 
       # activate link & section styling
       $(this).addClass CSS_ACTIVE_SECTION
+      $(this).attr('aria-pressed','true')
       $section.addClass CSS_ACTIVE_SECTION
 
       # tracking

--- a/lms/static/js/fixtures/accordion.html
+++ b/lms/static/js/fixtures/accordion.html
@@ -8,21 +8,21 @@
     <div class="chapter-content-container is-open" id="accordion-menu-1" tabindex="-1">
       <div class="chapter-menu is-open">
           <div class="menu-item">
-          <a href="#">
+          <button type="button">
             <p>1 edX Homepage</p>
             <p class="subtitle">Ungraded</p>
-          </a>
+          </button>
         </div>
         <div class="menu-item active">
-          <a href="#">
+          <button type="button">
             <p>1 The edX Blog</p>
-          </a>
+        </button>
         </div>
         <div class="menu-item graded">
-          <a href="#">
+          <button type="button">
             <p>1 Courses Dashboard</p>
             <p class="subtitle">Graded</p>
-          </a>
+          </button>
         </div>
       </div>
       <a href="accordion-menu-2" role="button" class="button-chapter chapter" aria-controls="accordion-menu-2" aria-expanded="false">
@@ -33,15 +33,15 @@
       <div class="chapter-content-container" id="accordion-menu-2" tabindex="-1">
         <div class="chapter-menu">
           <div class="menu-item">
-            <a href="#">
+            <button type="button">
               <p>2 edX Homepage</p>
               <p class="subtitle">Ungraded</p>
-            </a>
+            </button>
           </div>
           <div class="menu-item">
-            <a href="#">
+            <button type="button">
               <p>2 The edX Blog</p>
-            </a>
+            </button>
           </div>
           <div class="menu-item">
             <a class="graded" href="#">

--- a/lms/static/js/fixtures/dashboard/dashboard.html
+++ b/lms/static/js/fixtures/dashboard/dashboard.html
@@ -21,9 +21,9 @@
 
 <a data-course-key="edX/DemoX/Demo_Course" class="verified-info" href="/what_is_verified_cert">Learn more about the verified Certificate of Achievement</a>.
 
-<a href="#" class="btn-find-courses">Find New Courses</a>
+<button type="button" class="btn-find-courses">Find New Courses</button>
 
-<a href="#" class="verified-info" data-course-key="edX/DemoX/Demo_Course"></a>
+<button type="button" class="verified-info" data-course-key="edX/DemoX/Demo_Course"></button>
 
 
 <div class="course-container">

--- a/lms/static/js/groups/views/cohorts.js
+++ b/lms/static/js/groups/views/cohorts.js
@@ -304,7 +304,6 @@
                                 });
                             }
                         }).render();
-                        this.$('#file-upload-form-file').focus();
                     }
                 },
                 showDiscussionTopics: function(event) {
@@ -330,7 +329,7 @@
                 },
 
                 getSectionCss: function(section) {
-                    return ".instructor-nav .nav-item a[data-section='" + section + "']";
+                    return ".instructor-nav .nav-item [data-section='" + section + "']";
                 }
             });
             return CohortsView;

--- a/lms/static/js/spec/groups/views/cohorts_spec.js
+++ b/lms/static/js/spec/groups/views/cohorts_spec.js
@@ -353,8 +353,9 @@ define(['backbone', 'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers
             };
 
             beforeEach(function() {
-                setFixtures('<ul class="instructor-nav"><li class="nav-item"><<a href data-section=' +
-                    '"cohort_management" class="active-section">Cohort Management</a></li></ul><div></div>' +
+                setFixtures('<ul class="instructor-nav">' +
+                    '<li class="nav-item"><button type="button" data-section="cohort_management" ' +
+                    'class="active-section">Cohort Management</button></li></ul><div></div>' +
                     '<div class="cohort-management"><div class="cohort-state-message"></div></div>');
                 TemplateHelpers.installTemplate('templates/instructor/instructor_dashboard_2/cohorts');
                 TemplateHelpers.installTemplate('templates/instructor/instructor_dashboard_2/cohort-form');
@@ -608,7 +609,7 @@ define(['backbone', 'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers
 
                 it('can select the Settings tab', function() {
                     createCohortsView(this, {selectCohort: 1});
-                    cohortsView.$('.tab-settings a').click();
+                    cohortsView.$('.tab-settings button').click();
                     expect(cohortsView.$('.tab-manage_students')).not.toHaveClass('is-selected');
                     expect(cohortsView.$('.tab-settings')).toHaveClass('is-selected');
                     expect(cohortsView.$('.tab-content-manage_students')).toHaveClass('is-hidden');

--- a/lms/static/js/spec/views/fields_spec.js
+++ b/lms/static/js/spec/views/fields_spec.js
@@ -12,7 +12,7 @@ define(['backbone', 'jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helper
                 timerCallback,
                 dropdownSelectClass = '.u-field-value > select',
                 dropdownButtonClass = '.u-field-value > button',
-                textareaLinkClass = '.u-field-value a';
+                textareaLinkClass = '.u-field-value .clickable';
 
             var fieldViewClasses = [
                 FieldViews.ReadonlyFieldView,

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -512,6 +512,7 @@
             fieldTemplate: field_textarea_template,
 
             events: {
+                'keydown .wrapper-u-field': 'startEditing',
                 'click .wrapper-u-field': 'startEditing',
                 'click .u-field-placeholder': 'startEditing',
                 'focusout textarea': 'finishEditing',

--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -247,60 +247,55 @@ mark {
 }
 
 .help-tab {
-  @include transform(rotate(-90deg));
-  @include transform-origin(0 0);
-  @extend %ui-depth2;
-  @extend %ui-print-excluded;
-  top: 250px;
-  left: 0;
-  position: fixed;
+    @include transform(rotate(-90deg));
+    @include transform-origin(0 0);
+    @extend %ui-depth2;
+    @extend %ui-print-excluded;
+    position: fixed;
+    top: 250px;
+    left: 0;
 
-  a:link, a:visited {
-    cursor: pointer;
-    border: 1px solid $gray-l3;
-    border-top-style: none;
-    border-radius: 0 0 ($baseline/2) ($baseline/2);
-    background: transparentize($white, 0.25);
-    color: transparentize(#333, 0.25);
-    font-weight: bold;
-    text-decoration: none;
-    padding: 6px 22px 11px;
-    display: inline-block;
+    a:link,
+    a:visited {
+        border: 1px solid $gray-l3;
+        border-top-style: none;
+        border-radius: 0 0 ($baseline/2) ($baseline/2);
+        background: transparentize($white, 0.25);
+        color: transparentize($base-font-color, 0.25);
+        font-weight: bold;
+        text-decoration: none;
+        padding: 6px 22px 11px;
+        display: inline-block;
 
-    &:hover, &:focus {
-      color: $white;
-      background: $link-color;
+        &:hover,
+        &:focus {
+            color: $white;
+            background: $link-color;
+        }
     }
-  }
 }
 
 .help-buttons {
-  padding: ($baseline/2) ($baseline*2.5);
-
-  a:link, a:visited {
-    padding: ($baseline*0.75) 0;
+    padding: ($baseline/2) ($baseline*2.5);
     text-align: center;
-    cursor: pointer;
-    background: $white;
-    text-decoration: none;
-    display: block;
-    border: 1px solid $gray-l3;
 
-    &#feedback_link_problem {
-      border-bottom-style: none;
-      border-radius: ($baseline/2) ($baseline/2) 0 0;
+    button {
+        @extend %btn-secondary-blue-outline;
+        margin: .5rem 0;
+        font-weight: initial;
+        text-shadow: none;
+        letter-spacing: initial !important;
+        text-transform: normal !important;
+        vertical-align: initial;
+        
+        &:hover,
+        &:focus {
+            background: $link-color !important;
+            color: $white;
+            box-shadow: none !important;
+            text-shadow: none !important;
+        }
     }
-
-    &#feedback_link_question {
-      border-top-style: none;
-      border-radius: 0 0 ($baseline/2) ($baseline/2);
-    }
-
-    &:hover, &:focus {
-      color: $white;
-      background: $link-color;
-    }
-  }
 }
 
 #feedback_form {

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -262,25 +262,33 @@
   }
 
   .instructor-nav {
-    @extend %ui-no-list;
-    border-top: 1px solid $gray-l3;
-    border-bottom: 1px solid $gray-l3;
+        @extend %ui-no-list;
+        border-top: 1px solid $gray-l3;
+        border-bottom: 1px solid $gray-l3;
 
-    .nav-item {
-      @extend %t-copy-base;
-      display: inline-block;
-      margin: ($baseline/2) $baseline;
+        .nav-item {
+            @extend %t-copy-base;
+            display: inline-block;
 
-      a {
-        display: block;
-        text-transform: uppercase;
+            .btn-link {
+                display: inline-block;
+                padding: ($baseline/2) $baseline;
+                border: 0;
+                box-shadow: none;
+                text-shadow: none;
 
-        &.active-section {
-          color: $black;
+                &:hover,
+                &:focus {
+                    background: $gray-l5 !important;
+                }
+
+                &.active-section {
+                    background: $gray-l5;
+                    color: $black;
+                }
+            }
         }
-      }
     }
-  }
 }
 
 // elements - general
@@ -1015,9 +1023,21 @@
 
   // CSV-based file upload for auto cohort assigning and
   // cohort the discussion topics.
-  .toggle-cohort-management-secondary, .toggle-cohort-management-discussions {
-    @extend %t-copy-sub1;
-  }
+    .toggle-cohort-management-secondary,
+    .toggle-cohort-management-discussions {
+        @extend %t-copy-sub1;
+        background: transparent;
+        border: none;
+        box-shadow: none;
+        text-shadow: none;
+        padding: 0;
+        color: $uxpl-blue-base;
+        
+        &:hover,
+        &:focus {
+            text-decoration: underline;
+        }
+    }
 
   .cohort-management-file-upload {
 
@@ -1056,7 +1076,7 @@
     @extend %t-copy-sub1;
     margin-top: $baseline;
     padding: ($baseline/2) $baseline;
-    background: $gray-l5;
+    background: $gray-l6;
     border-radius: ($baseline/10);
 
 
@@ -1215,9 +1235,14 @@
       position: relative;
       display: inline-block;
 
-      a {
+      .toggle-button {
         display: inline-block;
         padding: ($baseline - 5);
+        background: transparent;
+        border-radius: 0;
+        border: 0;
+        box-shadow: none;
+        color: $uxpl-blue-base;
         // These transitions null out previously/globally set transitions
         -webkit-transition: none;
         -moz-transition: none;
@@ -1228,7 +1253,7 @@
 
       &.is-selected { // Active or selected tabs (<li>) get this class. Also useful for aria stuff if ever implemented in the future.
 
-        a {
+        .toggle-button {
           padding-bottom: ($baseline - 5);
           border-style: solid;
           @include border-width(1px 1px 0 1px);

--- a/lms/static/sass/elements/_controls.scss
+++ b/lms/static/sass/elements/_controls.scss
@@ -459,6 +459,8 @@
     padding: 1px;
     background: $transparent;
     background-image: none;
+    box-shadow: none;
+    text-shadow: none;
 
     @extend %t-action3;
     @extend %t-strong;

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -59,17 +59,20 @@
             @include text-align(left);
             text-shadow: 0 1px rgba(255,255,255, 0.6);
 
-            a {
-              color: $lighter-base-font-color;
-              font: italic 700 0.6em/1em $sans-serif;
-              letter-spacing: 0px;
-              @include margin-left($baseline*0.75);
-              text-shadow: 0 1px rgba(255,255,255, 0.6);
-              text-transform: none;
+            .button-org {
+                @include margin-left($baseline*0.75);
+                background: transparent !important;
+                border: none !important;
+                box-shadow: none !important;
+                text-shadow: none !important;
+                text-transform: normal !important;
+                font-size: $body-font-size;
+                color: $base-font-color !important;
+                letter-spacing: 0px !important;
 
-              &:hover, &:focus {
-                color: $link-color;
-              }
+                &:hover, &:focus {
+                    color: $link-color;
+                }
             }
           }
 
@@ -78,7 +81,7 @@
             margin: 0;
 
             a {
-              color: $lighter-base-font-color;
+              color: $base-font-color;
               font: italic 700 1em/1em $sans-serif;
               letter-spacing: 0px;
               text-shadow: 0 1px rgba(255,255,255, 0.6);

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -266,10 +266,22 @@
             display: block;
             margin-bottom: ($baseline/2);
             margin-top: ($baseline/4);
-            color: $m-blue-d5;
+            border: none;
+            padding: 0;
+            background: transparent;
+            box-shadow: none;
+            text-transform: initial;
+            letter-spacing: normal;
+            color: $uxpl-blue-base;
             font-weight: $font-regular;
-            text-decoration: none !important; // needed but nasty
+            text-decoration: none;
+            text-shadow: none;
             font-family: $sans-serif;
+            
+            &:hover,
+            &:focus {
+                text-decoration: underline;
+            }
         }
 
         input,

--- a/lms/templates/ccx/coach_dashboard.html
+++ b/lms/templates/ccx/coach_dashboard.html
@@ -56,16 +56,16 @@ from openedx.core.djangolib.js_utils import (
           %if ccx:
           <ul class="instructor-nav">
             <li class="nav-item">
-              <a href="#" data-section="membership">${_("Enrollment")}</a>
+              <button type="button" class="btn-link" data-section="membership">${_("Enrollment")}</button>
             </li>
             <li class="nav-item">
-              <a href="#" data-section="schedule">${_("Schedule")}</a>
+              <button type="button" class="btn-link" data-section="schedule">${_("Schedule")}</button>
             </li>
             <li class="nav-item">
-              <a href="#" data-section="student_admin">${_("Student Admin")}</a>
+              <button type="button" class="btn-link" data-section="student_admin">${_("Student Admin")}</button>
             </li>
             <li class="nav-item">
-              <a href="#" data-section="grading_policy">${_("Grading Policy")}</a>
+              <button type="button" class="btn-link" data-section="grading_policy">${_("Grading Policy")}</button>
             </li>
           </ul>
           <section id="membership" class="idash-section" aria-label="${_('Batch Enrollment')}">

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -115,7 +115,7 @@ from openedx.core.lib.courses import course_image_url
         <div class="heading-group">
           <h1>
             ${course.display_name_with_default_escaped}
-            <a href="#">${course.display_org_with_default | h}</a>
+            <button type="button">${course.display_org_with_default | h}</button>
           </h1>
         </div>
 

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -391,8 +391,8 @@ from student.helpers import (
                 "to request payment, or you can "
                 "{unenroll_link_start}unenroll{unenroll_link_end} "
                 "from this course")).format(
-              contact_link_start=HTML('<a href="#">'),
-              contact_link_end=HTML('</a>'),
+              contact_link_start=HTML('<button type="button">'),
+              contact_link_end=HTML('</button>'),
               unenroll_link_start=HTML(
                 '<a id="unregister_block_course" rel="leanModal" '
                 'data-course-id="{course_id}" data-course-number="{course_number}" data-course-name="{course_name}" '

--- a/lms/templates/edxnotes/note-item.underscore
+++ b/lms/templates/edxnotes/note-item.underscore
@@ -4,9 +4,9 @@
         <p class="note-excerpt-p"><%- message %>
           <% if (show_link) { %>
           <% if (is_expanded) { %>
-              <a href="#" class="note-excerpt-more-link"><%- gettext('Less') %></a>
+              <button type="button" class="note-excerpt-more-link"><%- gettext('Less') %></button>
           <% } else { %>
-              <a href="#" class="note-excerpt-more-link"><%- gettext('More') %></a>
+              <button type="button" class="note-excerpt-more-link"><%- gettext('More') %></button>
           <% } %>
           <% } %>
         </p>

--- a/lms/templates/edxnotes/tab-item.underscore
+++ b/lms/templates/edxnotes/tab-item.underscore
@@ -5,9 +5,8 @@
 </a>
 
 <% if (is_closable) { %>
-  <a href="#" class="action-close">
+  <button type="button" class="action-close">
     <span class="icon fa fa-times-circle" aria-hidden="true"></span>
     <span class="sr"><%- gettext("Clear search results") %></span>
-  </a>
+  </button>
 <% } %>
-

--- a/lms/templates/fields/field_textarea.underscore
+++ b/lms/templates/fields/field_textarea.underscore
@@ -3,7 +3,7 @@
         <% if (mode === 'edit') { %>
             <label class="u-field-title" for="u-field-textarea-<%- id %>" id="u-field-title-<%- id %>"></label>
         <% } else { %>
-            <span class="u-field-title" id="u-field-title-<%- id %>" aria-hidden="true"></span>
+            <span class="u-field-title" id="u-field-title-<%- id %>"></span>
         <% } %>
         <% if (messagePosition === 'header') { %>
             <span class="u-field-message" id="u-field-message-<%- id %>">
@@ -27,8 +27,12 @@
             <% } %>
             ><%- value %></span>
         <% } else { %>
-            ><a href="#"><p class="sr"><%- screenReaderTitle %></p><span class="u-field-value-readonly" aria-hidden="false" aria-describedby="u-field-placeholder-value-<%- id %>"><%- value %></span><span class="sr"><%- gettext('Click to edit') %></span></a>
+            ><span class="clickable" role="button" tabindex="0">
+            <span class="sr"><%- screenReaderTitle %></span>
+            <span class="u-field-value-readonly" aria-hidden="false" aria-describedby="u-field-placeholder-value-<%- id %>"><%- value %></span>
+            <span class="sr"><%- gettext('Click to edit') %></span>
             <span class="sr" id="u-field-placeholder-value-<%- id %>"><%- placeholderValue %></span>
+            </span>
         <% } %>
     </div>
 

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -73,9 +73,9 @@ from xmodule.tabs import CourseTabList
     <hr>
 
     <div class="help-buttons">
-      <a href="#" id="feedback_link_problem">${_('Report a problem')}</a>
-      <a href="#" id="feedback_link_suggestion">${_('Make a suggestion')}</a>
-      <a href="#" id="feedback_link_question">${_('Ask a question')}</a>
+      <button type="button" class="" id="feedback_link_problem">${_('Report a problem')}</button><br />
+      <button type="button" class="" id="feedback_link_suggestion">${_('Make a suggestion')}</button><br />
+      <button type="button" class="" id="feedback_link_question">${_('Ask a question')}</button>
     </div>
 
     <p class="note">${_('Please note: The {platform_name} support team is English speaking. While we will do our best to address your inquiry in any language, our responses will be in English.').format(
@@ -268,8 +268,8 @@ from xmodule.tabs import CourseTabList
             htmlStr = "${_('An error has occurred.') | n, js_escaped_string}";
 % if settings.FEEDBACK_SUBMISSION_EMAIL:
             htmlStr += " " + "${Text(_('Please {link_start}send us e-mail{link_end}.')).format(
-              link_start=HTML('<a href="#" id="feedback_email">'),
-              link_end=HTML('</a>'),
+              link_start=HTML('<button type="button" id="feedback_email">'),
+              link_end=HTML('</button>'),
             ) | n, js_escaped_string}";
 % else:
             // If no email is configured, we can't do much other than

--- a/lms/templates/instructor/instructor_dashboard_2/cohort-editor.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort-editor.underscore
@@ -2,8 +2,8 @@
     <header class="cohort-management-group-header"></header>
 
     <ul class="wrapper-tabs">
-        <li class="tab tab-manage_students is-selected" data-tab="manage_students"><a href="#"><span class="sr"><%- gettext('Selected tab') %> </span><%- gettext("Manage Students") %></a></li>
-        <li class="tab tab-settings" data-tab="settings"><a href="#"><%- gettext("Settings") %></a></li>
+        <li class="tab tab-manage_students is-selected" data-tab="manage_students"><button type="button" class="toggle-button"><span class="sr"><%- gettext('Selected tab') %> </span><%- gettext("Manage Students") %></button></li>
+        <li class="tab tab-settings" data-tab="settings"><button type="button" class="toggle-button"><%- gettext("Settings") %></button></li>
     </ul>
 
     <div class="cohort-management-group-add tab-content tab-content-manage_students" tabindex="-1">

--- a/lms/templates/instructor/instructor_dashboard_2/cohorts.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohorts.underscore
@@ -34,17 +34,17 @@
         <hr class="divider divider-lv1" />
 
         <!-- Uploading a CSV file of cohort assignments. -->
-        <a class="toggle-cohort-management-secondary" href="#cohort-management-file-upload"><%- gettext('Assign students to cohorts by uploading a CSV file') %></a>
-        <div class="cohort-management-file-upload csv-upload is-hidden" id="cohort-management-file-upload"></div>
+        <button class="toggle-cohort-management-secondary" data-href="#cohort-management-file-upload"><%- gettext('Assign students to cohorts by uploading a CSV file') %></button>
+        <div class="cohort-management-file-upload csv-upload is-hidden" id="cohort-management-file-upload" tabindex="-1"></div>
 
         <div class="cohort-management-supplemental">
             <p class="">
                 <span class="icon fa fa-info-circle" aria-hidden="true"></span>
                 <%= HtmlUtils.interpolateHtml(
-                    gettext('To review student cohort assignments or see the results of uploading a CSV file, download course profile information or cohort results on {link_start} the Data Download page. {link_end}'),
+                    gettext('To review student cohort assignments or see the results of uploading a CSV file, download course profile information or cohort results on the {link_start}Data Download{link_end} page.'),
                     {
-                        link_start: HtmlUtils.HTML('<a href="" class="link-cross-reference" data-section="data_download">'),
-                        link_end: HtmlUtils.HTML('</a>')
+                        link_start: HtmlUtils.HTML('<button type="button" class="btn-link link-cross-reference" data-section="data_download">'),
+                        link_end: HtmlUtils.HTML('</button>')
                     })
                 %>
             </p>
@@ -53,8 +53,8 @@
         <hr class="divider divider-lv1" />
 
         <!-- Discussion Topics. -->
-        <a class="toggle-cohort-management-discussions" href="#cohort-discussions-management"><%- gettext('Specify whether discussion topics are divided by cohort') %></a>
-        <div class="cohort-discussions-nav is-hidden" id="cohort-management-discussion-topics">
+        <button class="toggle-cohort-management-discussions" data-href="#cohort-discussions-management"><%- gettext('Specify whether discussion topics are divided by cohort') %></button>
+        <div class="cohort-discussions-nav is-hidden" id="cohort-discussions-management" tabindex="-1">
             <div class="cohort-course-wide-discussions-nav"></div>
             <div class="cohort-inline-discussions-nav"></div>
         </div>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -109,7 +109,7 @@ from django.core.urlresolvers import reverse
           % for section_data in sections:
             ## This is necessary so we don't scrape 'section_display_name' as a string.
             <% dname = section_data['section_display_name'] %>
-            <li class="nav-item"><a href="" data-section="${ section_data['section_key'] }">${_(dname)}</a></li>
+            <li class="nav-item"><button type="button" class="btn-link" data-section="${ section_data['section_key'] }">${_(dname)}</button></li>
           % endfor
         </ul>
 

--- a/lms/templates/instructor/instructor_dashboard_2/metrics.html
+++ b/lms/templates/instructor/instructor_dashboard_2/metrics.html
@@ -241,7 +241,7 @@ from django.template.defaultfilters import escapejs
       });
 
       if (window.location.hash === "#view-metrics") {
-        $('.instructor-nav a[data-section="metrics"]').click();
+        $('.instructor-nav [data-section="metrics"]').click();
         $('#graph_reload').hide();
         $('.metrics-header-container').hide();
       }

--- a/lms/templates/pdf_viewer.html
+++ b/lms/templates/pdf_viewer.html
@@ -1,5 +1,11 @@
+<%page expression_filter="h"/>
 ﻿<!DOCTYPE html>
 <%namespace name='static' file='static_content.html'/>
+<%!
+from openedx.core.djangolib.js_utils import (
+    js_escaped_string
+)
+%>
 <!--
 Copyright 2012 Mozilla Foundation
 
@@ -24,7 +30,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">
     <meta name="path_prefix" content="${EDX_ROOT_URL}">
-    <title>${current_chapter['title'] if current_chapter else '' |h}</title>
+    <title>${current_chapter['title'] if current_chapter else ''}</title>
 
     <link rel="stylesheet" href="${static.url('/static/css/vendor/pdfjs/viewer.css')}"/>
 
@@ -36,10 +42,10 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <script type="text/javascript" src="${static.url('/static/js/vendor/pdfjs/pdf.js')}"></script>
 
     <script type="text/javascript">
-        PDFJS.imageResourcesPath = "${static.url('/static/css/vendor/pdfjs/images/')}";
-        PDFJS.workerSrc = "${static.url('/static/js/vendor/pdfjs/pdf.worker.js')}";
-        PDFJS.cMapUrl = "${static.url('/static/css/vendor/pdfjs/cmaps/')}";
-        PDF_URL = '${current_url | h}';
+        PDFJS.imageResourcesPath = "${static.url('/static/css/vendor/pdfjs/images/') | n, js_escaped_string}";
+        PDFJS.workerSrc = "${static.url('/static/js/vendor/pdfjs/pdf.worker.js') | n, js_escaped_string}";
+        PDFJS.cMapUrl = "${static.url('/static/css/vendor/pdfjs/cmaps/') | n, js_escaped_string}";
+        PDF_URL = '${current_url | n, js_escaped_string}';
     </script>
 
     <script ${static.url('/static/js/vendor/pdfjs/debugger.js')}></script>
@@ -116,7 +122,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 
             <a href="#" id="secondaryViewBookmark" class="secondaryToolbarButton bookmark visibleSmallView" title="Current view (copy or open in new window)" data-l10n-id="bookmark">
               <span data-l10n-id="bookmark_label">Current View</span>
-            </a>
+          </a>
 
             <div class="horizontalToolbarSeparator visibleLargeView"></div>
 
@@ -191,9 +197,9 @@ http://sourceforge.net/adobe/cmap/wiki/License/
                   <span data-l10n-id="download_label">Download</span>
                 </button>
                 <!-- <div class="toolbarButtonSpacer"></div> -->
-                <a href="#" id="viewBookmark" class="toolbarButton bookmark hiddenSmallView" title="Current view (copy or open in new window)" data-l10n-id="bookmark">
+                <button id="viewBookmark" class="toolbarButton bookmark hiddenSmallView" title="Current view (copy or open in new window)" data-l10n-id="bookmark">
                   <span data-l10n-id="bookmark_label">Current View</span>
-                </a>
+              </button>
 
                 <div class="verticalToolbarSeparator hiddenSmallView"></div>
                 

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -69,14 +69,14 @@ ${block_content}
       <div data-location="${location | h}" data-location-name="${location.name | h}">
         [
         % if can_reset_attempts:
-        <a href="#" class="staff-debug-reset">${_('Reset Student Attempts')}</a>
+        <button type="button" class="btn-link staff-debug-reset">${_('Reset Student Attempts')}</button>
         |
         % endif
         % if has_instructor_access:
-        <a href="#" class="staff-debug-sdelete">${_('Delete Student State')}</a>
+        <button type="button" class="btn-link staff-debug-sdelete">${_('Delete Student State')}</button>
         % if can_rescore_problem:
         |
-        <a href="#" class="staff-debug-rescore">${_('Rescore Student Submission')}</a>
+        <button type="button" class="btn-link staff-debug-rescore">${_('Rescore Student Submission')}</button>
         % endif
         % endif
         ]
@@ -148,4 +148,3 @@ $(function () {
 });
 </script>
 %endif
-

--- a/lms/templates/static_htmlbook.html
+++ b/lms/templates/static_htmlbook.html
@@ -126,7 +126,7 @@ from openedx.core.djangolib.js_utils import (
               <ul id="booknav" class="treeview-booknav">
                 <%def name="print_entry(entry, index_value)">
                   <li id="htmlchapter-${index_value}">
-                    <a class="chapter">
+                    <a href="#bookpage" class="chapter">
                       ${entry.get('title')}
                     </a>
                   </li>

--- a/lms/templates/static_pdfbook.html
+++ b/lms/templates/static_pdfbook.html
@@ -1,8 +1,14 @@
+<%page expression_filter="h"/>
 <%! from django.utils.translation import ugettext as _ %>
 
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
-<%block name="pagetitle">${_('{course_number} Textbook').format(course_number=course.display_number_with_default) | h}</%block>
+<%!
+from openedx.core.djangolib.js_utils import (
+    js_escaped_string
+)
+%>
+<%block name="pagetitle">${_('{course_number} Textbook').format(course_number=course.display_number_with_default)}</%block>
 <%block name="headextra">
 <%static:css group='style-course-vendor'/>
 <%static:css group='style-course'/>
@@ -13,11 +19,11 @@
 <%include file="/courseware/course_navigation.html" args="active_page='pdftextbook/{0}'.format(book_index)" />
 <script>
 $(function(){
-  $('a.chapter').click(function(e){
+  $('.chapter').click(function(e){
     e.preventDefault();
     var url = $(this).attr('rel');
     $('#viewer-frame').attr({
-        'src': '${request.path}?viewer=true&file=' + url + '#zoom=page-fit&disableRange=true',
+        'src': '${request.path | n, js_escaped_string}?viewer=true&file=' + url + '#zoom=page-fit&disableRange=true',
         'title': $(this).text()
         });
     $('#viewer-frame').focus();
@@ -33,7 +39,7 @@ $(function(){
         <ul id="booknav">
           % for (index, entry) in enumerate(textbook['chapters']):
           <li>
-            <a class="chapter" rel="${entry['url']}" href="#">${entry.get('title')}</a>
+            <a class="chapter" rel="${entry['url']}" href="#viewer-frame">${entry.get('title')}</a>
           </li>
           % endfor
         </ul>
@@ -42,12 +48,13 @@ $(function(){
 
     <div class="book">
     <iframe
-    title="${current_chapter['title']|h}"
+    title="${current_chapter['title']}"
     id="viewer-frame"
     src="${request.path}?viewer=true${viewer_params}"
     width="856"
     height="1108"
     frameborder="0"
+    tabindex="-1"
     seamless></iframe>
     </div>
     </div>

--- a/lms/templates/student_account/account.underscore
+++ b/lms/templates/student_account/account.underscore
@@ -13,7 +13,7 @@
     <div id="request-email-status" />
 
     <div id="password-reset">
-        <a href="#"><%- gettext("Reset Password") %></a>
+        <button type="button"><%- gettext("Reset Password") %></button>
     </div>
     <div id="password-reset-status" />
 </form>

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -64,6 +64,6 @@
     <% } %>
 
     <% if( form === 'login' && name === 'password' ) { %>
-        <a href="#" class="forgot-password field-link"><%- gettext("Forgot password?") %></a>
+        <button type="button" class="forgot-password field-link"><%- gettext("Forgot password?") %></button>
     <% } %>
 </div>

--- a/lms/templates/student_profile/third_party_auth.html
+++ b/lms/templates/student_profile/third_party_auth.html
@@ -29,10 +29,10 @@ from third_party_auth import pipeline
                         % if state.has_account:
                             <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}">
 
-                            <a href="#" onclick="document.${state.get_unlink_form_name()}.submit()">
+                            <button type="button" onclick="document.${state.get_unlink_form_name()}.submit()">
                                 ## Translators: clicking on this removes the link between a user's edX account and their account with an external authentication provider (like Google or LinkedIn).
                                 ${_("Unlink")}
-                            </a>
+                            </button>
                         % elif state.provider.accepts_logins:
                             <a href="${pipeline.get_login_url(state.provider.provider_id, pipeline.AUTH_ENTRY_PROFILE)}">
                                 ## Translators: clicking on this creates a link between a user's edX account and their account with an external authentication provider (like Google or LinkedIn).

--- a/lms/templates/ux/reference/course-skeleton.html
+++ b/lms/templates/ux/reference/course-skeleton.html
@@ -19,9 +19,9 @@
             </li>
 
             <li class="tab">
-                <a href="#">
+                <button type="button">
                     Course
-                </a>
+                </button>
             </li>
 
             <li class="tab">

--- a/lms/templates/verify_student/review_photos_step.underscore
+++ b/lms/templates/verify_student/review_photos_step.underscore
@@ -30,9 +30,9 @@
               <li class="tip"><%- _.sprintf(  gettext( "Does the name on your ID match your account name: %(fullName)s?" ), { fullName: fullName } ) %>
                 <div class="help-tip is-expandable">
                   <label for="new-name">
-                    <a href="#" class="title title-expand" aria-expanded="false">
+                    <button type="button" class="title title-expand" aria-expanded="false">
                       <%- gettext( "Edit Your Name" ) %>
-                    </a>
+                    </button>
                   </label>
 
                   <div class="copy expandable-area">

--- a/lms/templates/wiki/history.html
+++ b/lms/templates/wiki/history.html
@@ -216,15 +216,15 @@
         {% trans "Back to history view" %}
       </a>
       {% if article|can_write:user %}
-        <a href="#" class="btn btn-large btn-primary switch-to-revision">
+        <button type="button" class="btn btn-large btn-primary switch-to-revision">
           <span class="icon fa fa-flag" aria-hidden="true"></span>
           {% trans "Switch to this version" %}
-        </a>
+        </button>
       {% else %}
-        <a href="#" class="btn btn-large btn-primary disabled">
+        <button type="button" class="btn btn-large btn-primary disabled">
           <span class="icon fa fa-lock" aria-hidden="true"></span>
           {% trans "Switch to this version" %}
-        </a>
+        </button>
       {% endif %}
       </div>
     </div>
@@ -251,15 +251,15 @@
           {% trans "Back to history view" %}
         </a>
         {% if article|can_write:user %}
-        <a href="#" class="btn btn-large btn-primary merge-revision-commit">
+        <button type="button" class="btn btn-large btn-primary merge-revision-commit">
           <span class="icon fa fa-file" aria-hidden="true"></span>
           {% trans "Create new merged version" %}
-        </a>
+        </button>
         {% else %}
-          <a href="#" class="btn btn-large btn-primary disabled">
+          <button type="button" class="btn btn-large btn-primary disabled">
             <span class="icon fa fa-lock" aria-hidden="true"></span>
             {% trans "Create new merged version" %}
-          </a>
+          </button>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
# AC-530

This fixes `link-href` ignored a11y checks in the platform, specifically the LMS. The remaining instances are:
- discussion forums (because they're currently being worked on)
- problem types (because they're currently being worked on)
- still quite a bit of un-tested a href="#" in Studio, but we'll do those later
## Visual changes

I changed the links on the Instructor Dashboard to buttons. The styling changed, but we are wanting to move away from ALL CAPS anyway, so I think it works.

<img width="1002" alt="screen shot 2016-08-02 at 8 55 05 am" src="https://cloud.githubusercontent.com/assets/2112024/17329073/eb642700-588e-11e6-8994-d6cf4fbc7d87.png">
_before_

<img width="808" alt="screen shot 2016-08-02 at 8 54 13 am" src="https://cloud.githubusercontent.com/assets/2112024/17329077/f27edaf8-588e-11e6-822d-b40750a0a8ef.png">
_after_

Other changes I tried to keep the same, requiring some updates to various Sass partials.
## Accessibility tests

I added accessibility checks were applicable. The staff view test had 27 errors, but since that's technically out of scope for this deadline, I created a ticket (AC-559) and ignored those checks for now.
## Safe template failures

There were 137 various safe template failures here. I started fixing them, but more things broke in the process. Since this ticket is long overdue and Quality tests are passing, I'm going to skip those for now.
## Sandbox

https://clrux-ac-530.sandbox.edx.org
## Tickets as a result of this work
- https://openedx.atlassian.net/browse/AC-560
## Reviewers
- [x] @cptvitamin (Accessibility, overall)
- [x] @cahrens (T&L, overall)
- [x] @saleem-latif (Marketing footer links specifically)
## Documentation updates

Links that were previously empty (`href="#"`) are now buttons. @lamagnifica #
