### PR TITLE
edx-ora2 1.1.6

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -75,7 +75,7 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@1.1.5#egg=ora2==1.1.5
+git+https://github.com/edx/edx-ora2.git@1.1.6#egg=ora2==1.1.6
 -e git+https://github.com/edx/edx-submissions.git@1.1.1#egg=edx-submissions==1.1.1
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.3.2#egg=i18n-tools==v0.3.2


### PR DESCRIPTION
@kevinjkim and @ssemenova - You have changes in this release, you'll need to test them on stage next week. Mind being my reviewers on this PR, once tests have passed?

Updating edx-ora2 version to fix a bug with version of django included in requirements. Also includes a few other changes made since the last release.
- Diff of included changes: https://github.com/edx/edx-ora2/compare/1.1.5...1.1.6
- Acceptance tests of ora2 master: http://jenkins.edx.org:8080/view/ora2/job/ora2-acceptance-tests/958/
- Travis build of ora2 master: https://travis-ci.org/edx/edx-ora2/builds/146226427

Acceptance tests will be running for a while, we can get this merged in the morning.
