### PR TITLE
AC-531 fixing nav-aria-label ignores in the platform

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -190,7 +190,7 @@
       % if static.show_language_selector():
         <% languages = static.get_released_languages() %>
         % if len(languages) > 1:
-        <nav class="user-language-selector">
+        <nav class="user-language-selector" aria-label="${_('Language preference')}">
           <form action="/i18n/setlang/" method="post" class="settings-language-form" id="language-settings-form">
               <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">
               % if user.is_authenticated():

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -657,7 +657,6 @@ class StudioLibraryA11yTest(StudioLibraryTest):
         lib_page.a11y_audit.config.set_rules({
             "ignore": [
                 'link-href',  # TODO: AC-226
-                'nav-aria-label',  # TODO: AC-227
                 'icon-aria-hidden',  # TODO: AC-229
             ],
         })

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -504,7 +504,6 @@ class StudioSettingsA11yTest(StudioCourseTest):
         self.settings_page.a11y_audit.config.set_rules({
             "ignore": [
                 'link-href',  # TODO: AC-226
-                'nav-aria-label',  # TODO: AC-227
                 'icon-aria-hidden',  # TODO: AC-229
             ],
         })


### PR DESCRIPTION
# AC-531

This fixes the `nav-aria-label` failures and ignored tests in the platform.

0/0 safe commit violations fixed.
## Sandbox

Not necessary in this context.
## Reviewers
- [x] @cahrens 
- [x] @cptvitamin (FYI)
