### PR TITLE
Retry on failures (database locking).

### DIFF
--- a/lms/djangoapps/verified_track_content/tasks.py
+++ b/lms/djangoapps/verified_track_content/tasks.py
@@ -15,8 +15,8 @@ from openedx.core.djangoapps.course_groups.cohorts import (
 LOGGER = get_task_logger(__name__)
 
 
-@task()
-def sync_cohort_with_mode(course_id, user_id, verified_cohort_name, default_cohort_name):
+@task(bind=True, default_retry_delay=60, max_retries=4)
+def sync_cohort_with_mode(self, course_id, user_id, verified_cohort_name, default_cohort_name):
     """
     If the learner's mode does not match their assigned cohort, move the learner into the correct cohort.
     It is assumed that this task is only initiated for courses that are using the
@@ -26,28 +26,35 @@ def sync_cohort_with_mode(course_id, user_id, verified_cohort_name, default_coho
     """
     course_key = CourseKey.from_string(course_id)
     user = User.objects.get(id=user_id)
-    enrollment = CourseEnrollment.get_enrollment(user, course_key)
-    # Note that this will enroll the user in the default cohort on initial enrollment.
-    # That's good because it will force creation of the default cohort if necessary.
-    current_cohort = get_cohort(user, course_key)
-    verified_cohort = get_cohort_by_name(course_key, verified_cohort_name)
+    try:
+        enrollment = CourseEnrollment.get_enrollment(user, course_key)
+        # Note that this will enroll the user in the default cohort on initial enrollment.
+        # That's good because it will force creation of the default cohort if necessary.
+        current_cohort = get_cohort(user, course_key)
+        verified_cohort = get_cohort_by_name(course_key, verified_cohort_name)
 
-    if enrollment.mode == CourseMode.VERIFIED and (current_cohort.id != verified_cohort.id):
-        LOGGER.info(
-            "MOVING_TO_VERIFIED: Moving user '%s' to the verified cohort '%s' for course '%s'",
-            user.username, verified_cohort.name, course_id
+        if enrollment.mode == CourseMode.VERIFIED and (current_cohort.id != verified_cohort.id):
+            LOGGER.info(
+                "MOVING_TO_VERIFIED: Moving user '%s' to the verified cohort '%s' for course '%s'",
+                user.username, verified_cohort.name, course_id
+            )
+            add_user_to_cohort(verified_cohort, user.username)
+        elif enrollment.mode != CourseMode.VERIFIED and current_cohort.id == verified_cohort.id:
+            default_cohort = get_cohort_by_name(course_key, default_cohort_name)
+            LOGGER.info(
+                "MOVING_TO_DEFAULT: Moving user '%s' to the default cohort '%s' for course '%s'",
+                user.username, default_cohort.name, course_id
+            )
+            add_user_to_cohort(default_cohort, user.username)
+        else:
+            LOGGER.info(
+                "NO_ACTION_NECESSARY: No action necessary for user '%s' in course '%s' and enrollment mode '%s'. "
+                "The user is already in cohort '%s'.",
+                user.username, course_id, enrollment.mode, current_cohort.name
+            )
+    except Exception as exc:
+        LOGGER.warning(
+            "SYNC_COHORT_WITH_MODE_RETRY: Exception encountered for course '%s' and user '%s': %s",
+            course_id, user.username, unicode(exc)
         )
-        add_user_to_cohort(verified_cohort, user.username)
-    elif enrollment.mode != CourseMode.VERIFIED and current_cohort.id == verified_cohort.id:
-        default_cohort = get_cohort_by_name(course_key, default_cohort_name)
-        LOGGER.info(
-            "MOVING_TO_DEFAULT: Moving user '%s' to the default cohort '%s' for course '%s'",
-            user.username, default_cohort.name, course_id
-        )
-        add_user_to_cohort(default_cohort, user.username)
-    else:
-        LOGGER.info(
-            "NO_ACTION_NECESSARY: No action necessary for user '%s' in course '%s' and enrollment mode '%s'. "
-            "The user is already in cohort '%s'.",
-            user.username, course_id, enrollment.mode, current_cohort.name
-        )
+        raise self.retry(exc=exc)


### PR DESCRIPTION
### Description

[TNL-5091](https://openedx.atlassian.net/browse/TNL-5091)

This adds retries to the celery task for moving a learner into the correct cohort (only for courses that have enabled verified track cohorting).

During a spike in registrations for a course, we saw database locking errors. Those errors may have been fixed by #13116, as the first unnecessary save deleted in that PR was the line where the deadlock always occurred (unfortunately I could not reproduce the bug). But to be safer and to recognize that sometimes an unexpected error may occur, I am adding retries.

Hint: suppress whitespace differences to review-- https://github.com/edx/edx-platform/pull/13131/files?w=1
### Sandbox
- [x] https://lock.sandbox.edx.org/courses/course-v1:DemoX+PERF101+course/info (verify track cohorting is enabled on this course)
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @PaulWattenberger (tagging you as you've recently written code using retries, which is not something I have written before)
### Devops assistance

@maxrothman can you take a look at this? I thought that retries would not throw an actual error until the max_retries value was reached, but when I purposefully raised an Exception in this code on my sandbox, I saw that celery.Exceptions:Retry was thrown each time. How are celery task retries generally handled?

Error on each retry:
https://rpm.newrelic.com/accounts/88178/applications/30219755/traced_errors/2f0f1eaa-55a4-11e6-af6e-f8bc124256a0_9807_14004

Exception when max_retries value is reached
https://rpm.newrelic.com/accounts/88178/applications/30219755/traced_errors/63fbe503-55a4-11e6-af6e-f8bc124256a0_4549_8968

FYI: @ormsbee 
### Post-review
- [x] Squash commits
