### PR TITLE
Fixed progress page update on save ccx and grade book crash issue

### DIFF
--- a/lms/djangoapps/ccx/api/v0/views.py
+++ b/lms/djangoapps/ccx/api/v0/views.py
@@ -17,6 +17,7 @@ from rest_framework_oauth.authentication import OAuth2Authentication
 
 from ccx_keys.locator import CCXLocator
 from courseware import courses
+from xmodule.modulestore.django import SignalHandler
 from edx_rest_framework_extensions.authentication import JwtAuthentication
 from instructor.enrollment import (
     enroll_email,
@@ -517,6 +518,14 @@ class CCXListView(GenericAPIView):
             )
 
         serializer = self.get_serializer(ccx_course_object)
+
+        # using CCX object as sender here.
+        responses = SignalHandler.course_published.send(
+            sender=ccx_course_object,
+            course_key=ccx_course_key
+        )
+        for rec, response in responses:
+            log.info('Signal fired when course is published. Receiver: %s. Response: %s', rec, response)
         return Response(
             status=status.HTTP_201_CREATED,
             data=serializer.data
@@ -759,6 +768,14 @@ class CCXDetailView(GenericAPIView):
                 )
                 # enroll the coach to the newly created ccx
                 assign_coach_role_to_ccx(ccx_course_key, coach, master_course_object.id)
+
+        # using CCX object as sender here.
+        responses = SignalHandler.course_published.send(
+            sender=ccx_course_object,
+            course_key=ccx_course_key
+        )
+        for rec, response in responses:
+            log.info('Signal fired when course is published. Receiver: %s. Response: %s', rec, response)
 
         return Response(
             status=status.HTTP_204_NO_CONTENT,

--- a/lms/djangoapps/ccx/api/v0/views.py
+++ b/lms/djangoapps/ccx/api/v0/views.py
@@ -492,7 +492,7 @@ class CCXListView(GenericAPIView):
             make_user_coach(coach, master_course_key)
 
             # pull the ccx course key
-            ccx_course_key = CCXLocator.from_course_locator(master_course_object.id, ccx_course_object.id)
+            ccx_course_key = CCXLocator.from_course_locator(master_course_object.id, unicode(ccx_course_object.id))
             # enroll the coach in the newly created ccx
             email_params = get_email_params(
                 master_course_object,

--- a/lms/djangoapps/ccx/tasks.py
+++ b/lms/djangoapps/ccx/tasks.py
@@ -33,7 +33,7 @@ def send_ccx_course_published(course_key):
     course_key = CourseLocator.from_string(course_key)
     for ccx in CustomCourseForEdX.objects.filter(course_id=course_key):
         try:
-            ccx_key = CCXLocator.from_course_locator(course_key, ccx.id)
+            ccx_key = CCXLocator.from_course_locator(course_key, unicode(ccx.id))
         except InvalidKeyError:
             log.info('Attempt to publish course with deprecated id. Course: %s. CCX: %s', course_key, ccx.id)
             continue

--- a/lms/djangoapps/ccx/tests/utils.py
+++ b/lms/djangoapps/ccx/tests/utils.py
@@ -80,7 +80,7 @@ class CcxTestCase(SharedModuleStoreTestCase):
         """
         super(CcxTestCase, self).setUp()
         # Create instructor account
-        self.coach = UserFactory.create()
+        self.coach = UserFactory.create(password="test")
         # create an instance of modulestore
         self.mstore = modulestore()
 

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -133,7 +133,7 @@ def dashboard(request, course, ccx=None):
         if ccx:
             url = reverse(
                 'ccx_coach_dashboard',
-                kwargs={'course_id': CCXLocator.from_course_locator(course.id, ccx.id)}
+                kwargs={'course_id': CCXLocator.from_course_locator(course.id, unicode(ccx.id))}
             )
             return redirect(url)
 
@@ -218,7 +218,7 @@ def create_ccx(request, course, ccx=None):
             for vertical in sequential.get_children():
                 override_field_for_ccx(ccx, vertical, hidden, True)
 
-    ccx_id = CCXLocator.from_course_locator(course.id, ccx.id)
+    ccx_id = CCXLocator.from_course_locator(course.id, unicode(ccx.id))
 
     url = reverse('ccx_coach_dashboard', kwargs={'course_id': ccx_id})
 
@@ -373,7 +373,7 @@ def set_grading_policy(request, course, ccx=None):
 
     url = reverse(
         'ccx_coach_dashboard',
-        kwargs={'course_id': CCXLocator.from_course_locator(course.id, ccx.id)}
+        kwargs={'course_id': CCXLocator.from_course_locator(course.id, unicode(ccx.id))}
     )
     return redirect(url)
 
@@ -474,7 +474,7 @@ def ccx_invite(request, course, ccx=None):
     identifiers_raw = request.POST.get('student-ids')
     identifiers = _split_input_list(identifiers_raw)
     email_students = 'email-students' in request.POST
-    course_key = CCXLocator.from_course_locator(course.id, ccx.id)
+    course_key = CCXLocator.from_course_locator(course.id, unicode(ccx.id))
     email_params = get_email_params(course, auto_enroll=True, course_key=course_key, display_name=ccx.display_name)
 
     ccx_students_enrolling_center(action, identifiers, email_students, course_key, email_params, ccx.coach)
@@ -497,7 +497,7 @@ def ccx_student_management(request, course, ccx=None):
     student_id = request.POST.get('student-id', '')
     email_students = 'email-students' in request.POST
     identifiers = [student_id]
-    course_key = CCXLocator.from_course_locator(course.id, ccx.id)
+    course_key = CCXLocator.from_course_locator(course.id, unicode(ccx.id))
     email_params = get_email_params(course, auto_enroll=True, course_key=course_key, display_name=ccx.display_name)
 
     errors = ccx_students_enrolling_center(action, identifiers, email_students, course_key, email_params, ccx.coach)


### PR DESCRIPTION
### Background

fixes https://github.com/mitocw/edx-platform/issues/252 https://openedx.atlassian.net/browse/TNL-4892
### What is done in this PR

**Studio Updates:** None.
**LMS Updates:** 
- Add signal on save_ccx api, So that other application can be up to date when ccx contents change,

@pdpinch @giocalitri 
### To test:
- Create a coach
- create a student
- Login to edX platform as coach, open coach dashboard. change schedule of subsection aka sequential and press save.
  <img width="615" alt="screen shot 2016-07-14 at 7 32 14 pm" src="https://cloud.githubusercontent.com/assets/10431250/16843215/cd27feea-49f9-11e6-9326-56e91ae61a5a.png">
  <img width="757" alt="screen shot 2016-07-14 at 7 32 23 pm" src="https://cloud.githubusercontent.com/assets/10431250/16843216/cd2b91fe-49f9-11e6-83bf-ec95ef18c708.png">
- Login as student (CCX enrolled student). Go to dashboard then open ccx course and go to progress and see the due date of that subsection(problem).
  <img width="1036" alt="screen shot 2016-07-14 at 7 34 41 pm" src="https://cloud.githubusercontent.com/assets/10431250/16843404/8c3e5a0e-49fa-11e6-8bbc-30b4c59773cd.png">
  <img width="971" alt="screen shot 2016-07-14 at 7 34 52 pm" src="https://cloud.githubusercontent.com/assets/10431250/16843408/8cfca5ae-49fa-11e6-8024-c25fad06b69a.png">
  <img width="653" alt="screen shot 2016-07-14 at 7 37 25 pm" src="https://cloud.githubusercontent.com/assets/10431250/16843409/8d27ef48-49fa-11e6-85f9-5c672c6f6250.png">
