### PR TITLE
Removing arguments to super for object subclass

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -173,7 +173,7 @@ class BulkOperationsMixin(object):
     mongo_connection.
     """
     def __init__(self, *args, **kwargs):
-        super(BulkOperationsMixin, self).__init__(*args, **kwargs)
+        super(BulkOperationsMixin, self).__init__()
         self._active_bulk_ops = ActiveBulkThread(self._bulk_ops_record_type)
         self.signal_handler = None
 


### PR DESCRIPTION
The `BulkOperationsMixin` subclasses from `object` and in its `__init__`
method attempts to call `super` with the `*args` and `**kwargs` that it
receives. This throws an exception because `object.__init__()` doesn't
take any parameters.
