### PR TITLE
Translatable bulk_email from Address based on platform`s default lang

### DIFF
--- a/cms/templates/js/mock/mock-settings-page.underscore
+++ b/cms/templates/js/mock/mock-settings-page.underscore
@@ -103,7 +103,7 @@
         <option value="" selected> - </option>
         <option value="en">English</option>
       </select>
-      <span class="tip tip-stacked">Identify the course language here. This is used to assist users find courses that are taught in a specific language.</span>
+      <span class="tip tip-stacked">Identify the course language here. This is used to assist users find courses that are taught in a specific language. It is also used to localize the 'From:' field in bulk emails.</span>
     </li>
 
   </ol>

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -284,7 +284,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
                   <option value="${lang}">${label}</option>
                 % endfor
               </select>
-              <span class="tip tip-stacked">${_("Identify the course language here. This is used to assist users find courses that are taught in a specific language.")}</span>
+              <span class="tip tip-stacked">${_("Identify the course language here. This is used to assist users find courses that are taught in a specific language. It is also used to localize the 'From:' field in bulk emails.")}</span>
             </li>
           </ol>
         </div>

--- a/lms/djangoapps/bulk_email/admin.py
+++ b/lms/djangoapps/bulk_email/admin.py
@@ -37,6 +37,7 @@ Other tags that may be used (surrounded by one curly brace on each side):
 {platform_name}        : the name of the platform
 {course_title}         : the name of the course
 {course_root}          : the URL path to the root of the course
+{course_language}      : the course language. The default is None.
 {course_url}           : the course's full URL
 {email}                : the user's email address
 {account_settings_url} : URL at which users can change account preferences

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -35,6 +35,7 @@ from django.contrib.auth.models import User
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.core.mail.message import forbid_multi_line_headers
 from django.core.urlresolvers import reverse
+from django.utils.translation import override as override_language, ugettext as _
 
 from bulk_email.models import CourseEmail, Optout
 from courseware.courses import get_course
@@ -373,7 +374,12 @@ def _get_source_address(course_id, course_title, truncate=True):
     # character appears.
     course_name = re.sub(r"[^\w.-]", '_', course_id.course)
 
-    from_addr_format = u'"{course_title}" Course Staff <{course_name}-{from_email}>'
+    with override_language(settings.LANGUAGE_CODE):
+        from_addr_format = u'{name} {email}'.format(
+            # Translators: Bulk email from address e.g. ("Physics 101" Course Staff)
+            name=_('"{course_title}" Course Staff'),
+            email=u'<{course_name}-{from_email}>',
+        )
 
     def format_address(course_title_no_quotes):
         """

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -16,6 +16,7 @@ from django.core.urlresolvers import reverse
 from django.core.management import call_command
 from django.test.utils import override_settings
 
+from django.utils import translation
 from bulk_email.models import Optout, BulkEmailFlag
 from bulk_email.tasks import _get_source_address, _get_course_email_context
 from openedx.core.djangoapps.course_groups.models import CourseCohort
@@ -130,6 +131,90 @@ class EmailSendFromDashboardTestCase(SharedModuleStoreTestCase):
     def tearDown(self):
         super(EmailSendFromDashboardTestCase, self).tearDown()
         BulkEmailFlag.objects.all().delete()
+
+
+@attr(shard=1)
+@patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
+class TestLocalizedFromAddress(EmailSendFromDashboardTestCase):
+
+    original_ugettext = None
+    mocked_lang = 'ar'
+
+    def setUp(self):
+        super(TestLocalizedFromAddress, self).setUp()
+
+        translations = translation.trans_real._translations  # pylint: disable=protected-access
+
+        with translation.override(self.mocked_lang):
+            # In order to undo it later
+            self.original_ugettext = translations[self.mocked_lang].ugettext
+
+            mocked_ugettext = self.get_mocked_ugettext(self.mocked_lang)
+            translations[self.mocked_lang].ugettext = mocked_ugettext
+
+    def get_mocked_ugettext(self, lang_code):
+        """
+        Mocks ugettext to return the lang code with the original string.
+
+        e.g.
+
+        >>> ugettext = self.mock_ugettext('ar')
+        >>> ugettext('Hello') == '@AR Hello@'
+        """
+        def mocked_ugettext(msg):
+            """
+            A mock of ugettext to isolate it from the real `.mo` files.
+            """
+            return u'@{} {}@'.format(lang_code.upper(), msg)
+
+        return mocked_ugettext
+
+    def send_email(self):
+        """
+        Sends a dummy email to check the `from_addr` translation.
+        """
+        test_email = {
+            'action': 'send',
+            'send_to': '["myself"]',
+            'subject': 'test subject for myself',
+            'message': 'test message for myself'
+        }
+
+        self.client.post(self.send_mail_url, test_email)
+
+        return mail.outbox[0]
+
+    @override_settings(LANGUAGE_CODE='en')
+    def test_english_platform(self):
+        """
+        Test if the email `from` is localized to the platform's preference.
+        """
+
+        message = self.send_email()
+
+        self.assertNotRegexpMatches(
+            message.from_email,
+            '@.* Course Staff@'
+        )
+
+    @override_settings(LANGUAGE_CODE='ar')
+    def test_arabic_platform(self):
+        """
+        Test if the email `from` is localized to the platform's preference.
+        """
+
+        message = self.send_email()
+
+        self.assertRegexpMatches(
+            message.from_email,
+            '@AR .* Course Staff@'
+        )
+
+    def tearDown(self):
+        super(TestLocalizedFromAddress, self).tearDown()
+
+        translations = translation.trans_real._translations  # pylint: disable=protected-access
+        translations[self.mocked_lang].ugettext = self.original_ugettext
 
 
 @attr(shard=1)

--- a/lms/djangoapps/bulk_email/tests/test_tasks.py
+++ b/lms/djangoapps/bulk_email/tests/test_tasks.py
@@ -440,6 +440,7 @@ class TestBulkEmailInstructorTask(InstructorTaskCourseTestCase):
         result = _get_course_email_context(self.course)
         self.assertIn('course_title', result)
         self.assertIn('course_root', result)
+        self.assertIn('course_language', result)
         self.assertIn('course_url', result)
         self.assertIn('course_image_url', result)
         self.assertIn('course_end_date', result)


### PR DESCRIPTION
## Overview
This pull request localizes the `From:` address in the bulk emails according to `LANGUAGE_CODE` and `course.language` with preference for the latter. We've had this pull request for a while in [our fork](https://github.com/Edraak/edx-platform/pull/185). It's time for it to go upstream.

Currently the "Course Staff" is not translated, and is appearing odd next to a non-English course name: 
<kbd>![screen shot 2016-07-20 at 12 35 32 pm](https://cloud.githubusercontent.com/assets/645156/16982057/821dc426-4e76-11e6-9c52-648aa4d2452a.png)</kbd>


## TODO

 - [x] Get initial product review
 - [x] If `course.language` is present, use it instead of platform's language
 - [x] Test it on devstack (manual steps are described below)
 - [ ] Get another review (product or engineering)
 - [ ]  After review: fix broken tests, address possible code quality issues, squash and rebase

## Manual Testing
 - Re-generate the po files: `$ ./manage.py lms makemessages -l ar --settings=devstack`
 - Translate to the string, possibly to something dummy: 
    ```po
    #. Translators: Bulk email from address e.g. ("Physics 101" Course Staff)
    #: lms/djangoapps/bulk_email/tasks.py:386
    #, python-brace-format
    msgid "\"{course_title}\" Course Staff"
    msgstr "فريق مساق \"{course_title}\""
    ```
 - **Non-Transifex Devstack Issues:** Make sure the [`fuzzy` tag is removed](http://share-experiences.com/blog/what-fuzzy-means-python-django-gettext/). Same applies to commented line `#| msgid "{course_number} Course Info"`. Also ensure `msgstr` has the correct format key `course_title`. Otherwise the string won't get translated. This should happen only in devstack as opposed to Transifex-based workflow: `$ paver i18n_robot_*`.
 - Compile the messages `$ ./manage.py lms compilemessages --settings=devstack`
 - Set/unset `LANGUAGE_CODE` and/or `course.language` with different combinations
 - Send a bulk email to yourself
 - Get the `From:` MIME header from the `$ paver lms` log
 - Use a [mime decoder](http://dogmamix.com/MimeHeadersDecoder/) when needed to verify the result: <kbd><img width="520" alt="screen shot 2017-04-19 at 3 21 36 pm" src="https://cloud.githubusercontent.com/assets/645156/25179783/048942ea-2514-11e7-9b08-f11e9fdd276e.png"></kbd>

## Background
This is my fourth attempt to get this fix upstream. Due to several unfortunate events it hasn't been merged. The last instance (#11055) was totally OK until it was closed in order to be included in (#11865) but it ended up being left out, quoting @adampalay's comment:

> @cahrens and @symbolist FYI. This is just #11865, rebased, and without the commit to translate the email from message. Since that commit has caused complications, I'm submitting this PR just so we can get the bug fixed.

### Related PRs
 - AWS SNS Bug: #12005, #11865
 - Previous attempts: #11055, #9808 and #6889