### PR TITLE
There is no need to call save after add/remove.

### DIFF
--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -95,7 +95,6 @@ class CohortMembership(models.Model):
         if 'force_insert' in kwargs and kwargs['force_insert'] is True:
             with transaction.atomic():
                 self.course_user_group.users.add(self.user)
-                self.course_user_group.save()
                 super(CohortMembership, self).save(*args, **kwargs)
             return
 
@@ -127,11 +126,9 @@ class CohortMembership(models.Model):
             self.previous_cohort_name = saved_membership.course_user_group.name
             self.previous_cohort_id = saved_membership.course_user_group.id
             self.previous_cohort.users.remove(self.user)
-            self.previous_cohort.save()
 
             saved_membership.course_user_group = self.course_user_group
             self.course_user_group.users.add(self.user)
-            self.course_user_group.save()
 
             super(CohortMembership, saved_membership).save(update_fields=['course_user_group'])
 


### PR DESCRIPTION
@ormsbee and @efischer19 please review. Unfortunately I have not been able to reproduce the issue (registering 2000+ users in a loop/2 processes on sandbox). But these saves are definitely wrong, so we might as well remove them.
