### PR TITLE
Document how to run tests on Paver scripts

### DIFF
--- a/docs/en_us/internal/testing.rst
+++ b/docs/en_us/internal/testing.rst
@@ -633,6 +633,13 @@ During acceptance test execution, Django log files are written to
 
 **Note**: The acceptance tests can *not* currently run in parallel.
 
+Running Tests on Paver Scripts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To run tests on the scripts that power the various Paver commands, use the following command::
+
+  nosetests paver
+
 
 Testing internationalization with dummy translations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Small change adding documentation for how to run the tests in the `pavelib/paver_tests` directory.

Someone from @edx/doc mind reviewing?
