### PR TITLE
MA-2076: add due date to course block API

### DIFF
--- a/lms/djangoapps/course_api/blocks/transformers/__init__.py
+++ b/lms/djangoapps/course_api/blocks/transformers/__init__.py
@@ -38,6 +38,7 @@ SUPPORTED_FIELDS = [
     SupportedFieldType('display_name', default_value=''),
     SupportedFieldType('graded'),
     SupportedFieldType('format'),
+    SupportedFieldType('due'),
     # 'student_view_data'
     SupportedFieldType(StudentViewTransformer.STUDENT_VIEW_DATA, StudentViewTransformer),
     # 'student_view_multi_device'

--- a/lms/djangoapps/course_api/blocks/transformers/blocks_api.py
+++ b/lms/djangoapps/course_api/blocks/transformers/blocks_api.py
@@ -43,7 +43,7 @@ class BlocksAPITransformer(BlockStructureTransformer):
         transform method.
         """
         # collect basic xblock fields
-        block_structure.request_xblock_fields('graded', 'format', 'display_name', 'category')
+        block_structure.request_xblock_fields('graded', 'format', 'display_name', 'category', 'due')
 
         # collect data from containing transformers
         StudentViewTransformer.collect(block_structure)

--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -30,7 +30,7 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
         GET /api/courses/v1/blocks/<usage_id>/?
             username=anjali
             &depth=all
-            &requested_fields=graded,format,student_view_multi_device,lti_url
+            &requested_fields=graded,format,student_view_multi_device,lti_url,due
             &block_counts=video
             &student_view_data=video
             &block_types_filter=problem,html
@@ -170,6 +170,8 @@ class BlocksView(DeveloperErrorViewMixin, ListAPIView):
           * lti_url: The block URL for an LTI consumer. Returned only if the
             "ENABLE_LTI_PROVIDER" Django settign is set to "True".
 
+          * due: The due date of the block. Returned only if "due" is included
+            in the "requested_fields" parameter.
     """
 
     def list(self, request, usage_key_string):  # pylint: disable=arguments-differ


### PR DESCRIPTION
### Description

[MA-2076](https://openedx.atlassian.net/browse/MA-2076)

Added 'due date' to requested_fields in course block API
### Sandbox
- [x] https://jia-due-date.sandbox.edx.org/
### Testing
- [x] Unit
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @verdanmahmood 
- [x] Code review: @nasthagiri 
### Post-review
- [x] Squash commits
