### PR TITLE
unawaz/ECOM-4787-account-settings-page-header

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -436,6 +436,7 @@ def account_settings_context(request):
     context = {
         'auth': {},
         'duplicate_provider': None,
+        'nav_hidden': True,
         'fields': {
             'country': {
                 'options': list(countries),


### PR DESCRIPTION
[ECOM-4787](https://openedx.atlassian.net/browse/ECOM-4787) 
Removing marketing site links from header from account settings page https://courses.edx.org/account/settings 
@schenedx please have a look. Thanks
