### PR TITLE
Expose course_version and subtree_edited_on in BlockStructures

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -953,7 +953,14 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             system.module_data.update(data_cache)
             system.cached_metadata.update(cached_metadata)
 
-        return system.load_item(location, for_parent=for_parent)
+        item = system.load_item(location, for_parent=for_parent)
+
+        # TODO Once PLAT-1055 is implemented, we can remove the following line
+        # of code. Until then, set the course_version field on the block to be
+        # consistent with the Split modulestore. Since Mongo modulestore doesn't
+        # maintain course versions set it to None.
+        item.course_version = None
+        return item
 
     def _load_items(self, course_key, items, depth=0, using_descriptor_system=None, for_parent=None):
         """

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -779,7 +779,15 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             self._add_cache(course_entry.structure['_id'], runtime)
             self.cache_items(runtime, block_keys, course_entry.course_key, depth, lazy)
 
-        return [runtime.load_item(block_key, course_entry, **kwargs) for block_key in block_keys]
+        blocks = [runtime.load_item(block_key, course_entry, **kwargs) for block_key in block_keys]
+
+        # TODO Once PLAT-1055 is implemented, we can expose the course version
+        # information within the key identifier of the block.  Until then, set
+        # the course_version as a field on each returned block so higher layers
+        # can use it when needed.
+        for block in blocks:
+            block.course_version = course_entry.course_key.version_guid
+        return blocks
 
     def _get_cache(self, course_version_guid):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -425,6 +425,25 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
                 revision=ModuleStoreEnum.RevisionOption.draft_preferred
             )
 
+    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
+    def test_course_version_on_block(self, default_ms):
+        self.initdb(default_ms)
+        self._create_block_hierarchy()
+
+        course = self.store.get_course(self.course.id)
+        course_version = course.course_version
+
+        if default_ms == ModuleStoreEnum.Type.split:
+            self.assertIsNotNone(course_version)
+        else:
+            self.assertIsNone(course_version)
+
+        blocks = self.store.get_items(self.course.id, qualifiers={'category': 'problem'})
+        blocks.append(self.store.get_item(self.problem_x1a_1))
+        self.assertEquals(len(blocks), 7)
+        for block in blocks:
+            self.assertEquals(block.course_version, course_version)
+
     @ddt.data((ModuleStoreEnum.Type.split, 2, False), (ModuleStoreEnum.Type.mongo, 3, True))
     @ddt.unpack
     def test_get_items_include_orphans(self, default_ms, expected_items_in_tree, orphan_in_items):

--- a/lms/djangoapps/course_blocks/transformers/tests/helpers.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/helpers.py
@@ -73,12 +73,12 @@ class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
 
         if block_type != 'course':
             kwargs['category'] = block_type
+            kwargs['publish_item'] = True,
         if parent:
             kwargs['parent'] = parent
 
         xblock = factory.create(
             display_name=self.create_block_id(block_type, block_ref),
-            publish_item=True,
             **kwargs
         )
         block_map[block_ref] = xblock

--- a/lms/djangoapps/grades/transformer.py
+++ b/lms/djangoapps/grades/transformer.py
@@ -30,8 +30,8 @@ class GradesTransformer(BlockStructureTransformer):
 
         max_score: (numeric)
     """
-    VERSION = 1
-    FIELDS_TO_COLLECT = [u'due', u'format', u'graded', u'has_score', u'weight']
+    VERSION = 2
+    FIELDS_TO_COLLECT = [u'due', u'format', u'graded', u'has_score', u'weight', u'course_version', u'subtree_edited_on']
 
     @classmethod
     def name(cls):


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-5010

These changes will allow us to detect whether the course and/or anything below the subsection changed since a learner's grade was computed.
- Update the Split Modulestore to expose the course structure's version-guid on each returned block.
  - I am calling this course_version for now.
- Update GradesTransformer to collect the following fields:
  - subtree_edited_on
  - course_version

Reviewers:
- @efischer19 
- @ormsbee 
