### PR TITLE
Change relative paths to absolute paths in in acceptance test imports

### DIFF
--- a/common/test/acceptance/tests/discussion/helpers.py
+++ b/common/test/acceptance/tests/discussion/helpers.py
@@ -5,15 +5,15 @@ Helper functions and classes for discussion tests.
 from uuid import uuid4
 import json
 
-from ...fixtures import LMS_BASE_URL
-from ...fixtures.course import CourseFixture
-from ...fixtures.discussion import (
+from common.test.acceptance.fixtures import LMS_BASE_URL
+from common.test.acceptance.fixtures.course import CourseFixture
+from common.test.acceptance.fixtures.discussion import (
     SingleThreadViewFixture,
     Thread,
     Response,
 )
-from ...pages.lms.discussion import DiscussionTabSingleThreadPage
-from ...tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.lms.discussion import DiscussionTabSingleThreadPage
+from common.test.acceptance.tests.helpers import UniqueCourseTest
 
 
 class BaseDiscussionMixin(object):

--- a/common/test/acceptance/tests/discussion/test_cohort_management.py
+++ b/common/test/acceptance/tests/discussion/test_cohort_management.py
@@ -8,13 +8,13 @@ from datetime import datetime
 from pytz import UTC, utc
 from bok_choy.promise import EmptyPromise
 from nose.plugins.attrib import attr
-from .helpers import CohortTestMixin
-from ..helpers import UniqueCourseTest, EventsTestMixin, create_user_partition_json
+from common.test.acceptance.tests.discussion.helpers import CohortTestMixin
+from common.test.acceptance.tests.helpers import UniqueCourseTest, EventsTestMixin, create_user_partition_json
 from xmodule.partitions.partitions import Group
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.instructor_dashboard import InstructorDashboardPage, DataDownloadPage
-from ...pages.studio.settings_group_configurations import GroupConfigurationsPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage, DataDownloadPage
+from common.test.acceptance.pages.studio.settings_group_configurations import GroupConfigurationsPage
 
 import os
 import unicodecsv

--- a/common/test/acceptance/tests/discussion/test_cohorts.py
+++ b/common/test/acceptance/tests/discussion/test_cohorts.py
@@ -3,14 +3,14 @@ Tests related to the cohorting feature.
 """
 from uuid import uuid4
 
-from .helpers import BaseDiscussionMixin, BaseDiscussionTestCase
-from .helpers import CohortTestMixin
-from ..helpers import UniqueCourseTest
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...fixtures.course import (CourseFixture, XBlockFixtureDesc)
+from common.test.acceptance.tests.discussion.helpers import BaseDiscussionMixin, BaseDiscussionTestCase
+from common.test.acceptance.tests.discussion.helpers import CohortTestMixin
+from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.fixtures.course import (CourseFixture, XBlockFixtureDesc)
 
-from ...pages.lms.discussion import (DiscussionTabSingleThreadPage, InlineDiscussionThreadPage, InlineDiscussionPage)
-from ...pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.discussion import (DiscussionTabSingleThreadPage, InlineDiscussionThreadPage, InlineDiscussionPage)
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
 
 from nose.plugins.attrib import attr
 

--- a/common/test/acceptance/tests/discussion/test_cohorts.py
+++ b/common/test/acceptance/tests/discussion/test_cohorts.py
@@ -9,7 +9,10 @@ from common.test.acceptance.tests.helpers import UniqueCourseTest
 from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
 from common.test.acceptance.fixtures.course import (CourseFixture, XBlockFixtureDesc)
 
-from common.test.acceptance.pages.lms.discussion import (DiscussionTabSingleThreadPage, InlineDiscussionThreadPage, InlineDiscussionPage)
+from common.test.acceptance.pages.lms.discussion import (
+    DiscussionTabSingleThreadPage,
+    InlineDiscussionThreadPage,
+    InlineDiscussionPage)
 from common.test.acceptance.pages.lms.courseware import CoursewarePage
 
 from nose.plugins.attrib import attr

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -8,11 +8,11 @@ from uuid import uuid4
 from nose.plugins.attrib import attr
 from pytz import UTC
 
-from .helpers import BaseDiscussionTestCase
-from ..helpers import UniqueCourseTest
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.discussion import (
+from common.test.acceptance.tests.discussion.helpers import BaseDiscussionTestCase
+from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.discussion import (
     DiscussionTabSingleThreadPage,
     InlineDiscussionPage,
     InlineDiscussionThreadPage,
@@ -20,10 +20,10 @@ from ...pages.lms.discussion import (
     DiscussionTabHomePage,
     DiscussionSortPreferencePage,
 )
-from ...pages.lms.learner_profile import LearnerProfilePage
+from common.test.acceptance.pages.lms.learner_profile import LearnerProfilePage
 
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
-from ...fixtures.discussion import (
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.fixtures.discussion import (
     SingleThreadViewFixture,
     UserProfileViewFixture,
     SearchResultFixture,
@@ -33,8 +33,9 @@ from ...fixtures.discussion import (
     SearchResult,
     MultipleThreadFixture)
 
-from .helpers import BaseDiscussionMixin
-from ..helpers import skip_if_browser
+from common.test.acceptance.tests.discussion.helpers import BaseDiscussionMixin
+from common.test.acceptance.tests.helpers import skip_if_browser
+
 
 
 THREAD_CONTENT_WITH_LATEX = """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -37,7 +37,6 @@ from common.test.acceptance.tests.discussion.helpers import BaseDiscussionMixin
 from common.test.acceptance.tests.helpers import skip_if_browser
 
 
-
 THREAD_CONTENT_WITH_LATEX = """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
                                ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
                                ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -29,7 +29,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from unittest import TestCase
 
 
-from ..pages.common import BASE_URL
+from common.test.acceptance.pages.common import BASE_URL
 
 
 MAX_EVENTS_IN_FAILURE_OUTPUT = 20

--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -10,11 +10,11 @@ from bok_choy.page_object import XSS_INJECTION
 from datetime import datetime
 from pytz import timezone, utc
 
-from ...pages.lms.account_settings import AccountSettingsPage
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.dashboard import DashboardPage
+from common.test.acceptance.pages.lms.account_settings import AccountSettingsPage
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.dashboard import DashboardPage
 
-from ..helpers import EventsTestMixin
+from common.test.acceptance.tests.helpers import EventsTestMixin
 
 
 class AccountSettingsTestMixin(EventsTestMixin, WebAppTest):

--- a/common/test/acceptance/tests/lms/test_bookmarks.py
+++ b/common/test/acceptance/tests/lms/test_bookmarks.py
@@ -5,17 +5,17 @@ End-to-end tests for the courseware unit bookmarks.
 import json
 from nose.plugins.attrib import attr
 import requests
-from ...pages.studio.auto_auth import AutoAuthPage as StudioAutoAuthPage
-from ...pages.lms.auto_auth import AutoAuthPage as LmsAutoAuthPage
-from ...pages.lms.bookmarks import BookmarksPage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.course_nav import CourseNavPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.common.logout import LogoutPage
-from ...pages.common import BASE_URL
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage as StudioAutoAuthPage
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage as LmsAutoAuthPage
+from common.test.acceptance.pages.lms.bookmarks import BookmarksPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.course_nav import CourseNavPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.common import BASE_URL
 
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
-from ..helpers import EventsTestMixin, UniqueCourseTest, is_404_page
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import EventsTestMixin, UniqueCourseTest, is_404_page
 
 
 class BookmarksTestMixin(EventsTestMixin, UniqueCourseTest):

--- a/common/test/acceptance/tests/lms/test_certificate_web_view.py
+++ b/common/test/acceptance/tests/lms/test_certificate_web_view.py
@@ -1,16 +1,16 @@
 """
 Acceptance tests for the certificate web view feature.
 """
-from ..helpers import UniqueCourseTest, EventsTestMixin, load_data_str, get_element_padding
+from common.test.acceptance.tests.helpers import UniqueCourseTest, EventsTestMixin, load_data_str, get_element_padding
 from nose.plugins.attrib import attr
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc, CourseUpdateDesc
-from ...fixtures.certificates import CertificateConfigFixture
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.certificate_page import CertificatePage
-from ...pages.lms.course_info import CourseInfoPage
-from ...pages.lms.tab_nav import TabNavPage
-from ...pages.lms.course_nav import CourseNavPage
-from ...pages.lms.progress import ProgressPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc, CourseUpdateDesc
+from common.test.acceptance.fixtures.certificates import CertificateConfigFixture
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.certificate_page import CertificatePage
+from common.test.acceptance.pages.lms.course_info import CourseInfoPage
+from common.test.acceptance.pages.lms.tab_nav import TabNavPage
+from common.test.acceptance.pages.lms.course_nav import CourseNavPage
+from common.test.acceptance.pages.lms.progress import ProgressPage
 
 
 @attr('shard_5')

--- a/common/test/acceptance/tests/lms/test_conditional.py
+++ b/common/test/acceptance/tests/lms/test_conditional.py
@@ -2,12 +2,12 @@
 Bok choy acceptance tests for conditionals in the LMS
 """
 from capa.tests.response_xml_factory import StringResponseXMLFactory
-from ..helpers import UniqueCourseTest
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.conditional import ConditionalPage, POLL_ANSWER
-from ...pages.lms.problem import ProblemPage
-from ...pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.conditional import ConditionalPage, POLL_ANSWER
+from common.test.acceptance.pages.lms.problem import ProblemPage
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
 
 
 class ConditionalTest(UniqueCourseTest):

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -9,13 +9,13 @@ from datetime import datetime
 from flaky import flaky
 from nose.plugins.attrib import attr
 
-from ...pages.common.logout import LogoutPage
-from ...pages.lms.account_settings import AccountSettingsPage
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.learner_profile import LearnerProfilePage
-from ...pages.lms.dashboard import DashboardPage
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.lms.account_settings import AccountSettingsPage
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.learner_profile import LearnerProfilePage
+from common.test.acceptance.pages.lms.dashboard import DashboardPage
 
-from ..helpers import EventsTestMixin
+from common.test.acceptance.tests.helpers import EventsTestMixin
 
 
 class LearnerProfileTestMixin(EventsTestMixin):

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -6,15 +6,15 @@ import ddt
 import textwrap
 
 from nose.plugins.attrib import attr
-from ..helpers import UniqueCourseTest, TestWithSearchIndexMixin
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.studio.library import StudioLibraryContentEditor, StudioLibraryContainerXBlockWrapper
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.library import LibraryContentXBlockWrapper
-from ...pages.common.logout import LogoutPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
-from ...fixtures.library import LibraryFixture
+from common.test.acceptance.tests.helpers import UniqueCourseTest, TestWithSearchIndexMixin
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.studio.library import StudioLibraryContentEditor, StudioLibraryContainerXBlockWrapper
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.library import LibraryContentXBlockWrapper
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.fixtures.library import LibraryFixture
 
 SECTION_NAME = 'Test Section'
 SUBSECTION_NAME = 'Test Subsection'

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -11,7 +11,7 @@ import pytz
 import urllib
 
 from bok_choy.promise import EmptyPromise
-from ..helpers import (
+from common.test.acceptance.tests.helpers import (
     UniqueCourseTest,
     EventsTestMixin,
     load_data_str,
@@ -21,25 +21,25 @@ from ..helpers import (
     select_option_by_text,
     get_selected_option_text
 )
-from ...pages.lms import BASE_URL
-from ...pages.lms.account_settings import AccountSettingsPage
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.create_mode import ModeCreationPage
-from ...pages.common.logout import LogoutPage
-from ...pages.lms.course_info import CourseInfoPage
-from ...pages.lms.tab_nav import TabNavPage
-from ...pages.lms.course_nav import CourseNavPage
-from ...pages.lms.progress import ProgressPage
-from ...pages.lms.dashboard import DashboardPage
-from ...pages.lms.problem import ProblemPage
-from ...pages.lms.video.video import VideoPage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.studio.settings import SettingsPage
-from ...pages.lms.login_and_register import CombinedLoginAndRegisterPage, ResetPasswordPage
-from ...pages.lms.track_selection import TrackSelectionPage
-from ...pages.lms.pay_and_verify import PaymentAndVerificationFlow, FakePaymentPage
-from ...pages.lms.course_wiki import CourseWikiPage, CourseWikiEditPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc, CourseUpdateDesc
+from common.test.acceptance.pages.lms import BASE_URL
+from common.test.acceptance.pages.lms.account_settings import AccountSettingsPage
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.create_mode import ModeCreationPage
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.lms.course_info import CourseInfoPage
+from common.test.acceptance.pages.lms.tab_nav import TabNavPage
+from common.test.acceptance.pages.lms.course_nav import CourseNavPage
+from common.test.acceptance.pages.lms.progress import ProgressPage
+from common.test.acceptance.pages.lms.dashboard import DashboardPage
+from common.test.acceptance.pages.lms.problem import ProblemPage
+from common.test.acceptance.pages.lms.video.video import VideoPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.studio.settings import SettingsPage
+from common.test.acceptance.pages.lms.login_and_register import CombinedLoginAndRegisterPage, ResetPasswordPage
+from common.test.acceptance.pages.lms.track_selection import TrackSelectionPage
+from common.test.acceptance.pages.lms.pay_and_verify import PaymentAndVerificationFlow, FakePaymentPage
+from common.test.acceptance.pages.lms.course_wiki import CourseWikiPage, CourseWikiEditPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc, CourseUpdateDesc
 
 
 @attr('shard_8')

--- a/common/test/acceptance/tests/lms/test_lms_acid_xblock.py
+++ b/common/test/acceptance/tests/lms/test_lms_acid_xblock.py
@@ -5,12 +5,12 @@ End-to-end tests for the LMS.
 
 from unittest import expectedFailure
 
-from ..helpers import UniqueCourseTest
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.course_info import CourseInfoPage
-from ...pages.lms.tab_nav import TabNavPage
-from ...pages.xblock.acid import AcidView
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.course_info import CourseInfoPage
+from common.test.acceptance.pages.lms.tab_nav import TabNavPage
+from common.test.acceptance.pages.xblock.acid import AcidView
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 
 
 class XBlockAcidBase(UniqueCourseTest):

--- a/common/test/acceptance/tests/lms/test_lms_cohorted_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_cohorted_courseware_search.py
@@ -5,22 +5,22 @@ Test courseware search
 import json
 import uuid
 
-from ..helpers import remove_file
-from ...pages.common.logout import LogoutPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.lms.courseware_search import CoursewareSearchPage
-from ...pages.lms.staff_view import StaffPage
-from ...fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import remove_file
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.lms.courseware_search import CoursewareSearchPage
+from common.test.acceptance.pages.lms.staff_view import StaffPage
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 
 from nose.plugins.attrib import attr
 
-from ..studio.base_studio_test import ContainerBase
+from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
 
-from ...pages.studio.settings_group_configurations import GroupConfigurationsPage
-from ...pages.studio.auto_auth import AutoAuthPage as StudioAutoAuthPage
-from ...fixtures import LMS_BASE_URL
-from ...pages.studio.component_editor import ComponentVisibilityEditorView
-from ...pages.lms.instructor_dashboard import InstructorDashboardPage
+from common.test.acceptance.pages.studio.settings_group_configurations import GroupConfigurationsPage
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage as StudioAutoAuthPage
+from common.test.acceptance.fixtures import LMS_BASE_URL
+from common.test.acceptance.pages.studio.component_editor import ComponentVisibilityEditorView
+from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage
 
 from bok_choy.promise import EmptyPromise
 

--- a/common/test/acceptance/tests/lms/test_lms_course_discovery.py
+++ b/common/test/acceptance/tests/lms/test_lms_course_discovery.py
@@ -6,11 +6,11 @@ import json
 import uuid
 
 from bok_choy.web_app_test import WebAppTest
-from ..helpers import remove_file
-from ...pages.common.logout import LogoutPage
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.lms.discovery import CourseDiscoveryPage
-from ...fixtures.course import CourseFixture
+from common.test.acceptance.tests.helpers import remove_file
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.discovery import CourseDiscoveryPage
+from common.test.acceptance.fixtures.course import CourseFixture
 
 
 class CourseDiscoveryTest(WebAppTest):

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -9,19 +9,19 @@ from datetime import datetime, timedelta
 import ddt
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
-from ..helpers import UniqueCourseTest, EventsTestMixin
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.lms.create_mode import ModeCreationPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.lms.courseware import CoursewarePage, CoursewareSequentialTabPage
-from ...pages.lms.course_nav import CourseNavPage
-from ...pages.lms.problem import ProblemPage
-from ...pages.common.logout import LogoutPage
-from ...pages.lms.staff_view import StaffPage
-from ...pages.lms.track_selection import TrackSelectionPage
-from ...pages.lms.pay_and_verify import PaymentAndVerificationFlow, FakePaymentPage
-from ...pages.lms.dashboard import DashboardPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import UniqueCourseTest, EventsTestMixin
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.create_mode import ModeCreationPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage, CoursewareSequentialTabPage
+from common.test.acceptance.pages.lms.course_nav import CourseNavPage
+from common.test.acceptance.pages.lms.problem import ProblemPage
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.lms.staff_view import StaffPage
+from common.test.acceptance.pages.lms.track_selection import TrackSelectionPage
+from common.test.acceptance.pages.lms.pay_and_verify import PaymentAndVerificationFlow, FakePaymentPage
+from common.test.acceptance.pages.lms.dashboard import DashboardPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 
 
 class CoursewareTest(UniqueCourseTest):

--- a/common/test/acceptance/tests/lms/test_lms_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware_search.py
@@ -5,15 +5,15 @@ import json
 
 from nose.plugins.attrib import attr
 
-from ..helpers import UniqueCourseTest, remove_file
-from ...pages.common.logout import LogoutPage
-from ...pages.common.utils import click_css
-from ...pages.studio.utils import add_html_component, type_in_codemirror
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.studio.container import ContainerPage
-from ...pages.lms.courseware_search import CoursewareSearchPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import UniqueCourseTest, remove_file
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.common.utils import click_css
+from common.test.acceptance.pages.studio.utils import add_html_component, type_in_codemirror
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.studio.container import ContainerPage
+from common.test.acceptance.pages.lms.courseware_search import CoursewareSearchPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 
 
 @attr('shard_5')

--- a/common/test/acceptance/tests/lms/test_lms_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard.py
@@ -5,10 +5,10 @@ End-to-end tests for the main LMS Dashboard (aka, Student Dashboard).
 import datetime
 from nose.plugins.attrib import attr
 
-from ..helpers import UniqueCourseTest, generate_course_key
-from ...fixtures.course import CourseFixture
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.dashboard import DashboardPage
+from common.test.acceptance.tests.helpers import UniqueCourseTest, generate_course_key
+from common.test.acceptance.fixtures.course import CourseFixture
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.dashboard import DashboardPage
 
 DEFAULT_SHORT_DATE_FORMAT = "%b %d, %Y"
 DEFAULT_DAY_AND_TIME_FORMAT = "%A at %-I%P"

--- a/common/test/acceptance/tests/lms/test_lms_dashboard_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard_search.py
@@ -5,15 +5,15 @@ import os
 import json
 
 from bok_choy.web_app_test import WebAppTest
-from ..helpers import generate_course_key
-from ...pages.common.logout import LogoutPage
-from ...pages.common.utils import click_css
-from ...pages.studio.utils import add_html_component, type_in_codemirror
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.studio.container import ContainerPage
-from ...pages.lms.dashboard_search import DashboardSearchPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import generate_course_key
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.common.utils import click_css
+from common.test.acceptance.pages.studio.utils import add_html_component, type_in_codemirror
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.studio.container import ContainerPage
+from common.test.acceptance.pages.lms.dashboard_search import DashboardSearchPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 
 
 class DashboardSearchTest(WebAppTest):

--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -6,13 +6,13 @@ import random
 from uuid import uuid4
 from datetime import datetime
 from nose.plugins.attrib import attr
-from ..helpers import UniqueCourseTest, EventsTestMixin
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.course_nav import CourseNavPage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.edxnotes import EdxNotesUnitPage, EdxNotesPage, EdxNotesPageNoContent
-from ...fixtures.edxnotes import EdxNotesFixture, Note, Range
+from common.test.acceptance.tests.helpers import UniqueCourseTest, EventsTestMixin
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.course_nav import CourseNavPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.edxnotes import EdxNotesUnitPage, EdxNotesPage, EdxNotesPageNoContent
+from common.test.acceptance.fixtures.edxnotes import EdxNotesFixture, Note, Range
 from flaky import flaky
 
 

--- a/common/test/acceptance/tests/lms/test_lms_entrance_exams.py
+++ b/common/test/acceptance/tests/lms/test_lms_entrance_exams.py
@@ -4,11 +4,11 @@ Bok choy acceptance tests for Entrance exams in the LMS
 """
 from textwrap import dedent
 
-from ..helpers import UniqueCourseTest
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.problem import ProblemPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.problem import ProblemPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 
 
 class EntranceExamTest(UniqueCourseTest):

--- a/common/test/acceptance/tests/lms/test_lms_gating.py
+++ b/common/test/acceptance/tests/lms/test_lms_gating.py
@@ -4,14 +4,14 @@ End-to-end tests for the gating feature.
 """
 from textwrap import dedent
 
-from ..helpers import UniqueCourseTest
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.problem import ProblemPage
-from ...pages.lms.staff_view import StaffPage
-from ...pages.common.logout import LogoutPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.problem import ProblemPage
+from common.test.acceptance.pages.lms.staff_view import StaffPage
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 
 
 class GatingTest(UniqueCourseTest):

--- a/common/test/acceptance/tests/lms/test_lms_index.py
+++ b/common/test/acceptance/tests/lms/test_lms_index.py
@@ -6,7 +6,7 @@ what students see @ edx.org because we redirect requests to a separate web appli
 import datetime
 
 from bok_choy.web_app_test import WebAppTest
-from ...pages.lms.index import IndexPage
+from common.test.acceptance.pages.lms.index import IndexPage
 
 
 class BaseLmsIndexTest(WebAppTest):

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -8,21 +8,21 @@ import ddt
 from nose.plugins.attrib import attr
 from bok_choy.promise import EmptyPromise
 
-from ..helpers import UniqueCourseTest, get_modal_alert, EventsTestMixin
-from ...pages.common.logout import LogoutPage
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.lms.create_mode import ModeCreationPage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.instructor_dashboard import InstructorDashboardPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
-from ...pages.lms.dashboard import DashboardPage
-from ...pages.lms.problem import ProblemPage
-from ...pages.lms.track_selection import TrackSelectionPage
-from ...pages.lms.pay_and_verify import PaymentAndVerificationFlow, FakePaymentPage
-from ...pages.lms.login_and_register import CombinedLoginAndRegisterPage
+from common.test.acceptance.tests.helpers import UniqueCourseTest, get_modal_alert, EventsTestMixin
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.lms.create_mode import ModeCreationPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.pages.lms.dashboard import DashboardPage
+from common.test.acceptance.pages.lms.problem import ProblemPage
+from common.test.acceptance.pages.lms.track_selection import TrackSelectionPage
+from common.test.acceptance.pages.lms.pay_and_verify import PaymentAndVerificationFlow, FakePaymentPage
+from common.test.acceptance.pages.lms.login_and_register import CombinedLoginAndRegisterPage
 from common.test.acceptance.tests.helpers import disable_animations
-from ...fixtures.certificates import CertificateConfigFixture
+from common.test.acceptance.fixtures.certificates import CertificateConfigFixture
 
 
 class BaseInstructorDashboardTest(EventsTestMixin, UniqueCourseTest):

--- a/common/test/acceptance/tests/lms/test_lms_matlab_problem.py
+++ b/common/test/acceptance/tests/lms/test_lms_matlab_problem.py
@@ -4,10 +4,10 @@ Test for matlab problems
 """
 import time
 
-from ...pages.lms.matlab_problem import MatlabProblemPage
-from ...fixtures.course import XBlockFixtureDesc
-from ...fixtures.xqueue import XQueueResponseFixture
-from .test_lms_problems import ProblemsTest
+from common.test.acceptance.pages.lms.matlab_problem import MatlabProblemPage
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.fixtures.xqueue import XQueueResponseFixture
+from common.test.acceptance.tests.lms.test_lms_problems import ProblemsTest
 from textwrap import dedent
 
 

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -6,13 +6,13 @@ See also old lettuce tests in lms/djangoapps/courseware/features/problems.featur
 """
 from textwrap import dedent
 
-from ..helpers import UniqueCourseTest
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.problem import ProblemPage
-from ...pages.lms.login_and_register import CombinedLoginAndRegisterPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
-from ..helpers import EventsTestMixin
+from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.problem import ProblemPage
+from common.test.acceptance.pages.lms.login_and_register import CombinedLoginAndRegisterPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import EventsTestMixin
 
 
 class ProblemsTest(UniqueCourseTest):

--- a/common/test/acceptance/tests/lms/test_lms_split_test_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_split_test_courseware_search.py
@@ -4,21 +4,21 @@ Test courseware search
 
 import json
 
-from ..helpers import remove_file
-from ...pages.common.logout import LogoutPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.lms.courseware_search import CoursewareSearchPage
-from ...pages.lms.course_nav import CourseNavPage
-from ...fixtures.course import XBlockFixtureDesc
-from ..helpers import create_user_partition_json
+from common.test.acceptance.tests.helpers import remove_file
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.lms.courseware_search import CoursewareSearchPage
+from common.test.acceptance.pages.lms.course_nav import CourseNavPage
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import create_user_partition_json
 
 from xmodule.partitions.partitions import Group
 
 from nose.plugins.attrib import attr
 
-from ..studio.base_studio_test import ContainerBase
+from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
 
-from ...pages.studio.auto_auth import AutoAuthPage as StudioAutoAuthPage
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage as StudioAutoAuthPage
 
 
 @attr('shard_1')

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -6,12 +6,12 @@ Tests the "preview" selector in the LMS that allows changing between Staff, Stud
 
 from nose.plugins.attrib import attr
 
-from ..helpers import UniqueCourseTest, create_user_partition_json
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.instructor_dashboard import InstructorDashboardPage
-from ...pages.lms.staff_view import StaffPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import UniqueCourseTest, create_user_partition_json
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage
+from common.test.acceptance.pages.lms.staff_view import StaffPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 from bok_choy.promise import EmptyPromise
 from xmodule.partitions.partitions import Group
 from textwrap import dedent

--- a/common/test/acceptance/tests/lms/test_programs.py
+++ b/common/test/acceptance/tests/lms/test_programs.py
@@ -1,12 +1,12 @@
 """Acceptance tests for LMS-hosted Programs pages"""
 from nose.plugins.attrib import attr
 
-from ...fixtures.catalog import CatalogFixture, CatalogConfigMixin
-from ...fixtures.programs import ProgramsFixture, ProgramsConfigMixin
-from ...fixtures.course import CourseFixture
-from ..helpers import UniqueCourseTest
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.programs import ProgramListingPage, ProgramDetailsPage
+from common.test.acceptance.fixtures.catalog import CatalogFixture, CatalogConfigMixin
+from common.test.acceptance.fixtures.programs import ProgramsFixture, ProgramsConfigMixin
+from common.test.acceptance.fixtures.course import CourseFixture
+from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.programs import ProgramListingPage, ProgramDetailsPage
 from openedx.core.djangoapps.catalog.tests import factories as catalog_factories
 from openedx.core.djangoapps.programs.tests import factories as program_factories
 

--- a/common/test/acceptance/tests/studio/base_studio_test.py
+++ b/common/test/acceptance/tests/studio/base_studio_test.py
@@ -3,12 +3,12 @@ Base classes used by studio tests.
 """
 from bok_choy.web_app_test import WebAppTest
 from bok_choy.page_object import XSS_INJECTION
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...fixtures.course import CourseFixture
-from ...fixtures.library import LibraryFixture
-from ..helpers import UniqueCourseTest
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.studio.utils import verify_ordering
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.fixtures.course import CourseFixture
+from common.test.acceptance.fixtures.library import LibraryFixture
+from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.studio.utils import verify_ordering
 
 
 class StudioCourseTest(UniqueCourseTest):

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -9,14 +9,14 @@ from flaky import flaky
 from abc import abstractmethod
 from bok_choy.promise import EmptyPromise
 
-from .base_studio_test import StudioLibraryTest, StudioCourseTest
-from ...fixtures.course import XBlockFixtureDesc
-from ...pages.studio.import_export import ExportLibraryPage, ExportCoursePage, ImportLibraryPage, ImportCoursePage
-from ...pages.studio.library import LibraryEditPage
-from ...pages.studio.container import ContainerPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.staff_view import StaffPage
+from common.test.acceptance.tests.studio.base_studio_test import StudioLibraryTest, StudioCourseTest
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.pages.studio.import_export import ExportLibraryPage, ExportCoursePage, ImportLibraryPage, ImportCoursePage
+from common.test.acceptance.pages.studio.library import LibraryEditPage
+from common.test.acceptance.pages.studio.container import ContainerPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.staff_view import StaffPage
 
 
 class ExportTestMixin(object):

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -11,7 +11,11 @@ from bok_choy.promise import EmptyPromise
 
 from common.test.acceptance.tests.studio.base_studio_test import StudioLibraryTest, StudioCourseTest
 from common.test.acceptance.fixtures.course import XBlockFixtureDesc
-from common.test.acceptance.pages.studio.import_export import ExportLibraryPage, ExportCoursePage, ImportLibraryPage, ImportCoursePage
+from common.test.acceptance.pages.studio.import_export import (
+    ExportLibraryPage,
+    ExportCoursePage,
+    ImportLibraryPage,
+    ImportCoursePage)
 from common.test.acceptance.pages.studio.library import LibraryEditPage
 from common.test.acceptance.pages.studio.container import ContainerPage
 from common.test.acceptance.pages.studio.overview import CourseOutlinePage

--- a/common/test/acceptance/tests/studio/test_studio_acid_xblock.py
+++ b/common/test/acceptance/tests/studio/test_studio_acid_xblock.py
@@ -3,10 +3,10 @@ Acceptance tests for Studio related to the acid xblock.
 """
 from bok_choy.web_app_test import WebAppTest
 
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.xblock.acid import AcidView
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.xblock.acid import AcidView
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 
 
 class XBlockAcidBase(WebAppTest):

--- a/common/test/acceptance/tests/studio/test_studio_asset.py
+++ b/common/test/acceptance/tests/studio/test_studio_asset.py
@@ -5,11 +5,11 @@ Acceptance tests for Studio related to the asset index page.
 from flaky import flaky
 from unittest import skip
 
-from ...pages.studio.asset_index import AssetIndexPage
+from common.test.acceptance.pages.studio.asset_index import AssetIndexPage
 
-from .base_studio_test import StudioCourseTest
-from ...fixtures.base import StudioApiLoginError
-from ..helpers import skip_if_browser
+from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
+from common.test.acceptance.fixtures.base import StudioApiLoginError
+from common.test.acceptance.tests.helpers import skip_if_browser
 
 
 @skip('FEDX-88')

--- a/common/test/acceptance/tests/studio/test_studio_bad_data.py
+++ b/common/test/acceptance/tests/studio/test_studio_bad_data.py
@@ -1,6 +1,6 @@
 from base_studio_test import ContainerBase
-from ...fixtures.course import XBlockFixtureDesc
-from ...pages.studio.utils import verify_ordering
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.pages.studio.utils import verify_ordering
 
 
 class BadComponentTest(ContainerBase):

--- a/common/test/acceptance/tests/studio/test_studio_components.py
+++ b/common/test/acceptance/tests/studio/test_studio_components.py
@@ -3,10 +3,10 @@ Acceptance tests for adding components in Studio.
 """
 import ddt
 
-from .base_studio_test import ContainerBase
-from ...fixtures.course import XBlockFixtureDesc
-from ...pages.studio.container import ContainerPage
-from ...pages.studio.utils import add_component, add_components
+from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.pages.studio.container import ContainerPage
+from common.test.acceptance.pages.studio.utils import add_component, add_components
 from common.test.acceptance.pages.studio.settings_advanced import AdvancedSettingsPage
 
 

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -6,14 +6,14 @@ for displaying containers within units.
 from nose.plugins.attrib import attr
 from unittest import skip
 
-from ...fixtures.course import XBlockFixtureDesc
-from ...pages.studio.component_editor import ComponentEditorView, ComponentVisibilityEditorView
-from ...pages.studio.container import ContainerPage
-from ...pages.studio.html_component_editor import HtmlComponentEditorView
-from ...pages.studio.utils import add_discussion, drag
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.staff_view import StaffPage
-from ...tests.helpers import create_user_partition_json
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.pages.studio.component_editor import ComponentEditorView, ComponentVisibilityEditorView
+from common.test.acceptance.pages.studio.container import ContainerPage
+from common.test.acceptance.pages.studio.html_component_editor import HtmlComponentEditorView
+from common.test.acceptance.pages.studio.utils import add_discussion, drag
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.staff_view import StaffPage
+from common.test.acceptance.tests.helpers import create_user_partition_json
 
 import datetime
 from bok_choy.promise import Promise, EmptyPromise

--- a/common/test/acceptance/tests/studio/test_studio_course_create.py
+++ b/common/test/acceptance/tests/studio/test_studio_course_create.py
@@ -5,9 +5,9 @@ import uuid
 from bok_choy.web_app_test import WebAppTest
 from nose.plugins.attrib import attr
 
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.studio.index import DashboardPage
-from ...pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.studio.index import DashboardPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
 
 
 @attr('shard_8')

--- a/common/test/acceptance/tests/studio/test_studio_course_team.py
+++ b/common/test/acceptance/tests/studio/test_studio_course_team.py
@@ -3,11 +3,11 @@ Acceptance tests for course in studio
 """
 from nose.plugins.attrib import attr
 
-from .base_studio_test import StudioCourseTest
-from ...pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
 
-from ...pages.studio.users import CourseTeamPage
-from ...pages.studio.index import DashboardPage
+from common.test.acceptance.pages.studio.users import CourseTeamPage
+from common.test.acceptance.pages.studio.index import DashboardPage
 
 
 @attr('shard_2')

--- a/common/test/acceptance/tests/studio/test_studio_help.py
+++ b/common/test/acceptance/tests/studio/test_studio_help.py
@@ -4,9 +4,9 @@ Test the Studio help links.
 
 from flaky import flaky
 
-from .base_studio_test import StudioCourseTest
-from ...pages.studio.index import DashboardPage
-from ...pages.studio.utils import click_studio_help, studio_help_links
+from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
+from common.test.acceptance.pages.studio.index import DashboardPage
+from common.test.acceptance.pages.studio.utils import click_studio_help, studio_help_links
 
 
 class StudioHelpTest(StudioCourseTest):

--- a/common/test/acceptance/tests/studio/test_studio_home.py
+++ b/common/test/acceptance/tests/studio/test_studio_home.py
@@ -6,8 +6,6 @@ from flaky import flaky
 from opaque_keys.edx.locator import LibraryLocator
 from uuid import uuid4
 
-from common.test.acceptance.fixtures import PROGRAMS_STUB_URL
-from common.test.acceptance.fixtures.config import ConfigModelFixture
 from common.test.acceptance.fixtures.programs import ProgramsFixture, ProgramsConfigMixin
 from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
 from common.test.acceptance.pages.studio.library import LibraryEditPage

--- a/common/test/acceptance/tests/studio/test_studio_home.py
+++ b/common/test/acceptance/tests/studio/test_studio_home.py
@@ -6,14 +6,14 @@ from flaky import flaky
 from opaque_keys.edx.locator import LibraryLocator
 from uuid import uuid4
 
-from ...fixtures import PROGRAMS_STUB_URL
-from ...fixtures.config import ConfigModelFixture
-from ...fixtures.programs import ProgramsFixture, ProgramsConfigMixin
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.studio.library import LibraryEditPage
-from ...pages.studio.index import DashboardPage, DashboardPageWithPrograms
-from ...pages.lms.account_settings import AccountSettingsPage
-from ..helpers import (
+from common.test.acceptance.fixtures import PROGRAMS_STUB_URL
+from common.test.acceptance.fixtures.config import ConfigModelFixture
+from common.test.acceptance.fixtures.programs import ProgramsFixture, ProgramsConfigMixin
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.studio.library import LibraryEditPage
+from common.test.acceptance.pages.studio.index import DashboardPage, DashboardPageWithPrograms
+from common.test.acceptance.pages.lms.account_settings import AccountSettingsPage
+from common.test.acceptance.tests.helpers import (
     select_option_by_text,
     get_selected_option_text
 )

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -5,12 +5,12 @@ from ddt import ddt, data
 from nose.plugins.attrib import attr
 from flaky import flaky
 
-from .base_studio_test import StudioLibraryTest
-from ...fixtures.course import XBlockFixtureDesc
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.studio.utils import add_component
-from ...pages.studio.library import LibraryEditPage
-from ...pages.studio.users import LibraryUsersPage
+from common.test.acceptance.tests.studio.base_studio_test import StudioLibraryTest
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.studio.utils import add_component
+from common.test.acceptance.pages.studio.library import LibraryEditPage
+from common.test.acceptance.pages.studio.users import LibraryUsersPage
 
 
 @attr('shard_2')

--- a/common/test/acceptance/tests/studio/test_studio_library_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_library_container.py
@@ -5,12 +5,12 @@ import ddt
 from nose.plugins.attrib import attr
 import textwrap
 
-from .base_studio_test import StudioLibraryTest
-from ...fixtures.course import CourseFixture
-from ..helpers import UniqueCourseTest, TestWithSearchIndexMixin
-from ...pages.studio.library import StudioLibraryContentEditor, StudioLibraryContainerXBlockWrapper
-from ...pages.studio.overview import CourseOutlinePage
-from ...fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.tests.studio.base_studio_test import StudioLibraryTest
+from common.test.acceptance.fixtures.course import CourseFixture
+from common.test.acceptance.tests.helpers import UniqueCourseTest, TestWithSearchIndexMixin
+from common.test.acceptance.pages.studio.library import StudioLibraryContentEditor, StudioLibraryContainerXBlockWrapper
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 
 SECTION_NAME = 'Test Section'
 SUBSECTION_NAME = 'Test Subsection'

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -8,18 +8,18 @@ from pytz import UTC
 from bok_choy.promise import EmptyPromise
 from nose.plugins.attrib import attr
 
-from ...pages.studio.settings_advanced import AdvancedSettingsPage
-from ...pages.studio.overview import CourseOutlinePage, ContainerPage, ExpandCollapseLinkState
-from ...pages.studio.utils import add_discussion, drag, verify_ordering
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.course_nav import CourseNavPage
-from ...pages.lms.staff_view import StaffPage
-from ...fixtures.config import ConfigModelFixture
-from ...fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.pages.studio.settings_advanced import AdvancedSettingsPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage, ContainerPage, ExpandCollapseLinkState
+from common.test.acceptance.pages.studio.utils import add_discussion, drag, verify_ordering
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.course_nav import CourseNavPage
+from common.test.acceptance.pages.lms.staff_view import StaffPage
+from common.test.acceptance.fixtures.config import ConfigModelFixture
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 
 from base_studio_test import StudioCourseTest
-from ..helpers import load_data_str
-from ...pages.lms.progress import ProgressPage
+from common.test.acceptance.tests.helpers import load_data_str
+from common.test.acceptance.pages.lms.progress import ProgressPage
 
 
 SECTION_NAME = 'Test Section'

--- a/common/test/acceptance/tests/studio/test_studio_rerun.py
+++ b/common/test/acceptance/tests/studio/test_studio_rerun.py
@@ -6,11 +6,11 @@ import random
 from bok_choy.promise import EmptyPromise
 from nose.tools import assert_in
 
-from ...pages.studio.index import DashboardPage
-from ...pages.studio.course_rerun import CourseRerunPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.lms.courseware import CoursewarePage
-from ...fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.pages.studio.index import DashboardPage
+from common.test.acceptance.pages.studio.course_rerun import CourseRerunPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 
 from base_studio_test import StudioCourseTest
 

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -10,13 +10,13 @@ from nose.plugins.attrib import attr
 
 from base_studio_test import StudioCourseTest
 from bok_choy.promise import EmptyPromise
-from ...fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 from common.test.acceptance.tests.helpers import create_user_partition_json, element_has_text
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.studio.settings import SettingsPage
-from ...pages.studio.settings_advanced import AdvancedSettingsPage
-from ...pages.studio.settings_group_configurations import GroupConfigurationsPage
-from ...pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.studio.settings import SettingsPage
+from common.test.acceptance.pages.studio.settings_advanced import AdvancedSettingsPage
+from common.test.acceptance.pages.studio.settings_group_configurations import GroupConfigurationsPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
 from common.test.acceptance.pages.studio.utils import get_input_value
 from textwrap import dedent
 from xmodule.partitions.partitions import Group

--- a/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
@@ -6,11 +6,11 @@ import uuid
 
 from nose.plugins.attrib import attr
 
-from .base_studio_test import StudioCourseTest
-from ...pages.lms.create_mode import ModeCreationPage
-from ...pages.studio.settings_certificates import CertificatesPage
-from ...pages.studio.settings_advanced import AdvancedSettingsPage
-from ..helpers import skip_if_browser
+from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
+from common.test.acceptance.pages.lms.create_mode import ModeCreationPage
+from common.test.acceptance.pages.studio.settings_certificates import CertificatesPage
+from common.test.acceptance.pages.studio.settings_advanced import AdvancedSettingsPage
+from common.test.acceptance.tests.helpers import skip_if_browser
 
 
 @attr('shard_8')

--- a/common/test/acceptance/tests/studio/test_studio_settings_details.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_details.py
@@ -6,12 +6,12 @@ from flaky import flaky
 from nose.plugins.attrib import attr
 from unittest import skip
 
-from ...fixtures.config import ConfigModelFixture
-from ...fixtures.course import CourseFixture
-from ...pages.studio.settings import SettingsPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...tests.studio.base_studio_test import StudioCourseTest
-from ..helpers import (
+from common.test.acceptance.fixtures.config import ConfigModelFixture
+from common.test.acceptance.fixtures.course import CourseFixture
+from common.test.acceptance.pages.studio.settings import SettingsPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
+from common.test.acceptance.tests.helpers import (
     generate_course_key,
     select_option_by_value,
     is_option_value_selected,

--- a/common/test/acceptance/tests/studio/test_studio_split_test.py
+++ b/common/test/acceptance/tests/studio/test_studio_split_test.py
@@ -10,15 +10,15 @@ from selenium.webdriver.support.ui import Select
 from xmodule.partitions.partitions import Group
 from bok_choy.promise import Promise, EmptyPromise
 
-from ...fixtures.course import XBlockFixtureDesc
-from ...pages.studio.component_editor import ComponentEditorView
-from ...pages.studio.overview import CourseOutlinePage, CourseOutlineUnit
-from ...pages.studio.container import ContainerPage
-from ...pages.studio.settings_group_configurations import GroupConfigurationsPage
-from ...pages.studio.utils import add_advanced_component
-from ...pages.xblock.utils import wait_for_xblock_initialization
-from ...pages.lms.courseware import CoursewarePage
-from ..helpers import create_user_partition_json
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.pages.studio.component_editor import ComponentEditorView
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage, CourseOutlineUnit
+from common.test.acceptance.pages.studio.container import ContainerPage
+from common.test.acceptance.pages.studio.settings_group_configurations import GroupConfigurationsPage
+from common.test.acceptance.pages.studio.utils import add_advanced_component
+from common.test.acceptance.pages.xblock.utils import wait_for_xblock_initialization
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.tests.helpers import create_user_partition_json
 
 from base_studio_test import StudioCourseTest
 

--- a/common/test/acceptance/tests/studio/test_studio_textbooks.py
+++ b/common/test/acceptance/tests/studio/test_studio_textbooks.py
@@ -2,9 +2,9 @@
 Acceptance tests for Studio related to the textbooks.
 """
 from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
-from ...pages.studio.textbook_upload import TextbookUploadPage
-from ...pages.lms.textbook_view import TextbookViewPage
-from ...tests.helpers import disable_animations
+from common.test.acceptance.pages.studio.textbook_upload import TextbookUploadPage
+from common.test.acceptance.pages.lms.textbook_view import TextbookViewPage
+from common.test.acceptance.tests.helpers import disable_animations
 from nose.plugins.attrib import attr
 
 

--- a/common/test/acceptance/tests/test_annotatable.py
+++ b/common/test/acceptance/tests/test_annotatable.py
@@ -3,13 +3,13 @@
 E2E tests for the LMS.
 """
 
-from .helpers import UniqueCourseTest
-from ..pages.studio.auto_auth import AutoAuthPage
-from ..pages.lms.courseware import CoursewarePage
-from ..pages.lms.annotation_component import AnnotationComponentPage
-from ..fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.annotation_component import AnnotationComponentPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 from textwrap import dedent
-from ..tests.helpers import disable_animations
+from common.test.acceptance.tests.helpers import disable_animations
 
 
 def _correctness(choice, target):

--- a/common/test/acceptance/tests/test_cohorted_courseware.py
+++ b/common/test/acceptance/tests/test_cohorted_courseware.py
@@ -7,15 +7,15 @@ from nose.plugins.attrib import attr
 
 from studio.base_studio_test import ContainerBase
 
-from ..pages.studio.settings_group_configurations import GroupConfigurationsPage
-from ..pages.studio.auto_auth import AutoAuthPage as StudioAutoAuthPage
-from ..fixtures.course import XBlockFixtureDesc
-from ..fixtures import LMS_BASE_URL
-from ..pages.studio.component_editor import ComponentVisibilityEditorView
-from ..pages.lms.instructor_dashboard import InstructorDashboardPage
-from ..pages.lms.courseware import CoursewarePage
-from ..pages.lms.auto_auth import AutoAuthPage as LmsAutoAuthPage
-from ..tests.lms.test_lms_user_preview import verify_expected_problem_visibility
+from common.test.acceptance.pages.studio.settings_group_configurations import GroupConfigurationsPage
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage as StudioAutoAuthPage
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
+from common.test.acceptance.fixtures import LMS_BASE_URL
+from common.test.acceptance.pages.studio.component_editor import ComponentVisibilityEditorView
+from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage as LmsAutoAuthPage
+from common.test.acceptance.tests.lms.test_lms_user_preview import verify_expected_problem_visibility
 
 from bok_choy.promise import EmptyPromise
 from bok_choy.page_object import XSS_INJECTION

--- a/common/test/acceptance/tests/video/test_studio_video_editor.py
+++ b/common/test/acceptance/tests/video/test_studio_video_editor.py
@@ -4,7 +4,7 @@
 Acceptance tests for CMS Video Editor.
 """
 from nose.plugins.attrib import attr
-from .test_studio_video_module import CMSVideoBaseTest
+from common.test.acceptance.tests.video.test_studio_video_module import CMSVideoBaseTest
 
 
 @attr('shard_6')

--- a/common/test/acceptance/tests/video/test_studio_video_module.py
+++ b/common/test/acceptance/tests/video/test_studio_video_module.py
@@ -8,11 +8,11 @@ import os
 from mock import patch
 from nose.plugins.attrib import attr
 from unittest import skipIf
-from ...pages.studio.auto_auth import AutoAuthPage
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.studio.video.video import VideoComponentPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
-from ..helpers import UniqueCourseTest, is_youtube_available, YouTubeStubConfig
+from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.studio.video.video import VideoComponentPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import UniqueCourseTest, is_youtube_available, YouTubeStubConfig
 
 
 @skipIf(is_youtube_available() is False, 'YouTube is not available!')

--- a/common/test/acceptance/tests/video/test_studio_video_transcript.py
+++ b/common/test/acceptance/tests/video/test_studio_video_transcript.py
@@ -19,7 +19,7 @@ front-end validation will not pass.
     t_not_exist - this file does not exist on YouTube; it exists locally
 """
 from nose.plugins.attrib import attr
-from .test_studio_video_module import CMSVideoBaseTest
+from common.test.acceptance.tests.video.test_studio_video_module import CMSVideoBaseTest
 
 
 @attr('shard_6')

--- a/common/test/acceptance/tests/video/test_video_events.py
+++ b/common/test/acceptance/tests/video/test_video_events.py
@@ -5,9 +5,9 @@ import json
 from nose.plugins.attrib import attr
 import ddt
 
-from ..helpers import EventsTestMixin
-from .test_video_module import VideoBaseTest
-from ...pages.lms.video.video import _parse_time_str
+from common.test.acceptance.tests.helpers import EventsTestMixin
+from common.test.acceptance.tests.video.test_video_module import VideoBaseTest
+from common.test.acceptance.pages.lms.video.video import _parse_time_str
 
 from openedx.core.lib.tests.assertions.events import assert_event_matches, assert_events_equal
 from opaque_keys.edx.keys import UsageKey, CourseKey

--- a/common/test/acceptance/tests/video/test_video_handout.py
+++ b/common/test/acceptance/tests/video/test_video_handout.py
@@ -4,7 +4,7 @@
 Acceptance tests for CMS Video Handout.
 """
 from nose.plugins.attrib import attr
-from .test_studio_video_module import CMSVideoBaseTest
+from common.test.acceptance.tests.video.test_studio_video_module import CMSVideoBaseTest
 
 
 @attr('shard_5')

--- a/common/test/acceptance/tests/video/test_video_license.py
+++ b/common/test/acceptance/tests/video/test_video_license.py
@@ -4,12 +4,12 @@ Acceptance tests for licensing of the Video module
 """
 from __future__ import unicode_literals
 from nose.plugins.attrib import attr
-from ..studio.base_studio_test import StudioCourseTest
+from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
 
-#from ..helpers import UniqueCourseTest
-from ...pages.studio.overview import CourseOutlinePage
-from ...pages.lms.courseware import CoursewarePage
-from ...fixtures.course import XBlockFixtureDesc
+#from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 
 
 @attr('shard_2')

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -10,15 +10,15 @@ from nose.plugins.attrib import attr
 from unittest import skipIf, skip
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
-from ..helpers import UniqueCourseTest, is_youtube_available, YouTubeStubConfig
-from ...pages.lms.video.video import VideoPage
-from ...pages.lms.tab_nav import TabNavPage
-from ...pages.lms.courseware import CoursewarePage
-from ...pages.lms.course_nav import CourseNavPage
-from ...pages.lms.auto_auth import AutoAuthPage
-from ...pages.lms.course_info import CourseInfoPage
-from ...fixtures.course import CourseFixture, XBlockFixtureDesc
-from ..helpers import skip_if_browser
+from common.test.acceptance.tests.helpers import UniqueCourseTest, is_youtube_available, YouTubeStubConfig
+from common.test.acceptance.pages.lms.video.video import VideoPage
+from common.test.acceptance.pages.lms.tab_nav import TabNavPage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.course_nav import CourseNavPage
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.course_info import CourseInfoPage
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import skip_if_browser
 
 from flaky import flaky
 

--- a/common/test/acceptance/tests/video/test_video_times.py
+++ b/common/test/acceptance/tests/video/test_video_times.py
@@ -1,7 +1,7 @@
 """
 Acceptance tests for Video Times(Start, End and Finish) functionality.
 """
-from .test_video_module import VideoBaseTest
+from common.test.acceptance.tests.video.test_video_module import VideoBaseTest
 
 
 class VideoTimesTest(VideoBaseTest):


### PR DESCRIPTION
**Background:**  This pull requests addresses byte-sized bug [TE-1194](https://openedx.atlassian.net/browse/TE-1194).  It changes all the relative paths in the imports in common/tests/acceptance to absolute paths.  @benpatterson gave me some guidance on how to tackle this.

**LMS Updates:**  None

**Studio Updates:** None
