### PR TITLE
Show user activation message if he has activation incomplete.

### DIFF
--- a/lms/static/js/spec/verify_student/make_payment_step_view_spec.js
+++ b/lms/static/js/spec/verify_student/make_payment_step_view_spec.js
@@ -142,6 +142,41 @@ define([
                 expectPaymentSubmitted( view, {foo: 'bar'} );
             });
 
+            it ('view containing verification msg when verification deadline is set and user is active', function() {
+                var verificationDeadlineDateFormat = 'Aug 14, 2016 at 23:59 UTC';
+                createView({
+                    userEmail: 'test@example.com',
+                    requirements: {
+                        isVisible:true
+                    },
+                    verificationDeadline: verificationDeadlineDateFormat,
+                    isActive: true
+                });
+                // Verify user does not get user activation message when he is already activated.
+                expect($('p.instruction-info:contains("test@example.com")').length).toEqual(0);
+                // Verify user gets verification message.
+                expect(
+                    $(
+                        'p.instruction-info:contains("You can pay now even if you don\'t have ' +
+                        'the following items available, but you will need to have these by ' +
+                        verificationDeadlineDateFormat + ' to qualify to earn a Verified Certificate.")'
+                    ).length
+                ).toEqual(1);
+            });
+
+            it ('view containing user email when verification deadline is set and user is not active', function() {
+                createView({
+                    userEmail: 'test@example.com',
+                    requirements: {
+                        isVisible:true
+                    },
+                    verificationDeadline: true,
+                    isActive: false
+                });
+                // Verify un-activated user gets activation message.
+                expect($('p.instruction-info:contains("test@example.com")').length).toEqual(1);
+            });
+
             it ('view containing user email', function() {
                 createView({userEmail: 'test@example.com', requirements: {isVisible:true}, isActive: false});
                 expect($('p.instruction-info:contains("test@example.com")').length).toEqual(1);

--- a/lms/templates/verify_student/make_payment_step.underscore
+++ b/lms/templates/verify_student/make_payment_step.underscore
@@ -30,7 +30,7 @@
     <div class="instruction <% if ( !upgrade && isActive ) { %>center-col<% } %>">
       <% if ( _.some( requirements, function( isVisible ) { return isVisible; } ) ) { %>
       <p class="instruction-info">
-        <% if ( verificationDeadline ) { %>
+        <% if ( verificationDeadline && isActive) { %>
           <%- _.sprintf(
             gettext( "You can pay now even if you don't have the following items available, but you will need to have these by %(date)s to qualify to earn a Verified Certificate." ),
             { date: verificationDeadline }


### PR DESCRIPTION
Show user activation message if he has activation incomplete.
Only show validation deadline message when user is activated and course has validation deadline.

**_Sandbox**_ 
https://ecom4926.sandbox.edx.org

**_Testing**_
1. Register as a new user (Do not activate account)
2. Enroll in a course
3. Go to [Dashboard page](https://ecom4926.sandbox.edx.org/dashboard), Click on `Upgrade to Verified` button
4. Observe that you get user activation message
5. Now activate email
6. Click on `Upgrade to Verified` button
7. Observe that you do not user activation message but a verification deadline message containing validation date
