### PR TITLE
Register CatalogIntegration model with the Django admin

### DIFF
--- a/openedx/core/djangoapps/catalog/admin.py
+++ b/openedx/core/djangoapps/catalog/admin.py
@@ -1,0 +1,10 @@
+"""
+Django admin bindings for catalog support models.
+"""
+from django.contrib import admin
+
+from config_models.admin import ConfigurationModelAdmin
+from openedx.core.djangoapps.catalog.models import CatalogIntegration
+
+
+admin.site.register(CatalogIntegration, ConfigurationModelAdmin)


### PR DESCRIPTION
@robrap I introduced a new model in the upcoming release, but forgot to register it with the Django admin. The commit on this PR does that, allowing me to verify my changes on stage. Would it be possible to merge this into the RC?
