### PR TITLE
Configure JWT auth when running Studio in devstack

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -123,6 +123,12 @@ REQUIRE_DEBUG = DEBUG
 ########################### OAUTH2 #################################
 OAUTH_OIDC_ISSUER = 'http://127.0.0.1:8000/oauth2'
 
+JWT_AUTH.update({
+    'JWT_SECRET_KEY': 'lms-secret',
+    'JWT_ISSUER': 'http://127.0.0.1:8000/oauth2',
+    'JWT_AUDIENCE': 'lms-key',
+})
+
 ###############################################################################
 # See if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -264,7 +264,6 @@ Ld/IRK0DgpGP5EJRwpKsDYe/UQ==
 -----END PRIVATE KEY-----"""
 
 JWT_AUTH.update({
-    'JWT_ALGORITHM': 'HS256',
     'JWT_SECRET_KEY': 'lms-secret',
     'JWT_ISSUER': 'http://127.0.0.1:8000/oauth2',
     'JWT_AUDIENCE': 'lms-key',


### PR DESCRIPTION
An important step towards being able to use Studio's program editor out of the box. Part of ECOM-4638.

@clintonb please review. @edx/ecommerce FYI.
