### PR TITLE
Updated and pinned version requirements for sandbox

### DIFF
--- a/common/lib/calc/setup.py
+++ b/common/lib/calc/setup.py
@@ -7,6 +7,6 @@ setup(
     install_requires=[
         "pyparsing==2.0.1",
         "numpy",
-        "scipy"
+        "scipy<0.18"
     ],
 )

--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -7,7 +7,7 @@ setup(
     install_requires=[
         "pyparsing==2.0.1",
         "numpy",
-        "scipy",
+        "scipy<0.18",
         "nltk<3.0",
     ],
 )

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -422,7 +422,7 @@ fi
 # compile numpy and scipy if requested
 
 NUMPY_VER="1.6.2"
-SCIPY_VER="0.10.1"
+SCIPY_VER="0.14.0"
 
 if [[ -n $compile ]]; then
     output "Downloading numpy and scipy"


### PR DESCRIPTION
The version requirements for the libraries referenced in `local.txt` for
the sandboxes do not have pinned version specifiers. Added missing
specifiers and updated the packages listed in the sandbox requirements
to use their latest versions.
