### PR TITLE
Fix program editor in studio for stage

### DIFF
--- a/cms/static/cms/js/build.js
+++ b/cms/static/cms/js/build.js
@@ -53,7 +53,8 @@
             'js/factories/settings_graders',
             'js/factories/textbooks',
             'js/factories/videos_index',
-            'js/factories/xblock_validation'
+            'js/factories/xblock_validation',
+            'js/programs/program_admin_app'
         ]),
         /**
          * By default all the configuration for optimization happens from the command


### PR DESCRIPTION
@AlasdairSwan @andy-armstrong Please review this change to fix the program editor in studio in stage.
@andy-armstrong In CMS, we don't have the `js_extra` block. We only have the `requirejs` block. So I am using that. I am also trying to spin up a sandbox for this change.

@alisan617 FYI
