### PR TITLE
Upgrade to Uglify 2.7.0 to remediate a security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "jquery.scrollto": "~2.1.2",
     "picturefill": "~3.0.2",
     "requirejs": "~2.1.22",
-    "uglify-js": "2.4.24",
+    "uglify-js": "2.7.0",
     "underscore": "~1.8.3",
     "underscore.string": "~3.3.4"
   },


### PR DESCRIPTION
VersionEye started failing our builds because there's a known security issue with the version of UglifyJS we're on. VersionEye is off now, but still good to fix the issue.

Only way to test this is by verifying on a sandbox that our JS still works: https://uglify.sandbox.edx.org
- [x] @andy-armstrong 
- [x] someone from devops
