### PR TITLE
Two RTL Fixups in Studio and CAPA problems

### DIFF
--- a/cms/static/sass/elements/_controls.scss
+++ b/cms/static/sass/elements/_controls.scss
@@ -193,9 +193,9 @@
 .button {
 
   .icon {
+    @include margin-right($baseline/4);
     display: inline-block;
     vertical-align: middle;
-    margin-right: ($baseline/4);
   }
 }
 
@@ -321,9 +321,9 @@
 
   .ui-toggle-expansion {
     @include transition(all $tmg-f2 ease-in-out 0s);
+    @include margin-right($baseline/4);
     @extend %t-action1;
     display: inline-block;
-    margin-right: ($baseline/4);
     color: $gray-l3;
     vertical-align: middle;
   }

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -141,6 +141,10 @@ div.problem {
     }
   }
 
+  input.math {
+    direction: ltr; // Equations are always English
+  }
+
   .inline {
     display: inline;
 


### PR DESCRIPTION
## 1. Fixed RTL icon margin in the studio

Before:

![image](https://cloud.githubusercontent.com/assets/645156/6168009/b81060e2-b2c9-11e4-814c-edfebd6bf59d.png)

After: 

![image](https://cloud.githubusercontent.com/assets/645156/6168025/f35d7aa4-b2c9-11e4-8df2-1bc8d5b6dc2b.png)

_Cherry picked from our fork (https://github.com/Edraak/edx-platform/pull/64)._

---
## 2. Make math equation fields always LTR in CAPA problems

This one is clear. Since all the equation input is in English, the field should be always LTR.

_Cherry picked from our fork (https://github.com/Edraak/edx-platform/pull/74)._
