### PR TITLE
MA-2139: Mark thread as read for learner on thread/comment creation 

### DIFF
--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -711,6 +711,7 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "username": self.user.username,
             "created_at": "2015-05-19T00:00:00Z",
             "updated_at": "2015-05-19T00:00:00Z",
+            "read": True,
         })
         self.register_post_thread_response(cs_thread)
         request_data = {
@@ -741,12 +742,12 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "voted": False,
             "vote_count": 0,
             "comment_count": 1,
-            "unread_comment_count": 1,
+            "unread_comment_count": 0,
             "comment_list_url": "http://testserver/api/discussion/v1/comments/?thread_id=test_thread",
             "endorsed_comment_list_url": None,
             "non_endorsed_comment_list_url": None,
             "editable_fields": ["abuse_flagged", "following", "raw_body", "read", "title", "topic_id", "type", "voted"],
-            "read": False,
+            "read": True,
             "has_endorsed": False,
             "response_count": 0,
         }
@@ -895,7 +896,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
     @ddt.unpack
     def test_closed_thread(self, field, value):
         self.register_get_user_response(self.user)
-        self.register_thread({"closed": True})
+        self.register_thread({"closed": True, "read": True})
         self.register_flag_response("thread", "test_thread")
         request_data = {field: value}
         response = self.request_patch(request_data)
@@ -904,11 +905,12 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
         self.assertEqual(
             response_data,
             self.expected_response_data({
+                "read": True,
                 "closed": True,
                 "abuse_flagged": value,
                 "editable_fields": ["abuse_flagged", "read"],
                 "comment_count": 1,
-                "unread_comment_count": 1,
+                "unread_comment_count": 0,
             })
         )
 


### PR DESCRIPTION
## [MA-2139](https://openedx.atlassian.net/browse/MA-2139)

Mark thread as read on thread and comment creation for leaner himself.
its corresponding cs_comment_service PR https://github.com/edx/cs_comments_service/pull/186 should be merged first.
### Testing
- [x] Unit
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @jcdyer 
- [x] Code review: @robrap 
### Post-review
- [x] Squash commits
