### PR TITLE
remove dropdown menu class that has pseudo border that double arrows

### DIFF
--- a/cms/templates/widgets/user_dropdown.html
+++ b/cms/templates/widgets/user_dropdown.html
@@ -12,7 +12,7 @@
           <span class="sr-only">${_("Currently signed in as:")}</span>
           <span class="account-username" title="${ user.username }">${ user.username }</span>
       </h3>
-      <button type="button" class="menu-button button-more has-dropdown js-dropdown-button default-icon" aria-haspopup="true" aria-expanded="false" aria-controls="${_("Usermenu")}">
+      <button type="button" class="menu-button button-more has-dropdown js-dropdown-button" aria-haspopup="true" aria-expanded="false" aria-controls="${_("Usermenu")}">
           <span class="icon-fallback icon-fallback-img">
             <span class="icon icon-angle-down" aria-hidden="true"></span>
             <span class="sr-only">${_("Usermenu dropdown")}</span>

--- a/lms/templates/user_dropdown.html
+++ b/lms/templates/user_dropdown.html
@@ -20,7 +20,7 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
             <img class="menu-image" src="${profile_image_url}" alt="">
             ${username}
         </a>
-        <button type="button" class="menu-button button-more has-dropdown js-dropdown-button default-icon" aria-haspopup="true" aria-expanded="false" aria-controls="${_("Usermenu")}">
+        <button type="button" class="menu-button button-more has-dropdown js-dropdown-button" aria-haspopup="true" aria-expanded="false" aria-controls="${_("Usermenu")}">
               <span class="icon fa fa-caret-down" aria-hidden="true"></span>
               <span class="sr-only">${_("Usermenu dropdown")}</span>
         </button>


### PR DESCRIPTION
 [TNL-5074](https://openedx.atlassian.net/browse/TNL-5074)
## Sandbox

[Sandbox](https://alisan-tnl-5074.sandbox.edx.org/courses/course-v1:DemoX+PERF101+course/discussion/forum)
## Description

Remove default-icon class that render pseudo border for the arrow. Use FA for icon consistency.
## Reviewer
- [x] Code review: @bjacobel 
- [x] Accessibility review: @clrux 
