### PR TITLE
Fix flaky asset page test

### DIFF
--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -13,7 +13,7 @@
 <%namespace name='static' file='static_content.html'/>
 
 <%block name="header_extras">
-% for template_name in ["asset-library", "asset"]:
+% for template_name in ["asset"]:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>

--- a/common/test/acceptance/pages/studio/asset_index.py
+++ b/common/test/acceptance/pages/studio/asset_index.py
@@ -7,10 +7,9 @@ import os
 from opaque_keys.edx.locator import CourseLocator
 from common.test.acceptance.pages.studio import BASE_URL
 from common.test.acceptance.pages.studio.course_page import CoursePage
-from bok_choy.javascript import wait_for_js, requirejs
+from bok_choy.javascript import wait_for_js
 
 
-@requirejs('js/views/assets')
 class AssetIndexPage(CoursePage):
 
     """

--- a/common/test/acceptance/tests/studio/test_studio_general.py
+++ b/common/test/acceptance/tests/studio/test_studio_general.py
@@ -79,7 +79,7 @@ class CoursePagesTest(StudioCourseTest):
         self.pages = [
             clz(self.browser, self.course_info['org'], self.course_info['number'], self.course_info['run'])
             for clz in [
-                # AssetIndexPage, # TODO: Skip testing this page due to FEDX-88
+                AssetIndexPage,
                 CourseUpdatesPage,
                 PagesPage, ExportCoursePage, ImportCoursePage, CourseTeamPage, CourseOutlinePage, SettingsPage,
                 AdvancedSettingsPage, GradingPage, TextbookUploadPage


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-4689

There was a race condition in loading `js/views/assets` in an optimized format vs. un-optimized format. I've removed the extraneous call and also an extraneous underscore template include.

Run 50 times on Jenkins:  https://build.testeng.edx.org/view/edx-platform-specific-tests/job/edx-platform-specific-tests/239/

Reviewers:
- [x] @andy-armstrong 
- [x] @bjacobel 
