### PR TITLE
Add validation messages to the required extra fields in the account settings

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -473,9 +473,10 @@ def account_settings_context(request):
 
         if value == 'required':
             fields[name]['required'] = True
-        elif value == 'optional':
+        elif value == 'optional' or value == ['hidden']:
+            # The hidden setting is ineffective, to retain backward compatible behaviour
             fields[name]['required'] = False
-        elif value != 'hidden':  # The hidden setting is ineffective.
+        else:
             raise ValueError(
                 u'Invalid registration settings was found: ({name}={value}) in `REGISTRATION_EXTRA_FIELDS`.'.format(
                     name=name,

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -193,17 +193,12 @@
             getUserField = function(list, search) {
                 return _.find(list, function(field) {
                     return field.view.options.valueAttribute === search;
-                });
+                }).view;
             };
-            userFields = _.find(aboutSectionsData, function(section) {
-                return section.title === gettext('Basic Account Information');
-            }).fields;
-            timeZoneDropdownField = getUserField(userFields, 'time_zone');
-            countryDropdownField = getUserField(userFields, 'country');
 
-            if (timeZoneDropdownField && countryDropdownField) {
-                timeZoneDropdownField.view.listenToCountryView(countryDropdownField.view);
-            }
+            timeZoneDropdownField = getUserField(allAccountFields, 'time_zone');
+            countryDropdownField = getUserField(allAccountFields, 'country');
+            timeZoneDropdownField.listenToCountryView(countryDropdownField);
 
             accountsSectionData = [
                 {

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -20,6 +20,7 @@
         ) {
             var accountSettingsElement, userAccountModel, userPreferencesModel, aboutSectionsData,
                 accountsSectionData, ordersSectionData, accountSettingsView, showAccountSettingsPage,
+                allAccountFields, additionalSectionFields,
                 showLoadingError, orderNumber, getUserField, userFields, timeZoneDropdownField, countryDropdownField;
 
             accountSettingsElement = $('.wrapper-account-settings');
@@ -30,157 +31,179 @@
             userPreferencesModel = new UserPreferencesModel();
             userPreferencesModel.url = userPreferencesApiUrl;
 
+            debugger;
+
+            allAccountFields = [
+                {
+                    view: new AccountSettingsFieldViews.ReadonlyFieldView({
+                        model: userAccountModel,
+                        title: gettext('Username'),
+                        valueAttribute: 'username',
+                        helpMessage: StringUtils.interpolate(
+                            gettext('The name that identifies you throughout {platform_name}. You cannot change your username.'),  // eslint-disable-line max-len
+                            {platform_name: platformName}
+                        )
+                    })
+                },
+                {
+                    view: new AccountSettingsFieldViews.TextFieldView({
+                        model: userAccountModel,
+                        title: gettext('Full Name'),
+                        valueAttribute: 'name',
+                        helpMessage: gettext(
+                            'The name that is used for ID verification and appears on your certificates. Other learners never see your full name. Make sure to enter your name exactly as it appears on your government-issued photo ID, including any non-Roman characters.'  // eslint-disable-line max-len
+                        ),
+                        persistChanges: true
+                    })
+                },
+                {
+                    view: new AccountSettingsFieldViews.EmailFieldView({
+                        model: userAccountModel,
+                        title: gettext('Email Address'),
+                        valueAttribute: 'email',
+                        helpMessage: StringUtils.interpolate(
+                            gettext('The email address you use to sign in. Communications from {platform_name} and your courses are sent to this address.'),  // eslint-disable-line max-len
+                            {platform_name: platformName}
+                        ),
+                        persistChanges: true
+                    })
+                },
+                {
+                    view: new AccountSettingsFieldViews.PasswordFieldView({
+                        model: userAccountModel,
+                        title: gettext('Password'),
+                        screenReaderTitle: gettext('Reset Your Password'),
+                        valueAttribute: 'password',
+                        emailAttribute: 'email',
+                        linkTitle: gettext('Reset Your Password'),
+                        linkHref: fieldsData.password.url,
+                        helpMessage: StringUtils.interpolate(
+                            gettext('When you select "Reset Your Password", a message will be sent to the email address for your {platform_name} account. Click the link in the message to reset your password.'),  // eslint-disable-line max-len
+                            {platform_name: platformName}
+                        )
+                    })
+                },
+                {
+                    view: new AccountSettingsFieldViews.LanguagePreferenceFieldView({
+                        model: userPreferencesModel,
+                        title: gettext('Language'),
+                        valueAttribute: 'pref-lang',
+                        refreshPageOnSave: true,
+                        helpMessage: StringUtils.interpolate(
+                            gettext('The language used throughout this site. This site is currently available in a limited number of languages.'),  // eslint-disable-line max-len
+                            {platform_name: platformName}
+                        ),
+                        options: fieldsData.language.options,
+                        required: fieldsData.language.required,
+                        optional: !fieldsData.language.required,
+                        persistChanges: true
+                    })
+                },
+                {
+                    view: new AccountSettingsFieldViews.DropdownFieldView({
+                        model: userAccountModel,
+                        title: gettext('Country or Region'),
+                        valueAttribute: 'country',
+                        options: fieldsData.country.options,
+                        optional: !fieldsData.country.required,
+                        persistChanges: true
+                    })
+                },
+                {
+                    view: new AccountSettingsFieldViews.TimeZoneFieldView({
+                        model: userPreferencesModel,
+                        title: gettext('Time Zone'),
+                        valueAttribute: 'time_zone',
+                        helpMessage: gettext('Select the time zone for displaying course dates. If you do not specify a time zone, course dates, including assignment deadlines, will be displayed in your browser\'s local time zone.'), // eslint-disable-line max-len
+                        groupOptions: [{
+                            groupTitle: gettext('All Time Zones'),
+                            selectOptions: fieldsData.time_zone.options,
+                            nullValueOptionLabel: gettext('Default (Local Time Zone)')
+                        }],
+                        required: fieldsData.time_zone.required,
+                        optional: !fieldsData.time_zone.required,
+                        persistChanges: true
+                    })
+                },
+                {
+                    view: new AccountSettingsFieldViews.DropdownFieldView({
+                        model: userAccountModel,
+                        title: gettext('Education Completed'),
+                        valueAttribute: 'level_of_education',
+                        options: fieldsData.level_of_education.options,
+                        optional: !fieldsData.level_of_education.required,
+                        persistChanges: true
+                    })
+                },
+                {
+                    view: new AccountSettingsFieldViews.DropdownFieldView({
+                        model: userAccountModel,
+                        title: gettext('Gender'),
+                        valueAttribute: 'gender',
+                        options: fieldsData.gender.options,
+                        optional: !fieldsData.gender.required,
+                        persistChanges: true
+                    })
+                },
+                {
+                    view: new AccountSettingsFieldViews.DropdownFieldView({
+                        model: userAccountModel,
+                        title: gettext('Year of Birth'),
+                        valueAttribute: 'year_of_birth',
+                        options: fieldsData.year_of_birth.options,
+                        optional: !fieldsData.year_of_birth.required,
+                        persistChanges: true
+                    })
+                },
+                {
+                    view: new AccountSettingsFieldViews.LanguageProficienciesFieldView({
+                        model: userAccountModel,
+                        title: gettext('Preferred Language'),
+                        valueAttribute: 'language_proficiencies',
+                        options: fieldsData.preferred_language.options,
+                        optional: !fieldsData.preferred_language.required,
+                        persistChanges: true
+                    })
+                }
+            ];
+
             aboutSectionsData = [
                 {
                     title: gettext('Basic Account Information'),
                     subtitle: gettext('These settings include basic information about your account. You can also specify additional information and see your linked social accounts on this page.'),  // eslint-disable-line max-len
-                    fields: [
-                        {
-                            view: new AccountSettingsFieldViews.ReadonlyFieldView({
-                                model: userAccountModel,
-                                title: gettext('Username'),
-                                valueAttribute: 'username',
-                                helpMessage: StringUtils.interpolate(
-                                    gettext('The name that identifies you throughout {platform_name}. You cannot change your username.'),  // eslint-disable-line max-len
-                                    {platform_name: platformName}
-                                )
-                            })
-                        },
-                        {
-                            view: new AccountSettingsFieldViews.TextFieldView({
-                                model: userAccountModel,
-                                title: gettext('Full Name'),
-                                valueAttribute: 'name',
-                                helpMessage: gettext(
-                                    'The name that is used for ID verification and appears on your certificates. Other learners never see your full name. Make sure to enter your name exactly as it appears on your government-issued photo ID, including any non-Roman characters.'  // eslint-disable-line max-len
-                                ),
-                                persistChanges: true
-                            })
-                        },
-                        {
-                            view: new AccountSettingsFieldViews.EmailFieldView({
-                                model: userAccountModel,
-                                title: gettext('Email Address'),
-                                valueAttribute: 'email',
-                                helpMessage: StringUtils.interpolate(
-                                    gettext('The email address you use to sign in. Communications from {platform_name} and your courses are sent to this address.'),  // eslint-disable-line max-len
-                                    {platform_name: platformName}
-                                ),
-                                persistChanges: true
-                            })
-                        },
-                        {
-                            view: new AccountSettingsFieldViews.PasswordFieldView({
-                                model: userAccountModel,
-                                title: gettext('Password'),
-                                screenReaderTitle: gettext('Reset Your Password'),
-                                valueAttribute: 'password',
-                                emailAttribute: 'email',
-                                linkTitle: gettext('Reset Your Password'),
-                                linkHref: fieldsData.password.url,
-                                helpMessage: StringUtils.interpolate(
-                                    gettext('When you select "Reset Your Password", a message will be sent to the email address for your {platform_name} account. Click the link in the message to reset your password.'),  // eslint-disable-line max-len
-                                    {platform_name: platformName}
-                                )
-                            })
-                        },
-                        {
-                            view: new AccountSettingsFieldViews.LanguagePreferenceFieldView({
-                                model: userPreferencesModel,
-                                title: gettext('Language'),
-                                valueAttribute: 'pref-lang',
-                                required: true,
-                                refreshPageOnSave: true,
-                                helpMessage: StringUtils.interpolate(
-                                    gettext('The language used throughout this site. This site is currently available in a limited number of languages.'),  // eslint-disable-line max-len
-                                    {platform_name: platformName}
-                                ),
-                                options: fieldsData.language.options,
-                                persistChanges: true
-                            })
-                        },
-                        {
-                            view: new AccountSettingsFieldViews.DropdownFieldView({
-                                model: userAccountModel,
-                                required: true,
-                                title: gettext('Country or Region'),
-                                valueAttribute: 'country',
-                                options: fieldsData.country.options,
-                                persistChanges: true
-                            })
-                        },
-                        {
-                            view: new AccountSettingsFieldViews.TimeZoneFieldView({
-                                model: userPreferencesModel,
-                                required: true,
-                                title: gettext('Time Zone'),
-                                valueAttribute: 'time_zone',
-                                helpMessage: gettext('Select the time zone for displaying course dates. If you do not specify a time zone, course dates, including assignment deadlines, will be displayed in your browser\'s local time zone.'), // eslint-disable-line max-len
-                                groupOptions: [{
-                                    groupTitle: gettext('All Time Zones'),
-                                    selectOptions: fieldsData.time_zone.options,
-                                    nullValueOptionLabel: gettext('Default (Local Time Zone)')
-                                }],
-                                persistChanges: true
-                            })
-                        }
-                    ]
-                },
-                {
-                    title: gettext('Additional Information'),
-                    fields: [
-                        {
-                            view: new AccountSettingsFieldViews.DropdownFieldView({
-                                model: userAccountModel,
-                                title: gettext('Education Completed'),
-                                valueAttribute: 'level_of_education',
-                                options: fieldsData.level_of_education.options,
-                                persistChanges: true
-                            })
-                        },
-                        {
-                            view: new AccountSettingsFieldViews.DropdownFieldView({
-                                model: userAccountModel,
-                                title: gettext('Gender'),
-                                valueAttribute: 'gender',
-                                options: fieldsData.gender.options,
-                                persistChanges: true
-                            })
-                        },
-                        {
-                            view: new AccountSettingsFieldViews.DropdownFieldView({
-                                model: userAccountModel,
-                                title: gettext('Year of Birth'),
-                                valueAttribute: 'year_of_birth',
-                                options: fieldsData.year_of_birth.options,
-                                persistChanges: true
-                            })
-                        },
-                        {
-                            view: new AccountSettingsFieldViews.LanguageProficienciesFieldView({
-                                model: userAccountModel,
-                                title: gettext('Preferred Language'),
-                                valueAttribute: 'language_proficiencies',
-                                options: fieldsData.preferred_language.options,
-                                persistChanges: true
-                            })
-                        }
-                    ]
+                    fields: _.filter(allAccountFields, function (field) {
+                        return !field.view.options.optional;
+                    })
                 }
             ];
+
+            additionalSectionFields = _.filter(allAccountFields, function (field) {
+                return field.view.options.optional;
+            });
+
+            if (additionalSectionFields.length) {
+                aboutSectionsData.push({
+                    title: gettext('Additional Information'),
+                    fields: additionalSectionFields
+                })
+            }
+
 
             // set TimeZoneField to listen to CountryField
             getUserField = function(list, search) {
                 return _.find(list, function(field) {
                     return field.view.options.valueAttribute === search;
-                }).view;
+                });
             };
             userFields = _.find(aboutSectionsData, function(section) {
                 return section.title === gettext('Basic Account Information');
             }).fields;
             timeZoneDropdownField = getUserField(userFields, 'time_zone');
             countryDropdownField = getUserField(userFields, 'country');
-            timeZoneDropdownField.listenToCountryView(countryDropdownField);
+
+            if (timeZoneDropdownField && countryDropdownField) {
+                timeZoneDropdownField.view.listenToCountryView(countryDropdownField.view);
+            }
 
             accountsSectionData = [
                 {

--- a/lms/static/sass/views/_account-settings.scss
+++ b/lms/static/sass/views/_account-settings.scss
@@ -293,15 +293,15 @@
                 
                 .u-field-message {
                     position: relative;
-                    padding: 24px 0 0 ($baseline*5);
+                    @include padding(24px, 0, 0, $baseline*5);
 
                     .u-field-message-notification {
+                        @include left(0);
+                        @include padding(38px, 0, 0, $baseline*5);
                         position: absolute;
-                        left: 0;
                         top: 0;
                         bottom: 0;
                         margin: auto;
-                        padding: 38px 0 0 ($baseline*5);
                     }
                 }
 

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from django.contrib.auth.models import User
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ungettext, ugettext as _
 
 from lms.djangoapps.badges.utils import badges_enabled
 from . import (
@@ -155,9 +155,11 @@ class AccountLegacyProfileSerializer(serializers.HyperlinkedModelSerializer, Rea
     def validate_name(self, new_name):
         """ Enforce minimum length for name. """
         if len(new_name) < NAME_MIN_LENGTH:
-            raise serializers.ValidationError(
-                "The name field must be at least {} characters long.".format(NAME_MIN_LENGTH)
-            )
+            raise serializers.ValidationError(ungettext(
+                "The name field must be at least {count} character long.",
+                "The name field must be at least {count} characters long.",
+                NAME_MIN_LENGTH
+            ).format(count=NAME_MIN_LENGTH))
         return new_name
 
     def validate_language_proficiencies(self, value):
@@ -165,7 +167,9 @@ class AccountLegacyProfileSerializer(serializers.HyperlinkedModelSerializer, Rea
         language_proficiencies = [language for language in value]
         unique_language_proficiencies = set(language["code"] for language in language_proficiencies)
         if len(language_proficiencies) != len(unique_language_proficiencies):
-            raise serializers.ValidationError("The language_proficiencies field must consist of unique languages")
+            raise serializers.ValidationError(
+                _("The language_proficiencies field must consist of unique languages")
+            )
         return value
 
     def validate(self, attrs):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -454,7 +454,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         ("country", "GB", "XY", u'"XY" is not a valid choice.'),
         ("year_of_birth", 2009, "not_an_int", u"A valid integer is required."),
         ("name", "bob", "z" * 256, u"Ensure this value has at most 255 characters (it has 256)."),
-        ("name", u"ȻħȺɍłɇs", "z   ", "The name field must be at least 2 characters long."),
+        ("name", u"ȻħȺɍłɇs", "z   ", u"The name field must be at least 2 characters long."),
         ("goals", "Smell the roses"),
         ("mailing_address", "Sesame Street"),
         # Note that we store the raw data, so it is up to client to escape the HTML.
@@ -686,7 +686,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         ),
         (
             [{u"code": u"kw"}, {u"code": u"el"}, {u"code": u"kw"}],
-            ['The language_proficiencies field must consist of unique languages']
+            [u'The language_proficiencies field must consist of unique languages']
         ),
     )
     @ddt.unpack

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -9,9 +9,10 @@ import json
 
 from django import forms
 from django.core.serializers.json import DjangoJSONEncoder
-from django.http import HttpResponseBadRequest
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
+from django.http import HttpResponseBadRequest
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -58,8 +59,8 @@ def intercept_errors(api_error, ignore_errors=None):
                             u"{exception}"
                         ).format(
                             func_name=func.func_name,
-                            args=args,
-                            kwargs=kwargs,
+                            args=force_text(args),
+                            kwargs=force_text(kwargs),
                             exception=ex.developer_message if hasattr(ex, 'developer_message') else repr(ex)
                         )
                         LOGGER.warning(msg)
@@ -72,8 +73,8 @@ def intercept_errors(api_error, ignore_errors=None):
                     u"{exception}"
                 ).format(
                     func_name=func.func_name,
-                    args=args,
-                    kwargs=kwargs,
+                    args=force_text(args),
+                    kwargs=force_text(kwargs),
                     exception=ex.developer_message if hasattr(ex, 'developer_message') else repr(ex)
                 )
                 LOGGER.exception(msg)

--- a/openedx/core/lib/api/view_utils.py
+++ b/openedx/core/lib/api/view_utils.py
@@ -116,7 +116,7 @@ def add_serializer_errors(serializer, data, field_errors):
                 'developer_message': u"Value '{field_value}' is not valid for field '{field_name}': {error}".format(
                     field_value=data.get(key, ''), field_name=key, error=error
                 ),
-                'user_message': _(u"This value is invalid."),
+                'user_message': ' '.join(error),
             }
     return field_errors
 


### PR DESCRIPTION
This is something that we've fixed in our fork (https://github.com/Edraak/edx-platform/pull/203) and I think it's good to have it here as well.


## TODOs
 - [x] Get initial product feedback
 - [ ] Finalize product feedback
 - [ ] Add more detailed description about the changes and the solved bugs
 - [ ] Write tests

## Original Bug Report

> **Summary:** 
> Account Settings: Some required fields displayed under "Additional Information (optional)" section  and accept null Value
> 
> **STR's:** 
> 1. Navigate to Edraak site 
> 2. Login using valid email and password 
> 3. Click on your username on the top nav. 
> 4. Observe the result under "Additional information " section 
> 
> **Actual Result:** 
> Account Settings: Some required fields displayed under "Additional Information (optional)" section  and accept the null Value
> 
> **Expected Result:** 
> All the fields under the account setting should be displayed as required data and should accept specific value 
> 
> **Screenshot:**
> ![account setting](https://cloud.githubusercontent.com/assets/645156/16974899/232277cc-4e4a-11e6-828f-1cf4c481b303.jpg)


