### PR TITLE
AC-543 fixing bulk cert exception implicit labels

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/certificate-white-list.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/certificate-white-list.underscore
@@ -1,16 +1,15 @@
 <h3 class="hd hd-3"><%- gettext("Generate Exception Certificates") %></h3>
-<p class="under-heading">
-<label>
-    <input type='radio' name='generate-exception-certificates-radio' checked="checked" value='new' aria-describedby='generate-exception-certificates-radio-new-tip'>
-    <span id='generate-exception-certificates-radio-new-tip'><%- gettext('Generate certificates for all users on the Exception list who do not yet have a certificate') %></span>
-
-</label>
-<br/>
-<label>
-    <input type='radio' name='generate-exception-certificates-radio' value='all' aria-describedby='generate-exception-certificates-radio-all-tip'>
-    <span id='generate-exception-certificates-radio-all-tip'><%- gettext('Generate a Certificate for all users on the Exception list') %></span>
-</label>
-</p>
+<fieldset class="under-heading">
+    <legend>Certificate exceptions group selection</legend>
+    <label>
+        <input type='radio' name='generate-exception-certificates-radio' checked="checked" value='new'>
+        <%- gettext('All users on the Exception list who do not yet have a certificate') %>
+    </label><br />
+    <label>
+        <input type='radio' name='generate-exception-certificates-radio' value='all'>
+        <%- gettext('All users on the Exception list') %>
+    </label>
+</fieldset>
 <button id="generate-exception-certificates" class="btn-blue" type="button"><%- gettext('Generate Exception Certificates') %></button>
 <br/>
 <% if (certificates.length === 0) { %>

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -26,7 +26,7 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
     <div class="bottom-bar">
       <label>
           <span class="label-text sr">{{add_placeholder}}</span>
-          <input type="text" id="add-field" name="add-field" class="add-field" placeholder="{{add_placeholder}}">
+          <input type="text" name="add-field" class="add-field" placeholder="{{add_placeholder}}">
       </label>
       <input type="button" name="add" class="add" value="{{add_btn_label}}">
     </div>


### PR DESCRIPTION
# [AC-543](https://openedx.atlassian.net/browse/AC-543)

This corrects the unnecessary combination of `for`/`id` with implicit labels on the instructor dashboard.
## Sandbox

https://clrux-ac-543.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor
## Reviewers
- [x] @cptvitamin 
