### PR TITLE
Updates to facilitate program category casing changes

### DIFF
--- a/cms/static/js/programs/models/program_model.js
+++ b/cms/static/js/programs/models/program_model.js
@@ -24,7 +24,8 @@ define([
                 },
                 category: {
                     required: true,
-                    oneOf: ['xseries', 'micromasters']
+                    // TODO: Populate with the results of an API call for valid categories.
+                    oneOf: ['XSeries', 'MicroMasters']
                 },
                 organizations: 'validateOrganizations',
                 marketing_slug: {

--- a/cms/static/js/spec/views/programs/program_creator_spec.js
+++ b/cms/static/js/spec/views/programs/program_creator_spec.js
@@ -77,7 +77,7 @@ define([
                 spyOn( Router.prototype, 'goHome' );
 
                 sampleInput = {
-                    category: 'xseries',
+                    category: 'XSeries',
                     organizations: 'test-org-key',
                     name: 'Test Course Name',
                     subtitle: 'Test Course Subtitle',
@@ -131,7 +131,7 @@ define([
 
             it( 'should submit the form correctly when creating micromasters program ', function(){
                 var programId = 221;
-                sampleInput.category = 'micromasters';
+                sampleInput.category = 'MicroMasters';
                 
                 completeForm( sampleInput );
 

--- a/cms/static/js/spec/views/programs/program_details_spec.js
+++ b/cms/static/js/spec/views/programs/program_details_spec.js
@@ -86,7 +86,7 @@ define([
                     }
                 ],
                 programData = {
-                    category: 'xseries',
+                    category: 'XSeries',
                     course_codes: [{
                         display_name: 'test-course-display_name',
                         key: 'test-course-key',

--- a/cms/templates/js/programs/program_creator_form.underscore
+++ b/cms/templates/js/programs/program_creator_form.underscore
@@ -5,8 +5,8 @@
             <label class="field-label" for="program-type"><%- gettext('Program type') %></label>
             <select id="program-type" class="field-input input-select program-type" name="category">
                 <option value=""><%- gettext('Select a type') %></option>
-                <option value="xseries"><%- gettext('XSeries') %></option>
-                <option value="micromasters"><%- gettext('MicroMasters') %></option>
+                <option value="XSeries"><%- gettext('XSeries') %></option>
+                <option value="MicroMasters"><%- gettext('MicroMasters') %></option>
             </select>
             <div class="field-message">
                 <span class="field-message-content"></span>

--- a/openedx/core/djangoapps/programs/tests/mixins.py
+++ b/openedx/core/djangoapps/programs/tests/mixins.py
@@ -99,11 +99,13 @@ class ProgramsDataMixin(object):
         ]
     }
 
-    def mock_programs_api(self, data=None, status_code=200):
+    def mock_programs_api(self, data=None, program_id='', status_code=200):
         """Utility for mocking out Programs API URLs."""
         self.assertTrue(httpretty.is_enabled(), msg='httpretty must be enabled to mock Programs API calls.')
 
         url = ProgramsApiConfig.current().internal_api_url.strip('/') + '/programs/'
+        if program_id:
+            url += '{}/'.format(str(program_id))
 
         if data is None:
             data = self.PROGRAMS_API_RESPONSE

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -48,7 +48,17 @@ def get_programs(user, program_id=None):
     # Bypass caching for staff users, who may be creating Programs and want
     # to see them displayed immediately.
     cache_key = programs_config.CACHE_KEY if programs_config.is_cache_enabled and not user.is_staff else None
-    return get_edx_api_data(programs_config, user, 'programs', resource_id=program_id, cache_key=cache_key)
+
+    data = get_edx_api_data(programs_config, user, 'programs', resource_id=program_id, cache_key=cache_key)
+
+    # TODO: Temporary, to be removed once category names are cased for display. ECOM-5018.
+    if program_id:
+        data['category'] = data['category'].lower()
+    else:
+        for program in data:
+            program['category'] = program['category'].lower()
+
+    return data
 
 
 def flatten_programs(programs, course_ids):


### PR DESCRIPTION
The LMS continues to expect lowercased category slugs, while the Studio program creator now uses correctly cased slugs. Programs should be updated before this is released. Part of ECOM-5018.

@schenedx @mikedikan please review. My plan is to deploy changes in https://github.com/edx/programs/pull/158 to programs, deploy these changes, then update the category strings stored in programs. This should allow us to perform this update without any downtime. Upcoming work will take advantage of these changes to remove hardcoded strings from the LMS.
