### PR TITLE
Calculator wording and translation improvements

### DIFF
--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -98,6 +98,7 @@
       }
 
       #calculator_output {
+        direction: ltr;  // Almost all of the real-world calculators are LTR
         background: $white;
         border: 1px solid $white;
         box-shadow: none;
@@ -130,6 +131,7 @@
         }
 
         #calculator_input {
+          direction: ltr;  // Almost all of the real-world calculators are LTR
           border: none;
           box-shadow: none;
           @include box-sizing(border-box);

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -71,8 +71,6 @@ from openedx.core.djangolib.markup import HTML, Text
                                                 ## Translators: Please do not translate mathematical symbols.
                                                 ${_("^ (raise to a power)")}<br />
                                                 ## Translators: Please do not translate mathematical symbols.
-                                                ${_("_ (add a subscript)")}<br />
-                                                ## Translators: Please do not translate mathematical symbols.
                                                 ${_("|| (parallel resistors)")}
                                             </td>
                                             <td>

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -57,7 +57,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                 ${_("Fractions")}<br />
                                                 ${_("Decimals")}
                                             </td>
-                                            <td>
+                                            <td dir="auto">
                                                 2520<br />
                                                 2/3<br />
                                                 3.14, .98
@@ -66,14 +66,14 @@ from openedx.core.djangolib.markup import HTML, Text
                                         <tr>
                                             <th scope="row">${_("Operators")}</th>
                                             ## Translators: Please do not translate mathematical symbols.
-                                            <td>
+                                            <td dir="auto">
                                                 ${_("+ - * / (add, subtract, multiply, divide)")}<br />
                                                 ## Translators: Please do not translate mathematical symbols.
                                                 ${_("^ (raise to a power)")}<br />
                                                 ## Translators: Please do not translate mathematical symbols.
                                                 ${_("|| (parallel resistors)")}
                                             </td>
-                                            <td>
+                                            <td dir="auto">
                                                 x+(2*y)/x-1
                                                 x^(n+1)<br />
                                                 v_IN+v_OUT<br />
@@ -82,16 +82,16 @@ from openedx.core.djangolib.markup import HTML, Text
                                         </tr>
                                         <tr>
                                             <th scope="row">${_("Constants")}</th>
-                                            <td>c, e, g, i, j, k, pi, q, T</td>
-                                            <td>
+                                            <td dir="auto">c, e, g, i, j, k, pi, q, T</td>
+                                            <td dir="auto">
                                                 20*c<br />
                                                 418*T
                                             </td>
                                         </tr>
                                         <tr>
                                             <th scope="row">${_("Affixes")}</th>
-                                            <td>${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
-                                            <td>
+                                            <td dir="auto">${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
+                                            <td dir="auto">
                                                 20%<br />
                                                 20c<br />
                                                 418T
@@ -99,37 +99,37 @@ from openedx.core.djangolib.markup import HTML, Text
                                         </tr>
                                         <tr>
                                             <th scope="row">${_("Basic functions")}</th>
-                                            <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
-                                            <td>
+                                            <td dir="auto">abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
+                                            <td dir="auto">
                                                 abs(x+y)<br />
                                                 sqrt(x^2-y)
                                             </td>
                                         </tr>
                                         <tr>
                                             <th scope="row">${_("Trigonometric functions")}</th>
-                                            <td>
+                                            <td dir="auto">
                                                 sin, cos, tan, sec, csc, cot<br />
                                                 arcsin, sinh, arcsinh, etc.<br />
                                             </td>
-                                            <td>
+                                            <td dir="auto">
                                                 sin(4x+y)<br />
                                                 arccsch(4x+y)
                                             </td>
-                                            <td></td>
+                                            <td dir="auto"></td>
                                         </tr>
                                         <tr>
                                             ## Translators: Please see http://en.wikipedia.org/wiki/Scientific_notation
                                             <th scope="row">${_("Scientific notation")}</th>
                                             ## Translators: 10^ is a mathematical symbol. Please do not translate.
-                                            <td>${_("10^ and the exponent")}</td>
-                                            <td>10^-9</td>
+                                            <td dir="auto">${_("10^ and the exponent")}</td>
+                                            <td dir="auto">10^-9</td>
                                         </tr>
                                         <tr>
                                             ## Translators: this is part of scientific notation. Please see http://en.wikipedia.org/wiki/Scientific_notation#E_notation
                                             <th scope="row">${_("e notation")}</th>
                                             ## Translators: 1e is a mathematical symbol. Please do not translate.
-                                            <td>${_("1e and the exponent")}</td>
-                                            <td>1e-9</td>
+                                            <td dir="auto">${_("1e and the exponent")}</td>
+                                            <td dir="auto">1e-9</td>
                                         </tr>
                                     </tbody>
                                 </table>

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -64,6 +64,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                             </td>
                                         </tr>
                                         <tr>
+                                            ## Translators: This refers to mathematical operators such as `plus`, `minus`, `division` and others.
                                             <th scope="row">${_("Operators")}</th>
                                             ## Translators: Please do not translate mathematical symbols.
                                             <td dir="auto">
@@ -81,6 +82,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                             </td>
                                         </tr>
                                         <tr>
+                                            ## Translators: This refers to symbols that are mathematical constants, such as "i" (square root of -1)
                                             <th scope="row">${_("Constants")}</th>
                                             <td dir="auto">c, e, g, i, j, k, pi, q, T</td>
                                             <td dir="auto">
@@ -89,6 +91,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                             </td>
                                         </tr>
                                         <tr>
+                                            ## Translators: This refers to symbols that appear at the end of a number, such as the percent sign (%) and metric affixes
                                             <th scope="row">${_("Affixes")}</th>
                                             <td dir="auto">${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
                                             <td dir="auto">
@@ -98,6 +101,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                             </td>
                                         </tr>
                                         <tr>
+                                            ## Translators: This refers to basic mathematical functions such as "square root"
                                             <th scope="row">${_("Basic functions")}</th>
                                             <td dir="auto">abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
                                             <td dir="auto">
@@ -106,6 +110,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                             </td>
                                         </tr>
                                         <tr>
+                                            ## Translators: This refers to mathematical Sine, Cosine and Tan
                                             <th scope="row">${_("Trigonometric functions")}</th>
                                             <td dir="auto">
                                                 sin, cos, tan, sec, csc, cot<br />

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -81,14 +81,6 @@ from openedx.core.djangolib.markup import HTML, Text
                                             </td>
                                         </tr>
                                         <tr>
-                                            <th scope="row">${_("Greek letters")}</th>
-                                            <td>${_("Name of letter")}</td>
-                                            <td>
-                                                alpha<br />
-                                                lambda
-                                            </td>
-                                        </tr>
-                                        <tr>
                                             <th scope="row">${_("Constants")}</th>
                                             <td>c, e, g, i, j, k, pi, q, T</td>
                                             <td>


### PR DESCRIPTION
This pull request fixes [TNL-3798](https://openedx.atlassian.net/browse/TNL-3798) (removing both subscript and Greek letters from the documentation) as well as the bug bellow:
## Bug: The direction is inverted for the English equations in the help popup

**Steps to Reproduce:** 
- Navigate and login to edraak site
- Navigate to "Solar Energy" course
- Click on the help popup button (i)
- Use the Arabic language in the interface
- Observe how the English math equations look, especially parentheses

**Actual:**
The direction of the English parentheses are incorrect.

![image](https://cloud.githubusercontent.com/assets/645156/11237387/46b02270-8de8-11e5-8ad2-b1b30a3db2f2.png)

**Expected Result:**
- To have the Math equations look properly, exactly like they do in the English interface.

![image](https://cloud.githubusercontent.com/assets/645156/11276312/4d1446b6-8eea-11e5-87cd-04eb514ab68a.png)

---

This is pull request is a follow up of #10648 which has been reverted in #11191 due to accessibility issues that @cptvitamin have found. This pull request does not include the commit (7a1100e Scrollable and centered calculator help popup) which caused the a11y issue.
