### PR TITLE
Delete text_customization.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -180,12 +180,6 @@ class CapaFields(object):
         help=_("Source code for LaTeX and Word problems. This feature is not well-supported."),
         scope=Scope.settings
     )
-    text_customization = Dict(
-        help=_("String customization substitutions for particular locations"),
-        scope=Scope.settings
-        # TODO: someday it should be possible to not duplicate this definition here
-        # and in inheritance.py
-    )
     use_latex_compiler = Boolean(
         help=_("Enable LaTeX templates?"),
         default=False,
@@ -408,21 +402,12 @@ class CapaMixin(CapaFields):
 
         Usually it is just "Check", but if this is the student's
         final attempt, change the name to "Final Check".
-        The text can be customized by the text_customization setting.
         """
         # The logic flow is a little odd so that _('xxx') strings can be found for
         # translation while also running _() just once for each string.
         _ = self.runtime.service(self, "i18n").ugettext
         check = _('Check')
         final_check = _('Final Check')
-
-        # Apply customizations if present
-        if 'custom_check' in self.text_customization:
-            check = _(self.text_customization.get('custom_check'))                # pylint: disable=translation-of-non-string
-        if 'custom_final_check' in self.text_customization:
-            final_check = _(self.text_customization.get('custom_final_check'))    # pylint: disable=translation-of-non-string
-        # TODO: need a way to get the customized words into the list of
-        # words to be translated
 
         if self.max_attempts is not None and self.attempts >= self.max_attempts - 1:
             return final_check
@@ -436,14 +421,7 @@ class CapaMixin(CapaFields):
         After the user presses the "check" button, the button will briefly
         display the value returned by this function until a response is
         received by the server.
-
-        The text can be customized by the text_customization setting.
-
         """
-        # Apply customizations if present
-        if 'custom_checking' in self.text_customization:
-            return self.text_customization.get('custom_checking')
-
         _ = self.runtime.service(self, "i18n").ugettext
         return _('Checking...')
 

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -212,7 +212,6 @@ class CapaDescriptor(CapaFields, RawDescriptor):
             CapaDescriptor.graceperiod,
             CapaDescriptor.force_save_button,
             CapaDescriptor.markdown,
-            CapaDescriptor.text_customization,
             CapaDescriptor.use_latex_compiler,
         ])
         return non_editable_fields

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -125,11 +125,6 @@ class InheritanceMixin(XBlockMixin):
         scope=Scope.settings,
         default='',
     )
-    text_customization = Dict(
-        display_name=_("Text Customization"),
-        help=_("Enter string customization substitutions for particular locations."),
-        scope=Scope.settings,
-    )
     use_latex_compiler = Boolean(
         display_name=_("Enable LaTeX Compiler"),
         help=_("Enter true or false. If true, you can use the LaTeX templates for HTML components and advanced Problem components."),

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1022,46 +1022,6 @@ class CapaModuleTest(unittest.TestCase):
         module = CapaFactory.create(attempts=1, max_attempts=10)
         self.assertEqual(module.check_button_checking_name(), "Checking...")
 
-        module = CapaFactory.create(attempts=10, max_attempts=10)
-        self.assertEqual(module.check_button_checking_name(), "Checking...")
-
-    def test_check_button_name_customization(self):
-        module = CapaFactory.create(
-            attempts=1,
-            max_attempts=10,
-            text_customization={"custom_check": "Submit", "custom_final_check": "Final Submit"}
-        )
-        self.assertEqual(module.check_button_name(), "Submit")
-
-        module = CapaFactory.create(attempts=9,
-                                    max_attempts=10,
-                                    text_customization={"custom_check": "Submit", "custom_final_check": "Final Submit"}
-                                    )
-        self.assertEqual(module.check_button_name(), "Final Submit")
-
-    def test_check_button_checking_name_customization(self):
-        module = CapaFactory.create(
-            attempts=1,
-            max_attempts=10,
-            text_customization={
-                "custom_check": "Submit",
-                "custom_final_check": "Final Submit",
-                "custom_checking": "Checking..."
-            }
-        )
-        self.assertEqual(module.check_button_checking_name(), "Checking...")
-
-        module = CapaFactory.create(
-            attempts=9,
-            max_attempts=10,
-            text_customization={
-                "custom_check": "Submit",
-                "custom_final_check": "Final Submit",
-                "custom_checking": "Checking..."
-            }
-        )
-        self.assertEqual(module.check_button_checking_name(), "Checking...")
-
     def test_should_show_check_button(self):
 
         attempts = random.randint(1, 10)

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -215,7 +215,6 @@ class AdvancedSettingsPage(CoursePage):
             'show_reset_button',
             'static_asset_path',
             'teams_configuration',
-            'text_customization',
             'annotation_storage_url',
             'social_sharing_url',
             'video_bumper',


### PR DESCRIPTION
### Description

[TNL-5077](https://openedx.atlassian.net/browse/TNL-5077)

This deletes the text_customization option added by Stanford to rename "Check" and "Checking" to "Submit" and "Submitting". 

@sstack22 has OK'd the removal of this code. It won't land in master until the button has been renamed as "Submit".

Related to #1106.
### Sandbox
- [x] customtext.sandbox.edx.org
### Testing
- [x] safecommit violation code review process. There are 44 violations, but all existing issues not related to my changes. It is outside the scope of this PR to address those issues.
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @alisan617 
- [x] Code review: @staubina 
- [ ] Doc Review: @catong FYI, but it appears this is not documented anyplace
- [x] Product review: @sstack22 

FYI: Tag anyone who might be interested in this PR here.
### Post-review
- [ ] Squash commits
