### PR TITLE
AC-526 fixing invalid-aria-attr-value failures and ignores in the platform

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -1050,10 +1050,9 @@ class CertificatesTest(BaseInstructorDashboardTest):
         ])
         self.certificates_section.a11y_audit.config.set_rules({
             "ignore": [
-                'aria-valid-attr-value',  # TODO: AC-491
                 'checkboxgroup',  # TODO: AC-491
-                'duplicate-id',  # TODO: AC-491
-                'label',  # TODO: AC-491
+                'duplicate-id',  # TODO: AC-523
+                'label',  # TODO: AC-524
                 'radiogroup',  # TODO: AC-491
             ]
         })
@@ -1268,7 +1267,6 @@ class CertificateInvalidationTest(BaseInstructorDashboardTest):
         ])
         self.certificates_section.a11y_audit.config.set_rules({
             "ignore": [
-                'aria-valid-attr-value',  # TODO: AC-491
                 'checkboxgroup',  # TODO: AC-491
                 'duplicate-id',  # TODO: AC-491
                 'label',  # TODO: AC-491

--- a/lms/templates/instructor/instructor_dashboard_2/certificate-invalidation.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/certificate-invalidation.underscore
@@ -3,8 +3,8 @@
 </p>
 
 <div class="add-certificate-invalidation">
-    <input class='student-username-or-email' id="certificate-invalidation-user" type="text" placeholder="<%- gettext('Username or email address') %>" aria-describedby='student-user-name-or-email-tip'>
-    <textarea class='notes-field' id="certificate-invalidation-notes" rows="10" placeholder="<%- gettext('Add notes about this learner') %>" aria-describedby='notes-field-tip'></textarea>
+    <input class='student-username-or-email' id="certificate-invalidation-user" type="text" placeholder="<%- gettext('Username or email address') %>">
+    <textarea class='notes-field' id="certificate-invalidation-notes" rows="10" placeholder="<%- gettext('Add notes about this learner') %>"></textarea>
     <br/>
     <button type="button" class="btn-blue" id="invalidate-certificate"><%- gettext('Invalidate Certificate') %></button>
 </div>

--- a/lms/templates/instructor/instructor_dashboard_2/certificate-white-list-editor.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/certificate-white-list-editor.underscore
@@ -2,8 +2,8 @@
 <p class="under-heading"> <%- gettext("Enter the username or email address of each learner that you want to add as an exception.") %></p>
 <div class='certificate-exception-inputs'>
     <div class="">
-    <input class='student-username-or-email' id="certificate-exception" type="text" placeholder="Student email or username" aria-describedby='student-user-name-or-email-tip'>
-    <textarea class='notes-field' id="notes" rows="10" placeholder="Free text notes" aria-describedby='notes-field-tip'></textarea>
+    <input class='student-username-or-email' id="certificate-exception" type="text" placeholder="Student email or username">
+    <textarea class='notes-field' id="notes" rows="10" placeholder="Free text notes"></textarea>
     </div>
     <div>
         <button type="button" class="btn-blue" id="add-exception" ><%- gettext("Add to Exception List") %> </button>


### PR DESCRIPTION
# AC-526

This corrects the failing tests for `invalid-aria-attr-value` and removes the ignore.

The focus should be on the "Invalidate Certificates" portion of the link below.
## Sandbox

https://clrux-ac-526.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-certificates
## Reviewers
- [x] @cahrens (TNL)
- [x] @lamagnifica (Docs)
- [x] @cptvitamin (FYI)
