### PR TITLE
Invalidate certificate as well when updating user enrolment using support tool

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -106,14 +106,15 @@ def get_certificates_for_user(username):
     ]
 
 
-def get_certificate_for_user(username, course_key):
+def get_certificate_for_user(username, course_key, format=True):
     """
     Retrieve certificate information for a particular user for a specific course.
 
     Arguments:
         username (unicode): The identifier of the user.
         course_key (CourseKey): A Course Key.
-    Returns: dict
+        format (Bool): If True, certificate would be formated.
+    Returns: dict if format=True otherwise GeneratedCertificate object.
     """
     try:
         cert = GeneratedCertificate.eligible_certificates.get(
@@ -122,7 +123,9 @@ def get_certificate_for_user(username, course_key):
         )
     except GeneratedCertificate.DoesNotExist:
         return None
-    return format_certificate_for_user(username, cert)
+    if cert and format:
+        return format_certificate_for_user(username, cert)
+    return cert
 
 
 def generate_user_certificates(student, course_key, course=None, insecure=False, generation_mode='batch',

--- a/lms/djangoapps/support/static/support/templates/enrollment-modal.underscore
+++ b/lms/djangoapps/support/static/support/templates/enrollment-modal.underscore
@@ -21,6 +21,10 @@
     <label class="sr" for="enrollment-reason-other"><%- gettext("Explain if other.") %></label>
     <input class="enrollment-reason-other" id="enrollment-reason-other" type="text" placeholder="<%- gettext('Explain if other.') %>" />
   </div>
+  <div class="enrolment-regenerate-cert-note">
+    <span>Note: </span>
+    <span>This would also invalidate user certificate if it exists. After updating user enrolment, you may want to generate user certificate as well.</span>
+  </div>
   <button class="enrollment-change-submit"><%- gettext("Submit enrollment change") %></button>
   <button class="enrollment-change-cancel"><%- gettext("Cancel") %></button>
 </form>

--- a/lms/static/sass/views/_support.scss
+++ b/lms/static/sass/views/_support.scss
@@ -77,6 +77,14 @@
       }
     }
 
+    .enrolment-regenerate-cert-note {
+      margin-top: 10px;
+
+      span {
+        font-size: 14px;
+      }
+    }
+
     .enrollment-change-errors {
       @extend %t-copy-sub1;
       @extend %t-light;


### PR DESCRIPTION
While updating enrolment of the user in Support Dashboard, make the certificate status to unavailable (if it exists) and put a certificate request on the queue.

[ECOM-5012](https://openedx.atlassian.net/browse/ECOM-5012)
