### PR TITLE
MA-2646: handle profile_image in requested_fields for anonymous user

### DIFF
--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -375,7 +375,9 @@ def _get_users(discussion_entity_type, discussion_entity, username_profile_dict)
 
         A dict of users with username as key and user profile details as value.
     """
-    users = {discussion_entity['author']: _user_profile(username_profile_dict[discussion_entity['author']])}
+    users = {}
+    if discussion_entity['author']:
+        users[discussion_entity['author']] = _user_profile(username_profile_dict[discussion_entity['author']])
 
     if discussion_entity_type == DiscussionEntity.comment and discussion_entity['endorsed']:
         users[discussion_entity['endorsed_by']] = _user_profile(username_profile_dict[discussion_entity['endorsed_by']])
@@ -446,7 +448,7 @@ def _serialize_discussion_entities(request, context, discussion_entities, reques
         results.append(serialized_entity)
 
         if include_profile_image:
-            if serialized_entity['author'] not in usernames:
+            if serialized_entity['author'] and serialized_entity['author'] not in usernames:
                 usernames.append(serialized_entity['author'])
             if (
                     'endorsed' in serialized_entity and serialized_entity['endorsed'] and


### PR DESCRIPTION
## [MA-2646](https://openedx.atlassian.net/browse/MA-2646)

Handle profile_image in requested_fields for threads with anonymous user.
'None' author was causing the API to crash.
### Testing
- [x] Unit
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @verdanmahmood 
- [x] Code review: @robrap 
### Post-review
- [x] Squash commits
