### PR TITLE
updating to Django 1.8.14 for XSS security fix

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -35,7 +35,7 @@ django-method-override==0.1.0
 # We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
-django==1.8.13
+django==1.8.14
 djangorestframework-jwt==1.8.0
 djangorestframework-oauth==1.1.0
 edx-ccx-keys==0.1.2


### PR DESCRIPTION
@doctoryes @jmbowman @edx/devops PTAL. Addresses CVE-2016-6186: XSS in admin's add/change related popup.

https://www.djangoproject.com/weblog/2016/jul/18/security-releases/
