### PR TITLE
Change python coveragerc file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -44,8 +44,8 @@ output = reports/coverage.xml
 
 [paths]
 jenkins_source =
-    /home/jenkins/workspace/edx-platform-unit-coverage
-    /home/jenkins/workspace/edx-platform-test-subset
+    /home/jenkins/workspace/$JOB_NAME
+    /home/jenkins/workspace/$SUBSET_JOB
 
 devstack_source =
     /edx/app/edxapp/edx-platform


### PR DESCRIPTION
@estute @jzoldak @benpatterson 
Changing the python coveragerc file to work when using different versions of the unit coverage and test subset job. For context, this file gets called by the unit coverage job in order to create the reports for coverage.py. Thus, the $JOB_NAME is the unit coverage job. This is done to make sure python unit tests pr job works on the various repositories.
