### PR TITLE
Bumps UXPL version to pick up new palettes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "backbone": "~1.3.2",
     "backbone-validation": "~0.11.5",
     "coffee-script": "1.6.1",
-    "edx-pattern-library": "0.16.1",
+    "edx-pattern-library": "0.16.3",
     "edx-ui-toolkit": "1.4.1",
     "jquery": "~2.2.0",
     "jquery-migrate": "^1.4.1",


### PR DESCRIPTION
# Version bump for pattern library

As more developers begin using our pattern library, we discovered some inconsistencies and shortcomings with our color palettes. Some of them - namely the base blue and green - weren't accessible on our light gray background.

I've spent some time, working with both UX and marketing, to revamp our color choices. They've been slimmed down and tweaked to provide solid options for nearly all of our use cases.

While I was under the hood, there were conversations on alert styles, and how they were all so heavy and didn't work in places where we needed a lighter variant. So I took the liberty to restyle them a bit and adding a few new examples for "slimmer" alerts.

Once the platform is updated, we'll be able to utilize the new color values and bring the platform into better harmony.
- [ ] @bjacobel (Currently waiting on Bower to update before tests will pass...)
