### PR TITLE
Extend existing verify_student service for ASU/GFA (companion PR to https://github.com/edx/xblock-lti-consumer/pull/20).

### DIFF
--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -138,7 +138,7 @@ class ReverificationService(object):
         course_key = CourseKey.from_string(course_id)
         return VerificationStatus.get_user_attempts(user_id, course_key, related_assessment_location)
 
-    def get_course_verification_status(self, user, course_id):
+    def get_course_verification_status(self, user_id, course_id):
         """
         This xBlock service method will return the status of the course level verification status, which
         is not the same as in-course reverification. This verification status is normally shown to the user
@@ -148,6 +148,8 @@ class ReverificationService(object):
         or if the user is not enrolled in the course under a course_mode that would
         require verification
         """
+
+        user = User.objects.get(id=user_id)
 
         enrollment = CourseEnrollment.get_enrollment(user, course_id)
         if not enrollment:

--- a/lms/djangoapps/verify_student/tests/test_services.py
+++ b/lms/djangoapps/verify_student/tests/test_services.py
@@ -198,7 +198,7 @@ class TestReverificationService(ModuleStoreTestCase):
         service = ReverificationService()
 
         self.enrollment.update_enrollment(mode=CourseMode.VERIFIED)
-        status = service.get_course_verification_status(self.user.id, self.course_id)
+        status = service.get_course_verification_status(self.user, self.course_id)
         self.assertEqual(status, VERIFY_STATUS_NEED_TO_VERIFY)
 
     def test_get_course_verification_status_not_enrolled(self):
@@ -212,7 +212,7 @@ class TestReverificationService(ModuleStoreTestCase):
         not_enrolled_course = CourseFactory.create(org='Robot', number='101', display_name='Second Test Course')
         self.assertIsNone(
             service.get_course_verification_status(
-                self.user.id,
+                self.user,
                 not_enrolled_course.id
             )
         )
@@ -227,5 +227,5 @@ class TestReverificationService(ModuleStoreTestCase):
 
         self.enrollment.update_enrollment(mode=CourseMode.HONOR)
         self.assertIsNone(
-            service.get_course_verification_status(self.user.id, self.course_id)
+            service.get_course_verification_status(self.user, self.course_id)
         )

--- a/lms/djangoapps/verify_student/tests/test_services.py
+++ b/lms/djangoapps/verify_student/tests/test_services.py
@@ -191,12 +191,24 @@ class TestReverificationService(ModuleStoreTestCase):
         self.assertEqual(status, service.NON_VERIFIED_TRACK)
 
     def test_get_course_verification_status(self):
-        # test that we can retrieve the course verification status via the service
+        """
+        test that we can retrieve the course verification status via the service
+        """
 
         service = ReverificationService()
 
-        # NEGATIVE TEST: we get back a None if we ask about a course that the user
-        # is not enrolled in
+        self.enrollment.update_enrollment(mode=CourseMode.VERIFIED)
+        status = service.get_course_verification_status(self.user.id, self.course_id)
+        self.assertEqual(status, VERIFY_STATUS_NEED_TO_VERIFY)
+
+    def test_get_course_verification_status_not_enrolled(self):
+        """
+        Test we get back a None if we ask about a course that the user
+        is not enrolled in
+        """
+
+        service = ReverificationService()
+
         not_enrolled_course = CourseFactory.create(org='Robot', number='101', display_name='Second Test Course')
         self.assertIsNone(
             service.get_course_verification_status(
@@ -205,13 +217,15 @@ class TestReverificationService(ModuleStoreTestCase):
             )
         )
 
-        # NEGATIVE TEST: we get back a None if we ask about a course that the user
-        # is not enrolled as verified
+    def test_get_course_verification_status_not_verified(self):
+        """
+        Test we get back a None if we ask about a course that the user
+        is not enrolled as verified
+        """
+
+        service = ReverificationService()
+
         self.enrollment.update_enrollment(mode=CourseMode.HONOR)
         self.assertIsNone(
             service.get_course_verification_status(self.user.id, self.course_id)
         )
-
-        self.enrollment.update_enrollment(mode=CourseMode.VERIFIED)
-        status = service.get_course_verification_status(self.user.id, self.course_id)
-        self.assertEqual(status, VERIFY_STATUS_NEED_TO_VERIFY)

--- a/lms/djangoapps/verify_student/tests/test_services.py
+++ b/lms/djangoapps/verify_student/tests/test_services.py
@@ -198,7 +198,7 @@ class TestReverificationService(ModuleStoreTestCase):
         service = ReverificationService()
 
         self.enrollment.update_enrollment(mode=CourseMode.VERIFIED)
-        status = service.get_course_verification_status(self.user, self.course_id)
+        status = service.get_course_verification_status(self.user.id, self.course_id)
         self.assertEqual(status, VERIFY_STATUS_NEED_TO_VERIFY)
 
     def test_get_course_verification_status_not_enrolled(self):
@@ -212,7 +212,7 @@ class TestReverificationService(ModuleStoreTestCase):
         not_enrolled_course = CourseFactory.create(org='Robot', number='101', display_name='Second Test Course')
         self.assertIsNone(
             service.get_course_verification_status(
-                self.user,
+                self.user.id,
                 not_enrolled_course.id
             )
         )
@@ -227,5 +227,5 @@ class TestReverificationService(ModuleStoreTestCase):
 
         self.enrollment.update_enrollment(mode=CourseMode.HONOR)
         self.assertIsNone(
-            service.get_course_verification_status(self.user, self.course_id)
+            service.get_course_verification_status(self.user.id, self.course_id)
         )


### PR DESCRIPTION
This is a companion PR to the primary set of changes performed in https://github.com/edx/xblock-lti-consumer/pull/20 in support of the ASU/GFA courses.

This pull-request extends the existing 'reverification' xBlock runtime service to allow xBlocks (in this case the LTI Consumer xBlock) to get the current user's course-level verification status when he/she is enrolled in a course as 'verified'.

For a more detailed description of the changes, including design documentation and screenshots, please see: https://github.com/edx/xblock-lti-consumer/pull/20

NOTE: this PR is safe to merge either before or after the PR against the xblock-lti-consumer, however for the full functionality of the desired changes for the ASU/GFA courses, both PRs must be completed.

In addition, once the PR against the xblock-lti-consumer is completed, we'll need to do a follow-on PR against edx-platform to bump up the requirements file to make sure the newer version of the LTI Consumer xBlock is deployed.

FYI, @douglashall 

Adding @nwilken,@aricken, and @jdenison72 as observers
