### PR TITLE
Country Time Zone API

### DIFF
--- a/openedx/core/djangoapps/user_api/errors.py
+++ b/openedx/core/djangoapps/user_api/errors.py
@@ -93,3 +93,8 @@ class PreferenceUpdateError(PreferenceRequestError):
     def __init__(self, developer_message, user_message=None):
         self.developer_message = developer_message
         self.user_message = user_message
+
+
+class CountryCodeError(ValueError):
+    """There was a problem with the country code"""
+    pass

--- a/openedx/core/djangoapps/user_api/legacy_urls.py
+++ b/openedx/core/djangoapps/user_api/legacy_urls.py
@@ -29,6 +29,10 @@ urlpatterns = patterns(
         user_api_views.UpdateEmailOptInPreference.as_view(),
         name="preferences_email_opt_in"
     ),
+    url(
+        r'^v1/preferences/time_zones/$',
+        user_api_views.CountryTimeZoneListView.as_view(),
+    ),
 )
 
 if settings.FEATURES.get('ENABLE_COMBINED_LOGIN_REGISTRATION'):

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
@@ -7,7 +7,7 @@ import ddt
 import unittest
 from mock import patch
 from nose.plugins.attrib import attr
-from pytz import UTC
+from pytz import common_timezones, utc
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -21,11 +21,22 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from ...accounts.api import create_account
-from ...errors import UserNotFound, UserNotAuthorized, PreferenceValidationError, PreferenceUpdateError
+from ...errors import (
+    UserNotFound,
+    UserNotAuthorized,
+    PreferenceValidationError,
+    PreferenceUpdateError,
+    CountryCodeError,
+)
 from ...models import UserProfile, UserOrgTag
 from ...preferences.api import (
-    get_user_preference, get_user_preferences, set_user_preference, update_user_preferences, delete_user_preference,
-    update_email_opt_in
+    get_user_preference,
+    get_user_preferences,
+    set_user_preference,
+    update_user_preferences,
+    delete_user_preference,
+    update_email_opt_in,
+    get_country_time_zones,
 )
 
 
@@ -407,7 +418,7 @@ class UpdateEmailOptInTests(ModuleStoreTestCase):
         # Set year of birth
         user = User.objects.get(username=self.USERNAME)
         profile = UserProfile.objects.get(user=user)
-        year_of_birth = datetime.datetime.now(UTC).year - age
+        year_of_birth = datetime.datetime.now(utc).year - age
         profile.year_of_birth = year_of_birth
         profile.save()
 
@@ -429,6 +440,26 @@ class UpdateEmailOptInTests(ModuleStoreTestCase):
             return False
         else:
             return True
+
+
+@ddt.ddt
+class CountryTimeZoneTest(TestCase):
+    """
+    Test cases to validate country code api functionality
+    """
+
+    @ddt.data(('NZ', ['Pacific/Auckland', 'Pacific/Chatham']),
+              (None, common_timezones))
+    @ddt.unpack
+    def test_get_country_time_zones(self, country_code, expected_time_zones):
+        """Verify that list of common country time zones are returned"""
+        country_time_zones = get_country_time_zones(country_code)
+        self.assertEqual(country_time_zones, expected_time_zones)
+
+    def test_country_code_errors(self):
+        """Verify that country code error is raised for invalid country code"""
+        with self.assertRaises(CountryCodeError):
+            get_country_time_zones('AA')
 
 
 def get_expected_validation_developer_message(preference_key, preference_value):

--- a/openedx/core/djangoapps/user_api/serializers.py
+++ b/openedx/core/djangoapps/user_api/serializers.py
@@ -3,6 +3,8 @@ Django REST Framework serializers for the User API application
 """
 from django.contrib.auth.models import User
 from rest_framework import serializers
+
+from openedx.core.lib.time_zone_utils import get_display_time_zone
 from student.models import UserProfile
 
 from .models import UserPreference
@@ -81,3 +83,23 @@ class ReadOnlyFieldsSerializerMixin(object):
         """
         all_fields = getattr(cls.Meta, 'fields', tuple())
         return tuple(set(all_fields) - set(cls.get_read_only_fields()))
+
+
+class CountryTimeZoneSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer that generates a list of common time zones for a country
+    """
+    time_zone = serializers.SerializerMethodField()
+    description = serializers.SerializerMethodField()
+
+    def get_time_zone(self, time_zone_name):
+        """
+        Returns inputted time zone name
+        """
+        return time_zone_name
+
+    def get_description(self, time_zone_name):
+        """
+        Returns the display version of time zone [e.g. US/Pacific (PST, UTC-0800)]
+        """
+        return get_display_time_zone(time_zone_name)

--- a/openedx/core/lib/tests/test_time_zone_utils.py
+++ b/openedx/core/lib/tests/test_time_zone_utils.py
@@ -3,7 +3,10 @@ from freezegun import freeze_time
 from student.tests.factories import UserFactory
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from openedx.core.lib.time_zone_utils import (
-    get_formatted_time_zone, get_time_zone_abbr, get_time_zone_offset, get_user_time_zone
+    get_display_time_zone,
+    get_time_zone_abbr,
+    get_time_zone_offset,
+    get_user_time_zone,
 )
 from pytz import timezone, utc
 from unittest import TestCase
@@ -36,59 +39,59 @@ class TestTimeZoneUtils(TestCase):
         user_tz = get_user_time_zone(self.user)
         self.assertEqual(user_tz, timezone('Asia/Tokyo'))
 
-    def _formatted_time_zone_helper(self, time_zone_string):
+    def _display_time_zone_helper(self, time_zone_string):
         """
-        Helper function to return all info from get_formatted_time_zone()
+        Helper function to return all info from get_display_time_zone()
         """
+        tz_str = get_display_time_zone(time_zone_string)
         time_zone = timezone(time_zone_string)
-        tz_str = get_formatted_time_zone(time_zone)
         tz_abbr = get_time_zone_abbr(time_zone)
         tz_offset = get_time_zone_offset(time_zone)
 
         return {'str': tz_str, 'abbr': tz_abbr, 'offset': tz_offset}
 
-    def _assert_time_zone_info_equal(self, formatted_tz_info, expected_name, expected_abbr, expected_offset):
+    def _assert_time_zone_info_equal(self, display_tz_info, expected_name, expected_abbr, expected_offset):
         """
-        Asserts that all formatted_tz_info is equal to the expected inputs
+        Asserts that all display_tz_info is equal to the expected inputs
         """
-        self.assertEqual(formatted_tz_info['str'], '{name} ({abbr}, UTC{offset})'.format(name=expected_name,
-                                                                                         abbr=expected_abbr,
-                                                                                         offset=expected_offset))
-        self.assertEqual(formatted_tz_info['abbr'], expected_abbr)
-        self.assertEqual(formatted_tz_info['offset'], expected_offset)
+        self.assertEqual(display_tz_info['str'], '{name} ({abbr}, UTC{offset})'.format(name=expected_name,
+                                                                                       abbr=expected_abbr,
+                                                                                       offset=expected_offset))
+        self.assertEqual(display_tz_info['abbr'], expected_abbr)
+        self.assertEqual(display_tz_info['offset'], expected_offset)
 
     @freeze_time("2015-02-09")
-    def test_formatted_time_zone_without_dst(self):
+    def test_display_time_zone_without_dst(self):
         """
-        Test to ensure get_formatted_time_zone() returns full formatted string when no kwargs specified
+        Test to ensure get_display_time_zone() returns full display string when no kwargs specified
         and returns just abbreviation or offset when specified
         """
-        tz_info = self._formatted_time_zone_helper('America/Los_Angeles')
+        tz_info = self._display_time_zone_helper('America/Los_Angeles')
         self._assert_time_zone_info_equal(tz_info, 'America/Los Angeles', 'PST', '-0800')
 
     @freeze_time("2015-04-02")
-    def test_formatted_time_zone_with_dst(self):
+    def test_display_time_zone_with_dst(self):
         """
-        Test to ensure get_formatted_time_zone() returns modified abbreviations and
+        Test to ensure get_display_time_zone() returns modified abbreviations and
         offsets during daylight savings time.
         """
-        tz_info = self._formatted_time_zone_helper('America/Los_Angeles')
+        tz_info = self._display_time_zone_helper('America/Los_Angeles')
         self._assert_time_zone_info_equal(tz_info, 'America/Los Angeles', 'PDT', '-0700')
 
     @freeze_time("2015-11-01 08:59:00")
-    def test_formatted_time_zone_ambiguous_before(self):
+    def test_display_time_zone_ambiguous_before(self):
         """
-        Test to ensure get_formatted_time_zone() returns correct abbreviations and offsets
+        Test to ensure get_display_time_zone() returns correct abbreviations and offsets
         during ambiguous time periods (e.g. when DST is about to start/end) before the change
         """
-        tz_info = self._formatted_time_zone_helper('America/Los_Angeles')
+        tz_info = self._display_time_zone_helper('America/Los_Angeles')
         self._assert_time_zone_info_equal(tz_info, 'America/Los Angeles', 'PDT', '-0700')
 
     @freeze_time("2015-11-01 09:00:00")
-    def test_formatted_time_zone_ambiguous_after(self):
+    def test_display_time_zone_ambiguous_after(self):
         """
-        Test to ensure get_formatted_time_zone() returns correct abbreviations and offsets
+        Test to ensure get_display_time_zone() returns correct abbreviations and offsets
         during ambiguous time periods (e.g. when DST is about to start/end) after the change
         """
-        tz_info = self._formatted_time_zone_helper('America/Los_Angeles')
+        tz_info = self._display_time_zone_helper('America/Los_Angeles')
         self._assert_time_zone_info_equal(tz_info, 'America/Los Angeles', 'PST', '-0800')

--- a/openedx/core/lib/time_zone_utils.py
+++ b/openedx/core/lib/time_zone_utils.py
@@ -43,12 +43,13 @@ def get_time_zone_offset(time_zone, date_time=None):
     return _format_time_zone_string(time_zone, date_time, '%z')
 
 
-def get_formatted_time_zone(time_zone):
+def get_display_time_zone(time_zone_name):
     """
-    Returns a formatted time zone (e.g. 'Asia/Tokyo (JST, UTC+0900)')
+    Returns a formatted display time zone (e.g. 'Asia/Tokyo (JST, UTC+0900)')
 
-    :param time_zone: Pytz time zone object
+    :param time_zone_name (str): Name of Pytz time zone
     """
+    time_zone = timezone(time_zone_name)
     tz_abbr = get_time_zone_abbr(time_zone)
     tz_offset = get_time_zone_offset(time_zone)
 
@@ -56,6 +57,6 @@ def get_formatted_time_zone(time_zone):
 
 
 TIME_ZONE_CHOICES = sorted(
-    [(tz, get_formatted_time_zone(timezone(tz))) for tz in common_timezones],
+    [(tz, get_display_time_zone(tz)) for tz in common_timezones],
     key=lambda tz_tuple: tz_tuple[1]
 )


### PR DESCRIPTION
### Description

[TNL-4792](https://openedx.atlassian.net/browse/TNL-4792)

Create an endpoint to retrieve commonly used timezones for each country.

Currently:
   `/user_api/v1/preferences/time_zones/` returns list of all time zones.
   `/user_api/v1/preferences/time_zones/?country_code=CA` returns list for that country code
### Sandbox
- [ ] Build a sandbox for your branch and add a link here
### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit violation code review process
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @jcdyer 
- [x] Code review: @efischer19 
- [ ] Doc Review: @...
- [ ] UX review: @...
- [ ] Accessibility review: @...
- [ ] Product review: @...

FYI: Tag anyone who might be interested in this PR here.
### Post-review
- [x] Squash commits
