### PR TITLE
Removing references to deleted module common.test.acceptance.pages.lm…

### DIFF
--- a/common/test/acceptance/pages/lms/peer_calibrate.py
+++ b/common/test/acceptance/pages/lms/peer_calibrate.py
@@ -5,7 +5,6 @@ Page that allows the student to grade calibration essays
 
 from bok_choy.page_object import PageObject
 from bok_choy.promise import Promise
-from .rubric import RubricPage
 
 
 class PeerCalibratePage(PageObject):
@@ -31,16 +30,6 @@ class PeerCalibratePage(PageObject):
         Continue to peer grading after completing calibration.
         """
         self.q(css='input.calibration-feedback-button').first.click()
-
-    @property
-    def rubric(self):
-        """
-        Return a `RubricPage` for the calibration essay.
-        If no rubric is available, raises a `BrokenPromise` exception.
-        """
-        rubric = RubricPage(self.browser)
-        rubric.wait_for_page(timeout=60)
-        return rubric
 
     @property
     def message(self):

--- a/common/test/acceptance/pages/lms/peer_grade.py
+++ b/common/test/acceptance/pages/lms/peer_grade.py
@@ -4,7 +4,6 @@ Students grade peer submissions.
 
 from bok_choy.page_object import PageObject
 from bok_choy.promise import Promise
-from .rubric import RubricPage
 
 
 class PeerGradePage(PageObject):
@@ -37,13 +36,3 @@ class PeerGradePage(PageObject):
         """
         index = self.problem_list.index(problem_name) + 1
         self.q(css='a.problem-button:nth-of-type({})'.format(index)).first.click()
-
-    @property
-    def rubric(self):
-        """
-        Return a `RubricPage` to allow students to grade their peers.
-        If no rubric is available, raises a `BrokenPromise` exception.
-        """
-        rubric = RubricPage(self.browser)
-        rubric.wait_for_page()
-        return rubric


### PR DESCRIPTION
### Description

Working on [this](https://github.com/edx/edx-platform/pull/12973) pull request, references to a removed module were found. The module common.test.acceptance.pages.lms.rubric was removed in [this](https://github.com/edx/edx-platform/commit/2af299c82b561c40fc966945009e48f527f04afc) commit. This fix removes all the references to this module
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @benpatterson 
