### PR TITLE
Make studio case-insensitive for course keys for creating courses.

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_create_course.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_create_course.py
@@ -61,3 +61,35 @@ class TestCreateCourse(ModuleStoreTestCase):
         )
         # pylint: disable=protected-access
         self.assertEqual(store, modulestore()._get_modulestore_for_courselike(new_key).get_modulestore_type())
+
+    @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
+    def test_get_course_with_different_case(self, default_store):
+        """
+        Tests that course can not be accessed with different case.
+
+        Scenario:
+            Create a course with lower case keys inside `bulk_operations` with `ignore_case=True`.
+            Verify that course is created.
+            Verify that get course from store using same course id but different case is not accessible.
+        """
+        org = 'org1'
+        number = 'course1'
+        run = 'run1'
+        with self.store.default_store(default_store):
+            lowercase_course_id = self.store.make_course_key(org, number, run)
+            with self.store.bulk_operations(lowercase_course_id, ignore_case=True):
+                # Create course with lowercase key & Verify that store returns course.
+                self.store.create_course(
+                    lowercase_course_id.org,
+                    lowercase_course_id.course,
+                    lowercase_course_id.run,
+                    self.user.id
+                )
+                course = self.store.get_course(lowercase_course_id)
+                self.assertIsNotNone(course, 'Course not found using lowercase course key.')
+                self.assertEqual(unicode(course.id), unicode(lowercase_course_id))
+
+                # Verify store does not return course with different case.
+                uppercase_course_id = self.store.make_course_key(org.upper(), number.upper(), run.upper())
+                course = self.store.get_course(uppercase_course_id)
+                self.assertIsNone(course, 'Course should not be accessed with uppercase course id.')

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -984,13 +984,13 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
             yield
 
     @contextmanager
-    def bulk_operations(self, course_id, emit_signals=True):
+    def bulk_operations(self, course_id, emit_signals=True, ignore_case=False):
         """
         A context manager for notifying the store of bulk operations.
         If course_id is None, the default store is used.
         """
         store = self._get_modulestore_for_courselike(course_id)
-        with store.bulk_operations(course_id, emit_signals):
+        with store.bulk_operations(course_id, emit_signals, ignore_case):
             yield
 
     def ensure_indexes(self):

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -482,7 +482,7 @@ class MongoBulkOpsMixin(BulkOperationsMixin):
     """
     _bulk_ops_record_type = MongoBulkOpsRecord
 
-    def _start_outermost_bulk_operation(self, bulk_ops_record, course_key):
+    def _start_outermost_bulk_operation(self, bulk_ops_record, course_key, ignore_case=False):
         """
         Prevent updating the meta-data inheritance cache for the given course
         """

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -226,11 +226,11 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
                 course_key.replace(org=None, course=None, run=None, branch=None)
             ]
 
-    def _start_outermost_bulk_operation(self, bulk_write_record, course_key):
+    def _start_outermost_bulk_operation(self, bulk_write_record, course_key, ignore_case=False):
         """
         Begin a bulk write operation on course_key.
         """
-        bulk_write_record.initial_index = self.db_connection.get_course_index(course_key)
+        bulk_write_record.initial_index = self.db_connection.get_course_index(course_key, ignore_case=ignore_case)
         # Ensure that any edits to the index don't pollute the initial_index
         bulk_write_record.index = copy.deepcopy(bulk_write_record.initial_index)
         bulk_write_record.course_key = course_key
@@ -1884,7 +1884,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         """
         Internal code for creating a course or library
         """
-        index = self.get_course_index(locator)
+        index = self.get_course_index(locator, ignore_case=True)
         if index is not None:
             raise DuplicateCourseError(locator, index)
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -33,7 +33,7 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
         Returns: a CourseDescriptor
         """
         master_branch = kwargs.pop('master_branch', ModuleStoreEnum.BranchName.draft)
-        with self.bulk_operations(CourseLocator(org, course, run)):
+        with self.bulk_operations(CourseLocator(org, course, run), ignore_case=True):
             item = super(DraftVersioningModuleStore, self).create_course(
                 org, course, run, user_id, master_branch=master_branch, **kwargs
             )

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -357,6 +357,18 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
             with self.assertRaises(DuplicateCourseError):
                 self.store.create_course('org_x', 'course_y', 'run_z', self.user_id)
 
+    @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
+    def test_duplicate_course_error_with_different_case_ids(self, default_store):
+        """
+        Verify that course can not be created with same course_id with different case.
+        """
+        self._initialize_mixed(mappings={})
+        with self.store.default_store(default_store):
+            self.store.create_course('org_x', 'course_y', 'run_z', self.user_id)
+
+            with self.assertRaises(DuplicateCourseError):
+                self.store.create_course('ORG_X', 'COURSE_Y', 'RUN_Z', self.user_id)
+
     # Draft:
     #    problem: One lookup to locate an item that exists
     #    fake: one w/ wildcard version

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore_bulk_operations.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore_bulk_operations.py
@@ -704,7 +704,7 @@ class TestBulkWriteMixinOpen(TestBulkWriteMixin):
             from_index=self.conn.get_course_index.return_value,
             course_context=self.course_key,
         )
-        self.conn.get_course_index.assert_called_once_with(self.course_key)
+        self.conn.get_course_index.assert_called_once_with(self.course_key, ignore_case=False)
 
 
 class TestBulkWriteMixinOpenAfterPrevTransaction(TestBulkWriteMixinOpen, TestBulkWriteMixinPreviousTransaction):

--- a/lms/djangoapps/ccx/modulestore.py
+++ b/lms/djangoapps/ccx/modulestore.py
@@ -296,8 +296,8 @@ class CCXModulestoreWrapper(object):
             yield
 
     @contextmanager
-    def bulk_operations(self, course_id, emit_signals=True):
+    def bulk_operations(self, course_id, emit_signals=True, ignore_case=False):
         """See the docs for xmodule.modulestore.mixed.MixedModuleStore"""
         course_id, _ = strip_ccx(course_id)
-        with self._modulestore.bulk_operations(course_id, emit_signals=emit_signals):
+        with self._modulestore.bulk_operations(course_id, emit_signals=emit_signals, ignore_case=ignore_case):
             yield


### PR DESCRIPTION
### Studio is case-insensitive for course keys, so for creating courses.

For re-runs, studio is case-insensitive for course keys, so for creating courses, it should also be case insensitive.
#### Methods Updated

1.[ bulk_operations](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/__init__.py#L181)
2. [_begin_bulk_operation](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/__init__.py#L242)
3. [_start_outermost_bulk_operation ](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/__init__.py#L234)
4. [_end_bulk_operation](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/__init__.py#L264)

[ECOM-4890](https://openedx.atlassian.net/browse/ECOM-4890)
