### PR TITLE
Run ESLint autofixer in CMS

### DIFF
--- a/cms/static/cms/js/build.js
+++ b/cms/static/cms/js/build.js
@@ -16,7 +16,7 @@
 
     var getModulesList = function(modules) {
         var result = [getModule(commonLibrariesPath)];
-        return result.concat(modules.map(function (moduleName) {
+        return result.concat(modules.map(function(moduleName) {
             return getModule(moduleName, true);
         }));
     };
@@ -171,4 +171,5 @@
          */
         logLevel: 1
     };
-}())
+}())  // eslint-disable-line semi
+// A semicolon on the line above will break the requirejs optimizer

--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -1,4 +1,4 @@
-;(function(require, define) {
+(function(require, define) {
     'use strict';
 
     if (window) {
@@ -210,12 +210,12 @@
                     window.MathJax.Hub.Config({
                         tex2jax: {
                             inlineMath: [
-                                ['\\(','\\)'],
-                                ['[mathjaxinline]','[/mathjaxinline]']
+                                ['\\(', '\\)'],
+                                ['[mathjaxinline]', '[/mathjaxinline]']
                             ],
                             displayMath: [
-                                ['\\[','\\]'],
-                                ['[mathjax]','[/mathjax]']
+                                ['\\[', '\\]'],
+                                ['[mathjax]', '[/mathjax]']
                             ]
                         }
                     });

--- a/cms/static/cms/js/spec/main_spec.js
+++ b/cms/static/cms/js/spec/main_spec.js
@@ -2,81 +2,81 @@
 
 (function(sandbox) {
     'use strict';
-    require(["jquery", "backbone", "cms/js/main", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "jquery.cookie"],
+    require(['jquery', 'backbone', 'cms/js/main', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'jquery.cookie'],
             function($, Backbone, main, AjaxHelpers) {
-        describe("CMS", function() {
-            it("should initialize URL", function() {
-                expect(window.CMS.URL).toBeDefined();
-            });
-        });
-        describe("main helper", function() {
-            beforeEach(function() {
-                this.previousAjaxSettings = $.extend(true, {}, $.ajaxSettings);
-                spyOn($, "cookie").and.callFake(function(param) {
-                    if (param === "csrftoken") {
-                        return "stubCSRFToken";
-                    }
+                describe('CMS', function() {
+                    it('should initialize URL', function() {
+                        expect(window.CMS.URL).toBeDefined();
+                    });
                 });
-                return main();
-            });
-            afterEach(function() {
-                $.ajaxSettings = this.previousAjaxSettings;
-                return $.ajaxSettings;
-            });
-            it("turn on Backbone emulateHTTP", function() {
-                expect(Backbone.emulateHTTP).toBeTruthy();
-            });
-            it("setup AJAX CSRF token", function() {
-                expect($.ajaxSettings.headers["X-CSRFToken"]).toEqual("stubCSRFToken");
-            });
-        });
-        describe("AJAX Errors", function() {
-            var server;
-            server = null;
-            beforeEach(function() {
-                appendSetFixtures(sandbox({
-                    id: "page-notification"
-                }));
-            });
-            afterEach(function() {
-                return server && server.restore();
-            });
-            it("successful AJAX request does not pop an error notification", function() {
-                server = AjaxHelpers.server([
-                    200, {
-                        "Content-Type": "application/json"
-                    }, "{}"
-                ]);
-                expect($("#page-notification")).toBeEmpty();
-                $.ajax("/test");
-                expect($("#page-notification")).toBeEmpty();
-                server.respond();
-                expect($("#page-notification")).toBeEmpty();
-            });
-            it("AJAX request with error should pop an error notification", function() {
-                server = AjaxHelpers.server([
-                    500, {
-                        "Content-Type": "application/json"
-                    }, "{}"
-                ]);
-                $.ajax("/test");
-                server.respond();
-                expect($("#page-notification")).not.toBeEmpty();
-                expect($("#page-notification")).toContainElement('div.wrapper-notification-error');
-            });
-            it("can override AJAX request with error so it does not pop an error notification", function() {
-                server = AjaxHelpers.server([
-                    500, {
-                        "Content-Type": "application/json"
-                    }, "{}"
-                ]);
-                $.ajax({
-                    url: "/test",
-                    notifyOnError: false
+                describe('main helper', function() {
+                    beforeEach(function() {
+                        this.previousAjaxSettings = $.extend(true, {}, $.ajaxSettings);
+                        spyOn($, 'cookie').and.callFake(function(param) {
+                            if (param === 'csrftoken') {
+                                return 'stubCSRFToken';
+                            }
+                        });
+                        return main();
+                    });
+                    afterEach(function() {
+                        $.ajaxSettings = this.previousAjaxSettings;
+                        return $.ajaxSettings;
+                    });
+                    it('turn on Backbone emulateHTTP', function() {
+                        expect(Backbone.emulateHTTP).toBeTruthy();
+                    });
+                    it('setup AJAX CSRF token', function() {
+                        expect($.ajaxSettings.headers['X-CSRFToken']).toEqual('stubCSRFToken');
+                    });
                 });
-                server.respond();
-                expect($("#page-notification")).toBeEmpty();
+                describe('AJAX Errors', function() {
+                    var server;
+                    server = null;
+                    beforeEach(function() {
+                        appendSetFixtures(sandbox({
+                            id: 'page-notification'
+                        }));
+                    });
+                    afterEach(function() {
+                        return server && server.restore();
+                    });
+                    it('successful AJAX request does not pop an error notification', function() {
+                        server = AjaxHelpers.server([
+                            200, {
+                                'Content-Type': 'application/json'
+                            }, '{}'
+                        ]);
+                        expect($('#page-notification')).toBeEmpty();
+                        $.ajax('/test');
+                        expect($('#page-notification')).toBeEmpty();
+                        server.respond();
+                        expect($('#page-notification')).toBeEmpty();
+                    });
+                    it('AJAX request with error should pop an error notification', function() {
+                        server = AjaxHelpers.server([
+                            500, {
+                                'Content-Type': 'application/json'
+                            }, '{}'
+                        ]);
+                        $.ajax('/test');
+                        server.respond();
+                        expect($('#page-notification')).not.toBeEmpty();
+                        expect($('#page-notification')).toContainElement('div.wrapper-notification-error');
+                    });
+                    it('can override AJAX request with error so it does not pop an error notification', function() {
+                        server = AjaxHelpers.server([
+                            500, {
+                                'Content-Type': 'application/json'
+                            }, '{}'
+                        ]);
+                        $.ajax({
+                            url: '/test',
+                            notifyOnError: false
+                        });
+                        server.respond();
+                        expect($('#page-notification')).toBeEmpty();
+                    });
+                });
             });
-        });
-    });
 }).call(this, sandbox);

--- a/cms/static/cms/js/xblock/cms.runtime.v1.js
+++ b/cms/static/cms/js/xblock/cms.runtime.v1.js
@@ -24,7 +24,6 @@ define(['jquery', 'backbone', 'xblock/runtime.v1', 'URI', 'gettext', 'js/utils/m
             StudioRuntime = {};
 
         BaseRuntime.v1 = (function(_super) {
-
             __extends(v1, _super);
 
             v1.prototype.handlerUrl = function(element, handlerName, suffix, query) {
@@ -150,11 +149,9 @@ define(['jquery', 'backbone', 'xblock/runtime.v1', 'URI', 'gettext', 'js/utils/m
             };
 
             return v1;
-
         })(XBlock.Runtime.v1);
 
         PreviewRuntime.v1 = (function(_super) {
-
             __extends(v1, _super);
 
             function v1() {
@@ -164,11 +161,9 @@ define(['jquery', 'backbone', 'xblock/runtime.v1', 'URI', 'gettext', 'js/utils/m
             v1.prototype.handlerPrefix = '/preview/xblock';
 
             return v1;
-
         })(BaseRuntime.v1);
 
         StudioRuntime.v1 = (function(_super) {
-
             __extends(v1, _super);
 
             function v1() {
@@ -178,7 +173,6 @@ define(['jquery', 'backbone', 'xblock/runtime.v1', 'URI', 'gettext', 'js/utils/m
             v1.prototype.handlerPrefix = '/xblock';
 
             return v1;
-
         })(BaseRuntime.v1);
 
         // Install the runtime's into the global namespace

--- a/cms/static/js/base.js
+++ b/cms/static/js/base.js
@@ -1,19 +1,19 @@
 require([
-    "domReady",
-    "jquery",
-    "underscore",
-    "gettext",
-    "common/js/components/views/feedback_notification",
-    "common/js/components/views/feedback_prompt",
-    "js/utils/date_utils",
-    "js/utils/module",
-    "js/utils/handle_iframe_binding",
-    "edx-ui-toolkit/js/dropdown-menu/dropdown-menu-view", 
-    "jquery.ui",
-    "jquery.leanModal",
-    "jquery.form",
-    "jquery.smoothScroll"
-    ],
+    'domReady',
+    'jquery',
+    'underscore',
+    'gettext',
+    'common/js/components/views/feedback_notification',
+    'common/js/components/views/feedback_prompt',
+    'js/utils/date_utils',
+    'js/utils/module',
+    'js/utils/handle_iframe_binding',
+    'edx-ui-toolkit/js/dropdown-menu/dropdown-menu-view',
+    'jquery.ui',
+    'jquery.leanModal',
+    'jquery.form',
+    'jquery.smoothScroll'
+],
     function(
         domReady,
         $,
@@ -27,113 +27,110 @@ require([
         DropdownMenuView
     )
 {
+        var $body;
 
-var $body;
+        domReady(function() {
+            var dropdownMenuView;
 
-domReady(function() {
-    var dropdownMenuView;
-    
-    $body = $('body');
+            $body = $('body');
 
-    $body.on('click', '.embeddable-xml-input', function() {
-        $(this).select();
-    });
+            $body.on('click', '.embeddable-xml-input', function() {
+                $(this).select();
+            });
 
-    $body.addClass('js');
+            $body.addClass('js');
 
-    // alerts/notifications - manual close
-    $('.action-alert-close, .alert.has-actions .nav-actions a').bind('click', hideAlert);
-    $('.action-notification-close').bind('click', hideNotification);
+            // alerts/notifications - manual close
+            $('.action-alert-close, .alert.has-actions .nav-actions a').bind('click', hideAlert);
+            $('.action-notification-close').bind('click', hideNotification);
 
-    // nav - dropdown related
-    $body.click(function(e) {
-        $('.nav-dd .nav-item .wrapper-nav-sub').removeClass('is-shown');
-        $('.nav-dd .nav-item .title').removeClass('is-selected');
-    });
+            // nav - dropdown related
+            $body.click(function(e) {
+                $('.nav-dd .nav-item .wrapper-nav-sub').removeClass('is-shown');
+                $('.nav-dd .nav-item .title').removeClass('is-selected');
+            });
 
-    $('.nav-dd .nav-item, .filterable-column .nav-item').click(function(e) {
+            $('.nav-dd .nav-item, .filterable-column .nav-item').click(function(e) {
+                $subnav = $(this).find('.wrapper-nav-sub');
+                $title = $(this).find('.title');
 
-        $subnav = $(this).find('.wrapper-nav-sub');
-        $title = $(this).find('.title');
-
-        if ($subnav.hasClass('is-shown')) {
-            $subnav.removeClass('is-shown');
-            $title.removeClass('is-selected');
-        } else {
-            $('.nav-dd .nav-item .title').removeClass('is-selected');
-            $('.nav-dd .nav-item .wrapper-nav-sub').removeClass('is-shown');
-            $title.addClass('is-selected');
-            $subnav.addClass('is-shown');
+                if ($subnav.hasClass('is-shown')) {
+                    $subnav.removeClass('is-shown');
+                    $title.removeClass('is-selected');
+                } else {
+                    $('.nav-dd .nav-item .title').removeClass('is-selected');
+                    $('.nav-dd .nav-item .wrapper-nav-sub').removeClass('is-shown');
+                    $title.addClass('is-selected');
+                    $subnav.addClass('is-shown');
             // if propagation is not stopped, the event will bubble up to the
             // body element, which will close the dropdown.
-            e.stopPropagation();
-        }
-    });
+                    e.stopPropagation();
+                }
+            });
 
-    // general link management - new window/tab
-    $('a[rel="external"]:not([title])').attr('title', gettext('This link will open in a new browser window/tab'));
-    $('a[rel="external"]').attr('target', '_blank');
+            // general link management - new window/tab
+            $('a[rel="external"]:not([title])').attr('title', gettext('This link will open in a new browser window/tab'));
+            $('a[rel="external"]').attr('target', '_blank');
 
-    // general link management - lean modal window
-    $('a[rel="modal"]').attr('title', gettext('This link will open in a modal window')).leanModal({
-        overlay: 0.50,
-        closeButton: '.action-modal-close'
-    });
-    $('.action-modal-close').click(function(e) {
-        (e).preventDefault();
-    });
+            // general link management - lean modal window
+            $('a[rel="modal"]').attr('title', gettext('This link will open in a modal window')).leanModal({
+                overlay: 0.50,
+                closeButton: '.action-modal-close'
+            });
+            $('.action-modal-close').click(function(e) {
+                (e).preventDefault();
+            });
 
-    // general link management - smooth scrolling page links
-    $('a[rel*="view"][href^="#"]').bind('click', smoothScrollLink);
+            // general link management - smooth scrolling page links
+            $('a[rel*="view"][href^="#"]').bind('click', smoothScrollLink);
 
-    IframeUtils.iframeBinding();
+            IframeUtils.iframeBinding();
 
-    // disable ajax caching in IE so that backbone fetches work
-    if ($.browser.msie) {
-        $.ajaxSetup({ cache: false });
-    }
+            // disable ajax caching in IE so that backbone fetches work
+            if ($.browser.msie) {
+                $.ajaxSetup({cache: false});
+            }
 
-    //Initiate the edx tool kit dropdown menu
-    if ($('.js-header-user-menu').length){
-        dropdownMenuView = new DropdownMenuView({
-            el: '.js-header-user-menu'
+            // Initiate the edx tool kit dropdown menu
+            if ($('.js-header-user-menu').length) {
+                dropdownMenuView = new DropdownMenuView({
+                    el: '.js-header-user-menu'
+                });
+                dropdownMenuView.postRender();
+            }
         });
-        dropdownMenuView.postRender();
-    }
-});
 
-function smoothScrollLink(e) {
-    (e).preventDefault();
+        function smoothScrollLink(e) {
+            (e).preventDefault();
 
-    $.smoothScroll({
-        offset: -200,
-        easing: 'swing',
-        speed: 1000,
-        scrollElement: null,
-        scrollTarget: $(this).attr('href')
-    });
-}
+            $.smoothScroll({
+                offset: -200,
+                easing: 'swing',
+                speed: 1000,
+                scrollElement: null,
+                scrollTarget: $(this).attr('href')
+            });
+        }
 
-function smoothScrollTop(e) {
-    (e).preventDefault();
+        function smoothScrollTop(e) {
+            (e).preventDefault();
 
-    $.smoothScroll({
-        offset: -200,
-        easing: 'swing',
-        speed: 1000,
-        scrollElement: null,
-        scrollTarget: $('#view-top')
-    });
-}
+            $.smoothScroll({
+                offset: -200,
+                easing: 'swing',
+                speed: 1000,
+                scrollElement: null,
+                scrollTarget: $('#view-top')
+            });
+        }
 
-function hideNotification(e) {
-    (e).preventDefault();
-    $(this).closest('.wrapper-notification').removeClass('is-shown').addClass('is-hiding').attr('aria-hidden', 'true');
-}
+        function hideNotification(e) {
+            (e).preventDefault();
+            $(this).closest('.wrapper-notification').removeClass('is-shown').addClass('is-hiding').attr('aria-hidden', 'true');
+        }
 
-function hideAlert(e) {
-    (e).preventDefault();
-    $(this).closest('.wrapper-alert').removeClass('is-shown');
-}
-
-}); // end require()
+        function hideAlert(e) {
+            (e).preventDefault();
+            $(this).closest('.wrapper-alert').removeClass('is-shown');
+        }
+    }); // end require()

--- a/cms/static/js/certificates/collections/certificates.js
+++ b/cms/static/js/certificates/collections/certificates.js
@@ -29,7 +29,7 @@ function(Backbone, gettext, Certificate) {
             } catch (ex) {
                 // If it didn't parse, and `certificate_info` is an object then return as it is
                 // otherwise return empty array
-                if (typeof certificate_info === 'object'){
+                if (typeof certificate_info === 'object') {
                     return_array = certificate_info;
                 }
                 else {
@@ -44,28 +44,28 @@ function(Backbone, gettext, Certificate) {
             return return_array;
         },
 
-        onModelRemoved: function () {
+        onModelRemoved: function() {
             // remove the certificate web preview UI.
-            if(window.certWebPreview && this.length === 0) {
+            if (window.certWebPreview && this.length === 0) {
                 window.certWebPreview.remove();
             }
             this.toggleAddNewItemButtonState();
         },
 
-        onModelAdd: function () {
+        onModelAdd: function() {
             this.toggleAddNewItemButtonState();
         },
 
         toggleAddNewItemButtonState: function() {
             // user can create a new item e.g certificate; if not exceeded the maxAllowed limit.
-            if(this.length >= this.maxAllowed) {
-                $(".action-add").addClass('action-add-hidden');
+            if (this.length >= this.maxAllowed) {
+                $('.action-add').addClass('action-add-hidden');
             } else {
-                $(".action-add").removeClass('action-add-hidden');
+                $('.action-add').removeClass('action-add-hidden');
             }
         },
 
-        parse: function (certificatesJson) {
+        parse: function(certificatesJson) {
             // Transforms the provided JSON into a Certificates collection
             var modelArray = this.certificate_array(certificatesJson);
 

--- a/cms/static/js/certificates/factories/certificates_page_factory.js
+++ b/cms/static/js/certificates/factories/certificates_page_factory.js
@@ -20,7 +20,7 @@ define([
 ],
 function($, CertificatesCollection, Certificate, CertificatesPage, CertificatePreview) {
     'use strict';
-    return function (certificatesJson, certificateUrl, courseOutlineUrl, course_modes, certificate_web_view_url,
+    return function(certificatesJson, certificateUrl, courseOutlineUrl, course_modes, certificate_web_view_url,
                      is_active, certificate_activation_handler_url) {
         // Initialize the model collection, passing any necessary options to the constructor
         var certificatesCollection = new CertificatesCollection(certificatesJson, {
@@ -31,7 +31,7 @@ function($, CertificatesCollection, Certificate, CertificatesPage, CertificatePr
 
         // associating the certificate_preview globally.
         // need to show / hide this view in some other places.
-        if(!window.certWebPreview && certificate_web_view_url) {
+        if (!window.certWebPreview && certificate_web_view_url) {
             window.certWebPreview = new CertificatePreview({
                 course_modes: course_modes,
                 certificate_web_view_url: certificate_web_view_url,

--- a/cms/static/js/certificates/models/certificate.js
+++ b/cms/static/js/certificates/models/certificate.js
@@ -1,15 +1,15 @@
 // Backbone.js Application Model: Certificate
 
 define([
-        'underscore',
-        'backbone',
-        'backbone-relational',
-        'backbone.associations',
-        'gettext',
-        'cms/js/main',
-        'js/certificates/models/signatory',
-        'js/certificates/collections/signatories'
-    ],
+    'underscore',
+    'backbone',
+    'backbone-relational',
+    'backbone.associations',
+    'gettext',
+    'cms/js/main',
+    'js/certificates/models/signatory',
+    'js/certificates/collections/signatories'
+],
     function(_, Backbone, BackboneRelational, BackboneAssociations, gettext, CoffeeSrcMain,
              SignatoryModel, SignatoryCollection) {
         'use strict';
@@ -78,7 +78,7 @@ define([
                         attributes: {name: true}
                     };
                 }
-                var allSignatoriesValid  = _.every(attrs.signatories.models, function(signatory){
+                var allSignatoriesValid = _.every(attrs.signatories.models, function(signatory) {
                     return signatory.isValid();
                 });
                 if (!allSignatoriesValid) {

--- a/cms/static/js/certificates/spec/custom_matchers.js
+++ b/cms/static/js/certificates/spec/custom_matchers.js
@@ -3,13 +3,13 @@
 
 define(['jquery'], function($) {  // eslint-disable-line no-unused-vars
     'use strict';
-    return function () {
+    return function() {
         jasmine.addMatchers({
-            toBeCorrectValuesInModel: function () {
+            toBeCorrectValuesInModel: function() {
                 // Assert the value being tested has key values which match the provided values
                 return {
-                    compare: function (actual, values) {
-                        var passed = _.every(values, function (value, key) {
+                    compare: function(actual, values) {
+                        var passed = _.every(values, function(value, key) {
                             return actual.get(key) === value;
                         }.bind(this));
 

--- a/cms/static/js/certificates/spec/models/certificate_spec.js
+++ b/cms/static/js/certificates/spec/models/certificate_spec.js
@@ -11,7 +11,7 @@ function(CertificateModel, CertificateCollection) {
         beforeEach(function() {
             this.newModelOptions = {add: true};
             this.model = new CertificateModel({editing: true}, this.newModelOptions);
-            this.collection = new CertificateCollection([ this.model ], {certificateUrl: '/outline'});
+            this.collection = new CertificateCollection([this.model], {certificateUrl: '/outline'});
         });
 
         describe('Basic', function() {
@@ -39,18 +39,16 @@ function(CertificateModel, CertificateCollection) {
 
         describe('Validation', function() {
             it('requires a name', function() {
-                var model = new CertificateModel({ name: '' }, this.newModelOptions);
+                var model = new CertificateModel({name: ''}, this.newModelOptions);
 
                 expect(model.isValid()).toBeFalsy();
             });
 
             it('can pass validation', function() {
-                var model = new CertificateModel({ name: 'foo' }, this.newModelOptions);
+                var model = new CertificateModel({name: 'foo'}, this.newModelOptions);
 
                 expect(model.isValid()).toBeTruthy();
             });
-
         });
     });
-
 });

--- a/cms/static/js/certificates/spec/views/certificate_details_spec.js
+++ b/cms/static/js/certificates/spec/views/certificate_details_spec.js
@@ -41,15 +41,15 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
         inputSignatoryTitle: '.signatory-title-input',
         inputSignatoryOrganization: '.signatory-organization-input'
     };
-    var verifyAndConfirmPrompt = function(promptSpy, promptText){
+    var verifyAndConfirmPrompt = function(promptSpy, promptText) {
         ViewHelpers.verifyPromptShowing(promptSpy, gettext(promptText));
         ViewHelpers.confirmPrompt(promptSpy);
         ViewHelpers.verifyPromptHidden(promptSpy);
     };
 
     describe('Certificate Details Spec:', function() {
-        var setValuesToInputs = function (view, values) {
-            _.each(values, function (value, selector) {
+        var setValuesToInputs = function(view, values) {
+            _.each(values, function(value, selector) {
                 if (SELECTORS[selector]) {
                     view.$(SELECTORS[selector]).val(value);
                     view.$(SELECTORS[selector]).trigger('change');
@@ -96,8 +96,8 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
                 is_active: true
             }, this.newModelOptions);
 
-            this.collection = new CertificatesCollection([ this.model ], {
-                certificateUrl: '/certificates/'+ window.course.id
+            this.collection = new CertificatesCollection([this.model], {
+                certificateUrl: '/certificates/' + window.course.id
             });
             this.model.set('id', 0);
             this.view = new CertificateDetailsView({
@@ -120,44 +120,43 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
 
 
         describe('The Certificate Details view', function() {
-
-            it('should parse a JSON string collection into a Backbone model collection', function () {
-                var course_title = "Test certificate course title override 2";
+            it('should parse a JSON string collection into a Backbone model collection', function() {
+                var course_title = 'Test certificate course title override 2';
                 var CERTIFICATE_JSON = '[{"course_title": "' + course_title + '", "signatories":"[]"}]';
                 this.collection.parse(CERTIFICATE_JSON);
                 var model = this.collection.at(1);
                 expect(model.get('course_title')).toEqual(course_title);
             });
 
-            it('should parse a JSON object collection into a Backbone model collection', function () {
-                var course_title = "Test certificate course title override 2";
+            it('should parse a JSON object collection into a Backbone model collection', function() {
+                var course_title = 'Test certificate course title override 2';
                 var CERTIFICATE_JSON_OBJECT = [{
-                    "course_title" : course_title,
-                    "signatories" : "[]"
+                    'course_title': course_title,
+                    'signatories': '[]'
                 }];
                 this.collection.parse(CERTIFICATE_JSON_OBJECT);
                 var model = this.collection.at(1);
                 expect(model.get('course_title')).toEqual(course_title);
             });
 
-            it('should have empty certificate collection if there is an error parsing certifcate JSON', function () {
+            it('should have empty certificate collection if there is an error parsing certifcate JSON', function() {
                 var CERTIFICATE_INVALID_JSON = '[{"course_title": Test certificate course title override, "signatories":"[]"}]';  // eslint-disable-line max-len
                 var collection_length = this.collection.length;
                 this.collection.parse(CERTIFICATE_INVALID_JSON);
-                //collection length should remain the same since we have error parsing JSON
+                // collection length should remain the same since we have error parsing JSON
                 expect(this.collection.length).toEqual(collection_length);
             });
 
-            it('should display the certificate course title override', function () {
+            it('should display the certificate course title override', function() {
                 expect(this.view.$(SELECTORS.course_title)).toExist();
                 expect(this.view.$(SELECTORS.course_title)).toContainText('Test Course Title Override');
             });
 
-            it('should present an Edit action', function () {
+            it('should present an Edit action', function() {
                 expect(this.view.$('.edit')).toExist();
             });
 
-            it('should change to "edit" mode when clicking the Edit button and confirming the prompt', function(){
+            it('should change to "edit" mode when clicking the Edit button and confirming the prompt', function() {
                 expect(this.view.$('.action-edit .edit')).toExist();
                 var promptSpy = ViewHelpers.createPromptSpy();
                 this.view.$('.action-edit .edit').click();
@@ -165,67 +164,64 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
                 expect(this.model.get('editing')).toBe(true);
             });
 
-            it('should not show confirmation prompt when clicked on "edit" in case of inactive certificate', function(){
+            it('should not show confirmation prompt when clicked on "edit" in case of inactive certificate', function() {
                 this.model.set('is_active', false);
                 expect(this.view.$('.action-edit .edit')).toExist();
                 this.view.$('.action-edit .edit').click();
                 expect(this.model.get('editing')).toBe(true);
             });
 
-            it('should not present a Edit action if user is not global staff and certificate is active', function () {
+            it('should not present a Edit action if user is not global staff and certificate is active', function() {
                 window.CMS.User = {isGlobalStaff: false};
                 appendSetFixtures(this.view.render().el);
                 expect(this.view.$('.action-edit .edit')).not.toExist();
             });
 
-            it('should present a Delete action', function () {
+            it('should present a Delete action', function() {
                 expect(this.view.$('.action-delete .delete')).toExist();
             });
 
-            it('should not present a Delete action if user is not global staff and certificate is active', function () {
+            it('should not present a Delete action if user is not global staff and certificate is active', function() {
                 window.CMS.User = {isGlobalStaff: false};
                 appendSetFixtures(this.view.render().el);
                 expect(this.view.$('.action-delete .delete')).not.toExist();
             });
 
-            it('should prompt the user when when clicking the Delete button', function(){
+            it('should prompt the user when when clicking the Delete button', function() {
                 expect(this.view.$('.action-delete .delete')).toExist();
                 this.view.$('.action-delete .delete').click();
             });
 
-            it('should scroll to top after rendering if necessary', function () {
+            it('should scroll to top after rendering if necessary', function() {
                 $.smoothScroll = jasmine.createSpy('jQuery.smoothScroll');
                 appendSetFixtures(this.view.render().el);
                 expect($.smoothScroll).toHaveBeenCalled();
             });
-
         });
 
-        describe('Signatory details', function(){
-
+        describe('Signatory details', function() {
             beforeEach(function() {
                 this.view.render();
             });
 
-            it('displays certificate signatories details', function(){
+            it('displays certificate signatories details', function() {
                 this.view.$('.show-details').click();
                 expect(this.view.$(SELECTORS.signatory_name_value)).toContainText('');
                 expect(this.view.$(SELECTORS.signatory_title_value)).toContainText('');
                 expect(this.view.$(SELECTORS.signatory_organization_value)).toContainText('');
             });
 
-            it('should present Edit action on signaotry', function () {
+            it('should present Edit action on signaotry', function() {
                 expect(this.view.$(SELECTORS.edit_signatory)).toExist();
             });
 
-            it('should not present Edit action on signaotry if user is not global staff and certificate is active', function () {
+            it('should not present Edit action on signaotry if user is not global staff and certificate is active', function() {
                 window.CMS.User = {isGlobalStaff: false};
                 this.view.render();
                 expect(this.view.$(SELECTORS.edit_signatory)).not.toExist();
             });
 
             it('supports in-line editing of signatory information', function() {
-
                 this.view.$(SELECTORS.edit_signatory).click();
                 expect(this.view.$(SELECTORS.inputSignatoryName)).toExist();
                 expect(this.view.$(SELECTORS.inputSignatoryTitle)).toExist();
@@ -233,7 +229,6 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
             });
 
             it('correctly persists changes made during in-line signatory editing', function() {
-
                 var requests = AjaxHelpers.requests(this),
                     notificationSpy = ViewHelpers.createNotificationSpy();
 

--- a/cms/static/js/certificates/spec/views/certificate_editor_spec.js
+++ b/cms/static/js/certificates/spec/views/certificate_editor_spec.js
@@ -37,14 +37,14 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
         note: '.wrapper-delete-button',
         addSignatoryButton: '.action-add-signatory',
         signatoryDeleteButton: '.signatory-panel-delete',
-        uploadSignatureButton:'.action-upload-signature',
+        uploadSignatureButton: '.action-upload-signature',
         uploadDialog: 'form.upload-dialog',
         uploadDialogButton: '.action-upload',
         uploadDialogFileInput: 'form.upload-dialog input[type=file]',
         saveCertificateButton: 'button.action-primary'
     };
 
-    var clickDeleteItem = function (that, promptText, element, url) {
+    var clickDeleteItem = function(that, promptText, element, url) {
         var requests = AjaxHelpers.requests(that),
             promptSpy = ViewHelpers.createPromptSpy(),
             notificationSpy = ViewHelpers.createNotificationSpy();
@@ -53,7 +53,7 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
         ViewHelpers.verifyPromptShowing(promptSpy, promptText);
         ViewHelpers.confirmPrompt(promptSpy);
         ViewHelpers.verifyPromptHidden(promptSpy);
-        if (!_.isUndefined(url)  && !_.isEmpty(url)){
+        if (!_.isUndefined(url) && !_.isEmpty(url)) {
             AjaxHelpers.expectJsonRequest(requests, 'POST', url);
             expect(_.last(requests).requestHeaders['X-HTTP-Method-Override']).toBe('DELETE');
             ViewHelpers.verifyNotificationShowing(notificationSpy, /Deleting/);
@@ -62,7 +62,7 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
         }
     };
 
-    var showConfirmPromptAndClickCancel = function (view, element, promptText) {
+    var showConfirmPromptAndClickCancel = function(view, element, promptText) {
         var promptSpy = ViewHelpers.createPromptSpy();
         view.$(element).click();
         ViewHelpers.verifyPromptShowing(promptSpy, promptText);
@@ -70,15 +70,15 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
         ViewHelpers.verifyPromptHidden(promptSpy);
     };
 
-    var uploadFile = function (file_path, requests){
+    var uploadFile = function(file_path, requests) {
         $(SELECTORS.uploadDialogFileInput).change();
         $(SELECTORS.uploadDialogButton).click();
         AjaxHelpers.respondWithJson(requests, {asset: {url: file_path}});
     };
 
     describe('Certificate editor view', function() {
-        var setValuesToInputs = function (view, values) {
-            _.each(values, function (value, selector) {
+        var setValuesToInputs = function(view, values) {
+            _.each(values, function(value, selector) {
                 if (SELECTORS[selector]) {
                     view.$(SELECTORS[selector]).val(value);
                     view.$(SELECTORS[selector]).trigger('change');
@@ -86,8 +86,8 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
             });
         };
         var basicModalTpl = readFixtures('basic-modal.underscore'),
-        modalButtonTpl = readFixtures('modal-button.underscore'),
-        uploadDialogTpl = readFixtures('upload-dialog.underscore');
+            modalButtonTpl = readFixtures('modal-button.underscore'),
+            uploadDialogTpl = readFixtures('upload-dialog.underscore');
 
         beforeEach(function() {
             TemplateHelpers.installTemplates(['certificate-editor', 'signatory-editor'], true);
@@ -110,8 +110,8 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
 
             }, this.newModelOptions);
 
-            this.collection = new CertificatesCollection([ this.model ], {
-                certificateUrl: '/certificates/'+ window.course.id
+            this.collection = new CertificatesCollection([this.model], {
+                certificateUrl: '/certificates/' + window.course.id
             });
             this.model.set('id', 0);
             this.view = new CertificateEditorView({
@@ -127,20 +127,20 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
             delete window.CMS.User;
         });
 
-        describe('Basic', function () {
-            beforeEach(function(){
+        describe('Basic', function() {
+            beforeEach(function() {
                 appendSetFixtures(
-                    $("<script>", { id: "basic-modal-tpl", type: "text/template" }).text(basicModalTpl)
+                    $('<script>', {id: 'basic-modal-tpl', type: 'text/template'}).text(basicModalTpl)
                 );
                 appendSetFixtures(
-                    $("<script>", { id: "modal-button-tpl", type: "text/template" }).text(modalButtonTpl)
+                    $('<script>', {id: 'modal-button-tpl', type: 'text/template'}).text(modalButtonTpl)
                 );
                 appendSetFixtures(
-                    $("<script>", { id: "upload-dialog-tpl", type: "text/template" }).text(uploadDialogTpl)
+                    $('<script>', {id: 'upload-dialog-tpl', type: 'text/template'}).text(uploadDialogTpl)
                 );
             });
 
-            afterEach(function(){
+            afterEach(function() {
                 $('.wrapper-modal-window-assetupload').remove();
             });
 
@@ -198,11 +198,10 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
             });
 
             it('user can only add signatories up to limit', function() {
-                for(var i = 1; i < MAX_SIGNATORIES_LIMIT ; i++) {
+                for (var i = 1; i < MAX_SIGNATORIES_LIMIT; i++) {
                     this.view.$(SELECTORS.addSignatoryButton).click();
                 }
                 expect(this.view.$(SELECTORS.addSignatoryButton)).toHaveClass('disableClick');
-
             });
 
             it('user can add signatories if not reached the upper limit', function() {
@@ -214,14 +213,14 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
 
             it('user can add signatories when signatory reached the upper limit But after deleting a signatory',
                 function() {
-                    for(var i = 1; i < MAX_SIGNATORIES_LIMIT ; i++) {
+                    for (var i = 1; i < MAX_SIGNATORIES_LIMIT; i++) {
                         this.view.$(SELECTORS.addSignatoryButton).click();
                     }
                     expect(this.view.$(SELECTORS.addSignatoryButton)).toHaveClass('disableClick');
 
                     // now delete anyone of the signatory, Add signatory should be enabled.
                     var signatory = this.model.get('signatories').at(0);
-                    var text = 'Delete "'+ signatory.get('name') +'" from the list of signatories?';
+                    var text = 'Delete "' + signatory.get('name') + '" from the list of signatories?';
                     clickDeleteItem(this, text, SELECTORS.signatoryDeleteButton + ':first');
                     expect(this.view.$(SELECTORS.addSignatoryButton)).not.toHaveClass('disableClick');
                 }
@@ -273,8 +272,8 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
                 var signatory = this.model.get('signatories').at(0);
                 var signatory_url = '/certificates/signatory';
                 signatory.url = signatory_url;
-                spyOn(signatory, "isNew").and.returnValue(false);
-                var text = 'Delete "'+ signatory.get('name') +'" from the list of signatories?';
+                spyOn(signatory, 'isNew').and.returnValue(false);
+                var text = 'Delete "' + signatory.get('name') + '" from the list of signatories?';
                 clickDeleteItem(this, text, SELECTORS.signatoryDeleteButton + ':first', signatory_url);
                 expect(this.model.get('signatories').length).toEqual(total_signatories - 1);
             });
@@ -282,13 +281,13 @@ function(_, Course, CertificateModel, SignatoryModel, CertificatesCollection, Ce
             it('can cancel deletion of signatories', function() {
                 this.view.$(SELECTORS.addSignatoryButton).click();
                 var signatory = this.model.get('signatories').at(0);
-                spyOn(signatory, "isNew").and.returnValue(false);
+                spyOn(signatory, 'isNew').and.returnValue(false);
                 // add one more signatory
                 this.view.$(SELECTORS.addSignatoryButton).click();
                 var total_signatories = this.model.get('signatories').length;
                 var signatory_url = '/certificates/signatory';
                 signatory.url = signatory_url;
-                var text = 'Delete "'+ signatory.get('name') +'" from the list of signatories?';
+                var text = 'Delete "' + signatory.get('name') + '" from the list of signatories?';
                 showConfirmPromptAndClickCancel(this.view, SELECTORS.signatoryDeleteButton + ':first', text);
                 expect(this.model.get('signatories').length).toEqual(total_signatories);
             });

--- a/cms/static/js/certificates/spec/views/certificate_preview_spec.js
+++ b/cms/static/js/certificates/spec/views/certificate_preview_spec.js
@@ -19,8 +19,7 @@ function(_, $, Course, CertificatePreview, TemplateHelpers, ViewHelpers, AjaxHel
     };
 
     describe('Certificate Web Preview Spec:', function() {
-
-        var selectDropDownByText = function ( element, value ) {
+        var selectDropDownByText = function(element, value) {
             if (value) {
                 element.val(value);
                 element.trigger('change');
@@ -44,7 +43,7 @@ function(_, $, Course, CertificatePreview, TemplateHelpers, ViewHelpers, AjaxHel
                 el: $('.preview-certificate'),
                 course_modes: ['test1', 'test2', 'test3'],
                 certificate_web_view_url: '/users/1/courses/orgX/009/2016?preview=test1',
-                certificate_activation_handler_url: '/certificates/activation/'+ window.course.id,
+                certificate_activation_handler_url: '/certificates/activation/' + window.course.id,
                 is_active: true
             });
             appendSetFixtures(this.view.render().el);
@@ -56,14 +55,14 @@ function(_, $, Course, CertificatePreview, TemplateHelpers, ViewHelpers, AjaxHel
         });
 
         describe('Certificate preview', function() {
-            it('course mode event should call when user choose a new mode', function () {
+            it('course mode event should call when user choose a new mode', function() {
                 spyOn(this.view, 'courseModeChanged');
                 this.view.delegateEvents();
                 selectDropDownByText(this.view.$(SELECTORS.course_modes), 'test3');
                 expect(this.view.courseModeChanged).toHaveBeenCalled();
             });
 
-            it('course mode selection updating the link successfully', function () {
+            it('course mode selection updating the link successfully', function() {
                 selectDropDownByText(this.view.$(SELECTORS.course_modes), 'test1');
                 expect(this.view.$(SELECTORS.preview_certificate).attr('href')).
                     toEqual('/users/1/courses/orgX/009/2016?preview=test1');
@@ -77,54 +76,52 @@ function(_, $, Course, CertificatePreview, TemplateHelpers, ViewHelpers, AjaxHel
                     toEqual('/users/1/courses/orgX/009/2016?preview=test3');
             });
 
-            it('toggle certificate activation event works fine', function () {
+            it('toggle certificate activation event works fine', function() {
                 spyOn(this.view, 'toggleCertificateActivation');
                 this.view.delegateEvents();
                 this.view.$(SELECTORS.activate_certificate).click();
                 expect(this.view.toggleCertificateActivation).toHaveBeenCalled();
             });
 
-            it('toggle certificate activation button should not be present if user is not global staff', function () {
+            it('toggle certificate activation button should not be present if user is not global staff', function() {
                 window.CMS.User = {isGlobalStaff: false};
                 appendSetFixtures(this.view.render().el);
                 expect(this.view.$(SELECTORS.activate_certificate)).not.toExist();
             });
 
-            it('certificate deactivation works fine', function () {
+            it('certificate deactivation works fine', function() {
                 var requests = AjaxHelpers.requests(this),
                     notificationSpy = ViewHelpers.createNotificationSpy();
                 this.view.$(SELECTORS.activate_certificate).click();
-                AjaxHelpers.expectJsonRequest(requests, 'POST', '/certificates/activation/'+ window.course.id, {
+                AjaxHelpers.expectJsonRequest(requests, 'POST', '/certificates/activation/' + window.course.id, {
                     is_active: false
                 });
                 ViewHelpers.verifyNotificationShowing(notificationSpy, /Deactivating/);
-
             });
 
-            it('certificate activation works fine', function () {
+            it('certificate activation works fine', function() {
                 var requests = AjaxHelpers.requests(this),
                     notificationSpy = ViewHelpers.createNotificationSpy();
                 this.view.is_active = false;
                 this.view.$(SELECTORS.activate_certificate).click();
-                AjaxHelpers.expectJsonRequest(requests, 'POST', '/certificates/activation/'+ window.course.id, {
+                AjaxHelpers.expectJsonRequest(requests, 'POST', '/certificates/activation/' + window.course.id, {
                     is_active: true
                 });
                 ViewHelpers.verifyNotificationShowing(notificationSpy, /Activating/);
-
             });
 
-            it('certificate should be deactivate when method "remove" called', function () {
+            it('certificate should be deactivate when method "remove" called', function() {
                 this.view.remove();
                 expect(this.view.is_active).toBe(false);
             });
 
-            it('certificate web preview should be removed when method "remove" called', function () {
+            it('certificate web preview should be removed when method "remove" called', function() {
                 this.view.remove();
                 expect(this.view.el.innerHTML).toBe('');
             });
 
-            it('method "show" should call the render function', function () {
-                spyOn(this.view, "render");
+            it('method "show" should call the render function', function() {
+                spyOn(this.view, 'render');
                 this.view.show();
                 expect(this.view.render).toHaveBeenCalled();
             });

--- a/cms/static/js/certificates/spec/views/certificates_list_spec.js
+++ b/cms/static/js/certificates/spec/views/certificates_list_spec.js
@@ -16,7 +16,7 @@ define([
     'js/certificates/spec/custom_matchers'
 ],
 function(_, Course, CertificatesCollection, CertificateModel, CertificateDetailsView, CertificateEditorView,
-         CertificateItemView, CertificatesListView, CertificatePreview,  Notification, AjaxHelpers, TemplateHelpers,
+         CertificateItemView, CertificatesListView, CertificatePreview, Notification, AjaxHelpers, TemplateHelpers,
          CustomMatchers) {
     'use strict';
 
@@ -54,7 +54,7 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
             }, {add: true});
 
             this.collection = new CertificatesCollection([], {
-                certificateUrl: '/certificates/'+ window.course.id
+                certificateUrl: '/certificates/' + window.course.id
             });
             this.model.set('id', 0);
             this.view = new CertificatesListView({
@@ -70,7 +70,7 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
             delete window.CMS.User;
         });
 
-        describe('empty template', function () {
+        describe('empty template', function() {
             it('should be rendered if no certificates', function() {
                 expect(this.view.$(SELECTORS.noContent)).toExist();
                 expect(this.view.$(SELECTORS.noContent)).toContainText(emptyMessage);
@@ -99,7 +99,6 @@ function(_, Course, CertificatesCollection, CertificateModel, CertificateDetails
                 this.collection.add(this.model);
                 expect(this.view.$(SELECTORS.itemEditView)).toExist();
             });
-
         });
     });
 });

--- a/cms/static/js/certificates/views/certificate_details.js
+++ b/cms/static/js/certificates/views/certificate_details.js
@@ -21,7 +21,7 @@ function($, _, str, gettext, BaseView, SignatoryModel, SignatoryDetailsView, Vie
             'click .edit': 'editCertificate'
         },
 
-        className: function () {
+        className: function() {
             // Determine the CSS class names for this model instance
             return [
                 'collection',
@@ -40,7 +40,7 @@ function($, _, str, gettext, BaseView, SignatoryModel, SignatoryDetailsView, Vie
             // Flip the model into 'editing' mode
             if (event && event.preventDefault) { event.preventDefault(); }
             var self = this;
-            if (this.model.get("is_active") === true){
+            if (this.model.get('is_active') === true) {
                 ViewUtils.confirmThenRunOperation(
                     gettext('Edit this certificate?'),
                     gettext('This certificate has already been activated and is live. Are you sure you want to continue editing?'),
@@ -50,7 +50,7 @@ function($, _, str, gettext, BaseView, SignatoryModel, SignatoryDetailsView, Vie
                     }
                 );
             }
-            else{
+            else {
                 this.model.set('editing', true);
             }
         },
@@ -63,15 +63,15 @@ function($, _, str, gettext, BaseView, SignatoryModel, SignatoryDetailsView, Vie
                 showDetails: this.showDetails || showDetails || false
             });
             this.$el.html(_.template(certificateDetailsTemplate)(attrs));
-            if(this.showDetails || showDetails) {
+            if (this.showDetails || showDetails) {
                 var self = this;
-                this.model.get("signatories").each(function (modelSignatory) {
+                this.model.get('signatories').each(function(modelSignatory) {
                     var signatory_detail_view = new SignatoryDetailsView({model: modelSignatory});
                     self.$('div.signatory-details-list').append($(signatory_detail_view.render().$el));
                 });
             }
 
-            if(this.model.collection.length > 0 && window.certWebPreview) {
+            if (this.model.collection.length > 0 && window.certWebPreview) {
                 window.certWebPreview.show();
             }
             $.smoothScroll({

--- a/cms/static/js/certificates/views/certificate_editor.js
+++ b/cms/static/js/certificates/views/certificate_editor.js
@@ -30,7 +30,7 @@ function($, _, Backbone, gettext,
             'click .action-add-signatory': 'addSignatory'
         },
 
-        className: function () {
+        className: function() {
             // Determine the CSS class names for this model instance
             var index = this.model.collection.indexOf(this.model);
 
@@ -44,12 +44,12 @@ function($, _, Backbone, gettext,
 
         initialize: function(options) {
             // Set up the initial state of the attributes set for this model instance
-            _.bindAll(this, "onSignatoryRemoved", "clearErrorMessage");
+            _.bindAll(this, 'onSignatoryRemoved', 'clearErrorMessage');
             this.max_signatories_limit = options.max_signatories_limit || MAX_SIGNATORIES_LIMIT;
             this.template = _.template(certificateEditorTemplate);
             this.eventAgg = _.extend({}, Backbone.Events);
-            this.eventAgg.bind("onSignatoryRemoved", this.onSignatoryRemoved);
-            this.eventAgg.bind("onSignatoryUpdated", this.clearErrorMessage);
+            this.eventAgg.bind('onSignatoryRemoved', this.onSignatoryRemoved);
+            this.eventAgg.bind('onSignatoryUpdated', this.clearErrorMessage);
             ListItemEditorView.prototype.initialize.call(this);
         },
 
@@ -69,7 +69,7 @@ function($, _, Backbone, gettext,
             ListItemEditorView.prototype.render.call(this);
             var self = this;
             // Ensure we have at least one signatory associated with the certificate.
-            this.model.get("signatories").each(function( modelSignatory) {
+            this.model.get('signatories').each(function(modelSignatory) {
                 var signatory_view = new SignatoryEditorView({
                     model: modelSignatory,
                     isEditingAllCollections: true,
@@ -89,8 +89,8 @@ function($, _, Backbone, gettext,
 
         disableAddSignatoryButton: function() {
             // Disable the 'Add Signatory' link if the constraint has been met.
-            if(this.$(".signatory-edit-list > div.signatory-edit").length >= this.max_signatories_limit) {
-                this.$(".action-add-signatory").addClass("disableClick");
+            if (this.$('.signatory-edit-list > div.signatory-edit').length >= this.max_signatories_limit) {
+                this.$('.action-add-signatory').addClass('disableClick');
             }
         },
 
@@ -118,7 +118,7 @@ function($, _, Backbone, gettext,
             if (event && event.preventDefault) { event.preventDefault(); }
             this.model.set(
                 'name', this.$('.collection-name-input').val(),
-                { silent: true }
+                {silent: true}
             );
         },
 
@@ -128,7 +128,7 @@ function($, _, Backbone, gettext,
             this.model.set(
                 'description',
                 this.$('.certificate-description-input').val(),
-                { silent: true }
+                {silent: true}
             );
         },
 
@@ -138,7 +138,7 @@ function($, _, Backbone, gettext,
             this.model.set(
                 'course_title',
                 this.$('.certificate-course-title-input').val(),
-                { silent: true }
+                {silent: true}
             );
         },
 

--- a/cms/static/js/certificates/views/certificate_item.js
+++ b/cms/static/js/certificates/views/certificate_item.js
@@ -7,7 +7,7 @@ define([
     'js/certificates/views/certificate_details',
     'js/certificates/views/certificate_editor'
 ],
-function (gettext, ListItemView, CertificateDetailsView, CertificateEditorView) {
+function(gettext, ListItemView, CertificateDetailsView, CertificateEditorView) {
     'use strict';
     var CertificateItemView = ListItemView.extend({
         events: {
@@ -20,7 +20,7 @@ function (gettext, ListItemView, CertificateDetailsView, CertificateEditorView) 
         // Translators: This field pertains to the custom label for a certificate.
         itemDisplayName: gettext('certificate'),
 
-        attributes: function () {
+        attributes: function() {
             // Retrieves the defined attribute set
             return {
                 'id': this.model.get('id'),

--- a/cms/static/js/certificates/views/certificate_preview.js
+++ b/cms/static/js/certificates/views/certificate_preview.js
@@ -8,25 +8,25 @@ define([
     'js/views/baseview',
     'common/js/components/utils/view_utils',
     'common/js/components/views/feedback_notification',
-    "text!templates/certificate-web-preview.underscore"
+    'text!templates/certificate-web-preview.underscore'
 ],
 function(_, gettext, BaseView, ViewUtils, NotificationView, certificateWebPreviewTemplate) {
     'use strict';
     var CertificateWebPreview = BaseView.extend({
-        el: $(".preview-certificate"),
+        el: $('.preview-certificate'),
         events: {
-            "change #course-modes": "courseModeChanged",
-            "click .activate-cert": "toggleCertificateActivation"
+            'change #course-modes': 'courseModeChanged',
+            'click .activate-cert': 'toggleCertificateActivation'
         },
 
-        initialize: function (options) {
+        initialize: function(options) {
             this.course_modes = options.course_modes;
             this.certificate_web_view_url = options.certificate_web_view_url;
             this.certificate_activation_handler_url = options.certificate_activation_handler_url;
             this.is_active = options.is_active;
         },
 
-        render: function () {
+        render: function() {
             this.$el.html(_.template(certificateWebPreviewTemplate)({
                 course_modes: this.course_modes,
                 certificate_web_view_url: this.certificate_web_view_url,
@@ -36,9 +36,9 @@ function(_, gettext, BaseView, ViewUtils, NotificationView, certificateWebPrevie
         },
 
         toggleCertificateActivation: function() {
-            var msg = "Activating";
-            if(this.is_active) {
-                msg = "Deactivating";
+            var msg = 'Activating';
+            if (this.is_active) {
+                msg = 'Deactivating';
             }
 
             var notification = new NotificationView.Mini({
@@ -47,24 +47,24 @@ function(_, gettext, BaseView, ViewUtils, NotificationView, certificateWebPrevie
 
             $.ajax({
                 url: this.certificate_activation_handler_url,
-                type: "POST",
-                dataType: "json",
-                contentType: "application/json",
+                type: 'POST',
+                dataType: 'json',
+                contentType: 'application/json',
                 data: JSON.stringify({
                     is_active: !this.is_active
                 }),
                 beforeSend: function() {
                     notification.show();
                 },
-                success: function(){
+                success: function() {
                     notification.hide();
                     location.reload();
                 }
             });
         },
 
-        courseModeChanged: function (event) {
-            $('.preview-certificate-link').attr('href', function(index, value){
+        courseModeChanged: function(event) {
+            $('.preview-certificate-link').attr('href', function(index, value) {
                 return value.replace(/preview=([^&]+)/, function() {
                     return 'preview=' + event.target.options[event.target.selectedIndex].text;
                 });

--- a/cms/static/js/certificates/views/certificates_list.js
+++ b/cms/static/js/certificates/views/certificates_list.js
@@ -5,7 +5,7 @@ define([
     'js/views/list',
     'js/certificates/views/certificate_item'
 ],
-function (gettext, ListView, CertificateItemView) {
+function(gettext, ListView, CertificateItemView) {
     'use strict';
     var CertificatesListView = ListView.extend({
         tagName: 'div',

--- a/cms/static/js/certificates/views/certificates_page.js
+++ b/cms/static/js/certificates/views/certificates_page.js
@@ -7,7 +7,7 @@ define([
     'js/views/pages/base_page',
     'js/certificates/views/certificates_list'
 ],
-function ($, _, gettext, BasePage, CertificatesListView) {
+function($, _, gettext, BasePage, CertificatesListView) {
     'use strict';
     var CertificatesPage = BasePage.extend({
 

--- a/cms/static/js/certificates/views/signatory_details.js
+++ b/cms/static/js/certificates/views/signatory_details.js
@@ -13,7 +13,7 @@ define([
     'text!templates/signatory-details.underscore',
     'text!templates/signatory-actions.underscore'
 ],
-function ($, _, str, Backbone, gettext, TemplateUtils, ViewUtils, BaseView, SignatoryEditorView,
+function($, _, str, Backbone, gettext, TemplateUtils, ViewUtils, BaseView, SignatoryEditorView,
           signatoryDetailsTemplate, signatoryActionsTemplate) {
     'use strict';
     var SignatoryDetailsView = BaseView.extend({
@@ -25,7 +25,7 @@ function ($, _, str, Backbone, gettext, TemplateUtils, ViewUtils, BaseView, Sign
 
         },
 
-        className: function () {
+        className: function() {
             // Determine the CSS class names for this model instance
             var index = this.model.collection.indexOf(this.model);
             return [
@@ -62,13 +62,13 @@ function ($, _, str, Backbone, gettext, TemplateUtils, ViewUtils, BaseView, Sign
             // Persist the data for this model
             if (event && event.preventDefault) { event.preventDefault(); }
             var certificate = this.model.get('certificate');
-            if (!certificate.isValid()){
+            if (!certificate.isValid()) {
                 return;
             }
             var self = this;
             ViewUtils.runOperationShowingMessage(
                 gettext('Saving'),
-                function () {
+                function() {
                     var dfd = $.Deferred();
                     var actionableModel = certificate;
                     actionableModel.save({}, {

--- a/cms/static/js/certificates/views/signatory_editor.js
+++ b/cms/static/js/certificates/views/signatory_editor.js
@@ -13,7 +13,7 @@ define([
     'js/views/uploads',
     'text!templates/signatory-editor.underscore'
 ],
-function ($, _, Backbone, gettext,
+function($, _, Backbone, gettext,
           TemplateUtils, ViewUtils, PromptView, NotificationView, FileUploadModel, FileUploadDialog,
           signatoryEditorTemplate) {
     'use strict';
@@ -28,7 +28,7 @@ function ($, _, Backbone, gettext,
             'click .action-upload-signature': 'uploadSignatureImage'
         },
 
-        className: function () {
+        className: function() {
             // Determine the CSS class names for this model instance
             var index = this.getModelIndex(this.model);
             return [
@@ -39,7 +39,7 @@ function ($, _, Backbone, gettext,
 
         initialize: function(options) {
             // Set up the initial state of the attributes set for this model instance
-             _.bindAll(this, 'render');
+            _.bindAll(this, 'render');
             this.model.bind('change', this.render);
             this.eventAgg = options.eventAgg;
             this.isEditingAllCollections = options.isEditingAllCollections;
@@ -58,8 +58,8 @@ function ($, _, Backbone, gettext,
         getTotalSignatoriesOnServer: function() {
             // Retrieve the count of signatories stored server-side
             var count = 0;
-            this.model.collection.each(function( modelSignatory) {
-                if(!modelSignatory.isNew()) {
+            this.model.collection.each(function(modelSignatory) {
+                if (!modelSignatory.isNew()) {
                     count ++;
                 }
             });
@@ -87,10 +87,10 @@ function ($, _, Backbone, gettext,
             this.model.set(
                 'name',
                 this.$('.signatory-name-input').val(),
-                { silent: true }
+                {silent: true}
             );
             this.toggleValidationErrorMessage('name');
-            this.eventAgg.trigger("onSignatoryUpdated", this.model);
+            this.eventAgg.trigger('onSignatoryUpdated', this.model);
         },
 
         setSignatoryTitle: function(event) {
@@ -99,10 +99,10 @@ function ($, _, Backbone, gettext,
             this.model.set(
                 'title',
                 this.$('.signatory-title-input').val(),
-                { silent:true }
+                {silent: true}
             );
             this.toggleValidationErrorMessage('title');
-            this.eventAgg.trigger("onSignatoryUpdated", this.model);
+            this.eventAgg.trigger('onSignatoryUpdated', this.model);
         },
 
         setSignatoryOrganization: function(event) {
@@ -111,9 +111,9 @@ function ($, _, Backbone, gettext,
             this.model.set(
                 'organization',
                 this.$('.signatory-organization-input').val(),
-                { silent: true }
+                {silent: true}
             );
-            this.eventAgg.trigger("onSignatoryUpdated", this.model);
+            this.eventAgg.trigger('onSignatoryUpdated', this.model);
         },
 
         setSignatorySignatureImagePath: function(event) {
@@ -121,7 +121,7 @@ function ($, _, Backbone, gettext,
             this.model.set(
                 'signature_image_path',
                 this.$('.signatory-signature-input').val(),
-                { silent: true }
+                {silent: true}
             );
         },
 
@@ -137,21 +137,21 @@ function ($, _, Backbone, gettext,
                 actions: {
                     primary: {
                         text: gettext('Delete'),
-                        click: function () {
+                        click: function() {
                             var deleting = new NotificationView.Mini({
                                 title: gettext('Deleting')
                             });
-                            if (model.isNew()){
+                            if (model.isNew()) {
                                 model.collection.remove(model);
-                                self.eventAgg.trigger("onSignatoryRemoved", model);
+                                self.eventAgg.trigger('onSignatoryRemoved', model);
                             }
                             else {
                                 deleting.show();
                                 model.destroy({
                                     wait: true,
-                                    success: function (model) {
+                                    success: function(model) {
                                         deleting.hide();
-                                        self.eventAgg.trigger("onSignatoryRemoved", model);
+                                        self.eventAgg.trigger('onSignatoryRemoved', model);
                                     }
                                 });
                             }
@@ -172,8 +172,8 @@ function ($, _, Backbone, gettext,
         uploadSignatureImage: function(event) {
             event.preventDefault();
             var upload = new FileUploadModel({
-                title: gettext("Upload signature image."),
-                message: gettext("Image must be in PNG format."),
+                title: gettext('Upload signature image.'),
+                message: gettext('Image must be in PNG format.'),
                 mimeTypes: ['image/png']
             });
             var self = this;
@@ -192,20 +192,19 @@ function ($, _, Backbone, gettext,
          * @param string modelAttribute - the attribute of the signatory model e.g. name, title.
         */
         toggleValidationErrorMessage: function(modelAttribute) {
-            var selector = "div.add-signatory-" + modelAttribute;
+            var selector = 'div.add-signatory-' + modelAttribute;
             if (!this.model.isValid() && _.has(this.model.validationError, modelAttribute)) {
-
                 // Show the error message if it is not exist before.
-                if( !$(selector).hasClass('error')) {
+                if (!$(selector).hasClass('error')) {
                     var errorMessage = this.model.validationError[modelAttribute];
-                    $(selector).addClass("error");
-                    $(selector).append("<span class='message-error'>" + errorMessage + "</span>");
+                    $(selector).addClass('error');
+                    $(selector).append("<span class='message-error'>" + errorMessage + '</span>');
                 }
             }
             else {
                 // Remove the error message.
-                $(selector).removeClass("error");
-                $(selector + ">span.message-error").remove();
+                $(selector).removeClass('error');
+                $(selector + '>span.message-error').remove();
             }
         }
 

--- a/cms/static/js/collections/asset.js
+++ b/cms/static/js/collections/asset.js
@@ -1,13 +1,13 @@
 define([
-    "underscore",
-    "edx-ui-toolkit/js/pagination/paging-collection",
-    "js/models/asset"
+    'underscore',
+    'edx-ui-toolkit/js/pagination/paging-collection',
+    'js/models/asset'
 ], function(_, PagingCollection, AssetModel) {
     'use strict';
 
     var AssetCollection = PagingCollection.extend({
         assetType: '',
-        model : AssetModel,
+        model: AssetModel,
 
         state: {
             firstPage: 0,

--- a/cms/static/js/collections/chapter.js
+++ b/cms/static/js/collections/chapter.js
@@ -1,9 +1,9 @@
-define(["backbone", "js/models/chapter"], function(Backbone, ChapterModel) {
+define(['backbone', 'js/models/chapter'], function(Backbone, ChapterModel) {
     var ChapterCollection = Backbone.Collection.extend({
         model: ChapterModel,
-        comparator: "order",
+        comparator: 'order',
         nextOrder: function() {
-            if(!this.length) return 1;
+            if (!this.length) return 1;
             return this.last().get('order') + 1;
         },
         isEmpty: function() {

--- a/cms/static/js/collections/component_template.js
+++ b/cms/static/js/collections/component_template.js
@@ -1,5 +1,5 @@
-define(["backbone", "js/models/component_template"], function(Backbone, ComponentTemplate) {
+define(['backbone', 'js/models/component_template'], function(Backbone, ComponentTemplate) {
     return Backbone.Collection.extend({
-        model : ComponentTemplate
+        model: ComponentTemplate
     });
 });

--- a/cms/static/js/collections/course_grader.js
+++ b/cms/static/js/collections/course_grader.js
@@ -1,11 +1,10 @@
-define(["backbone", "js/models/settings/course_grader"], function(Backbone, CourseGrader) {
+define(['backbone', 'js/models/settings/course_grader'], function(Backbone, CourseGrader) {
+    var CourseGraderCollection = Backbone.Collection.extend({
+        model: CourseGrader,
+        sumWeights: function() {
+            return this.reduce(function(subtotal, grader) { return subtotal + grader.get('weight'); }, 0);
+        }
+    });
 
-var CourseGraderCollection = Backbone.Collection.extend({
-    model : CourseGrader,
-    sumWeights : function() {
-        return this.reduce(function(subtotal, grader) { return subtotal + grader.get('weight'); }, 0);
-    }
-});
-
-return CourseGraderCollection;
+    return CourseGraderCollection;
 }); // end define()

--- a/cms/static/js/collections/course_update.js
+++ b/cms/static/js/collections/course_update.js
@@ -1,4 +1,4 @@
-define(["backbone", "js/models/course_update"], function(Backbone, CourseUpdateModel) {
+define(['backbone', 'js/models/course_update'], function(Backbone, CourseUpdateModel) {
     /*
         The intitializer of this collection must set id to the update's location.url and courseLocation to the course's location. Must pass the
         collection of updates as [{ date : "month day", content : "html"}]
@@ -6,7 +6,7 @@ define(["backbone", "js/models/course_update"], function(Backbone, CourseUpdateM
     var CourseUpdateCollection = Backbone.Collection.extend({
         // instantiator must set url
 
-        model : CourseUpdateModel
+        model: CourseUpdateModel
     });
     return CourseUpdateCollection;
 });

--- a/cms/static/js/collections/group.js
+++ b/cms/static/js/collections/group.js
@@ -1,7 +1,7 @@
 define([
     'underscore', 'underscore.string', 'backbone', 'gettext', 'js/models/group'
 ],
-function (_, str, Backbone, gettext, GroupModel) {
+function(_, str, Backbone, gettext, GroupModel) {
     'use strict';
     var GroupCollection = Backbone.Collection.extend({
         model: GroupModel,
@@ -11,7 +11,7 @@ function (_, str, Backbone, gettext, GroupModel) {
          * @return {Number}
          */
         nextOrder: function() {
-            if(!this.length) {
+            if (!this.length) {
                 return 0;
             }
 
@@ -33,7 +33,7 @@ function (_, str, Backbone, gettext, GroupModel) {
          * @examples
          * Group A, Group B, Group AA, Group ZZZ etc.
          */
-        getNextDefaultGroupName: function () {
+        getNextDefaultGroupName: function() {
             var index = this.nextOrder(),
                 usedNames = _.pluck(this.toJSON(), 'name'),
                 name = '';
@@ -53,7 +53,7 @@ function (_, str, Backbone, gettext, GroupModel) {
          * @examples
          * A, B, AA in Group A, Group B, ..., Group AA, etc.
          */
-        getGroupId: (function () {
+        getGroupId: (function() {
             /*
                 Translators: Dictionary used for creation ids that are used in
                 default group names. For example: A, B, AA in Group A,

--- a/cms/static/js/collections/metadata.js
+++ b/cms/static/js/collections/metadata.js
@@ -1,7 +1,7 @@
-define(["backbone", "js/models/metadata"], function(Backbone, MetadataModel) {
+define(['backbone', 'js/models/metadata'], function(Backbone, MetadataModel) {
     var MetadataCollection = Backbone.Collection.extend({
-        model : MetadataModel,
-        comparator: "display_name"
+        model: MetadataModel,
+        comparator: 'display_name'
     });
     return MetadataCollection;
 });

--- a/cms/static/js/collections/textbook.js
+++ b/cms/static/js/collections/textbook.js
@@ -1,8 +1,8 @@
-define(["backbone", "js/models/textbook"],
+define(['backbone', 'js/models/textbook'],
         function(Backbone, TextbookModel) {
-    var TextbookCollection = Backbone.Collection.extend({
-        model: TextbookModel,
-        url: function() { return CMS.URL.TEXTBOOKS; }
-    });
-    return TextbookCollection;
-});
+            var TextbookCollection = Backbone.Collection.extend({
+                model: TextbookModel,
+                url: function() { return CMS.URL.TEXTBOOKS; }
+            });
+            return TextbookCollection;
+        });

--- a/cms/static/js/factories/asset_index.js
+++ b/cms/static/js/factories/asset_index.js
@@ -2,17 +2,17 @@ define([
     'jquery', 'js/collections/asset', 'js/views/assets', 'jquery.fileupload'
 ], function($, AssetCollection, AssetsView) {
     'use strict';
-    return function (config) {
+    return function(config) {
         var assets = new AssetCollection(),
             assetsView;
 
         assets.url = config.assetCallbackUrl;
         assetsView = new AssetsView({
-          collection: assets,
-          el: $('.wrapper-assets'),
-          uploadChunkSizeInMBs: config.uploadChunkSizeInMBs,
-          maxFileSizeInMBs: config.maxFileSizeInMBs,
-          maxFileSizeRedirectUrl: config.maxFileSizeRedirectUrl
+            collection: assets,
+            el: $('.wrapper-assets'),
+            uploadChunkSizeInMBs: config.uploadChunkSizeInMBs,
+            maxFileSizeInMBs: config.maxFileSizeInMBs,
+            maxFileSizeRedirectUrl: config.maxFileSizeRedirectUrl
         });
         assetsView.render();
     };

--- a/cms/static/js/factories/container.js
+++ b/cms/static/js/factories/container.js
@@ -5,7 +5,7 @@ define([
 ],
 function($, _, XBlockContainerInfo, ContainerPage, ComponentTemplates, xmoduleLoader) {
     'use strict';
-    return function (componentTemplates, XBlockInfoJson, action, options) {
+    return function(componentTemplates, XBlockInfoJson, action, options) {
         var main_options = {
             el: $('#content'),
             model: new XBlockContainerInfo(XBlockInfoJson, {parse: true}),
@@ -13,7 +13,7 @@ function($, _, XBlockContainerInfo, ContainerPage, ComponentTemplates, xmoduleLo
             templates: new ComponentTemplates(componentTemplates, {parse: true})
         };
 
-        xmoduleLoader.done(function () {
+        xmoduleLoader.done(function() {
             var view = new ContainerPage(_.extend(main_options, options));
             view.render();
         });

--- a/cms/static/js/factories/course_create_rerun.js
+++ b/cms/static/js/factories/course_create_rerun.js
@@ -1,4 +1,4 @@
-define(['jquery', 'jquery.form', 'js/views/course_rerun'], function ($) {
+define(['jquery', 'jquery.form', 'js/views/course_rerun'], function($) {
     'use strict';
-    return function () {};
+    return function() {};
 });

--- a/cms/static/js/factories/course_info.js
+++ b/cms/static/js/factories/course_info.js
@@ -3,7 +3,7 @@ define([
     'js/models/course_info', 'js/views/course_info_edit'
 ], function($, CourseUpdateCollection, ModuleInfoModel, CourseInfoModel, CourseInfoEditView) {
     'use strict';
-    return function (updatesUrl, handoutsLocator, baseAssetUrl, push_notification_enabled) {
+    return function(updatesUrl, handoutsLocator, baseAssetUrl, push_notification_enabled) {
         var course_updates = new CourseUpdateCollection(),
             course_handouts, editor;
 
@@ -14,10 +14,10 @@ define([
         });
         editor = new CourseInfoEditView({
             el: $('.main-wrapper'),
-            model : new CourseInfoModel({
-                updates : course_updates,
-                base_asset_url : baseAssetUrl,
-                handouts : course_handouts
+            model: new CourseInfoModel({
+                updates: course_updates,
+                base_asset_url: baseAssetUrl,
+                handouts: course_handouts
             }),
             push_notification_enabled: push_notification_enabled
         });

--- a/cms/static/js/factories/edit_tabs.js
+++ b/cms/static/js/factories/edit_tabs.js
@@ -1,9 +1,9 @@
 define([
     'js/models/explicit_url', 'js/views/tabs', 'xmodule', 'cms/js/main', 'xblock/cms.runtime.v1'
-], function (TabsModel, TabsEditView, xmoduleLoader) {
+], function(TabsModel, TabsEditView, xmoduleLoader) {
     'use strict';
-    return function (courseLocation, explicitUrl) {
-        xmoduleLoader.done(function () {
+    return function(courseLocation, explicitUrl) {
+        xmoduleLoader.done(function() {
             var model = new TabsModel({
                     id: courseLocation,
                     explicit_url: explicitUrl

--- a/cms/static/js/factories/export.js
+++ b/cms/static/js/factories/export.js
@@ -1,8 +1,8 @@
 define(['gettext', 'common/js/components/views/feedback_prompt'], function(gettext, PromptView) {
     'use strict';
-    return function (hasUnit, editUnitUrl, courselikeHomeUrl, library, errMsg) {
+    return function(hasUnit, editUnitUrl, courselikeHomeUrl, library, errMsg) {
         var dialog;
-        if(hasUnit) {
+        if (hasUnit) {
             dialog = new PromptView({
                 title: gettext('There has been an error while exporting.'),
                 message: gettext('There has been a failure to export to XML at least one component. It is recommended that you go to the edit page and repair the error before attempting another export. Please check that all components on the page are valid and do not display any error messages.'),
@@ -28,10 +28,10 @@ define(['gettext', 'common/js/components/views/feedback_prompt'], function(gette
             var action;
             if (library) {
                 msg += gettext('Your library could not be exported to XML. There is not enough information to identify the failed component. Inspect your library to identify any problematic components and try again.');
-                action = gettext('Take me to the main library page')
+                action = gettext('Take me to the main library page');
             } else {
                 msg += gettext('Your course could not be exported to XML. There is not enough information to identify the failed component. Inspect your course to identify any problematic components and try again.');
-                action = gettext('Take me to the main course page')
+                action = gettext('Take me to the main course page');
             }
             msg += '</p><p>' + gettext('The raw error message is:') + '</p>' + errMsg;
             dialog = new PromptView({
@@ -49,7 +49,7 @@ define(['gettext', 'common/js/components/views/feedback_prompt'], function(gette
                     secondary: {
                         text: gettext('Cancel'),
                         click: function(view) {
-                          view.hide();
+                            view.hide();
                         }
                     }
                 }

--- a/cms/static/js/factories/group_configurations.js
+++ b/cms/static/js/factories/group_configurations.js
@@ -2,7 +2,7 @@ define([
     'js/collections/group_configuration', 'js/models/group_configuration', 'js/views/pages/group_configurations'
 ], function(GroupConfigurationCollection, GroupConfigurationModel, GroupConfigurationsPage) {
     'use strict';
-    return function (experimentsEnabled, experimentGroupConfigurationsJson, contentGroupConfigurationJson,
+    return function(experimentsEnabled, experimentGroupConfigurationsJson, contentGroupConfigurationJson,
                      groupConfigurationUrl, courseOutlineUrl) {
         var experimentGroupConfigurations = new GroupConfigurationCollection(
                 experimentGroupConfigurationsJson, {parse: true}

--- a/cms/static/js/factories/import.js
+++ b/cms/static/js/factories/import.js
@@ -1,10 +1,9 @@
 define([
     'domReady', 'js/views/import', 'jquery', 'gettext', 'jquery.fileupload', 'jquery.cookie'
 ], function(domReady, Import, $, gettext) {
-
     'use strict';
 
-    return function (feedbackUrl, library) {
+    return function(feedbackUrl, library) {
         var dbError;
 
         if (library) {
@@ -27,14 +26,14 @@ define([
             previousImport = Import.storedImport(),
             file;
 
-        var onComplete = function () {
+        var onComplete = function() {
             bar.hide();
             chooseBtn
-                .find('.copy').html(gettext("Choose new file")).end()
+                .find('.copy').html(gettext('Choose new file')).end()
                 .show();
-        }
+        };
 
-        $(window).on('beforeunload', function (event) { unloading = true; });
+        $(window).on('beforeunload', function(event) { unloading = true; });
 
         // Display the status of last file upload on page load
         if (previousImport) {
@@ -70,11 +69,11 @@ define([
                         ).then(onComplete);
 
                         submitBtn.hide();
-                        data.submit().complete(function (result, textStatus, xhr) {
+                        data.submit().complete(function(result, textStatus, xhr) {
                             if (xhr.status !== 200) {
                                 var serverMsg, errMsg, stage;
 
-                                try{
+                                try {
                                     serverMsg = $.parseJSON(result.responseText) || {};
                                 } catch (e) {
                                     return;
@@ -104,7 +103,7 @@ define([
                 }
             },
 
-            progressall: function(e, data){
+            progressall: function(e, data) {
                 var percentInt = data.loaded / data.total * 100,
                     percentVal = parseInt(percentInt, 10) + '%',
                     doneAt;
@@ -121,7 +120,7 @@ define([
 
                     // Start feedback with delay so that current stage of
                     // import properly updates in session
-                    setTimeout(function () { Import.pollStatus(); }, 3000);
+                    setTimeout(function() { Import.pollStatus(); }, 3000);
                 } else {
                     bar.show();
                     fill.width(percentVal).html(percentVal);
@@ -132,7 +131,7 @@ define([
         });
 
 
-        var showImportSubmit = function (e) {
+        var showImportSubmit = function(e) {
             var filepath = $(this).val();
 
             if (filepath.substr(filepath.length - 6, 6) === 'tar.gz') {
@@ -150,10 +149,10 @@ define([
             }
         };
 
-        domReady(function () {
+        domReady(function() {
             // import form setup
             $('.view-import .file-input').bind('change', showImportSubmit);
-            $('.view-import .choose-file-button, .view-import .choose-file-button-inline').bind('click', function (e) {
+            $('.view-import .choose-file-button, .view-import .choose-file-button-inline').bind('click', function(e) {
                 e.preventDefault();
                 $('.view-import .file-input').click();
             });

--- a/cms/static/js/factories/index.js
+++ b/cms/static/js/factories/index.js
@@ -1,6 +1,6 @@
 define(['jquery.form', 'js/index'], function() {
     'use strict';
-    return function () {
+    return function() {
         // showing/hiding creation rights UI
         $('.show-creationrights').click(function(e) {
             e.preventDefault();
@@ -11,11 +11,11 @@ define(['jquery.form', 'js/index'], function() {
                     .toggleClass('current');
         });
 
-        var reloadPage = function () {
+        var reloadPage = function() {
             location.reload();
         };
 
-        var showError = function ()  {
+        var showError = function() {
             $('#request-coursecreator-submit')
                 .toggleClass('has-error')
                 .find('.label')
@@ -30,7 +30,7 @@ define(['jquery.form', 'js/index'], function() {
             success: reloadPage
         });
 
-        $('#request-coursecreator-submit').click(function(event){
+        $('#request-coursecreator-submit').click(function(event) {
             $(this)
                 .toggleClass('is-disabled is-submitting')
                 .attr('aria-disabled', $(this).hasClass('is-disabled'))

--- a/cms/static/js/factories/library.js
+++ b/cms/static/js/factories/library.js
@@ -5,7 +5,7 @@ define([
 ],
 function($, _, XBlockInfo, PagedContainerPage, LibraryContainerView, ComponentTemplates, xmoduleLoader) {
     'use strict';
-    return function (componentTemplates, XBlockInfoJson, options) {
+    return function(componentTemplates, XBlockInfoJson, options) {
         var main_options = {
             el: $('#content'),
             model: new XBlockInfo(XBlockInfoJson, {parse: true}),
@@ -15,7 +15,7 @@ function($, _, XBlockInfo, PagedContainerPage, LibraryContainerView, ComponentTe
             canEdit: true
         };
 
-        xmoduleLoader.done(function () {
+        xmoduleLoader.done(function() {
             var view = new PagedContainerPage(_.extend(main_options, options));
             view.render();
         });

--- a/cms/static/js/factories/login.js
+++ b/cms/static/js/factories/login.js
@@ -1,22 +1,22 @@
 define(['jquery.cookie', 'utility', 'common/js/components/utils/view_utils'], function(cookie, utility, ViewUtils) {
     'use strict';
-    return function (homepageURL) {
+    return function(homepageURL) {
         function postJSON(url, data, callback) {
             $.ajax({
-                type:'POST',
+                type: 'POST',
                 url: url,
                 dataType: 'json',
                 data: data,
-                success: callback,
+                success: callback
             });
         }
 
         // Clear the login error message when credentials are edited
-        $('input#email').on('input',function() {
+        $('input#email').on('input', function() {
             $('#login_error').removeClass('is-shown');
         });
 
-        $('input#password').on('input',function() {
+        $('input#password').on('input', function() {
             $('#login_error').removeClass('is-shown');
         });
 
@@ -29,14 +29,14 @@ define(['jquery.cookie', 'utility', 'common/js/components/utils/view_utils'], fu
             var submit_data = $('#login_form').serialize();
 
             postJSON('/login_post', submit_data, function(json) {
-                if(json.success) {
+                if (json.success) {
                     var next = /next=([^&]*)/g.exec(decodeURIComponent(window.location.search));
                     if (next && next.length > 1 && !isExternal(next[1])) {
                         ViewUtils.redirect(next[1]);
                     } else {
                         ViewUtils.redirect(homepageURL);
                     }
-                } else if($('#login_error').length === 0) {
+                } else if ($('#login_error').length === 0) {
                     $('#login_form').prepend(
                         '<div id="login_error" class="message message-status error">' +
                         json.value +

--- a/cms/static/js/factories/manage_users.js
+++ b/cms/static/js/factories/manage_users.js
@@ -4,7 +4,7 @@
 define(['underscore', 'gettext', 'js/views/manage_users_and_roles'],
 function(_, gettext, ManageUsersAndRoles) {
     'use strict';
-    return function (containerName, users, tplUserURL, current_user_id, allow_actions) {
+    return function(containerName, users, tplUserURL, current_user_id, allow_actions) {
         function updateMessages(messages) {
             var local_messages = _.extend({}, messages);
             local_messages.alreadyMember.title = gettext('Already a course team member');
@@ -16,10 +16,10 @@ function(_, gettext, ManageUsersAndRoles) {
         // Roles order are important: first role is considered initial role (the role added to user when (s)he's added
         // Last role is considered an admin role (unrestricted access + ability to manage other users' permissions)
         // Changing roles is performed in promote-demote fashion, so moves only to adjacent roles is allowed
-        var roles = [{key:'staff', name:gettext('Staff')}, {key:'instructor', 'name': gettext("Admin")}];
+        var roles = [{key: 'staff', name: gettext('Staff')}, {key: 'instructor', 'name': gettext('Admin')}];
 
         var options = {
-            el: $("#content"),
+            el: $('#content'),
             containerName: containerName,
             tplUserURL: tplUserURL,
             roles: roles,

--- a/cms/static/js/factories/manage_users_lib.js
+++ b/cms/static/js/factories/manage_users_lib.js
@@ -4,7 +4,7 @@
 define(['underscore', 'gettext', 'js/views/manage_users_and_roles'],
 function(_, gettext, ManageUsersAndRoles) {
     'use strict';
-    return function (containerName, users, tplUserURL, current_user_id, allow_actions) {
+    return function(containerName, users, tplUserURL, current_user_id, allow_actions) {
         function updateMessages(messages) {
             var local_messages = _.extend({}, messages);
             local_messages.alreadyMember.title = gettext('Already a library team member');
@@ -17,13 +17,13 @@ function(_, gettext, ManageUsersAndRoles) {
         // Last role is considered an admin role (unrestricted access + ability to manage other users' permissions)
         // Changing roles is performed in promote-demote fashion, so moves only to adjacent roles is allowed
         var roles = [
-            {key:'library_user', name:gettext('Library User')},
-            {key:'staff', name:gettext('Staff')},
-            {key:'instructor', 'name': gettext("Admin")}
+            {key: 'library_user', name: gettext('Library User')},
+            {key: 'staff', name: gettext('Staff')},
+            {key: 'instructor', 'name': gettext('Admin')}
         ];
 
         var options = {
-            el: $("#content"),
+            el: $('#content'),
             containerName: containerName,
             tplUserURL: tplUserURL,
             roles: roles,

--- a/cms/static/js/factories/outline.js
+++ b/cms/static/js/factories/outline.js
@@ -2,7 +2,7 @@ define([
     'js/views/pages/course_outline', 'js/models/xblock_outline_info'
 ], function(CourseOutlinePage, XBlockOutlineInfo) {
     'use strict';
-    return function (XBlockOutlineInfoJson, initialStateJson) {
+    return function(XBlockOutlineInfoJson, initialStateJson) {
         var courseXBlock = new XBlockOutlineInfo(XBlockOutlineInfoJson, {parse: true}),
             view = new CourseOutlinePage({
                 el: $('#content'),

--- a/cms/static/js/factories/register.js
+++ b/cms/static/js/factories/register.js
@@ -1,6 +1,6 @@
 define(['jquery', 'jquery.cookie'], function($) {
     'use strict';
-    return function () {
+    return function() {
         $('form :input')
             .focus(function() {
                 $('label[for="' + this.id + '"]').addClass('is-focused');
@@ -21,11 +21,11 @@ define(['jquery', 'jquery.cookie'], function($) {
                 notifyOnError: false,
                 data: submit_data,
                 success: function(json) {
-                   location.href = '/course/';
+                    location.href = '/course/';
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
-                   var json = $.parseJSON(jqXHR.responseText);
-                   $('#register_error').html(json.value).stop().addClass('is-shown');
+                    var json = $.parseJSON(jqXHR.responseText);
+                    $('#register_error').html(json.value).stop().addClass('is-shown');
                 }
             });
         });

--- a/cms/static/js/factories/settings.js
+++ b/cms/static/js/factories/settings.js
@@ -2,7 +2,7 @@ define([
     'jquery', 'js/models/settings/course_details', 'js/views/settings/main'
 ], function($, CourseDetailsModel, MainView) {
     'use strict';
-    return function (detailsUrl, showMinGradeWarning) {
+    return function(detailsUrl, showMinGradeWarning) {
         var model;
         // highlighting labels when fields are focused in
         $('form :input')

--- a/cms/static/js/factories/settings_advanced.js
+++ b/cms/static/js/factories/settings_advanced.js
@@ -2,7 +2,7 @@ define([
     'jquery', 'gettext', 'js/models/settings/advanced', 'js/views/settings/advanced'
 ], function($, gettext, AdvancedSettingsModel, AdvancedSettingsView) {
     'use strict';
-    return function (advancedDict, advancedSettingsUrl) {
+    return function(advancedDict, advancedSettingsUrl) {
         var advancedModel, editor;
 
         $('form :input')

--- a/cms/static/js/factories/settings_graders.js
+++ b/cms/static/js/factories/settings_graders.js
@@ -2,7 +2,7 @@ define([
     'jquery', 'js/views/settings/grading', 'js/models/settings/course_grading_policy'
 ], function($, GradingView, CourseGradingPolicyModel) {
     'use strict';
-    return function (courseDetails, gradingUrl) {
+    return function(courseDetails, gradingUrl) {
         var model, editor;
 
         $('form :input')
@@ -13,11 +13,11 @@ define([
                 $('label').removeClass('is-focused');
             });
 
-        model = new CourseGradingPolicyModel(courseDetails,{parse:true});
+        model = new CourseGradingPolicyModel(courseDetails, {parse: true});
         model.urlRoot = gradingUrl;
         editor = new GradingView({
             el: $('.settings-grading'),
-            model : model
+            model: model
         });
         editor.render();
     };

--- a/cms/static/js/factories/textbooks.js
+++ b/cms/static/js/factories/textbooks.js
@@ -2,7 +2,7 @@ define([
     'gettext', 'js/models/section', 'js/collections/textbook', 'js/views/list_textbooks'
 ], function(gettext, Section, TextbookCollection, ListTextbooksView) {
     'use strict';
-    return function (textbooksJson) {
+    return function(textbooksJson) {
         var textbooks = new TextbookCollection(textbooksJson, {parse: true}),
             tbView = new ListTextbooksView({collection: textbooks});
 
@@ -12,7 +12,7 @@ define([
         });
         $(window).on('beforeunload', function() {
             var dirty = textbooks.find(function(textbook) { return textbook.isDirty(); });
-            if(dirty) {
+            if (dirty) {
                 return gettext('You have unsaved changes. Do you really want to leave this page?');
             }
         });

--- a/cms/static/js/factories/videos_index.js
+++ b/cms/static/js/factories/videos_index.js
@@ -1,7 +1,7 @@
 define(
-    ["jquery", "backbone", "js/views/active_video_upload_list", "js/views/previous_video_upload_list"],
-    function ($, Backbone, ActiveVideoUploadListView, PreviousVideoUploadListView) {
-        "use strict";
+    ['jquery', 'backbone', 'js/views/active_video_upload_list', 'js/views/previous_video_upload_list'],
+    function($, Backbone, ActiveVideoUploadListView, PreviousVideoUploadListView) {
+        'use strict';
         var VideosIndexFactory = function(
             $contentWrapper,
             postUrl,

--- a/cms/static/js/factories/xblock_validation.js
+++ b/cms/static/js/factories/xblock_validation.js
@@ -1,14 +1,14 @@
-define(["js/views/xblock_validation", "js/models/xblock_validation"],
-function (XBlockValidationView, XBlockValidationModel) {
+define(['js/views/xblock_validation', 'js/models/xblock_validation'],
+function(XBlockValidationView, XBlockValidationModel) {
     'use strict';
-    return function (validationMessages, hasEditingUrl, isRoot, validationEle) {
+    return function(validationMessages, hasEditingUrl, isRoot, validationEle) {
         if (hasEditingUrl && !isRoot) {
             validationMessages.showSummaryOnly = true;
         }
 
         var model = new XBlockValidationModel(validationMessages, {parse: true});
 
-        if (!model.get("empty")) {
+        if (!model.get('empty')) {
             new XBlockValidationView({el: validationEle, model: model, root: isRoot}).render();
         }
     };

--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -1,7 +1,7 @@
-define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/views/utils/create_course_utils",
-    "js/views/utils/create_library_utils", "common/js/components/utils/view_utils"],
-    function (domReady, $, _, CancelOnEscape, CreateCourseUtilsFactory, CreateLibraryUtilsFactory, ViewUtils) {
-        "use strict";
+define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/views/utils/create_course_utils',
+    'js/views/utils/create_library_utils', 'common/js/components/utils/view_utils'],
+    function(domReady, $, _, CancelOnEscape, CreateCourseUtilsFactory, CreateLibraryUtilsFactory, ViewUtils) {
+        'use strict';
         var CreateCourseUtils = new CreateCourseUtilsFactory({
             name: '.new-course-name',
             org: '.new-course-org',
@@ -39,7 +39,7 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
             error: 'error'
         });
 
-        var saveNewCourse = function (e) {
+        var saveNewCourse = function(e) {
             e.preventDefault();
 
             if (CreateCourseUtils.hasInvalidRequiredFields()) {
@@ -60,27 +60,27 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
             };
 
             analytics.track('Created a Course', course_info);
-            CreateCourseUtils.create(course_info, function (errorMessage) {
+            CreateCourseUtils.create(course_info, function(errorMessage) {
                 $('.create-course .wrap-error').addClass('is-shown');
                 $('#course_creation_error').html('<p>' + errorMessage + '</p>');
                 $('.new-course-save').addClass('is-disabled').attr('aria-disabled', true);
             });
         };
 
-        var makeCancelHandler = function (addType) {
+        var makeCancelHandler = function(addType) {
             return function(e) {
                 e.preventDefault();
-                $('.new-'+addType+'-button').removeClass('is-disabled').attr('aria-disabled', false);
-                $('.wrapper-create-'+addType).removeClass('is-shown');
+                $('.new-' + addType + '-button').removeClass('is-disabled').attr('aria-disabled', false);
+                $('.wrapper-create-' + addType).removeClass('is-shown');
                 // Clear out existing fields and errors
-                $('#create-'+addType+'-form input[type=text]').val('');
-                $('#'+addType+'_creation_error').html('');
-                $('.create-'+addType+' .wrap-error').removeClass('is-shown');
-                $('.new-'+addType+'-save').off('click');
+                $('#create-' + addType + '-form input[type=text]').val('');
+                $('#' + addType + '_creation_error').html('');
+                $('.create-' + addType + ' .wrap-error').removeClass('is-shown');
+                $('.new-' + addType + '-save').off('click');
             };
         };
 
-        var addNewCourse = function (e) {
+        var addNewCourse = function(e) {
             e.preventDefault();
             $('.new-course-button').addClass('is-disabled').attr('aria-disabled', true);
             $('.new-course-save').addClass('is-disabled').attr('aria-disabled', true);
@@ -95,7 +95,7 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
             CreateCourseUtils.configureHandlers();
         };
 
-        var saveNewLibrary = function (e) {
+        var saveNewLibrary = function(e) {
             e.preventDefault();
 
             if (CreateLibraryUtils.hasInvalidRequiredFields()) {
@@ -110,18 +110,18 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
             var lib_info = {
                 org: org,
                 number: number,
-                display_name: display_name,
+                display_name: display_name
             };
 
             analytics.track('Created a Library', lib_info);
-            CreateLibraryUtils.create(lib_info, function (errorMessage) {
+            CreateLibraryUtils.create(lib_info, function(errorMessage) {
                 $('.create-library .wrap-error').addClass('is-shown');
                 $('#library_creation_error').html('<p>' + errorMessage + '</p>');
                 $('.new-library-save').addClass('is-disabled').attr('aria-disabled', true);
             });
         };
 
-        var addNewLibrary = function (e) {
+        var addNewLibrary = function(e) {
             e.preventDefault();
             $('.new-library-button').addClass('is-disabled').attr('aria-disabled', true);
             $('.new-library-save').addClass('is-disabled').attr('aria-disabled', true);
@@ -137,22 +137,22 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
         };
 
         var showTab = function(tab) {
-          return function(e) {
-            e.preventDefault();
-            $('.courses-tab').toggleClass('active', tab === 'courses');
-            $('.libraries-tab').toggleClass('active', tab === 'libraries');
-            $('.programs-tab').toggleClass('active', tab === 'programs');
+            return function(e) {
+                e.preventDefault();
+                $('.courses-tab').toggleClass('active', tab === 'courses');
+                $('.libraries-tab').toggleClass('active', tab === 'libraries');
+                $('.programs-tab').toggleClass('active', tab === 'programs');
 
             // Also toggle this course-related notice shown below the course tab, if it is present:
-            $('.wrapper-creationrights').toggleClass('is-hidden', tab !== 'courses');
-          };
+                $('.wrapper-creationrights').toggleClass('is-hidden', tab !== 'courses');
+            };
         };
 
-        var onReady = function () {
+        var onReady = function() {
             $('.new-course-button').bind('click', addNewCourse);
             $('.new-library-button').bind('click', addNewLibrary);
 
-            $('.dismiss-button').bind('click', ViewUtils.deleteNotificationHandler(function () {
+            $('.dismiss-button').bind('click', ViewUtils.deleteNotificationHandler(function() {
                 ViewUtils.reload();
             }));
 

--- a/cms/static/js/models/active_video_upload.js
+++ b/cms/static/js/models/active_video_upload.js
@@ -1,19 +1,19 @@
 define(
-    ["backbone", "gettext"],
+    ['backbone', 'gettext'],
     function(Backbone, gettext) {
-        "use strict";
+        'use strict';
 
         var statusStrings = {
             // Translators: This is the status of a video upload that is queued
             // waiting for other uploads to complete
-            STATUS_QUEUED: gettext("Queued"),
+            STATUS_QUEUED: gettext('Queued'),
             // Translators: This is the status of an active video upload
-            STATUS_UPLOADING: gettext("Uploading"),
+            STATUS_UPLOADING: gettext('Uploading'),
             // Translators: This is the status of a video upload that has
             // completed successfully
-            STATUS_COMPLETED: gettext("Upload completed"),
+            STATUS_COMPLETED: gettext('Upload completed'),
             // Translators: This is the status of a video upload that has failed
-            STATUS_FAILED: gettext("Upload failed")
+            STATUS_FAILED: gettext('Upload failed')
         };
 
         var ActiveVideoUpload = Backbone.Model.extend(

--- a/cms/static/js/models/asset.js
+++ b/cms/static/js/models/asset.js
@@ -1,23 +1,23 @@
-define(["backbone"], function(Backbone) {
+define(['backbone'], function(Backbone) {
   /**
    * Simple model for an asset.
    */
-  var Asset = Backbone.Model.extend({
-    defaults: {
-      display_name: "",
-      content_type: "",
-      thumbnail: "",
-      date_added: "",
-      url: "",
-      external_url: "",
-      portable_url: "",
-      locked: false
-    },
-    get_extension: function(){
-      var name_segments = this.get("display_name").split(".").reverse();
-      var asset_type = (name_segments.length > 1) ? name_segments[0].toUpperCase() : "";
-      return asset_type;
-    }
-  });
-  return Asset;
+    var Asset = Backbone.Model.extend({
+        defaults: {
+            display_name: '',
+            content_type: '',
+            thumbnail: '',
+            date_added: '',
+            url: '',
+            external_url: '',
+            portable_url: '',
+            locked: false
+        },
+        get_extension: function() {
+            var name_segments = this.get('display_name').split('.').reverse();
+            var asset_type = (name_segments.length > 1) ? name_segments[0].toUpperCase() : '';
+            return asset_type;
+        }
+    });
+    return Asset;
 });

--- a/cms/static/js/models/assignment_grade.js
+++ b/cms/static/js/models/assignment_grade.js
@@ -1,11 +1,11 @@
-define(["backbone", "underscore"], function(Backbone, _) {
+define(['backbone', 'underscore'], function(Backbone, _) {
     var AssignmentGrade = Backbone.Model.extend({
-        defaults : {
-            graderType : null, // the type label (string). May be "notgraded" which implies None.
-            locator : null // locator for the block
+        defaults: {
+            graderType: null, // the type label (string). May be "notgraded" which implies None.
+            locator: null // locator for the block
         },
         idAttribute: 'locator',
-        urlRoot : '/xblock/',
+        urlRoot: '/xblock/',
         url: function() {
             // add ?fields=graderType to the request url (only needed for fetch, but innocuous for others)
             return Backbone.Model.prototype.url.apply(this) + '?' + $.param({fields: 'graderType'});

--- a/cms/static/js/models/chapter.js
+++ b/cms/static/js/models/chapter.js
@@ -1,9 +1,9 @@
-define(["backbone", "gettext", "backbone.associations"], function(Backbone, gettext) {
+define(['backbone', 'gettext', 'backbone.associations'], function(Backbone, gettext) {
     var Chapter = Backbone.AssociatedModel.extend({
         defaults: function() {
             return {
-                name: "",
-                asset_path: "",
+                name: '',
+                asset_path: '',
                 order: this.collection ? this.collection.nextOrder() : 1
             };
         },
@@ -11,11 +11,11 @@ define(["backbone", "gettext", "backbone.associations"], function(Backbone, gett
             return !this.get('name') && !this.get('asset_path');
         },
         parse: function(response) {
-            if("title" in response && !("name" in response)) {
+            if ('title' in response && !('name' in response)) {
                 response.name = response.title;
                 delete response.title;
             }
-            if("url" in response && !("asset_path" in response)) {
+            if ('url' in response && !('asset_path' in response)) {
                 response.asset_path = response.url;
                 delete response.url;
             }
@@ -30,19 +30,19 @@ define(["backbone", "gettext", "backbone.associations"], function(Backbone, gett
         // NOTE: validation functions should return non-internationalized error
         // messages. The messages will be passed through gettext in the template.
         validate: function(attrs, options) {
-            if(!attrs.name && !attrs.asset_path) {
+            if (!attrs.name && !attrs.asset_path) {
                 return {
-                    message: gettext("Chapter name and asset_path are both required"),
+                    message: gettext('Chapter name and asset_path are both required'),
                     attributes: {name: true, asset_path: true}
                 };
-            } else if(!attrs.name) {
+            } else if (!attrs.name) {
                 return {
-                    message: gettext("Chapter name is required"),
+                    message: gettext('Chapter name is required'),
                     attributes: {name: true}
                 };
             } else if (!attrs.asset_path) {
                 return {
-                    message: gettext("asset_path is required"),
+                    message: gettext('asset_path is required'),
                     attributes: {asset_path: true}
                 };
             }

--- a/cms/static/js/models/checklist.js
+++ b/cms/static/js/models/checklist.js
@@ -1,4 +1,4 @@
-define(["backbone"], function(Backbone) {
+define(['backbone'], function(Backbone) {
     var Checklist = Backbone.Model.extend({
     });
     return Checklist;

--- a/cms/static/js/models/component_template.js
+++ b/cms/static/js/models/component_template.js
@@ -1,10 +1,10 @@
 /**
  * Simple model for adding a component of a given type (for example, "video" or "html").
  */
-define(["backbone"], function (Backbone) {
+define(['backbone'], function(Backbone) {
     return Backbone.Model.extend({
         defaults: {
-            type: "",
+            type: '',
             // Each entry in the template array is an Object with the following keys:
             // display_name
             // category (may or may not match "type")
@@ -13,7 +13,7 @@ define(["backbone"], function (Backbone) {
             templates: [],
             support_legend: {}
         },
-        parse: function (response) {
+        parse: function(response) {
             // Returns true only for templates that both have no boilerplate and are of
             // the overall type of the menu. This allows other component types to be added
             // and they will get sorted alphabetically rather than just at the top.
@@ -28,7 +28,7 @@ define(["backbone"], function (Backbone) {
             this.support_legend = response.support_legend;
 
             // Sort the templates.
-            this.templates.sort(function (a, b) {
+            this.templates.sort(function(a, b) {
                 // The blank problem for the current type goes first
                 if (isPrimaryBlankTemplate(a)) {
                     return -1;

--- a/cms/static/js/models/course.js
+++ b/cms/static/js/models/course.js
@@ -1,11 +1,11 @@
-define(['backbone'], function(Backbone){
+define(['backbone'], function(Backbone) {
     var Course = Backbone.Model.extend({
         defaults: {
-            "name": ""
+            'name': ''
         },
         validate: function(attrs, options) {
             if (!attrs.name) {
-                return gettext("You must specify a name");
+                return gettext('You must specify a name');
             }
         }
     });

--- a/cms/static/js/models/course_info.js
+++ b/cms/static/js/models/course_info.js
@@ -1,13 +1,13 @@
-define(["backbone"], function(Backbone) {
+define(['backbone'], function(Backbone) {
     // single per course holds the updates and handouts
     var CourseInfo = Backbone.Model.extend({
         // This model class is not suited for restful operations and is considered just a server side initialized container
         url: '',
 
         defaults: {
-            "updates" : null,   // UpdateCollection
-            "handouts": null    // HandoutCollection
-            }
+            'updates': null,   // UpdateCollection
+            'handouts': null    // HandoutCollection
+        }
     });
     return CourseInfo;
 });

--- a/cms/static/js/models/course_update.js
+++ b/cms/static/js/models/course_update.js
@@ -1,17 +1,17 @@
-define(["backbone", "jquery", "jquery.ui"], function(Backbone, $) {
+define(['backbone', 'jquery', 'jquery.ui'], function(Backbone, $) {
     // course update -- biggest kludge here is the lack of a real id to map updates to originals
     var CourseUpdate = Backbone.Model.extend({
         defaults: {
-            "date" : $.datepicker.formatDate('MM d, yy', new Date()),
-            "content" : "",
-            "push_notification_enabled": false,
-            "push_notification_selected" : false
+            'date': $.datepicker.formatDate('MM d, yy', new Date()),
+            'content': '',
+            'push_notification_enabled': false,
+            'push_notification_selected': false
         },
         validate: function(attrs) {
-            var date_exists = (attrs.date !== null && attrs.date !== "");
+            var date_exists = (attrs.date !== null && attrs.date !== '');
             var date_is_valid_string = ($.datepicker.formatDate('MM d, yy', new Date(attrs.date)) === attrs.date);
             if (!(date_exists && date_is_valid_string)) {
-                return {"date_required": gettext("Action required: Enter a valid date.")};
+                return {'date_required': gettext('Action required: Enter a valid date.')};
             }
         }
     });

--- a/cms/static/js/models/custom_sync_xblock_info.js
+++ b/cms/static/js/models/custom_sync_xblock_info.js
@@ -1,4 +1,4 @@
-define(["js/models/xblock_info"],
+define(['js/models/xblock_info'],
     function(XBlockInfo) {
         var CustomSyncXBlockInfo = XBlockInfo.extend({
             sync: function(method, model, options) {

--- a/cms/static/js/models/explicit_url.js
+++ b/cms/static/js/models/explicit_url.js
@@ -2,13 +2,13 @@
  * A model that simply allows the update URL to be passed
  * in as an argument.
  */
-define(["backbone"], function(Backbone){
+define(['backbone'], function(Backbone) {
     return Backbone.Model.extend({
         defaults: {
-            "explicit_url": ""
+            'explicit_url': ''
         },
         url: function() {
-            return this.get("explicit_url");
+            return this.get('explicit_url');
         }
     });
 });

--- a/cms/static/js/models/group.js
+++ b/cms/static/js/models/group.js
@@ -12,13 +12,13 @@ define([
                 usage: []
             };
         },
-        url : function() {
+        url: function() {
             var parentModel = this.collection.parents[0];
             return parentModel.urlRoot + '/' + encodeURIComponent(parentModel.id) + '/' + encodeURIComponent(this.id);
         },
 
         reset: function() {
-            this.set(this._originalAttributes, { parse: true });
+            this.set(this._originalAttributes, {parse: true});
         },
 
         isEmpty: function() {
@@ -31,14 +31,14 @@ define([
                 name: this.get('name'),
                 version: this.get('version'),
                 usage: this.get('usage')
-             };
+            };
         },
 
         validate: function(attrs) {
             if (!str.trim(attrs.name)) {
                 return {
                     message: gettext('Group name is required'),
-                    attributes: { name: true }
+                    attributes: {name: true}
                 };
             }
         }

--- a/cms/static/js/models/license.js
+++ b/cms/static/js/models/license.js
@@ -1,43 +1,43 @@
-define(["backbone", "underscore"], function(Backbone, _) {
+define(['backbone', 'underscore'], function(Backbone, _) {
     var LicenseModel = Backbone.Model.extend({
         defaults: {
-            "type": null,
-            "options": {},
-            "custom": false // either `false`, or a string
+            'type': null,
+            'options': {},
+            'custom': false // either `false`, or a string
         },
 
         initialize: function(attributes) {
-            if(attributes && attributes.asString) {
+            if (attributes && attributes.asString) {
                 this.setFromString(attributes.asString);
-                this.unset("asString");
+                this.unset('asString');
             }
         },
 
         toString: function() {
-            var custom = this.get("custom");
+            var custom = this.get('custom');
             if (custom) {
                 return custom;
             }
 
-            var type = this.get("type"),
-                options = this.get("options");
+            var type = this.get('type'),
+                options = this.get('options');
 
             if (_.isEmpty(options)) {
-                return type || "";
+                return type || '';
             }
 
             // options are where it gets tricky
-            var optionStrings = _.map(options, function (value, key) {
-                if(_.isBoolean(value)) {
-                    return value ? key : null
+            var optionStrings = _.map(options, function(value, key) {
+                if (_.isBoolean(value)) {
+                    return value ? key : null;
                 } else {
-                    return key + "=" + value
+                    return key + '=' + value;
                 }
             });
             // filter out nulls
             optionStrings = _.filter(optionStrings, _.identity);
             // build license string and return
-            return type + ": " + optionStrings.join(" ");
+            return type + ': ' + optionStrings.join(' ');
         },
 
         setFromString: function(string, options) {
@@ -46,8 +46,8 @@ define(["backbone", "underscore"], function(Backbone, _) {
                 return this.set(this.defaults, options);
             }
 
-            var colonIndex = string.indexOf(":"),
-                spaceIndex = string.indexOf(" ");
+            var colonIndex = string.indexOf(':'),
+                spaceIndex = string.indexOf(' ');
 
             // a string without a colon could be a custom license, or a license
             // type without options
@@ -55,16 +55,16 @@ define(["backbone", "underscore"], function(Backbone, _) {
                 if (spaceIndex == -1) {
                     // if there's no space, it's a license type without options
                     return this.set({
-                        "type": string,
-                        "options": {},
-                        "custom": false
+                        'type': string,
+                        'options': {},
+                        'custom': false
                     }, options);
                 } else {
                 // if there is a space, it's a custom license
                     return this.set({
-                        "type": null,
-                        "options": {},
-                        "custom": string
+                        'type': null,
+                        'options': {},
+                        'custom': string
                     }, options);
                 }
             }
@@ -74,24 +74,24 @@ define(["backbone", "underscore"], function(Backbone, _) {
                 optionsObj = {},
                 optionsString = string.substring(colonIndex + 1);
 
-                _.each(optionsString.split(" "), function(optionString) {
-                    if (_.isEmpty(optionString)) {
-                        return;
-                    }
-                    var eqIndex = optionString.indexOf("=");
-                    if(eqIndex == -1) {
+            _.each(optionsString.split(' '), function(optionString) {
+                if (_.isEmpty(optionString)) {
+                    return;
+                }
+                var eqIndex = optionString.indexOf('=');
+                if (eqIndex == -1) {
                         // this is a boolean flag
-                        optionsObj[optionString] = true;
-                    } else {
+                    optionsObj[optionString] = true;
+                } else {
                         // this is a key-value pair
-                        var optionKey = optionString.substring(0, eqIndex);
-                        var optionVal = optionString.substring(eqIndex + 1);
-                        optionsObj[optionKey] = optionVal;
-                    }
-                });
+                    var optionKey = optionString.substring(0, eqIndex);
+                    var optionVal = optionString.substring(eqIndex + 1);
+                    optionsObj[optionKey] = optionVal;
+                }
+            });
 
             return this.set({
-                "type": type, "options": optionsObj, "custom": false,
+                'type': type, 'options': optionsObj, 'custom': false
             }, options);
         }
     });

--- a/cms/static/js/models/location.js
+++ b/cms/static/js/models/location.js
@@ -1,22 +1,22 @@
-define(["backbone", "underscore"], function(Backbone, _) {
+define(['backbone', 'underscore'], function(Backbone, _) {
     var Location = Backbone.Model.extend({
         defaults: {
-            tag: "",
-            org: "",
-            course: "",
-            category: "",
-            name: ""
+            tag: '',
+            org: '',
+            course: '',
+            category: '',
+            name: ''
         },
         toUrl: function(overrides) {
-            return
-                (overrides && overrides['tag'] ? overrides['tag'] : this.get('tag')) + "://" +
-                (overrides && overrides['org'] ? overrides['org'] : this.get('org')) + "/" +
-                (overrides && overrides['course'] ? overrides['course'] : this.get('course')) + "/" +
-                (overrides && overrides['category'] ? overrides['category'] : this.get('category')) + "/" +
-                (overrides && overrides['name'] ? overrides['name'] : this.get('name')) + "/";
+            return;
+            (overrides && overrides['tag'] ? overrides['tag'] : this.get('tag')) + '://' +
+                (overrides && overrides['org'] ? overrides['org'] : this.get('org')) + '/' +
+                (overrides && overrides['course'] ? overrides['course'] : this.get('course')) + '/' +
+                (overrides && overrides['category'] ? overrides['category'] : this.get('category')) + '/' +
+                (overrides && overrides['name'] ? overrides['name'] : this.get('name')) + '/';
         },
-        _tagPattern : /[^:]+/g,
-        _fieldPattern : new RegExp('[^/]+','g'),
+        _tagPattern: /[^:]+/g,
+        _fieldPattern: new RegExp('[^/]+', 'g'),
 
         parse: function(payload) {
             if (_.isArray(payload)) {
@@ -47,12 +47,12 @@ define(["backbone", "underscore"], function(Backbone, _) {
                 return payload;
             }
         },
-        getNextField : function(payload) {
+        getNextField: function(payload) {
             try {
                 return this._fieldPattern.exec(payload)[0];
             }
             catch (err) {
-                return "";
+                return '';
             }
         }
     });

--- a/cms/static/js/models/metadata.js
+++ b/cms/static/js/models/metadata.js
@@ -1,17 +1,17 @@
-define(["backbone"], function(Backbone) {
+define(['backbone'], function(Backbone) {
     /**
      * Model used for metadata setting editors. This model does not do its own saving,
      * as that is done by module_edit.coffee.
      */
     var Metadata = Backbone.Model.extend({
         defaults: {
-            "field_name": null,
-            "display_name": null,
-            "value" : null,
-            "explicitly_set": null,
-            "default_value" : null,
-            "options" : null,
-            "type" : null
+            'field_name': null,
+            'display_name': null,
+            'value': null,
+            'explicitly_set': null,
+            'default_value': null,
+            'options': null,
+            'type': null
         },
 
         initialize: function() {
@@ -23,7 +23,7 @@ define(["backbone"], function(Backbone) {
          * Returns true if the stored value is different, or if the "explicitly_set"
          * property has changed.
          */
-        isModified : function() {
+        isModified: function() {
             if (!this.get('explicitly_set') && !this.original_explicitly_set) {
                 return false;
             }
@@ -43,7 +43,7 @@ define(["backbone"], function(Backbone) {
         /**
          * The value, as shown in the UI. This may be an inherited or default value.
          */
-        getDisplayValue : function () {
+        getDisplayValue: function() {
             return this.get('value');
         },
 
@@ -59,7 +59,7 @@ define(["backbone"], function(Backbone) {
         /**
          * Sets the displayed value.
          */
-        setValue: function (value) {
+        setValue: function(value) {
             this.set({
                 explicitly_set: true,
                 value: value
@@ -70,7 +70,7 @@ define(["backbone"], function(Backbone) {
          * Returns the field name, which should be used for persisting the metadata
          * field to the server.
          */
-        getFieldName: function () {
+        getFieldName: function() {
             return this.get('field_name');
         },
 
@@ -78,7 +78,7 @@ define(["backbone"], function(Backbone) {
          * Returns the options. This may be a array of possible values, or an object
          * with properties like "max", "min" and "step".
          */
-        getOptions: function () {
+        getOptions: function() {
             return this.get('options');
         },
 
@@ -102,14 +102,14 @@ define(["backbone"], function(Backbone) {
         }
     });
 
-    Metadata.SELECT_TYPE = "Select";
-    Metadata.INTEGER_TYPE = "Integer";
-    Metadata.FLOAT_TYPE = "Float";
-    Metadata.GENERIC_TYPE = "Generic";
-    Metadata.LIST_TYPE = "List";
-    Metadata.DICT_TYPE = "Dict";
-    Metadata.VIDEO_LIST_TYPE = "VideoList";
-    Metadata.RELATIVE_TIME_TYPE = "RelativeTime";
+    Metadata.SELECT_TYPE = 'Select';
+    Metadata.INTEGER_TYPE = 'Integer';
+    Metadata.FLOAT_TYPE = 'Float';
+    Metadata.GENERIC_TYPE = 'Generic';
+    Metadata.LIST_TYPE = 'List';
+    Metadata.DICT_TYPE = 'Dict';
+    Metadata.VIDEO_LIST_TYPE = 'VideoList';
+    Metadata.RELATIVE_TIME_TYPE = 'RelativeTime';
 
     return Metadata;
 });

--- a/cms/static/js/models/module_info.js
+++ b/cms/static/js/models/module_info.js
@@ -1,13 +1,13 @@
-define(["backbone", "js/utils/module"], function(Backbone, ModuleUtils) {
+define(['backbone', 'js/utils/module'], function(Backbone, ModuleUtils) {
     var ModuleInfo = Backbone.Model.extend({
-      urlRoot: ModuleUtils.urlRoot,
+        urlRoot: ModuleUtils.urlRoot,
 
-      defaults: {
-        "id": null,
-        "data": null,
-        "metadata" : null,
-        "children" : null
-      }
+        defaults: {
+            'id': null,
+            'data': null,
+            'metadata': null,
+            'children': null
+        }
     });
     return ModuleInfo;
 });

--- a/cms/static/js/models/section.js
+++ b/cms/static/js/models/section.js
@@ -1,39 +1,38 @@
-define(["backbone", "gettext", "common/js/components/views/feedback_notification", "js/utils/module"],
+define(['backbone', 'gettext', 'common/js/components/views/feedback_notification', 'js/utils/module'],
     function(Backbone, gettext, NotificationView, ModuleUtils) {
-
-    var Section = Backbone.Model.extend({
-        defaults: {
-            "name": ""
-        },
-        validate: function(attrs, options) {
-            if (!attrs.name) {
-                return gettext("You must specify a name");
-            }
-        },
-        urlRoot: ModuleUtils.urlRoot,
-        toJSON: function() {
-            return {
-                metadata: {
-                    display_name: this.get("name")
+        var Section = Backbone.Model.extend({
+            defaults: {
+                'name': ''
+            },
+            validate: function(attrs, options) {
+                if (!attrs.name) {
+                    return gettext('You must specify a name');
                 }
-            };
-        },
-        initialize: function() {
-            this.listenTo(this, "request", this.showNotification);
-            this.listenTo(this, "sync", this.hideNotification);
-        },
-        showNotification: function() {
-            if(!this.msg) {
-                this.msg = new NotificationView.Mini({
-                    title: gettext("Saving")
-                });
+            },
+            urlRoot: ModuleUtils.urlRoot,
+            toJSON: function() {
+                return {
+                    metadata: {
+                        display_name: this.get('name')
+                    }
+                };
+            },
+            initialize: function() {
+                this.listenTo(this, 'request', this.showNotification);
+                this.listenTo(this, 'sync', this.hideNotification);
+            },
+            showNotification: function() {
+                if (!this.msg) {
+                    this.msg = new NotificationView.Mini({
+                        title: gettext('Saving')
+                    });
+                }
+                this.msg.show();
+            },
+            hideNotification: function() {
+                if (!this.msg) { return; }
+                this.msg.hide();
             }
-            this.msg.show();
-        },
-        hideNotification: function() {
-            if(!this.msg) { return; }
-            this.msg.hide();
-        }
+        });
+        return Section;
     });
-    return Section;
-});

--- a/cms/static/js/models/settings/advanced.js
+++ b/cms/static/js/models/settings/advanced.js
@@ -1,19 +1,18 @@
-define(["backbone"], function(Backbone) {
+define(['backbone'], function(Backbone) {
+    var Advanced = Backbone.Model.extend({
 
-var Advanced = Backbone.Model.extend({
-
-    defaults: {
+        defaults: {
         // There will be one property per course setting. Each property's value is an object with keys
         // 'display_name', 'help', 'value', and 'deprecated. The property keys are the setting names.
         // For instance: advanced_modules: {display_name: "Advanced Modules, help:"Beta modules...",
         //                                  value: ["word_cloud", "split_module"], deprecated: False}
         // Only 'value' is editable.
-    },
+        },
 
-    validate: function (attrs) {
+        validate: function(attrs) {
         // Keys can no longer be edited. We are currently not validating values.
-    }
-});
+        }
+    });
 
-return Advanced;
+    return Advanced;
 }); // end define()

--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -1,108 +1,106 @@
-define(["backbone", "underscore", "gettext", "js/models/validation_helpers", "js/utils/date_utils"],
+define(['backbone', 'underscore', 'gettext', 'js/models/validation_helpers', 'js/utils/date_utils'],
     function(Backbone, _, gettext, ValidationHelpers, DateUtils) {
+        var CourseDetails = Backbone.Model.extend({
+            defaults: {
+                org: '',
+                course_id: '',
+                run: '',
+                language: '',
+                start_date: null,	// maps to 'start'
+                end_date: null,		// maps to 'end'
+                enrollment_start: null,
+                enrollment_end: null,
+                syllabus: null,
+                title: '',
+                subtitle: '',
+                duration: '',
+                description: '',
+                short_description: '',
+                overview: '',
+                intro_video: null,
+                effort: null,	// an int or null,
+                license: null,
+                course_image_name: '', // the filename
+                course_image_asset_path: '', // the full URL (/c4x/org/course/num/asset/filename)
+                banner_image_name: '',
+                banner_image_asset_path: '',
+                video_thumbnail_image_name: '',
+                video_thumbnail_image_asset_path: '',
+                pre_requisite_courses: [],
+                entrance_exam_enabled: '',
+                entrance_exam_minimum_score_pct: '50',
+                learning_info: [],
+                instructor_info: {}
+            },
 
-var CourseDetails = Backbone.Model.extend({
-    defaults: {
-        org : '',
-        course_id: '',
-        run: '',
-        language: '',
-        start_date: null,	// maps to 'start'
-        end_date: null,		// maps to 'end'
-        enrollment_start: null,
-        enrollment_end: null,
-        syllabus: null,
-        title: "",
-        subtitle: "",
-        duration: "",
-        description: "",
-        short_description: "",
-        overview: "",
-        intro_video: null,
-        effort: null,	// an int or null,
-        license: null,
-        course_image_name: '', // the filename
-        course_image_asset_path: '', // the full URL (/c4x/org/course/num/asset/filename)
-        banner_image_name: '',
-        banner_image_asset_path: '',
-        video_thumbnail_image_name: '',
-        video_thumbnail_image_asset_path: '',
-        pre_requisite_courses: [],
-        entrance_exam_enabled : '',
-        entrance_exam_minimum_score_pct: '50',
-        learning_info: [],
-        instructor_info: {}
-    },
-
-    validate: function(newattrs) {
+            validate: function(newattrs) {
         // Returns either nothing (no return call) so that validate works or an object of {field: errorstring} pairs
         // A bit funny in that the video key validation is asynchronous; so, it won't stop the validation.
-        var errors = {};
-        newattrs = DateUtils.convertDateStringsToObjects(
-            newattrs, ["start_date", "end_date", "enrollment_start", "enrollment_end"]
+                var errors = {};
+                newattrs = DateUtils.convertDateStringsToObjects(
+            newattrs, ['start_date', 'end_date', 'enrollment_start', 'enrollment_end']
         );
 
-        if (newattrs.start_date === null) {
-            errors.start_date = gettext("The course must have an assigned start date.");
-        }
+                if (newattrs.start_date === null) {
+                    errors.start_date = gettext('The course must have an assigned start date.');
+                }
 
-        if (newattrs.start_date && newattrs.end_date && newattrs.start_date >= newattrs.end_date) {
-            errors.end_date = gettext("The course end date must be later than the course start date.");
-        }
-        if (newattrs.start_date && newattrs.enrollment_start && newattrs.start_date < newattrs.enrollment_start) {
-            errors.enrollment_start = gettext("The course start date must be later than the enrollment start date.");
-        }
-        if (newattrs.enrollment_start && newattrs.enrollment_end && newattrs.enrollment_start >= newattrs.enrollment_end) {
-            errors.enrollment_end = gettext("The enrollment start date cannot be after the enrollment end date.");
-        }
-        if (newattrs.end_date && newattrs.enrollment_end && newattrs.end_date < newattrs.enrollment_end) {
-            errors.enrollment_end = gettext("The enrollment end date cannot be after the course end date.");
-        }
-        if (newattrs.intro_video && newattrs.intro_video !== this.get('intro_video')) {
-            if (this._videokey_illegal_chars.exec(newattrs.intro_video)) {
-                errors.intro_video = gettext("Key should only contain letters, numbers, _, or -");
-            }
+                if (newattrs.start_date && newattrs.end_date && newattrs.start_date >= newattrs.end_date) {
+                    errors.end_date = gettext('The course end date must be later than the course start date.');
+                }
+                if (newattrs.start_date && newattrs.enrollment_start && newattrs.start_date < newattrs.enrollment_start) {
+                    errors.enrollment_start = gettext('The course start date must be later than the enrollment start date.');
+                }
+                if (newattrs.enrollment_start && newattrs.enrollment_end && newattrs.enrollment_start >= newattrs.enrollment_end) {
+                    errors.enrollment_end = gettext('The enrollment start date cannot be after the enrollment end date.');
+                }
+                if (newattrs.end_date && newattrs.enrollment_end && newattrs.end_date < newattrs.enrollment_end) {
+                    errors.enrollment_end = gettext('The enrollment end date cannot be after the course end date.');
+                }
+                if (newattrs.intro_video && newattrs.intro_video !== this.get('intro_video')) {
+                    if (this._videokey_illegal_chars.exec(newattrs.intro_video)) {
+                        errors.intro_video = gettext('Key should only contain letters, numbers, _, or -');
+                    }
             // TODO check if key points to a real video using google's youtube api
-        }
-        if(_.has(newattrs, 'entrance_exam_minimum_score_pct')){
-            var range = {
-                min: 1,
-                max: 100
-            };
-            if(!ValidationHelpers.validateIntegerRange(newattrs.entrance_exam_minimum_score_pct, range)){
-                errors.entrance_exam_minimum_score_pct = interpolate(gettext("Please enter an integer between %(min)s and %(max)s."), range, true);
-            }
-        }
-        if (!_.isEmpty(errors)) return errors;
+                }
+                if (_.has(newattrs, 'entrance_exam_minimum_score_pct')) {
+                    var range = {
+                        min: 1,
+                        max: 100
+                    };
+                    if (!ValidationHelpers.validateIntegerRange(newattrs.entrance_exam_minimum_score_pct, range)) {
+                        errors.entrance_exam_minimum_score_pct = interpolate(gettext('Please enter an integer between %(min)s and %(max)s.'), range, true);
+                    }
+                }
+                if (!_.isEmpty(errors)) return errors;
         // NOTE don't return empty errors as that will be interpreted as an error state
-    },
+            },
 
-    _videokey_illegal_chars : /[^a-zA-Z0-9_-]/g,
+            _videokey_illegal_chars: /[^a-zA-Z0-9_-]/g,
 
-    set_videosource: function(newsource) {
+            set_videosource: function(newsource) {
         // newsource either is <video youtube="speed:key, *"/> or just the "speed:key, *" string
         // returns the videosource for the preview which iss the key whose speed is closest to 1
-        if (_.isEmpty(newsource) && !_.isEmpty(this.get('intro_video'))) this.set({'intro_video': null}, {validate: true});
+                if (_.isEmpty(newsource) && !_.isEmpty(this.get('intro_video'))) this.set({'intro_video': null}, {validate: true});
         // TODO remove all whitespace w/in string
-        else {
-            if (this.get('intro_video') !== newsource) this.set('intro_video', newsource, {validate: true});
-        }
+                else {
+                    if (this.get('intro_video') !== newsource) this.set('intro_video', newsource, {validate: true});
+                }
 
-        return this.videosourceSample();
-    },
+                return this.videosourceSample();
+            },
 
-    videosourceSample : function() {
-        if (this.has('intro_video')) return "//www.youtube.com/embed/" + this.get('intro_video');
-        else return "";
-    },
+            videosourceSample: function() {
+                if (this.has('intro_video')) return '//www.youtube.com/embed/' + this.get('intro_video');
+                else return '';
+            },
 
     // Whether or not the course pacing can be toggled. If the course
     // has already started, returns false; otherwise, returns true.
-    canTogglePace: function () {
-        return new Date() <= new Date(this.get('start_date'));
-    }
-});
+            canTogglePace: function() {
+                return new Date() <= new Date(this.get('start_date'));
+            }
+        });
 
-return CourseDetails;
-
-}); // end define()
+        return CourseDetails;
+    }); // end define()

--- a/cms/static/js/models/settings/course_grader.js
+++ b/cms/static/js/models/settings/course_grader.js
@@ -1,79 +1,78 @@
-define(["backbone", "underscore", "gettext"], function(Backbone, _, gettext) {
-
-var CourseGrader = Backbone.Model.extend({
-    defaults: {
-        "type" : "",    // must be unique w/in collection (ie. w/in course)
-        "min_count" : 1,
-        "drop_count" : 0,
-        "short_label" : "", // what to use in place of type if space is an issue
-        "weight" : 0 // int 0..100
-    },
-    parse : function(attrs) {
+define(['backbone', 'underscore', 'gettext'], function(Backbone, _, gettext) {
+    var CourseGrader = Backbone.Model.extend({
+        defaults: {
+            'type': '',    // must be unique w/in collection (ie. w/in course)
+            'min_count': 1,
+            'drop_count': 0,
+            'short_label': '', // what to use in place of type if space is an issue
+            'weight': 0 // int 0..100
+        },
+        parse: function(attrs) {
         // round off values while converting them to integer
-        if (attrs['weight']) {
-            attrs.weight = Math.round(attrs.weight);
-        }
-        if (attrs['min_count']) {
-            attrs.min_count = Math.round(attrs.min_count);
-        }
-        if (attrs['drop_count']) {
-            attrs.drop_count = Math.round(attrs.drop_count);
-        }
-        return attrs;
-    },
-    validate : function(attrs) {
-        var errors = {};
-        if (_.has(attrs, 'type')) {
-            if (_.isEmpty(attrs['type'])) {
-                errors.type = "The assignment type must have a name.";
+            if (attrs['weight']) {
+                attrs.weight = Math.round(attrs.weight);
             }
-            else {
+            if (attrs['min_count']) {
+                attrs.min_count = Math.round(attrs.min_count);
+            }
+            if (attrs['drop_count']) {
+                attrs.drop_count = Math.round(attrs.drop_count);
+            }
+            return attrs;
+        },
+        validate: function(attrs) {
+            var errors = {};
+            if (_.has(attrs, 'type')) {
+                if (_.isEmpty(attrs['type'])) {
+                    errors.type = 'The assignment type must have a name.';
+                }
+                else {
                 // FIXME somehow this.collection is unbound sometimes. I can't track down when
-                var existing = this.collection && this.collection.some(function(other) { return (other.cid != this.cid) && (other.get('type') == attrs['type']);}, this);
-                if (existing) {
-                    errors.type = gettext("There's already another assignment type with this name.");
+                    var existing = this.collection && this.collection.some(function(other) { return (other.cid != this.cid) && (other.get('type') == attrs['type']); }, this);
+                    if (existing) {
+                        errors.type = gettext("There's already another assignment type with this name.");
+                    }
                 }
             }
-        }
-        if (_.has(attrs, 'weight')) {
-            var intWeight = Math.round(attrs.weight); // see if this ensures value saved is int
-            if (!isFinite(intWeight) || /\D+/.test(attrs.weight) || intWeight < 0 || intWeight > 100) {
-                errors.weight = gettext("Please enter an integer between 0 and 100.");
-            }
-            else {
-                attrs.weight = intWeight;
-                if (this.collection && attrs.weight > 0) {
+            if (_.has(attrs, 'weight')) {
+                var intWeight = Math.round(attrs.weight); // see if this ensures value saved is int
+                if (!isFinite(intWeight) || /\D+/.test(attrs.weight) || intWeight < 0 || intWeight > 100) {
+                    errors.weight = gettext('Please enter an integer between 0 and 100.');
+                }
+                else {
+                    attrs.weight = intWeight;
+                    if (this.collection && attrs.weight > 0) {
                     // FIXME b/c saves don't update the models if validation fails, we should
                     // either revert the field value to the one in the model and make them make room
                     // or figure out a holistic way to balance the vals across the whole
 //                  if ((this.collection.sumWeights() + attrs.weight - this.get('weight')) > 100)
 //                  errors.weight = "The weights cannot add to more than 100.";
+                    }
+                } }
+            if (_.has(attrs, 'min_count')) {
+                var intMinCount = Math.round(attrs.min_count);
+                if (!isFinite(intMinCount) || /\D+/.test(attrs.min_count) || intMinCount < 1) {
+                    errors.min_count = gettext('Please enter an integer greater than 0.');
                 }
-            }}
-        if (_.has(attrs, 'min_count')) {
-            var intMinCount = Math.round(attrs.min_count);
-            if (!isFinite(intMinCount) || /\D+/.test(attrs.min_count) || intMinCount < 1) {
-                errors.min_count = gettext("Please enter an integer greater than 0.");
+                else attrs.min_count = intMinCount;
             }
-            else attrs.min_count = intMinCount;
-        }
-        if (_.has(attrs, 'drop_count')) {
-            var dropCount = attrs.drop_count;
-            var intDropCount = Math.round(dropCount);
-            if (!isFinite(intDropCount) || /\D+/.test(dropCount) || (_.isString(dropCount) && _.isEmpty(dropCount.trim())) || intDropCount < 0) {
-                errors.drop_count = gettext("Please enter non-negative integer.");
+            if (_.has(attrs, 'drop_count')) {
+                var dropCount = attrs.drop_count;
+                var intDropCount = Math.round(dropCount);
+                if (!isFinite(intDropCount) || /\D+/.test(dropCount) || (_.isString(dropCount) && _.isEmpty(dropCount.trim())) || intDropCount < 0) {
+                    errors.drop_count = gettext('Please enter non-negative integer.');
+                }
+                else attrs.drop_count = intDropCount;
             }
-            else attrs.drop_count = intDropCount;
-        }
-        if (_.has(attrs, 'min_count') && _.has(attrs, 'drop_count') && !_.has(errors, 'min_count') && !_.has(errors, 'drop_count') && attrs.drop_count > attrs.min_count) {
-            var template = _.template(
-                gettext("Cannot drop more <%= types %> assignments than are assigned.")
+            if (_.has(attrs, 'min_count') && _.has(attrs, 'drop_count') && !_.has(errors, 'min_count') && !_.has(errors, 'drop_count') && attrs.drop_count > attrs.min_count) {
+                var template = _.template(
+                gettext('Cannot drop more <%= types %> assignments than are assigned.')
             );
-            errors.drop_count = template({types: attrs.type});
+                errors.drop_count = template({types: attrs.type});
+            }
+            if (!_.isEmpty(errors)) return errors;
         }
-        if (!_.isEmpty(errors)) return errors;
-    }
-});
+    });
 
-return CourseGrader;
+    return CourseGrader;
 }); // end define()

--- a/cms/static/js/models/settings/course_grading_policy.js
+++ b/cms/static/js/models/settings/course_grading_policy.js
@@ -1,96 +1,95 @@
-define(["backbone", "js/models/location", "js/collections/course_grader"],
+define(['backbone', 'js/models/location', 'js/collections/course_grader'],
     function(Backbone, Location, CourseGraderCollection) {
-
-var CourseGradingPolicy = Backbone.Model.extend({
-    defaults : {
-        graders : null,  // CourseGraderCollection
-        grade_cutoffs : null,  // CourseGradeCutoff model
-        grace_period : null, // either null or { hours: n, minutes: m, ...}
-        minimum_grade_credit : null // either null or percentage
-    },
-    parse: function(attributes) {
-        if (attributes['graders']) {
-            var graderCollection;
+        var CourseGradingPolicy = Backbone.Model.extend({
+            defaults: {
+                graders: null,  // CourseGraderCollection
+                grade_cutoffs: null,  // CourseGradeCutoff model
+                grace_period: null, // either null or { hours: n, minutes: m, ...}
+                minimum_grade_credit: null // either null or percentage
+            },
+            parse: function(attributes) {
+                if (attributes['graders']) {
+                    var graderCollection;
             // interesting race condition: if {parse:true} when newing, then parse called before .attributes created
-            if (this.attributes && this.has('graders')) {
-                graderCollection = this.get('graders');
-                graderCollection.reset(attributes.graders, {parse:true});
-            }
-            else {
-                graderCollection = new CourseGraderCollection(attributes.graders, {parse:true});
-            }
-            attributes.graders = graderCollection;
-        }
+                    if (this.attributes && this.has('graders')) {
+                        graderCollection = this.get('graders');
+                        graderCollection.reset(attributes.graders, {parse: true});
+                    }
+                    else {
+                        graderCollection = new CourseGraderCollection(attributes.graders, {parse: true});
+                    }
+                    attributes.graders = graderCollection;
+                }
         // If grace period is unset or equal to 00:00 on the server,
         // it's received as null
-        if (attributes['grace_period'] === null) {
-            attributes.grace_period = {
-                hours: 0,
-                minutes: 0
-            }
-        }
+                if (attributes['grace_period'] === null) {
+                    attributes.grace_period = {
+                        hours: 0,
+                        minutes: 0
+                    };
+                }
         // If minimum_grade_credit is unset or equal to 0 on the server,
         // it's received as 0
-        if (attributes.minimum_grade_credit === null) {
-            attributes.minimum_grade_credit = 0;
-        }
-        return attributes;
-    },
-    gracePeriodToDate : function() {
-        var newDate = new Date();
-        if (this.has('grace_period') && this.get('grace_period')['hours'])
-            newDate.setHours(this.get('grace_period')['hours']);
-        else newDate.setHours(0);
-        if (this.has('grace_period') && this.get('grace_period')['minutes'])
-            newDate.setMinutes(this.get('grace_period')['minutes']);
-        else newDate.setMinutes(0);
-        if (this.has('grace_period') && this.get('grace_period')['seconds'])
-            newDate.setSeconds(this.get('grace_period')['seconds']);
-        else newDate.setSeconds(0);
-
-        return newDate;
-    },
-    parseGracePeriod : function(grace_period) {
-        // Enforce hours:minutes format
-        if(!/^\d{2,3}:\d{2}$/.test(grace_period)) {
-            return null;
-        }
-        var pieces = grace_period.split(/:/);
-        return {
-            hours: parseInt(pieces[0], 10),
-            minutes: parseInt(pieces[1], 10)
-        }
-    },
-    parseMinimumGradeCredit : function(minimum_grade_credit) {
-        // get the value of minimum grade credit value in percentage
-        if (isNaN(minimum_grade_credit)) {
-            return 0;
-        }
-        return parseInt(minimum_grade_credit);
-    },
-    validate : function(attrs) {
-        if(_.has(attrs, 'grace_period')) {
-            if(attrs['grace_period'] === null) {
-                return {
-                    'grace_period': gettext('Grace period must be specified in HH:MM format.')
+                if (attributes.minimum_grade_credit === null) {
+                    attributes.minimum_grade_credit = 0;
                 }
-            }
-        }
-        if(this.get('is_credit_course') && _.has(attrs, 'minimum_grade_credit')) {
-            // Getting minimum grade cutoff value
-            var minimum_grade_cutoff = _.min(_.values(attrs.grade_cutoffs));
-            if(isNaN(attrs.minimum_grade_credit) || attrs.minimum_grade_credit === null || attrs.minimum_grade_credit < minimum_grade_cutoff) {
+                return attributes;
+            },
+            gracePeriodToDate: function() {
+                var newDate = new Date();
+                if (this.has('grace_period') && this.get('grace_period')['hours'])
+                    newDate.setHours(this.get('grace_period')['hours']);
+                else newDate.setHours(0);
+                if (this.has('grace_period') && this.get('grace_period')['minutes'])
+                    newDate.setMinutes(this.get('grace_period')['minutes']);
+                else newDate.setMinutes(0);
+                if (this.has('grace_period') && this.get('grace_period')['seconds'])
+                    newDate.setSeconds(this.get('grace_period')['seconds']);
+                else newDate.setSeconds(0);
+
+                return newDate;
+            },
+            parseGracePeriod: function(grace_period) {
+        // Enforce hours:minutes format
+                if (!/^\d{2,3}:\d{2}$/.test(grace_period)) {
+                    return null;
+                }
+                var pieces = grace_period.split(/:/);
                 return {
-                    'minimum_grade_credit': interpolate(
+                    hours: parseInt(pieces[0], 10),
+                    minutes: parseInt(pieces[1], 10)
+                };
+            },
+            parseMinimumGradeCredit: function(minimum_grade_credit) {
+        // get the value of minimum grade credit value in percentage
+                if (isNaN(minimum_grade_credit)) {
+                    return 0;
+                }
+                return parseInt(minimum_grade_credit);
+            },
+            validate: function(attrs) {
+                if (_.has(attrs, 'grace_period')) {
+                    if (attrs['grace_period'] === null) {
+                        return {
+                            'grace_period': gettext('Grace period must be specified in HH:MM format.')
+                        };
+                    }
+                }
+                if (this.get('is_credit_course') && _.has(attrs, 'minimum_grade_credit')) {
+            // Getting minimum grade cutoff value
+                    var minimum_grade_cutoff = _.min(_.values(attrs.grade_cutoffs));
+                    if (isNaN(attrs.minimum_grade_credit) || attrs.minimum_grade_credit === null || attrs.minimum_grade_credit < minimum_grade_cutoff) {
+                        return {
+                            'minimum_grade_credit': interpolate(
                         gettext('Not able to set passing grade to less than %(minimum_grade_cutoff)s%.'),
                         {minimum_grade_cutoff: minimum_grade_cutoff * 100},
                         true
                     )
-                };
+                        };
+                    }
+                }
             }
-        }
-    }
-});
+        });
 
-return CourseGradingPolicy;
-}); // end define()
+        return CourseGradingPolicy;
+    }); // end define()

--- a/cms/static/js/models/textbook.js
+++ b/cms/static/js/models/textbook.js
@@ -1,90 +1,89 @@
-define(["backbone", "underscore", "gettext", "js/models/chapter", "js/collections/chapter",
-        "backbone.associations", "cms/js/main"],
+define(['backbone', 'underscore', 'gettext', 'js/models/chapter', 'js/collections/chapter',
+        'backbone.associations', 'cms/js/main'],
     function(Backbone, _, gettext, ChapterModel, ChapterCollection) {
-
-    var Textbook = Backbone.AssociatedModel.extend({
-        defaults: function() {
-            return {
-                name: "",
-                chapters: new ChapterCollection([{}]),
-                showChapters: false,
-                editing: false
-            };
-        },
-        relations: [{
-            type: Backbone.Many,
-            key: "chapters",
-            relatedModel: ChapterModel,
-            collectionType: ChapterCollection
-        }],
-        initialize: function() {
-            this.setOriginalAttributes();
-            return this;
-        },
-        setOriginalAttributes: function() {
-            this._originalAttributes = this.parse(this.toJSON());
-        },
-        reset: function() {
-            this.set(this._originalAttributes, {parse: true});
-        },
-        isDirty: function() {
-            return !_.isEqual(this._originalAttributes, this.parse(this.toJSON()));
-        },
-        isEmpty: function() {
-            return !this.get('name') && this.get('chapters').isEmpty();
-        },
-        urlRoot: function() { return CMS.URL.TEXTBOOKS; },
-        parse: function(response) {
-            var ret = $.extend(true, {}, response);
-            if("tab_title" in ret && !("name" in ret)) {
-                ret.name = ret.tab_title;
-                delete ret.tab_title;
-            }
-            if("url" in ret && !("chapters" in ret)) {
-                ret.chapters = {"url": ret.url};
-                delete ret.url;
-            }
-            _.each(ret.chapters, function(chapter, i) {
-                chapter.order = chapter.order || i+1;
-            });
-            return ret;
-        },
-        toJSON: function() {
-            return {
-                tab_title: this.get('name'),
-                chapters: this.get('chapters').toJSON()
-            };
-        },
+        var Textbook = Backbone.AssociatedModel.extend({
+            defaults: function() {
+                return {
+                    name: '',
+                    chapters: new ChapterCollection([{}]),
+                    showChapters: false,
+                    editing: false
+                };
+            },
+            relations: [{
+                type: Backbone.Many,
+                key: 'chapters',
+                relatedModel: ChapterModel,
+                collectionType: ChapterCollection
+            }],
+            initialize: function() {
+                this.setOriginalAttributes();
+                return this;
+            },
+            setOriginalAttributes: function() {
+                this._originalAttributes = this.parse(this.toJSON());
+            },
+            reset: function() {
+                this.set(this._originalAttributes, {parse: true});
+            },
+            isDirty: function() {
+                return !_.isEqual(this._originalAttributes, this.parse(this.toJSON()));
+            },
+            isEmpty: function() {
+                return !this.get('name') && this.get('chapters').isEmpty();
+            },
+            urlRoot: function() { return CMS.URL.TEXTBOOKS; },
+            parse: function(response) {
+                var ret = $.extend(true, {}, response);
+                if ('tab_title' in ret && !('name' in ret)) {
+                    ret.name = ret.tab_title;
+                    delete ret.tab_title;
+                }
+                if ('url' in ret && !('chapters' in ret)) {
+                    ret.chapters = {'url': ret.url};
+                    delete ret.url;
+                }
+                _.each(ret.chapters, function(chapter, i) {
+                    chapter.order = chapter.order || i + 1;
+                });
+                return ret;
+            },
+            toJSON: function() {
+                return {
+                    tab_title: this.get('name'),
+                    chapters: this.get('chapters').toJSON()
+                };
+            },
         // NOTE: validation functions should return non-internationalized error
         // messages. The messages will be passed through gettext in the template.
-        validate: function(attrs, options) {
-            if (!attrs.name) {
-                return {
-                    message: gettext("Textbook name is required"),
-                    attributes: {name: true}
-                };
-            }
-            if (attrs.chapters.length === 0) {
-                return {
-                    message: gettext("Please add at least one chapter"),
-                    attributes: {chapters: true}
-                };
-            } else {
-                // validate all chapters
-                var invalidChapters = [];
-                attrs.chapters.each(function(chapter) {
-                    if(!chapter.isValid()) {
-                        invalidChapters.push(chapter);
-                    }
-                });
-                if(!_.isEmpty(invalidChapters)) {
+            validate: function(attrs, options) {
+                if (!attrs.name) {
                     return {
-                        message: gettext("All chapters must have a name and asset"),
-                        attributes: {chapters: invalidChapters}
+                        message: gettext('Textbook name is required'),
+                        attributes: {name: true}
                     };
                 }
+                if (attrs.chapters.length === 0) {
+                    return {
+                        message: gettext('Please add at least one chapter'),
+                        attributes: {chapters: true}
+                    };
+                } else {
+                // validate all chapters
+                    var invalidChapters = [];
+                    attrs.chapters.each(function(chapter) {
+                        if (!chapter.isValid()) {
+                            invalidChapters.push(chapter);
+                        }
+                    });
+                    if (!_.isEmpty(invalidChapters)) {
+                        return {
+                            message: gettext('All chapters must have a name and asset'),
+                            attributes: {chapters: invalidChapters}
+                        };
+                    }
+                }
             }
-        }
+        });
+        return Textbook;
     });
-    return Textbook;
-});

--- a/cms/static/js/models/uploads.js
+++ b/cms/static/js/models/uploads.js
@@ -1,85 +1,84 @@
-define(["backbone", "underscore", "gettext"], function(Backbone, _, gettext) {
-
-var FileUpload = Backbone.Model.extend({
-    defaults: {
-        "title": "",
-        "message": "",
-        "selectedFile": null,
-        "uploading": false,
-        "uploadedBytes": 0,
-        "totalBytes": 0,
-        "finished": false,
-        "mimeTypes": [],
-        "fileFormats": []
-    },
-    validate: function(attrs, options) {
-        if(attrs.selectedFile && !this.checkTypeValidity(attrs.selectedFile)) {
-            return {
-                message: _.template(gettext('Only <%= fileTypes %> files can be uploaded. Please select a file ending in <%= fileExtensions %> to upload.'))(  // eslint-disable-line max-len
+define(['backbone', 'underscore', 'gettext'], function(Backbone, _, gettext) {
+    var FileUpload = Backbone.Model.extend({
+        defaults: {
+            'title': '',
+            'message': '',
+            'selectedFile': null,
+            'uploading': false,
+            'uploadedBytes': 0,
+            'totalBytes': 0,
+            'finished': false,
+            'mimeTypes': [],
+            'fileFormats': []
+        },
+        validate: function(attrs, options) {
+            if (attrs.selectedFile && !this.checkTypeValidity(attrs.selectedFile)) {
+                return {
+                    message: _.template(gettext('Only <%= fileTypes %> files can be uploaded. Please select a file ending in <%= fileExtensions %> to upload.'))(  // eslint-disable-line max-len
                     this.formatValidTypes()
                 ),
-                attributes: {selectedFile: true}
-            };
-        }
-    },
+                    attributes: {selectedFile: true}
+                };
+            }
+        },
     // Return a list of this uploader's valid file types
-    fileTypes: function() {
-        var mimeTypes = _.map(
+        fileTypes: function() {
+            var mimeTypes = _.map(
                 this.attributes.mimeTypes,
                 function(type) {
                     return type.split('/')[1].toUpperCase();
                 }
             ),
-            fileFormats = _.map(
+                fileFormats = _.map(
                 this.attributes.fileFormats,
                 function(type) {
                     return type.toUpperCase();
                 }
             );
 
-        return mimeTypes.concat(fileFormats);
-    },
-    checkTypeValidity: function (file) {
-        var attrs = this.attributes,
-            getRegExp = function (formats) {
+            return mimeTypes.concat(fileFormats);
+        },
+        checkTypeValidity: function(file) {
+            var attrs = this.attributes,
+                getRegExp = function(formats) {
                 // Creates regular expression like: /(?:.+)\.(jpg|png|gif)$/i
-                return  RegExp(('(?:.+)\\.(' + formats.join('|') + ')$'), 'i');
-            };
+                    return RegExp(('(?:.+)\\.(' + formats.join('|') + ')$'), 'i');
+                };
 
-        return (attrs.mimeTypes.length === 0 && attrs.fileFormats.length === 0) ||
+            return (attrs.mimeTypes.length === 0 && attrs.fileFormats.length === 0) ||
                 _.contains(attrs.mimeTypes, file.type) ||
                 getRegExp(attrs.fileFormats).test(file.name);
-    },
+        },
     // Return strings for the valid file types and extensions this
     // uploader accepts, formatted as natural language
-    formatValidTypes: function() {
-        var attrs = this.attributes;
+        formatValidTypes: function() {
+            var attrs = this.attributes;
 
-        if(attrs.mimeTypes.concat(attrs.fileFormats).length === 1) {
-            return {
-                fileTypes: this.fileTypes()[0],
-                fileExtensions: '.' + this.fileTypes()[0].toLowerCase()
+            if (attrs.mimeTypes.concat(attrs.fileFormats).length === 1) {
+                return {
+                    fileTypes: this.fileTypes()[0],
+                    fileExtensions: '.' + this.fileTypes()[0].toLowerCase()
+                };
+            }
+            var or = gettext('or');
+            var formatTypes = function(types) {
+                return _.template('<%= initial %> <%= or %> <%= last %>')({
+                    initial: _.initial(types).join(', '),
+                    or: or,
+                    last: _.last(types)
+                });
             };
-        }
-        var or = gettext('or');
-        var formatTypes = function(types) {
-            return _.template('<%= initial %> <%= or %> <%= last %>')({
-                initial: _.initial(types).join(', '),
-                or: or,
-                last: _.last(types)
-            });
-        };
-        return {
-            fileTypes: formatTypes(this.fileTypes()),
-            fileExtensions: formatTypes(
+            return {
+                fileTypes: formatTypes(this.fileTypes()),
+                fileExtensions: formatTypes(
                 _.map(this.fileTypes(),
                       function(type) {
                           return '.' + type.toLowerCase();
                       })
             )
-        };
-    }
-});
+            };
+        }
+    });
 
-return FileUpload;
+    return FileUpload;
 }); // end define()

--- a/cms/static/js/models/validation_helpers.js
+++ b/cms/static/js/models/validation_helpers.js
@@ -1,20 +1,19 @@
 /**
  * Provide helper methods for modal validation.
 */
-define(["jquery"],
+define(['jquery'],
     function($) {
-
         var validateIntegerRange = function(attributeVal, range) {
-            //Validating attribute should have an integer value and should be under the given range.
+            // Validating attribute should have an integer value and should be under the given range.
             var isIntegerUnderRange = true;
             var value = Math.round(attributeVal); // see if this ensures value saved is int
             if (!isFinite(value) || /\D+/.test(attributeVal) || value < range.min || value > range.max) {
                 isIntegerUnderRange = false;
             }
             return isIntegerUnderRange;
-        }
+        };
 
         return {
             'validateIntegerRange': validateIntegerRange
-        }
+        };
     });

--- a/cms/static/js/models/xblock_container_info.js
+++ b/cms/static/js/models/xblock_container_info.js
@@ -1,4 +1,4 @@
-define(["js/models/custom_sync_xblock_info"],
+define(['js/models/custom_sync_xblock_info'],
     function(CustomSyncXBlockInfo) {
         var XBlockContainerInfo = CustomSyncXBlockInfo.extend({
             urlRoots: {

--- a/cms/static/js/models/xblock_info.js
+++ b/cms/static/js/models/xblock_info.js
@@ -13,7 +13,7 @@ function(Backbone, _, str, ModuleUtils) {
             'display_name': null,
             'category': null,
             'data': null,
-            'metadata' : null,
+            'metadata': null,
             /**
              * The Studio URL for this xblock, or null if it doesn't have one.
              */
@@ -30,16 +30,16 @@ function(Backbone, _, str, ModuleUtils) {
             /**
              * Date of the last edit to this xblock or any of its descendants.
              */
-            'edited_on':null,
+            'edited_on': null,
             /**
              * User who last edited the xblock or any of its descendants. Will only be present if
              * publishing info was explicitly requested.
              */
-            'edited_by':null,
+            'edited_by': null,
             /**
              * True iff a published version of the xblock exists.
              */
-            "published": null,
+            'published': null,
             /**
              * Date of the last publish of this xblock, or null if never published.
              */
@@ -54,12 +54,12 @@ function(Backbone, _, str, ModuleUtils) {
              * Note: this is not always provided as a performance optimization. It is only provided for
              * verticals functioning as units.
              */
-            "has_changes": null,
+            'has_changes': null,
             /**
              * Represents the possible publish states for an xblock. See the documentation
              * for XBlockVisibility to see a comprehensive enumeration of the states.
              */
-            "visibility_state": null,
+            'visibility_state': null,
             /**
              * True if the release date of the xblock is in the past.
              */
@@ -75,7 +75,7 @@ function(Backbone, _, str, ModuleUtils) {
              * This can be null if the release date is unscheduled. Will only be present if
              * publishing info was explicitly requested.
              */
-            'release_date_from':null,
+            'release_date_from': null,
             /**
              * True if this xblock is currently visible to students. This is computed server-side
              * so that the logic isn't duplicated on the client. Will only be present if
@@ -149,16 +149,16 @@ function(Backbone, _, str, ModuleUtils) {
              * The XBlock's group access rules.  This is a dictionary keyed to user partition IDs,
              * where the values are lists of group IDs.
              */
-             'group_access': null,
+            'group_access': null,
             /**
              * User partition dictionary.  This is pre-processed by Studio, so it contains
              * some additional fields that are not stored in the course descriptor
              * (for example, which groups are selected for this particular XBlock).
              */
-             'user_partitions': null,
+            'user_partitions': null
         },
 
-        initialize: function () {
+        initialize: function() {
             // Extend our Model by helper methods.
             _.extend(this, this.getCategoryHelpers());
         },
@@ -180,7 +180,7 @@ function(Backbone, _, str, ModuleUtils) {
         },
 
         createChild: function(response) {
-            return new XBlockInfo(response, { parse: true });
+            return new XBlockInfo(response, {parse: true});
         },
 
         hasChildren: function() {
@@ -188,7 +188,7 @@ function(Backbone, _, str, ModuleUtils) {
             return childInfo && childInfo.children.length > 0;
         },
 
-        isPublishable: function(){
+        isPublishable: function() {
             return !this.get('published') || this.get('has_changes');
         },
 
@@ -200,13 +200,13 @@ function(Backbone, _, str, ModuleUtils) {
             return this.isActionRequired('draggable');
         },
 
-        isChildAddable: function(){
+        isChildAddable: function() {
             return this.isActionRequired('childAddable');
         },
 
-        isHeaderVisible: function(){
-            if(this.get('is_header_visible') !== null) {
-              return this.get('is_header_visible');
+        isHeaderVisible: function() {
+            if (this.get('is_header_visible') !== null) {
+                return this.get('is_header_visible');
             }
             return true;
         },
@@ -217,7 +217,7 @@ function(Backbone, _, str, ModuleUtils) {
         */
         isActionRequired: function(actionName) {
             var actions = this.get('actions');
-            if(actions !== null) {
+            if (actions !== null) {
                 if (_.has(actions, actionName) && !actions[actionName]) {
                     return false;
                 }
@@ -229,26 +229,26 @@ function(Backbone, _, str, ModuleUtils) {
          * Return a list of convenience methods to check affiliation to the category.
          * @return {Array}
         */
-       getCategoryHelpers: function () {
+        getCategoryHelpers: function() {
             var categories = ['course', 'chapter', 'sequential', 'vertical'],
                 helpers = {};
 
-            _.each(categories, function (item) {
-                helpers['is' + str.titleize(item)] = function () {
+            _.each(categories, function(item) {
+                helpers['is' + str.titleize(item)] = function() {
                     return this.get('category') === item;
                 };
             }, this);
 
             return helpers;
-       },
+        },
 
        /**
         * Check if we can edit current XBlock or not on Course Outline page.
         * @return {Boolean}
         */
-       isEditableOnCourseOutline: function() {
-           return this.isSequential() || this.isChapter() || this.isVertical();
-       },
+        isEditableOnCourseOutline: function() {
+            return this.isSequential() || this.isChapter() || this.isVertical();
+        },
 
        /*
         * Check whether any verification checkpoints are defined in the course.
@@ -256,10 +256,10 @@ function(Backbone, _, str, ModuleUtils) {
         * that uses the verification partition scheme.
         */
         hasVerifiedCheckpoints: function() {
-            var partitions = this.get("user_partitions") || [];
+            var partitions = this.get('user_partitions') || [];
 
             return Boolean(_.find(partitions, function(p) {
-                return p.scheme === "verification";
+                return p.scheme === 'verification';
             }));
         }
     });

--- a/cms/static/js/models/xblock_outline_info.js
+++ b/cms/static/js/models/xblock_outline_info.js
@@ -1,4 +1,4 @@
-define(["js/models/custom_sync_xblock_info"],
+define(['js/models/custom_sync_xblock_info'],
     function(CustomSyncXBlockInfo) {
         var XBlockOutlineInfo = CustomSyncXBlockInfo.extend({
 
@@ -7,7 +7,7 @@ define(["js/models/custom_sync_xblock_info"],
             },
 
             createChild: function(response) {
-                return new XBlockOutlineInfo(response, { parse: true });
+                return new XBlockOutlineInfo(response, {parse: true});
             }
         });
         return XBlockOutlineInfo;

--- a/cms/static/js/models/xblock_validation.js
+++ b/cms/static/js/models/xblock_validation.js
@@ -1,4 +1,4 @@
-define(["backbone", "gettext", "underscore"], function (Backbone, gettext, _) {
+define(['backbone', 'gettext', 'underscore'], function(Backbone, gettext, _) {
     /**
      * Model for xblock validation messages as displayed in Studio.
      */
@@ -10,21 +10,21 @@ define(["backbone", "gettext", "underscore"], function (Backbone, gettext, _) {
             xblock_id: null
         },
 
-        WARNING : "warning",
-        ERROR: "error",
-        NOT_CONFIGURED: "not-configured",
+        WARNING: 'warning',
+        ERROR: 'error',
+        NOT_CONFIGURED: 'not-configured',
 
         parse: function(response) {
             if (!response.empty) {
-                var summary = "summary" in response ? response.summary : {};
-                var messages = "messages" in response ? response.messages : [];
+                var summary = 'summary' in response ? response.summary : {};
+                var messages = 'messages' in response ? response.messages : [];
                 if (!summary.text) {
-                    summary.text = gettext("This component has validation issues.");
+                    summary.text = gettext('This component has validation issues.');
                 }
                 if (!summary.type) {
                     summary.type = this.WARNING;
                     // Possible types are ERROR, WARNING, and NOT_CONFIGURED. NOT_CONFIGURED is treated as a warning.
-                    _.find(messages, function (message) {
+                    _.find(messages, function(message) {
                         if (message.type === this.ERROR) {
                             summary.type = this.ERROR;
                             return true;

--- a/cms/static/js/programs/collections/auto_auth_collection.js
+++ b/cms/static/js/programs/collections/auto_auth_collection.js
@@ -1,8 +1,8 @@
 define([
-        'backbone',
-        'js/programs/utils/auth_utils'
-    ],
-    function( Backbone, auth ) {
+    'backbone',
+    'js/programs/utils/auth_utils'
+],
+    function(Backbone, auth) {
         'use strict';
 
         return Backbone.Collection.extend(auth.autoSync);

--- a/cms/static/js/programs/collections/course_runs_collection.js
+++ b/cms/static/js/programs/collections/course_runs_collection.js
@@ -1,11 +1,11 @@
 define([
-        'backbone',
-        'jquery',
-        'js/programs/utils/api_config',
-        'js/programs/collections/auto_auth_collection',
-        'jquery.cookie'
-    ],
-    function( Backbone, $, apiConfig, AutoAuthCollection ) {
+    'backbone',
+    'jquery',
+    'js/programs/utils/api_config',
+    'js/programs/collections/auto_auth_collection',
+    'jquery.cookie'
+],
+    function(Backbone, $, apiConfig, AutoAuthCollection) {
         'use strict';
 
         return AutoAuthCollection.extend({
@@ -43,7 +43,7 @@ define([
 
             // Adds a run back into the model for selection
             addRun: function(id) {
-                var courseRun = _.findWhere( this.allRuns, { id: id });
+                var courseRun = _.findWhere(this.allRuns, {id: id});
 
                 this.create(courseRun);
             },

--- a/cms/static/js/programs/collections/programs_collection.js
+++ b/cms/static/js/programs/collections/programs_collection.js
@@ -1,9 +1,9 @@
 define([
-        'backbone',
-        'jquery',
-        'js/programs/models/program_model'
-    ],
-    function( Backbone, $, ProgramModel ) {
+    'backbone',
+    'jquery',
+    'js/programs/models/program_model'
+],
+    function(Backbone, $, ProgramModel) {
         'use strict';
 
         return Backbone.Collection.extend({

--- a/cms/static/js/programs/models/api_config_model.js
+++ b/cms/static/js/programs/models/api_config_model.js
@@ -1,7 +1,7 @@
 define([
-        'backbone'
-    ],
-    function( Backbone ) {
+    'backbone'
+],
+    function(Backbone) {
         'use strict';
 
         return Backbone.Model.extend({

--- a/cms/static/js/programs/models/auto_auth_model.js
+++ b/cms/static/js/programs/models/auto_auth_model.js
@@ -1,8 +1,8 @@
 define([
-        'backbone',
-        'js/programs/utils/auth_utils'
-    ],
-    function( Backbone, auth ) {
+    'backbone',
+    'js/programs/utils/auth_utils'
+],
+    function(Backbone, auth) {
         'use strict';
 
         return Backbone.Model.extend(auth.autoSync);

--- a/cms/static/js/programs/models/course_model.js
+++ b/cms/static/js/programs/models/course_model.js
@@ -1,12 +1,12 @@
 define([
-        'backbone',
-        'jquery',
-        'js/programs/utils/api_config',
-        'js/programs/models/auto_auth_model',
-        'jquery.cookie',
-        'gettext'
-    ],
-    function( Backbone, $, apiConfig, AutoAuthModel ) {
+    'backbone',
+    'jquery',
+    'js/programs/utils/api_config',
+    'js/programs/models/auto_auth_model',
+    'jquery.cookie',
+    'gettext'
+],
+    function(Backbone, $, apiConfig, AutoAuthModel) {
         'use strict';
 
         return AutoAuthModel.extend({

--- a/cms/static/js/programs/models/course_run_model.js
+++ b/cms/static/js/programs/models/course_run_model.js
@@ -1,7 +1,7 @@
 define([
-        'backbone'
-    ],
-    function( Backbone ) {
+    'backbone'
+],
+    function(Backbone) {
         'use strict';
 
         return Backbone.Model.extend({

--- a/cms/static/js/programs/models/organizations_model.js
+++ b/cms/static/js/programs/models/organizations_model.js
@@ -1,8 +1,8 @@
 define([
-        'js/programs/utils/api_config',
-        'js/programs/models/auto_auth_model'
-    ],
-    function( apiConfig, AutoAuthModel ) {
+    'js/programs/utils/api_config',
+    'js/programs/models/auto_auth_model'
+],
+    function(apiConfig, AutoAuthModel) {
         'use strict';
 
         return AutoAuthModel.extend({

--- a/cms/static/js/programs/models/program_model.js
+++ b/cms/static/js/programs/models/program_model.js
@@ -1,12 +1,12 @@
 define([
-        'backbone',
-        'jquery',
-        'js/programs/utils/api_config',
-        'js/programs/models/auto_auth_model',
-        'gettext',
-        'jquery.cookie'
-    ],
-    function( Backbone, $, apiConfig, AutoAuthModel, gettext ) {
+    'backbone',
+    'jquery',
+    'js/programs/utils/api_config',
+    'js/programs/models/auto_auth_model',
+    'gettext',
+    'jquery.cookie'
+],
+    function(Backbone, $, apiConfig, AutoAuthModel, gettext) {
         'use strict';
 
         return AutoAuthModel.extend({
@@ -37,7 +37,7 @@ define([
                 this.url = apiConfig.get('programsApiUrl') + 'programs/' + this.id + '/';
             },
 
-            validateOrganizations: function( orgArray ) {
+            validateOrganizations: function(orgArray) {
                 /**
                  * The array passed to this method contains a single object representing
                  * the selected organization; the object contains the organization's key.
@@ -46,61 +46,61 @@ define([
                 var i,
                     len = orgArray ? orgArray.length : 0;
 
-                for ( i = 0; i < len; i++ ) {
-                    if ( orgArray[i].key === 'false' ) {
+                for (i = 0; i < len; i++) {
+                    if (orgArray[i].key === 'false') {
                         return gettext('Please select a valid organization.');
                     }
                 }
             },
 
-            getConfig: function( options ) {
+            getConfig: function(options) {
                 var patch = options && options.patch,
                     params = patch ? this.get('id') + '/' : '',
-                    config = _.extend({ validate: true, parse: true }, {
+                    config = _.extend({validate: true, parse: true}, {
                         type: patch ? 'PATCH' : 'POST',
                         url: apiConfig.get('programsApiUrl') + 'programs/' + params,
                         contentType: patch ? 'application/merge-patch+json' : 'application/json',
                         context: this,
                         // NB: setting context fails in tests
-                        success: _.bind( this.saveSuccess, this ),
-                        error: _.bind( this.saveError, this )
+                        success: _.bind(this.saveSuccess, this),
+                        error: _.bind(this.saveError, this)
                     });
 
-                if ( patch ) {
-                    config.data = JSON.stringify( options.update ) || this.attributes;
+                if (patch) {
+                    config.data = JSON.stringify(options.update) || this.attributes;
                 }
 
                 return config;
             },
 
-            patch: function( data ) {
+            patch: function(data) {
                 this.save({
                     patch: true,
                     update: data
                 });
             },
 
-            save: function( options ) {
+            save: function(options) {
                 var method,
                     patch = options && options.patch ? true : false,
-                    config = this.getConfig( options );
+                    config = this.getConfig(options);
 
                 /**
                  * Simplified version of code from the default Backbone save function
                  * http://backbonejs.org/docs/backbone.html#section-87
                  */
-                method = this.isNew() ? 'create' : ( patch ? 'patch' : 'update' );
+                method = this.isNew() ? 'create' : (patch ? 'patch' : 'update');
 
-                this.sync( method, this, config );
+                this.sync(method, this, config);
             },
 
-            saveError: function( jqXHR ) {
-                this.trigger( 'error', jqXHR );
+            saveError: function(jqXHR) {
+                this.trigger('error', jqXHR);
             },
 
-            saveSuccess: function( data ) {
-                this.set({ id: data.id });
-                this.trigger( 'sync', this );
+            saveSuccess: function(data) {
+                this.set({id: data.id});
+                this.trigger('sync', this);
             }
         });
     }

--- a/cms/static/js/programs/program_admin_app.js
+++ b/cms/static/js/programs/program_admin_app.js
@@ -1,9 +1,9 @@
 (function() {
     'use strict';
     require([
-            'js/programs/views/program_admin_app_view'
-        ],
-        function( ProgramAdminAppView ) {
+        'js/programs/views/program_admin_app_view'
+    ],
+        function(ProgramAdminAppView) {
             return new ProgramAdminAppView();
         }
     );

--- a/cms/static/js/programs/router.js
+++ b/cms/static/js/programs/router.js
@@ -1,10 +1,10 @@
 define([
-        'backbone',
-        'js/programs/views/program_creator_view',
-        'js/programs/views/program_details_view',
-        'js/programs/models/program_model'
-    ],
-    function( Backbone, ProgramCreatorView, ProgramDetailsView, ProgramModel ) {
+    'backbone',
+    'js/programs/views/program_creator_view',
+    'js/programs/views/program_details_view',
+    'js/programs/models/program_model'
+],
+    function(Backbone, ProgramCreatorView, ProgramDetailsView, ProgramModel) {
         'use strict';
 
         return Backbone.Router.extend({
@@ -15,7 +15,7 @@ define([
                 ':id': 'programDetails'
             },
 
-            initialize: function( options ) {
+            initialize: function(options) {
                 this.homeUrl = options.homeUrl;
             },
 
@@ -30,7 +30,7 @@ define([
             },
 
             programCreator: function() {
-                if ( this.programCreatorView ) {
+                if (this.programCreatorView) {
                     this.programCreatorView.destroy();
                 }
 
@@ -39,20 +39,20 @@ define([
                 });
             },
 
-            programDetails: function( id ) {
-                 this.programModel = new ProgramModel({
+            programDetails: function(id) {
+                this.programModel = new ProgramModel({
                     id: id
                 });
 
-                this.programModel.on( 'sync', this.loadProgramDetails, this );
+                this.programModel.on('sync', this.loadProgramDetails, this);
                 this.programModel.fetch();
             },
 
             /**
              * Starts the router.
              */
-            start: function () {
-                if ( !Backbone.history.started ) {
+            start: function() {
+                if (!Backbone.history.started) {
                     Backbone.history.start({
                         pushState: true,
                         root: this.root

--- a/cms/static/js/programs/shims/gettext.js
+++ b/cms/static/js/programs/shims/gettext.js
@@ -6,14 +6,14 @@
 (function() {
     'use strict';
 
-    if ( !window.gettext ) {
-        window.gettext = function (text) {
+    if (!window.gettext) {
+        window.gettext = function(text) {
             return text;
         };
     }
 
-    if ( !window.interpolate ) {
-        window.interpolate = function (text) {
+    if (!window.interpolate) {
+        window.interpolate = function(text) {
             return text;
         };
     }

--- a/cms/static/js/programs/utils/api_config.js
+++ b/cms/static/js/programs/utils/api_config.js
@@ -1,7 +1,7 @@
 define([
-        'js/programs/models/api_config_model'
-    ],
-    function( ApiConfigModel ) {
+    'js/programs/models/api_config_model'
+],
+    function(ApiConfigModel) {
         'use strict';
 
         /**
@@ -16,6 +16,5 @@ define([
         }
 
         return instance;
-
     }
 );

--- a/cms/static/js/programs/utils/auth_utils.js
+++ b/cms/static/js/programs/utils/auth_utils.js
@@ -1,9 +1,9 @@
 define([
-        'jquery',
-        'underscore',
-        'js/programs/utils/api_config'
-    ],
-    function( $, _, apiConfig ) {
+    'jquery',
+    'underscore',
+    'js/programs/utils/api_config'
+],
+    function($, _, apiConfig) {
         'use strict';
 
         var auth = {
@@ -20,11 +20,10 @@ define([
                  * implementation.
                  *
                  */
-                sync: function( method, model, options ) {
-
+                sync: function(method, model, options) {
                     var oldError = options.error;
 
-                    this._setHeaders( options );
+                    this._setHeaders(options);
 
                     options.notifyOnError = false;  // suppress Studio error pop-up that will happen if we get a 401
 
@@ -38,7 +37,7 @@ define([
                                 delete options.xhr;  // remove the failed (401) xhr from the last try.
 
                                 // update authorization header
-                                this._setHeaders( options );
+                                this._setHeaders(options);
 
                                 Backbone.sync.call(this, method, model, options);
                             }.bind(this));
@@ -54,11 +53,11 @@ define([
                  * Fix up headers on an imminent AJAX sync, ensuring that the JWT token is enclosed
                  * and that credentials are included when the request is being made cross-domain.
                  */
-                _setHeaders: function( ajaxOptions ) {
-                    ajaxOptions.headers = _.extend ( ajaxOptions.headers || {}, {
-                        Authorization: 'JWT ' + apiConfig.get( 'idToken' )
+                _setHeaders: function(ajaxOptions) {
+                    ajaxOptions.headers = _.extend(ajaxOptions.headers || {}, {
+                        Authorization: 'JWT ' + apiConfig.get('idToken')
                     });
-                    ajaxOptions.xhrFields = _.extend( ajaxOptions.xhrFields || {}, {
+                    ajaxOptions.xhrFields = _.extend(ajaxOptions.xhrFields || {}, {
                         withCredentials: true
                     });
                 },
@@ -67,8 +66,7 @@ define([
                  * Fetch a new id token from the configured endpoint, update the api config,
                  * and invoke the specified callback.
                  */
-                _updateToken: function( success ) {
-
+                _updateToken: function(success) {
                     $.ajax({
                         url: apiConfig.get('authUrl'),
                         xhrFields: {
@@ -76,10 +74,10 @@ define([
                             withCredentials: true
                         },
                         crossDomain: true
-                    }).done(function ( data ) {
+                    }).done(function(data) {
                         // save the newly-retrieved id token
-                        apiConfig.set( 'idToken', data.id_token );
-                    }).done( success );
+                        apiConfig.set('idToken', data.id_token);
+                    }).done(success);
                 }
             }
         };

--- a/cms/static/js/programs/utils/validation_config.js
+++ b/cms/static/js/programs/utils/validation_config.js
@@ -1,10 +1,10 @@
 define([
-        'backbone',
-        'backbone.validation',
-        'underscore',
-        'gettext'
-    ],
-    function( Backbone, BackboneValidation, _, gettext ) {
+    'backbone',
+    'backbone.validation',
+    'underscore',
+    'gettext'
+],
+    function(Backbone, BackboneValidation, _, gettext) {
         'use strict';
 
         var errorClass = 'has-error',
@@ -14,52 +14,52 @@ define([
         // These are the same messages provided by Backbone.Validation,
         // marked for translation.
         // See: http://thedersen.com/projects/backbone-validation/#overriding-the-default-error-messages.
-        _.extend( Backbone.Validation.messages, {
-            required: gettext( '{0} is required' ),
-            acceptance: gettext( '{0} must be accepted' ),
-            min: gettext( '{0} must be greater than or equal to {1}' ),
-            max: gettext( '{0} must be less than or equal to {1}' ),
-            range: gettext( '{0} must be between {1} and {2}' ),
-            length: gettext( '{0} must be {1} characters' ),
-            minLength: gettext( '{0} must be at least {1} characters' ),
-            maxLength: gettext( '{0} must be at most {1} characters' ),
-            rangeLength: gettext( '{0} must be between {1} and {2} characters' ),
-            oneOf: gettext( '{0} must be one of: {1}' ),
-            equalTo: gettext( '{0} must be the same as {1}' ),
-            digits: gettext( '{0} must only contain digits' ),
-            number: gettext( '{0} must be a number' ),
-            email: gettext( '{0} must be a valid email' ),
-            url: gettext( '{0} must be a valid url' ),
-            inlinePattern: gettext( '{0} is invalid' )
+        _.extend(Backbone.Validation.messages, {
+            required: gettext('{0} is required'),
+            acceptance: gettext('{0} must be accepted'),
+            min: gettext('{0} must be greater than or equal to {1}'),
+            max: gettext('{0} must be less than or equal to {1}'),
+            range: gettext('{0} must be between {1} and {2}'),
+            length: gettext('{0} must be {1} characters'),
+            minLength: gettext('{0} must be at least {1} characters'),
+            maxLength: gettext('{0} must be at most {1} characters'),
+            rangeLength: gettext('{0} must be between {1} and {2} characters'),
+            oneOf: gettext('{0} must be one of: {1}'),
+            equalTo: gettext('{0} must be the same as {1}'),
+            digits: gettext('{0} must only contain digits'),
+            number: gettext('{0} must be a number'),
+            email: gettext('{0} must be a valid email'),
+            url: gettext('{0} must be a valid url'),
+            inlinePattern: gettext('{0} is invalid')
         });
 
-        _.extend( Backbone.Validation.callbacks, {
+        _.extend(Backbone.Validation.callbacks, {
             // Gets called when a previously invalid field in the
             // view becomes valid. Removes any error message.
-            valid: function( view, attr, selector ) {
-                var $input = view.$( '[' + selector + '~="' + attr + '"]' ),
-                    $message = $input.siblings( messageEl );
+            valid: function(view, attr, selector) {
+                var $input = view.$('[' + selector + '~="' + attr + '"]'),
+                    $message = $input.siblings(messageEl);
 
-                $input.removeClass( errorClass )
-                      .removeAttr( 'data-error' );
+                $input.removeClass(errorClass)
+                      .removeAttr('data-error');
 
-                $message.removeClass( errorClass )
-                        .find( messageContent )
-                        .text( '' );
+                $message.removeClass(errorClass)
+                        .find(messageContent)
+                        .text('');
             },
 
             // Gets called when a field in the view becomes invalid.
             // Adds a error message.
-            invalid: function( view, attr, error, selector ) {
-                var $input = view.$( '[' + selector + '~="' + attr + '"]' ),
-                    $message = $input.siblings( messageEl );
+            invalid: function(view, attr, error, selector) {
+                var $input = view.$('[' + selector + '~="' + attr + '"]'),
+                    $message = $input.siblings(messageEl);
 
-                $input.addClass( errorClass )
-                      .attr( 'data-error', error );
+                $input.addClass(errorClass)
+                      .attr('data-error', error);
 
-                $message.addClass( errorClass )
-                        .find( messageContent )
-                        .text( $input.data('error') );
+                $message.addClass(errorClass)
+                        .find(messageContent)
+                        .text($input.data('error'));
             }
         });
 

--- a/cms/static/js/programs/views/confirm_modal_view.js
+++ b/cms/static/js/programs/views/confirm_modal_view.js
@@ -1,13 +1,13 @@
 define([
-        'backbone',
-        'jquery',
-        'underscore',
-        'js/programs/utils/constants',
-        'text!templates/programs/confirm_modal.underscore',
-        'edx-ui-toolkit/js/utils/html-utils',
-        'gettext'
-    ],
-    function( Backbone, $, _, constants, ModalTpl, HtmlUtils ) {
+    'backbone',
+    'jquery',
+    'underscore',
+    'js/programs/utils/constants',
+    'text!templates/programs/confirm_modal.underscore',
+    'edx-ui-toolkit/js/utils/html-utils',
+    'gettext'
+],
+    function(Backbone, $, _, constants, ModalTpl, HtmlUtils) {
         'use strict';
 
         return Backbone.View.extend({
@@ -17,17 +17,17 @@ define([
                 'keydown': 'handleKeydown'
             },
 
-            tpl: HtmlUtils.template( ModalTpl ),
+            tpl: HtmlUtils.template(ModalTpl),
 
-            initialize: function( options ) {
-                this.$parentEl = $( options.parentEl );
+            initialize: function(options) {
+                this.$parentEl = $(options.parentEl);
                 this.callback = options.callback;
                 this.content = options.content;
                 this.render();
             },
 
             render: function() {
-                HtmlUtils.setHtml(this.$el, this.tpl( this.content ));
+                HtmlUtils.setHtml(this.$el, this.tpl(this.content));
                 HtmlUtils.setHtml(this.$parentEl, HtmlUtils.HTML(this.$el));
                 this.postRender();
             },
@@ -47,10 +47,10 @@ define([
                 this.$parentEl.html('');
             },
 
-            handleKeydown: function( event ) {
+            handleKeydown: function(event) {
                 var keyCode = event.keyCode;
 
-                if ( keyCode === constants.keyCodes.esc ) {
+                if (keyCode === constants.keyCodes.esc) {
                     this.destroy();
                 }
             }

--- a/cms/static/js/programs/views/course_details_view.js
+++ b/cms/static/js/programs/views/course_details_view.js
@@ -1,19 +1,19 @@
 define([
-        'backbone',
-        'backbone.validation',
-        'jquery',
-        'underscore',
-        'js/programs/models/course_model',
-        'js/programs/models/course_run_model',
-        'js/programs/models/program_model',
-        'js/programs/views/course_run_view',
-        'text!templates/programs/course_details.underscore',
-        'edx-ui-toolkit/js/utils/html-utils',
-        'gettext',
-        'js/programs/utils/validation_config'
-    ],
-    function( Backbone, BackboneValidation, $, _, CourseModel, CourseRunModel,
-        ProgramModel, CourseRunView, ListTpl, HtmlUtils ) {
+    'backbone',
+    'backbone.validation',
+    'jquery',
+    'underscore',
+    'js/programs/models/course_model',
+    'js/programs/models/course_run_model',
+    'js/programs/models/program_model',
+    'js/programs/views/course_run_view',
+    'text!templates/programs/course_details.underscore',
+    'edx-ui-toolkit/js/utils/html-utils',
+    'gettext',
+    'js/programs/utils/validation_config'
+],
+    function(Backbone, BackboneValidation, $, _, CourseModel, CourseRunModel,
+        ProgramModel, CourseRunView, ListTpl, HtmlUtils) {
         'use strict';
 
         return Backbone.View.extend({
@@ -27,19 +27,19 @@ define([
                 'click .js-add-course-run': 'addCourseRun'
             },
 
-            tpl: HtmlUtils.template( ListTpl ),
+            tpl: HtmlUtils.template(ListTpl),
 
-            initialize: function( options ) {
+            initialize: function(options) {
                 this.model = new CourseModel();
-                Backbone.Validation.bind( this );
-                this.$parentEl = $( this.parentEl );
+                Backbone.Validation.bind(this);
+                this.$parentEl = $(this.parentEl);
 
                 // For managing subViews
                 this.courseRunViews = [];
                 this.courseRuns = options.courseRuns;
                 this.programModel = options.programModel;
-                
-                if ( options.courseData ) {
+
+                if (options.courseData) {
                     this.model.set(options.courseData);
                 } else {
                     this.model.set({run_modes: []});
@@ -53,13 +53,13 @@ define([
 
             render: function() {
                 HtmlUtils.setHtml(this.$el, this.tpl(this.formatData()));
-                this.$parentEl.append( this.$el );
+                this.$parentEl.append(this.$el);
                 this.postRender();
             },
 
             postRender: function() {
                 var runs = this.model.get('run_modes');
-                if ( runs && runs.length > 0 ) {
+                if (runs && runs.length > 0) {
                     this.addCourseRuns();
                 }
             },
@@ -81,7 +81,7 @@ define([
                     $parentEl: $runsContainer
                 });
 
-                this.courseRunViews.push( runView );
+                this.courseRunViews.push(runView);
             },
 
             addCourseRuns: function() {
@@ -89,7 +89,7 @@ define([
                 var runs = this.model.get('run_modes'),
                     $runsContainer = this.$el.find('.js-course-runs');
 
-                _.each( runs, function( run ) {
+                _.each(runs, function(run) {
                     var runModel = new CourseRunModel(),
                         runView;
 
@@ -103,20 +103,20 @@ define([
                         $parentEl: $runsContainer
                     });
 
-                    this.courseRunViews.push( runView );
+                    this.courseRunViews.push(runView);
 
                     return runView;
-                }.bind(this) );
+                }.bind(this));
             },
 
             addCourseToProgram: function() {
                 var courseCodes = this.programModel.get('course_codes'),
                     courseData = this.model.toJSON();
 
-                if ( this.programModel.isValid( true ) ) {
+                if (this.programModel.isValid(true)) {
                     // We don't want to save the cid so omit it
-                    courseCodes.push( _.omit(courseData, 'cid') );
-                    this.programModel.patch({ course_codes: courseCodes });
+                    courseCodes.push(_.omit(courseData, 'cid'));
+                    this.programModel.patch({course_codes: courseCodes});
                 }
             },
             // Delete this view
@@ -131,16 +131,16 @@ define([
             destroyChildren: function() {
                 var runs = this.courseRunViews;
 
-                _.each( runs, function( run ) {
+                _.each(runs, function(run) {
                     run.removeRun();
                 });
             },
 
             // Format data to be passed to the template
             formatData: function() {
-                var data = $.extend( {}, 
-                    { courseRuns: this.courseRuns.models },
-                    _.omit( this.programModel.toJSON(), 'run_modes'),
+                var data = $.extend({},
+                    {courseRuns: this.courseRuns.models},
+                    _.omit(this.programModel.toJSON(), 'run_modes'),
                     this.model.toJSON()
                 );
 
@@ -153,14 +153,14 @@ define([
                     name = this.model.get('display_name'),
                     update = [];
 
-                update = _.reject( courseCodes, function(course) {
+                update = _.reject(courseCodes, function(course) {
                     return course.key === key && course.display_name === name;
                 });
 
-                this.programModel.patch({ course_codes: update });
+                this.programModel.patch({course_codes: update});
             },
 
-            setCourse: function( event ) {
+            setCourse: function(event) {
                 var $form = this.$('.js-course-form'),
                     title = $form.find('.display-name').val(),
                     key = $form.find('.course-key').val();
@@ -173,7 +173,7 @@ define([
                     organization: this.programModel.get('organizations')[0]
                 });
 
-                if ( this.model.isValid(true) ) {
+                if (this.model.isValid(true)) {
                     this.addCourseToProgram();
                     this.updateDOM();
                     this.addCourseRuns();
@@ -181,7 +181,7 @@ define([
             },
 
             updateDOM: function() {
-                HtmlUtils.setHtml(this.$el, this.tpl( this.formatData() ) );
+                HtmlUtils.setHtml(this.$el, this.tpl(this.formatData()));
             },
 
             updateRuns: function() {
@@ -190,13 +190,13 @@ define([
                     name = this.model.get('display_name'),
                     index;
 
-                if ( this.programModel.isValid( true ) ) {
-                    index = _.findIndex( courseCodes, function(course) {
+                if (this.programModel.isValid(true)) {
+                    index = _.findIndex(courseCodes, function(course) {
                         return course.key === key && course.display_name === name;
                     });
                     courseCodes[index] = this.model.toJSON();
 
-                    this.programModel.patch({ course_codes: courseCodes });
+                    this.programModel.patch({course_codes: courseCodes});
                 }
             }
         });

--- a/cms/static/js/programs/views/course_run_view.js
+++ b/cms/static/js/programs/views/course_run_view.js
@@ -1,11 +1,11 @@
 define([
-        'backbone',
-        'jquery',
-        'underscore',
-        'text!templates/programs/course_run.underscore',
-        'edx-ui-toolkit/js/utils/html-utils'
-    ],
-    function ( Backbone, $, _, CourseRunTpl, HtmlUtils ) {
+    'backbone',
+    'jquery',
+    'underscore',
+    'text!templates/programs/course_run.underscore',
+    'edx-ui-toolkit/js/utils/html-utils'
+],
+    function(Backbone, $, _, CourseRunTpl, HtmlUtils) {
         'use strict';
 
         return Backbone.View.extend({
@@ -14,9 +14,9 @@ define([
                 'click .js-remove-run': 'removeRun'
             },
 
-            tpl: HtmlUtils.template( CourseRunTpl ),
+            tpl: HtmlUtils.template(CourseRunTpl),
 
-            initialize: function( options ) {
+            initialize: function(options) {
                 /**
                  * Need the run model for the template, and the courseModel
                  * to keep parent view up to date with run changes
@@ -37,12 +37,12 @@ define([
 
                 data.programStatus = this.programStatus;
 
-                if ( !!this.courseRuns ) {
+                if (!!this.courseRuns) {
                     data.courseRuns = this.courseRuns.toJSON();
                 }
 
-                HtmlUtils.setHtml(this.$el, this.tpl( data ) );
-                this.$parentEl.append( this.$el );
+                HtmlUtils.setHtml(this.$el, this.tpl(data));
+                this.$parentEl.append(this.$el);
             },
 
             // Delete this view
@@ -52,7 +52,7 @@ define([
             },
 
             // Data returned from courseList API is not the correct format
-            formatData: function( data ) {
+            formatData: function(data) {
                 return {
                     course_key: data.id,
                     mode_slug: 'verified',
@@ -72,7 +72,7 @@ define([
                     runs = _.clone(this.courseModel.get('run_modes')),
                     updatedRuns = [];
 
-                updatedRuns = _.reject( runs, function( obj ) {
+                updatedRuns = _.reject(runs, function(obj) {
                     return obj.start_date === startDate &&
                            obj.course_key === courseKey;
                 });
@@ -96,7 +96,7 @@ define([
                     runs = _.clone(this.courseModel.get('run_modes')),
                     data = this.formatData(runObj);
 
-                this.model.set( data );
+                this.model.set(data);
                 runs.push(data);
                 this.courseModel.set({run_modes: runs});
                 this.courseRuns.removeRun(id);
@@ -104,7 +104,7 @@ define([
 
             // If a run has not been selected update the dropdown options
             updateDropdown: function() {
-                if ( !this.model.get('course_key') ) {
+                if (!this.model.get('course_key')) {
                     this.render();
                 }
             }

--- a/cms/static/js/programs/views/program_admin_app_view.js
+++ b/cms/static/js/programs/views/program_admin_app_view.js
@@ -2,11 +2,11 @@
     'use strict';
 
     define([
-            'backbone',
-            'js/programs/router',
-            'js/programs/utils/api_config'
-        ],
-        function( Backbone, ProgramRouter, apiConfig ) {
+        'backbone',
+        'js/programs/router',
+        'js/programs/utils/api_config'
+    ],
+        function(Backbone, ProgramRouter, apiConfig) {
             return Backbone.View.extend({
                 el: '.js-program-admin',
 
@@ -37,14 +37,14 @@
                  * @param {Event} event - Event being handled.
                  * @returns {boolean} - Indicates if event handling succeeded (always true).
                  */
-                navigate: function (event) {
-                    var url = $(event.target).attr('href').replace( this.app.root, '' );
+                navigate: function(event) {
+                    var url = $(event.target).attr('href').replace(this.app.root, '');
 
                     /**
                      * Handle the cases where the user wants to open the link in a new tab/window.
                      * event.which === 2 checks for the middle mouse button (https://api.jquery.com/event.which/)
                      */
-                    if ( event.ctrlKey || event.shiftKey || event.metaKey || event.which === 2 ) {
+                    if (event.ctrlKey || event.shiftKey || event.metaKey || event.which === 2) {
                         return true;
                     }
 
@@ -52,14 +52,14 @@
                     event.preventDefault();
 
                     // Process the navigation in the app/router.
-                    if ( url === Backbone.history.getFragment() && url === '' ) {
+                    if (url === Backbone.history.getFragment() && url === '') {
                         /**
                          * Note: We must call the index directly since Backbone
                          * does not support routing to the same route.
                          */
                         this.app.index();
                     } else {
-                        this.app.navigate( url, { trigger: true } );
+                        this.app.navigate(url, {trigger: true});
                     }
                 }
             });

--- a/cms/static/js/programs/views/program_creator_view.js
+++ b/cms/static/js/programs/views/program_creator_view.js
@@ -1,16 +1,16 @@
 define([
-        'backbone',
-        'backbone.validation',
-        'jquery',
-        'underscore',
-        'js/programs/models/organizations_model',
-        'js/programs/models/program_model',
-        'text!templates/programs/program_creator_form.underscore',
-        'edx-ui-toolkit/js/utils/html-utils',
-        'gettext',
-        'js/programs/utils/validation_config'
-    ],
-    function ( Backbone, BackboneValidation, $, _, OrganizationsModel, ProgramModel, ListTpl, HtmlUtils ) {
+    'backbone',
+    'backbone.validation',
+    'jquery',
+    'underscore',
+    'js/programs/models/organizations_model',
+    'js/programs/models/program_model',
+    'text!templates/programs/program_creator_form.underscore',
+    'edx-ui-toolkit/js/utils/html-utils',
+    'gettext',
+    'js/programs/utils/validation_config'
+],
+    function(Backbone, BackboneValidation, $, _, OrganizationsModel, ProgramModel, ListTpl, HtmlUtils) {
         'use strict';
 
         return Backbone.View.extend({
@@ -21,21 +21,21 @@ define([
                 'click .js-abort-view': 'abort'
             },
 
-            tpl: HtmlUtils.template( ListTpl ),
+            tpl: HtmlUtils.template(ListTpl),
 
-            initialize: function( options ) {
-                this.$parentEl = $( this.parentEl );
+            initialize: function(options) {
+                this.$parentEl = $(this.parentEl);
 
                 this.model = new ProgramModel();
-                this.model.on( 'sync', this.saveSuccess, this );
-                this.model.on( 'error', this.saveError, this );
+                this.model.on('sync', this.saveSuccess, this);
+                this.model.on('error', this.saveError, this);
 
                 // Hook up validation.
                 // See: http://thedersen.com/projects/backbone-validation/#validation-binding.
-                Backbone.Validation.bind( this );
+                Backbone.Validation.bind(this);
 
                 this.organizations = new OrganizationsModel();
-                this.organizations.on( 'sync', this.render, this );
+                this.organizations.on('sync', this.render, this);
                 this.organizations.fetch();
 
                 this.router = options.router;
@@ -44,31 +44,31 @@ define([
             render: function() {
                 HtmlUtils.setHtml(
                     this.$el,
-                    this.tpl( {
+                    this.tpl({
                         orgs: this.organizations.get('results')
                     })
                 );
 
-                HtmlUtils.setHtml(this.$parentEl, HtmlUtils.HTML( this.$el ));
+                HtmlUtils.setHtml(this.$parentEl, HtmlUtils.HTML(this.$el));
             },
 
-            abort: function( event ) {
+            abort: function(event) {
                 event.preventDefault();
                 this.router.goHome();
             },
 
-            createProgram: function( event ) {
+            createProgram: function(event) {
                 var data = this.getData();
 
                 event.preventDefault();
-                this.model.set( data );
+                this.model.set(data);
 
                 // Check if the model is valid before saving. Invalid attributes are looked
                 // up by name. The corresponding elements receieve an `invalid` class and a
                 // `data-error` attribute. Both are removed when formerly invalid attributes
                 // become valid.
                 // See: http://thedersen.com/projects/backbone-validation/#isvalid.
-                if ( this.model.isValid(true) ) {
+                if (this.model.isValid(true)) {
                     this.model.save();
                 }
             },
@@ -84,28 +84,28 @@ define([
 
             getData: function() {
                 return {
-                    name: this.$el.find( '.program-name' ).val(),
-                    subtitle: this.$el.find( '.program-subtitle' ).val(),
-                    category: this.$el.find( '.program-type' ).val(),
-                    marketing_slug: this.$el.find( '.program-marketing-slug' ).val(),
+                    name: this.$el.find('.program-name').val(),
+                    subtitle: this.$el.find('.program-subtitle').val(),
+                    category: this.$el.find('.program-type').val(),
+                    marketing_slug: this.$el.find('.program-marketing-slug').val(),
                     organizations: [{
-                        key: this.$el.find( '.program-org' ).val()
+                        key: this.$el.find('.program-org').val()
                     }]
                 };
             },
 
-            goToView: function( uri ) {
-                Backbone.history.navigate( uri, { trigger: true } );
+            goToView: function(uri) {
+                Backbone.history.navigate(uri, {trigger: true});
                 this.destroy();
             },
 
             // TODO: add user messaging to show errors
-            saveError: function( jqXHR ) {
-                console.log( 'saveError: ', jqXHR );
+            saveError: function(jqXHR) {
+                console.log('saveError: ', jqXHR);
             },
 
             saveSuccess: function() {
-                this.goToView( String( this.model.get( 'id' ) ) );
+                this.goToView(String(this.model.get('id')));
             }
         });
     }

--- a/cms/static/js/programs/views/program_details_view.js
+++ b/cms/static/js/programs/views/program_details_view.js
@@ -1,20 +1,20 @@
 define([
-        'backbone',
-        'backbone.validation',
-        'jquery',
-        'underscore',
-        'js/programs/collections/course_runs_collection',
-        'js/programs/models/program_model',
-        'js/programs/views/confirm_modal_view',
-        'js/programs/views/course_details_view',
-        'text!templates/programs/program_details.underscore',
-        'edx-ui-toolkit/js/utils/html-utils',
-        'gettext',
-        'js/programs/utils/validation_config'
-    ],
-    function( Backbone, BackboneValidation, $, _, CourseRunsCollection,
+    'backbone',
+    'backbone.validation',
+    'jquery',
+    'underscore',
+    'js/programs/collections/course_runs_collection',
+    'js/programs/models/program_model',
+    'js/programs/views/confirm_modal_view',
+    'js/programs/views/course_details_view',
+    'text!templates/programs/program_details.underscore',
+    'edx-ui-toolkit/js/utils/html-utils',
+    'gettext',
+    'js/programs/utils/validation_config'
+],
+    function(Backbone, BackboneValidation, $, _, CourseRunsCollection,
         ProgramModel, ModalView, CourseView, ListTpl,
-            HtmlUtils ) {
+            HtmlUtils) {
         'use strict';
 
         return Backbone.View.extend({
@@ -27,10 +27,10 @@ define([
                 'click .js-publish-program': 'confirmPublish'
             },
 
-            tpl: HtmlUtils.template( ListTpl ),
+            tpl: HtmlUtils.template(ListTpl),
 
             initialize: function() {
-                Backbone.Validation.bind( this );
+                Backbone.Validation.bind(this);
 
                 this.courseRuns = new CourseRunsCollection([], {
                     organization: this.model.get('organizations')[0]
@@ -41,25 +41,25 @@ define([
             },
 
             render: function() {
-                HtmlUtils.setHtml(this.$el, this.tpl( this.model.toJSON() ) );
+                HtmlUtils.setHtml(this.$el, this.tpl(this.model.toJSON()));
                 this.postRender();
             },
 
             postRender: function() {
-                var courses = this.model.get( 'course_codes' );
+                var courses = this.model.get('course_codes');
 
-                _.each( courses, function( course ) {
+                _.each(courses, function(course) {
                     var title = course.key + 'Course';
 
-                    this[ title ] = new CourseView({
+                    this[title] = new CourseView({
                         courseRuns: this.courseRuns,
                         programModel: this.model,
                         courseData: course
                     });
-                }.bind(this) );
+                }.bind(this));
 
                 // Stop listening to the model sync set when publishing
-                this.model.off( 'sync' );
+                this.model.off('sync');
             },
 
             addCourse: function() {
@@ -69,7 +69,7 @@ define([
                 });
             },
 
-            checkEdit: function( event ) {
+            checkEdit: function(event) {
                 var $input = $(event.target),
                     $span = $input.prevAll('.js-model-value'),
                     $btn = $input.next('.js-enable-edit'),
@@ -83,12 +83,12 @@ define([
                 $btn.removeClass('is-hidden');
                 $span.removeClass('is-hidden');
 
-                if ( this.model.get( key ) !== value ) {
-                    this.model.set( data );
+                if (this.model.get(key) !== value) {
+                    this.model.set(data);
 
-                    if ( this.model.isValid( true ) ) {
-                        this.model.patch( data );
-                        $span.text( value );
+                    if (this.model.isValid(true)) {
+                        this.model.patch(data);
+                        $span.text(value);
                     }
                 }
             },
@@ -97,7 +97,7 @@ define([
              * Loads modal that user clicks a confirmation button
              * in to publish the course (or they can cancel out of it)
              */
-            confirmPublish: function( event ) {
+            confirmPublish: function(event) {
                 event.preventDefault();
 
                 /**
@@ -106,10 +106,10 @@ define([
                  * the program creation form and is only happening here
                  * it makes sense to have the validation at the view level
                  */
-                if ( this.model.isValid( true ) && this.validateMarketingSlug() ) {
+                if (this.model.isValid(true) && this.validateMarketingSlug()) {
                     this.modalView = new ModalView({
                         model: this.model,
-                        callback: _.bind( this.publishProgram, this ),
+                        callback: _.bind(this.publishProgram, this),
                         content: this.getModalContent(),
                         parentEl: '.js-publish-modal',
                         parentView: this
@@ -117,21 +117,21 @@ define([
                 }
             },
 
-            editField: function( event ) {
+            editField: function(event) {
                 /**
                  * Making the assumption that users can only see
                  * programs that they have permission to edit
                  */
-                var $btn = $( event.currentTarget ),
-                    $el = $btn.prev( 'input' );
+                var $btn = $(event.currentTarget),
+                    $el = $btn.prev('input');
 
                 event.preventDefault();
 
-                $el.prevAll( '.js-model-value' ).addClass( 'is-hidden' );
-                $el.removeClass( 'is-hidden' )
-                   .addClass( 'edit' )
+                $el.prevAll('.js-model-value').addClass('is-hidden');
+                $el.removeClass('is-hidden')
+                   .addClass('edit')
                    .focus();
-                $btn.addClass( 'is-hidden' );
+                $btn.addClass('is-hidden');
             },
 
             getModalContent: function() {
@@ -153,9 +153,9 @@ define([
                     status: 'active'
                 };
 
-                this.model.set( data, { silent: true } );
-                this.model.on( 'sync', this.render, this );
-                this.model.patch( data );
+                this.model.set(data, {silent: true});
+                this.model.on('sync', this.render, this);
+                this.model.patch(data);
             },
 
             setAvailableCourseRuns: function() {
@@ -165,12 +165,12 @@ define([
                     availableRuns = allRuns;
 
                 if (courses.length) {
-                    selectedRuns = _.pluck( courses, 'run_modes' );
-                    selectedRuns = _.flatten( selectedRuns );
+                    selectedRuns = _.pluck(courses, 'run_modes');
+                    selectedRuns = _.flatten(selectedRuns);
                 }
 
                 availableRuns = _.reject(allRuns, function(run) {
-                    var selectedCourseRun = _.findWhere( selectedRuns, {
+                    var selectedCourseRun = _.findWhere(selectedRuns, {
                         course_key: run.id,
                         start_date: run.start
                     });
@@ -186,17 +186,17 @@ define([
                     $input = {},
                     $message = {};
 
-                if ( this.model.get( 'marketing_slug' ).length > 0 ) {
+                if (this.model.get('marketing_slug').length > 0) {
                     isValid = true;
                 } else {
-                    $input = this.$el.find( '#program-marketing-slug' );
-                    $message = $input.siblings( '.field-message' );
+                    $input = this.$el.find('#program-marketing-slug');
+                    $message = $input.siblings('.field-message');
 
                     // Update DOM
-                    $input.addClass( 'has-error' );
-                    $message.addClass( 'has-error' );
-                    $message.find( '.field-message-content' )
-                        .text( gettext( 'Marketing Slug is required.') );
+                    $input.addClass('has-error');
+                    $message.addClass('has-error');
+                    $message.find('.field-message-content')
+                        .text(gettext('Marketing Slug is required.'));
                 }
 
                 return isValid;

--- a/cms/static/js/sock.js
+++ b/cms/static/js/sock.js
@@ -1,6 +1,6 @@
-require(["domReady", "jquery", "jquery.smoothScroll"],
-    function (domReady, $) {
-        var toggleSock = function (e) {
+require(['domReady', 'jquery', 'jquery.smoothScroll'],
+    function(domReady, $) {
+        var toggleSock = function(e) {
             e.preventDefault();
 
             var $btnShowSockLabel = $(this).find('.copy-show');
@@ -11,13 +11,13 @@ require(["domReady", "jquery", "jquery.smoothScroll"],
             if ($sock.hasClass('is-shown')) {
                 $sock.removeClass('is-shown');
                 $sockContent.hide('fast');
-                $btnHideSockLabel.removeClass("is-shown").addClass("is-hidden");
-                $btnShowSockLabel.removeClass("is-hidden").addClass("is-shown");
+                $btnHideSockLabel.removeClass('is-shown').addClass('is-hidden');
+                $btnShowSockLabel.removeClass('is-hidden').addClass('is-shown');
             } else {
                 $sock.addClass('is-shown');
                 $sockContent.show('fast');
-                $btnHideSockLabel.removeClass("is-hidden").addClass("is-shown");
-                $btnShowSockLabel.removeClass("is-shown").addClass("is-hidden");
+                $btnHideSockLabel.removeClass('is-hidden').addClass('is-shown');
+                $btnShowSockLabel.removeClass('is-shown').addClass('is-hidden');
             }
 
             $.smoothScroll({
@@ -29,7 +29,7 @@ require(["domReady", "jquery", "jquery.smoothScroll"],
             });
         };
 
-        domReady(function () {
+        domReady(function() {
             // toggling footer additional support
             $('.cta-show-sock').bind('click', toggleSock);
         });

--- a/cms/static/js/spec/factories/xblock_validation_spec.js
+++ b/cms/static/js/spec/factories/xblock_validation_spec.js
@@ -1,33 +1,32 @@
 define(['jquery', 'js/factories/xblock_validation', 'common/js/spec_helpers/template_helpers'],
     function($, XBlockValidationFactory, TemplateHelpers) {
-
         describe('XBlockValidationFactory', function() {
             var messageDiv;
 
-            beforeEach(function () {
+            beforeEach(function() {
                 TemplateHelpers.installTemplate('xblock-validation-messages');
                 appendSetFixtures($('<div class="messages"></div>'));
                 messageDiv = $('.messages');
             });
 
             it('Does not attach a view if messages is empty', function() {
-                XBlockValidationFactory({"empty": true}, false, false, messageDiv);
+                XBlockValidationFactory({'empty': true}, false, false, messageDiv);
                 expect(messageDiv.children().length).toEqual(0);
             });
 
             it('Does attach a view if messages are not empty', function() {
-                XBlockValidationFactory({"empty": false}, false, false, messageDiv);
+                XBlockValidationFactory({'empty': false}, false, false, messageDiv);
                 expect(messageDiv.children().length).toEqual(1);
             });
 
             it('Passes through the root property to the view.', function() {
-                var noContainerContent = "no-container-content";
+                var noContainerContent = 'no-container-content';
 
                 var notConfiguredMessages = {
-                    "empty": false,
-                    "summary": {"text": "my summary", "type": "not-configured"},
-                    "messages": [],
-                    "xblock_id": "id"
+                    'empty': false,
+                    'summary': {'text': 'my summary', 'type': 'not-configured'},
+                    'messages': [],
+                    'xblock_id': 'id'
                 };
                 // Root is false, will not add noContainerContent.
                 XBlockValidationFactory(notConfiguredMessages, true, false, messageDiv);
@@ -41,16 +40,16 @@ define(['jquery', 'js/factories/xblock_validation', 'common/js/spec_helpers/temp
             describe('Controls display of detailed messages based on url and root property', function() {
                 var messagesWithSummary, checkDetailedMessages;
 
-                beforeEach(function () {
+                beforeEach(function() {
                     messagesWithSummary = {
-                        "empty": false,
-                        "summary": {"text": "my summary"},
-                        "messages": [{"text": "one", "type": "warning"}, {"text": "two", "type": "error"}],
-                        "xblock_id": "id"
+                        'empty': false,
+                        'summary': {'text': 'my summary'},
+                        'messages': [{'text': 'one', 'type': 'warning'}, {'text': 'two', 'type': 'error'}],
+                        'xblock_id': 'id'
                     };
                 });
 
-                checkDetailedMessages = function (expectedDetailedMessages) {
+                checkDetailedMessages = function(expectedDetailedMessages) {
                     expect(messageDiv.children().length).toEqual(1);
                     expect(messageDiv.find('.xblock-message-item').length).toBe(expectedDetailedMessages);
                 };

--- a/cms/static/js/spec/models/auto_auth_model_spec.js
+++ b/cms/static/js/spec/models/auto_auth_model_spec.js
@@ -1,15 +1,14 @@
 define([
-        'underscore',
-        'backbone',
-        'jquery',
-        'js/programs/utils/api_config',
-        'js/programs/models/auto_auth_model'
-    ],
-    function( _, Backbone, $, apiConfig, AutoAuthModel ) {
+    'underscore',
+    'backbone',
+    'jquery',
+    'js/programs/utils/api_config',
+    'js/programs/models/auto_auth_model'
+],
+    function(_, Backbone, $, apiConfig, AutoAuthModel) {
         'use strict';
 
-        describe('AutoAuthModel', function () {
-
+        describe('AutoAuthModel', function() {
             var model,
                 testErrorCallback,
                 fakeAjaxDeferred,
@@ -17,10 +16,9 @@ define([
                 callSync,
                 checkAuthAttempted,
                 dummyModel = {'dummy': 'model'},
-                authUrl = apiConfig.get( 'authUrl' );
+                authUrl = apiConfig.get('authUrl');
 
-            beforeEach( function() {
-
+            beforeEach(function() {
                 // instance under test
                 model = new AutoAuthModel();
 
@@ -28,49 +26,47 @@ define([
                 testErrorCallback = jasmine.createSpy();
 
                 fakeAjaxDeferred = $.Deferred();
-                spyOn( $, 'ajax' ).and.returnValue( fakeAjaxDeferred );
+                spyOn($, 'ajax').and.returnValue(fakeAjaxDeferred);
                 return fakeAjaxDeferred;
-
             });
 
-            spyOnBackboneSync = function( status ) {
+            spyOnBackboneSync = function(status) {
                 // set up Backbone.sync to invoke its error callback with the desired HTTP status
-                spyOn( Backbone, 'sync' ).and.callFake( function(method, model, options) {
-                    var fakeXhr = options.xhr = { status: status };
+                spyOn(Backbone, 'sync').and.callFake(function(method, model, options) {
+                    var fakeXhr = options.xhr = {status: status};
                     options.error(fakeXhr, 0, '');
                 });
             };
 
             callSync = function(options) {
                 var params,
-                    syncOptions = _.extend( { error: testErrorCallback }, options || {} );
+                    syncOptions = _.extend({error: testErrorCallback}, options || {});
 
                 model.sync('GET', dummyModel, syncOptions);
 
                 // make sure Backbone.sync was called with custom error handling
-                expect( Backbone.sync.calls.count() ).toEqual(1);
-                params = _.object( ['method', 'model', 'options'], Backbone.sync.calls.mostRecent().args );
-                expect( params.method ).toEqual( 'GET' );
-                expect( params.model ).toEqual( dummyModel );
-                expect( params.options.error ).not.toEqual( testErrorCallback );
+                expect(Backbone.sync.calls.count()).toEqual(1);
+                params = _.object(['method', 'model', 'options'], Backbone.sync.calls.mostRecent().args);
+                expect(params.method).toEqual('GET');
+                expect(params.model).toEqual(dummyModel);
+                expect(params.options.error).not.toEqual(testErrorCallback);
                 return params;
             };
 
             checkAuthAttempted = function(isExpected) {
                 if (isExpected) {
-                    expect( $.ajax ).toHaveBeenCalled();
-                    expect( $.ajax.calls.mostRecent().args[0].url ).toEqual( authUrl );
+                    expect($.ajax).toHaveBeenCalled();
+                    expect($.ajax.calls.mostRecent().args[0].url).toEqual(authUrl);
                 } else {
-                    expect( $.ajax ).not.toHaveBeenCalled();
+                    expect($.ajax).not.toHaveBeenCalled();
                 }
             };
 
-            it( 'should exist', function () {
-                expect( model ).toBeDefined();
+            it('should exist', function() {
+                expect(model).toBeDefined();
             });
 
-            it( 'should intercept 401 errors and attempt auth', function() {
-
+            it('should intercept 401 errors and attempt auth', function() {
                 var callParams;
 
                 spyOnBackboneSync(401);
@@ -81,20 +77,18 @@ define([
                 checkAuthAttempted(true);
 
                 // fire the success handler for the fake ajax call, with id token response data
-                fakeAjaxDeferred.resolve( {id_token: 'test-id-token'} );
+                fakeAjaxDeferred.resolve({id_token: 'test-id-token'});
 
                 // make sure the original request was retried with token, and without custom error handling
-                expect( Backbone.sync.calls.count() ).toEqual(2);
-                callParams = _.object( ['method', 'model', 'options'], Backbone.sync.calls.mostRecent().args );
-                expect( callParams.method ).toEqual( 'GET' );
-                expect( callParams.model ).toEqual( dummyModel );
-                expect( callParams.options.error ).toEqual( testErrorCallback );
-                expect( callParams.options.headers.Authorization ).toEqual( 'JWT test-id-token' );
-
+                expect(Backbone.sync.calls.count()).toEqual(2);
+                callParams = _.object(['method', 'model', 'options'], Backbone.sync.calls.mostRecent().args);
+                expect(callParams.method).toEqual('GET');
+                expect(callParams.model).toEqual(dummyModel);
+                expect(callParams.options.error).toEqual(testErrorCallback);
+                expect(callParams.options.headers.Authorization).toEqual('JWT test-id-token');
             });
 
-            it( 'should not intercept non-401 errors', function() {
-
+            it('should not intercept non-401 errors', function() {
                 spyOnBackboneSync(403);
 
                 // invoke AutoAuthModel.sync
@@ -104,13 +98,11 @@ define([
                 checkAuthAttempted(false);
 
                 // make sure the original request was not retried
-                expect( Backbone.sync.calls.count() ).toEqual(1);
+                expect(Backbone.sync.calls.count()).toEqual(1);
 
                 // make sure the default error handling was invoked
-                expect( testErrorCallback ).toHaveBeenCalled();
-
+                expect(testErrorCallback).toHaveBeenCalled();
             });
-
         });
     }
 );

--- a/cms/static/js/spec/models/component_template_spec.js
+++ b/cms/static/js/spec/models/component_template_spec.js
@@ -1,65 +1,64 @@
-define(["js/models/component_template"],
-    function (ComponentTemplate) {
-
-        describe("ComponentTemplates", function() {
+define(['js/models/component_template'],
+    function(ComponentTemplate) {
+        describe('ComponentTemplates', function() {
             var mockTemplateJSON = {
-                "templates": [
+                'templates': [
                     {
-                        "category": "problem",
-                        "boilerplate_name": "formularesponse.yaml",
-                        "display_name": "Math Expression Input"
+                        'category': 'problem',
+                        'boilerplate_name': 'formularesponse.yaml',
+                        'display_name': 'Math Expression Input'
                     }, {
-                        "category": "problem",
-                        "boilerplate_name": null,
-                        "display_name": "Blank Advanced Problem"
+                        'category': 'problem',
+                        'boilerplate_name': null,
+                        'display_name': 'Blank Advanced Problem'
                     }, {
-                        "category": "problem",
-                        "boilerplate_name": "checkboxes.yaml",
-                        "display_name": "Checkboxes"
+                        'category': 'problem',
+                        'boilerplate_name': 'checkboxes.yaml',
+                        'display_name': 'Checkboxes'
                     }, {
-                        "category": "problem",
-                        "boilerplate_name": "multiple_choice.yaml",
-                        "display_name": "Multiple Choice"
+                        'category': 'problem',
+                        'boilerplate_name': 'multiple_choice.yaml',
+                        'display_name': 'Multiple Choice'
                     }, {
-                        "category": "problem",
-                        "boilerplate_name": "drag_and_drop.yaml",
-                        "display_name": "Drag and Drop"
+                        'category': 'problem',
+                        'boilerplate_name': 'drag_and_drop.yaml',
+                        'display_name': 'Drag and Drop'
                     }, {
-                        "category": "problem",
-                        "boilerplate_name": "problem_with_hint.yaml",
-                        "display_name": "Problem with Adaptive Hint"
+                        'category': 'problem',
+                        'boilerplate_name': 'problem_with_hint.yaml',
+                        'display_name': 'Problem with Adaptive Hint'
                     }, {
-                        "category": "problem",
-                        "boilerplate_name": "imageresponse.yaml",
-                        "display_name": "Image Mapped Input"
+                        'category': 'problem',
+                        'boilerplate_name': 'imageresponse.yaml',
+                        'display_name': 'Image Mapped Input'
                     }, {
-                        "category": "openassessment",
-                        "boilerplate_name": null,
-                        "display_name": "Peer Assessment"
+                        'category': 'openassessment',
+                        'boilerplate_name': null,
+                        'display_name': 'Peer Assessment'
                     }, {
-                        "category": "problem",
-                        "boilerplate_name": "an_easy_problem.yaml",
-                        "display_name": "An Easy Problem"
+                        'category': 'problem',
+                        'boilerplate_name': 'an_easy_problem.yaml',
+                        'display_name': 'An Easy Problem'
                     }, {
-                        "category": "word_cloud",
-                        "boilerplate_name": null,
-                        "display_name": "Word Cloud"
+                        'category': 'word_cloud',
+                        'boilerplate_name': null,
+                        'display_name': 'Word Cloud'
                     }, { // duplicate display name to verify sort behavior
-                        "category": "word_cloud",
-                        "boilerplate_name": "alternate_word_cloud.yaml",
-                        "display_name": "Word Cloud"
+                        'category': 'word_cloud',
+                        'boilerplate_name': 'alternate_word_cloud.yaml',
+                        'display_name': 'Word Cloud'
                     }],
-                "type": "problem",
-                "support_legend": {"show_legend": false}
+                'type': 'problem',
+                'support_legend': {'show_legend': false}
             };
 
-            it('orders templates correctly', function () {
+            it('orders templates correctly', function() {
                 var lastTemplate = null,
                     firstComparison = true,
                     componentTemplate = new ComponentTemplate(),
                     template, templateName, i;
                 componentTemplate.parse(mockTemplateJSON);
-                for (i=0; i < componentTemplate.templates.length; i++) {
+                for (i = 0; i < componentTemplate.templates.length; i++) {
                     template = componentTemplate.templates[i];
                     templateName = template['display_name'];
                     if (lastTemplate) {

--- a/cms/static/js/spec/models/explicit_url_spec.js
+++ b/cms/static/js/spec/models/explicit_url_spec.js
@@ -1,10 +1,10 @@
 define(['js/models/explicit_url'],
-    function (Model) {
-        describe('Model ', function () {
-            it('allows url to be passed in constructor', function () {
+    function(Model) {
+        describe('Model ', function() {
+            it('allows url to be passed in constructor', function() {
                 expect(new Model({'explicit_url': '/fancy/url'}).url()).toBe('/fancy/url');
             });
-            it('returns empty string if url not set', function () {
+            it('returns empty string if url not set', function() {
                 expect(new Model().url()).toBe('');
             });
         });

--- a/cms/static/js/spec/models/group_configuration_spec.js
+++ b/cms/static/js/spec/models/group_configuration_spec.js
@@ -1,29 +1,29 @@
 define([
     'backbone', 'cms/js/main', 'js/models/group_configuration',
     'js/models/group', 'js/collections/group', 'squire'
-], function (Backbone, main, GroupConfigurationModel, GroupModel, GroupCollection, Squire) {
+], function(Backbone, main, GroupConfigurationModel, GroupModel, GroupCollection, Squire) {
     'use strict';
 
-    describe('GroupConfigurationModel', function () {
-        beforeEach(function () {
+    describe('GroupConfigurationModel', function() {
+        beforeEach(function() {
             main();
             this.model = new GroupConfigurationModel();
         });
 
-        describe('Basic', function () {
-            it('should have an empty name by default', function () {
+        describe('Basic', function() {
+            it('should have an empty name by default', function() {
                 expect(this.model.get('name')).toEqual('');
             });
 
-            it('should have an empty description by default', function () {
+            it('should have an empty description by default', function() {
                 expect(this.model.get('description')).toEqual('');
             });
 
-            it('should not show groups by default', function () {
+            it('should not show groups by default', function() {
                 expect(this.model.get('showGroups')).toBeFalsy();
             });
 
-            it('should have a collection with 2 groups by default', function () {
+            it('should have a collection with 2 groups by default', function() {
                 var groups = this.model.get('groups');
 
                 expect(groups).toBeInstanceOf(GroupCollection);
@@ -31,11 +31,11 @@ define([
                 expect(groups.at(1).get('name')).toBe('Group B');
             });
 
-            it('should have an empty usage by default', function () {
+            it('should have an empty usage by default', function() {
                 expect(this.model.get('usage').length).toBe(0);
             });
 
-            it('should be able to reset itself', function () {
+            it('should be able to reset itself', function() {
                 var originalName = 'Original Name',
                     model = new GroupConfigurationModel({name: originalName});
                 model.set({name: 'New Name'});
@@ -44,18 +44,18 @@ define([
                 expect(model.get('name')).toEqual(originalName);
             });
 
-            it('should be dirty after it\'s been changed', function () {
+            it('should be dirty after it\'s been changed', function() {
                 this.model.set('name', 'foobar');
 
                 expect(this.model.isDirty()).toBeTruthy();
             });
 
-            describe('should not be dirty', function () {
-                it('by default', function () {
+            describe('should not be dirty', function() {
+                it('by default', function() {
                     expect(this.model.isDirty()).toBeFalsy();
                 });
 
-                it('after calling setOriginalAttributes', function () {
+                it('after calling setOriginalAttributes', function() {
                     this.model.set('name', 'foobar');
                     this.model.setOriginalAttributes();
 
@@ -64,8 +64,8 @@ define([
             });
         });
 
-        describe('Input/Output', function () {
-            var deepAttributes = function (obj) {
+        describe('Input/Output', function() {
+            var deepAttributes = function(obj) {
                 if (obj instanceof Backbone.Model) {
                     return deepAttributes(obj.attributes);
                 } else if (obj instanceof Backbone.Collection) {
@@ -84,7 +84,7 @@ define([
                 }
             };
 
-            it('should match server model to client model', function () {
+            it('should match server model to client model', function() {
                 var serverModelSpec = {
                         'id': 10,
                         'name': 'My Group Configuration',
@@ -135,14 +135,14 @@ define([
             });
         });
 
-        describe('Validation', function () {
-            it('requires a name', function () {
+        describe('Validation', function() {
+            it('requires a name', function() {
                 var model = new GroupConfigurationModel({name: ''});
 
                 expect(model.isValid()).toBeFalsy();
             });
 
-            it('can pass validation', function () {
+            it('can pass validation', function() {
                 // Note that two groups - Group A and Group B - are
                 // created by default.
                 var model = new GroupConfigurationModel({name: 'foo'});
@@ -150,7 +150,7 @@ define([
                 expect(model.isValid()).toBeTruthy();
             });
 
-            it('requires at least one group', function () {
+            it('requires at least one group', function() {
                 var group1 = new GroupModel({name: 'Group A'}),
                     model = new GroupConfigurationModel({name: 'foo', groups: []});
 
@@ -160,19 +160,19 @@ define([
                 expect(model.isValid()).toBeTruthy();
             });
 
-            it('requires a valid group', function () {
+            it('requires a valid group', function() {
                 var model = new GroupConfigurationModel({name: 'foo', groups: [{name: ''}]});
 
                 expect(model.isValid()).toBeFalsy();
             });
 
-            it('requires all groups to be valid', function () {
+            it('requires all groups to be valid', function() {
                 var model = new GroupConfigurationModel({name: 'foo', groups: [{name: 'Group A'}, {name: ''}]});
 
                 expect(model.isValid()).toBeFalsy();
             });
 
-            it('requires all groups to have unique names', function () {
+            it('requires all groups to have unique names', function() {
                 var model = new GroupConfigurationModel({
                     name: 'foo', groups: [{name: 'Group A'}, {name: 'Group A'}]
                 });
@@ -182,30 +182,30 @@ define([
         });
     });
 
-    describe('GroupModel', function () {
-        beforeEach(function () {
+    describe('GroupModel', function() {
+        beforeEach(function() {
             this.collection = new GroupCollection([{}]);
             this.model = this.collection.at(0);
         });
 
-        describe('Basic', function () {
-            it('should have an empty name by default', function () {
+        describe('Basic', function() {
+            it('should have an empty name by default', function() {
                 expect(this.model.get('name')).toEqual('');
             });
 
-            it('should be empty by default', function () {
+            it('should be empty by default', function() {
                 expect(this.model.isEmpty()).toBeTruthy();
             });
         });
 
-        describe('Validation', function () {
-            it('requires a name', function () {
+        describe('Validation', function() {
+            it('requires a name', function() {
                 var model = new GroupModel({name: ''});
 
                 expect(model.isValid()).toBeFalsy();
             });
 
-            it('can pass validation', function () {
+            it('can pass validation', function() {
                 var model = new GroupConfigurationModel({name: 'foo'});
 
                 expect(model.isValid()).toBeTruthy();
@@ -213,22 +213,22 @@ define([
         });
     });
 
-    describe('GroupCollection', function () {
-        beforeEach(function () {
+    describe('GroupCollection', function() {
+        beforeEach(function() {
             this.collection = new GroupCollection();
         });
 
-        it('is empty by default', function () {
+        it('is empty by default', function() {
             expect(this.collection.isEmpty()).toBeTruthy();
         });
 
-        it('is empty if all groups are empty', function () {
+        it('is empty if all groups are empty', function() {
             this.collection.add([{name: ''}, {name: ''}, {name: ''}]);
 
             expect(this.collection.isEmpty()).toBeTruthy();
         });
 
-        it('is not empty if a group is not empty', function () {
+        it('is not empty if a group is not empty', function() {
             this.collection.add([
                 {name: ''}, {name: 'full'}, {name: ''}
             ]);
@@ -236,14 +236,14 @@ define([
             expect(this.collection.isEmpty()).toBeFalsy();
         });
 
-        describe('getGroupId', function () {
+        describe('getGroupId', function() {
             var collection, injector, mockGettext, initializeGroupModel, cleanUp;
 
-            mockGettext = function (returnedValue) {
+            mockGettext = function(returnedValue) {
                 var injector = new Squire();
 
-                injector.mock('gettext', function () {
-                    return function () {
+                injector.mock('gettext', function() {
+                    return function() {
                         return returnedValue;
                     };
                 });
@@ -251,12 +251,12 @@ define([
                 return injector;
             };
 
-            initializeGroupModel = function (dict) {
+            initializeGroupModel = function(dict) {
                 var deferred = $.Deferred();
 
                 injector = mockGettext(dict);
                 injector.require(['js/collections/group'],
-                    function (GroupCollection) {
+                    function(GroupCollection) {
                         collection = new GroupCollection();
                         deferred.resolve(collection);
                     });
@@ -264,13 +264,13 @@ define([
                 return deferred.promise();
             };
 
-            cleanUp = function () {
+            cleanUp = function() {
                 collection = null;
                 injector.clean();
                 injector.remove();
             };
 
-            it('returns correct ids', function () {
+            it('returns correct ids', function() {
                 var collection = new GroupCollection();
 
                 expect(collection.getGroupId(0)).toBe('A');
@@ -283,22 +283,22 @@ define([
                 expect(collection.getGroupId(475279)).toBe('AAAAZ');
             });
 
-            it('just 1 character in the dictionary', function (done) {
+            it('just 1 character in the dictionary', function(done) {
                 initializeGroupModel('1')
-                    .then(function (collection) {
+                    .then(function(collection) {
                         expect(collection.getGroupId(0)).toBe('1');
                         expect(collection.getGroupId(1)).toBe('11');
                         expect(collection.getGroupId(5)).toBe('111111');
                     })
-                    .always(function () {
+                    .always(function() {
                         cleanUp();
                         done();
                     });
             });
 
-            it('allow to use unicode characters in the dict', function (done) {
+            it('allow to use unicode characters in the dict', function(done) {
                 initializeGroupModel('ö诶úeœ')
-                    .then(function (collection) {
+                    .then(function(collection) {
                         expect(collection.getGroupId(0)).toBe('ö');
                         expect(collection.getGroupId(1)).toBe('诶');
                         expect(collection.getGroupId(5)).toBe('öö');
@@ -306,20 +306,20 @@ define([
                         expect(collection.getGroupId(30)).toBe('ööö');
                         expect(collection.getGroupId(43)).toBe('öúe');
                     })
-                    .always(function () {
+                    .always(function() {
                         cleanUp();
                         done();
                     });
             });
 
-            it('return initial value if dictionary is empty', function (done) {
+            it('return initial value if dictionary is empty', function(done) {
                 initializeGroupModel('')
-                    .then(function (collection) {
+                    .then(function(collection) {
                         expect(collection.getGroupId(0)).toBe('0');
                         expect(collection.getGroupId(5)).toBe('5');
                         expect(collection.getGroupId(30)).toBe('30');
                     })
-                    .always(function () {
+                    .always(function() {
                         cleanUp();
                         done();
                     });

--- a/cms/static/js/spec/models/license_spec.js
+++ b/cms/static/js/spec/models/license_spec.js
@@ -1,72 +1,72 @@
-define(["js/models/license"], function(LicenseModel) {
-    describe("License model constructor", function() {
-        it("accepts no arguments", function() {
-            var model = new LicenseModel()
-            expect(model.get("type")).toBeNull();
-            expect(model.get("options")).toEqual({});
-            expect(model.get("custom")).toBeFalsy();
+define(['js/models/license'], function(LicenseModel) {
+    describe('License model constructor', function() {
+        it('accepts no arguments', function() {
+            var model = new LicenseModel();
+            expect(model.get('type')).toBeNull();
+            expect(model.get('options')).toEqual({});
+            expect(model.get('custom')).toBeFalsy();
         });
 
-        it("accepts normal arguments", function() {
+        it('accepts normal arguments', function() {
             var model = new LicenseModel({
-                "type": "creative-commons",
-                "options": {"fake-boolean": true, "version": "your momma"}
+                'type': 'creative-commons',
+                'options': {'fake-boolean': true, 'version': 'your momma'}
             });
-            expect(model.get("type")).toEqual("creative-commons");
-            expect(model.get("options")).toEqual({"fake-boolean": true, "version": "your momma"});
-        })
-
-        it("accepts a license string argument", function() {
-            var model = new LicenseModel({"asString": "all-rights-reserved"});
-            expect(model.get("type")).toEqual("all-rights-reserved");
-            expect(model.get("options")).toEqual({});
-            expect(model.get("custom")).toBeFalsy();
+            expect(model.get('type')).toEqual('creative-commons');
+            expect(model.get('options')).toEqual({'fake-boolean': true, 'version': 'your momma'});
         });
 
-        it("accepts a custom license argument", function() {
-            var model = new LicenseModel({"asString": "Mozilla Public License 2.0"})
-            expect(model.get("type")).toBeNull();
-            expect(model.get("options")).toEqual({});
-            expect(model.get("custom")).toEqual("Mozilla Public License 2.0");
+        it('accepts a license string argument', function() {
+            var model = new LicenseModel({'asString': 'all-rights-reserved'});
+            expect(model.get('type')).toEqual('all-rights-reserved');
+            expect(model.get('options')).toEqual({});
+            expect(model.get('custom')).toBeFalsy();
+        });
+
+        it('accepts a custom license argument', function() {
+            var model = new LicenseModel({'asString': 'Mozilla Public License 2.0'});
+            expect(model.get('type')).toBeNull();
+            expect(model.get('options')).toEqual({});
+            expect(model.get('custom')).toEqual('Mozilla Public License 2.0');
         });
     });
 
-    describe("License model", function() {
+    describe('License model', function() {
         beforeEach(function() {
             this.model = new LicenseModel();
         });
 
-        it("can parse license strings", function() {
-            this.model.setFromString("creative-commons: BY")
-            expect(this.model.get("type")).toEqual("creative-commons")
-            expect(this.model.get("options")).toEqual({"BY": true})
-            expect(this.model.get("custom")).toBeFalsy();
+        it('can parse license strings', function() {
+            this.model.setFromString('creative-commons: BY');
+            expect(this.model.get('type')).toEqual('creative-commons');
+            expect(this.model.get('options')).toEqual({'BY': true});
+            expect(this.model.get('custom')).toBeFalsy();
         });
 
-        it("can stringify a null license", function() {
-            expect(this.model.toString()).toEqual("");
+        it('can stringify a null license', function() {
+            expect(this.model.toString()).toEqual('');
         });
 
-        it("can stringify a simple license", function() {
-            this.model.set("type", "foobie thinger");
-            expect(this.model.toString()).toEqual("foobie thinger");
+        it('can stringify a simple license', function() {
+            this.model.set('type', 'foobie thinger');
+            expect(this.model.toString()).toEqual('foobie thinger');
         });
 
-        it("can stringify a license with options", function() {
+        it('can stringify a license with options', function() {
             this.model.set({
-                "type": "abc",
-                "options": {"ping": "pong", "bing": true, "buzz": true, "beep": false}}
+                'type': 'abc',
+                'options': {'ping': 'pong', 'bing': true, 'buzz': true, 'beep': false}}
             );
-            expect(this.model.toString()).toEqual("abc: ping=pong bing buzz");
+            expect(this.model.toString()).toEqual('abc: ping=pong bing buzz');
         });
 
-        it("can stringify a custom license", function() {
+        it('can stringify a custom license', function() {
             this.model.set({
-                "type": "doesn't matter",
-                "options": {"ignore": "me"},
-                "custom": "this is my super cool license"
+                'type': "doesn't matter",
+                'options': {'ignore': 'me'},
+                'custom': 'this is my super cool license'
             });
-            expect(this.model.toString()).toEqual("this is my super cool license");
+            expect(this.model.toString()).toEqual('this is my super cool license');
         });
-    })
-})
+    });
+});

--- a/cms/static/js/spec/models/xblock_info_spec.js
+++ b/cms/static/js/spec/models/xblock_info_spec.js
@@ -10,26 +10,25 @@ define(['backbone', 'js/models/xblock_info'],
         });
 
         describe('XblockInfo actions state and header visibility ', function() {
-
-            it('works correct to hide icons e.g. trash icon, drag when actions are not required', function(){
-                expect(new XBlockInfo({'category': 'chapter', 'actions': {'deletable':false}})
+            it('works correct to hide icons e.g. trash icon, drag when actions are not required', function() {
+                expect(new XBlockInfo({'category': 'chapter', 'actions': {'deletable': false}})
                     .isDeletable()).toBe(false);
-                expect(new XBlockInfo({'category': 'chapter', 'actions': {'draggable':false}})
+                expect(new XBlockInfo({'category': 'chapter', 'actions': {'draggable': false}})
                     .isDraggable()).toBe(false);
-                expect(new XBlockInfo({'category': 'chapter', 'actions': {'childAddable':false}})
+                expect(new XBlockInfo({'category': 'chapter', 'actions': {'childAddable': false}})
                     .isChildAddable()).toBe(false);
             });
 
-            it('works correct to show icons e.g. trash icon, drag when actions are required', function(){
-                expect(new XBlockInfo({'category': 'chapter', 'actions': {'deletable':true}})
+            it('works correct to show icons e.g. trash icon, drag when actions are required', function() {
+                expect(new XBlockInfo({'category': 'chapter', 'actions': {'deletable': true}})
                     .isDeletable()).toBe(true);
-                expect(new XBlockInfo({'category': 'chapter', 'actions': {'draggable':true}})
+                expect(new XBlockInfo({'category': 'chapter', 'actions': {'draggable': true}})
                     .isDraggable()).toBe(true);
-                expect(new XBlockInfo({'category': 'chapter', 'actions': {'childAddable':true}})
+                expect(new XBlockInfo({'category': 'chapter', 'actions': {'childAddable': true}})
                     .isChildAddable()).toBe(true);
             });
 
-            it('displays icons e.g. trash icon, drag when actions are undefined', function(){
+            it('displays icons e.g. trash icon, drag when actions are undefined', function() {
                 expect(new XBlockInfo({'category': 'chapter', 'actions': {}})
                     .isDeletable()).toBe(true);
                 expect(new XBlockInfo({'category': 'chapter', 'actions': {}})
@@ -38,7 +37,7 @@ define(['backbone', 'js/models/xblock_info'],
                     .isChildAddable()).toBe(true);
             });
 
-            it('works correct to hide header content', function(){
+            it('works correct to hide header content', function() {
                 expect(new XBlockInfo({'category': 'sequential', 'is_header_visible': false})
                     .isHeaderVisible()).toBe(false);
             });
@@ -47,7 +46,6 @@ define(['backbone', 'js/models/xblock_info'],
                 expect(new XBlockInfo({'category': 'sequential', 'actions': {'deletable': true}})
                     .isHeaderVisible()).toBe(true);
             });
-
         });
     }
 );

--- a/cms/static/js/spec/models/xblock_validation_spec.js
+++ b/cms/static/js/spec/models/xblock_validation_spec.js
@@ -3,27 +3,27 @@ define(['js/models/xblock_validation'],
         var verifyModel;
 
         verifyModel = function(model, expected_empty, expected_summary, expected_messages, expected_xblock_id) {
-            expect(model.get("empty")).toBe(expected_empty);
-            expect(model.get("summary")).toEqual(expected_summary);
-            expect(model.get("messages")).toEqual(expected_messages);
-            expect(model.get("xblock_id")).toBe(expected_xblock_id);
+            expect(model.get('empty')).toBe(expected_empty);
+            expect(model.get('summary')).toEqual(expected_summary);
+            expect(model.get('messages')).toEqual(expected_messages);
+            expect(model.get('xblock_id')).toBe(expected_xblock_id);
         };
 
         describe('XBlockValidationModel', function() {
             it('handles empty variable', function() {
                 verifyModel(new XBlockValidationModel({parse: true}), true, {}, [], null);
-                verifyModel(new XBlockValidationModel({"empty": true}, {parse: true}), true, {}, [], null);
+                verifyModel(new XBlockValidationModel({'empty': true}, {parse: true}), true, {}, [], null);
 
                 // It is assumed that the "empty" state on the JSON object passed in is correct
                 // (no attempt is made to correct other variables based on empty==true).
                 verifyModel(
                     new XBlockValidationModel(
-                        {"empty": true, "messages": [{"text": "Bad JSON case"}], "xblock_id": "id"},
+                        {'empty': true, 'messages': [{'text': 'Bad JSON case'}], 'xblock_id': 'id'},
                         {parse: true}
                     ),
                     true,
                     {},
-                    [{"text": "Bad JSON case"}], "id"
+                    [{'text': 'Bad JSON case'}], 'id'
                 );
             });
 
@@ -31,37 +31,37 @@ define(['js/models/xblock_validation'],
                 // Single warning message.
                 verifyModel(
                     new XBlockValidationModel({
-                        "empty": false,
-                        "xblock_id": "id"
+                        'empty': false,
+                        'xblock_id': 'id'
                     }, {parse: true}),
                     false,
-                    {"text": "This component has validation issues.", "type": "warning"},
+                    {'text': 'This component has validation issues.', 'type': 'warning'},
                     [],
-                    "id"
+                    'id'
                 );
                 // Two messages that compute to a "warning" state in the summary.
                 verifyModel(
                     new XBlockValidationModel({
-                        "empty": false,
-                        "messages": [{"text": "one", "type": "not-configured"}, {"text": "two", "type": "warning"}],
-                        "xblock_id": "id"
+                        'empty': false,
+                        'messages': [{'text': 'one', 'type': 'not-configured'}, {'text': 'two', 'type': 'warning'}],
+                        'xblock_id': 'id'
                     }, {parse: true}),
                     false,
-                    {"text": "This component has validation issues.", "type": "warning"},
-                    [{"text": "one", "type": "not-configured"}, {"text": "two", "type": "warning"}],
-                    "id"
+                    {'text': 'This component has validation issues.', 'type': 'warning'},
+                    [{'text': 'one', 'type': 'not-configured'}, {'text': 'two', 'type': 'warning'}],
+                    'id'
                 );
                 // Two messages, with one of them "error", resulting in an "error" state in the summary.
                 verifyModel(
                     new XBlockValidationModel({
-                        "empty": false,
-                        "messages": [{"text": "one", "type": "warning"}, {"text": "two", "type": "error"}],
-                        "xblock_id": "id"
+                        'empty': false,
+                        'messages': [{'text': 'one', 'type': 'warning'}, {'text': 'two', 'type': 'error'}],
+                        'xblock_id': 'id'
                     }, {parse: true}),
                     false,
-                    {"text": "This component has validation issues.", "type": "error"},
-                    [{"text": "one", "type": "warning"}, {"text": "two", "type": "error"}],
-                    "id"
+                    {'text': 'This component has validation issues.', 'type': 'error'},
+                    [{'text': 'one', 'type': 'warning'}, {'text': 'two', 'type': 'error'}],
+                    'id'
                 );
             });
 
@@ -69,82 +69,82 @@ define(['js/models/xblock_validation'],
                 // Summary already present (both text and type), no messages.
                 verifyModel(
                     new XBlockValidationModel({
-                        "empty": false,
-                        "xblock_id": "id",
-                        "summary": {"text": "my summary", "type": "custom type"}
+                        'empty': false,
+                        'xblock_id': 'id',
+                        'summary': {'text': 'my summary', 'type': 'custom type'}
                     }, {parse: true}),
                     false,
-                    {"text": "my summary", "type": "custom type"},
+                    {'text': 'my summary', 'type': 'custom type'},
                     [],
-                    "id"
+                    'id'
                 );
                 // Summary text present, but not type (will get default value of warning).
                 verifyModel(
                     new XBlockValidationModel({
-                        "empty": false,
-                        "xblock_id": "id",
-                        "summary": {"text": "my summary"}
+                        'empty': false,
+                        'xblock_id': 'id',
+                        'summary': {'text': 'my summary'}
                     }, {parse: true}),
                     false,
-                    {"text": "my summary", "type": "warning"},
+                    {'text': 'my summary', 'type': 'warning'},
                     [],
-                    "id"
+                    'id'
                 );
                 // Summary type present, but not text.
                 verifyModel(
                     new XBlockValidationModel({
-                        "empty": false,
-                        "summary": {"type": "custom type"},
-                        "messages": [{"text": "one", "type": "not-configured"}, {"text": "two", "type": "warning"}],
-                        "xblock_id": "id"
+                        'empty': false,
+                        'summary': {'type': 'custom type'},
+                        'messages': [{'text': 'one', 'type': 'not-configured'}, {'text': 'two', 'type': 'warning'}],
+                        'xblock_id': 'id'
                     }, {parse: true}),
                     false,
-                    {"text": "This component has validation issues.", "type": "custom type"},
-                    [{"text": "one", "type": "not-configured"}, {"text": "two", "type": "warning"}],
-                    "id"
+                    {'text': 'This component has validation issues.', 'type': 'custom type'},
+                    [{'text': 'one', 'type': 'not-configured'}, {'text': 'two', 'type': 'warning'}],
+                    'id'
                 );
                 // Summary text present, type will be computed as error.
                 verifyModel(
                     new XBlockValidationModel({
-                        "empty": false,
-                        "summary": {"text": "my summary"},
-                        "messages": [{"text": "one", "type": "warning"}, {"text": "two", "type": "error"}],
-                        "xblock_id": "id"
+                        'empty': false,
+                        'summary': {'text': 'my summary'},
+                        'messages': [{'text': 'one', 'type': 'warning'}, {'text': 'two', 'type': 'error'}],
+                        'xblock_id': 'id'
                     }, {parse: true}),
                     false,
-                    {"text": "my summary", "type": "error"},
-                    [{"text": "one", "type": "warning"}, {"text": "two", "type": "error"}],
-                    "id"
+                    {'text': 'my summary', 'type': 'error'},
+                    [{'text': 'one', 'type': 'warning'}, {'text': 'two', 'type': 'error'}],
+                    'id'
                 );
             });
 
             it('clears messages if showSummaryOnly is true', function() {
                 verifyModel(
                     new XBlockValidationModel({
-                        "empty": false,
-                        "xblock_id": "id",
-                        "summary": {"text": "my summary"},
-                        "messages": [{"text": "one", "type": "warning"}, {"text": "two", "type": "error"}],
-                        "showSummaryOnly": true
+                        'empty': false,
+                        'xblock_id': 'id',
+                        'summary': {'text': 'my summary'},
+                        'messages': [{'text': 'one', 'type': 'warning'}, {'text': 'two', 'type': 'error'}],
+                        'showSummaryOnly': true
                     }, {parse: true}),
                     false,
-                    {"text": "my summary", "type": "error"},
+                    {'text': 'my summary', 'type': 'error'},
                     [],
-                    "id"
+                    'id'
                 );
 
                 verifyModel(
                     new XBlockValidationModel({
-                        "empty": false,
-                        "xblock_id": "id",
-                        "summary": {"text": "my summary"},
-                        "messages": [{"text": "one", "type": "warning"}, {"text": "two", "type": "error"}],
-                        "showSummaryOnly": false
+                        'empty': false,
+                        'xblock_id': 'id',
+                        'summary': {'text': 'my summary'},
+                        'messages': [{'text': 'one', 'type': 'warning'}, {'text': 'two', 'type': 'error'}],
+                        'showSummaryOnly': false
                     }, {parse: true}),
                     false,
-                    {"text": "my summary", "type": "error"},
-                    [{"text": "one", "type": "warning"}, {"text": "two", "type": "error"}],
-                    "id"
+                    {'text': 'my summary', 'type': 'error'},
+                    [{'text': 'one', 'type': 'warning'}, {'text': 'two', 'type': 'error'}],
+                    'id'
                 );
             });
         });

--- a/cms/static/js/spec/utils/drag_and_drop_spec.js
+++ b/cms/static/js/spec/utils/drag_and_drop_spec.js
@@ -1,12 +1,12 @@
-define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notification", 
-        "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "jquery", "underscore"],
-    function (ContentDragger, Notification, AjaxHelpers, $, _) {
-        describe("Overview drag and drop functionality", function () {
-            beforeEach(function () {
+define(['js/utils/drag_and_drop', 'common/js/components/views/feedback_notification',
+        'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'jquery', 'underscore'],
+    function(ContentDragger, Notification, AjaxHelpers, $, _) {
+        describe('Overview drag and drop functionality', function() {
+            beforeEach(function() {
                 setFixtures(readFixtures('mock/mock-outline.underscore'));
                 _.each(
                     $('.unit'),
-                    function (element) {
+                    function(element) {
                         ContentDragger.makeDraggable(element, {
                             type: '.unit',
                             handleClass: '.unit-drag-handle',
@@ -19,7 +19,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                 );
                 _.each(
                     $('.courseware-subsection'),
-                    function (element) {
+                    function(element) {
                         ContentDragger.makeDraggable(element, {
                             type: '.courseware-subsection',
                             handleClass: '.subsection-drag-handle',
@@ -32,8 +32,8 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                 );
             });
 
-            describe("findDestination", function () {
-                it("correctly finds the drop target of a drag", function () {
+            describe('findDestination', function() {
+                it('correctly finds the drop target of a drag', function() {
                     var $ele, destination;
                     $ele = $('#unit-1');
                     $ele.offset({
@@ -44,7 +44,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect(destination.ele).toEqual($('#unit-2'));
                     expect(destination.attachMethod).toBe('before');
                 });
-                it("can drag and drop across section boundaries, with special handling for single sibling", function () {
+                it('can drag and drop across section boundaries, with special handling for single sibling', function() {
                     var $ele, $unit0, $unit4, destination;
                     $ele = $('#unit-1');
                     $unit4 = $('#unit-4');
@@ -74,7 +74,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect(destination.ele).toEqual($unit0);
                     expect(destination.attachMethod).toBe('before');
                 });
-                it("can drop before the first element, even if element being dragged is\nslightly before the first element", function () {
+                it('can drop before the first element, even if element being dragged is\nslightly before the first element', function() {
                     var $ele, destination;
                     $ele = $('#subsection-2');
                     $ele.offset({
@@ -85,7 +85,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect(destination.ele).toEqual($('#subsection-0'));
                     expect(destination.attachMethod).toBe('before');
                 });
-                it("can drag and drop across section boundaries, with special handling for last element", function () {
+                it('can drag and drop across section boundaries, with special handling for last element', function() {
                     var $ele, destination;
                     $ele = $('#unit-4');
                     $ele.offset({
@@ -103,7 +103,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect(destination.ele).toEqual($('#unit-3'));
                     expect(destination.attachMethod).toBe('before');
                 });
-                it("can drop past the last element, even if element being dragged is\nslightly before/taller then the last element", function () {
+                it('can drop past the last element, even if element being dragged is\nslightly before/taller then the last element', function() {
                     var $ele, destination;
                     $ele = $('#subsection-2');
                     $ele.offset({
@@ -114,7 +114,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect(destination.ele).toEqual($('#subsection-4'));
                     expect(destination.attachMethod).toBe('after');
                 });
-                it("can drag into an empty list", function () {
+                it('can drag into an empty list', function() {
                     var $ele, destination;
                     $ele = $('#unit-1');
                     $ele.offset({
@@ -125,7 +125,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect(destination.ele).toEqual($('#subsection-list-3'));
                     expect(destination.attachMethod).toBe('prepend');
                 });
-                it("reports a null destination on a failed drag", function () {
+                it('reports a null destination on a failed drag', function() {
                     var $ele, destination;
                     $ele = $('#unit-1');
                     $ele.offset({
@@ -135,10 +135,10 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     destination = ContentDragger.findDestination($ele, 1);
                     expect(destination).toEqual({
                         ele: null,
-                        attachMethod: ""
+                        attachMethod: ''
                     });
                 });
-                it("can drag into a collapsed list", function () {
+                it('can drag into a collapsed list', function() {
                     var $ele, destination;
                     $('#subsection-2').addClass('is-collapsed');
                     $ele = $('#unit-2');
@@ -152,8 +152,8 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect(destination.attachMethod).toBe('prepend');
                 });
             });
-            describe("onDragStart", function () {
-                it("sets the dragState to its default values", function () {
+            describe('onDragStart', function() {
+                it('sets the dragState to its default values', function() {
                     expect(ContentDragger.dragState).toEqual({});
                     ContentDragger.onDragStart({
                         element: $('#unit-1')
@@ -166,7 +166,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                         dragDirection: 0
                     });
                 });
-                it("collapses expanded elements", function () {
+                it('collapses expanded elements', function() {
                     expect($('#subsection-1')).not.toHaveClass('is-collapsed');
                     ContentDragger.onDragStart({
                         element: $('#subsection-1')
@@ -175,11 +175,11 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect($('#subsection-1')).toHaveClass('expand-on-drop');
                 });
             });
-            describe("onDragMove", function () {
-                beforeEach(function () {
+            describe('onDragMove', function() {
+                beforeEach(function() {
                     this.redirectSpy = spyOn(window, 'scrollBy').and.callThrough();
                 });
-                it("adds the correct CSS class to the drop destination", function () {
+                it('adds the correct CSS class to the drop destination', function() {
                     var $ele, dragX, dragY;
                     $ele = $('#unit-1');
                     dragY = $ele.offset().top + 10;
@@ -199,7 +199,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect($('#unit-2')).toHaveClass('drop-target drop-target-before');
                     expect($ele).toHaveClass('valid-drop');
                 });
-                it("does not add CSS class to the drop destination if out of bounds", function () {
+                it('does not add CSS class to the drop destination if out of bounds', function() {
                     var $ele, dragY;
                     $ele = $('#unit-1');
                     dragY = $ele.offset().top + 10;
@@ -218,7 +218,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect($('#unit-2')).not.toHaveClass('drop-target drop-target-before');
                     expect($ele).not.toHaveClass('valid-drop');
                 });
-                it("scrolls up if necessary", function () {
+                it('scrolls up if necessary', function() {
                     ContentDragger.onDragMove({
                         element: $('#unit-1')
                     }, '', {
@@ -226,7 +226,7 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     });
                     expect(this.redirectSpy).toHaveBeenCalledWith(0, -10);
                 });
-                it("scrolls down if necessary", function () {
+                it('scrolls down if necessary', function() {
                     ContentDragger.onDragMove({
                         element: $('#unit-1')
                     }, '', {
@@ -235,16 +235,16 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect(this.redirectSpy).toHaveBeenCalledWith(0, 10);
                 });
             });
-            describe("onDragEnd", function () {
-                beforeEach(function () {
+            describe('onDragEnd', function() {
+                beforeEach(function() {
                     this.reorderSpy = spyOn(ContentDragger, 'handleReorder');
                 });
-                afterEach(function () {
+                afterEach(function() {
                     this.reorderSpy.calls.reset();
                 });
-                it("calls handleReorder on a successful drag", function () {
+                it('calls handleReorder on a successful drag', function() {
                     ContentDragger.dragState.dropDestination = $('#unit-2');
-                    ContentDragger.dragState.attachMethod = "after";
+                    ContentDragger.dragState.attachMethod = 'after';
                     ContentDragger.dragState.parentList = $('#subsection-1');
                     $('#unit-1').offset({
                         top: $('#unit-1').offset().top + 10,
@@ -257,20 +257,20 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     });
                     expect(this.reorderSpy).toHaveBeenCalled();
                 });
-                it("clears out the drag state", function () {
+                it('clears out the drag state', function() {
                     ContentDragger.onDragEnd({
                         element: $('#unit-1')
                     }, null, null);
                     expect(ContentDragger.dragState).toEqual({});
                 });
-                it("sets the element to the correct position", function () {
+                it('sets the element to the correct position', function() {
                     ContentDragger.onDragEnd({
                         element: $('#unit-1')
                     }, null, null);
                     expect(['0px', 'auto']).toContain($('#unit-1').css('top'));
                     expect(['0px', 'auto']).toContain($('#unit-1').css('left'));
                 });
-                it("expands an element if it was collapsed on drag start", function () {
+                it('expands an element if it was collapsed on drag start', function() {
                     $('#subsection-1').addClass('is-collapsed');
                     $('#subsection-1').addClass('expand-on-drop');
                     ContentDragger.onDragEnd({
@@ -279,14 +279,14 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect($('#subsection-1')).not.toHaveClass('is-collapsed');
                     expect($('#subsection-1')).not.toHaveClass('expand-on-drop');
                 });
-                it("expands a collapsed element when something is dropped in it", function () {
+                it('expands a collapsed element when something is dropped in it', function() {
                     var expandElementSpy = spyOn(ContentDragger, 'expandElement').and.callThrough();
                     expect(expandElementSpy).not.toHaveBeenCalled();
                     expect($('#subsection-2').data('ensureChildrenRendered')).not.toHaveBeenCalled();
 
                     $('#subsection-2').addClass('is-collapsed');
                     ContentDragger.dragState.dropDestination = $('#list-2');
-                    ContentDragger.dragState.attachMethod = "prepend";
+                    ContentDragger.dragState.attachMethod = 'prepend';
                     ContentDragger.dragState.parentList = $('#subsection-2');
                     ContentDragger.onDragEnd({
                         element: $('#unit-1')
@@ -300,20 +300,20 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     expect($('#subsection-2')).not.toHaveClass('is-collapsed');
                 });
             });
-            describe("AJAX", function () {
-                beforeEach(function () {
-                    this.savingSpies = jasmine.stealth.spyOnConstructor(Notification, "Mini", ["show", "hide"]);
+            describe('AJAX', function() {
+                beforeEach(function() {
+                    this.savingSpies = jasmine.stealth.spyOnConstructor(Notification, 'Mini', ['show', 'hide']);
                     this.savingSpies.show.and.returnValue(this.savingSpies);
                     this.clock = sinon.useFakeTimers();
                 });
-                afterEach(function () {
+                afterEach(function() {
                     this.clock.restore();
                 });
-                it("should send an update on reorder from one parent to another", function () {
+                it('should send an update on reorder from one parent to another', function() {
                     var requests, request, savingOptions;
-                    requests = AjaxHelpers["requests"](this);
+                    requests = AjaxHelpers['requests'](this);
                     ContentDragger.dragState.dropDestination = $('#unit-4');
-                    ContentDragger.dragState.attachMethod = "after";
+                    ContentDragger.dragState.attachMethod = 'after';
                     ContentDragger.dragState.parentList = $('#subsection-2');
                     $('#unit-1').offset({
                         top: $('#unit-4').offset().top + 10,
@@ -341,11 +341,11 @@ define(["js/utils/drag_and_drop", "common/js/components/views/feedback_notificat
                     // target
                     expect($('#subsection-2').data('refresh')).toHaveBeenCalled();
                 });
-                it("should send an update on reorder within the same parent", function () {
-                    var requests = AjaxHelpers["requests"](this),
+                it('should send an update on reorder within the same parent', function() {
+                    var requests = AjaxHelpers['requests'](this),
                         request;
                     ContentDragger.dragState.dropDestination = $('#unit-2');
-                    ContentDragger.dragState.attachMethod = "after";
+                    ContentDragger.dragState.attachMethod = 'after';
                     ContentDragger.dragState.parentList = $('#subsection-1');
                     $('#unit-1').offset({
                         top: $('#unit-1').offset().top + 10,

--- a/cms/static/js/spec/utils/handle_iframe_binding_spec.js
+++ b/cms/static/js/spec/utils/handle_iframe_binding_spec.js
@@ -1,55 +1,54 @@
 define(
     [
-        "jquery", "underscore",
-        "js/utils/handle_iframe_binding"
+        'jquery', 'underscore',
+        'js/utils/handle_iframe_binding'
     ],
-function ($, _, IframeBinding) {
-
-    describe("IframeBinding", function () {
-        var doc = document.implementation.createHTMLDocument("New Document");
+function($, _, IframeBinding) {
+    describe('IframeBinding', function() {
+        var doc = document.implementation.createHTMLDocument('New Document');
         var iframe_html = '<iframe src="http://www.youtube.com/embed/NHd27UvY-lw" frameborder="0" height="350" width="618"></iframe>';
         iframe_html += '<iframe src="http://www.youtube.com/embed/NHd27UvY-lw?allowFullScreen=false" frameborder="0" height="350" width="618"></iframe>';
         iframe_html += '<embed type="application/x-shockwave-flash" src="http://www.youtube.com/embed/NHd27UvY-lw" height="315" width="560">';
         doc.body.innerHTML = iframe_html;
 
-        var verify_no_modification = function (src) {
+        var verify_no_modification = function(src) {
             iframe_html = '<iframe width="618" height="350" src="' + src + '" frameborder="0" allowfullscreen></iframe>';
             doc.body.innerHTML = iframe_html;
 
             IframeBinding.iframeBinding(doc);
 
-            expect($(doc).find("iframe")[0].src).toEqual(src);
+            expect($(doc).find('iframe')[0].src).toEqual(src);
         };
 
-        it("modifies src url of DOM iframe and embed elements when iframeBinding function is executed", function () {
-            expect($(doc).find("iframe")[0].src).toEqual("http://www.youtube.com/embed/NHd27UvY-lw");
-            expect($(doc).find("iframe")[1].src).toEqual("http://www.youtube.com/embed/NHd27UvY-lw?allowFullScreen=false");
-            expect($(doc).find("embed")[0].hasAttribute("wmode")).toBe(false);
+        it('modifies src url of DOM iframe and embed elements when iframeBinding function is executed', function() {
+            expect($(doc).find('iframe')[0].src).toEqual('http://www.youtube.com/embed/NHd27UvY-lw');
+            expect($(doc).find('iframe')[1].src).toEqual('http://www.youtube.com/embed/NHd27UvY-lw?allowFullScreen=false');
+            expect($(doc).find('embed')[0].hasAttribute('wmode')).toBe(false);
 
             IframeBinding.iframeBinding(doc);
 
-            //after calling iframeBinding function: src url of iframes should have "wmode=transparent" in its querystring
-            //and embed objects should have "wmode='transparent'" as an attribute
-            expect($(doc).find("iframe")[0].src).toEqual("http://www.youtube.com/embed/NHd27UvY-lw?wmode=transparent");
-            expect($(doc).find("iframe")[1].src).toEqual("http://www.youtube.com/embed/NHd27UvY-lw?wmode=transparent&allowFullScreen=false");
-            expect($(doc).find("embed")[0].hasAttribute("wmode")).toBe(true);
+            // after calling iframeBinding function: src url of iframes should have "wmode=transparent" in its querystring
+            // and embed objects should have "wmode='transparent'" as an attribute
+            expect($(doc).find('iframe')[0].src).toEqual('http://www.youtube.com/embed/NHd27UvY-lw?wmode=transparent');
+            expect($(doc).find('iframe')[1].src).toEqual('http://www.youtube.com/embed/NHd27UvY-lw?wmode=transparent&allowFullScreen=false');
+            expect($(doc).find('embed')[0].hasAttribute('wmode')).toBe(true);
 
             iframe_html = IframeBinding.iframeBindingHtml(iframe_html);
 
-            //after calling iframeBinding function: src url of iframes should have "wmode=transparent" in its querystring
-            //and embed objects should have "wmode='transparent'" as an attribute
+            // after calling iframeBinding function: src url of iframes should have "wmode=transparent" in its querystring
+            // and embed objects should have "wmode='transparent'" as an attribute
             expect(iframe_html).toContain('<iframe src="http://www.youtube.com/embed/NHd27UvY-lw?wmode=transparent"');
             expect(iframe_html).toContainHtml(
               '<embed wmode="transparent" type="application/x-shockwave-flash"' +
               ' src="http://www.youtube.com/embed/NHd27UvY-lw"');
         });
 
-        it("does not modify src url of DOM iframe if it is empty", function () {
-            verify_no_modification("");
+        it('does not modify src url of DOM iframe if it is empty', function() {
+            verify_no_modification('');
         });
 
-        it("does nothing on tinymce iframe", function () {
-            verify_no_modification("javascript:");
+        it('does nothing on tinymce iframe', function() {
+            verify_no_modification('javascript:');
         });
     });
 });

--- a/cms/static/js/spec/utils/module_spec.js
+++ b/cms/static/js/spec/utils/module_spec.js
@@ -1,16 +1,16 @@
 define(['js/utils/module'],
-    function (ModuleUtils) {
-        describe('urlRoot ', function () {
-            it('defines xblock urlRoot', function () {
+    function(ModuleUtils) {
+        describe('urlRoot ', function() {
+            it('defines xblock urlRoot', function() {
                 expect(ModuleUtils.urlRoot).toBe('/xblock');
             });
         });
-        describe('getUpdateUrl ', function () {
-            it('can take no arguments', function () {
+        describe('getUpdateUrl ', function() {
+            it('can take no arguments', function() {
                 expect(ModuleUtils.getUpdateUrl()).toBe('/xblock/');
             });
-            it('appends a locator', function () {
-                expect(ModuleUtils.getUpdateUrl("locator")).toBe('/xblock/locator');
+            it('appends a locator', function() {
+                expect(ModuleUtils.getUpdateUrl('locator')).toBe('/xblock/locator');
             });
         });
     }

--- a/cms/static/js/spec/video/file_uploader_editor_spec.js
+++ b/cms/static/js/spec/video/file_uploader_editor_spec.js
@@ -2,9 +2,9 @@ define(
     [
         'jquery', 'underscore', 'squire'
     ],
-function ($, _, Squire) {
+function($, _, Squire) {
     'use strict';
-    describe('FileUploader', function () {
+    describe('FileUploader', function() {
         var FileUploaderTemplate = readFixtures(
                 'metadata-file-uploader-entry.underscore'
             ),
@@ -23,12 +23,12 @@ function ($, _, Squire) {
             },
             self, injector;
 
-        var setValue = function (view, value) {
+        var setValue = function(view, value) {
             view.setValueInEditor(value);
             view.updateModel();
         };
 
-        var createPromptSpy = function (name) {
+        var createPromptSpy = function(name) {
             var spy = jasmine.createSpyObj(name, ['constructor', 'show', 'hide']);
             spy.constructor.and.returnValue(spy);
             spy.show.and.returnValue(spy);
@@ -37,15 +37,15 @@ function ($, _, Squire) {
             return spy;
         };
 
-        beforeEach(function (done) {
+        beforeEach(function(done) {
             self = this;
 
             jasmine.addMatchers({
                 assertValueInView: function() {
                     return {
-                        compare: function (actual, expected) {
+                        compare: function(actual, expected) {
                             var value = actual.getValueFromEditor(),
-                            passed = _.isEqual(value, expected);
+                                passed = _.isEqual(value, expected);
 
                             return {
                                 pass: passed,
@@ -54,9 +54,9 @@ function ($, _, Squire) {
                         }
                     };
                 },
-                assertCanUpdateView: function () {
+                assertCanUpdateView: function() {
                     return {
-                        compare: function (actual, expected) {
+                        compare: function(actual, expected) {
                             var view = actual,
                                 value,
                                 passed;
@@ -73,9 +73,9 @@ function ($, _, Squire) {
                         }
                     };
                 },
-                assertClear: function () {
+                assertClear: function() {
                     return {
-                        compare: function (actual, modelValue) {
+                        compare: function(actual, modelValue) {
                             var view = actual,
                                 model = view.model,
                                 passed;
@@ -90,9 +90,9 @@ function ($, _, Squire) {
                         }
                     };
                 },
-                assertUpdateModel: function () {
+                assertUpdateModel: function() {
                     return {
-                        compare: function (actual, originalValue, newValue) {
+                        compare: function(actual, originalValue, newValue) {
                             var view = actual,
                                 model = view.model,
                                 expectOriginal,
@@ -111,9 +111,9 @@ function ($, _, Squire) {
                         }
                     };
                 },
-                verifyButtons: function () {
+                verifyButtons: function() {
                     return {
-                        compare: function (actual, upload, download) {
+                        compare: function(actual, upload, download) {
                             var view = actual,
                                 uploadBtn = view.$('.upload-setting'),
                                 downloadBtn = view.$('.download-setting'),
@@ -144,16 +144,16 @@ function ($, _, Squire) {
             this.uploadSpies = createPromptSpy('UploadDialog');
 
             injector = new Squire();
-            injector.mock('js/views/uploads', function () {
+            injector.mock('js/views/uploads', function() {
                 return self.uploadSpies.constructor;
             });
             injector.mock('js/views/video/transcripts/metadata_videolist');
             injector.mock('js/views/video/translations_editor');
 
             injector.require([
-                    'js/models/metadata', 'js/views/metadata'
-                ],
-                function (MetadataModel, MetadataView) {
+                'js/models/metadata', 'js/views/metadata'
+            ],
+                function(MetadataModel, MetadataView) {
                     var model = new MetadataModel($.extend(true, {}, modelStub));
                     self.view = new MetadataView.FileUploader({
                         model: model,
@@ -164,21 +164,21 @@ function ($, _, Squire) {
                 });
         });
 
-        afterEach(function () {
+        afterEach(function() {
             injector.clean();
             injector.remove();
         });
 
-        it('returns the initial value upon initialization', function () {
+        it('returns the initial value upon initialization', function() {
             expect(this.view).assertValueInView('http://example.org/test_1');
             expect(this.view).verifyButtons(true, true);
         });
 
-        it('updates its value correctly', function () {
+        it('updates its value correctly', function() {
             expect(this.view).assertCanUpdateView('http://example.org/test_2');
         });
 
-        it('upload works correctly', function () {
+        it('upload works correctly', function() {
             var options;
 
             setValue(this.view, '');
@@ -200,14 +200,14 @@ function ($, _, Squire) {
             expect(this.view.getValueFromEditor()).toEqual('http://example.org/test_3');
         });
 
-        it('has a clear method to revert to the model default', function () {
+        it('has a clear method to revert to the model default', function() {
             setValue(this.view, 'http://example.org/test_5');
 
             this.view.clear();
             expect(this.view).assertClear('http://example.org/test_1');
         });
 
-        it('has an update model method', function () {
+        it('has an update model method', function() {
             expect(this.view).assertUpdateModel(null, 'http://example.org/test_6');
         });
     });

--- a/cms/static/js/spec/video/transcripts/editor_spec.js
+++ b/cms/static/js/spec/video/transcripts/editor_spec.js
@@ -1,12 +1,12 @@
 define(
     [
-        "jquery", "backbone", "underscore",
-        "js/views/video/transcripts/utils", "js/views/video/transcripts/editor",
-        "js/views/metadata", "js/models/metadata", "js/collections/metadata",
-        "underscore.string", "xmodule", "js/views/video/transcripts/metadata_videolist"
+        'jquery', 'backbone', 'underscore',
+        'js/views/video/transcripts/utils', 'js/views/video/transcripts/editor',
+        'js/views/metadata', 'js/models/metadata', 'js/collections/metadata',
+        'underscore.string', 'xmodule', 'js/views/video/transcripts/metadata_videolist'
     ],
-function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCollection, _str) {
-    describe('Transcripts.Editor', function () {
+function($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCollection, _str) {
+    describe('Transcripts.Editor', function() {
         var VideoListEntry = {
                 default_value: ['a thing', 'another thing'],
                 display_name: 'Video URL',
@@ -42,31 +42,31 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
             },
             transcripts, container;
 
-        var waitsForDisplayName = function (collection) {
-            return jasmine.waitUntil(function () {
+        var waitsForDisplayName = function(collection) {
+            return jasmine.waitUntil(function() {
                 var displayNameValue = collection[0].getValue();
                 return displayNameValue !== '' && displayNameValue !== 'video_id';
             });
         };
 
-        beforeEach(function () {
+        beforeEach(function() {
             var tpl = sandbox({
-                    'class': 'wrapper-comp-settings basic_metadata_edit',
-                    'data-metadata': JSON.stringify(metadataDict['object'])
-                });
+                'class': 'wrapper-comp-settings basic_metadata_edit',
+                'data-metadata': JSON.stringify(metadataDict['object'])
+            });
 
-                appendSetFixtures(tpl);
-                container = $('.basic_metadata_edit');
+            appendSetFixtures(tpl);
+            container = $('.basic_metadata_edit');
 
             spyOn(Utils, 'command');
         });
 
-        afterEach(function () {
+        afterEach(function() {
             Utils.Storage.remove('sub');
         });
 
-        describe('Test initialization', function () {
-            beforeEach(function () {
+        describe('Test initialization', function() {
+            beforeEach(function() {
                 spyOn(MetadataView, 'Editor');
 
                 transcripts = new Editor({
@@ -75,14 +75,12 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
             });
 
             $.each(metadataDict, function(index, val) {
-                it('toModels with argument as ' + index, function () {
-
+                it('toModels with argument as ' + index, function() {
                     expect(transcripts.toModels(val)).toEqual(models);
                 });
             });
 
-            it('MetadataView.Editor is initialized', function () {
-
+            it('MetadataView.Editor is initialized', function() {
                 expect(MetadataView.Editor).toHaveBeenCalledWith({
                     el: container,
                     collection: transcripts.collection
@@ -90,7 +88,7 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
             });
         });
 
-        describe('Test synchronization', function () {
+        describe('Test synchronization', function() {
             var nameEntry = {
                     default_value: 'default value',
                     display_name: 'Display Name',
@@ -138,7 +136,7 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                 metadataView;
 
 
-            beforeEach(function () {
+            beforeEach(function() {
                 spyOn(MetadataView, 'Editor');
 
                 transcripts = new Editor({
@@ -162,13 +160,13 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                 );
             });
 
-            describe('Test Advanced to Basic synchronization', function () {
-                it('Correct data', function (done) {
+            describe('Test Advanced to Basic synchronization', function() {
+                it('Correct data', function(done) {
                     transcripts.syncBasicTab(metadataCollection, metadataView);
                     var collection = transcripts.collection.models;
 
                     waitsForDisplayName(collection)
-                        .then(function () {
+                        .then(function() {
                             var displayNameValue = collection[0].getValue(),
                                 videoUrlValue = collection[1].getValue();
 
@@ -182,7 +180,7 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                         .always(done);
                 });
 
-                it('If metadataCollection is not defined', function () {
+                it('If metadataCollection is not defined', function() {
                     transcripts.syncBasicTab(null);
 
                     var collection = transcripts.collection.models,
@@ -195,7 +193,7 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                     ]);
                 });
 
-                it('Youtube Id has length not eqaul 11', function () {
+                it('Youtube Id has length not eqaul 11', function() {
                     var model = metadataCollection.findWhere({
                         field_name: 'youtube_id_1_0'
                     });
@@ -219,13 +217,13 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                 });
             });
 
-            describe('Test Basic to Advanced synchronization', function () {
-                it('Correct data', function (done) {
+            describe('Test Basic to Advanced synchronization', function() {
+                it('Correct data', function(done) {
                     transcripts.syncAdvancedTab(metadataCollection);
 
                     var collection = metadataCollection.models;
                     waitsForDisplayName(collection)
-                        .then(function () {
+                        .then(function() {
                             var displayNameValue = collection[0].getValue();
                             var subValue = collection[1].getValue();
                             var html5SourcesValue = collection[2].getValue();
@@ -242,7 +240,7 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                         .always(done);
                 });
 
-                it('metadataCollection is not defined', function () {
+                it('metadataCollection is not defined', function() {
                     transcripts.syncAdvancedTab(null);
 
                     var collection = metadataCollection.models,
@@ -260,7 +258,7 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                     expect(youtubeValue).toEqual('OEoXaMPEzfM');
                 });
 
-                it('Youtube Id is not adjusted', function () {
+                it('Youtube Id is not adjusted', function() {
                     var model = transcripts.collection.models[1];
 
                     model.setValue([
@@ -281,7 +279,7 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                     expect(youtubeValue).toEqual('');
                 });
 
-                it('Timed Transcript field is updated', function () {
+                it('Timed Transcript field is updated', function() {
                     Utils.Storage.set('sub', 'test_value');
 
                     transcripts.syncAdvancedTab(metadataCollection);
@@ -292,7 +290,7 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                     expect(subValue).toEqual('test_value');
                 });
 
-                it('Timed Transcript field is updated just once', function () {
+                it('Timed Transcript field is updated just once', function() {
                     Utils.Storage.set('sub', 'test_value');
 
                     var collection = metadataCollection.models,
@@ -305,7 +303,6 @@ function ($, Backbone, _, Utils, Editor, MetadataView, MetadataModel, MetadataCo
                     transcripts.syncAdvancedTab(metadataCollection);
                     expect(subModel.setValue.calls.count()).toEqual(1);
                 });
-
             });
         });
     });

--- a/cms/static/js/spec/video/transcripts/file_uploader_spec.js
+++ b/cms/static/js/spec/video/transcripts/file_uploader_spec.js
@@ -1,13 +1,13 @@
 define(
     [
-        "jquery", "underscore",
-        "js/views/video/transcripts/utils", "js/views/video/transcripts/file_uploader",
-        "xmodule", "jquery.form"
+        'jquery', 'underscore',
+        'js/views/video/transcripts/utils', 'js/views/video/transcripts/file_uploader',
+        'xmodule', 'jquery.form'
     ],
-function ($, _, Utils, FileUploader) {
+function($, _, Utils, FileUploader) {
     'use strict';
 
-    describe('Transcripts.FileUploader', function () {
+    describe('Transcripts.FileUploader', function() {
         var videoListEntryTemplate = readFixtures(
                 'video/transcripts/metadata-videolist-entry.underscore'
             ),
@@ -16,16 +16,16 @@ function ($, _, Utils, FileUploader) {
             ),
             view;
 
-        beforeEach(function () {
+        beforeEach(function() {
             setFixtures(
-                $("<div>", {id: "metadata-videolist-entry"})
+                $('<div>', {id: 'metadata-videolist-entry'})
                     .html(videoListEntryTemplate)
             );
             appendSetFixtures(
-                $("<script>",
+                $('<script>',
                     {
-                        id: "file-upload",
-                        type: "text/template"
+                        id: 'file-upload',
+                        type: 'text/template'
                     }
                 ).text(fileUploadTemplate)
             );
@@ -54,18 +54,17 @@ function ($, _, Utils, FileUploader) {
             });
         });
 
-        it('Initialize', function () {
+        it('Initialize', function() {
             expect(view.file).toBe(false);
             expect(FileUploader.prototype.render).toHaveBeenCalled();
         });
 
-        describe('Render', function () {
-
-            beforeEach(function () {
+        describe('Render', function() {
+            beforeEach(function() {
                 spyOn(_, 'template').and.callThrough();
             });
 
-            it('Template doesn\'t exist', function () {
+            it('Template doesn\'t exist', function() {
                 spyOn(console, 'error');
                 view.uploadTpl = '';
 
@@ -75,7 +74,7 @@ function ($, _, Utils, FileUploader) {
             });
 
             it('Container where template will be inserted doesn\'t exist',
-                function () {
+                function() {
                     $('.transcripts-file-uploader').remove();
 
                     expect(view.render).not.toThrow();
@@ -83,12 +82,12 @@ function ($, _, Utils, FileUploader) {
                 }
             );
 
-            it('All works okay if all data is okay', function () {
+            it('All works okay if all data is okay', function() {
                 var elList = ['$form', '$input', '$progress'],
                     validFileExtensions = ['srt', 'sjson'],
                     result = $.map(validFileExtensions, function(item, index) {
-                                return '.' + item;
-                            }).join(', ');
+                        return '.' + item;
+                    }).join(', ');
 
                 view.validFileExtensions = validFileExtensions;
                 expect(view.render).not.toThrow();
@@ -97,19 +96,18 @@ function ($, _, Utils, FileUploader) {
                     expect(view[el].length).not.toBe(0);
                 });
                 expect(view.$input.attr('accept')).toBe(result);
-
             });
         });
 
-        describe('Upload', function () {
-            it('File is not chosen', function () {
+        describe('Upload', function() {
+            it('File is not chosen', function() {
                 spyOn($.fn, 'ajaxSubmit');
                 view.upload();
 
                 expect(view.$form.ajaxSubmit).not.toHaveBeenCalled();
             });
 
-            it('File is chosen', function () {
+            it('File is chosen', function() {
                 spyOn($.fn, 'ajaxSubmit');
 
                 view.file = {};
@@ -119,7 +117,7 @@ function ($, _, Utils, FileUploader) {
             });
         });
 
-        it('clickHandler', function () {
+        it('clickHandler', function() {
             spyOn($.fn, 'trigger');
 
             $('.setting-upload').click();
@@ -128,12 +126,12 @@ function ($, _, Utils, FileUploader) {
             expect(view.$input).toHaveValue('');
         });
 
-        describe('changeHadler', function () {
-            beforeEach(function () {
+        describe('changeHadler', function() {
+            beforeEach(function() {
                 spyOn(view, 'upload');
             });
 
-            it('Valid File Type - error should be hided', function () {
+            it('Valid File Type - error should be hided', function() {
                 spyOn(view, 'checkExtValidity').and.returnValue(true);
 
                 view.$input.change();
@@ -143,7 +141,7 @@ function ($, _, Utils, FileUploader) {
                 expect(view.options.messenger.hideError).toHaveBeenCalled();
             });
 
-            it('Invalid File Type - error should be shown', function () {
+            it('Invalid File Type - error should be shown', function() {
                 spyOn(view, 'checkExtValidity').and.returnValue(false);
 
                 view.$input.change();
@@ -154,20 +152,20 @@ function ($, _, Utils, FileUploader) {
             });
         });
 
-        describe('checkExtValidity', function () {
+        describe('checkExtValidity', function() {
             var data = {
-                    Correct: {
-                        name: 'file_name.srt',
-                        isValid: true
-                    },
-                    Incorrect: {
-                        name: 'file_name.mp4',
-                        isValid: false
-                    }
-                };
+                Correct: {
+                    name: 'file_name.srt',
+                    isValid: true
+                },
+                Incorrect: {
+                    name: 'file_name.mp4',
+                    isValid: false
+                }
+            };
 
             $.each(data, function(fileType, fileInfo) {
-                it(fileType + ' file type', function () {
+                it(fileType + ' file type', function() {
                     var result = view.checkExtValidity(fileInfo);
 
                     expect(result).toBe(fileInfo.isValid);
@@ -175,14 +173,14 @@ function ($, _, Utils, FileUploader) {
             });
         });
 
-        it('xhrResetProgressBar', function () {
+        it('xhrResetProgressBar', function() {
             view.xhrResetProgressBar();
             expect(view.$progress.width()).toBe(0);
             expect(view.$progress.html()).toBe('0%');
             expect(view.$progress).not.toHaveClass('is-invisible');
         });
 
-        it('xhrProgressHandler', function () {
+        it('xhrProgressHandler', function() {
             var percent = 26;
 
             spyOn($.fn, 'width').and.callThrough();
@@ -192,8 +190,8 @@ function ($, _, Utils, FileUploader) {
             expect(view.$progress.html()).toBe(percent + '%');
         });
 
-        describe('xhrCompleteHandler', function () {
-            it('Ajax Success', function () {
+        describe('xhrCompleteHandler', function() {
+            it('Ajax Success', function() {
                 var xhr = {
                     status: 200,
                     responseText: JSON.stringify({
@@ -211,7 +209,7 @@ function ($, _, Utils, FileUploader) {
                     .toHaveBeenCalledWith('sub', 'test');
             });
 
-            var assertAjaxError = function (xhr) {
+            var assertAjaxError = function(xhr) {
                 spyOn(Utils.Storage, 'set');
                 view.xhrCompleteHandler(xhr);
 
@@ -225,7 +223,7 @@ function ($, _, Utils, FileUploader) {
                     .toHaveBeenCalledWith('sub', 'test');
             };
 
-            it('Ajax transport Error', function () {
+            it('Ajax transport Error', function() {
                 var xhr = {
                     status: 400,
                     responseText: JSON.stringify({})

--- a/cms/static/js/spec/video/transcripts/message_manager_spec.js
+++ b/cms/static/js/spec/video/transcripts/message_manager_spec.js
@@ -1,14 +1,14 @@
 define(
     [
-        "jquery", "underscore",
-        "js/views/video/transcripts/utils", "js/views/video/transcripts/message_manager",
-        "js/views/video/transcripts/file_uploader", "sinon",
-        "xmodule"
+        'jquery', 'underscore',
+        'js/views/video/transcripts/utils', 'js/views/video/transcripts/message_manager',
+        'js/views/video/transcripts/file_uploader', 'sinon',
+        'xmodule'
     ],
-function ($, _, Utils, MessageManager, FileUploader, sinon) {
+function($, _, Utils, MessageManager, FileUploader, sinon) {
     'use strict';
 
-    describe('Transcripts.MessageManager', function () {
+    describe('Transcripts.MessageManager', function() {
         var videoListEntryTemplate = readFixtures(
                 'video/transcripts/metadata-videolist-entry.underscore'
             ),
@@ -22,20 +22,20 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
             },
             view, fileUploader, sinonXhr;
 
-        beforeEach(function () {
+        beforeEach(function() {
             var videoList, $container;
 
             fileUploader = FileUploader.prototype;
 
             setFixtures(
-                $("<div>", {id: "metadata-videolist-entry"})
+                $('<div>', {id: 'metadata-videolist-entry'})
                     .html(videoListEntryTemplate)
             );
             appendSetFixtures(
-                $("<script>",
+                $('<script>',
                     {
-                        id: "transcripts-found",
-                        type: "text/template"
+                        id: 'transcripts-found',
+                        type: 'text/template'
                     }
                 ).text(foundTemplate)
             );
@@ -57,7 +57,7 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
             });
         });
 
-        it('Initialize', function () {
+        it('Initialize', function() {
             expect(fileUploader.initialize).toHaveBeenCalledWith({
                 el: view.$el,
                 messenger: view,
@@ -66,14 +66,13 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
             });
         });
 
-        describe('Render', function () {
-
-            beforeEach(function () {
-                spyOn(_,'template').and.callThrough();
+        describe('Render', function() {
+            beforeEach(function() {
+                spyOn(_, 'template').and.callThrough();
                 spyOn(view.fileUploader, 'render');
             });
 
-            it('Template doesn\'t exist', function () {
+            it('Template doesn\'t exist', function() {
                 view.render('incorrect_template_name');
 
                 expect(console.error).toHaveBeenCalled();
@@ -83,7 +82,7 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
                 expect(view.fileUploader.render).not.toHaveBeenCalled();
             });
 
-            it('All works okay if correct data is passed', function () {
+            it('All works okay if correct data is passed', function() {
                 view.render('found');
 
                 expect(console.error).not.toHaveBeenCalled();
@@ -93,11 +92,11 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
             });
         });
 
-        describe('showError', function () {
-            var errorMessage ='error',
+        describe('showError', function() {
+            var errorMessage = 'error',
                 $error, $buttons;
 
-            beforeEach(function () {
+            beforeEach(function() {
                 view.render('found');
                 spyOn(view, 'hideError');
                 spyOn($.fn, 'html').and.callThrough();
@@ -105,7 +104,7 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
                 $buttons = view.$el.find('.wrapper-transcripts-buttons');
             });
 
-            it('Error message is not passed', function () {
+            it('Error message is not passed', function() {
                 view.showError(null);
 
                 expect(view.hideError).not.toHaveBeenCalled();
@@ -114,7 +113,7 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
                 expect($buttons).not.toHaveClass('is-invisible');
             });
 
-            it('Show message and buttons', function () {
+            it('Show message and buttons', function() {
                 view.showError(errorMessage);
 
                 expect(view.hideError).toHaveBeenCalled();
@@ -123,7 +122,7 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
                 expect($buttons).not.toHaveClass('is-invisible');
             });
 
-            it('Show message and hide buttons', function () {
+            it('Show message and hide buttons', function() {
                 view.showError(errorMessage, true);
 
                 expect(view.hideError).toHaveBeenCalled();
@@ -133,7 +132,7 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
             });
         });
 
-        it('hideError', function () {
+        it('hideError', function() {
             view.render('found');
 
             var $error = view.$el.find('.transcripts-error-message'),
@@ -144,59 +143,59 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
         });
 
         $.each(handlers, function(key, value) {
-             it(key, function () {
+            it(key, function() {
                 var eventObj = jasmine.createSpyObj('event', ['preventDefault']);
                 spyOn($.fn, 'data').and.returnValue('video_id');
                 spyOn(view, 'processCommand');
                 view[key](eventObj);
                 expect(view.processCommand.calls.mostRecent().args).toEqual(value);
-             });
+            });
         });
 
-        describe('processCommand', function () {
+        describe('processCommand', function() {
             var action = 'replace',
                 errorMessage = 'errorMessage',
                 videoList = void(0),
                 extraParamas = 'video_id';
 
-            beforeEach(function () {
+            beforeEach(function() {
                 view.render('found');
                 spyOn(Utils, 'command').and.callThrough();
                 spyOn(view, 'render');
                 spyOn(view, 'showError');
 
-                sinonXhr =  sinon.fakeServer.create();
+                sinonXhr = sinon.fakeServer.create();
                 sinonXhr.autoRespond = true;
             });
 
-            afterEach(function () {
+            afterEach(function() {
                 sinonXhr.restore();
             });
 
-            var assertCommand = function (config) {
+            var assertCommand = function(config) {
                 var defaults = {
-                        action: 'replace',
-                        errorMessage: 'errorMessage',
-                        extraParamas: void(0)
-                    };
+                    action: 'replace',
+                    errorMessage: 'errorMessage',
+                    extraParamas: void(0)
+                };
                 var args = $.extend({}, defaults, config);
 
                 return view
                     .processCommand(args.action, args.errorMessage, args.extraParamas);
             };
 
-            it('Invoke without extraParamas', function (done) {
+            it('Invoke without extraParamas', function(done) {
                 sinonXhr.respondWith([
                     200,
-                    { "Content-Type": "application/json"},
+                    {'Content-Type': 'application/json'},
                     JSON.stringify({
-                      status: 'Success',
-                      subs: 'video_id'
+                        status: 'Success',
+                        subs: 'video_id'
                     })
                 ]);
 
                 assertCommand({})
-                    .then(function () {
+                    .then(function() {
                         expect(Utils.command).toHaveBeenCalledWith(
                             action,
                             view.component_locator,
@@ -211,20 +210,20 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
                     .always(done);
             });
 
-            it('Invoke with extraParamas', function (done) {
+            it('Invoke with extraParamas', function(done) {
                 sinonXhr.respondWith([
                     200,
-                    { "Content-Type": "application/json"},
+                    {'Content-Type': 'application/json'},
                     JSON.stringify({
-                      status: 'Success',
-                      subs: 'video_id'
+                        status: 'Success',
+                        subs: 'video_id'
                     })
                 ]);
 
                 view.processCommand(action, errorMessage, extraParamas);
 
-                assertCommand({extraParamas : extraParamas})
-                    .then(function () {
+                assertCommand({extraParamas: extraParamas})
+                    .then(function() {
                         expect(Utils.command).toHaveBeenCalledWith(
                             action,
                             view.component_locator,
@@ -240,10 +239,10 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
                     .always(done);
             });
 
-            it('Fail', function (done) {
+            it('Fail', function(done) {
                 sinonXhr.respondWith([400, {}, '']);
                 assertCommand({})
-                    .then(function () {
+                    .then(function() {
                         expect(Utils.command).toHaveBeenCalledWith(
                             action,
                             view.component_locator,
@@ -257,6 +256,5 @@ function ($, _, Utils, MessageManager, FileUploader, sinon) {
                     .always(done);
             });
         });
-
     });
 });

--- a/cms/static/js/spec/video/transcripts/utils_spec.js
+++ b/cms/static/js/spec/video/transcripts/utils_spec.js
@@ -4,55 +4,53 @@ define(
         'js/views/video/transcripts/utils',
         'underscore.string', 'xmodule'
     ],
-function ($, _, Utils, _str) {
-'use strict';
-describe('Transcripts.Utils', function () {
-    var videoId = 'OEoXaMPEzfM',
-        ytLinksList = (function (id) {
-            var links = [
-                'http://www.youtube.com/watch?v=%s&feature=feedrec_grec_index',
-                'http://www.youtube.com/user/IngridMichaelsonVEVO#p/a/u/1/%s',
-                'http://www.youtube.com/v/%s?fs=1&amp;hl=en_US&amp;rel=0',
-                'http://www.youtube.com/watch?v=%s#t=0m10s',
-                'http://www.youtube.com/embed/%s?rel=0',
-                'http://www.youtube.com/watch?v=%s',
-                'http://youtu.be/%s'
-            ];
+function($, _, Utils, _str) {
+    'use strict';
+    describe('Transcripts.Utils', function() {
+        var videoId = 'OEoXaMPEzfM',
+            ytLinksList = (function(id) {
+                var links = [
+                    'http://www.youtube.com/watch?v=%s&feature=feedrec_grec_index',
+                    'http://www.youtube.com/user/IngridMichaelsonVEVO#p/a/u/1/%s',
+                    'http://www.youtube.com/v/%s?fs=1&amp;hl=en_US&amp;rel=0',
+                    'http://www.youtube.com/watch?v=%s#t=0m10s',
+                    'http://www.youtube.com/embed/%s?rel=0',
+                    'http://www.youtube.com/watch?v=%s',
+                    'http://youtu.be/%s'
+                ];
 
-            return $.map(links, function (link) {
-                return _str.sprintf(link, id);
-            });
-
-        } (videoId)),
-        html5FileName = 'file_name',
-        html5LinksList =  (function (videoName) {
-            var videoTypes = ['mp4', 'webm', 'm4v', 'ogv'],
-                links = [
-                    'http://somelink.com/%s.%s?param=1&param=2#hash',
-                    'http://somelink.com/%s.%s#hash',
-                    'http://somelink.com/%s.%s?param=1&param=2',
-                    'http://somelink.com/%s.%s',
-                    'ftp://somelink.com/%s.%s',
-                    'https://somelink.com/%s.%s',
-                    'https://somelink.com/sub/sub/%s.%s',
-                    'http://cdn.somecdn.net/v/%s.%s',
-                    'somelink.com/%s.%s',
-                     '%s.%s'
-                ],
-                data = {};
-
-            $.each(videoTypes, function (index, type) {
-                data[type] = $.map(links, function (link) {
-                    return _str.sprintf(link, videoName, type);
+                return $.map(links, function(link) {
+                    return _str.sprintf(link, id);
                 });
-            });
+            }(videoId)),
+            html5FileName = 'file_name',
+            html5LinksList = (function(videoName) {
+                var videoTypes = ['mp4', 'webm', 'm4v', 'ogv'],
+                    links = [
+                        'http://somelink.com/%s.%s?param=1&param=2#hash',
+                        'http://somelink.com/%s.%s#hash',
+                        'http://somelink.com/%s.%s?param=1&param=2',
+                        'http://somelink.com/%s.%s',
+                        'ftp://somelink.com/%s.%s',
+                        'https://somelink.com/%s.%s',
+                        'https://somelink.com/sub/sub/%s.%s',
+                        'http://cdn.somecdn.net/v/%s.%s',
+                        'somelink.com/%s.%s',
+                        '%s.%s'
+                    ],
+                    data = {};
 
-            return data;
+                $.each(videoTypes, function(index, type) {
+                    data[type] = $.map(links, function(link) {
+                        return _str.sprintf(link, videoName, type);
+                    });
+                });
 
-        } (html5FileName)),
-        otherLinkId = 'other_link_id',
-        otherLinksList =  (function (linkId) {
-            var links = [
+                return data;
+            }(html5FileName)),
+            otherLinkId = 'other_link_id',
+            otherLinksList = (function(linkId) {
+                var links = [
                     'http://goo.gl/%s?param=1&param=2#hash',
                     'http://goo.gl/%s?param=1&param=2',
                     'http://goo.gl/%s#hash',
@@ -60,229 +58,228 @@ describe('Transcripts.Utils', function () {
                     'http://goo.gl/%s',
                     'ftp://goo.gl/%s',
                     'https://goo.gl/%s',
-                     '%s'
+                    '%s'
                 ];
 
-            return $.map(links, function (link) {
-                return _str.sprintf(link, linkId);
-            });
+                return $.map(links, function(link) {
+                    return _str.sprintf(link, linkId);
+                });
+            }(otherLinkId));
 
-        } (otherLinkId));
+        describe('Method: getField', function() {
+            var collection,
+                testFieldName = 'test_field';
 
-    describe('Method: getField', function (){
-        var collection,
-            testFieldName = 'test_field';
-
-        beforeEach(function() {
-            collection = jasmine.createSpyObj(
+            beforeEach(function() {
+                collection = jasmine.createSpyObj(
                                 'Collection',
-                                [
-                                    'findWhere'
-                                ]
+                    [
+                        'findWhere'
+                    ]
                             );
-        });
-
-        it('All works okay if all arguments are passed', function () {
-            Utils.getField(collection, testFieldName);
-
-            expect(collection.findWhere).toHaveBeenCalledWith({
-                field_name: testFieldName
             });
-        });
 
-        var wrongArgumentLists = [
-            {
-                argName: 'collection',
-                list: [undefined, testFieldName]
-            },
-            {
-                argName: 'field name',
-                list: [collection, undefined]
-            },
-            {
-                argName: 'both',
-                list: [undefined, undefined]
-            }
-        ];
+            it('All works okay if all arguments are passed', function() {
+                Utils.getField(collection, testFieldName);
 
-        $.each(wrongArgumentLists, function (index, element) {
-            it(element.argName + ' argument(s) is/are absent', function () {
-                var result = Utils.getField.apply(this, element.list);
-
-                expect(result).toBeUndefined();
-            });
-        });
-    });
-
-    describe('Method: parseYoutubeLink', function () {
-        describe('Supported urls', function () {
-            $.each(ytLinksList, function (index, link) {
-                it(link, function () {
-                    var result = Utils.parseYoutubeLink(link);
-
-                    expect(result).toBe(videoId);
+                expect(collection.findWhere).toHaveBeenCalledWith({
+                    field_name: testFieldName
                 });
             });
-        });
 
-        describe('Wrong arguments ', function () {
-            beforeEach(function(){
-                spyOn(console, 'log');
-            });
-
-            it('no arguments', function () {
-                var result = Utils.parseYoutubeLink();
-
-                expect(result).toBeUndefined();
-            });
-
-            it('wrong data type', function () {
-                var result = Utils.parseYoutubeLink(1);
-
-                expect(result).toBeUndefined();
-            });
-
-            var wrongUrls = [
-                'http://youtu.be/',
-                '/static/example',
-                'http://google.com/somevideo.mp4'
+            var wrongArgumentLists = [
+                {
+                    argName: 'collection',
+                    list: [undefined, testFieldName]
+                },
+                {
+                    argName: 'field name',
+                    list: [collection, undefined]
+                },
+                {
+                    argName: 'both',
+                    list: [undefined, undefined]
+                }
             ];
 
-            $.each(wrongUrls, function (index, link) {
-                it(link, function () {
-                    var result = Utils.parseYoutubeLink(link);
+            $.each(wrongArgumentLists, function(index, element) {
+                it(element.argName + ' argument(s) is/are absent', function() {
+                    var result = Utils.getField.apply(this, element.list);
 
                     expect(result).toBeUndefined();
                 });
             });
         });
-    });
 
-    describe('Method: parseHTML5Link', function () {
-        describe('Supported urls', function () {
-            $.each(html5LinksList, function (format, linksList) {
-                $.each(linksList, function (index, link) {
-                    it(link, function () {
+        describe('Method: parseYoutubeLink', function() {
+            describe('Supported urls', function() {
+                $.each(ytLinksList, function(index, link) {
+                    it(link, function() {
+                        var result = Utils.parseYoutubeLink(link);
+
+                        expect(result).toBe(videoId);
+                    });
+                });
+            });
+
+            describe('Wrong arguments ', function() {
+                beforeEach(function() {
+                    spyOn(console, 'log');
+                });
+
+                it('no arguments', function() {
+                    var result = Utils.parseYoutubeLink();
+
+                    expect(result).toBeUndefined();
+                });
+
+                it('wrong data type', function() {
+                    var result = Utils.parseYoutubeLink(1);
+
+                    expect(result).toBeUndefined();
+                });
+
+                var wrongUrls = [
+                    'http://youtu.be/',
+                    '/static/example',
+                    'http://google.com/somevideo.mp4'
+                ];
+
+                $.each(wrongUrls, function(index, link) {
+                    it(link, function() {
+                        var result = Utils.parseYoutubeLink(link);
+
+                        expect(result).toBeUndefined();
+                    });
+                });
+            });
+        });
+
+        describe('Method: parseHTML5Link', function() {
+            describe('Supported urls', function() {
+                $.each(html5LinksList, function(format, linksList) {
+                    $.each(linksList, function(index, link) {
+                        it(link, function() {
+                            var result = Utils.parseHTML5Link(link);
+
+                            expect(result).toEqual({
+                                video: html5FileName,
+                                type: format
+                            });
+                        });
+                    });
+                });
+
+                $.each(otherLinksList, function(index, link) {
+                    it(link, function() {
                         var result = Utils.parseHTML5Link(link);
 
                         expect(result).toEqual({
-                            video: html5FileName,
-                            type: format
+                            video: otherLinkId,
+                            type: 'other'
                         });
                     });
                 });
             });
 
-            $.each(otherLinksList, function (index, link) {
-                it(link, function () {
-                    var result = Utils.parseHTML5Link(link);
+            describe('Wrong arguments ', function() {
+                beforeEach(function() {
+                    spyOn(console, 'log');
+                });
 
-                    expect(result).toEqual({
-                        video: otherLinkId,
-                        type: 'other'
+                it('no arguments', function() {
+                    var result = Utils.parseHTML5Link();
+
+                    expect(result).toBeUndefined();
+                });
+
+                it('wrong data type', function() {
+                    var result = Utils.parseHTML5Link(1);
+
+                    expect(result).toBeUndefined();
+                });
+
+                var html5WrongUrls = [
+                    'http://youtu.be/',
+                    'http://example.com/.mp4',
+                    'http://example.com/video_name.',
+                    'http://example.com/',
+                    'http://example.com'
+                ];
+
+                $.each(html5WrongUrls, function(index, link) {
+                    it(link, function() {
+                        var result = Utils.parseHTML5Link(link);
+
+                        expect(result).toBeUndefined();
                     });
                 });
             });
         });
 
-        describe('Wrong arguments ', function () {
-            beforeEach(function(){
-                spyOn(console, 'log');
+        it('Method: getYoutubeLink', function() {
+            var videoId = 'video_id',
+                result = Utils.getYoutubeLink(videoId),
+                expectedResult = 'http://youtu.be/' + videoId;
+
+            expect(result).toBe(expectedResult);
+        });
+
+        describe('Method: parseLink', function() {
+            var resultDataDict = {
+                'html5': {
+                    link: html5LinksList.mp4[0],
+                    resp: {
+                        mode: 'html5',
+                        video: html5FileName,
+                        type: 'mp4'
+                    }
+                },
+                'youtube': {
+                    link: ytLinksList[0],
+                    resp: {
+                        mode: 'youtube',
+                        video: videoId,
+                        type: 'youtube'
+                    }
+                },
+                'incorrect': {
+                    link: 'http://example.com',
+                    resp: {
+                        mode: 'incorrect'
+                    }
+                }
+            };
+
+            $.each(resultDataDict, function(mode, data) {
+                it(mode, function() {
+                    var result = Utils.parseLink(data.link);
+
+                    expect(result).toEqual(data.resp);
+                });
             });
 
-            it('no arguments', function () {
-                var result = Utils.parseHTML5Link();
+            describe('Wrong arguments ', function() {
+                it('youtube videoId is wrong', function() {
+                    var videoId = 'wrong_id',
+                        link = 'http://youtu.be/' + videoId,
+                        result = Utils.parseLink(link);
 
-                expect(result).toBeUndefined();
-            });
+                    expect(result).toEqual({mode: 'incorrect'});
+                });
 
-            it('wrong data type', function () {
-                var result = Utils.parseHTML5Link(1);
+                it('no arguments', function() {
+                    var result = Utils.parseLink();
 
-                expect(result).toBeUndefined();
-            });
+                    expect(result).toBeUndefined();
+                });
 
-            var html5WrongUrls = [
-                'http://youtu.be/',
-                'http://example.com/.mp4',
-                'http://example.com/video_name.',
-                'http://example.com/',
-                'http://example.com'
-            ];
-
-            $.each(html5WrongUrls, function (index, link) {
-                it(link, function () {
-                    var result = Utils.parseHTML5Link(link);
+                it('wrong data type', function() {
+                    var result = Utils.parseLink(1);
 
                     expect(result).toBeUndefined();
                 });
             });
         });
     });
-
-    it('Method: getYoutubeLink', function () {
-        var videoId = 'video_id',
-            result = Utils.getYoutubeLink(videoId),
-            expectedResult = 'http://youtu.be/' + videoId;
-
-        expect(result).toBe(expectedResult);
-    });
-
-    describe('Method: parseLink', function () {
-        var resultDataDict = {
-            'html5': {
-                 link: html5LinksList.mp4[0],
-                 resp: {
-                    mode: 'html5',
-                    video: html5FileName,
-                    type: 'mp4'
-                }
-            },
-            'youtube': {
-                link: ytLinksList[0],
-                resp: {
-                    mode: 'youtube',
-                    video: videoId,
-                    type: 'youtube'
-                }
-            },
-            'incorrect': {
-                link: 'http://example.com',
-                resp: {
-                    mode: 'incorrect'
-                }
-            }
-        };
-
-        $.each(resultDataDict, function (mode, data) {
-            it(mode, function () {
-                var result = Utils.parseLink(data.link);
-
-                expect(result).toEqual(data.resp);
-            });
-        });
-
-        describe('Wrong arguments ', function () {
-            it('youtube videoId is wrong', function () {
-                var videoId = 'wrong_id',
-                    link = 'http://youtu.be/' + videoId,
-                    result = Utils.parseLink(link);
-
-                expect(result).toEqual({ mode : 'incorrect' });
-            });
-
-            it('no arguments', function () {
-                var result = Utils.parseLink();
-
-                expect(result).toBeUndefined();
-            });
-
-            it('wrong data type', function () {
-                var result = Utils.parseLink(1);
-
-                expect(result).toBeUndefined();
-            });
-        });
-    });
-});
 });

--- a/cms/static/js/spec/video/transcripts/videolist_spec.js
+++ b/cms/static/js/spec/video/transcripts/videolist_spec.js
@@ -7,9 +7,9 @@ define(
         'js/views/abstract_editor',
         'xmodule'
     ],
-function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
+function($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
     'use strict';
-    describe('CMS.Views.Metadata.VideoList', function () {
+    describe('CMS.Views.Metadata.VideoList', function() {
         var videoListEntryTemplate = readFixtures(
                 'video/transcripts/metadata-videolist-entry.underscore'
             ),
@@ -54,11 +54,11 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             MessageManager, messenger;
 
 
-        var createMockAjaxServer = function () {
+        var createMockAjaxServer = function() {
             var mockServer = AjaxHelpers.server(
                 [
                     200,
-                    { 'Content-Type': 'application/json'},
+                    {'Content-Type': 'application/json'},
                     response
                 ]
             );
@@ -66,11 +66,11 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             return mockServer;
         };
 
-        beforeEach(function () {
+        beforeEach(function() {
             var tpl = sandbox({
-                    'class': 'component',
-                    'data-locator': component_locator
-                });
+                'class': 'component',
+                'data-locator': component_locator
+            });
 
             setFixtures(tpl);
 
@@ -91,15 +91,15 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             spyOn(abstractEditor, 'render').and.callThrough();
             spyOn(console, 'error');
 
-            messenger = jasmine.createSpyObj('MessageManager',[
+            messenger = jasmine.createSpyObj('MessageManager', [
                 'initialize', 'render', 'showError', 'hideError'
             ]);
 
             $.each(messenger, function(index, method) {
-                 method.and.returnValue(messenger);
+                method.and.returnValue(messenger);
             });
 
-            MessageManager = function () {
+            MessageManager = function() {
                 messenger.initialize();
 
                 return messenger;
@@ -108,9 +108,9 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             jasmine.addMatchers({
                 assertValueInView: function() {
                     return {
-                        compare: function (actual, expected) {
+                        compare: function(actual, expected) {
                             var actualValue = actual.getValueFromEditor(),
-                            passed = _.isEqual(actualValue, expected);
+                                passed = _.isEqual(actualValue, expected);
 
                             return {
                                 pass: passed
@@ -118,9 +118,9 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                         }
                     };
                 },
-                assertCanUpdateView: function () {
+                assertCanUpdateView: function() {
                     return {
-                        compare: function (actual, expected) {
+                        compare: function(actual, expected) {
                             var actualValue,
                                 passed;
 
@@ -134,11 +134,11 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                         }
                     };
                 },
-                assertIsCorrectVideoList: function () {
+                assertIsCorrectVideoList: function() {
                     return {
-                        compare: function (actual, expected) {
+                        compare: function(actual, expected) {
                             var actualValue = actual.getVideoObjectsList(),
-                            passed = _.isEqual(actualValue, expected);
+                                passed = _.isEqual(actualValue, expected);
 
                             return {
                                 pass: passed
@@ -149,12 +149,12 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             });
         });
 
-        afterEach(function () {
+        afterEach(function() {
             // restore mock server
             this.mockServer.restore();
         });
 
-        var createVideoListView = function () {
+        var createVideoListView = function() {
             var model = new MetadataModel(modelStub);
             return new VideoList({
                 el: $('.component'),
@@ -163,8 +163,8 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             });
         };
 
-        var waitsForResponse = function (mockServer) {
-            return jasmine.waitUntil(function () {
+        var waitsForResponse = function(mockServer) {
+            return jasmine.waitUntil(function() {
                 var requests = mockServer.requests,
                     len = requests.length;
 
@@ -173,10 +173,10 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
         };
 
 
-        it('Initialize', function (done) {
+        it('Initialize', function(done) {
             var view = createVideoListView();
             waitsForResponse(this.mockServer)
-              .then(function () {
+              .then(function() {
                   expect(abstractEditor.initialize).toHaveBeenCalled();
                   expect(messenger.initialize).toHaveBeenCalled();
                   expect(view.component_locator).toBe(component_locator);
@@ -184,8 +184,8 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
               }).always(done);
         });
 
-        describe('Render', function () {
-            var assertToHaveBeenRendered = function (videoList) {
+        describe('Render', function() {
+            var assertToHaveBeenRendered = function(videoList) {
                     expect(abstractEditor.render).toHaveBeenCalled();
                     expect(Utils.command).toHaveBeenCalledWith(
                         'check',
@@ -202,28 +202,28 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                     mockServer.requests.length = 0;
                 };
 
-            it('is rendered in correct way', function (done) {
+            it('is rendered in correct way', function(done) {
                 createVideoListView();
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       assertToHaveBeenRendered(videoList);
                   })
                   .always(done);
             });
 
-            it('is rendered with opened extra videos bar', function (done) {
+            it('is rendered with opened extra videos bar', function(done) {
                 var view = createVideoListView();
                 var videoListLength = [
-                        {
-                            mode: 'youtube',
-                            type: 'youtube',
-                            video: '12345678901'
-                        },
-                        {
-                            mode: 'html5',
-                            type: 'mp4',
-                            video: 'video'
-                        }
+                    {
+                        mode: 'youtube',
+                        type: 'youtube',
+                        video: '12345678901'
+                    },
+                    {
+                        mode: 'html5',
+                        type: 'mp4',
+                        video: 'video'
+                    }
                     ],
                     videoListHtml5mode = [
                         {
@@ -240,27 +240,26 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                 view.render();
 
                 waitsForResponse(this.mockServer)
-                    .then(function () {
+                    .then(function() {
                         assertToHaveBeenRendered(videoListLength);
                         view.getVideoObjectsList.and.returnValue(videoListLength);
                         expect(view.openExtraVideosBar).toHaveBeenCalled();
                     })
-                    .then(_.bind(function () {
+                    .then(_.bind(function() {
                         resetSpies(this.mockServer);
                         view.openExtraVideosBar.calls.reset();
                         view.getVideoObjectsList.and.returnValue(videoListHtml5mode);
                         view.render();
 
                         return waitsForResponse(this.mockServer)
-                            .then(function () {
+                            .then(function() {
                                 assertToHaveBeenRendered(videoListHtml5mode);
                                 expect(view.openExtraVideosBar).toHaveBeenCalled();
                             }).then(done);
                     }, this));
-
             });
 
-            it('is rendered without opened extra videos bar', function (done) {
+            it('is rendered without opened extra videos bar', function(done) {
                 var view = createVideoListView(),
                     videoList = [
                         {
@@ -277,7 +276,7 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                 view.render();
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       assertToHaveBeenRendered(videoList);
                       expect(view.closeExtraVideosBar).toHaveBeenCalled();
                   })
@@ -285,8 +284,8 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             });
         });
 
-        describe('isUniqOtherVideos', function () {
-            it('Unique data - return true', function (done) {
+        describe('isUniqOtherVideos', function() {
+            it('Unique data - return true', function(done) {
                 var view = createVideoListView(),
                     data = videoList.concat([{
                         mode: 'html5',
@@ -295,14 +294,14 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                     }]);
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       var result = view.isUniqOtherVideos(data);
                       expect(result).toBe(true);
                   })
                   .always(done);
             });
 
-            it('Not Unique data - return false', function (done) {
+            it('Not Unique data - return false', function(done) {
                 var view = createVideoListView(),
                     data = [
                         {
@@ -333,7 +332,7 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                     ];
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       var result = view.isUniqOtherVideos(data);
                       expect(result).toBe(false);
                   })
@@ -341,20 +340,20 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             });
         });
 
-        describe('isUniqVideoTypes', function () {
-            it('Unique data - return true', function (done) {
+        describe('isUniqVideoTypes', function() {
+            it('Unique data - return true', function(done) {
                 var view = createVideoListView(),
                     data = videoList;
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       var result = view.isUniqVideoTypes(data);
                       expect(result).toBe(true);
                   })
                   .always(done);
             });
 
-            it('Not Unique data - return false', function (done) {
+            it('Not Unique data - return false', function(done) {
                 var view = createVideoListView(),
                     data = [
                         {
@@ -380,7 +379,7 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                     ];
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       var result = view.isUniqVideoTypes(data);
                       expect(result).toBe(false);
                   })
@@ -388,8 +387,8 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             });
         });
 
-        describe('checkIsUniqVideoTypes', function () {
-            it('Error is shown', function (done) {
+        describe('checkIsUniqVideoTypes', function() {
+            it('Error is shown', function(done) {
                 var view = createVideoListView(),
                     data = [
                         {
@@ -415,7 +414,7 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                     ];
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       var result = view.checkIsUniqVideoTypes(data);
 
                       expect(messenger.showError).toHaveBeenCalled();
@@ -424,12 +423,12 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                   .always(done);
             });
 
-            it('All works okay if arguments are not passed', function (done) {
+            it('All works okay if arguments are not passed', function(done) {
                 var view = createVideoListView();
                 spyOn(view, 'getVideoObjectsList').and.returnValue(videoList);
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       var result = view.checkIsUniqVideoTypes();
 
                       expect(view.getVideoObjectsList).toHaveBeenCalled();
@@ -440,15 +439,15 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             });
         });
 
-        describe('checkValidity', function () {
-            it('Error message is shown', function (done) {
+        describe('checkValidity', function() {
+            it('Error message is shown', function(done) {
                 var view = createVideoListView();
                 spyOn(view, 'checkIsUniqVideoTypes').and.returnValue(true);
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       var data = {mode: 'incorrect'},
-                        result = view.checkValidity(data, true);
+                          result = view.checkValidity(data, true);
 
                       expect(messenger.showError).toHaveBeenCalled();
                       expect(view.checkIsUniqVideoTypes).toHaveBeenCalled();
@@ -457,14 +456,14 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                   .always(done);
             });
 
-            it('Error message is shown when flag is not passed', function (done) {
+            it('Error message is shown when flag is not passed', function(done) {
                 var view = createVideoListView();
                 spyOn(view, 'checkIsUniqVideoTypes').and.returnValue(true);
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       var data = {mode: 'incorrect'},
-                        result = view.checkValidity(data);
+                          result = view.checkValidity(data);
 
                       expect(messenger.showError).not.toHaveBeenCalled();
                       expect(view.checkIsUniqVideoTypes).toHaveBeenCalled();
@@ -472,14 +471,14 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                   }).always(done);
             });
 
-            it('All works okay if correct data is passed', function (done) {
+            it('All works okay if correct data is passed', function(done) {
                 var view = createVideoListView();
                 spyOn(view, 'checkIsUniqVideoTypes').and.returnValue(true);
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       var data = videoList,
-                        result = view.checkValidity(data);
+                          result = view.checkValidity(data);
 
                       expect(messenger.showError).not.toHaveBeenCalled();
                       expect(view.checkIsUniqVideoTypes).toHaveBeenCalled();
@@ -489,10 +488,10 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             });
         });
 
-        it('openExtraVideosBar', function (done) {
+        it('openExtraVideosBar', function(done) {
             var view = createVideoListView();
             waitsForResponse(this.mockServer)
-              .then(function () {
+              .then(function() {
                   view.$extraVideosBar.removeClass('is-visible');
                   view.openExtraVideosBar();
                   expect(view.$extraVideosBar).toHaveClass('is-visible');
@@ -500,10 +499,10 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
               .always(done);
         });
 
-        it('closeExtraVideosBar', function (done) {
+        it('closeExtraVideosBar', function(done) {
             var view = createVideoListView();
             waitsForResponse(this.mockServer)
-              .then(function () {
+              .then(function() {
                   view.$extraVideosBar.addClass('is-visible');
                   view.closeExtraVideosBar();
 
@@ -512,10 +511,10 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
               .always(done);
         });
 
-        it('toggleExtraVideosBar', function (done) {
+        it('toggleExtraVideosBar', function(done) {
             var view = createVideoListView();
             waitsForResponse(this.mockServer)
-              .then(function () {
+              .then(function() {
                   view.$extraVideosBar.addClass('is-visible');
                   view.toggleExtraVideosBar();
                   expect(view.$extraVideosBar).not.toHaveClass('is-visible');
@@ -525,25 +524,25 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
               .always(done);
         });
 
-        it('getValueFromEditor', function (done) {
+        it('getValueFromEditor', function(done) {
             var view = createVideoListView();
             waitsForResponse(this.mockServer)
-              .then(function () {
+              .then(function() {
                   expect(view).assertValueInView(modelStub.value);
               })
               .always(done);
         });
 
-        it('setValueInEditor', function (done) {
+        it('setValueInEditor', function(done) {
             var view = createVideoListView();
             waitsForResponse(this.mockServer)
-              .then(function () {
+              .then(function() {
                   expect(view).assertCanUpdateView(['abc.mp4']);
               })
               .always(done);
         });
 
-        it('getVideoObjectsList', function (done) {
+        it('getVideoObjectsList', function(done) {
             var view = createVideoListView();
             var value = [
                 {
@@ -564,7 +563,7 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             ];
 
             waitsForResponse(this.mockServer)
-              .then(function () {
+              .then(function() {
                   view.setValueInEditor([
                       'http://youtu.be/12345678901',
                       'video.mp4',
@@ -576,16 +575,15 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
               .always(done);
         });
 
-        describe('getPlaceholders', function () {
-
-            it('All works okay if empty values are passed', function (done) {
+        describe('getPlaceholders', function() {
+            it('All works okay if empty values are passed', function(done) {
                 var view = createVideoListView(),
                     defaultPlaceholders = view.placeholders;
 
                 waitsForResponse(this.mockServer)
-                  .then(function () {
+                  .then(function() {
                       var result = view.getPlaceholders([]),
-                        expectedResult = _.values(defaultPlaceholders).reverse();
+                          expectedResult = _.values(defaultPlaceholders).reverse();
 
                       expect(result).toEqual(expectedResult);
                   })
@@ -594,7 +592,7 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
 
             it('On filling less than 3 fields, remaining fields should have ' +
 'placeholders for video types that were not filled yet',
-                function (done) {
+                function(done) {
                     var view = createVideoListView(),
                         defaultPlaceholders = view.placeholders;
                     var dataDict = {
@@ -626,8 +624,8 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
 
                     defaultPlaceholders = view.placeholders;
                     waitsForResponse(this.mockServer)
-                      .then(function () {
-                          $.each(dataDict, function (index, val) {
+                      .then(function() {
+                          $.each(dataDict, function(index, val) {
                               var result = view.getPlaceholders(val.value);
 
                               expect(result).toEqual(val.expectedResult);
@@ -638,16 +636,16 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             );
         });
 
-        describe('inputHandler', function () {
+        describe('inputHandler', function() {
             var eventObject;
 
-            var resetSpies = function (view) {
+            var resetSpies = function(view) {
                 messenger.hideError.calls.reset();
                 view.updateModel.calls.reset();
                 view.closeExtraVideosBar.calls.reset();
             };
 
-            var setUp = function (view) {
+            var setUp = function(view) {
                 eventObject = jQuery.Event('input');
 
                 spyOn(view, 'updateModel');
@@ -663,14 +661,14 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             };
 
             it('Field has invalid value - nothing should happen',
-                function (done) {
+                function(done) {
                     var view = createVideoListView();
                     setUp(view);
                     $.fn.hasClass.and.returnValue(false);
                     view.checkValidity.and.returnValue(false);
 
                     waitsForResponse(this.mockServer)
-                        .then(function () {
+                        .then(function() {
                             view.inputHandler(eventObject);
                             expect(messenger.hideError).not.toHaveBeenCalled();
                             expect(view.updateModel).not.toHaveBeenCalled();
@@ -687,14 +685,14 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             );
 
             it('Main field has invalid value - extra Videos Bar is closed',
-                function (done) {
+                function(done) {
                     var view = createVideoListView();
                     setUp(view);
                     $.fn.hasClass.and.returnValue(true);
                     view.checkValidity.and.returnValue(false);
 
                     waitsForResponse(this.mockServer)
-                        .then(function () {
+                        .then(function() {
                             view.inputHandler(eventObject);
                             expect(messenger.hideError).not.toHaveBeenCalled();
                             expect(view.updateModel).not.toHaveBeenCalled();
@@ -711,14 +709,14 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             );
 
             it('Model is updated if value is valid',
-                function (done) {
+                function(done) {
                     var view = createVideoListView();
                     setUp(view);
                     view.checkValidity.and.returnValue(true);
                     _.isEqual.and.returnValue(false);
 
                     waitsForResponse(this.mockServer)
-                        .then(function () {
+                        .then(function() {
                             view.inputHandler(eventObject);
                             expect(messenger.hideError).not.toHaveBeenCalled();
                             expect(view.updateModel).toHaveBeenCalled();
@@ -735,13 +733,13 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
             );
 
             it('Corner case: Error is hided',
-                function (done) {
+                function(done) {
                     var view = createVideoListView();
                     setUp(view);
                     view.checkValidity.and.returnValue(true);
                     _.isEqual.and.returnValue(true);
                     waitsForResponse(this.mockServer)
-                        .then(function () {
+                        .then(function() {
                             view.inputHandler(eventObject);
                             expect(messenger.hideError).toHaveBeenCalled();
                             expect(view.updateModel).not.toHaveBeenCalled();
@@ -756,8 +754,6 @@ function ($, _, AjaxHelpers, Utils, VideoList, MetadataModel, AbstractEditor) {
                         .always(done);
                 }
             );
-
         });
-
     });
 });

--- a/cms/static/js/spec/video/translations_editor_spec.js
+++ b/cms/static/js/spec/video/translations_editor_spec.js
@@ -2,10 +2,10 @@ define(
     [
         'jquery', 'underscore', 'squire'
     ],
-function ($, _, Squire) {
+function($, _, Squire) {
     'use strict';
     // TODO: fix BLD-1100 Disabled due to intermittent failure on master and in PR builds
-    xdescribe('VideoTranslations', function () {
+    xdescribe('VideoTranslations', function() {
         var TranslationsEntryTemplate = readFixtures(
                 'video/metadata-translations-entry.underscore'
             ),
@@ -38,12 +38,12 @@ function ($, _, Squire) {
             },
             self, injector;
 
-        var setValue = function (view, value) {
+        var setValue = function(view, value) {
             view.setValueInEditor(value);
             view.updateModel();
         };
 
-        var createPromptSpy = function (name) {
+        var createPromptSpy = function(name) {
             var spy = jasmine.createSpyObj(name, ['constructor', 'show', 'hide']);
             spy.constructor.and.returnValue(spy);
             spy.show.and.returnValue(spy);
@@ -52,13 +52,13 @@ function ($, _, Squire) {
             return spy;
         };
 
-        beforeEach(function (done) {
+        beforeEach(function(done) {
             self = this;
 
             jasmine.addMatchers({
                 assertValueInView: function() {
                     return {
-                        compare: function (actual, expected) {
+                        compare: function(actual, expected) {
                             var value = actual.getValueFromEditor();
                             var passed = _.isEqual(value, expected);
 
@@ -69,9 +69,9 @@ function ($, _, Squire) {
                         }
                     };
                 },
-                assertCanUpdateView: function () {
+                assertCanUpdateView: function() {
                     return {
-                        compare: function (actual, expected) {
+                        compare: function(actual, expected) {
                             var view = actual,
                                 value,
                                 passed;
@@ -87,9 +87,9 @@ function ($, _, Squire) {
                         }
                     };
                 },
-                assertClear: function () {
+                assertClear: function() {
                     return {
-                        compare: function (actual, modelValue) {
+                        compare: function(actual, modelValue) {
                             var view = actual,
                                 model = view.model,
                                 passed;
@@ -104,9 +104,9 @@ function ($, _, Squire) {
                         }
                     };
                 },
-                assertUpdateModel: function () {
+                assertUpdateModel: function() {
                     return {
-                        compare: function (actual, originalValue, newValue) {
+                        compare: function(actual, originalValue, newValue) {
                             var view = actual,
                                 model = view.model,
                                 expectOriginal,
@@ -125,9 +125,9 @@ function ($, _, Squire) {
                         }
                     };
                 },
-                verifyKeysUnique: function () {
+                verifyKeysUnique: function() {
                     return {
-                        compare: function (actual, initial, expected, testData) {
+                        compare: function(actual, initial, expected, testData) {
                             var view = this.actual,
                                 item,
                                 value,
@@ -149,9 +149,9 @@ function ($, _, Squire) {
                         }
                     };
                 },
-                verifyButtons: function () {
+                verifyButtons: function() {
                     return {
-                        compare: function (actual, upload, download, remove, index) {
+                        compare: function(actual, upload, download, remove, index) {
                             var view = this.actual,
                                 items = view.$el.find('.list-settings-item'),
                                 item = index ? items.eq(index) : items.last(),
@@ -188,14 +188,14 @@ function ($, _, Squire) {
             this.uploadSpies = createPromptSpy('UploadDialog');
 
             injector = new Squire();
-            injector.mock('js/views/uploads', function () {
+            injector.mock('js/views/uploads', function() {
                 return self.uploadSpies;
             });
 
             injector.require([
-                    'js/models/metadata', 'js/views/video/translations_editor'
-                ],
-                function (MetadataModel, Translations) {
+                'js/models/metadata', 'js/views/video/translations_editor'
+            ],
+                function(MetadataModel, Translations) {
                     var model = new MetadataModel($.extend(true, {}, modelStub));
                     self.view = new Translations({model: model});
 
@@ -203,12 +203,12 @@ function ($, _, Squire) {
                 });
         });
 
-        afterEach(function () {
+        afterEach(function() {
             injector.clean();
             injector.remove();
         });
 
-        it('returns the initial value upon initialization', function () {
+        it('returns the initial value upon initialization', function() {
             expect(this.view).assertValueInView({
                 'en': 'en.srt',
                 'ru': 'ru.srt',
@@ -219,7 +219,7 @@ function ($, _, Squire) {
             expect(this.view).verifyButtons(true, true, true);
         });
 
-        it('updates its value correctly', function () {
+        it('updates its value correctly', function() {
             expect(this.view).assertCanUpdateView({
                 'ru': 'ru.srt',
                 'uk': 'uk.srt',
@@ -227,7 +227,7 @@ function ($, _, Squire) {
             });
         });
 
-        it('upload works correctly', function () {
+        it('upload works correctly', function() {
             var options;
 
             setValue(this.view, {
@@ -259,7 +259,7 @@ function ($, _, Squire) {
             });
         });
 
-        it('has a clear method to revert to the model default', function () {
+        it('has a clear method to revert to the model default', function() {
             setValue(this.view, {
                 'fr': 'en.srt',
                 'uk': 'ru.srt'
@@ -277,17 +277,17 @@ function ($, _, Squire) {
             expect(this.view.$el.find('.create-setting')).not.toHaveClass('is-disabled');
         });
 
-        it('has an update model method', function () {
+        it('has an update model method', function() {
             expect(this.view).assertUpdateModel(null, {'fr': 'fr.srt'});
         });
 
-        it('can add an entry', function () {
+        it('can add an entry', function() {
             expect(_.keys(this.view.model.get('value')).length).toEqual(4);
             this.view.$el.find('.create-setting').click();
             expect(this.view.$el.find('select').length).toEqual(5);
         });
 
-        it('can remove an entry', function () {
+        it('can remove an entry', function() {
             setValue(this.view, {
                 'en': 'en.srt',
                 'ru': 'ru.srt',
@@ -298,14 +298,14 @@ function ($, _, Squire) {
             expect(_.keys(this.view.model.get('value')).length).toEqual(2);
         });
 
-        it('only allows one blank entry at a time', function () {
+        it('only allows one blank entry at a time', function() {
             expect(this.view.$el.find('select').length).toEqual(4);
             this.view.$el.find('.create-setting').click();
             this.view.$el.find('.create-setting').click();
             expect(this.view.$el.find('select').length).toEqual(5);
         });
 
-        it('only allows unique keys', function () {
+        it('only allows unique keys', function() {
             expect(this.view).verifyKeysUnique(
                 {'ru': 'ru.srt'}, {'ru': 'ru.srt'}, {'key': 'ru', 'value': ''}
             );
@@ -319,7 +319,7 @@ function ($, _, Squire) {
             );
         });
 
-        it('re-enables the add setting button after entering a new value', function () {
+        it('re-enables the add setting button after entering a new value', function() {
             expect(this.view.$el.find('select').length).toEqual(4);
             this.view.$el.find('.create-setting').click();
             expect(this.view).verifyButtons(false, false, true);

--- a/cms/static/js/spec/views/active_video_upload_list_spec.js
+++ b/cms/static/js/spec/views/active_video_upload_list_spec.js
@@ -1,21 +1,21 @@
 define(
     [
-        "jquery",
-        "js/models/active_video_upload",
-        "js/views/active_video_upload_list",
-        "common/js/spec_helpers/template_helpers",
-        "mock-ajax"
+        'jquery',
+        'js/models/active_video_upload',
+        'js/views/active_video_upload_list',
+        'common/js/spec_helpers/template_helpers',
+        'mock-ajax'
     ],
     function($, ActiveVideoUpload, ActiveVideoUploadListView, TemplateHelpers) {
-        "use strict";
+        'use strict';
         var concurrentUploadLimit = 2;
 
-        describe("ActiveVideoUploadListView", function() {
+        describe('ActiveVideoUploadListView', function() {
             beforeEach(function() {
-                TemplateHelpers.installTemplate("active-video-upload", true);
-                TemplateHelpers.installTemplate("active-video-upload-list");
-                this.postUrl = "/test/post/url";
-                this.uploadButton = $("<button>");
+                TemplateHelpers.installTemplate('active-video-upload', true);
+                TemplateHelpers.installTemplate('active-video-upload-list');
+                this.postUrl = '/test/post/url';
+                this.uploadButton = $('<button>');
                 this.view = new ActiveVideoUploadListView({
                     concurrentUploadLimit: concurrentUploadLimit,
                     postUrl: this.postUrl,
@@ -29,55 +29,55 @@ define(
 
             // Remove window unload handler triggered by the upload requests
             afterEach(function() {
-                $(window).off("beforeunload");
+                $(window).off('beforeunload');
                 jasmine.Ajax.uninstall();
             });
 
-            it("should trigger file selection when either the upload button or the drop zone is clicked", function() {
+            it('should trigger file selection when either the upload button or the drop zone is clicked', function() {
                 var clickSpy = jasmine.createSpy();
                 clickSpy.and.callFake(function(event) { event.preventDefault(); });
-                this.view.$(".js-file-input").on("click", clickSpy);
-                this.view.$(".file-drop-area").click();
+                this.view.$('.js-file-input').on('click', clickSpy);
+                this.view.$('.file-drop-area').click();
                 expect(clickSpy).toHaveBeenCalled();
                 clickSpy.calls.reset();
                 this.uploadButton.click();
                 expect(clickSpy).toHaveBeenCalled();
             });
 
-            it('should not show a notification message if there are no active video uploads', function () {
+            it('should not show a notification message if there are no active video uploads', function() {
                 expect(this.view.onBeforeUnload()).toBeUndefined();
             });
 
             var makeUploadUrl = function(fileName) {
-                return "http://www.example.com/test_url/" + fileName;
+                return 'http://www.example.com/test_url/' + fileName;
             };
 
             var getSentRequests = function() {
-                return jasmine.Ajax.requests.filter(function (request) {
+                return jasmine.Ajax.requests.filter(function(request) {
                     return request.readyState > 0;
                 });
             };
 
             _.each(
                 [
-                    {desc: "a single file", numFiles: 1},
-                    {desc: "multiple files", numFiles: concurrentUploadLimit},
-                    {desc: "more files than upload limit", numFiles: concurrentUploadLimit + 1}
+                    {desc: 'a single file', numFiles: 1},
+                    {desc: 'multiple files', numFiles: concurrentUploadLimit},
+                    {desc: 'more files than upload limit', numFiles: concurrentUploadLimit + 1}
                 ],
                 function(caseInfo) {
                     var fileNames = _.map(
                         _.range(caseInfo.numFiles),
-                        function(i) { return "test" + i + ".mp4";}
+                        function(i) { return 'test' + i + '.mp4'; }
                     );
 
-                    describe("on selection of " + caseInfo.desc, function() {
+                    describe('on selection of ' + caseInfo.desc, function() {
                         beforeEach(function() {
                             // The files property cannot be set on a file input for
                             // security reasons, so we must mock the access mechanism
                             // that jQuery-File-Upload uses to retrieve it.
                             var realProp = $.prop;
-                            spyOn($, "prop").and.callFake(function(el, propName) {
-                                if (arguments.length == 2 && propName == "files") {
+                            spyOn($, 'prop').and.callFake(function(el, propName) {
+                                if (arguments.length == 2 && propName == 'files') {
                                     return _.map(
                                         fileNames,
                                         function(fileName) { return {name: fileName}; }
@@ -86,29 +86,29 @@ define(
                                     realProp.apply(this, arguments);
                                 }
                             });
-                            this.view.$(".js-file-input").change();
+                            this.view.$('.js-file-input').change();
                             this.request = jasmine.Ajax.requests.mostRecent();
                         });
 
-                        it("should trigger the correct request", function() {
+                        it('should trigger the correct request', function() {
                             expect(this.request.url).toEqual(this.postUrl);
-                            expect(this.request.method).toEqual("POST");
-                            expect(this.request.requestHeaders["Content-Type"]).toEqual("application/json");
-                            expect(this.request.requestHeaders["Accept"]).toContain("application/json");
+                            expect(this.request.method).toEqual('POST');
+                            expect(this.request.requestHeaders['Content-Type']).toEqual('application/json');
+                            expect(this.request.requestHeaders['Accept']).toContain('application/json');
                             expect(JSON.parse(this.request.params)).toEqual({
-                                "files": _.map(
+                                'files': _.map(
                                     fileNames,
-                                    function(fileName) { return {"file_name": fileName}; }
+                                    function(fileName) { return {'file_name': fileName}; }
                                 )
                             });
                         });
 
-                        it("should trigger the global AJAX error handler on server error", function() {
+                        it('should trigger the global AJAX error handler on server error', function() {
                             this.request.respondWith({status: 500});
                             expect(this.globalAjaxError).toHaveBeenCalled();
                         });
 
-                        describe("and successful server response", function() {
+                        describe('and successful server response', function() {
                             beforeEach(function() {
                                 jasmine.Ajax.requests.reset();
                                 this.request.respondWith({
@@ -118,17 +118,17 @@ define(
                                             fileNames,
                                             function(fileName) {
                                                 return {
-                                                    "file_name": fileName,
-                                                    "upload_url": makeUploadUrl(fileName)
+                                                    'file_name': fileName,
+                                                    'upload_url': makeUploadUrl(fileName)
                                                 };
                                             }
                                         )
                                     })
                                 });
-                                this.$uploadElems = this.view.$(".active-video-upload");
+                                this.$uploadElems = this.view.$('.active-video-upload');
                             });
 
-                            it("should start uploads", function() {
+                            it('should start uploads', function() {
                                 var spec = this;
                                 var sentRequests = getSentRequests();
                                 expect(sentRequests.length).toEqual(
@@ -140,33 +140,33 @@ define(
                                         expect(uploadRequest.url).toEqual(
                                             makeUploadUrl(fileNames[i])
                                         );
-                                        expect(uploadRequest.method).toEqual("PUT");
+                                        expect(uploadRequest.method).toEqual('PUT');
                                     }
                                 );
                             });
 
-                            it("should display upload status and progress", function() {
+                            it('should display upload status and progress', function() {
                                 expect(this.$uploadElems.length).toEqual(caseInfo.numFiles);
                                 this.$uploadElems.each(function(i, uploadElem) {
                                     var $uploadElem = $(uploadElem);
                                     var queued = i >= concurrentUploadLimit;
-                                    expect($.trim($uploadElem.find(".video-detail-name").text())).toEqual(
+                                    expect($.trim($uploadElem.find('.video-detail-name').text())).toEqual(
                                         fileNames[i]
                                     );
-                                    expect($.trim($uploadElem.find(".video-detail-status").text())).toEqual(
+                                    expect($.trim($uploadElem.find('.video-detail-status').text())).toEqual(
                                         queued ?
                                             ActiveVideoUpload.STATUS_QUEUED :
                                             ActiveVideoUpload.STATUS_UPLOADING
                                     );
-                                    expect($uploadElem.find(".video-detail-progress").val()).toEqual(0);
-                                    expect($uploadElem).not.toHaveClass("success");
-                                    expect($uploadElem).not.toHaveClass("error");
-                                    expect($uploadElem.hasClass("queued")).toEqual(queued);
+                                    expect($uploadElem.find('.video-detail-progress').val()).toEqual(0);
+                                    expect($uploadElem).not.toHaveClass('success');
+                                    expect($uploadElem).not.toHaveClass('error');
+                                    expect($uploadElem.hasClass('queued')).toEqual(queued);
                                 });
                             });
 
-                            it('should show a notification message when there are active video uploads', function () {
-                                expect(this.view.onBeforeUnload()).toBe("Your video uploads are not complete.");
+                            it('should show a notification message when there are active video uploads', function() {
+                                expect(this.view.onBeforeUnload()).toBe('Your video uploads are not complete.');
                             });
 
                             // TODO: test progress update; the libraries we are using to mock ajax
@@ -177,71 +177,71 @@ define(
                             _.each(
                                 [
                                     {
-                                        desc: "completion",
+                                        desc: 'completion',
                                         responseStatus: 204,
                                         statusText: ActiveVideoUpload.STATUS_COMPLETED,
                                         progressValue: 1,
-                                        presentClass: "success",
-                                        absentClass: "error"
+                                        presentClass: 'success',
+                                        absentClass: 'error'
                                     },
                                     {
-                                        desc: "failure",
+                                        desc: 'failure',
                                         responseStatus: 500,
                                         statusText: ActiveVideoUpload.STATUS_FAILED,
                                         progressValue: 0,
-                                        presentClass: "error",
-                                        absentClass: "success"
+                                        presentClass: 'error',
+                                        absentClass: 'success'
                                     }
                                 ],
                                 function(subCaseInfo) {
-                                    describe("and upload " + subCaseInfo.desc, function() {
+                                    describe('and upload ' + subCaseInfo.desc, function() {
                                         beforeEach(function() {
                                             getSentRequests()[0].respondWith({status: subCaseInfo.responseStatus});
                                         });
 
-                                        it("should update status and progress", function() {
-                                            var $uploadElem = this.view.$(".active-video-upload:first");
+                                        it('should update status and progress', function() {
+                                            var $uploadElem = this.view.$('.active-video-upload:first');
                                             expect($uploadElem.length).toEqual(1);
-                                            expect($.trim($uploadElem.find(".video-detail-status").text())).toEqual(
+                                            expect($.trim($uploadElem.find('.video-detail-status').text())).toEqual(
                                                 subCaseInfo.statusText
                                             );
                                             expect(
-                                                $uploadElem.find(".video-detail-progress").val()
+                                                $uploadElem.find('.video-detail-progress').val()
                                             ).toEqual(subCaseInfo.progressValue);
                                             expect($uploadElem).toHaveClass(subCaseInfo.presentClass);
                                             expect($uploadElem).not.toHaveClass(subCaseInfo.absentClass);
                                         });
 
-                                        it("should not trigger the global AJAX error handler", function() {
+                                        it('should not trigger the global AJAX error handler', function() {
                                             expect(this.globalAjaxError).not.toHaveBeenCalled();
                                         });
 
                                         if (caseInfo.numFiles > concurrentUploadLimit) {
-                                            it("should start a new upload", function() {
+                                            it('should start a new upload', function() {
                                                 expect(getSentRequests().length).toEqual(
                                                     concurrentUploadLimit + 1
                                                 );
                                                 var $uploadElem = $(this.$uploadElems[concurrentUploadLimit]);
-                                                expect($.trim($uploadElem.find(".video-detail-status").text())).toEqual(
+                                                expect($.trim($uploadElem.find('.video-detail-status').text())).toEqual(
                                                     ActiveVideoUpload.STATUS_UPLOADING
                                                 );
-                                                expect($uploadElem).not.toHaveClass("queued");
+                                                expect($uploadElem).not.toHaveClass('queued');
                                             });
                                         }
 
-                                        // If we're uploading more files than the one we've closed above, 
+                                        // If we're uploading more files than the one we've closed above,
                                         // the unload warning should still be shown
                                         if (caseInfo.numFiles > 1) {
-                                            it('should show notification when videos are still uploading', 
-                                                function () {
+                                            it('should show notification when videos are still uploading',
+                                                function() {
                                                     expect(this.view.onBeforeUnload()).toBe(
-                                                        "Your video uploads are not complete.");
-                                            });
+                                                        'Your video uploads are not complete.');
+                                                });
                                         } else {
-                                            it('should not show notification once video uploads are complete', 
-                                                function () {
+                                            it('should not show notification once video uploads are complete',
+                                                function() {
                                                     expect(this.view.onBeforeUnload()).toBeUndefined();
-                                            });
+                                                });
                                         }
                                     });
                                 }

--- a/cms/static/js/spec/views/assets_spec.js
+++ b/cms/static/js/spec/views/assets_spec.js
@@ -1,8 +1,7 @@
-define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "js/views/assets",
-         "js/collections/asset", "common/js/spec_helpers/view_helpers"],
-    function ($, AjaxHelpers, URI, AssetsView, AssetCollection, ViewHelpers) {
-
-        describe("Assets", function() {
+define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'URI', 'js/views/assets',
+         'js/collections/asset', 'common/js/spec_helpers/view_helpers'],
+    function($, AjaxHelpers, URI, AssetsView, AssetCollection, ViewHelpers) {
+        describe('Assets', function() {
             var assetsView, mockEmptyAssetsResponse, mockAssetUploadResponse, mockFileUpload,
                 assetLibraryTpl, assetTpl, uploadModalTpl;
 
@@ -10,13 +9,13 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
             assetTpl = readFixtures('asset.underscore');
             uploadModalTpl = readFixtures('asset-upload-modal.underscore');
 
-            beforeEach(function () {
-                setFixtures($("<script>", { id: "asset-library-tpl", type: "text/template" }).text(assetLibraryTpl));
-                appendSetFixtures($("<script>", { id: "asset-tpl", type: "text/template" }).text(assetTpl));
+            beforeEach(function() {
+                setFixtures($('<script>', {id: 'asset-library-tpl', type: 'text/template'}).text(assetLibraryTpl));
+                appendSetFixtures($('<script>', {id: 'asset-tpl', type: 'text/template'}).text(assetTpl));
                 appendSetFixtures(uploadModalTpl);
-                appendSetFixtures(sandbox({ id: "asset_table_body" }));
+                appendSetFixtures(sandbox({id: 'asset_table_body'}));
 
-                spyOn($.fn, "fileupload").and.returnValue("");
+                spyOn($.fn, 'fileupload').and.returnValue('');
 
                 var TestAssetsCollection = AssetCollection.extend({
                     state: {
@@ -25,7 +24,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     }
                 });
                 var collection = new TestAssetsCollection();
-                collection.url = "assets-url";
+                collection.url = 'assets-url';
                 assetsView = new AssetsView({
                     collection: collection,
                     el: $('#asset_table_body')
@@ -35,7 +34,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
             });
 
             var mockAsset = {
-                display_name: "dummy.jpg",
+                display_name: 'dummy.jpg',
                 url: 'actual_asset_url',
                 portable_url: 'portable_url',
                 date_added: 'date',
@@ -54,38 +53,38 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
             };
 
             var mockExampleAssetsResponse = {
-                sort: "uploadDate",
+                sort: 'uploadDate',
                 end: 2,
                 assets: [
                     {
-                        "display_name": "test.jpg",
-                        "url": "/c4x/A/CS102/asset/test.jpg",
-                        "date_added": "Nov 07, 2014 at 17:47 UTC",
-                        "id": "/c4x/A/CS102/asset/test.jpg",
-                        "portable_url": "/static/test.jpg",
-                        "thumbnail": "/c4x/A/CS102/thumbnail/test.jpg",
-                        "locked": false,
-                        "external_url": "localhost:8000/c4x/A/CS102/asset/test.jpg"
+                        'display_name': 'test.jpg',
+                        'url': '/c4x/A/CS102/asset/test.jpg',
+                        'date_added': 'Nov 07, 2014 at 17:47 UTC',
+                        'id': '/c4x/A/CS102/asset/test.jpg',
+                        'portable_url': '/static/test.jpg',
+                        'thumbnail': '/c4x/A/CS102/thumbnail/test.jpg',
+                        'locked': false,
+                        'external_url': 'localhost:8000/c4x/A/CS102/asset/test.jpg'
                     },
                     {
-                        "display_name": "test.pdf",
-                        "url": "/c4x/A/CS102/asset/test.pdf",
-                        "date_added": "Oct 20, 2014 at 11:00 UTC",
-                        "id": "/c4x/A/CS102/asset/test.pdf",
-                        "portable_url": "/static/test.pdf",
-                        "thumbnail": null,
-                        "locked": false,
-                        "external_url": "localhost:8000/c4x/A/CS102/asset/test.pdf"
+                        'display_name': 'test.pdf',
+                        'url': '/c4x/A/CS102/asset/test.pdf',
+                        'date_added': 'Oct 20, 2014 at 11:00 UTC',
+                        'id': '/c4x/A/CS102/asset/test.pdf',
+                        'portable_url': '/static/test.pdf',
+                        'thumbnail': null,
+                        'locked': false,
+                        'external_url': 'localhost:8000/c4x/A/CS102/asset/test.pdf'
                     },
                     {
-                        "display_name": "test.odt",
-                        "url": "/c4x/A/CS102/asset/test.odt",
-                        "date_added": "Oct 20, 2014 at 11:00 UTC",
-                        "id": "/c4x/A/CS102/asset/test.odt",
-                        "portable_url": "/static/test.odt",
-                        "thumbnail": null,
-                        "locked": false,
-                        "external_url": "localhost:8000/c4x/A/CS102/asset/test.odt"
+                        'display_name': 'test.odt',
+                        'url': '/c4x/A/CS102/asset/test.odt',
+                        'date_added': 'Oct 20, 2014 at 11:00 UTC',
+                        'id': '/c4x/A/CS102/asset/test.odt',
+                        'portable_url': '/static/test.odt',
+                        'thumbnail': null,
+                        'locked': false,
+                        'external_url': 'localhost:8000/c4x/A/CS102/asset/test.odt'
                     }
                 ],
                 pageSize: 2,
@@ -95,18 +94,18 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
             };
 
             var mockExampleFilteredAssetsResponse = {
-                sort: "uploadDate",
+                sort: 'uploadDate',
                 end: 1,
                 assets: [
                     {
-                        "display_name": "test.jpg",
-                        "url": "/c4x/A/CS102/asset/test.jpg",
-                        "date_added": "Nov 07, 2014 at 17:47 UTC",
-                        "id": "/c4x/A/CS102/asset/test.jpg",
-                        "portable_url": "/static/test.jpg",
-                        "thumbnail": "/c4x/A/CS102/thumbnail/test.jpg",
-                        "locked": false,
-                        "external_url": "localhost:8000/c4x/A/CS102/asset/test.jpg"
+                        'display_name': 'test.jpg',
+                        'url': '/c4x/A/CS102/asset/test.jpg',
+                        'date_added': 'Nov 07, 2014 at 17:47 UTC',
+                        'id': '/c4x/A/CS102/asset/test.jpg',
+                        'portable_url': '/static/test.jpg',
+                        'thumbnail': '/c4x/A/CS102/thumbnail/test.jpg',
+                        'locked': false,
+                        'external_url': 'localhost:8000/c4x/A/CS102/asset/test.jpg'
                     }
                 ],
                 pageSize: 1,
@@ -117,7 +116,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
 
             mockAssetUploadResponse = {
                 asset: mockAsset,
-                msg: "Upload completed"
+                msg: 'Upload completed'
             };
 
             mockFileUpload = {
@@ -134,14 +133,14 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
             };
 
             var event = {};
-            event.target = {"value": "dummy.jpg"};
+            event.target = {'value': 'dummy.jpg'};
 
-            describe("AssetsView", function () {
+            describe('AssetsView', function() {
                 var setup;
                 setup = function(responseData) {
                     var requests = AjaxHelpers.requests(this);
                     assetsView.pagingView.setPage(1);
-                    if (!responseData){
+                    if (!responseData) {
                         AjaxHelpers.respondWithJson(requests, mockEmptyAssetsResponse);
                     } else {
                         AjaxHelpers.respondWithJson(requests, responseData);
@@ -149,15 +148,15 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     return requests;
                 };
 
-                beforeEach(function () {
+                beforeEach(function() {
                     ViewHelpers.installMockAnalytics();
                 });
 
-                afterEach(function () {
+                afterEach(function() {
                     ViewHelpers.removeMockAnalytics();
                 });
 
-                it('shows the upload modal when clicked on "Upload your first asset" button', function () {
+                it('shows the upload modal when clicked on "Upload your first asset" button', function() {
                     expect(assetsView).toBeDefined();
                     appendSetFixtures('<div class="ui-loading"/>');
                     expect($('.ui-loading').is(':visible')).toBe(true);
@@ -183,10 +182,10 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     expect(assetsView.largeFileErrorMsg).toBeNull();
                 });
 
-                it('uploads file properly', function () {
+                it('uploads file properly', function() {
                     var requests = setup.call(this);
                     expect(assetsView).toBeDefined();
-                    spyOn(assetsView, "addAsset").and.callFake(function () {
+                    spyOn(assetsView, 'addAsset').and.callFake(function() {
                         assetsView.collection.add(mockAssetUploadResponse.asset);
                         assetsView.pagingView.renderPageItems();
                         assetsView.pagingView.setPage(1);
@@ -196,18 +195,18 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     expect($('.upload-modal').is(':visible')).toBe(true);
 
                     $('.choose-file-button').click();
-                    $("input[type=file]").change();
-                    expect($('.upload-modal h1').text()).toContain("Uploading");
+                    $('input[type=file]').change();
+                    expect($('.upload-modal h1').text()).toContain('Uploading');
 
                     assetsView.showUploadFeedback(event, 100);
-                    expect($('div.progress-bar').text()).toContain("100%");
+                    expect($('div.progress-bar').text()).toContain('100%');
 
                     assetsView.displayFinishedUpload(mockAssetUploadResponse);
-                    expect($('div.progress-bar').text()).toContain("Upload completed");
+                    expect($('div.progress-bar').text()).toContain('Upload completed');
                     $('.close-button').click();
                     expect($('.upload-modal').is(':visible')).toBe(false);
 
-                    expect($('#asset_table_body').html()).toContain("dummy.jpg");
+                    expect($('#asset_table_body').html()).toContain('dummy.jpg');
                     expect(assetsView.collection.length).toBe(1);
                 });
 
@@ -217,11 +216,11 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     mockFileUpload.files[0].size = assetsView.maxFileSize * 10;
 
                     $('.choose-file-button').click();
-                    $(".upload-modal .file-chooser").fileupload('add', mockFileUpload);
-                    expect($('.upload-modal h1').text()).not.toContain("Uploading");
+                    $('.upload-modal .file-chooser').fileupload('add', mockFileUpload);
+                    expect($('.upload-modal h1').text()).not.toContain('Uploading');
 
                     expect(assetsView.largeFileErrorMsg).toBeDefined();
-                    expect($('div.progress-bar').text()).not.toContain("Upload completed");
+                    expect($('div.progress-bar').text()).not.toContain('Upload completed');
                     expect($('div.progress-fill').width()).toBe(0);
                 });
 
@@ -231,7 +230,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     mockFileUpload.files[0].size = assetsView.maxFileSize;
 
                     $('.choose-file-button').click();
-                    $(".upload-modal .file-chooser").fileupload('add', mockFileUpload);
+                    $('.upload-modal .file-chooser').fileupload('add', mockFileUpload);
 
                     expect(assetsView.largeFileErrorMsg).toBeNull();
                 });
@@ -242,12 +241,12 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     mockFileUpload.files[0].size = assetsView.maxFileSize / 100;
 
                     $('.choose-file-button').click();
-                    $(".upload-modal .file-chooser").fileupload('add', mockFileUpload);
+                    $('.upload-modal .file-chooser').fileupload('add', mockFileUpload);
 
                     expect(assetsView.largeFileErrorMsg).toBeNull();
                 });
 
-                it('returns the registered info for a filter column', function () {
+                it('returns the registered info for a filter column', function() {
                     assetsView.pagingView.registerSortableColumn('test-col', 'Test Column', 'testField', 'asc');
                     assetsView.pagingView.registerFilterableColumn('js-asset-type-col', 'Type', 'asset_type');
                     var filterInfo = assetsView.pagingView.filterableColumnInfo('js-asset-type-col');
@@ -255,24 +254,24 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     expect(filterInfo.fieldName).toBe('asset_type');
                 });
 
-                it('throws an exception for an unregistered filter column', function () {
+                it('throws an exception for an unregistered filter column', function() {
                     expect(function() {
                         assetsView.filterableColumnInfo('no-such-column');
                     }).toThrow();
                 });
 
 
-                it('make sure selectFilter sets collection filter if undefined', function () {
+                it('make sure selectFilter sets collection filter if undefined', function() {
                     expect(assetsView).toBeDefined();
                     assetsView.collection.filterField = '';
                     assetsView.pagingView.selectFilter('js-asset-type-col');
                     expect(assetsView.collection.filterField).toEqual('asset_type');
                 });
 
-                it('make sure _toggleFilterColumn filters asset list', function () {
+                it('make sure _toggleFilterColumn filters asset list', function() {
                     expect(assetsView).toBeDefined();
                     var requests = AjaxHelpers.requests(this);
-                    $.each(assetsView.pagingView.filterableColumns, function(columnID, columnData){
+                    $.each(assetsView.pagingView.filterableColumns, function(columnID, columnData) {
                         var $typeColumn = $('#' + columnID);
                         assetsView.pagingView.setPage(1);
                         respondWithMockAssets(requests);
@@ -285,10 +284,10 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     });
                 });
 
-                it('opens and closes select type menu', function () {
+                it('opens and closes select type menu', function() {
                     expect(assetsView).toBeDefined();
                     setup.call(this, mockExampleAssetsResponse);
-                    $.each(assetsView.pagingView.filterableColumns, function(columnID, columnData){
+                    $.each(assetsView.pagingView.filterableColumns, function(columnID, columnData) {
                         var $typeColumn = $('#' + columnID);
                         expect($typeColumn).toBeVisible();
                         var assetsNumber = $('#asset-table-body .type-col').length;
@@ -301,7 +300,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     });
                 });
 
-                it('check filtering works with sorting by column on', function () {
+                it('check filtering works with sorting by column on', function() {
                     expect(assetsView).toBeDefined();
                     var requests = AjaxHelpers.requests(this);
                     assetsView.pagingView.registerSortableColumn('name-col', 'Name Column', 'nameField', 'asc');
@@ -316,10 +315,9 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     respondWithMockAssets(requests);
                     var assetsNumberFiltered = assetsView.collection.length;
                     expect(assetsNumberFiltered).toBe(1);
-
                 });
 
-                it('shows type select menu, selects type, and filters results', function () {
+                it('shows type select menu, selects type, and filters results', function() {
                     expect(assetsView).toBeDefined();
                     var requests = AjaxHelpers.requests(this);
                     $.each(assetsView.pagingView.filterableColumns, function(columnID, columnData) {
@@ -352,68 +350,68 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                     mockFileUpload.files[0].size = assetsView.maxFileSize;
 
                     $('.choose-file-button').click();
-                    $(".upload-modal .file-chooser").fileupload('add', mockFileUpload);
+                    $('.upload-modal .file-chooser').fileupload('add', mockFileUpload);
 
                     expect(assetsView.largeFileErrorMsg).toBeDefined();
 
                     mockFileUpload.files[0].size = assetsView.maxFileSize / 10;
                     $('.choose-file-button').click();
-                    $(".upload-modal .file-chooser").fileupload('add', mockFileUpload);
+                    $('.upload-modal .file-chooser').fileupload('add', mockFileUpload);
                     expect(assetsView.largeFileErrorMsg).toBeNull();
                 });
 
-                describe('Paging footer', function () {
+                describe('Paging footer', function() {
                     var firstPageAssets = {
-                        sort: "uploadDate",
-                        end: 1,
-                        assets: [
-                            {
-                                "display_name": "test.jpg",
-                                "url": "/c4x/A/CS102/asset/test.jpg",
-                                "date_added": "Nov 07, 2014 at 17:47 UTC",
-                                "id": "/c4x/A/CS102/asset/test.jpg",
-                                "portable_url": "/static/test.jpg",
-                                "thumbnail": "/c4x/A/CS102/thumbnail/test.jpg",
-                                "locked": false,
-                                "external_url": "localhost:8000/c4x/A/CS102/asset/test.jpg"
-                            },
-                            {
-                                "display_name": "test.pdf",
-                                "url": "/c4x/A/CS102/asset/test.pdf",
-                                "date_added": "Oct 20, 2014 at 11:00 UTC",
-                                "id": "/c4x/A/CS102/asset/test.pdf",
-                                "portable_url": "/static/test.pdf",
-                                "thumbnail": null,
-                                "locked": false,
-                                "external_url": "localhost:8000/c4x/A/CS102/asset/test.pdf"
-                            }
-                        ],
-                        pageSize: 2,
-                        totalCount: 3,
-                        start: 0,
-                        page: 0
-                    }, secondPageAssets = {
-                        sort: "uploadDate",
-                        end: 2,
-                        assets: [
-                            {
-                                "display_name": "test.odt",
-                                "url": "/c4x/A/CS102/asset/test.odt",
-                                "date_added": "Oct 20, 2014 at 11:00 UTC",
-                                "id": "/c4x/A/CS102/asset/test.odt",
-                                "portable_url": "/static/test.odt",
-                                "thumbnail": null,
-                                "locked": false,
-                                "external_url": "localhost:8000/c4x/A/CS102/asset/test.odt"
-                            }
-                        ],
-                        pageSize: 2,
-                        totalCount: 3,
-                        start: 2,
-                        page: 1
-                    };
+                            sort: 'uploadDate',
+                            end: 1,
+                            assets: [
+                                {
+                                    'display_name': 'test.jpg',
+                                    'url': '/c4x/A/CS102/asset/test.jpg',
+                                    'date_added': 'Nov 07, 2014 at 17:47 UTC',
+                                    'id': '/c4x/A/CS102/asset/test.jpg',
+                                    'portable_url': '/static/test.jpg',
+                                    'thumbnail': '/c4x/A/CS102/thumbnail/test.jpg',
+                                    'locked': false,
+                                    'external_url': 'localhost:8000/c4x/A/CS102/asset/test.jpg'
+                                },
+                                {
+                                    'display_name': 'test.pdf',
+                                    'url': '/c4x/A/CS102/asset/test.pdf',
+                                    'date_added': 'Oct 20, 2014 at 11:00 UTC',
+                                    'id': '/c4x/A/CS102/asset/test.pdf',
+                                    'portable_url': '/static/test.pdf',
+                                    'thumbnail': null,
+                                    'locked': false,
+                                    'external_url': 'localhost:8000/c4x/A/CS102/asset/test.pdf'
+                                }
+                            ],
+                            pageSize: 2,
+                            totalCount: 3,
+                            start: 0,
+                            page: 0
+                        }, secondPageAssets = {
+                            sort: 'uploadDate',
+                            end: 2,
+                            assets: [
+                                {
+                                    'display_name': 'test.odt',
+                                    'url': '/c4x/A/CS102/asset/test.odt',
+                                    'date_added': 'Oct 20, 2014 at 11:00 UTC',
+                                    'id': '/c4x/A/CS102/asset/test.odt',
+                                    'portable_url': '/static/test.odt',
+                                    'thumbnail': null,
+                                    'locked': false,
+                                    'external_url': 'localhost:8000/c4x/A/CS102/asset/test.odt'
+                                }
+                            ],
+                            pageSize: 2,
+                            totalCount: 3,
+                            start: 2,
+                            page: 1
+                        };
 
-                    it('can move forward a page using the next page button', function () {
+                    it('can move forward a page using the next page button', function() {
                         var requests = AjaxHelpers.requests(this);
                         assetsView.pagingView.setPage(1);
                         AjaxHelpers.respondWithJson(requests, firstPageAssets);
@@ -426,7 +424,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                             .toHaveClass('is-disabled');
                     });
 
-                    it('can move back a page using the previous page button', function () {
+                    it('can move back a page using the previous page button', function() {
                         var requests = AjaxHelpers.requests(this);
                         assetsView.pagingView.setPage(2);
                         AjaxHelpers.respondWithJson(requests, secondPageAssets);
@@ -439,7 +437,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "
                             .toHaveClass('is-disabled');
                     });
 
-                    it('can set the current page using the page number input', function () {
+                    it('can set the current page using the page number input', function() {
                         var requests = AjaxHelpers.requests(this);
                         assetsView.pagingView.setPage(1);
                         AjaxHelpers.respondWithJson(requests, firstPageAssets);

--- a/cms/static/js/spec/views/baseview_spec.js
+++ b/cms/static/js/spec/views/baseview_spec.js
@@ -1,15 +1,14 @@
-define(["jquery", "underscore", "js/views/baseview", "js/utils/handle_iframe_binding", "sinon"],
-    function ($, _, BaseView, IframeBinding, sinon) {
-
-        describe("BaseView", function() {
+define(['jquery', 'underscore', 'js/views/baseview', 'js/utils/handle_iframe_binding', 'sinon'],
+    function($, _, BaseView, IframeBinding, sinon) {
+        describe('BaseView', function() {
             var baseViewPrototype;
 
-            describe("BaseView rendering", function () {
+            describe('BaseView rendering', function() {
                 var iframeBinding_spy;
 
-                beforeEach(function () {
+                beforeEach(function() {
                     baseViewPrototype = BaseView.prototype;
-                    iframeBinding_spy = sinon.spy(IframeBinding, "iframeBinding");
+                    iframeBinding_spy = sinon.spy(IframeBinding, 'iframeBinding');
 
                     spyOn(baseViewPrototype, 'initialize');
                     spyOn(baseViewPrototype, 'beforeRender');
@@ -17,11 +16,11 @@ define(["jquery", "underscore", "js/views/baseview", "js/utils/handle_iframe_bin
                     spyOn(baseViewPrototype, 'afterRender').and.callThrough();
                 });
 
-                afterEach(function () {
+                afterEach(function() {
                     iframeBinding_spy.restore();
                 });
 
-                it('calls before and after render functions when render of baseview is called', function () {
+                it('calls before and after render functions when render of baseview is called', function() {
                     var baseView = new BaseView();
                     baseView.render();
 
@@ -31,20 +30,20 @@ define(["jquery", "underscore", "js/views/baseview", "js/utils/handle_iframe_bin
                     expect(baseViewPrototype.afterRender).toHaveBeenCalled();
                 });
 
-                it('calls iframeBinding function when afterRender of baseview is called', function () {
+                it('calls iframeBinding function when afterRender of baseview is called', function() {
                     var baseView = new BaseView();
                     baseView.render();
                     expect(baseViewPrototype.afterRender).toHaveBeenCalled();
                     expect(iframeBinding_spy.called).toEqual(true);
 
-                    //check calls count of iframeBinding function
+                    // check calls count of iframeBinding function
                     expect(iframeBinding_spy.callCount).toBe(1);
                     IframeBinding.iframeBinding();
                     expect(iframeBinding_spy.callCount).toBe(2);
                 });
             });
 
-            describe("Expand/Collapse", function () {
+            describe('Expand/Collapse', function() {
                 var view, MockCollapsibleViewClass;
 
                 MockCollapsibleViewClass = BaseView.extend({
@@ -57,7 +56,7 @@ define(["jquery", "underscore", "js/views/baseview", "js/utils/handle_iframe_bin
                     }
                 });
 
-                it('hides a collapsible node when clicking on the toggle link', function () {
+                it('hides a collapsible node when clicking on the toggle link', function() {
                     view = new MockCollapsibleViewClass();
                     view.render();
                     view.$('.ui-toggle-expansion').click();
@@ -66,7 +65,7 @@ define(["jquery", "underscore", "js/views/baseview", "js/utils/handle_iframe_bin
                     expect(view.$('.is-collapsible')).toHaveClass('collapsed');
                 });
 
-                it('expands a collapsible node when clicking twice on the toggle link', function () {
+                it('expands a collapsible node when clicking twice on the toggle link', function() {
                     view = new MockCollapsibleViewClass();
                     view.render();
                     view.$('.ui-toggle-expansion').click();

--- a/cms/static/js/spec/views/container_spec.js
+++ b/cms/static/js/spec/views/container_spec.js
@@ -1,12 +1,9 @@
-define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec_helpers/edit_helpers",
-    "js/views/container", "js/models/xblock_info", "jquery.simulate",
-    "xmodule", "cms/js/main", "xblock/cms.runtime.v1"],
-    function ($, AjaxHelpers, EditHelpers, ContainerView, XBlockInfo) {
-
-        describe("Container View", function () {
-
-            describe("Supports reordering components", function () {
-
+define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'js/spec_helpers/edit_helpers',
+    'js/views/container', 'js/models/xblock_info', 'jquery.simulate',
+    'xmodule', 'cms/js/main', 'xblock/cms.runtime.v1'],
+    function($, AjaxHelpers, EditHelpers, ContainerView, XBlockInfo) {
+        describe('Container View', function() {
+            describe('Supports reordering components', function() {
                 var model, containerView, mockContainerHTML, init, getComponent,
                     getDragHandle, dragComponentVertically, dragComponentAbove,
                     verifyRequest, verifyNumReorderCalls, respondToRequest, notificationSpy,
@@ -14,21 +11,21 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec
                     rootLocator = 'locator-container',
                     containerTestUrl = '/xblock/' + rootLocator,
 
-                    groupAUrl = "/xblock/locator-group-A",
-                    groupA = "locator-group-A",
-                    groupAComponent1 = "locator-component-A1",
-                    groupAComponent2 = "locator-component-A2",
-                    groupAComponent3 = "locator-component-A3",
+                    groupAUrl = '/xblock/locator-group-A',
+                    groupA = 'locator-group-A',
+                    groupAComponent1 = 'locator-component-A1',
+                    groupAComponent2 = 'locator-component-A2',
+                    groupAComponent3 = 'locator-component-A3',
 
-                    groupBUrl = "/xblock/locator-group-B",
-                    groupB = "locator-group-B",
-                    groupBComponent1 = "locator-component-B1",
-                    groupBComponent2 = "locator-component-B2",
-                    groupBComponent3 = "locator-component-B3";
+                    groupBUrl = '/xblock/locator-group-B',
+                    groupB = 'locator-group-B',
+                    groupBComponent1 = 'locator-component-B1',
+                    groupBComponent2 = 'locator-component-B2',
+                    groupBComponent3 = 'locator-component-B3';
 
                 mockContainerHTML = readFixtures('mock/mock-container-xblock.underscore');
 
-                beforeEach(function () {
+                beforeEach(function() {
                     EditHelpers.installMockXBlock();
                     EditHelpers.installViewTemplates();
                     appendSetFixtures('<div class="wrapper-xblock level-page studio-xblock-wrapper" data-locator="' + rootLocator + '"></div>');
@@ -46,18 +43,18 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec
                     });
                 });
 
-                afterEach(function () {
+                afterEach(function() {
                     EditHelpers.uninstallMockXBlock();
                     containerView.remove();
                 });
 
-                init = function (caller) {
+                init = function(caller) {
                     var requests = AjaxHelpers.requests(caller);
                     containerView.render();
 
                     AjaxHelpers.respondWithJson(requests, {
                         html: mockContainerHTML,
-                        "resources": []
+                        'resources': []
                     });
 
                     $('body').append(containerView.$el);
@@ -86,21 +83,21 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec
                     return $(component.find('.drag-handle')[0]);
                 };
 
-                dragComponentVertically = function (locator, dy) {
+                dragComponentVertically = function(locator, dy) {
                     var handle = getDragHandle(locator);
-                    handle.simulate("drag", {dy: dy});
+                    handle.simulate('drag', {dy: dy});
                 };
 
-                dragComponentAbove = function (sourceLocator, targetLocator) {
+                dragComponentAbove = function(sourceLocator, targetLocator) {
                     var targetElement = getComponent(targetLocator),
                         targetTop = targetElement.offset().top + 1,
                         handle = getDragHandle(sourceLocator),
                         handleY = handle.offset().top + (handle.height() / 2),
                         dy = targetTop - handleY;
-                    handle.simulate("drag", {dy: dy});
+                    handle.simulate('drag', {dy: dy});
                 };
 
-                verifyRequest = function (requests, reorderCallIndex, expectedURL, expectedChildren) {
+                verifyRequest = function(requests, reorderCallIndex, expectedURL, expectedChildren) {
                     var actualIndex, request, children, i;
                     // 0th call is the response to the initial render call to get HTML.
                     actualIndex = reorderCallIndex + 1;
@@ -114,12 +111,12 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec
                     }
                 };
 
-                verifyNumReorderCalls = function (requests, expectedCalls) {
+                verifyNumReorderCalls = function(requests, expectedCalls) {
                     // Number of calls will be 1 more than expected because of the initial render call to get HTML.
                     expect(requests.length).toEqual(expectedCalls + 1);
                 };
 
-                respondToRequest = function (requests, reorderCallIndex, status) {
+                respondToRequest = function(requests, reorderCallIndex, status) {
                     var actualIndex;
                     // Number of calls will be 1 more than expected because of the initial render call to get HTML.
                     actualIndex = reorderCallIndex + 1;
@@ -127,14 +124,14 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec
                     requests[actualIndex].respond(status);
                 };
 
-                it('does nothing if item not moved far enough', function () {
+                it('does nothing if item not moved far enough', function() {
                     var requests = init(this);
                     // Drag the first component in Group A down very slightly but not enough to move it.
                     dragComponentVertically(groupAComponent1, 5);
                     verifyNumReorderCalls(requests, 0);
                 });
 
-                it('can reorder within a group', function () {
+                it('can reorder within a group', function() {
                     var requests = init(this);
                     // Drag the third component in Group A to be the first
                     dragComponentAbove(groupAComponent3, groupAComponent1);
@@ -142,7 +139,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec
                     verifyRequest(requests, 0, groupAUrl, [groupAComponent3, groupAComponent1, groupAComponent2]);
                 });
 
-                it('can drag from one group to another', function () {
+                it('can drag from one group to another', function() {
                     var requests = init(this);
                     // Drag the first component in Group B to the top of group A.
                     dragComponentAbove(groupBComponent1, groupAComponent1);
@@ -156,7 +153,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec
                     verifyRequest(requests, 1, groupBUrl, [groupBComponent2, groupBComponent3]);
                 });
 
-                it('does not remove from old group if addition to new group fails', function () {
+                it('does not remove from old group if addition to new group fails', function() {
                     var requests = init(this);
                     // Drag the first component in Group B to the first group.
                     dragComponentAbove(groupBComponent1, groupAComponent1);
@@ -168,7 +165,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec
                     verifyNumReorderCalls(requests, 1);
                 });
 
-                it('can swap group A and group B', function () {
+                it('can swap group A and group B', function() {
                     var requests = init(this);
                     // Drag Group B before group A.
                     dragComponentAbove(groupB, groupA);
@@ -176,8 +173,8 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec
                     verifyRequest(requests, 0, containerTestUrl, [groupB, groupA]);
                 });
 
-                describe("Shows a saving message", function () {
-                    it('hides saving message upon success', function () {
+                describe('Shows a saving message', function() {
+                    it('hides saving message upon success', function() {
                         var requests, savingOptions;
                         requests = init(this);
 
@@ -190,7 +187,7 @@ define([ "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec
                         EditHelpers.verifyNotificationHidden(notificationSpy);
                     });
 
-                    it('does not hide saving message if failure', function () {
+                    it('does not hide saving message if failure', function() {
                         var requests = init(this);
 
                         // Drag the first component in Group B to the first group.

--- a/cms/static/js/spec/views/group_configuration_spec.js
+++ b/cms/static/js/spec/views/group_configuration_spec.js
@@ -40,23 +40,23 @@ define([
         note: '.wrapper-delete-button'
     };
 
-    var assertTheDetailsView = function (view, text) {
+    var assertTheDetailsView = function(view, text) {
         expect(view.$el).toContainText(text);
         expect(view.$el).toContainText('ID: 0');
         expect(view.$('.delete')).toExist();
     };
-    var assertShowEmptyUsages = function (view, usageText) {
+    var assertShowEmptyUsages = function(view, usageText) {
         expect(view.$(SELECTORS.usageCount)).not.toExist();
         expect(view.$(SELECTORS.usageText)).toContainText(usageText);
         expect(view.$(SELECTORS.usageTextAnchor)).toExist();
         expect(view.$(SELECTORS.usageUnit)).not.toExist();
     };
-    var assertHideEmptyUsages = function (view) {
+    var assertHideEmptyUsages = function(view) {
         expect(view.$(SELECTORS.usageText)).not.toExist();
         expect(view.$(SELECTORS.usageUnit)).not.toExist();
         expect(view.$(SELECTORS.usageCount)).toContainText('Not in Use');
     };
-    var assertShowNonEmptyUsages = function (view, usageText, toolTipText) {
+    var assertShowNonEmptyUsages = function(view, usageText, toolTipText) {
         var usageUnitAnchors = view.$(SELECTORS.usageUnitAnchor);
 
         expect(view.$(SELECTORS.note)).toHaveAttr(
@@ -72,24 +72,24 @@ define([
         expect(usageUnitAnchors.eq(1)).toContainText('label2');
         expect(usageUnitAnchors.eq(1).attr('href')).toBe('url2');
     };
-    var assertHideNonEmptyUsages = function (view) {
+    var assertHideNonEmptyUsages = function(view) {
         expect(view.$('.delete')).toHaveClass('is-disabled');
         expect(view.$(SELECTORS.usageText)).not.toExist();
         expect(view.$(SELECTORS.usageUnit)).not.toExist();
         expect(view.$(SELECTORS.usageCount)).toContainText('Used in 2 units');
     };
-    var setUsageInfo = function (model) {
+    var setUsageInfo = function(model) {
         model.set('usage', [
             {'label': 'label1', 'url': 'url1'},
             {'label': 'label2', 'url': 'url2'}
         ]);
     };
-    var assertHideValidationContent = function (view) {
+    var assertHideValidationContent = function(view) {
         expect(view.$(SELECTORS.usageUnitMessage)).not.toExist();
         expect(view.$(SELECTORS.usageUnitWarningIcon)).not.toExist();
         expect(view.$(SELECTORS.usageUnitErrorIcon)).not.toExist();
     };
-    var assertControllerView = function (view, detailsView, editView) {
+    var assertControllerView = function(view, detailsView, editView) {
         // Details view by default
         expect(view.$(detailsView)).toExist();
         view.$('.action-edit .edit').click();
@@ -99,7 +99,7 @@ define([
         expect(view.$(detailsView)).toExist();
         expect(view.$(editView)).not.toExist();
     };
-    var assertAndDeleteItemError = function (that, url, promptText) {
+    var assertAndDeleteItemError = function(that, url, promptText) {
         var requests = AjaxHelpers.requests(that),
             promptSpy = ViewHelpers.createPromptSpy(),
             notificationSpy = ViewHelpers.createNotificationSpy();
@@ -112,7 +112,7 @@ define([
         ViewHelpers.verifyNotificationHidden(notificationSpy);
         expect($(SELECTORS.itemView)).not.toExist();
     };
-    var assertAndDeleteItemWithError = function (that, url, listItemView, promptText) {
+    var assertAndDeleteItemWithError = function(that, url, listItemView, promptText) {
         var requests = AjaxHelpers.requests(that),
             promptSpy = ViewHelpers.createPromptSpy(),
             notificationSpy = ViewHelpers.createNotificationSpy();
@@ -124,7 +124,7 @@ define([
         ViewHelpers.verifyNotificationShowing(notificationSpy, /Deleting/);
         expect($(listItemView)).toExist();
     };
-    var assertCannotDeleteUsed = function (that, toolTipText, warningText) {
+    var assertCannotDeleteUsed = function(that, toolTipText, warningText) {
         setUsageInfo(that.model);
         that.view.render();
         expect(that.view.$(SELECTORS.note)).toHaveAttr(
@@ -134,7 +134,7 @@ define([
         expect(that.view.$(SELECTORS.warningIcon)).toExist();
         expect(that.view.$('.delete')).toHaveClass('is-disabled');
     };
-    var assertUnusedOptions = function (that) {
+    var assertUnusedOptions = function(that) {
         that.model.set('usage', []);
         that.view.render();
         expect(that.view.$(SELECTORS.warningMessage)).not.toExist();
@@ -155,7 +155,7 @@ define([
         jasmine.addMatchers({
             toContainText: function() {
                 return {
-                    compare: function (actual, text) {
+                    compare: function(actual, text) {
                         var trimmedText = $.trim(actual.text()),
                             passed;
 
@@ -171,16 +171,16 @@ define([
                     }
                 };
             },
-            toBeCorrectValuesInInputs: function () {
+            toBeCorrectValuesInInputs: function() {
                 return {
-                    compare: function (actual, values) {
+                    compare: function(actual, values) {
                         var expected = {
                             name: actual.$(SELECTORS.inputName).val(),
                             description: actual
                                 .$(SELECTORS.inputDescription).val()
                         };
 
-                        var passed =  _.isEqual(values, expected);
+                        var passed = _.isEqual(values, expected);
 
                         return {
                             pass: passed
@@ -188,10 +188,10 @@ define([
                     }
                 };
             },
-            toBeCorrectValuesInModel: function () {
+            toBeCorrectValuesInModel: function() {
                 return {
-                    compare: function (actual, values) {
-                        var passed = _.every(values, function (value, key) {
+                    compare: function(actual, values) {
+                        var passed = _.every(values, function(value, key) {
                             return actual.get(key) === value;
                         }.bind(this));
 
@@ -201,10 +201,10 @@ define([
                     }
                 };
             },
-            toHaveDefaultNames: function () {
+            toHaveDefaultNames: function() {
                 return {
-                    compare: function (actual, values) {
-                        var actualValues = $.map(actual, function (item) {
+                    compare: function(actual, values) {
+                        var actualValues = $.map(actual, function(item) {
                             return $(item).val();
                         });
 
@@ -233,7 +233,7 @@ define([
                 id: 0
             });
 
-            this.collection = new GroupConfigurationCollection([ this.model ]);
+            this.collection = new GroupConfigurationCollection([this.model]);
             this.collection.outlineUrl = '/outline';
             this.view = new GroupConfigurationDetailsView({
                 model: this.model
@@ -317,7 +317,7 @@ define([
                     'label': 'label1',
                     'url': 'url1',
                     'validation': {
-                        'text': "Warning message",
+                        'text': 'Warning message',
                         'type': 'warning'
                     }
                 }
@@ -335,7 +335,7 @@ define([
                     'label': 'label1',
                     'url': 'url1',
                     'validation': {
-                        'text': "Error message",
+                        'text': 'Error message',
                         'type': 'error'
                     }
                 }
@@ -357,9 +357,8 @@ define([
     });
 
     describe('Experiment group configurations editor view', function() {
-
-        var setValuesToInputs = function (view, values) {
-            _.each(values, function (value, selector) {
+        var setValuesToInputs = function(view, values) {
+            _.each(values, function(value, selector) {
                 if (SELECTORS[selector]) {
                     view.$(SELECTORS[selector]).val(value);
                 }
@@ -394,7 +393,7 @@ define([
             expect(this.view.$('.delete')).toExist();
         });
 
-        it ('should allow you to create new groups', function() {
+        it('should allow you to create new groups', function() {
             var numGroups = this.model.get('groups').length;
             this.view.$('.action-add-group').click();
             expect(this.model.get('groups').length).toEqual(numGroups + 1);
@@ -428,7 +427,7 @@ define([
             var requests = AjaxHelpers.requests(this),
                 notificationSpy = ViewHelpers.createNotificationSpy();
 
-            setValuesToInputs(this.view, { inputName: 'New Configuration' });
+            setValuesToInputs(this.view, {inputName: 'New Configuration'});
             ViewHelpers.submitAndVerifyFormError(this.view, requests, notificationSpy);
         });
 
@@ -467,7 +466,7 @@ define([
             var requests = AjaxHelpers.requests(this);
 
             // Set incorrect value
-            setValuesToInputs(this.view, { inputName: '' });
+            setValuesToInputs(this.view, {inputName: ''});
             // Try to save
             this.view.$('form').submit();
             // See error message
@@ -477,7 +476,7 @@ define([
             // No request
             AjaxHelpers.expectNoRequests(requests);
             // Set correct value
-            setValuesToInputs(this.view, { inputName: 'New Configuration' });
+            setValuesToInputs(this.view, {inputName: 'New Configuration'});
             // Try to save
             this.view.$('form').submit();
             AjaxHelpers.respondWithJson(requests, {});
@@ -490,12 +489,12 @@ define([
             AjaxHelpers.expectNoRequests(requests);
         });
 
-        describe('removes all newly created groups on cancel', function () {
+        describe('removes all newly created groups on cancel', function() {
             it('if the model has a non-empty groups', function() {
                 var groups = this.model.get('groups');
 
                 this.view.render();
-                groups.add([{ name: 'non-empty' }]);
+                groups.add([{name: 'non-empty'}]);
                 expect(groups.length).toEqual(3);
                 this.view.$('.action-cancel').click();
                 // Restore to default state (2 groups by default).
@@ -514,9 +513,9 @@ define([
             });
         });
 
-        it('groups have correct default names', function () {
-            var group1 = new GroupModel({ name: 'Group A' }),
-                group2 = new GroupModel({ name: 'Group B' }),
+        it('groups have correct default names', function() {
+            var group1 = new GroupModel({name: 'Group A'}),
+                group2 = new GroupModel({name: 'Group B'}),
                 collection = this.model.get('groups');
 
             collection.reset([group1, group2]); // Group A, Group B
@@ -543,7 +542,7 @@ define([
             ]);
         });
 
-        it('cannot be deleted if it is in use', function () {
+        it('cannot be deleted if it is in use', function() {
             assertCannotDeleteUsed(
                 this,
                 'Cannot delete when in use by an experiment',
@@ -553,8 +552,8 @@ define([
             );
         });
 
-        it('does not contain warning message if it is not in use', function () {
-           assertUnusedOptions(this);
+        it('does not contain warning message if it is not in use', function() {
+            assertUnusedOptions(this);
         });
     });
 
@@ -566,7 +565,7 @@ define([
                 ['group-configuration-editor', 'group-edit', 'list']
             );
 
-            this.model = new GroupConfigurationModel({ id: 0 });
+            this.model = new GroupConfigurationModel({id: 0});
             this.collection = new GroupConfigurationCollection();
             this.view = new GroupConfigurationsListView({
                 collection: this.collection
@@ -574,7 +573,7 @@ define([
             appendSetFixtures(this.view.render().el);
         });
 
-        describe('empty template', function () {
+        describe('empty template', function() {
             it('should be rendered if no group configurations', function() {
                 expect(this.view.$el).toContainText(emptyMessage);
                 expect(this.view.$('.new-button')).toExist();
@@ -597,7 +596,7 @@ define([
                 expect(this.view.$(SELECTORS.itemView)).not.toExist();
             });
 
-            it('can create a new group configuration', function () {
+            it('can create a new group configuration', function() {
                 this.view.$('.new-button').click();
                 expect($('.group-configuration-edit').length).toBeGreaterThan(0);
             });
@@ -605,13 +604,12 @@ define([
     });
 
     describe('Experiment group configurations controller view', function() {
-
         beforeEach(function() {
             TemplateHelpers.installTemplates([
                 'group-configuration-editor', 'group-configuration-details'
             ], true);
-            this.model = new GroupConfigurationModel({ id: 0 });
-            this.collection = new GroupConfigurationCollection([ this.model ]);
+            this.model = new GroupConfigurationModel({id: 0});
+            this.collection = new GroupConfigurationCollection([this.model]);
             this.collection.url = '/group_configurations';
             this.view = new GroupConfigurationItemView({
                 model: this.model
@@ -623,7 +621,7 @@ define([
             assertControllerView(this.view, SELECTORS.detailsView, SELECTORS.editView);
         });
 
-        it('should destroy itself on confirmation of deleting', function () {
+        it('should destroy itself on confirmation of deleting', function() {
             assertAndDeleteItemError(this, '/group_configurations/0', 'Delete this group configuration?');
         });
 
@@ -652,14 +650,14 @@ define([
             });
         });
 
-        describe('Basic', function () {
+        describe('Basic', function() {
             it('can render properly', function() {
                 this.view.render();
                 expect(this.view.$('.group-name').val()).toBe('Group A');
                 expect(this.view.$('.group-allocation')).toContainText('100%');
             });
 
-            it ('can delete itself', function() {
+            it('can delete itself', function() {
                 this.view.render().$('.action-close').click();
                 expect(this.collection.length).toEqual(0);
             });
@@ -685,8 +683,8 @@ define([
             }
         };
 
-        createGroups = function (groupNamesWithId) {
-            var groups = new GroupCollection(_.map(groupNamesWithId, function (groupName, id) {
+        createGroups = function(groupNamesWithId) {
+            var groups = new GroupCollection(_.map(groupNamesWithId, function(groupName, id) {
                     return {id: id, name: groupName};
                 })),
                 groupConfiguration = new GroupConfigurationModel({
@@ -872,25 +870,23 @@ define([
             view.collection.add({name: 'Editing Group', editing: true});
             verifyEditingGroup(view, true);
         });
-
     });
 
     describe('Content groups details view', function() {
-
         beforeEach(function() {
             TemplateHelpers.installTemplate('content-group-details', true);
-            this.model = new GroupModel({name: 'Content Group', id: 0, courseOutlineUrl: "CourseOutlineUrl"});
+            this.model = new GroupModel({name: 'Content Group', id: 0, courseOutlineUrl: 'CourseOutlineUrl'});
 
             var saveableModel = new GroupConfigurationModel({
                 name: 'Content Group Configuration',
                 id: 0,
-                scheme:'cohort',
-                groups: new GroupCollection([this.model]),
+                scheme: 'cohort',
+                groups: new GroupCollection([this.model])
             }, {canBeEmpty: true});
 
             saveableModel.urlRoot = '/mock_url';
 
-            this.collection = new GroupConfigurationCollection([ saveableModel ]);
+            this.collection = new GroupConfigurationCollection([saveableModel]);
             this.collection.outlineUrl = '/outline';
 
             this.view = new ContentGroupDetailsView({
@@ -942,7 +938,6 @@ define([
     });
 
     describe('Content groups editor view', function() {
-
         beforeEach(function() {
             ViewHelpers.installViewTemplates();
             TemplateHelpers.installTemplates(['content-group-editor']);
@@ -952,12 +947,12 @@ define([
             this.saveableModel = new GroupConfigurationModel({
                 name: 'Content Group Configuration',
                 id: 0,
-                scheme:'cohort',
+                scheme: 'cohort',
                 groups: new GroupCollection([this.model]),
-                editing:true
+                editing: true
             });
 
-            this.collection = new GroupConfigurationCollection([ this.saveableModel ]);
+            this.collection = new GroupConfigurationCollection([this.saveableModel]);
             this.collection.outlineUrl = '/outline';
             this.collection.url = '/group_configurations';
 
@@ -997,14 +992,14 @@ define([
 
             this.view.$('.action-cancel').click();
             expect(this.model).toBeCorrectValuesInModel({
-                name: 'Content Group',
+                name: 'Content Group'
             });
             // Model is still exist in the collection
             expect(this.collection.indexOf(this.saveableModel)).toBeGreaterThan(-1);
             expect(this.collection.length).toBe(1);
         });
 
-        it('cannot be deleted if it is in use', function () {
+        it('cannot be deleted if it is in use', function() {
             assertCannotDeleteUsed(
                 this,
                 'Cannot delete when in use by a unit',
@@ -1012,7 +1007,7 @@ define([
             );
         });
 
-        it('does not contain warning message if it is not in use', function () {
+        it('does not contain warning message if it is not in use', function() {
             assertUnusedOptions(this);
         });
     });
@@ -1028,11 +1023,11 @@ define([
             this.saveableModel = new GroupConfigurationModel({
                 name: 'Content Group Configuration',
                 id: 0,
-                scheme:'cohort',
+                scheme: 'cohort',
                 groups: new GroupCollection([this.model])
             });
             this.saveableModel.urlRoot = '/group_configurations';
-            this.collection = new GroupConfigurationCollection([ this.saveableModel ]);
+            this.collection = new GroupConfigurationCollection([this.saveableModel]);
             this.collection.url = '/group_configurations';
             this.view = new ContentGroupItemView({
                 model: this.model
@@ -1044,7 +1039,7 @@ define([
             assertControllerView(this.view, '.content-group-details', '.content-group-edit');
         });
 
-        it('should destroy itself on confirmation of deleting', function () {
+        it('should destroy itself on confirmation of deleting', function() {
             assertAndDeleteItemError(this, '/group_configurations/0/0', 'Delete this content group');
         });
 

--- a/cms/static/js/spec/views/license_spec.js
+++ b/cms/static/js/spec/views/license_spec.js
@@ -1,143 +1,141 @@
-define(["js/views/license", "js/models/license", "common/js/spec_helpers/template_helpers"],
+define(['js/views/license', 'js/models/license', 'common/js/spec_helpers/template_helpers'],
              function(LicenseView, LicenseModel, TemplateHelpers) {
-    describe("License view", function() {
+                 describe('License view', function() {
+                     beforeEach(function() {
+                         TemplateHelpers.installTemplate('license-selector', true);
+                         this.model = new LicenseModel();
+                         this.view = new LicenseView({model: this.model});
+                     });
 
-        beforeEach(function() {
-            TemplateHelpers.installTemplate("license-selector", true);
-            this.model = new LicenseModel();
-            this.view = new LicenseView({model: this.model});
-        });
+                     it('renders with no license', function() {
+                         this.view.render();
+                         expect(this.view.$('li[data-license=all-rights-reserved] button'))
+                .toHaveText('All Rights Reserved');
+                         expect(this.view.$('li[data-license=all-rights-reserved] button'))
+                .not.toHaveClass('is-selected');
+                         expect(this.view.$('li[data-license=creative-commons] button'))
+                .toHaveText('Creative Commons');
+                         expect(this.view.$('li[data-license=creative-commons] button'))
+                .not.toHaveClass('is-selected');
+                     });
 
-        it("renders with no license", function() {
-            this.view.render();
-            expect(this.view.$("li[data-license=all-rights-reserved] button"))
-                .toHaveText("All Rights Reserved");
-            expect(this.view.$("li[data-license=all-rights-reserved] button"))
-                .not.toHaveClass("is-selected");
-            expect(this.view.$("li[data-license=creative-commons] button"))
-                .toHaveText("Creative Commons");
-            expect(this.view.$("li[data-license=creative-commons] button"))
-                .not.toHaveClass("is-selected");
-        });
+                     it('renders with the right license selected', function() {
+                         this.model.set('type', 'all-rights-reserved');
+                         expect(this.view.$('li[data-license=all-rights-reserved] button'))
+                .toHaveClass('is-selected');
+                         expect(this.view.$('li[data-license=creative-commons] button'))
+                .not.toHaveClass('is-selected');
+                     });
 
-        it("renders with the right license selected", function() {
-            this.model.set("type", "all-rights-reserved");
-            expect(this.view.$("li[data-license=all-rights-reserved] button"))
-                .toHaveClass("is-selected");
-            expect(this.view.$("li[data-license=creative-commons] button"))
-                .not.toHaveClass("is-selected");
-        });
-
-        it("switches license type on click", function() {
-            var arrBtn = this.view.$("li[data-license=all-rights-reserved] button");
-            expect(this.model.get("type")).toBeNull();
-            arrBtn.click();
-            expect(this.model.get("type")).toEqual("all-rights-reserved");
+                     it('switches license type on click', function() {
+                         var arrBtn = this.view.$('li[data-license=all-rights-reserved] button');
+                         expect(this.model.get('type')).toBeNull();
+                         arrBtn.click();
+                         expect(this.model.get('type')).toEqual('all-rights-reserved');
             // view has re-rendered, so get a new reference to the button
-            arrBtn = this.view.$("li[data-license=all-rights-reserved] button");
-            expect(arrBtn).toHaveClass("is-selected");
+                         arrBtn = this.view.$('li[data-license=all-rights-reserved] button');
+                         expect(arrBtn).toHaveClass('is-selected');
             // now switch to creative commons
-            var ccBtn = this.view.$("li[data-license=creative-commons] button");
-            ccBtn.click();
-            expect(this.model.get("type")).toEqual("creative-commons");
+                         var ccBtn = this.view.$('li[data-license=creative-commons] button');
+                         ccBtn.click();
+                         expect(this.model.get('type')).toEqual('creative-commons');
             // update references again
-            arrBtn = this.view.$("li[data-license=all-rights-reserved] button");
-            ccBtn = this.view.$("li[data-license=creative-commons] button");
-            expect(arrBtn).not.toHaveClass("is-selected");
-            expect(ccBtn).toHaveClass("is-selected");
-        });
+                         arrBtn = this.view.$('li[data-license=all-rights-reserved] button');
+                         ccBtn = this.view.$('li[data-license=creative-commons] button');
+                         expect(arrBtn).not.toHaveClass('is-selected');
+                         expect(ccBtn).toHaveClass('is-selected');
+                     });
 
-        it("sets default license options when switching license types", function() {
-            expect(this.model.get("options")).toEqual({});
-            var ccBtn = this.view.$("li[data-license=creative-commons] button");
-            ccBtn.click()
-            expect(this.model.get("options")).toEqual(
-                {"ver": "4.0", "BY": true, "NC": true, "ND": true, "SA": false}
+                     it('sets default license options when switching license types', function() {
+                         expect(this.model.get('options')).toEqual({});
+                         var ccBtn = this.view.$('li[data-license=creative-commons] button');
+                         ccBtn.click();
+                         expect(this.model.get('options')).toEqual(
+                {'ver': '4.0', 'BY': true, 'NC': true, 'ND': true, 'SA': false}
             );
-            var arrBtn = this.view.$("li[data-license=all-rights-reserved] button");
-            arrBtn.click()
-            expect(this.model.get("options")).toEqual({});
-        });
+                         var arrBtn = this.view.$('li[data-license=all-rights-reserved] button');
+                         arrBtn.click();
+                         expect(this.model.get('options')).toEqual({});
+                     });
 
-        it("renders license options", function() {
-            this.model.set({"type": "creative-commons"})
-            expect(this.view.$("ul.license-options li[data-option=BY]"))
-                .toContainText("Attribution");
-            expect(this.view.$("ul.license-options li[data-option=NC]"))
-                .toContainText("Noncommercial");
-            expect(this.view.$("ul.license-options li[data-option=ND]"))
-                .toContainText("No Derivatives");
-            expect(this.view.$("ul.license-options li[data-option=SA]"))
-                .toContainText("Share Alike");
-            expect(this.view.$("ul.license-options li").length).toEqual(4);
-        });
+                     it('renders license options', function() {
+                         this.model.set({'type': 'creative-commons'});
+                         expect(this.view.$('ul.license-options li[data-option=BY]'))
+                .toContainText('Attribution');
+                         expect(this.view.$('ul.license-options li[data-option=NC]'))
+                .toContainText('Noncommercial');
+                         expect(this.view.$('ul.license-options li[data-option=ND]'))
+                .toContainText('No Derivatives');
+                         expect(this.view.$('ul.license-options li[data-option=SA]'))
+                .toContainText('Share Alike');
+                         expect(this.view.$('ul.license-options li').length).toEqual(4);
+                     });
 
-        it("toggles boolean options on click", function() {
-            this.view.$("li[data-license=creative-commons] button").click();
-            expect(this.model.get("options")).toEqual(
-                {"ver": "4.0", "BY": true, "NC": true, "ND": true, "SA": false}
+                     it('toggles boolean options on click', function() {
+                         this.view.$('li[data-license=creative-commons] button').click();
+                         expect(this.model.get('options')).toEqual(
+                {'ver': '4.0', 'BY': true, 'NC': true, 'ND': true, 'SA': false}
             );
             // toggle NC option
-            this.view.$("li[data-option=NC]").click();
-            expect(this.model.get("options")).toEqual(
-                {"ver": "4.0", "BY": true, "NC": false, "ND": true, "SA": false}
+                         this.view.$('li[data-option=NC]').click();
+                         expect(this.model.get('options')).toEqual(
+                {'ver': '4.0', 'BY': true, 'NC': false, 'ND': true, 'SA': false}
             );
-        });
+                     });
 
-        it("doesn't toggle disabled options", function() {
-            this.view.$("li[data-license=creative-commons] button").click();
-            expect(this.model.get("options")).toEqual(
-                {"ver": "4.0", "BY": true, "NC": true, "ND": true, "SA": false}
+                     it("doesn't toggle disabled options", function() {
+                         this.view.$('li[data-license=creative-commons] button').click();
+                         expect(this.model.get('options')).toEqual(
+                {'ver': '4.0', 'BY': true, 'NC': true, 'ND': true, 'SA': false}
             );
-            var BY = this.view.$("li[data-option=BY]");
-            expect(BY).toHaveClass("is-disabled");
+                         var BY = this.view.$('li[data-option=BY]');
+                         expect(BY).toHaveClass('is-disabled');
             // try to toggle BY option
-            BY.click()
+                         BY.click();
             // no change
-            expect(this.model.get("options")).toEqual(
-                {"ver": "4.0", "BY": true, "NC": true, "ND": true, "SA": false}
+                         expect(this.model.get('options')).toEqual(
+                {'ver': '4.0', 'BY': true, 'NC': true, 'ND': true, 'SA': false}
             );
-        });
+                     });
 
-        it("doesn't allow simultaneous conflicting options", function() {
-            this.view.$("li[data-license=creative-commons] button").click();
-            expect(this.model.get("options")).toEqual(
-                {"ver": "4.0", "BY": true, "NC": true, "ND": true, "SA": false}
+                     it("doesn't allow simultaneous conflicting options", function() {
+                         this.view.$('li[data-license=creative-commons] button').click();
+                         expect(this.model.get('options')).toEqual(
+                {'ver': '4.0', 'BY': true, 'NC': true, 'ND': true, 'SA': false}
             );
             // SA and ND conflict
-            var SA = this.view.$("li[data-option=SA]");
+                         var SA = this.view.$('li[data-option=SA]');
             // try to turn on SA option
-            SA.click()
+                         SA.click();
             // ND should no longer be selected
-            expect(this.model.get("options")).toEqual(
-                {"ver": "4.0", "BY": true, "NC": true, "ND": false, "SA": true}
+                         expect(this.model.get('options')).toEqual(
+                {'ver': '4.0', 'BY': true, 'NC': true, 'ND': false, 'SA': true}
             );
 
             // try to turn on ND option
-            ND = this.view.$("li[data-option=ND]");
-            ND.click();
-            expect(this.model.get("options")).toEqual(
-                {"ver": "4.0", "BY": true, "NC": true, "ND": true, "SA": false}
+                         ND = this.view.$('li[data-option=ND]');
+                         ND.click();
+                         expect(this.model.get('options')).toEqual(
+                {'ver': '4.0', 'BY': true, 'NC': true, 'ND': true, 'SA': false}
             );
-        });
+                     });
 
-        it("has no preview by default", function () {
-            this.view.render();
-            expect(this.view.$(".license-preview").length).toEqual(0)
-            this.view.$("li[data-license=creative-commons] button").click();
-            expect(this.view.$(".license-preview").length).toEqual(0)
-        });
+                     it('has no preview by default', function() {
+                         this.view.render();
+                         expect(this.view.$('.license-preview').length).toEqual(0);
+                         this.view.$('li[data-license=creative-commons] button').click();
+                         expect(this.view.$('.license-preview').length).toEqual(0);
+                     });
 
-        it("displays a preview if showPreview is true", function() {
-            this.view = new LicenseView({model: this.model, showPreview: true});
-            this.view.render()
-            expect(this.view.$(".license-preview").length).toEqual(1)
+                     it('displays a preview if showPreview is true', function() {
+                         this.view = new LicenseView({model: this.model, showPreview: true});
+                         this.view.render();
+                         expect(this.view.$('.license-preview').length).toEqual(1);
 	    // Expect default text to be "All Rights Reserved"
-            expect(this.view.$(".license-preview")).toContainText("All Rights Reserved");
-            this.view.$("li[data-license=creative-commons] button").click();
-            expect(this.view.$(".license-preview").length).toEqual(1)
-            expect(this.view.$(".license-preview")).toContainText("Some Rights Reserved");
-        });
-
-    })
-})
+                         expect(this.view.$('.license-preview')).toContainText('All Rights Reserved');
+                         this.view.$('li[data-license=creative-commons] button').click();
+                         expect(this.view.$('.license-preview').length).toEqual(1);
+                         expect(this.view.$('.license-preview')).toContainText('Some Rights Reserved');
+                     });
+                 });
+             });

--- a/cms/static/js/spec/views/login_studio_spec.js
+++ b/cms/static/js/spec/views/login_studio_spec.js
@@ -2,17 +2,17 @@ define(['jquery', 'js/factories/login', 'edx-ui-toolkit/js/utils/spec-helpers/aj
         'common/js/components/utils/view_utils'],
 function($, LoginFactory, AjaxHelpers, ViewUtils) {
     'use strict';
-    describe("Studio Login Page", function() {
+    describe('Studio Login Page', function() {
         var submitButton;
 
         beforeEach(function() {
             loadFixtures('mock/login.underscore');
-            var login_factory = new LoginFactory("/home/");
+            var login_factory = new LoginFactory('/home/');
             submitButton = $('#submit');
         });
 
         it('disable the submit button once it is clicked', function() {
-            spyOn(ViewUtils, 'redirect').and.callFake(function(){});
+            spyOn(ViewUtils, 'redirect').and.callFake(function() {});
             var requests = AjaxHelpers.requests(this);
             expect(submitButton).not.toHaveClass('is-disabled');
             submitButton.click();

--- a/cms/static/js/spec/views/modals/base_modal_spec.js
+++ b/cms/static/js/spec/views/modals/base_modal_spec.js
@@ -1,7 +1,6 @@
-define(["jquery", "underscore", "js/views/modals/base_modal", "js/spec_helpers/modal_helpers"],
-    function ($, _, BaseModal, ModelHelpers) {
-
-        describe("BaseModal", function() {
+define(['jquery', 'underscore', 'js/views/modals/base_modal', 'js/spec_helpers/modal_helpers'],
+    function($, _, BaseModal, ModelHelpers) {
+        describe('BaseModal', function() {
             var MockModal, modal, showMockModal;
 
             MockModal = BaseModal.extend({
@@ -12,12 +11,12 @@ define(["jquery", "underscore", "js/views/modals/base_modal", "js/spec_helpers/m
 
             showMockModal = function() {
                 modal = new MockModal({
-                    title: "Mock Modal"
+                    title: 'Mock Modal'
                 });
                 modal.show();
             };
 
-            beforeEach(function () {
+            beforeEach(function() {
                 ModelHelpers.installModalTemplates();
             });
 
@@ -25,8 +24,8 @@ define(["jquery", "underscore", "js/views/modals/base_modal", "js/spec_helpers/m
                 ModelHelpers.hideModalIfShowing(modal);
             });
 
-            describe("Single Modal", function() {
-                it('is visible after show is called', function () {
+            describe('Single Modal', function() {
+                it('is visible after show is called', function() {
                     showMockModal();
                     expect(ModelHelpers.isShowingModal(modal)).toBeTruthy();
                 });
@@ -40,26 +39,26 @@ define(["jquery", "underscore", "js/views/modals/base_modal", "js/spec_helpers/m
                     }).then(done);
                 });
 
-                it('is removed after hide is called', function () {
+                it('is removed after hide is called', function() {
                     showMockModal();
                     modal.hide();
                     expect(ModelHelpers.isShowingModal(modal)).toBeFalsy();
                 });
 
-                it('is removed after cancel is clicked', function () {
+                it('is removed after cancel is clicked', function() {
                     showMockModal();
                     ModelHelpers.cancelModal(modal);
                     expect(ModelHelpers.isShowingModal(modal)).toBeFalsy();
                 });
             });
 
-            describe("Nested Modal", function() {
+            describe('Nested Modal', function() {
                 var nestedModal, showNestedModal;
 
                 showNestedModal = function() {
                     showMockModal();
                     nestedModal = new MockModal({
-                        title: "Nested Modal",
+                        title: 'Nested Modal',
                         parent: modal
                     });
                     nestedModal.show();
@@ -71,12 +70,12 @@ define(["jquery", "underscore", "js/views/modals/base_modal", "js/spec_helpers/m
                     }
                 });
 
-                it('is visible after show is called', function () {
+                it('is visible after show is called', function() {
                     showNestedModal();
                     expect(ModelHelpers.isShowingModal(nestedModal)).toBeTruthy();
                 });
 
-                it('is removed after hide is called', function () {
+                it('is removed after hide is called', function() {
                     showNestedModal();
                     nestedModal.hide();
                     expect(ModelHelpers.isShowingModal(nestedModal)).toBeFalsy();
@@ -85,7 +84,7 @@ define(["jquery", "underscore", "js/views/modals/base_modal", "js/spec_helpers/m
                     expect(ModelHelpers.isShowingModal(modal)).toBeTruthy();
                 });
 
-                it('is removed after cancel is clicked', function () {
+                it('is removed after cancel is clicked', function() {
                     showNestedModal();
                     ModelHelpers.cancelModal(nestedModal);
                     expect(ModelHelpers.isShowingModal(nestedModal)).toBeFalsy();

--- a/cms/static/js/spec/views/modals/edit_xblock_spec.js
+++ b/cms/static/js/spec/views/modals/edit_xblock_spec.js
@@ -1,8 +1,7 @@
-define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec_helpers/edit_helpers",
-    "js/views/modals/edit_xblock", "js/models/xblock_info"],
-    function ($, _, AjaxHelpers, EditHelpers, EditXBlockModal, XBlockInfo) {
-
-        describe("EditXBlockModal", function() {
+define(['jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'js/spec_helpers/edit_helpers',
+    'js/views/modals/edit_xblock', 'js/models/xblock_info'],
+    function($, _, AjaxHelpers, EditHelpers, EditXBlockModal, XBlockInfo) {
+        describe('EditXBlockModal', function() {
             var model, modal, showModal;
 
             showModal = function(requests, mockHtml, options) {
@@ -10,7 +9,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                 return EditHelpers.showEditModal(requests, xblockElement, model, mockHtml, options);
             };
 
-            beforeEach(function () {
+            beforeEach(function() {
                 EditHelpers.installEditTemplates();
                 appendSetFixtures('<div class="xblock" data-locator="mock-xblock"></div>');
                 model = new XBlockInfo({
@@ -24,12 +23,12 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                 EditHelpers.cancelModalIfShowing();
             });
 
-            describe("XBlock Editor", function() {
+            describe('XBlock Editor', function() {
                 var mockXBlockEditorHtml;
 
                 mockXBlockEditorHtml = readFixtures('mock/mock-xblock-editor.underscore');
 
-                beforeEach(function () {
+                beforeEach(function() {
                     EditHelpers.installMockXBlock();
                 });
 
@@ -70,9 +69,9 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         refresh = function() {
                             refreshed = true;
                         };
-                    modal = showModal(requests, mockXBlockEditorHtml, { refresh: refresh });
-                    modal.editorView.notifyRuntime('save', { state: 'start' });
-                    modal.editorView.notifyRuntime('save', { state: 'end' });
+                    modal = showModal(requests, mockXBlockEditorHtml, {refresh: refresh});
+                    modal.editorView.notifyRuntime('save', {state: 'start'});
+                    modal.editorView.notifyRuntime('save', {state: 'end'});
                     expect(EditHelpers.isShowingModal(modal)).toBeFalsy();
                     expect(refreshed).toBeTruthy();
                 });
@@ -83,13 +82,13 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         refresh = function() {
                             refreshed = true;
                         };
-                    modal = showModal(requests, mockXBlockEditorHtml, { refresh: refresh });
+                    modal = showModal(requests, mockXBlockEditorHtml, {refresh: refresh});
                     modal.editorView.notifyRuntime('cancel');
                     expect(EditHelpers.isShowingModal(modal)).toBeFalsy();
                     expect(refreshed).toBeFalsy();
                 });
 
-                describe("Custom Buttons", function() {
+                describe('Custom Buttons', function() {
                     var mockCustomButtonsHtml;
 
                     mockCustomButtonsHtml = readFixtures('mock/mock-xblock-editor-with-custom-buttons.underscore');
@@ -102,7 +101,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                 });
             });
 
-            describe("XModule Editor", function() {
+            describe('XModule Editor', function() {
                 var mockXModuleEditorHtml;
 
                 mockXModuleEditorHtml = readFixtures('mock/mock-xmodule-editor.underscore');
@@ -111,7 +110,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     EditHelpers.installMockXModule();
                 });
 
-                afterEach(function () {
+                afterEach(function() {
                     EditHelpers.uninstallMockXModule();
                 });
 
@@ -158,7 +157,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     expect(modal.$('.metadata_edit')).toHaveClass('is-inactive');
                 });
 
-                describe("Custom Tabs", function() {
+                describe('Custom Tabs', function() {
                     var mockCustomTabsHtml;
 
                     mockCustomTabsHtml = readFixtures('mock/mock-xmodule-editor-with-custom-tabs.underscore');
@@ -177,7 +176,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                 });
             });
 
-            describe("XModule Editor (settings only)", function() {
+            describe('XModule Editor (settings only)', function() {
                 var mockXModuleEditorHtml;
 
                 mockXModuleEditorHtml = readFixtures('mock/mock-xmodule-settings-only-editor.underscore');
@@ -186,7 +185,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     EditHelpers.installMockXModule();
                 });
 
-                afterEach(function () {
+                afterEach(function() {
                     EditHelpers.uninstallMockXModule();
                 });
 

--- a/cms/static/js/spec/views/modals/validation_error_modal_spec.js
+++ b/cms/static/js/spec/views/modals/validation_error_modal_spec.js
@@ -1,10 +1,9 @@
 define(['jquery', 'underscore', 'js/spec_helpers/validation_helpers', 'js/views/modals/validation_error_modal'],
-    function ($, _, ValidationHelpers, ValidationErrorModal) {
-
+    function($, _, ValidationHelpers, ValidationErrorModal) {
         describe('ValidationErrorModal', function() {
             var modal, showModal;
 
-            showModal = function (jsonContent, callback) {
+            showModal = function(jsonContent, callback) {
                 modal = new ValidationErrorModal();
                 modal.setResetCallback(callback);
                 modal.setContent(jsonContent);
@@ -13,7 +12,7 @@ define(['jquery', 'underscore', 'js/spec_helpers/validation_helpers', 'js/views/
 
             /* Before each, install templates required for the base modal
                and validation error modal. */
-            beforeEach(function () {
+            beforeEach(function() {
                 ValidationHelpers.installValidationTemplates();
             });
 
@@ -21,12 +20,12 @@ define(['jquery', 'underscore', 'js/spec_helpers/validation_helpers', 'js/views/
                 ValidationHelpers.hideModalIfShowing(modal);
             });
 
-            it('is visible after show is called', function () {
+            it('is visible after show is called', function() {
                 showModal([]);
                 expect(ValidationHelpers.isShowingModal(modal)).toBeTruthy();
             });
 
-            it('displays none if no error given', function () {
+            it('displays none if no error given', function() {
                 var errorObjects = [];
 
                 showModal(errorObjects);
@@ -34,7 +33,7 @@ define(['jquery', 'underscore', 'js/spec_helpers/validation_helpers', 'js/views/
                 ValidationHelpers.checkErrorContents(modal, errorObjects);
             });
 
-            it('correctly displays json error message objects', function () {
+            it('correctly displays json error message objects', function() {
                 var errorObjects = [
                     {
                         model: {display_name: 'test_attribute1'},
@@ -51,7 +50,7 @@ define(['jquery', 'underscore', 'js/spec_helpers/validation_helpers', 'js/views/
                 ValidationHelpers.checkErrorContents(modal, errorObjects);
             });
 
-            it('run callback when undo changes button is clicked', function (done) {
+            it('run callback when undo changes button is clicked', function(done) {
                 var errorObjects = [
                     {
                         model: {display_name: 'test_attribute1'},

--- a/cms/static/js/spec/views/module_edit_spec.js
+++ b/cms/static/js/spec/views/module_edit_spec.js
@@ -228,7 +228,7 @@
                         return expect($('head').append).toHaveBeenCalledWith('head-html');
                     });
                     it("doesn't load body html", function() {
-                        return expect($.fn.append).not.toHaveBeenCalledWith("not-head-html");
+                        return expect($.fn.append).not.toHaveBeenCalledWith('not-head-html');
                     });
                     it("doesn't reload resources", function() {
                         var count;

--- a/cms/static/js/spec/views/paged_container_spec.js
+++ b/cms/static/js/spec/views/paged_container_spec.js
@@ -1,8 +1,7 @@
-define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "URI", "js/models/xblock_info",
-        "js/views/paged_container", "js/views/paging_header",
-        "common/js/components/views/paging_footer", "js/views/xblock"],
-    function ($, _, AjaxHelpers, URI, XBlockInfo, PagedContainer, PagingHeader, PagingFooter, XBlockView) {
-
+define(['jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'URI', 'js/models/xblock_info',
+        'js/views/paged_container', 'js/views/paging_header',
+        'common/js/components/views/paging_footer', 'js/views/xblock'],
+    function($, _, AjaxHelpers, URI, XBlockInfo, PagedContainer, PagingHeader, PagingFooter, XBlockView) {
         var htmlResponseTpl = _.template('' +
             '<div class="xblock-container-paging-parameters" ' +
                 'data-start="<%= start %>" ' +
@@ -11,7 +10,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                 'data-previews="<%= previews %>"></div>'
         );
 
-        function getResponseHtml(override_options){
+        function getResponseHtml(override_options) {
             var default_options = {
                 start: 0,
                 displayed: PAGE_SIZE,
@@ -23,7 +22,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                 '<div class="container-paging-header"></div>' +
                 htmlResponseTpl(options) +
                 '<div class="container-paging-footer"></div>' +
-                '</div>'
+                '</div>';
         }
 
         var makePage = function(html_parameters) {
@@ -36,9 +35,9 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
         var PAGE_SIZE = 3;
 
         var mockFirstPage = makePage({
-                start: 0,
-                displayed: PAGE_SIZE,
-                total: PAGE_SIZE + 1
+            start: 0,
+            displayed: PAGE_SIZE,
+            total: PAGE_SIZE + 1
         });
 
         var mockSecondPage = makePage({
@@ -59,7 +58,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                 var url = new URI(request.url);
                 var queryParameters = url.query(true); // Returns an object with each query parameter stored as a value
                 var page = queryParameters.page_number;
-                mockPage = page === "0" ? mockFirstPage : mockSecondPage;
+                mockPage = page === '0' ? mockFirstPage : mockSecondPage;
             }
             AjaxHelpers.respondWithJson(requests, mockPage);
         };
@@ -70,35 +69,34 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
             model: new XBlockInfo({}, {parse: true})
         });
 
-        describe("Paging Container", function() {
+        describe('Paging Container', function() {
             var pagingContainer;
 
-            beforeEach(function () {
+            beforeEach(function() {
                 pagingContainer = new MockPagingView({
                     page_size: PAGE_SIZE,
                     page: jasmine.createSpyObj('page', ['updatePreviewButton', 'renderAddXBlockComponents'])
                 });
             });
 
-            describe("Container", function () {
-                describe("rendering", function() {
-
+            describe('Container', function() {
+                describe('rendering', function() {
                     it('should set show_previews', function() {
-                       var requests = AjaxHelpers.requests(this);
-                       expect(pagingContainer.collection.showChildrenPreviews).toBe(true); //precondition check
+                        var requests = AjaxHelpers.requests(this);
+                        expect(pagingContainer.collection.showChildrenPreviews).toBe(true); // precondition check
 
-                       pagingContainer.setPage(0);
-                       respondWithMockPage(requests, makePage({previews: false}));
-                       expect(pagingContainer.collection.showChildrenPreviews).toBe(false);
+                        pagingContainer.setPage(0);
+                        respondWithMockPage(requests, makePage({previews: false}));
+                        expect(pagingContainer.collection.showChildrenPreviews).toBe(false);
 
-                       pagingContainer.setPage(0);
-                       respondWithMockPage(requests, makePage({previews: true}));
-                       expect(pagingContainer.collection.showChildrenPreviews).toBe(true);
-                   });
+                        pagingContainer.setPage(0);
+                        respondWithMockPage(requests, makePage({previews: true}));
+                        expect(pagingContainer.collection.showChildrenPreviews).toBe(true);
+                    });
                 });
 
-                describe("setPage", function () {
-                    it('can set the current page', function () {
+                describe('setPage', function() {
+                    it('can set the current page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -108,7 +106,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(1);
                     });
 
-                    it('should not change page after a server error', function () {
+                    it('should not change page after a server error', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -118,8 +116,8 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     });
                 });
 
-                describe("nextPage", function () {
-                    it('does not move forward after a server error', function () {
+                describe('nextPage', function() {
+                    it('does not move forward after a server error', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -128,7 +126,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(0);
                     });
 
-                    it('can move to the next page', function () {
+                    it('can move to the next page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -137,7 +135,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(1);
                     });
 
-                    it('can not move forward from the final page', function () {
+                    it('can not move forward from the final page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
@@ -146,8 +144,8 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     });
                 });
 
-                describe("previousPage", function () {
-                    it('can move back a page', function () {
+                describe('previousPage', function() {
+                    it('can move back a page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
@@ -156,7 +154,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(0);
                     });
 
-                    it('can not move back from the first page', function () {
+                    it('can not move back from the first page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -164,7 +162,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         AjaxHelpers.expectNoRequests(requests);
                     });
 
-                    it('does not move back after a server error', function () {
+                    it('does not move back after a server error', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
@@ -175,13 +173,13 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                 });
             });
 
-            describe("PagingHeader", function () {
-                describe("Next page button", function () {
-                    beforeEach(function () {
+            describe('PagingHeader', function() {
+                describe('Next page button', function() {
+                    beforeEach(function() {
                         pagingContainer.render();
                     });
 
-                    it('does not move forward if a server error occurs', function () {
+                    it('does not move forward if a server error occurs', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -190,7 +188,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(0);
                     });
 
-                    it('can move to the next page', function () {
+                    it('can move to the next page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -199,21 +197,21 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(1);
                     });
 
-                    it('should be enabled when there is at least one more page', function () {
+                    it('should be enabled when there is at least one more page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingHeader.$('.next-page-link')).not.toHaveClass('is-disabled');
                     });
 
-                    it('should be disabled on the final page', function () {
+                    it('should be disabled on the final page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingHeader.$('.next-page-link')).toHaveClass('is-disabled');
                     });
 
-                    it('should be disabled on an empty page', function () {
+                    it('should be disabled on an empty page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -221,12 +219,12 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     });
                 });
 
-                describe("Previous page button", function () {
-                    beforeEach(function () {
+                describe('Previous page button', function() {
+                    beforeEach(function() {
                         pagingContainer.render();
                     });
 
-                    it('does not move back if a server error occurs', function () {
+                    it('does not move back if a server error occurs', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
@@ -235,7 +233,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(1);
                     });
 
-                    it('can go back a page', function () {
+                    it('can go back a page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
@@ -244,21 +242,21 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(0);
                     });
 
-                    it('should be disabled on the first page', function () {
+                    it('should be disabled on the first page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingHeader.$('.previous-page-link')).toHaveClass('is-disabled');
                     });
 
-                    it('should be enabled on the second page', function () {
+                    it('should be enabled on the second page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingHeader.$('.previous-page-link')).not.toHaveClass('is-disabled');
                     });
 
-                    it('should be disabled for an empty page', function () {
+                    it('should be disabled for an empty page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -266,8 +264,8 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     });
                 });
 
-                describe("Page metadata section", function() {
-                    it('shows the correct metadata for the current page', function () {
+                describe('Page metadata section', function() {
+                    it('shows the correct metadata for the current page', function() {
                         var requests = AjaxHelpers.requests(this),
                             message;
                         pagingContainer.setPage(0);
@@ -279,22 +277,22 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     });
                 });
 
-                describe("Children count label", function () {
-                    it('should show correct count on first page', function () {
+                describe('Children count label', function() {
+                    it('should show correct count on first page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingHeader.$('.count-current-shown')).toHaveHtml('1-3');
                     });
 
-                    it('should show correct count on second page', function () {
+                    it('should show correct count on second page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingHeader.$('.count-current-shown')).toHaveHtml('4-4');
                     });
 
-                    it('should show correct count for an empty collection', function () {
+                    it('should show correct count for an empty collection', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -302,22 +300,22 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     });
                 });
 
-                describe("Children total label", function () {
-                    it('should show correct total on the first page', function () {
+                describe('Children total label', function() {
+                    it('should show correct total on the first page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingHeader.$('.count-total')).toHaveText('4 total');
                     });
 
-                    it('should show correct total on the second page', function () {
+                    it('should show correct total on the second page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingHeader.$('.count-total')).toHaveText('4 total');
                     });
 
-                    it('should show zero total for an empty collection', function () {
+                    it('should show zero total for an empty collection', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -326,14 +324,14 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                 });
             });
 
-            describe("PagingFooter", function () {
-                describe("Next page button", function () {
-                    beforeEach(function () {
+            describe('PagingFooter', function() {
+                describe('Next page button', function() {
+                    beforeEach(function() {
                         // Render the page and header so that they can react to events
                         pagingContainer.render();
                     });
 
-                    it('does not move forward if a server error occurs', function () {
+                    it('does not move forward if a server error occurs', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -342,7 +340,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(0);
                     });
 
-                    it('can move to the next page', function () {
+                    it('can move to the next page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -351,21 +349,21 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(1);
                     });
 
-                    it('should be enabled when there is at least one more page', function () {
+                    it('should be enabled when there is at least one more page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingFooter.$('.next-page-link')).not.toHaveClass('is-disabled');
                     });
 
-                    it('should be disabled on the final page', function () {
+                    it('should be disabled on the final page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingFooter.$('.next-page-link')).toHaveClass('is-disabled');
                     });
 
-                    it('should be disabled on an empty page', function () {
+                    it('should be disabled on an empty page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -373,13 +371,13 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     });
                 });
 
-                describe("Previous page button", function () {
-                    beforeEach(function () {
+                describe('Previous page button', function() {
+                    beforeEach(function() {
                         // Render the page and header so that they can react to events
                         pagingContainer.render();
                     });
 
-                    it('does not move back if a server error occurs', function () {
+                    it('does not move back if a server error occurs', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
@@ -388,7 +386,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(1);
                     });
 
-                    it('can go back a page', function () {
+                    it('can go back a page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
@@ -397,21 +395,21 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.collection.currentPage).toBe(0);
                     });
 
-                    it('should be disabled on the first page', function () {
+                    it('should be disabled on the first page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingFooter.$('.previous-page-link')).toHaveClass('is-disabled');
                     });
 
-                    it('should be enabled on the second page', function () {
+                    it('should be enabled on the second page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingFooter.$('.previous-page-link')).not.toHaveClass('is-disabled');
                     });
 
-                    it('should be disabled for an empty page', function () {
+                    it('should be disabled for an empty page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -419,22 +417,22 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     });
                 });
 
-                describe("Current page label", function () {
-                    it('should show 1 on the first page', function () {
+                describe('Current page label', function() {
+                    it('should show 1 on the first page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingFooter.$('.current-page')).toHaveText('1');
                     });
 
-                    it('should show 2 on the second page', function () {
+                    it('should show 2 on the second page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(1);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingFooter.$('.current-page')).toHaveText('2');
                     });
 
-                    it('should show 1 for an empty collection', function () {
+                    it('should show 1 for an empty collection', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -442,15 +440,15 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     });
                 });
 
-                describe("Page total label", function () {
-                    it('should show the correct value with more than one page', function () {
+                describe('Page total label', function() {
+                    it('should show the correct value with more than one page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingFooter.$('.total-pages')).toHaveText('2');
                     });
 
-                    it('should show page 1 when there are no assets', function () {
+                    it('should show page 1 when there are no assets', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -458,17 +456,17 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                     });
                 });
 
-                describe("Page input field", function () {
+                describe('Page input field', function() {
                     var input;
 
-                    it('should initially have a blank page input', function () {
+                    it('should initially have a blank page input', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
                         expect(pagingContainer.pagingFooter.$('.page-number-input')).toHaveValue('');
                     });
 
-                    it('should handle invalid page requests', function () {
+                    it('should handle invalid page requests', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -478,7 +476,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.pagingFooter.$('.page-number-input')).toHaveValue('');
                     });
 
-                    it('should switch pages via the input field', function () {
+                    it('should switch pages via the input field', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -489,7 +487,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.pagingFooter.$('.page-number-input')).toHaveValue('');
                     });
 
-                    it('should handle AJAX failures when switching pages via the input field', function () {
+                    it('should handle AJAX failures when switching pages via the input field', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);
@@ -502,34 +500,34 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                 });
             });
 
-            describe("Previews", function(){
-                describe("Toggle Previews", function(){
+            describe('Previews', function() {
+                describe('Toggle Previews', function() {
                     var testSendsAjax,
-                        defaultUrl = "/preview/xblock/handler/trigger_previews";
+                        defaultUrl = '/preview/xblock/handler/trigger_previews';
 
-                    testSendsAjax = function (show_previews) {
-                        it("should send " + (!show_previews) + " when showChildrenPreviews was " + show_previews, function(){
+                    testSendsAjax = function(show_previews) {
+                        it('should send ' + (!show_previews) + ' when showChildrenPreviews was ' + show_previews, function() {
                             var requests = AjaxHelpers.requests(this);
                             pagingContainer.collection.showChildrenPreviews = show_previews;
                             pagingContainer.togglePreviews();
-                            AjaxHelpers.expectJsonRequest(requests, 'POST', defaultUrl, { showChildrenPreviews: !show_previews});
-                            AjaxHelpers.respondWithJson(requests, { showChildrenPreviews: !show_previews });
+                            AjaxHelpers.expectJsonRequest(requests, 'POST', defaultUrl, {showChildrenPreviews: !show_previews});
+                            AjaxHelpers.respondWithJson(requests, {showChildrenPreviews: !show_previews});
                         });
                     };
                     testSendsAjax(true);
                     testSendsAjax(false);
 
-                    it("should trigger render on success", function(){
+                    it('should trigger render on success', function() {
                         spyOn(pagingContainer, 'render');
                         var requests = AjaxHelpers.requests(this);
 
                         pagingContainer.togglePreviews();
-                        AjaxHelpers.respondWithJson(requests, { showChildrenPreviews: true });
+                        AjaxHelpers.respondWithJson(requests, {showChildrenPreviews: true});
 
                         expect(pagingContainer.render).toHaveBeenCalled();
                     });
 
-                    it("should not trigger render on failure", function(){
+                    it('should not trigger render on failure', function() {
                         spyOn(pagingContainer, 'render');
                         var requests = AjaxHelpers.requests(this);
 
@@ -539,7 +537,7 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
                         expect(pagingContainer.render).not.toHaveBeenCalled();
                     });
 
-                    it("should send force_render when new block causes page change", function() {
+                    it('should send force_render when new block causes page change', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingContainer.setPage(0);
                         respondWithMockPage(requests);

--- a/cms/static/js/spec/views/pages/container_spec.js
+++ b/cms/static/js/spec/views/pages/container_spec.js
@@ -1,13 +1,13 @@
-define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers",
-        "common/js/spec_helpers/template_helpers", "js/spec_helpers/edit_helpers",
-        "js/views/pages/container", "js/views/pages/paged_container", "js/models/xblock_info",
-        "js/collections/component_template", "jquery.simulate"],
-    function ($, _, str, AjaxHelpers, TemplateHelpers, EditHelpers, ContainerPage, PagedContainerPage,
+define(['jquery', 'underscore', 'underscore.string', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
+        'common/js/spec_helpers/template_helpers', 'js/spec_helpers/edit_helpers',
+        'js/views/pages/container', 'js/views/pages/paged_container', 'js/models/xblock_info',
+        'js/collections/component_template', 'jquery.simulate'],
+    function($, _, str, AjaxHelpers, TemplateHelpers, EditHelpers, ContainerPage, PagedContainerPage,
               XBlockInfo, ComponentTemplates) {
         'use strict';
 
         function parameterized_suite(label, globalPageOptions) {
-            describe(label + " ContainerPage", function () {
+            describe(label + ' ContainerPage', function() {
                 var getContainerPage, renderContainerPage, handleContainerPageRefresh, expectComponents,
                     respondWithHtml, model, containerPage, requests, initialDisplayName,
                     mockContainerPage = readFixtures('mock/mock-container-page.underscore'),
@@ -22,7 +22,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     pagedSpecificTests = globalPageOptions.pagedSpecificTests,
                     hasVisibilityEditor = globalPageOptions.hasVisibilityEditor;
 
-                beforeEach(function () {
+                beforeEach(function() {
                     var newDisplayName = 'New Display Name';
 
                     EditHelpers.installEditTemplates();
@@ -31,7 +31,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     appendSetFixtures(mockContainerPage);
 
                     EditHelpers.installMockXBlock({
-                        data: "<p>Some HTML</p>",
+                        data: '<p>Some HTML</p>',
                         metadata: {
                             display_name: newDisplayName
                         }
@@ -46,18 +46,18 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     });
                 });
 
-                afterEach(function () {
+                afterEach(function() {
                     EditHelpers.uninstallMockXBlock();
                 });
 
-                respondWithHtml = function (html) {
+                respondWithHtml = function(html) {
                     AjaxHelpers.respondWithJson(
                         requests,
-                        { html: html, "resources": [] }
+                        {html: html, 'resources': []}
                     );
                 };
 
-                getContainerPage = function (options, componentTemplates) {
+                getContainerPage = function(options, componentTemplates) {
                     var default_options = {
                         model: model,
                         templates: componentTemplates === undefined ?
@@ -67,7 +67,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     return new PageClass(_.extend(options || {}, globalPageOptions, default_options));
                 };
 
-                renderContainerPage = function (test, html, options, componentTemplates) {
+                renderContainerPage = function(test, html, options, componentTemplates) {
                     requests = AjaxHelpers.requests(test);
                     containerPage = getContainerPage(options, componentTemplates);
                     containerPage.render();
@@ -86,23 +86,23 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     });
                 };
 
-                expectComponents = function (container, locators) {
+                expectComponents = function(container, locators) {
                     // verify expected components (in expected order) by their locators
                     var components = $(container).find('.studio-xblock-wrapper');
                     expect(components.length).toBe(locators.length);
-                    _.each(locators, function (locator, locator_index) {
+                    _.each(locators, function(locator, locator_index) {
                         expect($(components[locator_index]).data('locator')).toBe(locator);
                     });
                 };
 
-                describe("Initial display", function () {
-                    it('can render itself', function () {
+                describe('Initial display', function() {
+                    it('can render itself', function() {
                         renderContainerPage(this, mockContainerXBlockHtml);
                         expect(containerPage.$('.xblock-header').length).toBe(9);
                         expect(containerPage.$('.wrapper-xblock .level-nesting')).not.toHaveClass('is-hidden');
                     });
 
-                    it('shows a loading indicator', function () {
+                    it('shows a loading indicator', function() {
                         requests = AjaxHelpers.requests(this);
                         containerPage = getContainerPage();
                         containerPage.render();
@@ -111,19 +111,19 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         expect(containerPage.$('.ui-loading')).toHaveClass('is-hidden');
                     });
 
-                    it('can show an xblock with broken JavaScript', function () {
+                    it('can show an xblock with broken JavaScript', function() {
                         renderContainerPage(this, mockBadContainerXBlockHtml);
                         expect(containerPage.$('.wrapper-xblock .level-nesting')).not.toHaveClass('is-hidden');
                         expect(containerPage.$('.ui-loading')).toHaveClass('is-hidden');
                     });
 
-                    it('can show an xblock with an invalid XBlock', function () {
+                    it('can show an xblock with an invalid XBlock', function() {
                         renderContainerPage(this, mockBadXBlockContainerXBlockHtml);
                         expect(containerPage.$('.wrapper-xblock .level-nesting')).not.toHaveClass('is-hidden');
                         expect(containerPage.$('.ui-loading')).toHaveClass('is-hidden');
                     });
 
-                    it('inline edits the display name when performing a new action', function () {
+                    it('inline edits the display name when performing a new action', function() {
                         renderContainerPage(this, mockContainerXBlockHtml, {
                             action: 'new'
                         });
@@ -133,19 +133,19 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     });
                 });
 
-                describe("Editing the container", function () {
+                describe('Editing the container', function() {
                     var updatedDisplayName = 'Updated Test Container',
                         getDisplayNameWrapper;
 
-                    afterEach(function () {
+                    afterEach(function() {
                         EditHelpers.cancelModalIfShowing();
                     });
 
-                    getDisplayNameWrapper = function () {
+                    getDisplayNameWrapper = function() {
                         return containerPage.$('.wrapper-xblock-field');
                     };
 
-                    it('can edit itself', function () {
+                    it('can edit itself', function() {
                         var editButtons, displayNameElement, request;
                         renderContainerPage(this, mockContainerXBlockHtml);
                         displayNameElement = containerPage.$('.page-header-title');
@@ -175,13 +175,13 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         handleContainerPageRefresh(requests);
 
                         // Respond to the subsequent xblock info fetch request.
-                        AjaxHelpers.respondWithJson(requests, {"display_name": updatedDisplayName});
+                        AjaxHelpers.respondWithJson(requests, {'display_name': updatedDisplayName});
 
                         // Expect the title to have been updated
                         expect(displayNameElement.text().trim()).toBe(updatedDisplayName);
                     });
 
-                    it('can inline edit the display name', function () {
+                    it('can inline edit the display name', function() {
                         var displayNameInput, displayNameWrapper;
                         renderContainerPage(this, mockContainerXBlockHtml);
                         displayNameWrapper = getDisplayNameWrapper();
@@ -190,18 +190,18 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         // This is the response for the change operation.
                         AjaxHelpers.respondWithJson(requests, { });
                         // This is the response for the subsequent fetch operation.
-                        AjaxHelpers.respondWithJson(requests, {"display_name": updatedDisplayName});
+                        AjaxHelpers.respondWithJson(requests, {'display_name': updatedDisplayName});
                         EditHelpers.verifyInlineEditChange(displayNameWrapper, updatedDisplayName);
                         expect(containerPage.model.get('display_name')).toBe(updatedDisplayName);
                     });
                 });
 
-                describe("Editing an xblock", function () {
-                    afterEach(function () {
+                describe('Editing an xblock', function() {
+                    afterEach(function() {
                         EditHelpers.cancelModalIfShowing();
                     });
 
-                    it('can show an edit modal for a child xblock', function () {
+                    it('can show an edit modal for a child xblock', function() {
                         var editButtons, request;
                         renderContainerPage(this, mockContainerXBlockHtml);
                         editButtons = containerPage.$('.wrapper-xblock .edit-button');
@@ -218,7 +218,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         expect(EditHelpers.isShowingModal()).toBeTruthy();
                     });
 
-                    it('can show an edit modal for a child xblock with broken JavaScript', function () {
+                    it('can show an edit modal for a child xblock with broken JavaScript', function() {
                         var editButtons;
                         renderContainerPage(this, mockBadContainerXBlockHtml);
                         editButtons = containerPage.$('.wrapper-xblock .edit-button');
@@ -252,25 +252,25 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     });
                 });
 
-                describe("Editing an xmodule", function () {
+                describe('Editing an xmodule', function() {
                     var mockXModuleEditor = readFixtures('mock/mock-xmodule-editor.underscore'),
                         newDisplayName = 'New Display Name';
 
-                    beforeEach(function () {
+                    beforeEach(function() {
                         EditHelpers.installMockXModule({
-                            data: "<p>Some HTML</p>",
+                            data: '<p>Some HTML</p>',
                             metadata: {
                                 display_name: newDisplayName
                             }
                         });
                     });
 
-                    afterEach(function () {
+                    afterEach(function() {
                         EditHelpers.uninstallMockXModule();
                         EditHelpers.cancelModalIfShowing();
                     });
 
-                    it('can save changes to settings', function () {
+                    it('can save changes to settings', function() {
                         var editButtons, modal, mockUpdatedXBlockHtml;
                         mockUpdatedXBlockHtml = readFixtures('mock/mock-updated-xblock.underscore');
                         renderContainerPage(this, mockContainerXBlockHtml);
@@ -288,7 +288,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         // Click on the settings tab
                         modal.find('.settings-button').click();
                         // Change the display name's text
-                        modal.find('.setting-input').text("Mock Update");
+                        modal.find('.setting-input').text('Mock Update');
                         // Press the save button
                         modal.find('.action-save').click();
                         // Respond to the save
@@ -304,33 +304,32 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     });
                 });
 
-                describe("xblock operations", function () {
+                describe('xblock operations', function() {
                     var getGroupElement,
-                        NUM_COMPONENTS_PER_GROUP = 3, GROUP_TO_TEST = "A",
+                        NUM_COMPONENTS_PER_GROUP = 3, GROUP_TO_TEST = 'A',
                         allComponentsInGroup = _.map(
                             _.range(NUM_COMPONENTS_PER_GROUP),
-                            function (index) {
+                            function(index) {
                                 return 'locator-component-' + GROUP_TO_TEST + (index + 1);
                             }
                         );
 
-                    getGroupElement = function () {
+                    getGroupElement = function() {
                         return containerPage.$("[data-locator='locator-group-" + GROUP_TO_TEST + "']");
                     };
 
-                    describe("Deleting an xblock", function () {
+                    describe('Deleting an xblock', function() {
                         var clickDelete, deleteComponent, deleteComponentWithSuccess,
                             promptSpy;
 
-                        beforeEach(function () {
+                        beforeEach(function() {
                             promptSpy = EditHelpers.createPromptSpy();
                         });
 
 
-                        clickDelete = function (componentIndex, clickNo) {
-
+                        clickDelete = function(componentIndex, clickNo) {
                             // find all delete buttons for the given group
-                            var deleteButtons = getGroupElement().find(".delete-button");
+                            var deleteButtons = getGroupElement().find('.delete-button');
                             expect(deleteButtons.length).toBe(NUM_COMPONENTS_PER_GROUP);
 
                             // click the requested delete button
@@ -340,7 +339,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             EditHelpers.confirmPrompt(promptSpy, clickNo);
                         };
 
-                        deleteComponent = function (componentIndex) {
+                        deleteComponent = function(componentIndex) {
                             clickDelete(componentIndex);
 
                             // first request to delete the component
@@ -359,7 +358,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             AjaxHelpers.respondWithJson(requests, {});
                         };
 
-                        deleteComponentWithSuccess = function (componentIndex) {
+                        deleteComponentWithSuccess = function(componentIndex) {
                             deleteComponent(componentIndex);
 
                             // verify the new list of components within the group (unless reloading)
@@ -371,22 +370,22 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             }
                         };
 
-                        it("can delete the first xblock", function () {
+                        it('can delete the first xblock', function() {
                             renderContainerPage(this, mockContainerXBlockHtml);
                             deleteComponentWithSuccess(0);
                         });
 
-                        it("can delete a middle xblock", function () {
+                        it('can delete a middle xblock', function() {
                             renderContainerPage(this, mockContainerXBlockHtml);
                             deleteComponentWithSuccess(1);
                         });
 
-                        it("can delete the last xblock", function () {
+                        it('can delete the last xblock', function() {
                             renderContainerPage(this, mockContainerXBlockHtml);
                             deleteComponentWithSuccess(NUM_COMPONENTS_PER_GROUP - 1);
                         });
 
-                        it("can delete an xblock with broken JavaScript", function () {
+                        it('can delete an xblock with broken JavaScript', function() {
                             renderContainerPage(this, mockBadContainerXBlockHtml);
                             containerPage.$('.delete-button').first().click();
                             EditHelpers.confirmPrompt(promptSpy);
@@ -404,7 +403,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             AjaxHelpers.expectJsonRequest(requests, 'GET', '/xblock/locator-container');
                         });
 
-                        it('does not delete when clicking No in prompt', function () {
+                        it('does not delete when clicking No in prompt', function() {
                             renderContainerPage(this, mockContainerXBlockHtml);
 
                             // click delete on the first component but press no
@@ -417,7 +416,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             AjaxHelpers.expectNoRequests(requests);
                         });
 
-                        it('shows a notification during the delete operation', function () {
+                        it('shows a notification during the delete operation', function() {
                             var notificationSpy = EditHelpers.createNotificationSpy();
                             renderContainerPage(this, mockContainerXBlockHtml);
                             clickDelete(0);
@@ -426,7 +425,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             EditHelpers.verifyNotificationHidden(notificationSpy);
                         });
 
-                        it('does not delete an xblock upon failure', function () {
+                        it('does not delete an xblock upon failure', function() {
                             var notificationSpy = EditHelpers.createNotificationSpy();
                             renderContainerPage(this, mockContainerXBlockHtml);
                             clickDelete(0);
@@ -437,22 +436,21 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         });
                     });
 
-                    describe("Duplicating an xblock", function () {
+                    describe('Duplicating an xblock', function() {
                         var clickDuplicate, duplicateComponentWithSuccess,
                             refreshXBlockSpies;
 
-                        clickDuplicate = function (componentIndex) {
-
+                        clickDuplicate = function(componentIndex) {
                             // find all duplicate buttons for the given group
-                            var duplicateButtons = getGroupElement().find(".duplicate-button");
+                            var duplicateButtons = getGroupElement().find('.duplicate-button');
                             expect(duplicateButtons.length).toBe(NUM_COMPONENTS_PER_GROUP);
 
                             // click the requested duplicate button
                             duplicateButtons[componentIndex].click();
                         };
 
-                        duplicateComponentWithSuccess = function (componentIndex) {
-                            refreshXBlockSpies = spyOn(containerPage, "refreshXBlock");
+                        duplicateComponentWithSuccess = function(componentIndex) {
+                            refreshXBlockSpies = spyOn(containerPage, 'refreshXBlock');
 
                             clickDuplicate(componentIndex);
 
@@ -471,22 +469,22 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             expect(refreshXBlockSpies).toHaveBeenCalled();
                         };
 
-                        it("can duplicate the first xblock", function () {
+                        it('can duplicate the first xblock', function() {
                             renderContainerPage(this, mockContainerXBlockHtml);
                             duplicateComponentWithSuccess(0);
                         });
 
-                        it("can duplicate a middle xblock", function () {
+                        it('can duplicate a middle xblock', function() {
                             renderContainerPage(this, mockContainerXBlockHtml);
                             duplicateComponentWithSuccess(1);
                         });
 
-                        it("can duplicate the last xblock", function () {
+                        it('can duplicate the last xblock', function() {
                             renderContainerPage(this, mockContainerXBlockHtml);
                             duplicateComponentWithSuccess(NUM_COMPONENTS_PER_GROUP - 1);
                         });
 
-                        it("can duplicate an xblock with broken JavaScript", function () {
+                        it('can duplicate an xblock with broken JavaScript', function() {
                             renderContainerPage(this, mockBadContainerXBlockHtml);
                             containerPage.$('.duplicate-button').first().click();
                             AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/', {
@@ -495,19 +493,19 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             });
                         });
 
-                        it('shows a notification when duplicating', function () {
+                        it('shows a notification when duplicating', function() {
                             var notificationSpy = EditHelpers.createNotificationSpy();
                             renderContainerPage(this, mockContainerXBlockHtml);
                             clickDuplicate(0);
                             EditHelpers.verifyNotificationShowing(notificationSpy, /Duplicating/);
-                            AjaxHelpers.respondWithJson(requests, {"locator": "new_item"});
+                            AjaxHelpers.respondWithJson(requests, {'locator': 'new_item'});
                             EditHelpers.verifyNotificationHidden(notificationSpy);
                         });
 
-                        it('does not duplicate an xblock upon failure', function () {
+                        it('does not duplicate an xblock upon failure', function() {
                             var notificationSpy = EditHelpers.createNotificationSpy();
                             renderContainerPage(this, mockContainerXBlockHtml);
-                            refreshXBlockSpies = spyOn(containerPage, "refreshXBlock");
+                            refreshXBlockSpies = spyOn(containerPage, 'refreshXBlock');
                             clickDuplicate(0);
                             EditHelpers.verifyNotificationShowing(notificationSpy, /Duplicating/);
                             AjaxHelpers.respondWithError(requests);
@@ -517,28 +515,27 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         });
                     });
 
-                    describe("Previews", function () {
-
+                    describe('Previews', function() {
                         var getButtonIcon, getButtonText;
 
-                        getButtonIcon = function (containerPage) {
+                        getButtonIcon = function(containerPage) {
                             return containerPage.$('.action-toggle-preview .fa');
                         };
 
-                        getButtonText = function (containerPage) {
+                        getButtonText = function(containerPage) {
                             return containerPage.$('.action-toggle-preview .preview-text').text().trim();
                         };
 
                         if (pagedSpecificTests) {
-                            it('has no text on the preview button to start with', function () {
+                            it('has no text on the preview button to start with', function() {
                                 containerPage = getContainerPage();
                                 expect(getButtonIcon(containerPage)).toHaveClass('fa-refresh');
                                 expect(getButtonIcon(containerPage).parent()).toHaveClass('is-hidden');
-                                expect(getButtonText(containerPage)).toBe("");
+                                expect(getButtonText(containerPage)).toBe('');
                             });
 
                             var updatePreviewButtonTest = function(show_previews, expected_text) {
-                                it('can set preview button to "' + expected_text + '"', function () {
+                                it('can set preview button to "' + expected_text + '"', function() {
                                     containerPage = getContainerPage();
                                     containerPage.updatePreviewButton(show_previews);
                                     expect(getButtonText(containerPage)).toBe(expected_text);
@@ -548,7 +545,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             updatePreviewButtonTest(true, 'Hide Previews');
                             updatePreviewButtonTest(false, 'Show Previews');
 
-                            it('triggers underlying view togglePreviews when preview button clicked', function () {
+                            it('triggers underlying view togglePreviews when preview button clicked', function() {
                                 containerPage = getContainerPage();
                                 containerPage.render();
                                 spyOn(containerPage.xblockView, 'togglePreviews');
@@ -559,11 +556,11 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         }
                     });
 
-                    describe('createNewComponent ', function () {
+                    describe('createNewComponent ', function() {
                         var clickNewComponent;
 
-                        clickNewComponent = function (index) {
-                            containerPage.$(".new-component .new-component-type button.single-template")[index].click();
+                        clickNewComponent = function(index) {
+                            containerPage.$('.new-component .new-component-type button.single-template')[index].click();
                         };
 
                         it('Attaches a handler to new component button', function() {
@@ -575,36 +572,36 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             expect($.scrollTo).toHaveBeenCalled();
                         });
 
-                        it('sends the correct JSON to the server', function () {
+                        it('sends the correct JSON to the server', function() {
                             renderContainerPage(this, mockContainerXBlockHtml);
                             clickNewComponent(0);
                             EditHelpers.verifyXBlockRequest(requests, {
-                                "category": "discussion",
-                                "type": "discussion",
-                                "parent_locator": "locator-group-A"
+                                'category': 'discussion',
+                                'type': 'discussion',
+                                'parent_locator': 'locator-group-A'
                             });
                         });
 
-                        it('also works for older-style add component links', function () {
+                        it('also works for older-style add component links', function() {
                             // Some third party xblocks (problem-builder in particular) expect add
                             // event handlers on custom <a> add buttons which is what the platform
                             // used to use instead of <button>s.
                             // This can be removed once there is a proper API that XBlocks can use
                             // to add children or allow authors to add children.
                             renderContainerPage(this, mockContainerXBlockHtml);
-                            $(".add-xblock-component-button").each(function() {
-                                var htmlAsLink = $($(this).prop('outerHTML').replace(/(<\/?)button/g, "$1a"));
+                            $('.add-xblock-component-button').each(function() {
+                                var htmlAsLink = $($(this).prop('outerHTML').replace(/(<\/?)button/g, '$1a'));
                                 $(this).replaceWith(htmlAsLink);
                             });
-                            $(".add-xblock-component-button").first().click();
+                            $('.add-xblock-component-button').first().click();
                             EditHelpers.verifyXBlockRequest(requests, {
-                                "category": "discussion",
-                                "type": "discussion",
-                                "parent_locator": "locator-group-A"
+                                'category': 'discussion',
+                                'type': 'discussion',
+                                'parent_locator': 'locator-group-A'
                             });
                         });
 
-                        it('shows a notification while creating', function () {
+                        it('shows a notification while creating', function() {
                             var notificationSpy = EditHelpers.createNotificationSpy();
                             renderContainerPage(this, mockContainerXBlockHtml);
                             clickNewComponent(0);
@@ -613,7 +610,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             EditHelpers.verifyNotificationHidden(notificationSpy);
                         });
 
-                        it('does not insert component upon failure', function () {
+                        it('does not insert component upon failure', function() {
                             renderContainerPage(this, mockContainerXBlockHtml);
                             clickNewComponent(0);
                             AjaxHelpers.respondWithError(requests);
@@ -622,74 +619,74 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             expectComponents(getGroupElement(), allComponentsInGroup);
                         });
 
-                        describe('Template Picker', function () {
+                        describe('Template Picker', function() {
                             var showTemplatePicker, verifyCreateHtmlComponent;
 
-                            showTemplatePicker = function () {
+                            showTemplatePicker = function() {
                                 containerPage.$('.new-component .new-component-type button.multiple-templates')[0].click();
                             };
 
-                            verifyCreateHtmlComponent = function (test, templateIndex, expectedRequest) {
+                            verifyCreateHtmlComponent = function(test, templateIndex, expectedRequest) {
                                 var xblockCount;
                                 renderContainerPage(test, mockContainerXBlockHtml);
                                 showTemplatePicker();
                                 xblockCount = containerPage.$('.studio-xblock-wrapper').length;
                                 containerPage.$('.new-component-html button')[templateIndex].click();
                                 EditHelpers.verifyXBlockRequest(requests, expectedRequest);
-                                AjaxHelpers.respondWithJson(requests, {"locator": "new_item"});
+                                AjaxHelpers.respondWithJson(requests, {'locator': 'new_item'});
                                 respondWithHtml(mockXBlockHtml);
                                 expect(containerPage.$('.studio-xblock-wrapper').length).toBe(xblockCount + 1);
                             };
 
-                            it('can add an HTML component without a template', function () {
+                            it('can add an HTML component without a template', function() {
                                 verifyCreateHtmlComponent(this, 0, {
-                                    "category": "html",
-                                    "parent_locator": "locator-group-A"
+                                    'category': 'html',
+                                    'parent_locator': 'locator-group-A'
                                 });
                             });
 
-                            it('can add an HTML component with a template', function () {
+                            it('can add an HTML component with a template', function() {
                                 verifyCreateHtmlComponent(this, 1, {
-                                    "category": "html",
-                                    "boilerplate": "announcement.yaml",
-                                    "parent_locator": "locator-group-A"
+                                    'category': 'html',
+                                    'boilerplate': 'announcement.yaml',
+                                    'parent_locator': 'locator-group-A'
                                 });
                             });
 
-                            it('does not show the support legend if show_legend is false', function () {
+                            it('does not show the support legend if show_legend is false', function() {
                                 // By default, show_legend is false in the mock component Templates.
                                 renderContainerPage(this, mockContainerXBlockHtml);
                                 showTemplatePicker();
                                 expect(containerPage.$('.support-documentation').length).toBe(0);
                             });
 
-                            it('does show the support legend if show_legend is true', function () {
+                            it('does show the support legend if show_legend is true', function() {
                                 var templates = new ComponentTemplates([
-                                 {
-                                    "templates": [
-                                        {
-                                            "category": "html",
-                                            "boilerplate_name": null,
-                                            "display_name": "Text"
-                                        }, {
-                                            "category": "html",
-                                            "boilerplate_name": "announcement.yaml",
-                                            "display_name": "Announcement"
-                                        }, {
-                                            "category": "html",
-                                            "boilerplate_name": "raw.yaml",
-                                            "display_name": "Raw HTML"
-                                        }],
-                                    "type": "html",
-                                    "support_legend": {
-                                        "show_legend": true,
-                                        "documentation_label": "Documentation Label:",
-                                        "allow_unsupported_xblocks": false
-                                    }
-                                }],
-                                {
-                                    parse: true
-                                }), supportDocumentation;
+                                    {
+                                        'templates': [
+                                            {
+                                                'category': 'html',
+                                                'boilerplate_name': null,
+                                                'display_name': 'Text'
+                                            }, {
+                                                'category': 'html',
+                                                'boilerplate_name': 'announcement.yaml',
+                                                'display_name': 'Announcement'
+                                            }, {
+                                                'category': 'html',
+                                                'boilerplate_name': 'raw.yaml',
+                                                'display_name': 'Raw HTML'
+                                            }],
+                                        'type': 'html',
+                                        'support_legend': {
+                                            'show_legend': true,
+                                            'documentation_label': 'Documentation Label:',
+                                            'allow_unsupported_xblocks': false
+                                        }
+                                    }],
+                                    {
+                                        parse: true
+                                    }), supportDocumentation;
                                 renderContainerPage(this, mockContainerXBlockHtml, {}, templates);
                                 showTemplatePicker();
                                 supportDocumentation = containerPage.$('.support-documentation');
@@ -704,33 +701,33 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                                 expect($(supportDocumentation[0]).find('.support-documentation-level').length).toBe(2);
                             });
 
-                            it('does show unsupported level if enabled', function () {
+                            it('does show unsupported level if enabled', function() {
                                 var templates = new ComponentTemplates([
-                                 {
-                                    "templates": [
-                                        {
-                                            "category": "html",
-                                            "boilerplate_name": null,
-                                            "display_name": "Text"
-                                        }, {
-                                            "category": "html",
-                                            "boilerplate_name": "announcement.yaml",
-                                            "display_name": "Announcement"
-                                        }, {
-                                            "category": "html",
-                                            "boilerplate_name": "raw.yaml",
-                                            "display_name": "Raw HTML"
-                                        }],
-                                    "type": "html",
-                                    "support_legend": {
-                                        "show_legend": true,
-                                        "documentation_label": "Documentation Label:",
-                                        "allow_unsupported_xblocks": true
-                                    }
-                                }],
-                                {
-                                    parse: true
-                                }), supportDocumentation;
+                                    {
+                                        'templates': [
+                                            {
+                                                'category': 'html',
+                                                'boilerplate_name': null,
+                                                'display_name': 'Text'
+                                            }, {
+                                                'category': 'html',
+                                                'boilerplate_name': 'announcement.yaml',
+                                                'display_name': 'Announcement'
+                                            }, {
+                                                'category': 'html',
+                                                'boilerplate_name': 'raw.yaml',
+                                                'display_name': 'Raw HTML'
+                                            }],
+                                        'type': 'html',
+                                        'support_legend': {
+                                            'show_legend': true,
+                                            'documentation_label': 'Documentation Label:',
+                                            'allow_unsupported_xblocks': true
+                                        }
+                                    }],
+                                    {
+                                        parse: true
+                                    }), supportDocumentation;
                                 renderContainerPage(this, mockContainerXBlockHtml, {}, templates);
                                 showTemplatePicker();
                                 supportDocumentation = containerPage.$('.support-documentation');
@@ -741,37 +738,37 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                                 // verify only one has the unsupported item
                                 expect($(supportDocumentation[0]).find('.fa-circle-o').length).toBe(1);
                             });
-                            
-                            it('does render support level indicators if present in JSON', function () {
+
+                            it('does render support level indicators if present in JSON', function() {
                                 var templates = new ComponentTemplates([
-                                 {
-                                    "templates": [
-                                        {
-                                            "category": "html",
-                                            "boilerplate_name": null,
-                                            "display_name": "Text",
-                                            "support_level": "fs"
-                                        }, {
-                                            "category": "html",
-                                            "boilerplate_name": "announcement.yaml",
-                                            "display_name": "Announcement",
-                                            "support_level": "ps"
-                                        }, {
-                                            "category": "html",
-                                            "boilerplate_name": "raw.yaml",
-                                            "display_name": "Raw HTML",
-                                            "support_level": "us"
-                                        }],
-                                    "type": "html",
-                                    "support_legend": {
-                                        "show_legend": true,
-                                        "documentation_label": "Documentation Label:",
-                                        "allow_unsupported_xblocks": true
-                                    }
-                                }],
-                                {
-                                    parse: true
-                                }), supportLevelIndicators, getScreenReaderText;
+                                    {
+                                        'templates': [
+                                            {
+                                                'category': 'html',
+                                                'boilerplate_name': null,
+                                                'display_name': 'Text',
+                                                'support_level': 'fs'
+                                            }, {
+                                                'category': 'html',
+                                                'boilerplate_name': 'announcement.yaml',
+                                                'display_name': 'Announcement',
+                                                'support_level': 'ps'
+                                            }, {
+                                                'category': 'html',
+                                                'boilerplate_name': 'raw.yaml',
+                                                'display_name': 'Raw HTML',
+                                                'support_level': 'us'
+                                            }],
+                                        'type': 'html',
+                                        'support_legend': {
+                                            'show_legend': true,
+                                            'documentation_label': 'Documentation Label:',
+                                            'allow_unsupported_xblocks': true
+                                        }
+                                    }],
+                                    {
+                                        parse: true
+                                    }), supportLevelIndicators, getScreenReaderText;
                                 renderContainerPage(this, mockContainerXBlockHtml, {}, templates);
                                 showTemplatePicker();
 
@@ -779,7 +776,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                                     .find('.support-level');
                                 expect(supportLevelIndicators.length).toBe(3);
 
-                                getScreenReaderText = function(index){
+                                getScreenReaderText = function(index) {
                                     return $($(supportLevelIndicators[index]).siblings()[0]).text().trim();
                                 };
                                 // Verify one level of each type was rendered.
@@ -794,7 +791,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
         }
 
         // Create a suite for a non-paged container that includes 'edit visibility' buttons
-        parameterized_suite("Non paged",
+        parameterized_suite('Non paged',
             {
                 page: ContainerPage,
                 requiresPageRefresh: false,
@@ -806,7 +803,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
         );
 
         // Create a suite for a paged container that does not include 'edit visibility' buttons
-        parameterized_suite("Paged",
+        parameterized_suite('Paged',
             {
                 page: PagedContainerPage,
                 page_size: 42,

--- a/cms/static/js/spec/views/pages/container_subviews_spec.js
+++ b/cms/static/js/spec/views/pages/container_subviews_spec.js
@@ -1,20 +1,20 @@
-define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers",
-        "common/js/spec_helpers/template_helpers", "js/spec_helpers/edit_helpers",
-        "common/js/components/views/feedback_prompt", "js/views/pages/container",
-        "js/views/pages/container_subviews", "js/models/xblock_info", "js/views/utils/xblock_utils",
+define(['jquery', 'underscore', 'underscore.string', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
+        'common/js/spec_helpers/template_helpers', 'js/spec_helpers/edit_helpers',
+        'common/js/components/views/feedback_prompt', 'js/views/pages/container',
+        'js/views/pages/container_subviews', 'js/models/xblock_info', 'js/views/utils/xblock_utils',
         'js/models/course'],
-    function ($, _, str, AjaxHelpers, TemplateHelpers, EditHelpers, Prompt, ContainerPage, ContainerSubviews,
+    function($, _, str, AjaxHelpers, TemplateHelpers, EditHelpers, Prompt, ContainerPage, ContainerSubviews,
               XBlockInfo, XBlockUtils, Course) {
         var VisibilityState = XBlockUtils.VisibilityState;
 
-        describe("Container Subviews", function() {
+        describe('Container Subviews', function() {
             var model, containerPage, requests, createContainerPage, renderContainerPage,
                 respondWithHtml, fetch,
-                disabledCss = "is-disabled", defaultXBlockInfo, createXBlockInfo,
+                disabledCss = 'is-disabled', defaultXBlockInfo, createXBlockInfo,
                 mockContainerPage = readFixtures('mock/mock-container-page.underscore'),
                 mockContainerXBlockHtml = readFixtures('mock/mock-empty-container-xblock.underscore');
 
-            beforeEach(function () {
+            beforeEach(function() {
                 window.course = new Course({
                     id: '5',
                     name: 'Course Name',
@@ -44,8 +44,8 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                 published: false,
                 has_changes: false,
                 visibility_state: VisibilityState.unscheduled,
-                edited_on: "Jul 02, 2014 at 14:20 UTC", edited_by: "joe",
-                published_on: "Jul 01, 2014 at 12:45 UTC", published_by: "amako",
+                edited_on: 'Jul 02, 2014 at 14:20 UTC', edited_by: 'joe',
+                published_on: 'Jul 01, 2014 at 12:45 UTC', published_by: 'amako',
                 currently_visible_to_students: false
             };
 
@@ -53,8 +53,8 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                 return _.extend(_.extend({}, defaultXBlockInfo), options || {});
             };
 
-            createContainerPage = function (test, options) {
-                model = new XBlockInfo(createXBlockInfo(options), { parse: true });
+            createContainerPage = function(test, options) {
+                model = new XBlockInfo(createXBlockInfo(options), {parse: true});
                 containerPage = new ContainerPage({
                     model: model,
                     templates: EditHelpers.mockComponentTemplates,
@@ -63,7 +63,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                 });
             };
 
-            renderContainerPage = function (test, html, options) {
+            renderContainerPage = function(test, html, options) {
                 createContainerPage(test, options);
                 containerPage.render();
                 respondWithHtml(html, options);
@@ -72,32 +72,32 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
             respondWithHtml = function(html, options) {
                 AjaxHelpers.respondWithJson(
                     requests,
-                    { html: html, "resources": [] }
+                    {html: html, 'resources': []}
                 );
                 AjaxHelpers.expectJsonRequest(requests, 'GET', '/xblock/locator-container');
                 AjaxHelpers.respondWithJson(requests, createXBlockInfo(options));
             };
 
-            fetch = function (json) {
+            fetch = function(json) {
                 json = createXBlockInfo(json);
                 model.fetch();
                 AjaxHelpers.expectJsonRequest(requests, 'GET', '/xblock/locator-container');
                 AjaxHelpers.respondWithJson(requests, json);
             };
 
-            describe("ViewLiveButtonController", function () {
+            describe('ViewLiveButtonController', function() {
                 var viewPublishedCss = '.button-view',
                     visibilityNoteCss = '.note-visibility';
 
-                it('renders correctly for unscheduled unit', function () {
+                it('renders correctly for unscheduled unit', function() {
                     renderContainerPage(this, mockContainerXBlockHtml);
                     expect(containerPage.$(viewPublishedCss)).toHaveClass(disabledCss);
-                    expect(containerPage.$(viewPublishedCss).attr('title')).toBe("Open the courseware in the LMS");
+                    expect(containerPage.$(viewPublishedCss).attr('title')).toBe('Open the courseware in the LMS');
                     expect(containerPage.$('.button-preview')).not.toHaveClass(disabledCss);
-                    expect(containerPage.$('.button-preview').attr('title')).toBe("Preview the courseware in the LMS");
+                    expect(containerPage.$('.button-preview').attr('title')).toBe('Preview the courseware in the LMS');
                 });
 
-                it('updates when publish state changes', function () {
+                it('updates when publish state changes', function() {
                     renderContainerPage(this, mockContainerXBlockHtml);
                     fetch({published: true});
                     expect(containerPage.$(viewPublishedCss)).not.toHaveClass(disabledCss);
@@ -106,7 +106,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     expect(containerPage.$(viewPublishedCss)).toHaveClass(disabledCss);
                 });
 
-                it('updates when has_content_group_components attribute changes', function () {
+                it('updates when has_content_group_components attribute changes', function() {
                     renderContainerPage(this, mockContainerXBlockHtml);
                     fetch({has_content_group_components: false});
                     expect(containerPage.$(visibilityNoteCss).length).toBe(0);
@@ -119,22 +119,22 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                 });
             });
 
-            describe("Publisher", function () {
+            describe('Publisher', function() {
                 var headerCss = '.pub-status',
-                    bitPublishingCss = "div.bit-publishing",
-                    liveClass = "is-live",
-                    readyClass = "is-ready",
-                    staffOnlyClass = "is-staff-only",
-                    scheduledClass = "is-scheduled",
-                    unscheduledClass = "",
+                    bitPublishingCss = 'div.bit-publishing',
+                    liveClass = 'is-live',
+                    readyClass = 'is-ready',
+                    staffOnlyClass = 'is-staff-only',
+                    scheduledClass = 'is-scheduled',
+                    unscheduledClass = '',
                     hasWarningsClass = 'has-warnings',
-                    publishButtonCss = ".action-publish",
-                    discardChangesButtonCss = ".action-discard",
-                    lastDraftCss = ".wrapper-last-draft",
-                    releaseDateTitleCss = ".wrapper-release .title",
-                    releaseDateContentCss = ".wrapper-release .copy",
-                    releaseDateDateCss = ".wrapper-release .copy .release-date",
-                    releaseDateWithCss = ".wrapper-release .copy .release-with",
+                    publishButtonCss = '.action-publish',
+                    discardChangesButtonCss = '.action-discard',
+                    lastDraftCss = '.wrapper-last-draft',
+                    releaseDateTitleCss = '.wrapper-release .title',
+                    releaseDateContentCss = '.wrapper-release .copy',
+                    releaseDateDateCss = '.wrapper-release .copy .release-date',
+                    releaseDateWithCss = '.wrapper-release .copy .release-with',
                     promptSpies, sendDiscardChangesToServer, verifyPublishingBitUnscheduled;
 
                 sendDiscardChangesToServer = function() {
@@ -151,8 +151,8 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     expect(promptSpies.constructor).toHaveBeenCalled();
                     promptSpies.constructor.calls.mostRecent().args[0].actions.primary.click(promptSpies);
 
-                    AjaxHelpers.expectJsonRequest(requests, "POST", "/xblock/locator-container",
-                        {"publish": "discard_changes"}
+                    AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/locator-container',
+                        {'publish': 'discard_changes'}
                     );
                 };
 
@@ -166,11 +166,11 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                 };
 
                 beforeEach(function() {
-                    promptSpies = jasmine.stealth.spyOnConstructor(Prompt, "Warning", ["show", "hide"]);
+                    promptSpies = jasmine.stealth.spyOnConstructor(Prompt, 'Warning', ['show', 'hide']);
                     promptSpies.show.and.returnValue(this.promptSpies);
                 });
 
-                it('renders correctly with private content', function () {
+                it('renders correctly with private content', function() {
                     var verifyPrivateState = function() {
                         expect(containerPage.$(headerCss).text()).toContain('Draft (Never published)');
                         expect(containerPage.$(publishButtonCss)).not.toHaveClass(disabledCss);
@@ -187,11 +187,11 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     verifyPrivateState();
                 });
 
-                it('renders correctly with published content', function () {
+                it('renders correctly with published content', function() {
                     renderContainerPage(this, mockContainerXBlockHtml);
                     fetch({
                         published: true, has_changes: false, visibility_state: VisibilityState.ready,
-                        release_date: "Jul 02, 2030 at 14:20 UTC"
+                        release_date: 'Jul 02, 2030 at 14:20 UTC'
                     });
                     expect(containerPage.$(headerCss).text()).toContain('Published (not yet released)');
                     expect(containerPage.$(publishButtonCss)).toHaveClass(disabledCss);
@@ -201,7 +201,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
 
                     fetch({
                         published: true, has_changes: true, visibility_state: VisibilityState.needsAttention,
-                        release_date: "Jul 02, 2030 at 14:20 UTC"
+                        release_date: 'Jul 02, 2030 at 14:20 UTC'
                     });
                     expect(containerPage.$(headerCss).text()).toContain('Draft (Unpublished changes)');
                     expect(containerPage.$(publishButtonCss)).not.toHaveClass(disabledCss);
@@ -210,7 +210,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     expect(containerPage.$(bitPublishingCss)).toHaveClass(scheduledClass);
 
                     fetch({published: true, has_changes: false, visibility_state: VisibilityState.live,
-                        release_date: "Jul 02, 1990 at 14:20 UTC"
+                        release_date: 'Jul 02, 1990 at 14:20 UTC'
                     });
                     expect(containerPage.$(headerCss).text()).toContain('Published and Live');
                     expect(containerPage.$(publishButtonCss)).toHaveClass(disabledCss);
@@ -227,7 +227,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     verifyPublishingBitUnscheduled();
                 });
 
-                it('can publish private content', function () {
+                it('can publish private content', function() {
                     var notificationSpy = EditHelpers.createNotificationSpy();
                     renderContainerPage(this, mockContainerXBlockHtml);
                     expect(containerPage.$(bitPublishingCss)).not.toHaveClass(hasWarningsClass);
@@ -238,15 +238,15 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     containerPage.$(publishButtonCss).click();
                     EditHelpers.verifyNotificationShowing(notificationSpy, /Publishing/);
 
-                    AjaxHelpers.expectJsonRequest(requests, "POST", "/xblock/locator-container",
-                        {"publish": "make_public"}
+                    AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/locator-container',
+                        {'publish': 'make_public'}
                     );
 
                     // Response to publish call
-                    AjaxHelpers.respondWithJson(requests, {"id": "locator-container", "data": null, "metadata":{}});
+                    AjaxHelpers.respondWithJson(requests, {'id': 'locator-container', 'data': null, 'metadata': {}});
                     EditHelpers.verifyNotificationHidden(notificationSpy);
 
-                    AjaxHelpers.expectJsonRequest(requests, "GET", "/xblock/locator-container");
+                    AjaxHelpers.expectJsonRequest(requests, 'GET', '/xblock/locator-container');
                     // Response to fetch
                     AjaxHelpers.respondWithJson(
                         requests,
@@ -258,10 +258,10 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     // Verify updates displayed
                     expect(containerPage.$(bitPublishingCss)).toHaveClass(readyClass);
                     // Verify that the "published" value has been cleared out of the model.
-                    expect(containerPage.model.get("publish")).toBeNull();
+                    expect(containerPage.model.get('publish')).toBeNull();
                 });
 
-                it('does not refresh if publish fails', function () {
+                it('does not refresh if publish fails', function() {
                     renderContainerPage(this, mockContainerXBlockHtml);
                     verifyPublishingBitUnscheduled();
 
@@ -275,10 +275,10 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     // Verify still in draft (unscheduled) state.
                     verifyPublishingBitUnscheduled();
                     // Verify that the "published" value has been cleared out of the model.
-                    expect(containerPage.model.get("publish")).toBeNull();
+                    expect(containerPage.model.get('publish')).toBeNull();
                 });
 
-                it('can discard changes', function () {
+                it('can discard changes', function() {
                     var notificationSpy, renderPageSpy, numRequests;
                     createContainerPage(this);
                     notificationSpy = EditHelpers.createNotificationSpy();
@@ -288,17 +288,17 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     numRequests = requests.length;
 
                     // Respond with success.
-                    AjaxHelpers.respondWithJson(requests, {"id": "locator-container"});
+                    AjaxHelpers.respondWithJson(requests, {'id': 'locator-container'});
                     EditHelpers.verifyNotificationHidden(notificationSpy);
 
                     // Verify other requests are sent to the server to update page state.
                     // Response to fetch, specifying the very next request (as multiple requests will be sent to server)
                     expect(requests.length > numRequests).toBeTruthy();
-                    expect(containerPage.model.get("publish")).toBeNull();
+                    expect(containerPage.model.get('publish')).toBeNull();
                     expect(renderPageSpy).toHaveBeenCalled();
                 });
 
-                it('does not fetch if discard changes fails', function () {
+                it('does not fetch if discard changes fails', function() {
                     var renderPageSpy, numRequests;
                     createContainerPage(this);
                     renderPageSpy = spyOn(containerPage.xblockPublisher, 'renderPage').and.callThrough();
@@ -309,11 +309,11 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     AjaxHelpers.respondWithError(requests);
                     AjaxHelpers.expectNoRequests(requests);
                     expect(containerPage.$(discardChangesButtonCss)).not.toHaveClass('is-disabled');
-                    expect(containerPage.model.get("publish")).toBeNull();
+                    expect(containerPage.model.get('publish')).toBeNull();
                     expect(renderPageSpy).not.toHaveBeenCalled();
                 });
 
-                it('does not discard changes on cancel', function () {
+                it('does not discard changes on cancel', function() {
                     renderContainerPage(this, mockContainerXBlockHtml);
                     fetch({published: true, has_changes: true, visibility_state: VisibilityState.needsAttention});
 
@@ -328,67 +328,67 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     expect(containerPage.$(discardChangesButtonCss)).not.toHaveClass('is-disabled');
                 });
 
-                it('renders the last published date and user when there are no changes', function () {
+                it('renders the last published date and user when there are no changes', function() {
                     renderContainerPage(this, mockContainerXBlockHtml);
-                    fetch({published_on: "Jul 01, 2014 at 12:45 UTC", published_by: "amako"});
+                    fetch({published_on: 'Jul 01, 2014 at 12:45 UTC', published_by: 'amako'});
                     expect(containerPage.$(lastDraftCss).text()).
-                        toContain("Last published Jul 01, 2014 at 12:45 UTC by amako");
+                        toContain('Last published Jul 01, 2014 at 12:45 UTC by amako');
                 });
 
-                it('renders the last saved date and user when there are changes', function () {
+                it('renders the last saved date and user when there are changes', function() {
                     renderContainerPage(this, mockContainerXBlockHtml);
-                    fetch({has_changes: true, edited_on: "Jul 02, 2014 at 14:20 UTC", edited_by: "joe"});
+                    fetch({has_changes: true, edited_on: 'Jul 02, 2014 at 14:20 UTC', edited_by: 'joe'});
                     expect(containerPage.$(lastDraftCss).text()).
-                        toContain("Draft saved on Jul 02, 2014 at 14:20 UTC by joe");
+                        toContain('Draft saved on Jul 02, 2014 at 14:20 UTC by joe');
                 });
 
-                describe("Release Date", function() {
-                    it('renders correctly when unreleased', function () {
+                describe('Release Date', function() {
+                    it('renders correctly when unreleased', function() {
                         renderContainerPage(this, mockContainerXBlockHtml);
                         fetch({
                             visibility_state: VisibilityState.ready, released_to_students: false,
-                            release_date: "Jul 02, 2014 at 14:20 UTC", release_date_from: 'Section "Week 1"'
+                            release_date: 'Jul 02, 2014 at 14:20 UTC', release_date_from: 'Section "Week 1"'
                         });
-                        expect(containerPage.$(releaseDateTitleCss).text()).toContain("Scheduled:");
+                        expect(containerPage.$(releaseDateTitleCss).text()).toContain('Scheduled:');
                         expect(containerPage.$(releaseDateDateCss).text()).toContain('Jul 02, 2014 at 14:20 UTC');
                         expect(containerPage.$(releaseDateWithCss).text()).toContain('with Section "Week 1"');
                     });
 
-                    it('renders correctly when released', function () {
+                    it('renders correctly when released', function() {
                         renderContainerPage(this, mockContainerXBlockHtml);
                         fetch({
                             visibility_state: VisibilityState.live, released_to_students: true,
-                            release_date: "Jul 02, 2014 at 14:20 UTC", release_date_from: 'Section "Week 1"'
+                            release_date: 'Jul 02, 2014 at 14:20 UTC', release_date_from: 'Section "Week 1"'
                         });
-                        expect(containerPage.$(releaseDateTitleCss).text()).toContain("Released:");
+                        expect(containerPage.$(releaseDateTitleCss).text()).toContain('Released:');
                         expect(containerPage.$(releaseDateDateCss).text()).toContain('Jul 02, 2014 at 14:20 UTC');
                         expect(containerPage.$(releaseDateWithCss).text()).toContain('with Section "Week 1"');
                     });
 
-                    it('renders correctly when the release date is not set', function () {
+                    it('renders correctly when the release date is not set', function() {
                         renderContainerPage(this, mockContainerXBlockHtml);
                         fetch({
-                            visibility_state: VisibilityState.unscheduled, "released_to_students": false,
+                            visibility_state: VisibilityState.unscheduled, 'released_to_students': false,
                             release_date: null, release_date_from: null
                         });
-                        expect(containerPage.$(releaseDateTitleCss).text()).toContain("Release:");
-                        expect(containerPage.$(releaseDateContentCss).text()).toContain("Unscheduled");
+                        expect(containerPage.$(releaseDateTitleCss).text()).toContain('Release:');
+                        expect(containerPage.$(releaseDateContentCss).text()).toContain('Unscheduled');
                     });
 
-                    it('renders correctly when the unit is not published', function () {
+                    it('renders correctly when the unit is not published', function() {
                         renderContainerPage(this, mockContainerXBlockHtml);
                         fetch({
                             visibility_state: VisibilityState.needsAttention, released_to_students: true,
-                            release_date: "Jul 02, 2014 at 14:20 UTC", release_date_from: 'Section "Week 1"'
+                            release_date: 'Jul 02, 2014 at 14:20 UTC', release_date_from: 'Section "Week 1"'
                         });
                         containerPage.xblockPublisher.render();
-                        expect(containerPage.$(releaseDateTitleCss).text()).toContain("Release:");
+                        expect(containerPage.$(releaseDateTitleCss).text()).toContain('Release:');
                         expect(containerPage.$(releaseDateDateCss).text()).toContain('Jul 02, 2014 at 14:20 UTC');
                         expect(containerPage.$(releaseDateWithCss).text()).toContain('with Section "Week 1"');
                     });
                 });
 
-                describe("Content Visibility", function () {
+                describe('Content Visibility', function() {
                     var requestStaffOnly, verifyStaffOnly, verifyExplicitStaffOnly, verifyImplicitStaffOnly, promptSpy,
                         visibilityTitleCss = '.wrapper-visibility .title';
 
@@ -404,11 +404,11 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
 
                         AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/locator-container', {
                             publish: 'republish',
-                            metadata: { visible_to_staff_only: isStaffOnly ? true : null }
+                            metadata: {visible_to_staff_only: isStaffOnly ? true : null}
                         });
                         AjaxHelpers.respondWithJson(requests, {
                             data: null,
-                            id: "locator-container",
+                            id: 'locator-container',
                             metadata: {
                                 visible_to_staff_only: isStaffOnly ? true : null
                             }
@@ -424,7 +424,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                             published: containerPage.model.get('published'),
                             has_explicit_staff_lock: isStaffOnly,
                             visibility_state: newVisibilityState,
-                            release_date: "Jul 02, 2000 at 14:20 UTC"
+                            release_date: 'Jul 02, 2000 at 14:20 UTC'
                         }));
                     };
 
@@ -457,7 +457,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         }
                     };
 
-                    it("is initially shown to all", function() {
+                    it('is initially shown to all', function() {
                         renderContainerPage(this, mockContainerXBlockHtml);
                         verifyStaffOnly(false);
                     });
@@ -480,7 +480,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         expect(containerPage.$(visibilityTitleCss).text()).toContain('Will Be Visible To');
                     });
 
-                    it("can be explicitly set to staff only", function() {
+                    it('can be explicitly set to staff only', function() {
                         renderContainerPage(this, mockContainerXBlockHtml);
                         requestStaffOnly(true);
                         verifyExplicitStaffOnly(true);
@@ -488,22 +488,22 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         verifyStaffOnly(true);
                     });
 
-                    it("can be implicitly set to staff only", function() {
+                    it('can be implicitly set to staff only', function() {
                         renderContainerPage(this, mockContainerXBlockHtml, {
                             visibility_state: VisibilityState.staffOnly,
                             ancestor_has_staff_lock: true,
-                            staff_lock_from: "Section Foo"
+                            staff_lock_from: 'Section Foo'
                         });
                         verifyImplicitStaffOnly(true);
                         verifyExplicitStaffOnly(false);
                         verifyStaffOnly(true);
                     });
 
-                    it("can be explicitly and implicitly set to staff only", function() {
+                    it('can be explicitly and implicitly set to staff only', function() {
                         renderContainerPage(this, mockContainerXBlockHtml, {
                             visibility_state: VisibilityState.staffOnly,
                             ancestor_has_staff_lock: true,
-                            staff_lock_from: "Section Foo"
+                            staff_lock_from: 'Section Foo'
                         });
                         requestStaffOnly(true);
                         // explicit staff lock overrides the display of implicit staff lock
@@ -512,7 +512,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         verifyStaffOnly(true);
                     });
 
-                    it("can remove explicit staff only setting without having implicit staff only", function() {
+                    it('can remove explicit staff only setting without having implicit staff only', function() {
                         promptSpy = EditHelpers.createPromptSpy();
                         renderContainerPage(this, mockContainerXBlockHtml, {
                             visibility_state: VisibilityState.staffOnly,
@@ -523,13 +523,13 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         verifyStaffOnly(false);
                     });
 
-                    it("can remove explicit staff only setting while having implicit staff only", function() {
+                    it('can remove explicit staff only setting while having implicit staff only', function() {
                         promptSpy = EditHelpers.createPromptSpy();
                         renderContainerPage(this, mockContainerXBlockHtml, {
                             visibility_state: VisibilityState.staffOnly,
                             ancestor_has_staff_lock: true,
                             has_explicit_staff_lock: true,
-                            staff_lock_from: "Section Foo"
+                            staff_lock_from: 'Section Foo'
                         });
                         requestStaffOnly(false);
                         verifyExplicitStaffOnly(false);
@@ -537,7 +537,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         verifyStaffOnly(true);
                     });
 
-                    it("does not refresh if removing staff only is canceled", function() {
+                    it('does not refresh if removing staff only is canceled', function() {
                         promptSpy = EditHelpers.createPromptSpy();
                         renderContainerPage(this, mockContainerXBlockHtml, {
                             visibility_state: VisibilityState.staffOnly,
@@ -551,7 +551,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                         verifyStaffOnly(true);
                     });
 
-                    it("does not refresh when failing to set staff only", function() {
+                    it('does not refresh when failing to set staff only', function() {
                         renderContainerPage(this, mockContainerXBlockHtml);
                         containerPage.$('.action-staff-lock').click();
                         AjaxHelpers.respondWithError(requests);
@@ -561,35 +561,35 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                 });
             });
 
-            describe("PublishHistory", function () {
-                var lastPublishCss = ".wrapper-last-publish";
+            describe('PublishHistory', function() {
+                var lastPublishCss = '.wrapper-last-publish';
 
-                it('renders never published when the block is unpublished', function () {
+                it('renders never published when the block is unpublished', function() {
                     renderContainerPage(this, mockContainerXBlockHtml, {
                         published: false, published_on: null, published_by: null
                     });
-                    expect(containerPage.$(lastPublishCss).text()).toContain("Never published");
+                    expect(containerPage.$(lastPublishCss).text()).toContain('Never published');
                 });
 
                 it('renders the last published date and user when the block is published', function() {
                     renderContainerPage(this, mockContainerXBlockHtml);
                     fetch({
-                        published: true, published_on: "Jul 01, 2014 at 12:45 UTC", published_by: "amako"
+                        published: true, published_on: 'Jul 01, 2014 at 12:45 UTC', published_by: 'amako'
                     });
                     expect(containerPage.$(lastPublishCss).text()).
-                        toContain("Last published Jul 01, 2014 at 12:45 UTC by amako");
+                        toContain('Last published Jul 01, 2014 at 12:45 UTC by amako');
                 });
 
-                it('renders correctly when the block is published without publish info', function () {
+                it('renders correctly when the block is published without publish info', function() {
                     renderContainerPage(this, mockContainerXBlockHtml);
                     fetch({
                         published: true, published_on: null, published_by: null
                     });
-                    expect(containerPage.$(lastPublishCss).text()).toContain("Previously published");
+                    expect(containerPage.$(lastPublishCss).text()).toContain('Previously published');
                 });
             });
 
-            describe("Message Area", function() {
+            describe('Message Area', function() {
                 var messageSelector = '.container-message .warning',
                     warningMessage = 'Caution: The last published version of this unit is live. ' +
                         'By publishing changes you will change the student experience.';
@@ -612,7 +612,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     renderContainerPage(this, mockContainerXBlockHtml, {
                         currently_visible_to_students: true
                     });
-                    fetch({ currently_visible_to_students: false });
+                    fetch({currently_visible_to_students: false});
                     expect(containerPage.$(messageSelector).text().trim()).toBe('');
                 });
 
@@ -620,7 +620,7 @@ define(["jquery", "underscore", "underscore.string", "edx-ui-toolkit/js/utils/sp
                     renderContainerPage(this, mockContainerXBlockHtml, {
                         currently_visible_to_students: false
                     });
-                    fetch({ currently_visible_to_students: true });
+                    fetch({currently_visible_to_students: true});
                     expect(containerPage.$(messageSelector).text().trim()).toBe(warningMessage);
                 });
             });

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -1,10 +1,9 @@
-define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/js/components/utils/view_utils",
-        "js/views/pages/course_outline", "js/models/xblock_outline_info", "js/utils/date_utils",
-        "js/spec_helpers/edit_helpers", "common/js/spec_helpers/template_helpers", 'js/models/course'],
+define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/js/components/utils/view_utils',
+        'js/views/pages/course_outline', 'js/models/xblock_outline_info', 'js/utils/date_utils',
+        'js/spec_helpers/edit_helpers', 'common/js/spec_helpers/template_helpers', 'js/models/course'],
     function($, AjaxHelpers, ViewUtils, CourseOutlinePage, XBlockOutlineInfo, DateUtils,
              EditHelpers, TemplateHelpers, Course) {
-
-        describe("CourseOutlinePage", function() {
+        describe('CourseOutlinePage', function() {
             var createCourseOutlinePage, displayNameInput, model, outlinePage, requests,
                 getItemsOfType, getItemHeaders, verifyItemsExpanded, expandItemsAndVerifyState,
                 collapseItemsAndVerifyState, selectBasicSettings, selectAdvancedSettings, createMockCourseJSON,
@@ -66,7 +65,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     published: true,
                     edited_on: 'Jul 02, 2014 at 20:56 UTC',
                     edited_by: 'MockUser',
-                    course_graders: ["Lab", "Howework"],
+                    course_graders: ['Lab', 'Howework'],
                     has_explicit_staff_lock: false,
                     is_prereq: false,
                     prereqs: [],
@@ -96,16 +95,16 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
             };
 
             createMockIndexJSON = function(option) {
-                if(option){
+                if (option) {
                     return JSON.stringify({
-                        "developer_message" : "Course has been successfully reindexed.",
-                        "user_message": "Course has been successfully reindexed."
+                        'developer_message': 'Course has been successfully reindexed.',
+                        'user_message': 'Course has been successfully reindexed.'
                     });
                 }
                 else {
                     return JSON.stringify({
-                        "developer_message" : "Could not reindex course.",
-                        "user_message": "Could not reindex course."
+                        'developer_message': 'Could not reindex course.',
+                        'user_message': 'Could not reindex course.'
                     });
                 }
             };
@@ -138,16 +137,16 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
             };
 
             selectBasicSettings = function() {
-               this.$(".modal-section .settings-tab-button[data-tab='basic']").click();
+                this.$(".modal-section .settings-tab-button[data-tab='basic']").click();
             };
 
             selectAdvancedSettings = function() {
-               this.$(".modal-section .settings-tab-button[data-tab='advanced']").click();
+                this.$(".modal-section .settings-tab-button[data-tab='advanced']").click();
             };
 
             createCourseOutlinePage = function(test, courseJSON, createOnly) {
                 requests = AjaxHelpers.requests(test);
-                model = new XBlockOutlineInfo(courseJSON, { parse: true });
+                model = new XBlockOutlineInfo(courseJSON, {parse: true});
                 outlinePage = new CourseOutlinePage({
                     model: model,
                     el: $('#content')
@@ -158,17 +157,17 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 return outlinePage;
             };
 
-            verifyTypePublishable = function (type, getMockCourseJSON) {
+            verifyTypePublishable = function(type, getMockCourseJSON) {
                 var createCourseOutlinePageAndShowUnit, verifyPublishButton;
 
-                createCourseOutlinePageAndShowUnit = function (test, courseJSON, createOnly) {
+                createCourseOutlinePageAndShowUnit = function(test, courseJSON, createOnly) {
                     outlinePage = createCourseOutlinePage.apply(this, arguments);
                     if (type === 'unit') {
                         expandItemsAndVerifyState('subsection');
                     }
                 };
 
-                verifyPublishButton = function (test, courseJSON, createOnly) {
+                verifyPublishButton = function(test, courseJSON, createOnly) {
                     createCourseOutlinePageAndShowUnit.apply(this, arguments);
                     expect(getItemHeaders(type).find('.publish-button')).toExist();
                 };
@@ -179,9 +178,9 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     });
                     createCourseOutlinePageAndShowUnit(this, mockCourseJSON);
                     getItemHeaders(type).find('.publish-button').click();
-                    $(".wrapper-modal-window .action-publish").click();
+                    $('.wrapper-modal-window .action-publish').click();
                     AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/mock-' + type, {
-                        publish : 'make_public'
+                        publish: 'make_public'
                     });
                     expect(requests[0].requestHeaders['X-HTTP-Method-Override']).toBe('PATCH');
                     AjaxHelpers.respondWithJson(requests, {});
@@ -222,7 +221,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 });
             };
 
-            beforeEach(function () {
+            beforeEach(function() {
                 window.course = new Course({
                     id: '5',
                     name: 'Course Name',
@@ -238,7 +237,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     'course-outline', 'xblock-string-field-editor', 'modal-button',
                     'basic-modal', 'course-outline-modal', 'release-date-editor',
                     'due-date-editor', 'grading-editor', 'publish-editor',
-                    'staff-lock-editor','content-visibility-editor', 'settings-modal-tabs',
+                    'staff-lock-editor', 'content-visibility-editor', 'settings-modal-tabs',
                     'timed-examination-preference-editor', 'access-editor'
                 ]);
                 appendSetFixtures(mockOutlinePage);
@@ -270,15 +269,14 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     num: 'course_num',
                     revision: 'course_rev'
                 });
-
             });
 
-            afterEach(function () {
+            afterEach(function() {
                 EditHelpers.removeMockAnalytics();
                 EditHelpers.cancelModalIfShowing();
                 // Clean up after the $.datepicker
-                $("#start_date").datepicker( "destroy" );
-                $("#due_date").datepicker( "destroy" );
+                $('#start_date').datepicker('destroy');
+                $('#due_date').datepicker('destroy');
                 $('.ui-datepicker').remove();
                 delete window.course;
             });
@@ -310,8 +308,8 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 });
             });
 
-            describe("Rerun notification", function () {
-                it("can be dismissed", function () {
+            describe('Rerun notification', function() {
+                it('can be dismissed', function() {
                     appendSetFixtures(mockRerunNotification);
                     createCourseOutlinePage(this, mockEmptyCourseJSON);
                     expect($('.wrapper-alert-announcement')).not.toHaveClass('is-hidden');
@@ -322,7 +320,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 });
             });
 
-            describe("Button bar", function() {
+            describe('Button bar', function() {
                 it('can add a section', function() {
                     createCourseOutlinePage(this, mockEmptyCourseJSON);
                     outlinePage.$('.nav-actions .button-new').click();
@@ -332,8 +330,8 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                         'parent_locator': 'mock-course'
                     });
                     AjaxHelpers.respondWithJson(requests, {
-                        "locator": 'mock-section',
-                        "courseKey": 'slashes:MockCourse'
+                        'locator': 'mock-section',
+                        'courseKey': 'slashes:MockCourse'
                     });
                     AjaxHelpers.expectJsonRequest(requests, 'GET', '/xblock/outline/mock-course');
                     AjaxHelpers.respondWithJson(requests, mockSingleSectionCourseJSON);
@@ -351,8 +349,8 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                         'parent_locator': 'mock-course'
                     });
                     AjaxHelpers.respondWithJson(requests, {
-                        "locator": 'mock-section-2',
-                        "courseKey": 'slashes:MockCourse'
+                        'locator': 'mock-section-2',
+                        'courseKey': 'slashes:MockCourse'
                     });
                     // Expect the UI to just fetch the new section and repaint it
                     AjaxHelpers.expectJsonRequest(requests, 'GET', '/xblock/outline/mock-section-2');
@@ -379,7 +377,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     var successSpy = spyOn(outlinePage, 'onIndexSuccess').and.callThrough();
                     var reindexButton = outlinePage.$('.button.button-reindex');
                     var test_url = '/course/5/search_reindex';
-                    reindexButton.attr('href', test_url)
+                    reindexButton.attr('href', test_url);
                     reindexButton.trigger('click');
                     AjaxHelpers.expectJsonRequest(requests, 'GET', test_url);
                     AjaxHelpers.respondWithJson(requests, createMockIndexJSON(true));
@@ -402,7 +400,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 });
             });
 
-            describe("Empty course", function() {
+            describe('Empty course', function() {
                 it('shows an empty course message initially', function() {
                     createCourseOutlinePage(this, mockEmptyCourseJSON);
                     expect(outlinePage.$('.no-content')).not.toHaveClass('is-hidden');
@@ -418,8 +416,8 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                         'parent_locator': 'mock-course'
                     });
                     AjaxHelpers.respondWithJson(requests, {
-                        "locator": "mock-section",
-                        "courseKey": "slashes:MockCourse"
+                        'locator': 'mock-section',
+                        'courseKey': 'slashes:MockCourse'
                     });
                     AjaxHelpers.expectJsonRequest(requests, 'GET', '/xblock/outline/mock-course');
                     AjaxHelpers.respondWithJson(requests, mockSingleSectionCourseJSON);
@@ -443,7 +441,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 });
             });
 
-            describe("Section", function() {
+            describe('Section', function() {
                 var getDisplayNameWrapper;
 
                 getDisplayNameWrapper = function() {
@@ -499,13 +497,12 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                         'parent_locator': 'mock-section'
                     });
                     AjaxHelpers.respondWithJson(requests, {
-                        "locator": "new-mock-subsection",
-                        "courseKey": "slashes:MockCourse"
+                        'locator': 'new-mock-subsection',
+                        'courseKey': 'slashes:MockCourse'
                     });
                     // Note: verification of the server response and the UI's handling of it
                     // is handled in the acceptance tests.
                     AjaxHelpers.expectJsonRequest(requests, 'GET', '/xblock/outline/mock-section');
-
                 });
 
                 it('can be renamed inline', function() {
@@ -519,7 +516,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     // This is the response for the change operation.
                     AjaxHelpers.respondWithJson(requests, { });
                     // This is the response for the subsequent fetch operation.
-                    AjaxHelpers.respondWithJson(requests, {"display_name":  updatedDisplayName});
+                    AjaxHelpers.respondWithJson(requests, {'display_name': updatedDisplayName});
                     EditHelpers.verifyInlineEditChange(displayNameWrapper, updatedDisplayName);
                     sectionModel = outlinePage.model.get('child_info').children[0];
                     expect(sectionModel.get('display_name')).toBe(updatedDisplayName);
@@ -535,22 +532,22 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 it('can be edited', function() {
                     createCourseOutlinePage(this, mockCourseJSON, false);
                     outlinePage.$('.section-header-actions .configure-button').click();
-                    $("#start_date").val("1/2/2015");
+                    $('#start_date').val('1/2/2015');
                     // Section release date can't be cleared.
-                    expect($(".wrapper-modal-window .action-clear")).not.toExist();
+                    expect($('.wrapper-modal-window .action-clear')).not.toExist();
 
                     // Section does not contain due_date or grading type selector
-                    expect($("due_date")).not.toExist();
-                    expect($("grading_format")).not.toExist();
+                    expect($('due_date')).not.toExist();
+                    expect($('grading_format')).not.toExist();
 
                     // Staff lock controls are always visible on the advanced tab
                     selectAdvancedSettings();
-                    expect($("#staff_lock")).toExist();
+                    expect($('#staff_lock')).toExist();
                     selectBasicSettings();
-                    $(".wrapper-modal-window .action-save").click();
+                    $('.wrapper-modal-window .action-save').click();
                     AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/mock-section', {
-                        "metadata":{
-                            "start":"2015-01-02T00:00:00.000Z"
+                        'metadata': {
+                            'start': '2015-01-02T00:00:00.000Z'
                         }
                     });
                     expect(requests[0].requestHeaders['X-HTTP-Method-Override']).toBe('PATCH');
@@ -558,22 +555,22 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     // This is the response for the change operation.
                     AjaxHelpers.respondWithJson(requests, {});
                     var mockResponseSectionJSON = createMockSectionJSON({
-                            release_date: 'Jan 02, 2015 at 00:00 UTC'
-                        }, [
-                            createMockSubsectionJSON({}, [
-                                createMockVerticalJSON({
-                                    has_changes: true,
-                                    published: false
-                                })
-                            ])
-                        ]);
+                        release_date: 'Jan 02, 2015 at 00:00 UTC'
+                    }, [
+                        createMockSubsectionJSON({}, [
+                            createMockVerticalJSON({
+                                has_changes: true,
+                                published: false
+                            })
+                        ])
+                    ]);
                     AjaxHelpers.expectJsonRequest(requests, 'GET', '/xblock/outline/mock-section');
                     AjaxHelpers.respondWithJson(requests, mockResponseSectionJSON);
                     AjaxHelpers.expectNoRequests(requests);
-                    expect($(".outline-section .status-release-value")).toContainText("Jan 02, 2015 at 00:00 UTC");
+                    expect($('.outline-section .status-release-value')).toContainText('Jan 02, 2015 at 00:00 UTC');
                 });
 
-                verifyTypePublishable('section', function (options) {
+                verifyTypePublishable('section', function(options) {
                     return createMockCourseJSON({}, [
                         createMockSectionJSON(options, [
                             createMockSubsectionJSON({}, [
@@ -583,7 +580,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     ]);
                 });
 
-                it('can display a publish modal with a list of unpublished subsections and units', function () {
+                it('can display a publish modal with a list of unpublished subsections and units', function() {
                     var mockCourseJSON = createMockCourseJSON({}, [
                             createMockSectionJSON({has_changes: true}, [
                                 createMockSubsectionJSON({has_changes: true}, [
@@ -607,15 +604,15 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     getItemHeaders('section').first().find('.publish-button').click();
                     modalWindow = $('.wrapper-modal-window');
                     expect(modalWindow.find('.outline-unit').length).toBe(3);
-                    expect(_.compact(_.map(modalWindow.find('.outline-unit').text().split("\n"), $.trim))).toEqual(
+                    expect(_.compact(_.map(modalWindow.find('.outline-unit').text().split('\n'), $.trim))).toEqual(
                         ['Unit 100', 'Unit 50', 'Unit 1']
                     );
                     expect(modalWindow.find('.outline-subsection').length).toBe(2);
                 });
             });
 
-            describe("Subsection", function() {
-                var getDisplayNameWrapper, setEditModalValues, setContentVisibility,  mockServerValuesJson,
+            describe('Subsection', function() {
+                var getDisplayNameWrapper, setEditModalValues, setContentVisibility, mockServerValuesJson,
                     selectDisableSpecialExams, selectTimedExam, selectProctoredExam, selectPracticeExam,
                     selectPrerequisite, selectLastPrerequisiteSubsection, checkOptionFieldVisibility;
 
@@ -623,46 +620,46 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     return getItemHeaders('subsection').find('.wrapper-xblock-field');
                 };
 
-                setEditModalValues = function (start_date, due_date, grading_type) {
-                    $("#start_date").val(start_date);
-                    $("#due_date").val(due_date);
-                    $("#grading_type").val(grading_type);
+                setEditModalValues = function(start_date, due_date, grading_type) {
+                    $('#start_date').val(start_date);
+                    $('#due_date').val(due_date);
+                    $('#grading_type').val(grading_type);
                 };
 
-                setContentVisibility = function (visibility) {
-                    $('input[name=content-visibility][value='+visibility+']').prop('checked', true);
+                setContentVisibility = function(visibility) {
+                    $('input[name=content-visibility][value=' + visibility + ']').prop('checked', true);
                 };
 
                 selectDisableSpecialExams = function() {
-                    this.$("input.no_special_exam").prop('checked', true).trigger('change');
+                    this.$('input.no_special_exam').prop('checked', true).trigger('change');
                 };
 
                 selectTimedExam = function(time_limit) {
-                    this.$("input.timed_exam").prop('checked', true).trigger('change');
-                    this.$(".field-time-limit input").val(time_limit);
-                    this.$(".field-time-limit input").trigger('focusout');
-                    setContentVisibility("hide_after_due");
+                    this.$('input.timed_exam').prop('checked', true).trigger('change');
+                    this.$('.field-time-limit input').val(time_limit);
+                    this.$('.field-time-limit input').trigger('focusout');
+                    setContentVisibility('hide_after_due');
                 };
 
                 selectProctoredExam = function(time_limit) {
-                    this.$("input.proctored_exam").prop('checked', true).trigger('change');
-                    this.$(".field-time-limit input").val(time_limit);
-                    this.$(".field-time-limit input").trigger('focusout');
+                    this.$('input.proctored_exam').prop('checked', true).trigger('change');
+                    this.$('.field-time-limit input').val(time_limit);
+                    this.$('.field-time-limit input').trigger('focusout');
                 };
 
                 selectPracticeExam = function(time_limit) {
-                    this.$("input.practice_exam").prop('checked', true).trigger('change');
-                    this.$(".field-time-limit input").val(time_limit);
-                    this.$(".field-time-limit input").trigger('focusout');
+                    this.$('input.practice_exam').prop('checked', true).trigger('change');
+                    this.$('.field-time-limit input').val(time_limit);
+                    this.$('.field-time-limit input').trigger('focusout');
                 };
 
                 selectPrerequisite = function() {
-                    this.$("#is_prereq").prop('checked', true).trigger('change');
+                    this.$('#is_prereq').prop('checked', true).trigger('change');
                 };
 
                 selectLastPrerequisiteSubsection = function(minScore) {
-                    this.$("#prereq option:last").prop('selected', true).trigger('change');
-                    this.$("#prereq_min_score").val(minScore).trigger('keyup');
+                    this.$('#prereq option:last').prop('selected', true).trigger('change');
+                    this.$('#prereq_min_score').val(minScore).trigger('keyup');
                 };
 
                 // Helper to validate oft-checked additional option fields' visibility
@@ -673,30 +670,30 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
 
                 // Contains hard-coded dates because dates are presented in different formats.
                 mockServerValuesJson = createMockSectionJSON({
-                        release_date: 'Jan 01, 2970 at 05:00 UTC'
+                    release_date: 'Jan 01, 2970 at 05:00 UTC'
+                }, [
+                    createMockSubsectionJSON({
+                        graded: true,
+                        due_date: 'Jul 10, 2014 at 00:00 UTC',
+                        release_date: 'Jul 09, 2014 at 00:00 UTC',
+                        start: '2014-07-09T00:00:00Z',
+                        format: 'Lab',
+                        due: '2014-07-10T00:00:00Z',
+                        has_explicit_staff_lock: true,
+                        staff_only_message: true,
+                        is_prereq: false,
+                        'is_time_limited': true,
+                        'is_practice_exam': false,
+                        'is_proctored_exam': false,
+                        'default_time_limit_minutes': 150,
+                        'hide_after_due': true
                     }, [
-                        createMockSubsectionJSON({
-                            graded: true,
-                            due_date: 'Jul 10, 2014 at 00:00 UTC',
-                            release_date: 'Jul 09, 2014 at 00:00 UTC',
-                            start: "2014-07-09T00:00:00Z",
-                            format: "Lab",
-                            due: "2014-07-10T00:00:00Z",
-                            has_explicit_staff_lock: true,
-                            staff_only_message: true,
-                            is_prereq: false,
-                            "is_time_limited": true,
-                            "is_practice_exam": false,
-                            "is_proctored_exam": false,
-                            "default_time_limit_minutes": 150,
-                            "hide_after_due": true,
-                        }, [
-                            createMockVerticalJSON({
-                                has_changes: true,
-                                published: false
-                            })
-                        ])
-                    ]);
+                        createMockVerticalJSON({
+                            has_changes: true,
+                            published: false
+                        })
+                    ])
+                ]);
 
                 it('can be deleted', function() {
                     var promptSpy = EditHelpers.createPromptSpy();
@@ -721,8 +718,8 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                         'parent_locator': 'mock-subsection'
                     });
                     AjaxHelpers.respondWithJson(requests, {
-                        "locator": "new-mock-unit",
-                        "courseKey": "slashes:MockCourse"
+                        'locator': 'new-mock-unit',
+                        'courseKey': 'slashes:MockCourse'
                     });
                     expect(redirectSpy).toHaveBeenCalledWith('/container/new-mock-unit?action=new');
                 });
@@ -791,7 +788,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     ]);
                     createCourseOutlinePage(this, mockCourseJSON, false);
                     outlinePage.$('.outline-unit .configure-button').click();
-                    expect($(".settings-tabs-header").length).toBe(0);
+                    expect($('.settings-tabs-header').length).toBe(0);
                 });
 
                 it('can show correct editors for self_paced course', function() {
@@ -804,10 +801,10 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     /* global course */
                     course.set('self_paced', true);
                     outlinePage.$('.outline-subsection .configure-button').click();
-                    expect($(".edit-settings-release").length).toBe(0);
-                    expect($(".grading-due-date").length).toBe(0);
-                    expect($(".edit-settings-grading").length).toBe(1);
-                    expect($(".edit-content-visibility").length).toBe(1);
+                    expect($('.edit-settings-release').length).toBe(0);
+                    expect($('.grading-due-date').length).toBe(0);
+                    expect($('.edit-settings-grading').length).toBe(1);
+                    expect($('.edit-content-visibility').length).toBe(1);
                 });
 
                 it('can select valid time', function() {
@@ -815,45 +812,45 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     outlinePage.$('.outline-subsection .configure-button').click();
                     selectAdvancedSettings();
 
-                    var default_time = "00:30";
-                    var valid_times = ["00:30", "23:00", "24:00", "99:00"];
-                    var invalid_times = ["00:00", "100:00", "01:60"];
+                    var default_time = '00:30';
+                    var valid_times = ['00:30', '23:00', '24:00', '99:00'];
+                    var invalid_times = ['00:00', '100:00', '01:60'];
                     var time_limit, i;
 
-                    for (i = 0; i < valid_times.length; i++){
+                    for (i = 0; i < valid_times.length; i++) {
                         time_limit = valid_times[i];
                         selectTimedExam(time_limit);
-                        expect($(".field-time-limit input").val()).toEqual(time_limit);
+                        expect($('.field-time-limit input').val()).toEqual(time_limit);
                     }
-                    for (i = 0; i < invalid_times.length; i++){
+                    for (i = 0; i < invalid_times.length; i++) {
                         time_limit = invalid_times[i];
                         selectTimedExam(time_limit);
-                        expect($(".field-time-limit input").val()).not.toEqual(time_limit);
-                        expect($(".field-time-limit input").val()).toEqual(default_time);
+                        expect($('.field-time-limit input').val()).not.toEqual(time_limit);
+                        expect($('.field-time-limit input').val()).toEqual(default_time);
                     }
                 });
 
                 it('can be edited', function() {
                     createCourseOutlinePage(this, mockCourseJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
-                    setEditModalValues("7/9/2014", "7/10/2014", "Lab");
+                    setEditModalValues('7/9/2014', '7/10/2014', 'Lab');
                     selectAdvancedSettings();
-                    selectTimedExam("02:30");
-                    $(".wrapper-modal-window .action-save").click();
+                    selectTimedExam('02:30');
+                    $('.wrapper-modal-window .action-save').click();
                     AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/mock-subsection', {
-                        "graderType":"Lab",
-                        "publish": "republish",
-                        "isPrereq": false,
-                        "metadata":{
-                            "visible_to_staff_only": null,
-                            "start":"2014-07-09T00:00:00.000Z",
-                            "due":"2014-07-10T00:00:00.000Z",
-                            "exam_review_rules": "",
-                            "is_time_limited": true,
-                            "is_practice_exam": false,
-                            "is_proctored_enabled": false,
-                            "default_time_limit_minutes": 150,
-                            "hide_after_due": true,
+                        'graderType': 'Lab',
+                        'publish': 'republish',
+                        'isPrereq': false,
+                        'metadata': {
+                            'visible_to_staff_only': null,
+                            'start': '2014-07-09T00:00:00.000Z',
+                            'due': '2014-07-10T00:00:00.000Z',
+                            'exam_review_rules': '',
+                            'is_time_limited': true,
+                            'is_practice_exam': false,
+                            'is_proctored_enabled': false,
+                            'default_time_limit_minutes': 150,
+                            'hide_after_due': true
                         }
                     });
                     expect(requests[0].requestHeaders['X-HTTP-Method-Override']).toBe('PATCH');
@@ -863,39 +860,39 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     AjaxHelpers.respondWithJson(requests, mockServerValuesJson);
                     AjaxHelpers.expectNoRequests(requests);
 
-                    expect($(".outline-subsection .status-release-value")).toContainText(
-                        "Jul 09, 2014 at 00:00 UTC"
+                    expect($('.outline-subsection .status-release-value')).toContainText(
+                        'Jul 09, 2014 at 00:00 UTC'
                     );
-                    expect($(".outline-subsection .status-grading-date")).toContainText(
-                        "Due: Jul 10, 2014 at 00:00 UTC"
+                    expect($('.outline-subsection .status-grading-date')).toContainText(
+                        'Due: Jul 10, 2014 at 00:00 UTC'
                     );
-                    expect($(".outline-subsection .status-grading-value")).toContainText(
-                        "Lab"
+                    expect($('.outline-subsection .status-grading-value')).toContainText(
+                        'Lab'
                     );
-                    expect($(".outline-subsection .status-message-copy")).toContainText(
-                        "Contains staff only content"
+                    expect($('.outline-subsection .status-message-copy')).toContainText(
+                        'Contains staff only content'
                     );
 
-                    expect($(".outline-item .outline-subsection .status-grading-value")).toContainText("Lab");
+                    expect($('.outline-item .outline-subsection .status-grading-value')).toContainText('Lab');
                     outlinePage.$('.outline-item .outline-subsection .configure-button').click();
-                    expect($("#start_date").val()).toBe('7/9/2014');
-                    expect($("#due_date").val()).toBe('7/10/2014');
-                    expect($("#grading_type").val()).toBe('Lab');
-                    expect($("input[name=content-visibility][value=staff_only]").is(":checked")).toBe(true);
-                    expect($("input.timed_exam").is(":checked")).toBe(true);
-                    expect($("input.proctored_exam").is(":checked")).toBe(false);
-                    expect($("input.no_special_exam").is(":checked")).toBe(false);
-                    expect($("input.practice_exam").is(":checked")).toBe(false);
-                    expect($(".field-time-limit input").val()).toBe("02:30");
+                    expect($('#start_date').val()).toBe('7/9/2014');
+                    expect($('#due_date').val()).toBe('7/10/2014');
+                    expect($('#grading_type').val()).toBe('Lab');
+                    expect($('input[name=content-visibility][value=staff_only]').is(':checked')).toBe(true);
+                    expect($('input.timed_exam').is(':checked')).toBe(true);
+                    expect($('input.proctored_exam').is(':checked')).toBe(false);
+                    expect($('input.no_special_exam').is(':checked')).toBe(false);
+                    expect($('input.practice_exam').is(':checked')).toBe(false);
+                    expect($('.field-time-limit input').val()).toBe('02:30');
                 });
 
                 it('can hide time limit and hide after due fields when the None radio box is selected', function() {
                     createCourseOutlinePage(this, mockCourseJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
-                    setEditModalValues("7/9/2014", "7/10/2014", "Lab");
+                    setEditModalValues('7/9/2014', '7/10/2014', 'Lab');
                     selectAdvancedSettings();
                     selectDisableSpecialExams();
-                    setContentVisibility("staff_only");
+                    setContentVisibility('staff_only');
 
                     // all additional options should be hidden
                     expect($('.exam-options').is(':hidden')).toBe(true);
@@ -904,228 +901,226 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 it('can select the practice exam', function() {
                     createCourseOutlinePage(this, mockCourseJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
-                    setEditModalValues("7/9/2014", "7/10/2014", "Lab");
+                    setEditModalValues('7/9/2014', '7/10/2014', 'Lab');
                     selectAdvancedSettings();
-                    selectPracticeExam("00:30");
-                    setContentVisibility("staff_only");
+                    selectPracticeExam('00:30');
+                    setContentVisibility('staff_only');
 
                     // time limit should be visible, review rules should be hidden
                     checkOptionFieldVisibility(true, false);
-                    
-                    $(".wrapper-modal-window .action-save").click();
+
+                    $('.wrapper-modal-window .action-save').click();
                 });
 
                 it('can select the timed exam', function() {
                     createCourseOutlinePage(this, mockCourseJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
-                    setEditModalValues("7/9/2014", "7/10/2014", "Lab");
+                    setEditModalValues('7/9/2014', '7/10/2014', 'Lab');
                     selectAdvancedSettings();
-                    selectTimedExam("00:30");
-                    
+                    selectTimedExam('00:30');
+
                     // time limit should be visible, review rules should be hidden
                     checkOptionFieldVisibility(true, false);
-                
-                    $(".wrapper-modal-window .action-save").click();
+
+                    $('.wrapper-modal-window .action-save').click();
                 });
 
                 it('can select the Proctored exam option', function() {
                     createCourseOutlinePage(this, mockCourseJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
-                    setEditModalValues("7/9/2014", "7/10/2014", "Lab");
+                    setEditModalValues('7/9/2014', '7/10/2014', 'Lab');
                     selectAdvancedSettings();
-                    selectProctoredExam("00:30");
-                    setContentVisibility("staff_only");
-                    
+                    selectProctoredExam('00:30');
+                    setContentVisibility('staff_only');
+
                     // time limit and review rules should be visible
                     checkOptionFieldVisibility(true, true);
 
-                    $(".wrapper-modal-window .action-save").click();
-
+                    $('.wrapper-modal-window .action-save').click();
                 });
 
                 it('entering invalid time format uses default value of 30 minutes.', function() {
                     createCourseOutlinePage(this, mockCourseJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
-                    setEditModalValues("7/9/2014", "7/10/2014", "Lab");
+                    setEditModalValues('7/9/2014', '7/10/2014', 'Lab');
                     selectAdvancedSettings();
-                    selectProctoredExam("abcd");
-                    setContentVisibility("staff_only");
+                    selectProctoredExam('abcd');
+                    setContentVisibility('staff_only');
 
                     // time limit field should be visible and have the correct value
                     expect($('.field-time-limit').is(':visible')).toBe(true);
-                    expect($('.field-time-limit input').val()).toEqual("00:30");
-
+                    expect($('.field-time-limit input').val()).toEqual('00:30');
                 });
 
                 it('can show a saved non-special exam correctly', function() {
                     var mockCourseWithSpecialExamJSON = createMockCourseJSON({}, [
-                            createMockSectionJSON({
-                                has_changes: true,
-                                enable_proctored_exams: true,
-                                enable_timed_exams: true
+                        createMockSectionJSON({
+                            has_changes: true,
+                            enable_proctored_exams: true,
+                            enable_timed_exams: true
 
+                        }, [
+                            createMockSubsectionJSON({
+                                has_changes: true,
+                                'is_time_limited': false,
+                                'is_practice_exam': false,
+                                'is_proctored_exam': false,
+                                'default_time_limit_minutes': 150,
+                                'hide_after_due': false
                             }, [
-                                createMockSubsectionJSON({
-                                    has_changes: true,
-                                    "is_time_limited": false,
-                                    "is_practice_exam": false,
-                                    "is_proctored_exam": false,
-                                    "default_time_limit_minutes": 150,
-                                    "hide_after_due": false,
-                                }, [
-                                ]),
                             ])
-                        ]);
+                        ])
+                    ]);
                     createCourseOutlinePage(this, mockCourseWithSpecialExamJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
                     selectAdvancedSettings();
-                    expect($("input.timed_exam").is(":checked")).toBe(false);
-                    expect($("input.proctored_exam").is(":checked")).toBe(false);
-                    expect($("input.no_special_exam").is(":checked")).toBe(true);
-                    expect($("input.practice_exam").is(":checked")).toBe(false);
-                    expect($(".field-time-limit input").val()).toBe("02:30");
+                    expect($('input.timed_exam').is(':checked')).toBe(false);
+                    expect($('input.proctored_exam').is(':checked')).toBe(false);
+                    expect($('input.no_special_exam').is(':checked')).toBe(true);
+                    expect($('input.practice_exam').is(':checked')).toBe(false);
+                    expect($('.field-time-limit input').val()).toBe('02:30');
                 });
 
                 it('can show a saved timed exam correctly when hide_after_due is true', function() {
                     var mockCourseWithSpecialExamJSON = createMockCourseJSON({}, [
-                            createMockSectionJSON({
-                                has_changes: true,
-                                enable_proctored_exams: true,
-                                enable_timed_exams: true
+                        createMockSectionJSON({
+                            has_changes: true,
+                            enable_proctored_exams: true,
+                            enable_timed_exams: true
 
+                        }, [
+                            createMockSubsectionJSON({
+                                has_changes: true,
+                                'is_time_limited': true,
+                                'is_practice_exam': false,
+                                'is_proctored_exam': false,
+                                'default_time_limit_minutes': 10,
+                                'hide_after_due': true
                             }, [
-                                createMockSubsectionJSON({
-                                    has_changes: true,
-                                    "is_time_limited": true,
-                                    "is_practice_exam": false,
-                                    "is_proctored_exam": false,
-                                    "default_time_limit_minutes": 10,
-                                    "hide_after_due": true,
-                                }, [
-                                ]),
                             ])
-                        ]);
+                        ])
+                    ]);
                     createCourseOutlinePage(this, mockCourseWithSpecialExamJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
                     selectAdvancedSettings();
-                    expect($("input.timed_exam").is(":checked")).toBe(true);
-                    expect($("input.proctored_exam").is(":checked")).toBe(false);
-                    expect($("input.no_special_exam").is(":checked")).toBe(false);
-                    expect($("input.practice_exam").is(":checked")).toBe(false);
-                    expect($(".field-time-limit input").val()).toBe("00:10");
+                    expect($('input.timed_exam').is(':checked')).toBe(true);
+                    expect($('input.proctored_exam').is(':checked')).toBe(false);
+                    expect($('input.no_special_exam').is(':checked')).toBe(false);
+                    expect($('input.practice_exam').is(':checked')).toBe(false);
+                    expect($('.field-time-limit input').val()).toBe('00:10');
                 });
 
                 it('can show a saved timed exam correctly when hide_after_due is true', function() {
                     var mockCourseWithSpecialExamJSON = createMockCourseJSON({}, [
-                            createMockSectionJSON({
-                                has_changes: true,
-                                enable_proctored_exams: true,
-                                enable_timed_exams: true
+                        createMockSectionJSON({
+                            has_changes: true,
+                            enable_proctored_exams: true,
+                            enable_timed_exams: true
 
+                        }, [
+                            createMockSubsectionJSON({
+                                has_changes: true,
+                                'is_time_limited': true,
+                                'is_practice_exam': false,
+                                'is_proctored_exam': false,
+                                'default_time_limit_minutes': 10,
+                                'hide_after_due': false
                             }, [
-                                createMockSubsectionJSON({
-                                    has_changes: true,
-                                    "is_time_limited": true,
-                                    "is_practice_exam": false,
-                                    "is_proctored_exam": false,
-                                    "default_time_limit_minutes": 10,
-                                    "hide_after_due": false,
-                                }, [
-                                ]),
                             ])
-                        ]);
+                        ])
+                    ]);
                     createCourseOutlinePage(this, mockCourseWithSpecialExamJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
                     selectAdvancedSettings();
-                    expect($("input.timed_exam").is(":checked")).toBe(true);
-                    expect($("input.proctored_exam").is(":checked")).toBe(false);
-                    expect($("input.no_special_exam").is(":checked")).toBe(false);
-                    expect($("input.practice_exam").is(":checked")).toBe(false);
-                    expect($(".field-time-limit input").val()).toBe("00:10");
-                    expect($('.field-hide-after-due input').is(":checked")).toBe(false);
+                    expect($('input.timed_exam').is(':checked')).toBe(true);
+                    expect($('input.proctored_exam').is(':checked')).toBe(false);
+                    expect($('input.no_special_exam').is(':checked')).toBe(false);
+                    expect($('input.practice_exam').is(':checked')).toBe(false);
+                    expect($('.field-time-limit input').val()).toBe('00:10');
+                    expect($('.field-hide-after-due input').is(':checked')).toBe(false);
                 });
 
                 it('can show a saved practice exam correctly', function() {
                     var mockCourseWithSpecialExamJSON = createMockCourseJSON({}, [
-                            createMockSectionJSON({
-                                has_changes: true,
-                                enable_proctored_exams: true,
-                                enable_timed_exams: true
+                        createMockSectionJSON({
+                            has_changes: true,
+                            enable_proctored_exams: true,
+                            enable_timed_exams: true
 
+                        }, [
+                            createMockSubsectionJSON({
+                                has_changes: true,
+                                'is_time_limited': true,
+                                'is_practice_exam': true,
+                                'is_proctored_exam': true,
+                                'default_time_limit_minutes': 150
                             }, [
-                                createMockSubsectionJSON({
-                                    has_changes: true,
-                                    "is_time_limited": true,
-                                    "is_practice_exam": true,
-                                    "is_proctored_exam": true,
-                                    "default_time_limit_minutes": 150
-                                }, [
-                                ]),
                             ])
-                        ]);
+                        ])
+                    ]);
                     createCourseOutlinePage(this, mockCourseWithSpecialExamJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
                     selectAdvancedSettings();
-                    expect($("input.timed_exam").is(":checked")).toBe(false);
-                    expect($("input.proctored_exam").is(":checked")).toBe(false);
-                    expect($("input.no_special_exam").is(":checked")).toBe(false);
-                    expect($("input.practice_exam").is(":checked")).toBe(true);
-                    expect($(".field-time-limit input").val()).toBe("02:30");
+                    expect($('input.timed_exam').is(':checked')).toBe(false);
+                    expect($('input.proctored_exam').is(':checked')).toBe(false);
+                    expect($('input.no_special_exam').is(':checked')).toBe(false);
+                    expect($('input.practice_exam').is(':checked')).toBe(true);
+                    expect($('.field-time-limit input').val()).toBe('02:30');
                 });
 
                 it('can show a saved proctored exam correctly', function() {
                     var mockCourseWithSpecialExamJSON = createMockCourseJSON({}, [
-                            createMockSectionJSON({
-                                has_changes: true,
-                                enable_proctored_exams: true,
-                                enable_timed_exams: true
+                        createMockSectionJSON({
+                            has_changes: true,
+                            enable_proctored_exams: true,
+                            enable_timed_exams: true
 
+                        }, [
+                            createMockSubsectionJSON({
+                                has_changes: true,
+                                'is_time_limited': true,
+                                'is_practice_exam': false,
+                                'is_proctored_exam': true,
+                                'default_time_limit_minutes': 150
                             }, [
-                                createMockSubsectionJSON({
-                                    has_changes: true,
-                                    "is_time_limited": true,
-                                    "is_practice_exam": false,
-                                    "is_proctored_exam": true,
-                                    "default_time_limit_minutes": 150
-                                }, [
-                                ]),
                             ])
-                        ]);
+                        ])
+                    ]);
                     createCourseOutlinePage(this, mockCourseWithSpecialExamJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
                     selectAdvancedSettings();
-                    expect($("input.timed_exam").is(":checked")).toBe(false);
-                    expect($("input.proctored_exam").is(":checked")).toBe(true);
-                    expect($("input.no_special_exam").is(":checked")).toBe(false);
-                    expect($("input.practice_exam").is(":checked")).toBe(false);
-                    expect($(".field-time-limit input").val()).toBe("02:30");
+                    expect($('input.timed_exam').is(':checked')).toBe(false);
+                    expect($('input.proctored_exam').is(':checked')).toBe(true);
+                    expect($('input.no_special_exam').is(':checked')).toBe(false);
+                    expect($('input.practice_exam').is(':checked')).toBe(false);
+                    expect($('.field-time-limit input').val()).toBe('02:30');
                 });
 
                 it('does not show proctored settings if proctored exams not enabled', function() {
                     var mockCourseWithSpecialExamJSON = createMockCourseJSON({}, [
-                            createMockSectionJSON({
-                                has_changes: true,
-                                enable_proctored_exams: false,
-                                enable_timed_exams: true
+                        createMockSectionJSON({
+                            has_changes: true,
+                            enable_proctored_exams: false,
+                            enable_timed_exams: true
 
+                        }, [
+                            createMockSubsectionJSON({
+                                has_changes: true,
+                                'is_time_limited': true,
+                                'is_practice_exam': false,
+                                'is_proctored_exam': false,
+                                'default_time_limit_minutes': 150,
+                                'hide_after_due': true
                             }, [
-                                createMockSubsectionJSON({
-                                    has_changes: true,
-                                    "is_time_limited": true,
-                                    "is_practice_exam": false,
-                                    "is_proctored_exam": false,
-                                    "default_time_limit_minutes": 150,
-                                    "hide_after_due": true,
-                                }, [
-                                ]),
                             ])
-                        ]);
+                        ])
+                    ]);
                     createCourseOutlinePage(this, mockCourseWithSpecialExamJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
                     selectAdvancedSettings();
-                    expect($("input.timed_exam").is(":checked")).toBe(true);
-                    expect($("input.no_special_exam").is(":checked")).toBe(false);
-                    expect($(".field-time-limit input").val()).toBe("02:30");
+                    expect($('input.timed_exam').is(':checked')).toBe(true);
+                    expect($('input.no_special_exam').is(':checked')).toBe(false);
+                    expect($('.field-time-limit input').val()).toBe('02:30');
                 });
 
                 it('can select prerequisite', function() {
@@ -1141,8 +1136,8 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     var mockCourseWithPrequisiteJSON = createMockCourseJSON({}, [
                         createMockSectionJSON({}, [
                             createMockSubsectionJSON({
-                                is_prereq: true,
-                            }, []),
+                                is_prereq: true
+                            }, [])
                         ])
                     ]);
                     createCourseOutlinePage(this, mockCourseWithPrequisiteJSON, false);
@@ -1157,8 +1152,8 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     var mockCourseWithPrequisiteJSON = createMockCourseJSON({}, [
                         createMockSectionJSON({}, [
                             createMockSubsectionJSON({
-                                is_prereq: true,
-                            }, []),
+                                is_prereq: true
+                            }, [])
                         ])
                     ]);
                     createCourseOutlinePage(this, mockCourseWithPrequisiteJSON, false);
@@ -1177,7 +1172,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                         createMockSectionJSON({}, [
                             createMockSubsectionJSON({
                                 prereqs: [{block_usage_key: 'usage_key', block_display_name: 'Prereq Subsection 1'}]
-                            }, []),
+                            }, [])
                         ])
                     ]);
                     createCourseOutlinePage(this, mockCourseWithPreqsJSON, false);
@@ -1190,7 +1185,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                         createMockSectionJSON({}, [
                             createMockSubsectionJSON({
                                 prereqs: [{block_usage_key: 'usage_key', block_display_name: 'Prereq Subsection 1'}]
-                            }, []),
+                            }, [])
                         ])
                     ]);
                     createCourseOutlinePage(this, mockCourseWithPreqsJSON, false);
@@ -1210,12 +1205,12 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                                 prereqs: [{block_usage_key: 'usage_key', block_display_name: 'Prereq Subsection 1'}],
                                 prereq: 'usage_key',
                                 prereq_min_score: '80'
-                            }, []),
+                            }, [])
                         ])
                     ]);
                     createCourseOutlinePage(this, mockCourseWithPreqsJSON, false);
-                    expect($(".outline-subsection .status-message-copy")).toContainText(
-                        "Prerequisite: Prereq Subsection 1"
+                    expect($('.outline-subsection .status-message-copy')).toContainText(
+                        'Prerequisite: Prereq Subsection 1'
                     );
                 });
 
@@ -1226,7 +1221,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                                 prereqs: [{block_usage_key: 'usage_key', block_display_name: 'Prereq Subsection 1'}],
                                 prereq: 'usage_key',
                                 prereq_min_score: '80'
-                            }, []),
+                            }, [])
                         ])
                     ]);
                     createCourseOutlinePage(this, mockCourseWithPreqsJSON, false);
@@ -1242,19 +1237,19 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                         createMockSectionJSON({}, [
                             createMockSubsectionJSON({
                                 prereqs: [{block_usage_key: 'usage_key', block_display_name: 'Prereq Subsection 1'}]
-                            }, []),
+                            }, [])
                         ])
                     ]);
                     createCourseOutlinePage(this, mockCourseWithPreqsJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
                     selectLastPrerequisiteSubsection('abc');
                     expect($('#prereq_min_score_error').css('display')).not.toBe('none');
-                    expect($(".wrapper-modal-window .action-save").prop('disabled')).toBe(true);
-                    expect($(".wrapper-modal-window .action-save").hasClass('is-disabled')).toBe(true);
+                    expect($('.wrapper-modal-window .action-save').prop('disabled')).toBe(true);
+                    expect($('.wrapper-modal-window .action-save').hasClass('is-disabled')).toBe(true);
                     selectLastPrerequisiteSubsection('5.5');
                     expect($('#prereq_min_score_error').css('display')).not.toBe('none');
-                    expect($(".wrapper-modal-window .action-save").prop('disabled')).toBe(true);
-                    expect($(".wrapper-modal-window .action-save").hasClass('is-disabled')).toBe(true);
+                    expect($('.wrapper-modal-window .action-save').prop('disabled')).toBe(true);
+                    expect($('.wrapper-modal-window .action-save').hasClass('is-disabled')).toBe(true);
                 });
 
                 it('can display validation error on out of bounds minimum score', function() {
@@ -1262,19 +1257,19 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                         createMockSectionJSON({}, [
                             createMockSubsectionJSON({
                                 prereqs: [{block_usage_key: 'usage_key', block_display_name: 'Prereq Subsection 1'}]
-                            }, []),
+                            }, [])
                         ])
                     ]);
                     createCourseOutlinePage(this, mockCourseWithPreqsJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
                     selectLastPrerequisiteSubsection('-5');
                     expect($('#prereq_min_score_error').css('display')).not.toBe('none');
-                    expect($(".wrapper-modal-window .action-save").prop('disabled')).toBe(true);
-                    expect($(".wrapper-modal-window .action-save").hasClass('is-disabled')).toBe(true);
+                    expect($('.wrapper-modal-window .action-save').prop('disabled')).toBe(true);
+                    expect($('.wrapper-modal-window .action-save').hasClass('is-disabled')).toBe(true);
                     selectLastPrerequisiteSubsection('105');
                     expect($('#prereq_min_score_error').css('display')).not.toBe('none');
-                    expect($(".wrapper-modal-window .action-save").prop('disabled')).toBe(true);
-                    expect($(".wrapper-modal-window .action-save").hasClass('is-disabled')).toBe(true);
+                    expect($('.wrapper-modal-window .action-save').prop('disabled')).toBe(true);
+                    expect($('.wrapper-modal-window .action-save').hasClass('is-disabled')).toBe(true);
                 });
 
                 it('does not display validation error on valid minimum score', function() {
@@ -1282,7 +1277,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                         createMockSectionJSON({}, [
                             createMockSubsectionJSON({
                                 prereqs: [{block_usage_key: 'usage_key', block_display_name: 'Prereq Subsection 1'}]
-                            }, []),
+                            }, [])
                         ])
                     ]);
                     createCourseOutlinePage(this, mockCourseWithPreqsJSON, false);
@@ -1301,43 +1296,43 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 it('release date, due date, grading type, and staff lock can be cleared.', function() {
                     createCourseOutlinePage(this, mockCourseJSON, false);
                     outlinePage.$('.outline-item .outline-subsection .configure-button').click();
-                    setEditModalValues("7/9/2014", "7/10/2014", "Lab");
-                    setContentVisibility("staff_only");
-                    $(".wrapper-modal-window .action-save").click();
+                    setEditModalValues('7/9/2014', '7/10/2014', 'Lab');
+                    setContentVisibility('staff_only');
+                    $('.wrapper-modal-window .action-save').click();
 
                     // This is the response for the change operation.
                     AjaxHelpers.respondWithJson(requests, {});
                     // This is the response for the subsequent fetch operation.
                     AjaxHelpers.respondWithJson(requests, mockServerValuesJson);
 
-                    expect($(".outline-subsection .status-release-value")).toContainText(
-                        "Jul 09, 2014 at 00:00 UTC"
+                    expect($('.outline-subsection .status-release-value')).toContainText(
+                        'Jul 09, 2014 at 00:00 UTC'
                     );
-                    expect($(".outline-subsection .status-grading-date")).toContainText(
-                        "Due: Jul 10, 2014 at 00:00 UTC"
+                    expect($('.outline-subsection .status-grading-date')).toContainText(
+                        'Due: Jul 10, 2014 at 00:00 UTC'
                     );
-                    expect($(".outline-subsection .status-grading-value")).toContainText(
-                        "Lab"
+                    expect($('.outline-subsection .status-grading-value')).toContainText(
+                        'Lab'
                     );
-                    expect($(".outline-subsection .status-message-copy")).toContainText(
-                        "Contains staff only content"
+                    expect($('.outline-subsection .status-message-copy')).toContainText(
+                        'Contains staff only content'
                     );
 
                     outlinePage.$('.outline-subsection .configure-button').click();
-                    expect($("#start_date").val()).toBe('7/9/2014');
-                    expect($("#due_date").val()).toBe('7/10/2014');
-                    expect($("#grading_type").val()).toBe('Lab');
-                    expect($("input[name=content-visibility][value=staff_only]").is(":checked")).toBe(true);
+                    expect($('#start_date').val()).toBe('7/9/2014');
+                    expect($('#due_date').val()).toBe('7/10/2014');
+                    expect($('#grading_type').val()).toBe('Lab');
+                    expect($('input[name=content-visibility][value=staff_only]').is(':checked')).toBe(true);
 
-                    $(".wrapper-modal-window .scheduled-date-input .action-clear").click();
-                    $(".wrapper-modal-window .due-date-input .action-clear").click();
-                    expect($("#start_date").val()).toBe('');
-                    expect($("#due_date").val()).toBe('');
+                    $('.wrapper-modal-window .scheduled-date-input .action-clear').click();
+                    $('.wrapper-modal-window .due-date-input .action-clear').click();
+                    expect($('#start_date').val()).toBe('');
+                    expect($('#due_date').val()).toBe('');
 
-                    $("#grading_type").val('notgraded');
-                    setContentVisibility("visible");
+                    $('#grading_type').val('notgraded');
+                    setContentVisibility('visible');
 
-                    $(".wrapper-modal-window .action-save").click();
+                    $('.wrapper-modal-window .action-save').click();
 
                     // This is the response for the change operation.
                     AjaxHelpers.respondWithJson(requests, {});
@@ -1345,17 +1340,17 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     AjaxHelpers.respondWithJson(requests,
                         createMockSectionJSON({}, [createMockSubsectionJSON()])
                     );
-                    expect($(".outline-subsection .status-release-value")).not.toContainText(
-                        "Jul 09, 2014 at 00:00 UTC"
+                    expect($('.outline-subsection .status-release-value')).not.toContainText(
+                        'Jul 09, 2014 at 00:00 UTC'
                     );
-                    expect($(".outline-subsection .status-grading-date")).not.toExist();
-                    expect($(".outline-subsection .status-grading-value")).not.toExist();
-                    expect($(".outline-subsection .status-message-copy")).not.toContainText(
-                        "Contains staff only content"
+                    expect($('.outline-subsection .status-grading-date')).not.toExist();
+                    expect($('.outline-subsection .status-grading-value')).not.toExist();
+                    expect($('.outline-subsection .status-message-copy')).not.toContainText(
+                        'Contains staff only content'
                     );
                 });
 
-                verifyTypePublishable('subsection', function (options) {
+                verifyTypePublishable('subsection', function(options) {
                     return createMockCourseJSON({}, [
                         createMockSectionJSON({}, [
                             createMockSubsectionJSON(options, [
@@ -1365,13 +1360,13 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     ]);
                 });
 
-                it('can display a publish modal with a list of unpublished units', function () {
+                it('can display a publish modal with a list of unpublished units', function() {
                     var mockCourseJSON = createMockCourseJSON({}, [
                             createMockSectionJSON({has_changes: true}, [
                                 createMockSubsectionJSON({has_changes: true}, [
                                     createMockVerticalJSON(),
-                                    createMockVerticalJSON({has_changes: true, display_name: "Unit 100"}),
-                                    createMockVerticalJSON({published: false, display_name: "Unit 50"})
+                                    createMockVerticalJSON({has_changes: true, display_name: 'Unit 100'}),
+                                    createMockVerticalJSON({published: false, display_name: 'Unit 50'})
                                 ]),
                                 createMockSubsectionJSON({has_changes: true}, [
                                     createMockVerticalJSON({has_changes: true})
@@ -1384,7 +1379,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     getItemHeaders('subsection').first().find('.publish-button').click();
                     modalWindow = $('.wrapper-modal-window');
                     expect(modalWindow.find('.outline-unit').length).toBe(2);
-                    expect(_.compact(_.map(modalWindow.find('.outline-unit').text().split("\n"), $.trim))).toEqual(
+                    expect(_.compact(_.map(modalWindow.find('.outline-unit').text().split('\n'), $.trim))).toEqual(
                         ['Unit 100', 'Unit 50']
                     );
                     expect(modalWindow.find('.outline-subsection')).not.toExist();
@@ -1392,7 +1387,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
             });
 
             // Note: most tests for units can be found in Bok Choy
-            describe("Unit", function() {
+            describe('Unit', function() {
                 it('can be deleted', function() {
                     var promptSpy = EditHelpers.createPromptSpy();
                     createCourseOutlinePage(this, mockCourseJSON);
@@ -1414,7 +1409,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     expect(unitAnchor.attr('href')).toBe('/container/mock-unit');
                 });
 
-                verifyTypePublishable('unit', function (options) {
+                verifyTypePublishable('unit', function(options) {
                     return createMockCourseJSON({}, [
                         createMockSectionJSON({}, [
                             createMockSubsectionJSON({}, [
@@ -1425,19 +1420,19 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 });
             });
 
-            describe("Date and Time picker", function() {
+            describe('Date and Time picker', function() {
                 // Two datetime formats can came from server: '%Y-%m-%dT%H:%M:%SZ' and %Y-%m-%dT%H:%M:%S+TZ:TZ'
                 it('can parse dates in both formats that can come from server', function() {
                     createCourseOutlinePage(this, mockCourseJSON, false);
                     outlinePage.$('.outline-subsection .configure-button').click();
-                    expect($("#start_date").val()).toBe('');
-                    expect($("#start_time").val()).toBe('');
-                    DateUtils.setDate($("#start_date"), ("#start_time"), "2015-08-10T05:10:00Z");
-                    expect($("#start_date").val()).toBe('8/10/2015');
-                    expect($("#start_time").val()).toBe('05:10');
-                    DateUtils.setDate($("#start_date"), ("#start_time"), "2014-07-09T00:00:00+00:00");
-                    expect($("#start_date").val()).toBe('7/9/2014');
-                    expect($("#start_time").val()).toBe('00:00');
+                    expect($('#start_date').val()).toBe('');
+                    expect($('#start_time').val()).toBe('');
+                    DateUtils.setDate($('#start_date'), ('#start_time'), '2015-08-10T05:10:00Z');
+                    expect($('#start_date').val()).toBe('8/10/2015');
+                    expect($('#start_time').val()).toBe('05:10');
+                    DateUtils.setDate($('#start_date'), ('#start_time'), '2014-07-09T00:00:00+00:00');
+                    expect($('#start_date').val()).toBe('7/9/2014');
+                    expect($('#start_time').val()).toBe('00:00');
                 });
             });
         });

--- a/cms/static/js/spec/views/pages/course_rerun_spec.js
+++ b/cms/static/js/spec/views/pages/course_rerun_spec.js
@@ -1,8 +1,8 @@
-define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/js/spec_helpers/view_helpers",
-        "js/views/course_rerun", "js/views/utils/create_course_utils", "common/js/components/utils/view_utils",
-        "jquery.simulate"],
-    function ($, AjaxHelpers, ViewHelpers, CourseRerunUtils, CreateCourseUtilsFactory, ViewUtils) {
-        describe("Create course rerun page", function () {
+define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/js/spec_helpers/view_helpers',
+        'js/views/course_rerun', 'js/views/utils/create_course_utils', 'common/js/components/utils/view_utils',
+        'jquery.simulate'],
+    function($, AjaxHelpers, ViewHelpers, CourseRerunUtils, CreateCourseUtilsFactory, ViewUtils) {
+        describe('Create course rerun page', function() {
             var selectors = {
                     org: '.rerun-course-org',
                     number: '.rerun-course-number',
@@ -29,68 +29,68 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
 
             var CreateCourseUtils = new CreateCourseUtilsFactory(selectors, classes);
 
-            var fillInFields = function (org, number, run, name) {
+            var fillInFields = function(org, number, run, name) {
                 $(selectors.org).val(org);
                 $(selectors.number).val(number);
                 $(selectors.run).val(run);
                 $(selectors.name).val(name);
             };
 
-            beforeEach(function () {
+            beforeEach(function() {
                 ViewHelpers.installMockAnalytics();
                 window.source_course_key = 'test_course_key';
                 appendSetFixtures(mockCreateCourseRerunHTML);
                 CourseRerunUtils.onReady();
             });
 
-            afterEach(function () {
+            afterEach(function() {
                 ViewHelpers.removeMockAnalytics();
                 delete window.source_course_key;
             });
 
-            describe("Field validation", function () {
-                it("returns a message for an empty string", function () {
+            describe('Field validation', function() {
+                it('returns a message for an empty string', function() {
                     var message = ViewUtils.validateRequiredField('');
                     expect(message).not.toBe('');
                 });
 
-                it("does not return a message for a non empty string", function () {
+                it('does not return a message for a non empty string', function() {
                     var message = ViewUtils.validateRequiredField('edX');
                     expect(message).toBe('');
                 });
             });
 
-            describe("Error messages", function () {
+            describe('Error messages', function() {
                 var setErrorMessage = function(selector, message) {
                     var element = $(selector).parent();
                     CreateCourseUtils.setFieldInErr(element, message);
                     return element;
                 };
 
-                var type = function (input, value) {
+                var type = function(input, value) {
                     input.val(value);
-                    input.simulate("keyup", { keyCode: $.simulate.keyCode.SPACE });
+                    input.simulate('keyup', {keyCode: $.simulate.keyCode.SPACE});
                 };
 
-                it("shows an error message", function () {
+                it('shows an error message', function() {
                     var element = setErrorMessage(selectors.org, 'error message');
                     expect(element).toHaveClass(classes.error);
                     expect(element.children(selectors.tipError)).not.toHaveClass(classes.hidden);
                     expect(element.children(selectors.tipError)).toContainText('error message');
                 });
 
-                it("hides an error message", function () {
+                it('hides an error message', function() {
                     var element = setErrorMessage(selectors.org, '');
                     expect(element).not.toHaveClass(classes.error);
                     expect(element.children(selectors.tipError)).toHaveClass(classes.hidden);
                 });
 
-                it("disables the save button", function () {
+                it('disables the save button', function() {
                     setErrorMessage(selectors.org, 'error message');
                     expect($(selectors.save)).toHaveClass(classes.disabled);
                 });
 
-                it("enables the save button when all errors are removed", function () {
+                it('enables the save button when all errors are removed', function() {
                     setErrorMessage(selectors.org, 'error message 1');
                     setErrorMessage(selectors.number, 'error message 2');
                     expect($(selectors.save)).toHaveClass(classes.disabled);
@@ -99,7 +99,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     expect($(selectors.save)).not.toHaveClass(classes.disabled);
                 });
 
-                it("does not enable the save button when errors remain", function () {
+                it('does not enable the save button when errors remain', function() {
                     setErrorMessage(selectors.org, 'error message 1');
                     setErrorMessage(selectors.number, 'error message 2');
                     expect($(selectors.save)).toHaveClass(classes.disabled);
@@ -107,30 +107,30 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     expect($(selectors.save)).toHaveClass(classes.disabled);
                 });
 
-                it("shows an error message when non URL characters are entered", function () {
+                it('shows an error message when non URL characters are entered', function() {
                     var input = $(selectors.org);
                     expect(input.parent()).not.toHaveClass(classes.error);
-                    type(input, "%");
+                    type(input, '%');
                     expect(input.parent()).toHaveClass(classes.error);
                 });
 
-                it("does not show an error message when tabbing into a field", function () {
+                it('does not show an error message when tabbing into a field', function() {
                     var input = $(selectors.number);
                     input.val('');
                     expect(input.parent()).not.toHaveClass(classes.error);
-                    input.simulate("keyup", { keyCode: $.simulate.keyCode.TAB });
+                    input.simulate('keyup', {keyCode: $.simulate.keyCode.TAB});
                     expect(input.parent()).not.toHaveClass(classes.error);
                 });
 
-                it("shows an error message when a required field is empty", function () {
+                it('shows an error message when a required field is empty', function() {
                     var input = $(selectors.org);
                     input.val('');
                     expect(input.parent()).not.toHaveClass(classes.error);
-                    input.simulate("keyup", { keyCode: $.simulate.keyCode.ENTER });
+                    input.simulate('keyup', {keyCode: $.simulate.keyCode.ENTER});
                     expect(input.parent()).toHaveClass(classes.error);
                 });
 
-                it("shows an error message when spaces are entered and unicode is allowed", function () {
+                it('shows an error message when spaces are entered and unicode is allowed', function() {
                     var input = $(selectors.org);
                     $(selectors.allowUnicode).val('True');
                     expect(input.parent()).not.toHaveClass(classes.error);
@@ -138,7 +138,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     expect(input.parent()).toHaveClass(classes.error);
                 });
 
-                it("shows an error message when total length exceeds 65 characters", function () {
+                it('shows an error message when total length exceeds 65 characters', function() {
                     expect($(selectors.errorWrapper)).not.toHaveClass(classes.shown);
                     type($(selectors.org), 'ThisIsAVeryLongNameThatWillExceedTheSixtyFiveCharacterLimit');
                     type($(selectors.number), 'ThisIsAVeryLongNameThatWillExceedTheSixtyFiveCharacterLimit');
@@ -146,19 +146,19 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     expect($(selectors.errorWrapper)).toHaveClass(classes.shown);
                 });
 
-                describe("Name field", function () {
-                    it("does not show an error message when non URL characters are entered", function () {
+                describe('Name field', function() {
+                    it('does not show an error message when non URL characters are entered', function() {
                         var input = $(selectors.name);
                         expect(input.parent()).not.toHaveClass(classes.error);
-                        type(input, "%");
+                        type(input, '%');
                         expect(input.parent()).not.toHaveClass(classes.error);
                     });
                 });
             });
 
-            it("saves course reruns", function () {
+            it('saves course reruns', function() {
                 var requests = AjaxHelpers.requests(this);
-                var redirectSpy = spyOn(ViewUtils, 'redirect')
+                var redirectSpy = spyOn(ViewUtils, 'redirect');
                 fillInFields('DemoX', 'DM101', '2014', 'Demo course');
                 $(selectors.save).click();
                 AjaxHelpers.expectJsonRequest(requests, 'POST', '/course/', {
@@ -177,7 +177,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 expect(redirectSpy).toHaveBeenCalledWith('dummy_test_url');
             });
 
-            it("displays an error when saving fails", function () {
+            it('displays an error when saving fails', function() {
                 var requests = AjaxHelpers.requests(this);
                 fillInFields('DemoX', 'DM101', '2014', 'Demo course');
                 $(selectors.save).click();
@@ -190,14 +190,14 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 expect($(selectors.cancel)).not.toHaveClass(classes.hidden);
             });
 
-            it("does not save if there are validation errors", function () {
+            it('does not save if there are validation errors', function() {
                 var requests = AjaxHelpers.requests(this);
                 fillInFields('DemoX', 'DM101', '', 'Demo course');
                 $(selectors.save).click();
                 AjaxHelpers.expectNoRequests(requests);
             });
 
-            it("can be canceled", function () {
+            it('can be canceled', function() {
                 var redirectSpy = spyOn(ViewUtils, 'redirect');
                 $(selectors.cancel).click();
                 expect(redirectSpy).toHaveBeenCalledWith('/course/');

--- a/cms/static/js/spec/views/pages/group_configurations_spec.js
+++ b/cms/static/js/spec/views/pages/group_configurations_spec.js
@@ -2,7 +2,7 @@ define([
     'jquery', 'underscore', 'js/views/pages/group_configurations',
     'js/models/group_configuration', 'js/collections/group_configuration',
     'common/js/spec_helpers/template_helpers'
-], function ($, _, GroupConfigurationsPage, GroupConfigurationModel, GroupConfigurationCollection, TemplateHelpers) {
+], function($, _, GroupConfigurationsPage, GroupConfigurationModel, GroupConfigurationCollection, TemplateHelpers) {
     'use strict';
     describe('GroupConfigurationsPage', function() {
         var mockGroupConfigurationsPage = readFixtures(
@@ -10,14 +10,14 @@ define([
             ),
             groupConfigItemClassName = '.group-configurations-list-item';
 
-        var initializePage = function (disableSpy) {
+        var initializePage = function(disableSpy) {
             var view = new GroupConfigurationsPage({
                 el: $('#content'),
                 experimentsEnabled: true,
                 experimentGroupConfigurations: new GroupConfigurationCollection({
                     id: 0,
                     name: 'Configuration 1',
-                    courseOutlineUrl: "CourseOutlineUrl"
+                    courseOutlineUrl: 'CourseOutlineUrl'
                 }),
                 contentGroupConfiguration: new GroupConfigurationModel({groups: []})
             });
@@ -29,11 +29,11 @@ define([
             return view;
         };
 
-        var renderPage = function () {
+        var renderPage = function() {
             return initializePage().render();
         };
 
-        beforeEach(function () {
+        beforeEach(function() {
             setFixtures(mockGroupConfigurationsPage);
             TemplateHelpers.installTemplates([
                 'group-configuration-editor', 'group-configuration-details', 'content-group-details',
@@ -41,9 +41,9 @@ define([
             ]);
 
             jasmine.addMatchers({
-                toBeExpanded: function () {
+                toBeExpanded: function() {
                     return {
-                        compare: function (actual) {
+                        compare: function(actual) {
                             return {
                                 pass: Boolean($('a.group-toggle.hide-groups', $(actual)).length)
                             };
@@ -66,7 +66,7 @@ define([
         });
 
         describe('Experiment group configurations', function() {
-            beforeEach(function () {
+            beforeEach(function() {
                 spyOn($.fn, 'focus');
                 TemplateHelpers.installTemplate('group-configuration-details');
                 this.view = initializePage(true);
@@ -94,12 +94,12 @@ define([
                 expect(this.view.$(groupConfigItemClassName)).not.toBeExpanded();
             });
 
-            it('should not show a notification message if an experiment configuration is not changed', function () {
+            it('should not show a notification message if an experiment configuration is not changed', function() {
                 this.view.render();
                 expect(this.view.onBeforeUnload()).toBeUndefined();
             });
 
-            it('should show a notification message if an experiment configuration is changed', function () {
+            it('should show a notification message if an experiment configuration is changed', function() {
                 this.view.experimentGroupConfigurations.at(0).set('name', 'Configuration 2');
                 expect(this.view.onBeforeUnload())
                     .toBe('You have unsaved changes. Do you really want to leave this page?');
@@ -111,11 +111,11 @@ define([
                 this.view = renderPage();
             });
 
-            it('should not show a notification message if a content group is not changed', function () {
+            it('should not show a notification message if a content group is not changed', function() {
                 expect(this.view.onBeforeUnload()).toBeUndefined();
             });
 
-            it('should show a notification message if a content group is changed', function () {
+            it('should show a notification message if a content group is changed', function() {
                 this.view.contentGroupConfiguration.get('groups').add({id: 0, name: 'Content Group'});
                 expect(this.view.onBeforeUnload())
                     .toBe('You have unsaved changes. Do you really want to leave this page?');

--- a/cms/static/js/spec/views/pages/index_spec.js
+++ b/cms/static/js/spec/views/pages/index_spec.js
@@ -1,12 +1,12 @@
-define(["jquery",
-        "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers",
-        "common/js/spec_helpers/view_helpers", "js/index",
-        "common/js/components/utils/view_utils"],
-    function ($, AjaxHelpers, ViewHelpers, IndexUtils, ViewUtils) {
-        describe("Course listing page", function () {
+define(['jquery',
+        'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
+        'common/js/spec_helpers/view_helpers', 'js/index',
+        'common/js/components/utils/view_utils'],
+    function($, AjaxHelpers, ViewHelpers, IndexUtils, ViewUtils) {
+        describe('Course listing page', function() {
             var mockIndexPageHTML = readFixtures('mock/mock-index-page.underscore');
 
-            var fillInFields = function (org, number, run, name) {
+            var fillInFields = function(org, number, run, name) {
                 $('.new-course-org').val(org);
                 $('.new-course-number').val(number);
                 $('.new-course-run').val(run);
@@ -19,18 +19,18 @@ define(["jquery",
                 $('.new-library-name').val(name).keyup();
             };
 
-            beforeEach(function () {
+            beforeEach(function() {
                 ViewHelpers.installMockAnalytics();
                 appendSetFixtures(mockIndexPageHTML);
                 IndexUtils.onReady();
             });
 
-            afterEach(function () {
+            afterEach(function() {
                 ViewHelpers.removeMockAnalytics();
                 delete window.source_course_key;
             });
 
-            it("can dismiss notifications", function () {
+            it('can dismiss notifications', function() {
                 var requests = AjaxHelpers.requests(this);
                 var reloadSpy = spyOn(ViewUtils, 'reload');
                 $('.dismiss-button').click();
@@ -39,10 +39,10 @@ define(["jquery",
                 expect(reloadSpy).toHaveBeenCalled();
             });
 
-            it("saves new courses", function () {
+            it('saves new courses', function() {
                 var requests = AjaxHelpers.requests(this);
                 var redirectSpy = spyOn(ViewUtils, 'redirect');
-                $('.new-course-button').click()
+                $('.new-course-button').click();
                 AjaxHelpers.expectJsonRequest(requests, 'GET', '/organizations');
                 AjaxHelpers.respondWithJson(requests, ['DemoX', 'DemoX2', 'DemoX3']);
                 fillInFields('DemoX', 'DM101', '2014', 'Demo course');
@@ -57,10 +57,10 @@ define(["jquery",
                     url: 'dummy_test_url'
                 });
                 expect(redirectSpy).toHaveBeenCalledWith('dummy_test_url');
-                $(".new-course-org").autocomplete("destroy");
+                $('.new-course-org').autocomplete('destroy');
             });
 
-            it("displays an error when saving fails", function () {
+            it('displays an error when saving fails', function() {
                 var requests = AjaxHelpers.requests(this);
                 $('.new-course-button').click();
                 AjaxHelpers.expectJsonRequest(requests, 'GET', '/organizations');
@@ -74,10 +74,10 @@ define(["jquery",
                 expect($('#course_creation_error')).toContainText('error message');
                 expect($('.new-course-save')).toHaveClass('is-disabled');
                 expect($('.new-course-save')).toHaveAttr('aria-disabled', 'true');
-                $(".new-course-org").autocomplete("destroy");
+                $('.new-course-org').autocomplete('destroy');
             });
 
-            it("saves new libraries", function () {
+            it('saves new libraries', function() {
                 var requests = AjaxHelpers.requests(this);
                 var redirectSpy = spyOn(ViewUtils, 'redirect');
                 $('.new-library-button').click();
@@ -94,12 +94,12 @@ define(["jquery",
                 expect(redirectSpy).toHaveBeenCalledWith('dummy_test_url');
             });
 
-            it("displays an error when a required field is blank", function () {
+            it('displays an error when a required field is blank', function() {
                 var requests = AjaxHelpers.requests(this);
                 $('.new-library-button').click();
                 var values = ['DemoX', 'DM101', 'Demo library'];
                 // Try making each of these three values empty one at a time and ensure the form won't submit:
-                for (var i=0; i<values.length;i++) {
+                for (var i = 0; i < values.length; i++) {
                     var values_with_blank = values.slice();
                     values_with_blank[i] = '';
                     fillInLibraryFields.apply(this, values_with_blank);
@@ -111,7 +111,7 @@ define(["jquery",
                 }
             });
 
-            it("can cancel library creation", function () {
+            it('can cancel library creation', function() {
                 $('.new-library-button').click();
                 fillInLibraryFields('DemoX', 'DM101', 'Demo library');
                 $('.new-library-cancel').click();
@@ -121,7 +121,7 @@ define(["jquery",
                 });
             });
 
-            it("displays an error when saving a library fails", function () {
+            it('displays an error when saving a library fails', function() {
                 var requests = AjaxHelpers.requests(this);
                 $('.new-library-button').click();
                 fillInLibraryFields('DemoX', 'DM101', 'Demo library');
@@ -135,7 +135,7 @@ define(["jquery",
                 expect($('.new-library-save')).toHaveAttr('aria-disabled', 'true');
             });
 
-            it("can switch tabs", function() {
+            it('can switch tabs', function() {
                 var $courses_tab = $('.courses-tab'),
                     $libraraies_tab = $('.libraries-tab');
 

--- a/cms/static/js/spec/views/pages/library_users_spec.js
+++ b/cms/static/js/spec/views/pages/library_users_spec.js
@@ -1,16 +1,16 @@
 define([
-    "jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/js/spec_helpers/view_helpers",
-    "js/factories/manage_users_lib", "common/js/components/utils/view_utils"
+    'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/js/spec_helpers/view_helpers',
+    'js/factories/manage_users_lib', 'common/js/components/utils/view_utils'
 ],
-function ($, AjaxHelpers, ViewHelpers, ManageUsersFactory, ViewUtils) {
-    "use strict";
-    describe("Library Instructor Access Page", function () {
-        var changeRoleUrl = "dummy_change_role_url/@@EMAIL@@";
-        var team_member_fixture = readFixtures("team-member.underscore");
+function($, AjaxHelpers, ViewHelpers, ManageUsersFactory, ViewUtils) {
+    'use strict';
+    describe('Library Instructor Access Page', function() {
+        var changeRoleUrl = 'dummy_change_role_url/@@EMAIL@@';
+        var team_member_fixture = readFixtures('team-member.underscore');
 
-        function setRole(email, role){
-            var user_li = $('li.user-item[data-email="'+ email + '"]');
-            var role_action = $("li.action-role a.make-"+role, user_li);
+        function setRole(email, role) {
+            var user_li = $('li.user-item[data-email="' + email + '"]');
+            var role_action = $('li.action-role a.make-' + role, user_li);
             expect(role_action).toBeVisible();
             role_action.click();
         }
@@ -19,19 +19,19 @@ function ($, AjaxHelpers, ViewHelpers, ManageUsersFactory, ViewUtils) {
             return changeRoleUrl.replace('@@EMAIL@@', email);
         }
 
-        describe("read-write access", function() {
+        describe('read-write access', function() {
             var mockHTML = readFixtures('mock/mock-manage-users-lib.underscore');
 
-            beforeEach(function (done) {
+            beforeEach(function(done) {
                 ViewHelpers.installMockAnalytics();
                 setFixtures(mockHTML);
-                appendSetFixtures($("<script>", { id: "team-member-tpl", type: "text/template"}).text(team_member_fixture));
+                appendSetFixtures($('<script>', {id: 'team-member-tpl', type: 'text/template'}).text(team_member_fixture));
                 ManageUsersFactory(
-                    "Mock Library",
+                    'Mock Library',
                     [
-                        {id: 1, email: "honor@example.com", username:"honor", role: 'staff'},
-                        {id: 2, email: "audit@example.com", username:"audit", role: 'instructor'},
-                        {id: 3, email: "staff@example.com", username:"staff", role: 'library_user'}
+                        {id: 1, email: 'honor@example.com', username: 'honor', role: 'staff'},
+                        {id: 2, email: 'audit@example.com', username: 'audit', role: 'instructor'},
+                        {id: 3, email: 'staff@example.com', username: 'staff', role: 'library_user'}
                     ],
                     changeRoleUrl,
                     10000,
@@ -39,15 +39,15 @@ function ($, AjaxHelpers, ViewHelpers, ManageUsersFactory, ViewUtils) {
                 );
 
                 jasmine.waitUntil(function() {
-                    return ($(".ui-loading").length === 0);
+                    return ($('.ui-loading').length === 0);
                 }).then(done);
             });
 
-            afterEach(function () {
+            afterEach(function() {
                 ViewHelpers.removeMockAnalytics();
             });
 
-            it("can give a user permission to use the library", function () {
+            it('can give a user permission to use the library', function() {
                 var email = 'other@example.com';
                 var requests = AjaxHelpers.requests(this);
                 var reloadSpy = spyOn(ViewUtils, 'reload');
@@ -60,23 +60,23 @@ function ($, AjaxHelpers, ViewHelpers, ManageUsersFactory, ViewUtils) {
                 expect(reloadSpy).toHaveBeenCalled();
             });
 
-            it("can promote user", function() {
-                var email = "staff@example.com";
+            it('can promote user', function() {
+                var email = 'staff@example.com';
                 var requests = AjaxHelpers.requests(this);
                 var reloadSpy = spyOn(ViewUtils, 'reload');
-                setRole("staff@example.com", 'staff');
+                setRole('staff@example.com', 'staff');
                 AjaxHelpers.expectJsonRequest(requests, 'POST', getUrl(email), {role: 'staff'});
                 AjaxHelpers.respondWithJson(requests, {'result': 'ok'});
                 expect(reloadSpy).toHaveBeenCalled();
             });
 
-            it("can cancel adding a user to the library", function () {
+            it('can cancel adding a user to the library', function() {
                 $('.create-user-button').click();
                 $('.form-create.create-user .action-secondary').click();
                 expect($('.wrapper-create-user')).not.toHaveClass('is-shown');
             });
 
-            it("displays an error when the required field is blank", function () {
+            it('displays an error when the required field is blank', function() {
                 var requests = AjaxHelpers.requests(this);
                 $('.create-user-button').click();
                 $('.user-email-input').val('');
@@ -88,7 +88,7 @@ function ($, AjaxHelpers, ViewHelpers, ManageUsersFactory, ViewUtils) {
                 AjaxHelpers.expectNoRequests(requests);
             });
 
-            it("displays an error when the user has already been added", function () {
+            it('displays an error when the user has already been added', function() {
                 var requests = AjaxHelpers.requests(this);
                 var promptSpy = ViewHelpers.createPromptSpy();
                 $('.create-user-button').click();
@@ -99,12 +99,12 @@ function ($, AjaxHelpers, ViewHelpers, ManageUsersFactory, ViewUtils) {
             });
 
 
-            it("can remove a user's permission to access the library", function () {
+            it("can remove a user's permission to access the library", function() {
                 var requests = AjaxHelpers.requests(this);
                 var promptSpy = ViewHelpers.createPromptSpy();
                 var reloadSpy = spyOn(ViewUtils, 'reload');
-                var email = "honor@example.com";
-                $('.user-item[data-email="'+email+'"] .action-delete .delete').click();
+                var email = 'honor@example.com';
+                $('.user-item[data-email="' + email + '"] .action-delete .delete').click();
                 ViewHelpers.verifyPromptShowing(promptSpy, 'Are you sure?');
                 ViewHelpers.confirmPrompt(promptSpy);
                 ViewHelpers.verifyPromptHidden(promptSpy);
@@ -114,36 +114,36 @@ function ($, AjaxHelpers, ViewHelpers, ManageUsersFactory, ViewUtils) {
             });
         });
 
-        describe("read-only access", function() {
+        describe('read-only access', function() {
             var mockHTML = readFixtures('mock/mock-manage-users-lib-ro.underscore');
 
-            beforeEach(function () {
+            beforeEach(function() {
                 ViewHelpers.installMockAnalytics();
                 setFixtures(mockHTML);
-                appendSetFixtures($("<script>", { id: "team-member-tpl", type: "text/template"}).text(team_member_fixture));
+                appendSetFixtures($('<script>', {id: 'team-member-tpl', type: 'text/template'}).text(team_member_fixture));
                 ManageUsersFactory(
-                    "Mock Library",
+                    'Mock Library',
                     [
-                        {id: 1, email: "honor@example.com", username:"honor", role: 'staff'},
-                        {id: 2, email: "audit@example.com", username:"audit", role: 'instructor'},
-                        {id: 3, email: "staff@example.com", username:"staff", role: 'library_user'}
+                        {id: 1, email: 'honor@example.com', username: 'honor', role: 'staff'},
+                        {id: 2, email: 'audit@example.com', username: 'audit', role: 'instructor'},
+                        {id: 3, email: 'staff@example.com', username: 'staff', role: 'library_user'}
                     ],
-                    "dummy_change_role_url",
+                    'dummy_change_role_url',
                     10000,
                     false
                 );
             });
 
-            afterEach(function () {
+            afterEach(function() {
                 ViewHelpers.removeMockAnalytics();
             });
 
-            it("can't give a user permission to use the library", function () {
+            it("can't give a user permission to use the library", function() {
                 expect($('.create-user-button')).not.toBeVisible();
                 expect($('.wrapper-create-user')).not.toBeVisible();
             });
 
-            it("can't promote or demote user", function () {
+            it("can't promote or demote user", function() {
                 expect($('.action-role')).not.toBeVisible();
             });
         });

--- a/cms/static/js/spec/views/paging_spec.js
+++ b/cms/static/js/spec/views/paging_spec.js
@@ -1,12 +1,12 @@
 define([
-        "jquery",
-        "URI",
-        "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers",
-        "edx-ui-toolkit/js/pagination/paging-collection",
-        "js/views/paging",
-        "js/views/paging_header"
-    ],
-    function ($, URI, AjaxHelpers, PagingCollection, PagingView, PagingHeader) {
+    'jquery',
+    'URI',
+    'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
+    'edx-ui-toolkit/js/pagination/paging-collection',
+    'js/views/paging',
+    'js/views/paging_header'
+],
+    function($, URI, AjaxHelpers, PagingCollection, PagingView, PagingHeader) {
         'use strict';
 
         var createPageableItem = function(index) {
@@ -54,20 +54,20 @@ define([
             var url = new URI(request.url);
             var queryParameters = url.query(true); // Returns an object with each query parameter stored as a value
             var page = queryParameters.page;
-            var response = page === "0" ? mockFirstPage : mockSecondPage;
+            var response = page === '0' ? mockFirstPage : mockSecondPage;
             AjaxHelpers.respondWithJson(requests, response);
         };
 
         var MockPagingView = PagingView.extend({
             renderPageItems: function() {},
-            initialize : function() {
+            initialize: function() {
                 this.registerSortableColumn('name-col', 'Name', 'name', 'asc');
                 this.registerSortableColumn('date-col', 'Date', 'date', 'desc');
                 this.setInitialSortColumn('date-col');
             }
         });
 
-        describe("Paging", function() {
+        describe('Paging', function() {
             var pagingView,
                 TestPagingCollection = PagingCollection.extend({
                     state: {
@@ -77,15 +77,15 @@ define([
                     }
                 });
 
-            beforeEach(function () {
+            beforeEach(function() {
                 var collection = new TestPagingCollection();
                 collection.url = '/dummy/';
                 pagingView = new MockPagingView({collection: collection});
             });
 
-            describe("PagingView", function () {
-                describe("setPage", function () {
-                    it('can set the current page', function () {
+            describe('PagingView', function() {
+                describe('setPage', function() {
+                    it('can set the current page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
@@ -95,7 +95,7 @@ define([
                         expect(pagingView.collection.getPageNumber()).toBe(2);
                     });
 
-                    it('should not change page after a server error', function () {
+                    it('should not change page after a server error', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
@@ -107,8 +107,8 @@ define([
                     });
                 });
 
-                describe("nextPage", function () {
-                    it('does not move forward after a server error', function () {
+                describe('nextPage', function() {
+                    it('does not move forward after a server error', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
@@ -117,7 +117,7 @@ define([
                         expect(pagingView.collection.getPageNumber()).toBe(1);
                     });
 
-                    it('can move to the next page', function () {
+                    it('can move to the next page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
@@ -128,7 +128,7 @@ define([
                         expect(pagingView.collection.getPageNumber()).toBe(2);
                     });
 
-                    it('can not move forward from the final page', function () {
+                    it('can not move forward from the final page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(2);
                         respondWithMockItems(requests);
@@ -137,8 +137,8 @@ define([
                     });
                 });
 
-                describe("previousPage", function () {
-                    it('can move back a page', function () {
+                describe('previousPage', function() {
+                    it('can move back a page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(2);
                         respondWithMockItems(requests);
@@ -147,7 +147,7 @@ define([
                         expect(pagingView.collection.getPageNumber()).toBe(1);
                     });
 
-                    it('can not move back from the first page', function () {
+                    it('can not move back from the first page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
@@ -155,7 +155,7 @@ define([
                         AjaxHelpers.expectNoRequests(requests);
                     });
 
-                    it('does not move back after a server error', function () {
+                    it('does not move back after a server error', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(2);
                         respondWithMockItems(requests);
@@ -165,8 +165,8 @@ define([
                     });
                 });
 
-                describe("toggleSortOrder", function () {
-                    it('can toggle direction of the current sort', function () {
+                describe('toggleSortOrder', function() {
+                    it('can toggle direction of the current sort', function() {
                         var requests = AjaxHelpers.requests(this);
                         expect(pagingView.collection.sortDirection).toBe('desc');
                         pagingView.toggleSortOrder('date-col');
@@ -177,7 +177,7 @@ define([
                         expect(pagingView.collection.sortDirection).toBe('desc');
                     });
 
-                    it('sets the correct default sort direction for a column', function () {
+                    it('sets the correct default sort direction for a column', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.toggleSortOrder('name-col');
                         respondWithMockItems(requests);
@@ -190,9 +190,8 @@ define([
                     });
                 });
 
-                describe("sortableColumnInfo", function () {
-
-                    it('returns the registered info for a column', function () {
+                describe('sortableColumnInfo', function() {
+                    it('returns the registered info for a column', function() {
                         pagingView.registerSortableColumn('test-col', 'Test Column', 'testField', 'asc');
                         var sortInfo = pagingView.sortableColumnInfo('test-col');
                         expect(sortInfo.displayName).toBe('Test Column');
@@ -200,7 +199,7 @@ define([
                         expect(sortInfo.defaultSortDirection).toBe('asc');
                     });
 
-                    it('throws an exception for an unregistered column', function () {
+                    it('throws an exception for an unregistered column', function() {
                         expect(function() {
                             pagingView.sortableColumnInfo('no-such-column');
                         }).toThrow();
@@ -208,21 +207,21 @@ define([
                 });
             });
 
-            describe("PagingHeader", function () {
+            describe('PagingHeader', function() {
                 var pagingHeader;
 
-                beforeEach(function () {
+                beforeEach(function() {
                     pagingHeader = new PagingHeader({view: pagingView});
                 });
 
-                describe("Next page button", function () {
-                    beforeEach(function () {
+                describe('Next page button', function() {
+                    beforeEach(function() {
                         // Render the page and header so that they can react to events
                         pagingView.render();
                         pagingHeader.render();
                     });
 
-                    it('does not move forward if a server error occurs', function () {
+                    it('does not move forward if a server error occurs', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
@@ -232,7 +231,7 @@ define([
                         expect(pagingView.collection.getPageNumber()).toBe(1);
                     });
 
-                    it('can move to the next page', function () {
+                    it('can move to the next page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
@@ -241,21 +240,21 @@ define([
                         expect(pagingView.collection.getPageNumber()).toBe(2);
                     });
 
-                    it('should be enabled when there is at least one more page', function () {
+                    it('should be enabled when there is at least one more page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
                         expect(pagingHeader.$('.next-page-link')).not.toHaveClass('is-disabled');
                     });
 
-                    it('should be disabled on the final page', function () {
+                    it('should be disabled on the final page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(2);
                         respondWithMockItems(requests);
                         expect(pagingHeader.$('.next-page-link')).toHaveClass('is-disabled');
                     });
 
-                    it('should be disabled on an empty page', function () {
+                    it('should be disabled on an empty page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -263,14 +262,14 @@ define([
                     });
                 });
 
-                describe("Previous page button", function () {
-                    beforeEach(function () {
+                describe('Previous page button', function() {
+                    beforeEach(function() {
                         // Render the page and header so that they can react to events
                         pagingView.render();
                         pagingHeader.render();
                     });
 
-                    it('does not move back if a server error occurs', function () {
+                    it('does not move back if a server error occurs', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(2);
                         respondWithMockItems(requests);
@@ -279,7 +278,7 @@ define([
                         expect(pagingView.collection.getPageNumber()).toBe(2);
                     });
 
-                    it('can go back a page', function () {
+                    it('can go back a page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(2);
                         respondWithMockItems(requests);
@@ -288,21 +287,21 @@ define([
                         expect(pagingView.collection.getPageNumber()).toBe(1);
                     });
 
-                    it('should be disabled on the first page', function () {
+                    it('should be disabled on the first page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
                         expect(pagingHeader.$('.previous-page-link')).toHaveClass('is-disabled');
                     });
 
-                    it('should be enabled on the second page', function () {
+                    it('should be enabled on the second page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(2);
                         respondWithMockItems(requests);
                         expect(pagingHeader.$('.previous-page-link')).not.toHaveClass('is-disabled');
                     });
 
-                    it('should be disabled for an empty page', function () {
+                    it('should be disabled for an empty page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -310,8 +309,8 @@ define([
                     });
                 });
 
-                describe("Page metadata section", function() {
-                    it('shows the correct metadata for the current page', function () {
+                describe('Page metadata section', function() {
+                    it('shows the correct metadata for the current page', function() {
                         var requests = AjaxHelpers.requests(this),
                             message;
                         pagingView.setPage(1);
@@ -322,7 +321,7 @@ define([
                             'sorted by <span class="sort-order">Date</span> descending</p>');
                     });
 
-                    it('shows the correct metadata when sorted ascending', function () {
+                    it('shows the correct metadata when sorted ascending', function() {
                         var requests = AjaxHelpers.requests(this),
                             message;
                         pagingView.setPage(1);
@@ -335,22 +334,22 @@ define([
                     });
                 });
 
-                describe("Item count label", function () {
-                    it('should show correct count on first page', function () {
+                describe('Item count label', function() {
+                    it('should show correct count on first page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
                         expect(pagingHeader.$('.count-current-shown')).toHaveHtml('1-3');
                     });
 
-                    it('should show correct count on second page', function () {
+                    it('should show correct count on second page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(2);
                         respondWithMockItems(requests);
                         expect(pagingHeader.$('.count-current-shown')).toHaveHtml('4-4');
                     });
 
-                    it('should show correct count for an empty collection', function () {
+                    it('should show correct count for an empty collection', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -358,22 +357,22 @@ define([
                     });
                 });
 
-                describe("Item total label", function () {
-                    it('should show correct total on the first page', function () {
+                describe('Item total label', function() {
+                    it('should show correct total on the first page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
                         expect(pagingHeader.$('.count-total')).toHaveText('4 total');
                     });
 
-                    it('should show correct total on the second page', function () {
+                    it('should show correct total on the second page', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(2);
                         respondWithMockItems(requests);
                         expect(pagingHeader.$('.count-total')).toHaveText('4 total');
                     });
 
-                    it('should show zero total for an empty collection', function () {
+                    it('should show zero total for an empty collection', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         AjaxHelpers.respondWithJson(requests, mockEmptyPage);
@@ -381,15 +380,15 @@ define([
                     });
                 });
 
-                describe("Sort order label", function () {
-                    it('should show correct initial sort order', function () {
+                describe('Sort order label', function() {
+                    it('should show correct initial sort order', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.setPage(1);
                         respondWithMockItems(requests);
                         expect(pagingHeader.$('.sort-order')).toHaveText('Date');
                     });
 
-                    it('should show updated sort order', function () {
+                    it('should show updated sort order', function() {
                         var requests = AjaxHelpers.requests(this);
                         pagingView.toggleSortOrder('name-col');
                         respondWithMockItems(requests);

--- a/cms/static/js/spec/views/previous_video_upload_list_spec.js
+++ b/cms/static/js/spec/views/previous_video_upload_list_spec.js
@@ -1,20 +1,20 @@
 define(
-    ["jquery", "underscore", "backbone", "js/views/previous_video_upload_list", "common/js/spec_helpers/template_helpers"],
+    ['jquery', 'underscore', 'backbone', 'js/views/previous_video_upload_list', 'common/js/spec_helpers/template_helpers'],
     function($, _, Backbone, PreviousVideoUploadListView, TemplateHelpers) {
-        "use strict";
-        describe("PreviousVideoUploadListView", function() {
+        'use strict';
+        describe('PreviousVideoUploadListView', function() {
             beforeEach(function() {
-                TemplateHelpers.installTemplate("previous-video-upload", true);
-                TemplateHelpers.installTemplate("previous-video-upload-list");
+                TemplateHelpers.installTemplate('previous-video-upload', true);
+                TemplateHelpers.installTemplate('previous-video-upload-list');
             });
 
             var render = function(numModels) {
                 var modelData = {
-                    client_video_id: "foo.mp4",
+                    client_video_id: 'foo.mp4',
                     duration: 42,
-                    created: "2014-11-25T23:13:05",
-                    edx_video_id: "dummy_id",
-                    status: "uploading"
+                    created: '2014-11-25T23:13:05',
+                    edx_video_id: 'dummy_id',
+                    status: 'uploading'
                 };
                 var collection = new Backbone.Collection(
                     _.map(
@@ -26,16 +26,16 @@ define(
                 return view.render().$el;
             };
 
-            it("should render an empty collection", function() {
+            it('should render an empty collection', function() {
                 var $el = render(0);
-                expect($el.find(".js-table-body").length).toEqual(1);
-                expect($el.find(".js-table-body tr").length).toEqual(0);
+                expect($el.find('.js-table-body').length).toEqual(1);
+                expect($el.find('.js-table-body tr').length).toEqual(0);
             });
 
-            it("should render a non-empty collection", function() {
+            it('should render a non-empty collection', function() {
                 var $el = render(5);
-                expect($el.find(".js-table-body").length).toEqual(1);
-                expect($el.find(".js-table-body tr").length).toEqual(5);
+                expect($el.find('.js-table-body').length).toEqual(1);
+                expect($el.find('.js-table-body tr').length).toEqual(5);
             });
         });
     }

--- a/cms/static/js/spec/views/previous_video_upload_spec.js
+++ b/cms/static/js/spec/views/previous_video_upload_spec.js
@@ -1,19 +1,19 @@
 define(
-    ["jquery", "backbone", "js/views/previous_video_upload", "common/js/spec_helpers/template_helpers"],
+    ['jquery', 'backbone', 'js/views/previous_video_upload', 'common/js/spec_helpers/template_helpers'],
     function($, Backbone, PreviousVideoUploadView, TemplateHelpers) {
-        "use strict";
-        describe("PreviousVideoUploadView", function() {
+        'use strict';
+        describe('PreviousVideoUploadView', function() {
             beforeEach(function() {
-                TemplateHelpers.installTemplate("previous-video-upload", true);
+                TemplateHelpers.installTemplate('previous-video-upload', true);
             });
 
             var render = function(modelData) {
                 var defaultData = {
-                    client_video_id: "foo.mp4",
+                    client_video_id: 'foo.mp4',
                     duration: 42,
-                    created: "2014-11-25T23:13:05",
-                    edx_video_id: "dummy_id",
-                    status: "uploading"
+                    created: '2014-11-25T23:13:05',
+                    edx_video_id: 'dummy_id',
+                    status: 'uploading'
                 };
                 var view = new PreviousVideoUploadView(
                     {model: new Backbone.Model($.extend({}, defaultData, modelData))}
@@ -21,54 +21,54 @@ define(
                 return view.render().$el;
             };
 
-            it("should render video name correctly", function() {
-                var testName = "test name";
+            it('should render video name correctly', function() {
+                var testName = 'test name';
                 var $el = render({client_video_id: testName});
-                expect($el.find(".name-col").text()).toEqual(testName);
+                expect($el.find('.name-col').text()).toEqual(testName);
             });
 
             _.each(
                 [
-                    {desc: "zero as pending", seconds: 0, expected: "Pending"},
-                    {desc: "less than one second as zero", seconds: 0.75, expected: "0:00"},
-                    {desc: "with minutes and without seconds", seconds: 900, expected: "15:00"},
-                    {desc: "with seconds and without minutes", seconds: 15, expected: "0:15"},
-                    {desc: "with minutes and seconds", seconds: 915, expected: "15:15"},
-                    {desc: "with seconds padded", seconds: 5, expected: "0:05"},
-                    {desc: "longer than an hour as many minutes", seconds: 7425, expected: "123:45"}
+                    {desc: 'zero as pending', seconds: 0, expected: 'Pending'},
+                    {desc: 'less than one second as zero', seconds: 0.75, expected: '0:00'},
+                    {desc: 'with minutes and without seconds', seconds: 900, expected: '15:00'},
+                    {desc: 'with seconds and without minutes', seconds: 15, expected: '0:15'},
+                    {desc: 'with minutes and seconds', seconds: 915, expected: '15:15'},
+                    {desc: 'with seconds padded', seconds: 5, expected: '0:05'},
+                    {desc: 'longer than an hour as many minutes', seconds: 7425, expected: '123:45'}
                 ],
                 function(caseInfo) {
-                    it("should render duration " + caseInfo.desc, function() {
+                    it('should render duration ' + caseInfo.desc, function() {
                         var $el = render({duration: caseInfo.seconds});
-                        expect($el.find(".duration-col").text()).toEqual(caseInfo.expected);
+                        expect($el.find('.duration-col').text()).toEqual(caseInfo.expected);
                     });
                 }
             );
 
-            it("should render created timestamp correctly", function() {
-                var fakeDate = "fake formatted date";
-                spyOn(Date.prototype, "toLocaleString").and.callFake(
+            it('should render created timestamp correctly', function() {
+                var fakeDate = 'fake formatted date';
+                spyOn(Date.prototype, 'toLocaleString').and.callFake(
                     function(locales, options) {
                         expect(locales).toEqual([]);
-                        expect(options.timeZone).toEqual("UTC");
-                        expect(options.timeZoneName).toEqual("short");
+                        expect(options.timeZone).toEqual('UTC');
+                        expect(options.timeZoneName).toEqual('short');
                         return fakeDate;
                     }
                 );
                 var $el = render({});
-                expect($el.find(".date-col").text()).toEqual(fakeDate);
+                expect($el.find('.date-col').text()).toEqual(fakeDate);
             });
 
-            it("should render video id correctly", function() {
-                var testId = "test_id";
+            it('should render video id correctly', function() {
+                var testId = 'test_id';
                 var $el = render({edx_video_id: testId});
-                expect($el.find(".video-id-col").text()).toEqual(testId);
+                expect($el.find('.video-id-col').text()).toEqual(testId);
             });
 
-            it("should render status correctly", function() {
-                var testStatus = "Test Status";
+            it('should render status correctly', function() {
+                var testStatus = 'Test Status';
                 var $el = render({status: testStatus});
-                expect($el.find(".status-col").text()).toEqual(testStatus);
+                expect($el.find('.status-col').text()).toEqual(testStatus);
             });
         });
     }

--- a/cms/static/js/spec/views/programs/program_creator_spec.js
+++ b/cms/static/js/spec/views/programs/program_creator_spec.js
@@ -1,15 +1,15 @@
 define([
-        'backbone',
-        'jquery',
-        'js/programs/views/program_creator_view'
-    ],
-    function( Backbone, $, ProgramCreatorView ) {
+    'backbone',
+    'jquery',
+    'js/programs/views/program_creator_view'
+],
+    function(Backbone, $, ProgramCreatorView) {
         'use strict';
 
-        describe('ProgramCreatorView', function () {
+        describe('ProgramCreatorView', function() {
             var view = {},
                 Router = Backbone.Router.extend({
-                    initialize: function( options ) {
+                    initialize: function(options) {
                         this.homeUrl = options.homeUrl;
                     },
                     goHome: function() {
@@ -20,61 +20,61 @@ define([
                     count: 1,
                     previous: null,
                     'num_pages': 1,
-                    results:[{
+                    results: [{
                         'display_name': 'test-org-display_name',
                         'key': 'test-org-key'
                     }],
                     next: null
                 },
                 sampleInput,
-                completeForm = function( data ) {
-                    view.$el.find('#program-name').val( data.name );
-                    view.$el.find('#program-subtitle').val( data.subtitle );
-                    view.$el.find('#program-org').val( data.organizations );
+                completeForm = function(data) {
+                    view.$el.find('#program-name').val(data.name);
+                    view.$el.find('#program-subtitle').val(data.subtitle);
+                    view.$el.find('#program-org').val(data.organizations);
 
-                    if ( data.category ) {
-                        view.$el.find('#program-type').val( data.category );
+                    if (data.category) {
+                        view.$el.find('#program-type').val(data.category);
                     }
 
-                    if ( data.marketing_slug ) {
-                        view.$el.find('#program-marketing-slug').val( data.marketing_slug );
+                    if (data.marketing_slug) {
+                        view.$el.find('#program-marketing-slug').val(data.marketing_slug);
                     }
                 },
-                verifyValidation = function ( data, invalidAttr ) {
+                verifyValidation = function(data, invalidAttr) {
                     var errorClass = 'has-error',
-                        $invalidElement = view.$el.find( '[name="' + invalidAttr + '"]' ),
+                        $invalidElement = view.$el.find('[name="' + invalidAttr + '"]'),
                         $errorMsg = $invalidElement.siblings('.field-message'),
                         inputErrorMsg = '';
 
-                    completeForm( data );
+                    completeForm(data);
 
                     view.$el.find('.js-create-program').click();
                     inputErrorMsg = $invalidElement.data('error');
 
-                    expect( view.model.save ).not.toHaveBeenCalled();
-                    expect( $invalidElement ).toHaveClass( errorClass );
-                    expect( $errorMsg ).toHaveClass( errorClass );
-                    expect( inputErrorMsg ).toBeDefined();
-                    expect( $errorMsg.find('.field-message-content').html() ).toEqual( inputErrorMsg );
+                    expect(view.model.save).not.toHaveBeenCalled();
+                    expect($invalidElement).toHaveClass(errorClass);
+                    expect($errorMsg).toHaveClass(errorClass);
+                    expect(inputErrorMsg).toBeDefined();
+                    expect($errorMsg.find('.field-message-content').html()).toEqual(inputErrorMsg);
                 };
 
-            var validateFormSubmitted = function(view, programId){
-                expect( $.ajax ).toHaveBeenCalled();
-                expect( view.saveSuccess ).toHaveBeenCalled();
-                expect( view.goToView ).toHaveBeenCalledWith( String( programId ) );
-                expect( view.saveError ).not.toHaveBeenCalled();
+            var validateFormSubmitted = function(view, programId) {
+                expect($.ajax).toHaveBeenCalled();
+                expect(view.saveSuccess).toHaveBeenCalled();
+                expect(view.goToView).toHaveBeenCalledWith(String(programId));
+                expect(view.saveError).not.toHaveBeenCalled();
             };
 
-            beforeEach( function() {
+            beforeEach(function() {
                 // Set the DOM
-                setFixtures( '<div class="js-program-admin"></div>' );
+                setFixtures('<div class="js-program-admin"></div>');
 
                 jasmine.clock().install();
 
-                spyOn( ProgramCreatorView.prototype, 'saveSuccess' ).and.callThrough();
-                spyOn( ProgramCreatorView.prototype, 'goToView' ).and.callThrough();
-                spyOn( ProgramCreatorView.prototype, 'saveError' ).and.callThrough();
-                spyOn( Router.prototype, 'goHome' );
+                spyOn(ProgramCreatorView.prototype, 'saveSuccess').and.callThrough();
+                spyOn(ProgramCreatorView.prototype, 'goToView').and.callThrough();
+                spyOn(ProgramCreatorView.prototype, 'saveError').and.callThrough();
+                spyOn(Router.prototype, 'goHome');
 
                 sampleInput = {
                     category: 'XSeries',
@@ -90,38 +90,38 @@ define([
                     })
                 });
 
-                view.organizations.set( organizations );
+                view.organizations.set(organizations);
                 view.render();
             });
 
-            afterEach( function() {
+            afterEach(function() {
                 view.destroy();
 
                 jasmine.clock().uninstall();
             });
 
-            it( 'should exist', function () {
-                expect( view ).toBeDefined();
+            it('should exist', function() {
+                expect(view).toBeDefined();
             });
 
-            it ( 'should get the form data', function() {
+            it('should get the form data', function() {
                 var formData = {};
 
-                completeForm( sampleInput );
+                completeForm(sampleInput);
                 formData = view.getData();
 
-                expect( formData.name ).toEqual( sampleInput.name );
-                expect( formData.subtitle ).toEqual( sampleInput.subtitle );
-                expect( formData.organizations[0].key ).toEqual( sampleInput.organizations );
+                expect(formData.name).toEqual(sampleInput.name);
+                expect(formData.subtitle).toEqual(sampleInput.subtitle);
+                expect(formData.organizations[0].key).toEqual(sampleInput.organizations);
             });
 
-            it( 'should submit the form when the user clicks submit', function() {
+            it('should submit the form when the user clicks submit', function() {
                 var programId = 123;
 
-                completeForm( sampleInput );
+                completeForm(sampleInput);
 
-                spyOn( $, 'ajax' ).and.callFake( function( event ) {
-                    event.success({ id: programId });
+                spyOn($, 'ajax').and.callFake(function(event) {
+                    event.success({id: programId});
                 });
 
                 view.$el.find('.js-create-program').click();
@@ -129,14 +129,14 @@ define([
                 validateFormSubmitted(view, programId);
             });
 
-            it( 'should submit the form correctly when creating micromasters program ', function(){
+            it('should submit the form correctly when creating micromasters program ', function() {
                 var programId = 221;
                 sampleInput.category = 'MicroMasters';
-                
-                completeForm( sampleInput );
 
-                spyOn( $, 'ajax' ).and.callFake( function( event ) {
-                    event.success({ id: programId });
+                completeForm(sampleInput);
+
+                spyOn($, 'ajax').and.callFake(function(event) {
+                    event.success({id: programId});
                 });
 
                 view.$el.find('.js-create-program').click();
@@ -144,108 +144,108 @@ define([
                 validateFormSubmitted(view, programId);
             });
 
-            it( 'should run the saveError when model save failures occur', function() {
-                spyOn( $, 'ajax' ).and.callFake( function( event ) {
+            it('should run the saveError when model save failures occur', function() {
+                spyOn($, 'ajax').and.callFake(function(event) {
                     event.error();
                 });
 
                 // Fill out the form with valid data so that form model validation doesn't
                 // prevent the model from being saved.
-                completeForm( sampleInput );
+                completeForm(sampleInput);
                 view.$el.find('.js-create-program').click();
 
-                expect( $.ajax ).toHaveBeenCalled();
-                expect( view.saveSuccess ).not.toHaveBeenCalled();
-                expect( view.saveError ).toHaveBeenCalled();
+                expect($.ajax).toHaveBeenCalled();
+                expect(view.saveSuccess).not.toHaveBeenCalled();
+                expect(view.saveError).toHaveBeenCalled();
             });
 
-            it( 'should set the model when valid form data is submitted', function() {
-                completeForm( sampleInput );
+            it('should set the model when valid form data is submitted', function() {
+                completeForm(sampleInput);
 
-                spyOn( $, 'ajax' ).and.callFake( function( event ) {
-                    event.success({ id: 10001110101 });
+                spyOn($, 'ajax').and.callFake(function(event) {
+                    event.success({id: 10001110101});
                 });
 
                 view.$el.find('.js-create-program').click();
 
-                expect( view.model.get('name') ).toEqual( sampleInput.name );
-                expect( view.model.get('subtitle') ).toEqual( sampleInput.subtitle );
-                expect( view.model.get('organizations')[0].key ).toEqual( sampleInput.organizations );
-                expect( view.model.get('marketing_slug') ).toEqual( sampleInput.marketing_slug );
+                expect(view.model.get('name')).toEqual(sampleInput.name);
+                expect(view.model.get('subtitle')).toEqual(sampleInput.subtitle);
+                expect(view.model.get('organizations')[0].key).toEqual(sampleInput.organizations);
+                expect(view.model.get('marketing_slug')).toEqual(sampleInput.marketing_slug);
             });
 
-            it( 'should not set the model when bad program type selected', function() {
+            it('should not set the model when bad program type selected', function() {
                 var invalidInput = $.extend({}, sampleInput);
-                spyOn( view.model, 'save' );
+                spyOn(view.model, 'save');
 
                 // No name provided.
                 invalidInput.category = '';
-                verifyValidation( invalidInput, 'category' );
+                verifyValidation(invalidInput, 'category');
 
                 // bad program type name
                 invalidInput.name = 'badprogramtype';
-                verifyValidation( invalidInput, 'category' );
+                verifyValidation(invalidInput, 'category');
             });
 
-            it( 'should not set the model when an invalid program name is submitted', function() {
+            it('should not set the model when an invalid program name is submitted', function() {
                 var invalidInput = $.extend({}, sampleInput);
 
-                spyOn( view.model, 'save' );
+                spyOn(view.model, 'save');
 
                 // No name provided.
                 invalidInput.name = '';
-                verifyValidation( invalidInput, 'name' );
+                verifyValidation(invalidInput, 'name');
 
                 // Name is too long.
                 invalidInput.name = 'x'.repeat(256);
-                verifyValidation( invalidInput, 'name' );
+                verifyValidation(invalidInput, 'name');
             });
 
-            it( 'should not set the model when an invalid program subtitle is submitted', function() {
+            it('should not set the model when an invalid program subtitle is submitted', function() {
                 var invalidInput = $.extend({}, sampleInput);
 
-                spyOn( view.model, 'save' );
+                spyOn(view.model, 'save');
 
                 // Subtitle is too long.
                 invalidInput.subtitle = 'x'.repeat(300);
-                verifyValidation( invalidInput, 'subtitle' );
+                verifyValidation(invalidInput, 'subtitle');
             });
 
-            it( 'should not set the model when an invalid category is submitted', function() {
+            it('should not set the model when an invalid category is submitted', function() {
                 var invalidInput = $.extend({}, sampleInput);
 
-                spyOn( view.model, 'save' );
+                spyOn(view.model, 'save');
 
                 // Category other than 'xseries' selected.
                 invalidInput.category = 'yseries';
-                verifyValidation( invalidInput, 'category' );
+                verifyValidation(invalidInput, 'category');
             });
 
-            it( 'should not set the model when an invalid organization key is submitted', function() {
+            it('should not set the model when an invalid organization key is submitted', function() {
                 var invalidInput = $.extend({}, sampleInput);
 
-                spyOn( view.model, 'save' );
+                spyOn(view.model, 'save');
 
                 // No organization selected.
                 invalidInput.organizations = 'false';
-                verifyValidation( invalidInput, 'organizations' );
+                verifyValidation(invalidInput, 'organizations');
             });
 
-            it( 'should not set the model when an invalid marketing slug is submitted', function() {
+            it('should not set the model when an invalid marketing slug is submitted', function() {
                 var invalidInput = $.extend({}, sampleInput);
 
-                spyOn( view.model, 'save' );
+                spyOn(view.model, 'save');
 
                 // Marketing slug is too long.
                 invalidInput.marketing_slug = 'x'.repeat(256);
-                verifyValidation( invalidInput, 'marketing_slug' );
+                verifyValidation(invalidInput, 'marketing_slug');
             });
 
-            it( 'should abort the view when the cancel button is clicked', function() {
-                completeForm( sampleInput );
-                expect( view.$parentEl.html().length ).toBeGreaterThan( 0 );
+            it('should abort the view when the cancel button is clicked', function() {
+                completeForm(sampleInput);
+                expect(view.$parentEl.html().length).toBeGreaterThan(0);
                 view.$el.find('.js-abort-view').click();
-                expect( view.router.goHome ).toHaveBeenCalled();
+                expect(view.router.goHome).toHaveBeenCalled();
             });
         });
     }

--- a/cms/static/js/spec/views/programs/program_details_spec.js
+++ b/cms/static/js/spec/views/programs/program_details_spec.js
@@ -1,16 +1,16 @@
 define([
-        'jquery',
-        'js/programs/collections/course_runs_collection',
-        'js/programs/models/program_model',
-        'js/programs/views/course_run_view',
-        'js/programs/views/program_details_view',
-        'js/programs/utils/constants'
-    ],
-    function( $, CourseRunsCollection, ProgramModel, CourseRunView,
-              ProgramDetailsView, constants ) {
+    'jquery',
+    'js/programs/collections/course_runs_collection',
+    'js/programs/models/program_model',
+    'js/programs/views/course_run_view',
+    'js/programs/views/program_details_view',
+    'js/programs/utils/constants'
+],
+    function($, CourseRunsCollection, ProgramModel, CourseRunView,
+              ProgramDetailsView, constants) {
         'use strict';
 
-        describe('ProgramDetailsView', function () {
+        describe('ProgramDetailsView', function() {
             var view = {},
                 model = {},
                 courseRunsList = [
@@ -143,13 +143,13 @@ define([
                     $form,
                     $submitBtn;
 
-                expect( view.$el.find('.course-details').length ).toEqual( 1 );
+                expect(view.$el.find('.course-details').length).toEqual(1);
                 $addCourseBtn.click();
                 $form = view.$('.js-course-form');
                 $submitBtn = $form.find('.js-select-course');
                 completeCourseForm();
                 $submitBtn.click();
-                expect( $form.find('.field-message.has-error').length ).toEqual( 0 );
+                expect($form.find('.field-message.has-error').length).toEqual(0);
             };
 
             completeCourseForm = function() {
@@ -159,30 +159,30 @@ define([
                 $form.find('.display-name').val('test course 1');
             };
 
-            dropdownSelect = function( $select, value ) {
+            dropdownSelect = function($select, value) {
                 $select.find('option:selected').prop('selected', false);
                 $select.val(value).prop('selected', true);
                 $select.trigger('change');
             };
 
-            editField = function( el, str ) {
-                var $input = view.$el.find( el ),
-                    $btn = $input.next( '.js-enable-edit' );
+            editField = function(el, str) {
+                var $input = view.$el.find(el),
+                    $btn = $input.next('.js-enable-edit');
 
-                expect( document.activeElement ).not.toEqual( $input[0] );
-                expect( $input ).not.toHaveClass( 'edit' );
-                expect( $input ).toHaveClass( 'is-hidden' );
+                expect(document.activeElement).not.toEqual($input[0]);
+                expect($input).not.toHaveClass('edit');
+                expect($input).toHaveClass('is-hidden');
 
                 $btn.click();
 
-                $input.val( str );
+                $input.val(str);
 
                 // Enable editing
-                expect( $input ).not.toHaveClass( 'is-hidden' );
-                expect( $input ).toHaveClass( 'edit' );
+                expect($input).not.toHaveClass('is-hidden');
+                expect($input).toHaveClass('edit');
             };
 
-            keyPress = function( $el, key ) {
+            keyPress = function($el, key) {
                 $el.trigger({
                     type: 'keydown',
                     keyCode: key,
@@ -196,9 +196,9 @@ define([
                     defaultStatus = programData.status,
                     publishedStatus = 'active';
 
-                expect( view.modalView ).not.toBeDefined();
-                expect( view.model.get( 'status' ) ).toEqual( defaultStatus );
-                expect( view.model.get( 'status' ) ).not.toEqual( publishedStatus );
+                expect(view.modalView).not.toBeDefined();
+                expect(view.model.get('status')).toEqual(defaultStatus);
+                expect(view.model.get('status')).not.toEqual(publishedStatus);
 
                 $publishBtn.click();
             };
@@ -209,77 +209,77 @@ define([
                 programData.course_codes = [originalRun];
             };
 
-            testUnchangedFieldBlur = function( el ) {
-                var $input = view.$el.find( el ),
-                    $btn = view.$el.find( '.js-add-course' ),
+            testUnchangedFieldBlur = function(el) {
+                var $input = view.$el.find(el),
+                    $btn = view.$el.find('.js-add-course'),
                     title = $input.val(),
                     update = title;
 
-                editField( el, update );
+                editField(el, update);
                 $btn.focus();
                 $input.blur();
 
-                expect( title ).toEqual( update );
-                expect( view.model.save ).not.toHaveBeenCalled();
+                expect(title).toEqual(update);
+                expect(view.model.save).not.toHaveBeenCalled();
             };
 
-            testUpdatedFieldBlur = function( el, update ) {
-                var $input = view.$el.find( el ),
-                    $btn = view.$el.find( '.js-add-course' );
+            testUpdatedFieldBlur = function(el, update) {
+                var $input = view.$el.find(el),
+                    $btn = view.$el.find('.js-add-course');
 
-                expect( $input.val() ).not.toEqual( update );
+                expect($input.val()).not.toEqual(update);
 
-                editField( el, update );
+                editField(el, update);
 
                 $btn.focus();
                 $input.blur();
 
-                expect( $input.val() ).toEqual( update );
-                expect( view.model.save ).toHaveBeenCalled();
+                expect($input.val()).toEqual(update);
+                expect(view.model.save).toHaveBeenCalled();
             };
 
-            testHidingButtonsAfterPublish = function( el ) {
-                expect( view.$el.find( el ).length ).toBeGreaterThan( 0 );
-                view.model.set({ status: 'active' });
+            testHidingButtonsAfterPublish = function(el) {
+                expect(view.$el.find(el).length).toBeGreaterThan(0);
+                view.model.set({status: 'active'});
                 view.render();
-                expect( view.$el.find( el ).length ).toEqual( 0 );
+                expect(view.$el.find(el).length).toEqual(0);
             };
 
-            testInvalidUpdate = function( el, update ) {
-                var $input = view.$el.find( el ),
-                    $btn = view.$el.find( '.js-add-course' );
+            testInvalidUpdate = function(el, update) {
+                var $input = view.$el.find(el),
+                    $btn = view.$el.find('.js-add-course');
 
-                editField( el, update );
+                editField(el, update);
 
                 $btn.focus();
                 $input.blur();
 
-                expect( $input ).toHaveClass( errorClass );
-                expect( view.model.save ).not.toHaveBeenCalled();
+                expect($input).toHaveClass(errorClass);
+                expect(view.model.save).not.toHaveBeenCalled();
             };
 
-            beforeEach( function() {
+            beforeEach(function() {
                 // Set the DOM
-                setFixtures( '<div class="js-program-admin"></div>' );
+                setFixtures('<div class="js-program-admin"></div>');
 
                 jasmine.clock().install();
 
-                spyOn( ProgramModel.prototype, 'set' ).and.callThrough();
-                spyOn( ProgramModel.prototype, 'save' );
-                spyOn( CourseRunsCollection.prototype, 'fetch' );
+                spyOn(ProgramModel.prototype, 'set').and.callThrough();
+                spyOn(ProgramModel.prototype, 'save');
+                spyOn(CourseRunsCollection.prototype, 'fetch');
 
                 model = new ProgramModel();
-                model.set( programData );
+                model.set(programData);
 
                 view = new ProgramDetailsView({
                     model: model
                 });
 
-                view.courseRuns.set( courseRunsList );
-                view.courseRuns.parse({ results: courseRunsList });
+                view.courseRuns.set(courseRunsList);
+                view.courseRuns.parse({results: courseRunsList});
             });
 
-            afterEach( function() {
+            afterEach(function() {
                 resetCourseCodes();
                 view.undelegateEvents();
                 view.remove();
@@ -287,244 +287,244 @@ define([
                 jasmine.clock().uninstall();
             });
 
-            describe( 'View data', function() {
-                it( 'should exist', function () {
-                    expect( view ).toBeDefined();
+            describe('View data', function() {
+                it('should exist', function() {
+                    expect(view).toBeDefined();
                 });
 
-                it( 'should render all of the run_modes from the model', function() {
-                   var $runs = view.$el.find('.js-course-runs'),
-                       domLength = $runs.find('.js-remove-run').length,
-                       objLength = programData.course_codes[0].run_modes.length;
+                it('should render all of the run_modes from the model', function() {
+                    var $runs = view.$el.find('.js-course-runs'),
+                        domLength = $runs.find('.js-remove-run').length,
+                        objLength = programData.course_codes[0].run_modes.length;
 
-                    expect( domLength ).toEqual( objLength );
+                    expect(domLength).toEqual(objLength);
                 });
             });
 
-            describe( 'Delete data', function() {
-                it( 'should remove a course when the delete button is clicked', function() {
+            describe('Delete data', function() {
+                it('should remove a course when the delete button is clicked', function() {
                     var $el = view.$el.find('.js-course-list'),
                         $removeRunBtn = $el.find('.js-remove-course').first(),
                         count = programData.course_codes.length;
 
-                    expect( $el.find('.js-remove-course').length ).toEqual( count );
+                    expect($el.find('.js-remove-course').length).toEqual(count);
                     $removeRunBtn.click();
 
-                    setTimeout( function() {
-                        expect( $el.find('.js-remove-course').length ).toEqual( count - 1 );
-                    }, testTimeoutInterval );
+                    setTimeout(function() {
+                        expect($el.find('.js-remove-course').length).toEqual(count - 1);
+                    }, testTimeoutInterval);
 
-                    jasmine.clock().tick( testTimeoutInterval + 1 );
+                    jasmine.clock().tick(testTimeoutInterval + 1);
                 });
 
-                it( 'should remove a course run when the delete button is clicked', function() {
+                it('should remove a course run when the delete button is clicked', function() {
                     var $runs = view.$el.find('.js-course-runs'),
                         $removeRunBtn = $runs.find('.js-remove-run').first(),
                         count = programData.course_codes[0].run_modes.length;
 
-                    expect( $runs.find('.js-remove-run').length ).toEqual( count );
+                    expect($runs.find('.js-remove-run').length).toEqual(count);
                     $removeRunBtn.click();
 
-                    setTimeout( function() {
-                        expect( $runs.find('.js-remove-run').length ).toEqual( count - 1 );
-                    }, testTimeoutInterval );
+                    setTimeout(function() {
+                        expect($runs.find('.js-remove-run').length).toEqual(count - 1);
+                    }, testTimeoutInterval);
 
-                    jasmine.clock().tick( testTimeoutInterval + 1 );
+                    jasmine.clock().tick(testTimeoutInterval + 1);
                 });
 
-                it( 'should not show the delete course button if program status is not unpublished', function() {
+                it('should not show the delete course button if program status is not unpublished', function() {
                     testHidingButtonsAfterPublish('.js-remove-course');
                 });
 
-                it( 'should not show the add course button if program status is not unpublished', function() {
+                it('should not show the add course button if program status is not unpublished', function() {
                     testHidingButtonsAfterPublish('.js-add-course');
                 });
 
-                it( 'should not show the delete run button if program status is not unpublished', function() {
+                it('should not show the delete run button if program status is not unpublished', function() {
                     testHidingButtonsAfterPublish('.js-remove-run');
                 });
             });
 
-            describe( 'Add data', function() {
-                it( 'should add a new course details view on click of the add course button', function() {
+            describe('Add data', function() {
+                it('should add a new course details view on click of the add course button', function() {
                     var $btn = view.$el.find('.js-add-course').first();
 
-                    expect( view.$('.js-course-form').length ).toEqual( 0 );
+                    expect(view.$('.js-course-form').length).toEqual(0);
                     $btn.click();
-                    expect( view.$('.js-course-form').length ).toEqual( 1 );
+                    expect(view.$('.js-course-form').length).toEqual(1);
                 });
 
-                it( 'should add a course when the form is submitted', function() {
+                it('should add a course when the form is submitted', function() {
                     addCourse();
                 });
 
-                it( 'should not submit the course form when it is incomplete', function() {
+                it('should not submit the course form when it is incomplete', function() {
                     var $addCourseBtn = view.$el.find('.js-add-course').first(),
                         $form,
                         $submitBtn;
 
-                    expect( view.$el.find('.course-details').length ).toEqual( 1 );
+                    expect(view.$el.find('.course-details').length).toEqual(1);
                     $addCourseBtn.click();
                     $form = view.$('.js-course-form');
-                    expect( $form.find('.field-message.has-error').length ).toEqual( 0 );
+                    expect($form.find('.field-message.has-error').length).toEqual(0);
                     $submitBtn = $form.find('.js-select-course');
                     $submitBtn.click();
-                    expect( $form.find('.field-message.has-error').length ).toEqual( 2 );
+                    expect($form.find('.field-message.has-error').length).toEqual(2);
                 });
 
-                it( 'should allow a user to add a course run', function() {
+                it('should allow a user to add a course run', function() {
                     var runSelect = '.js-course-run-select',
                         $runSelect,
                         savedRunCount = programData.course_codes[0].run_modes.length;
 
                     addCourse();
-                    expect( view.$(runSelect).length ).toEqual(0);
+                    expect(view.$(runSelect).length).toEqual(0);
                     view.$('.js-add-course-run').first().click();
 
                     $runSelect = view.$(runSelect);
-                    expect( $runSelect.length ).toEqual(1);
-                    expect( view.$('.js-remove-run').length ).toEqual(savedRunCount);
+                    expect($runSelect.length).toEqual(1);
+                    expect(view.$('.js-remove-run').length).toEqual(savedRunCount);
                     dropdownSelect($runSelect, courseRunsList[0].id);
-                    expect( view.$(runSelect).length ).toEqual(0);
-                    expect( view.$('.js-remove-run').length ).toEqual(savedRunCount + 1);
+                    expect(view.$(runSelect).length).toEqual(0);
+                    expect(view.$('.js-remove-run').length).toEqual(savedRunCount + 1);
                 });
 
-                it( 'should update the course run dropdown if multiple are open and one is selected', function() {
+                it('should update the course run dropdown if multiple are open and one is selected', function() {
                     var runSelect = '.js-course-run-select',
                         $addRunBtn,
                         $courseView,
                         courseRunOptionsCount = courseRunsList.length + 1;
 
                     addCourse();
-                    expect( view.$(runSelect).length ).toEqual(0);
+                    expect(view.$(runSelect).length).toEqual(0);
 
                     $courseView = view.$('.course-container').last();
                     $addRunBtn = $courseView.find('.js-add-course-run');
                     $addRunBtn.click();
 
-                    expect( view.$(runSelect).length ).toEqual(1);
-                    expect( view.$(runSelect).find('option').length ).toEqual(courseRunOptionsCount);
+                    expect(view.$(runSelect).length).toEqual(1);
+                    expect(view.$(runSelect).find('option').length).toEqual(courseRunOptionsCount);
 
                     $addRunBtn.click();
-                    expect( view.$(runSelect).length ).toEqual(2);
+                    expect(view.$(runSelect).length).toEqual(2);
 
                     dropdownSelect(view.$(runSelect).first(), courseRunsList[0].id);
-                    expect( view.$(runSelect).length ).toEqual(1);
-                    expect( view.$(runSelect).find('option').length ).toEqual(courseRunOptionsCount - 1);
+                    expect(view.$(runSelect).length).toEqual(1);
+                    expect(view.$(runSelect).find('option').length).toEqual(courseRunOptionsCount - 1);
                 });
             });
 
-            describe( 'Edit data', function() {
-                it( 'should enable a user to edit the name, subtitle and marketing slug fields', function() {
-                    editField( '.program-name', 'name' );
-                    editField( '.program-subtitle', 'subtitle' );
-                    editField( '.program-marketing-slug', 'marketing-slug' );
+            describe('Edit data', function() {
+                it('should enable a user to edit the name, subtitle and marketing slug fields', function() {
+                    editField('.program-name', 'name');
+                    editField('.program-subtitle', 'subtitle');
+                    editField('.program-marketing-slug', 'marketing-slug');
                 });
 
-                it( 'should not send an API call if a user does not change the value of an editable field', function() {
-                    testUnchangedFieldBlur( '.program-name' );
-                    testUnchangedFieldBlur( '.program-subtitle' );
-                    testUnchangedFieldBlur( '.program-marketing-slug' );
+                it('should not send an API call if a user does not change the value of an editable field', function() {
+                    testUnchangedFieldBlur('.program-name');
+                    testUnchangedFieldBlur('.program-subtitle');
+                    testUnchangedFieldBlur('.program-marketing-slug');
                 });
 
-                it( 'should send an API call if a user changes the value of an editable field', function() {
-                    testUpdatedFieldBlur( '.program-name',  'new-title' );
-                    testUpdatedFieldBlur( '.program-subtitle',  'new-subtitle' );
-                    testUpdatedFieldBlur( '.program-marketing-slug',  'new-marketing-slug' );
+                it('should send an API call if a user changes the value of an editable field', function() {
+                    testUpdatedFieldBlur('.program-name', 'new-title');
+                    testUpdatedFieldBlur('.program-subtitle', 'new-subtitle');
+                    testUpdatedFieldBlur('.program-marketing-slug', 'new-marketing-slug');
                 });
 
-                it( 'should show error messaging if the updated required field is empty', function() {
-                    testInvalidUpdate( '.program-name',  '' );
+                it('should show error messaging if the updated required field is empty', function() {
+                    testInvalidUpdate('.program-name', '');
                 });
 
-                it( 'should show error messaging if the updated field value is too long', function() {
+                it('should show error messaging if the updated field value is too long', function() {
                     var chars256 = 'x'.repeat(256);
 
-                    testInvalidUpdate( '.program-name',  chars256 );
-                    testInvalidUpdate( '.program-subtitle',  chars256 );
-                    testInvalidUpdate( '.program-marketing-slug',  chars256 );
+                    testInvalidUpdate('.program-name', chars256);
+                    testInvalidUpdate('.program-subtitle', chars256);
+                    testInvalidUpdate('.program-marketing-slug', chars256);
                 });
 
-                it( 'should create a POST config object by default', function() {
+                it('should create a POST config object by default', function() {
                     var config = view.model.getConfig();
 
-                    expect( config.type ).toEqual( 'POST' );
-                    expect( config.contentType ).toEqual( 'application/json' );
-                    expect( config.data ).not.toBeDefined();
+                    expect(config.type).toEqual('POST');
+                    expect(config.contentType).toEqual('application/json');
+                    expect(config.data).not.toBeDefined();
                 });
 
-                it( 'should create a PATCH config object when passed in object sets patch as true', function() {
-                    var data = { name: 'patched name' },
+                it('should create a PATCH config object when passed in object sets patch as true', function() {
+                    var data = {name: 'patched name'},
                         config = view.model.getConfig({
                             patch: true,
                             update: data
                         });
 
-                    expect( config.type ).toEqual( 'PATCH' );
-                    expect( config.contentType ).toEqual( 'application/merge-patch+json' );
-                    expect( config.data ).toBeDefined();
-                    expect( config.data ).toEqual( JSON.stringify( data ) );
+                    expect(config.type).toEqual('PATCH');
+                    expect(config.contentType).toEqual('application/merge-patch+json');
+                    expect(config.data).toBeDefined();
+                    expect(config.data).toEqual(JSON.stringify(data));
                 });
             });
 
-            describe( 'Publish a Program', function() {
-                it( 'should open the publish modal when the publish button is clicked', function() {
+            describe('Publish a Program', function() {
+                it('should open the publish modal when the publish button is clicked', function() {
                     openPublishModal();
-                    expect( view.modalView ).toBeDefined();
+                    expect(view.modalView).toBeDefined();
                 });
 
-                it( 'should publish a program when the publish confirm button is clicked', function() {
+                it('should publish a program when the publish confirm button is clicked', function() {
                     var defaultStatus = programData.status,
                         publishedStatus = 'active';
 
                     openPublishModal();
-                    expect( view.modalView ).toBeDefined();
+                    expect(view.modalView).toBeDefined();
 
                     view.$el.find('.js-confirm').click();
 
                     // Model should be set and save called
-                    expect( view.model.set ).toHaveBeenCalled();
-                    expect( view.model.get( 'status' ) ).not.toEqual( defaultStatus );
-                    expect( view.model.get( 'status' ) ).toEqual( publishedStatus );
-                    expect( view.model.save ).toHaveBeenCalled();
+                    expect(view.model.set).toHaveBeenCalled();
+                    expect(view.model.get('status')).not.toEqual(defaultStatus);
+                    expect(view.model.get('status')).toEqual(publishedStatus);
+                    expect(view.model.save).toHaveBeenCalled();
 
                     // Publish button should be removed once API has completed its call
-                    expect( view.$el.find('.js-publish-program').length ).toEqual( 1 );
-                    view.model.trigger( 'sync' );
-                    expect( view.$el.find('.js-publish-program').length ).toEqual( 0 );
+                    expect(view.$el.find('.js-publish-program').length).toEqual(1);
+                    view.model.trigger('sync');
+                    expect(view.$el.find('.js-publish-program').length).toEqual(0);
                 });
 
-                it( 'should show a validation error when publish button pressed if validation fails', function() {
-                    var $input = view.$el.find( '#program-marketing-slug' );
+                it('should show a validation error when publish button pressed if validation fails', function() {
+                    var $input = view.$el.find('#program-marketing-slug');
 
                     view.model.set('marketing_slug', '');
                     openPublishModal();
-                    expect( view.modalView ).not.toBeDefined();
-                    expect( $input ).toHaveClass( errorClass );
+                    expect(view.modalView).not.toBeDefined();
+                    expect($input).toHaveClass(errorClass);
                 });
 
-                it( 'should destroy the publish modal when the cancel button is clicked', function() {
+                it('should destroy the publish modal when the cancel button is clicked', function() {
                     openPublishModal();
-                    expect( view.modalView ).toBeDefined();
+                    expect(view.modalView).toBeDefined();
 
                     // Close the modal
                     view.$el.find('.js-cancel').click();
 
                     // Expect the modal DOM elements to not be there anymore
-                    expect( view.$el.find('.js-cancel').length ).toEqual( 0 );
-                    expect( view.modalView.$parentEl.html().length ).toEqual( 0 );
+                    expect(view.$el.find('.js-cancel').length).toEqual(0);
+                    expect(view.modalView.$parentEl.html().length).toEqual(0);
                 });
 
-                it( 'should destroy the publish modal when the esc key is pressed', function() {
+                it('should destroy the publish modal when the esc key is pressed', function() {
                     openPublishModal();
-                    expect( view.modalView ).toBeDefined();
+                    expect(view.modalView).toBeDefined();
 
                     // Close the modal
-                    keyPress( view.modalView.$el, constants.keyCodes.esc );
+                    keyPress(view.modalView.$el, constants.keyCodes.esc);
 
                     // Expect the modal DOM elements to not be there anymore
-                    expect( view.$el.find('.js-cancel').length ).toEqual( 0 );
-                    expect( view.modalView.$parentEl.html().length ).toEqual( 0 );
+                    expect(view.$el.find('.js-cancel').length).toEqual(0);
+                    expect(view.modalView.$parentEl.html().length).toEqual(0);
                 });
             });
         });

--- a/cms/static/js/spec/views/settings/main_spec.js
+++ b/cms/static/js/spec/views/settings/main_spec.js
@@ -1,6 +1,6 @@
 define([
     'jquery', 'js/models/settings/course_details', 'js/views/settings/main',
-    'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/js/spec_helpers/template_helpers',
+    'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/js/spec_helpers/template_helpers'
 ], function($, CourseDetailsModel, MainView, AjaxHelpers, TemplateHelpers) {
     'use strict';
 
@@ -14,39 +14,39 @@ define([
         remove_instructor_data: '.remove-instructor-data'
     };
 
-    describe('Settings/Main', function () {
+    describe('Settings/Main', function() {
         var urlRoot = '/course/settings/org/DemoX/Demo_Course',
             modelData = {
-                start_date: "2014-10-05T00:00:00Z",
-                end_date: "2014-11-05T20:00:00Z",
-                enrollment_start: "2014-10-00T00:00:00Z",
-                enrollment_end: "2014-11-05T00:00:00Z",
-                org : '',
-                course_id : '',
-                run : '',
-                syllabus : null,
+                start_date: '2014-10-05T00:00:00Z',
+                end_date: '2014-11-05T20:00:00Z',
+                enrollment_start: '2014-10-00T00:00:00Z',
+                enrollment_end: '2014-11-05T00:00:00Z',
+                org: '',
+                course_id: '',
+                run: '',
+                syllabus: null,
                 title: '',
                 subtitle: '',
                 duration: '',
                 description: '',
-                short_description : '',
-                overview : '',
-                intro_video : null,
-                effort : null,
-                course_image_name : '',
-                course_image_asset_path : '',
-                banner_image_name : '',
-                banner_image_asset_path : '',
-                video_thumbnail_image_name : '',
-                video_thumbnail_image_asset_path : '',
-                pre_requisite_courses : [],
-                entrance_exam_enabled : '',
+                short_description: '',
+                overview: '',
+                intro_video: null,
+                effort: null,
+                course_image_name: '',
+                course_image_asset_path: '',
+                banner_image_name: '',
+                banner_image_asset_path: '',
+                video_thumbnail_image_name: '',
+                video_thumbnail_image_asset_path: '',
+                pre_requisite_courses: [],
+                entrance_exam_enabled: '',
                 entrance_exam_minimum_score_pct: '50',
                 license: null,
                 language: '',
                 learning_info: [''],
                 instructor_info: {
-                    'instructors': [{"name": "","title": "","organization": "","image": "","bio": ""}]
+                    'instructors': [{'name': '', 'title': '', 'organization': '', 'image': '', 'bio': ''}]
                 }
             },
 
@@ -54,20 +54,20 @@ define([
             learningInfoTpl = readFixtures('course-settings-learning-fields.underscore'),
             instructorInfoTpl = readFixtures('course-instructor-details.underscore');
 
-        beforeEach(function () {
+        beforeEach(function() {
             TemplateHelpers.installTemplates(['course-settings-learning-fields', 'course-instructor-details'], true);
             appendSetFixtures(mockSettingsPage);
             appendSetFixtures(
-                $("<script>", { id: "basic-learning-info-tpl", type: "text/template" }).text(learningInfoTpl)
+                $('<script>', {id: 'basic-learning-info-tpl', type: 'text/template'}).text(learningInfoTpl)
             );
             appendSetFixtures(
-                $("<script>", { id: "basic-instructor-info-tpl", type: "text/template" }).text(instructorInfoTpl)
+                $('<script>', {id: 'basic-instructor-info-tpl', type: 'text/template'}).text(instructorInfoTpl)
             );
 
 
             this.model = new CourseDetailsModel($.extend(true, {}, modelData, {
                 instructor_info: {
-                    'instructors': [{"name": "","title": "","organization": "","image": "","bio": ""}]
+                    'instructors': [{'name': '', 'title': '', 'organization': '', 'image': '', 'bio': ''}]
                 }}), {parse: true});
             this.model.urlRoot = urlRoot;
             this.view = new MainView({
@@ -76,18 +76,18 @@ define([
             }).render();
         });
 
-        afterEach(function () {
+        afterEach(function() {
             // Clean up after the $.datepicker
-            $("#start_date").datepicker("destroy");
-            $("#due_date").datepicker("destroy");
+            $('#start_date').datepicker('destroy');
+            $('#due_date').datepicker('destroy');
             $('.ui-datepicker').remove();
         });
 
-        it('Changing the time field do not affect other time fields', function () {
+        it('Changing the time field do not affect other time fields', function() {
             var requests = AjaxHelpers.requests(this),
                 expectedJson = $.extend(true, {}, modelData, {
                     // Expect to see changes just in `start_date` field.
-                    start_date: "2014-10-05T22:00:00.000Z"
+                    start_date: '2014-10-05T22:00:00.000Z'
                 });
             this.view.$el.find('#course-start-time')
                 .val('22:00')
@@ -101,7 +101,7 @@ define([
             );
         });
 
-        it('Selecting a course in pre-requisite drop down should save it as part of course details', function () {
+        it('Selecting a course in pre-requisite drop down should save it as part of course details', function() {
             var pre_requisite_courses = ['test/CSS101/2012_T1'];
             var requests = AjaxHelpers.requests(this),
                 expectedJson = $.extend(true, {}, modelData, {
@@ -118,27 +118,25 @@ define([
             AjaxHelpers.respondWithJson(requests, expectedJson);
         });
 
-        it('should disallow save with an invalid minimum score percentage', function(){
+        it('should disallow save with an invalid minimum score percentage', function() {
             var entrance_exam_enabled_field = this.view.$(SELECTORS.entrance_exam_enabled_field),
                 entrance_exam_min_score = this.view.$(SELECTORS.entrance_exam_min_score);
 
-            //input some invalid values.
-            expect(entrance_exam_min_score.val('101').trigger('input')).toHaveClass("error");
-            expect(entrance_exam_min_score.val('invalidVal').trigger('input')).toHaveClass("error");
+            // input some invalid values.
+            expect(entrance_exam_min_score.val('101').trigger('input')).toHaveClass('error');
+            expect(entrance_exam_min_score.val('invalidVal').trigger('input')).toHaveClass('error');
         });
 
         it('should provide a default value for the minimum score percentage', function() {
-
             var entrance_exam_min_score = this.view.$(SELECTORS.entrance_exam_min_score);
 
-            //if input an empty value, model should be populated with the default value.
+            // if input an empty value, model should be populated with the default value.
             entrance_exam_min_score.val('').trigger('input');
             expect(this.model.get('entrance_exam_minimum_score_pct'))
                 .toEqual(this.model.defaults.entrance_exam_minimum_score_pct);
         });
 
         it('shows and hide the grade requirement section appropriately', function() {
-
             var entrance_exam_enabled_field = this.view.$(SELECTORS.entrance_exam_enabled_field);
 
             // select the entrance-exam-enabled checkbox. grade requirement section should be visible.
@@ -155,10 +153,9 @@ define([
                 .trigger('change');
 
             expect(this.view.$(SELECTORS.grade_requirement_div)).toBeHidden();
-
         });
 
-        it('should save entrance exam course details information correctly', function () {
+        it('should save entrance exam course details information correctly', function() {
             var entrance_exam_minimum_score_pct = '60',
                 entrance_exam_enabled = 'true',
                 entrance_exam_min_score = this.view.$(SELECTORS.entrance_exam_min_score),
@@ -185,10 +182,10 @@ define([
             AjaxHelpers.respondWithJson(requests, expectedJson);
         });
 
-        it('should save language as part of course details', function(){
+        it('should save language as part of course details', function() {
             var requests = AjaxHelpers.requests(this);
             var expectedJson = $.extend(true, {}, modelData, {
-                language: 'en',
+                language: 'en'
             });
             $('#course-language').val('en').trigger('change');
             expect(this.model.get('language')).toEqual('en');
@@ -198,7 +195,7 @@ define([
             );
         });
 
-        it('should not error if about_page_editable is False', function(){
+        it('should not error if about_page_editable is False', function() {
             var requests = AjaxHelpers.requests(this);
             // if about_page_editable is false, there is no section.course_details
             $('.course_details').remove();
@@ -207,15 +204,15 @@ define([
             AjaxHelpers.expectJsonRequest(requests, 'POST', urlRoot, modelData);
         });
 
-        it('should save title', function(){
+        it('should save title', function() {
             var requests = AjaxHelpers.requests(this),
                 expectedJson = $.extend(true, {}, modelData, {
                     title: 'course title'
                 });
 
             // Input some value.
-            this.view.$("#course-title").val('course title');
-            this.view.$("#course-title").trigger('change');
+            this.view.$('#course-title').val('course title');
+            this.view.$('#course-title').trigger('change');
             this.view.saveView();
             AjaxHelpers.expectJsonRequest(
                 requests, 'POST', urlRoot, expectedJson
@@ -223,15 +220,15 @@ define([
             AjaxHelpers.respondWithJson(requests, expectedJson);
         });
 
-        it('should save subtitle', function(){
+        it('should save subtitle', function() {
             var requests = AjaxHelpers.requests(this),
                 expectedJson = $.extend(true, {}, modelData, {
                     subtitle: 'course subtitle'
                 });
 
             // Input some value.
-            this.view.$("#course-subtitle").val('course subtitle');
-            this.view.$("#course-subtitle").trigger('change');
+            this.view.$('#course-subtitle').val('course subtitle');
+            this.view.$('#course-subtitle').trigger('change');
             this.view.saveView();
             AjaxHelpers.expectJsonRequest(
                 requests, 'POST', urlRoot, expectedJson
@@ -239,15 +236,15 @@ define([
             AjaxHelpers.respondWithJson(requests, expectedJson);
         });
 
-        it('should save duration', function(){
+        it('should save duration', function() {
             var requests = AjaxHelpers.requests(this),
                 expectedJson = $.extend(true, {}, modelData, {
                     duration: '8 weeks'
                 });
 
             // Input some value.
-            this.view.$("#course-duration").val('8 weeks');
-            this.view.$("#course-duration").trigger('change');
+            this.view.$('#course-duration').val('8 weeks');
+            this.view.$('#course-duration').trigger('change');
             this.view.saveView();
             AjaxHelpers.expectJsonRequest(
                 requests, 'POST', urlRoot, expectedJson
@@ -255,15 +252,15 @@ define([
             AjaxHelpers.respondWithJson(requests, expectedJson);
         });
 
-        it('should save description', function(){
+        it('should save description', function() {
             var requests = AjaxHelpers.requests(this),
                 expectedJson = $.extend(true, {}, modelData, {
                     description: 'course description'
                 });
 
             // Input some value.
-            this.view.$("#course-description").val('course description');
-            this.view.$("#course-description").trigger('change');
+            this.view.$('#course-description').val('course description');
+            this.view.$('#course-description').trigger('change');
             this.view.saveView();
             AjaxHelpers.expectJsonRequest(
                 requests, 'POST', urlRoot, expectedJson
@@ -271,7 +268,7 @@ define([
             AjaxHelpers.respondWithJson(requests, expectedJson);
         });
 
-        it('can add learning information', function () {
+        it('can add learning information', function() {
             this.view.$(SELECTORS.add_course_learning_info).click();
             expect('click').not.toHaveBeenPreventedOn(SELECTORS.add_course_learning_info);
             expect(this.model.get('learning_info').length).toEqual(2);
@@ -279,8 +276,8 @@ define([
             expect(this.model.get('learning_info').length).toEqual(3);
         });
 
-        it('can delete learning information', function () {
-            for (var i = 0 ; i < 2; i++) {
+        it('can delete learning information', function() {
+            for (var i = 0; i < 2; i++) {
                 this.view.$(SELECTORS.add_course_learning_info).click();
             }
             expect(this.model.get('learning_info').length).toEqual(3);
@@ -289,7 +286,7 @@ define([
             expect(this.model.get('learning_info').length).toEqual(2);
         });
 
-        it('can save learning information', function () {
+        it('can save learning information', function() {
             expect(this.model.get('learning_info').length).toEqual(1);
             var requests = AjaxHelpers.requests(this),
                 expectedJson = $.extend(true, {}, modelData, {
@@ -297,8 +294,8 @@ define([
                 });
 
             // Input some value.
-            this.view.$("#course-learning-info-0").val('testing info');
-            this.view.$("#course-learning-info-0").trigger('change');
+            this.view.$('#course-learning-info-0').val('testing info');
+            this.view.$('#course-learning-info-0').trigger('change');
 
             this.view.saveView();
             AjaxHelpers.expectJsonRequest(
@@ -307,15 +304,14 @@ define([
             AjaxHelpers.respondWithJson(requests, expectedJson);
         });
 
-        it('can add instructor information', function () {
+        it('can add instructor information', function() {
             this.view.$(SELECTORS.add_course_instructor_info).click();
             expect(this.model.get('instructor_info').instructors.length).toEqual(2);
             this.view.$(SELECTORS.add_course_instructor_info).click();
             expect(this.model.get('instructor_info').instructors.length).toEqual(3);
-
         });
 
-        it('can delete instructor information', function () {
+        it('can delete instructor information', function() {
             this.view.$(SELECTORS.add_course_instructor_info).click();
             expect(this.model.get('instructor_info').instructors.length).toEqual(2);
             expect(this.view.$(SELECTORS.remove_instructor_data)).toExist();
@@ -323,34 +319,33 @@ define([
             expect(this.model.get('instructor_info').instructors.length).toEqual(1);
         });
 
-        it('can save instructor information', function () {
+        it('can save instructor information', function() {
             var requests = AjaxHelpers.requests(this),
                 expectedJson = $.extend(true, {}, modelData, {
                     instructor_info: {
                         instructors:
                             [{
-                            "name": "test_name",
-                            "title": "test_title",
-                            "organization": "test_org",
-                            "image": "test_image",
-                            "bio": "test_bio"
-                        }]
+                                'name': 'test_name',
+                                'title': 'test_title',
+                                'organization': 'test_org',
+                                'image': 'test_image',
+                                'bio': 'test_bio'
+                            }]
                     }
                 });
 
             // Input some value.
-            this.view.$("#course-instructor-name-0").val('test_name').trigger('change');
-            this.view.$("#course-instructor-title-0").val('test_title').trigger('change');
-            this.view.$("#course-instructor-organization-0").val('test_org').trigger('change');
-            this.view.$("#course-instructor-bio-0").val('test_bio').trigger('change');
-            this.view.$("#course-instructor-image-0").val('test_image').trigger('change');
+            this.view.$('#course-instructor-name-0').val('test_name').trigger('change');
+            this.view.$('#course-instructor-title-0').val('test_title').trigger('change');
+            this.view.$('#course-instructor-organization-0').val('test_org').trigger('change');
+            this.view.$('#course-instructor-bio-0').val('test_bio').trigger('change');
+            this.view.$('#course-instructor-image-0').val('test_image').trigger('change');
 
             this.view.saveView();
             AjaxHelpers.expectJsonRequest(
                 requests, 'POST', urlRoot, expectedJson
             );
             AjaxHelpers.respondWithJson(requests, expectedJson);
-
         });
     });
 });

--- a/cms/static/js/spec/views/unit_outline_spec.js
+++ b/cms/static/js/spec/views/unit_outline_spec.js
@@ -1,17 +1,17 @@
-define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/js/spec_helpers/template_helpers",
-        "common/js/spec_helpers/view_helpers", "common/js/components/utils/view_utils", "js/models/course",
-        "js/views/unit_outline", "js/models/xblock_info"],
+define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/js/spec_helpers/template_helpers',
+        'common/js/spec_helpers/view_helpers', 'common/js/components/utils/view_utils', 'js/models/course',
+        'js/views/unit_outline', 'js/models/xblock_info'],
     function($, AjaxHelpers, TemplateHelpers, ViewHelpers, ViewUtils,
               Course, UnitOutlineView, XBlockInfo) {
         'use strict';
 
-        describe("UnitOutlineView", function() {
+        describe('UnitOutlineView', function() {
             var createUnitOutlineView, createMockXBlockInfo,
                 requests, model, unitOutlineView;
 
             createUnitOutlineView = function(test, unitJSON, createOnly) {
                 requests = AjaxHelpers.requests(test);
-                model = new XBlockInfo(unitJSON, { parse: true });
+                model = new XBlockInfo(unitJSON, {parse: true});
                 unitOutlineView = new UnitOutlineView({
                     model: model,
                     el: $('.wrapper-unit-overview')
@@ -73,7 +73,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 };
             };
 
-            beforeEach(function () {
+            beforeEach(function() {
                 window.course = new Course({
                     id: '5',
                     name: 'Course Name',
@@ -88,7 +88,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                 appendSetFixtures('<div class="wrapper-unit-overview"></div>');
             });
 
-            afterEach(function () {
+            afterEach(function() {
                 delete window.course;
                 ViewHelpers.removeMockAnalytics();
             });
@@ -101,7 +101,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
             });
 
             it('highlights the current unit', function() {
-                createUnitOutlineView(this,  createMockXBlockInfo('Mock Unit'));
+                createUnitOutlineView(this, createMockXBlockInfo('Mock Unit'));
                 $('.outline-unit').each(function(i) {
                     if ($(this).data('locator') === model.get('id')) {
                         expect($(this)).toHaveClass('is-current');
@@ -122,8 +122,8 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                     parent_locator: 'mock-subsection'
                 });
                 AjaxHelpers.respondWithJson(requests, {
-                    locator: "new-mock-unit",
-                    courseKey: "slashes:MockCourse"
+                    locator: 'new-mock-unit',
+                    courseKey: 'slashes:MockCourse'
                 });
                 expect(redirectSpy).toHaveBeenCalledWith('/container/new-mock-unit?action=new');
             });

--- a/cms/static/js/spec/views/xblock_editor_spec.js
+++ b/cms/static/js/spec/views/xblock_editor_spec.js
@@ -1,19 +1,18 @@
-define([ "jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "js/spec_helpers/edit_helpers",
-    "js/views/xblock_editor", "js/models/xblock_info"],
-    function ($, _, AjaxHelpers, EditHelpers, XBlockEditorView, XBlockInfo) {
-
-        describe("XBlockEditorView", function() {
+define(['jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'js/spec_helpers/edit_helpers',
+    'js/views/xblock_editor', 'js/models/xblock_info'],
+    function($, _, AjaxHelpers, EditHelpers, XBlockEditorView, XBlockInfo) {
+        describe('XBlockEditorView', function() {
             var model, editor, testDisplayName, mockSaveResponse;
 
             testDisplayName = 'Test Display Name';
             mockSaveResponse = {
-                data: "<p>Some HTML</p>",
+                data: '<p>Some HTML</p>',
                 metadata: {
                     display_name: testDisplayName
                 }
             };
 
-            beforeEach(function () {
+            beforeEach(function() {
                 EditHelpers.installEditTemplates();
                 model = new XBlockInfo({
                     id: 'testCourse/branch/draft/block/verticalFFF',
@@ -25,10 +24,10 @@ define([ "jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-help
                 });
             });
 
-            describe("Editing an xblock", function() {
+            describe('Editing an xblock', function() {
                 var mockXBlockEditorHtml;
 
-                beforeEach(function () {
+                beforeEach(function() {
                     EditHelpers.installMockXBlock();
                 });
 
@@ -51,7 +50,7 @@ define([ "jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-help
                 });
             });
 
-            describe("Editing an xmodule", function() {
+            describe('Editing an xmodule', function() {
                 var mockXModuleEditorHtml;
 
                 mockXModuleEditorHtml = readFixtures('mock/mock-xmodule-editor.underscore');
@@ -60,7 +59,7 @@ define([ "jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-help
                     EditHelpers.installMockXModule(mockSaveResponse);
                 });
 
-                afterEach(function () {
+                afterEach(function() {
                     EditHelpers.uninstallMockXModule();
                 });
 

--- a/cms/static/js/spec/views/xblock_spec.js
+++ b/cms/static/js/spec/views/xblock_spec.js
@@ -1,11 +1,11 @@
-define(["jquery", "URI", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/js/components/utils/view_utils",
-        "js/views/xblock", "js/models/xblock_info", "xmodule", "cms/js/main", "xblock/cms.runtime.v1"],
-    function ($, URI, AjaxHelpers, ViewUtils, XBlockView, XBlockInfo) {
-        "use strict";
-        describe("XBlockView", function() {
+define(['jquery', 'URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/js/components/utils/view_utils',
+        'js/views/xblock', 'js/models/xblock_info', 'xmodule', 'cms/js/main', 'xblock/cms.runtime.v1'],
+    function($, URI, AjaxHelpers, ViewUtils, XBlockView, XBlockInfo) {
+        'use strict';
+        describe('XBlockView', function() {
             var model, xblockView, mockXBlockHtml;
 
-            beforeEach(function () {
+            beforeEach(function() {
                 model = new XBlockInfo({
                     id: 'testCourse/branch/draft/block/verticalFFF',
                     display_name: 'Test Unit',
@@ -29,13 +29,13 @@ define(["jquery", "URI", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "c
                 expect(xblockView.$el.select('.xblock-header')).toBeTruthy();
             });
 
-            describe("XBlock rendering", function() {
+            describe('XBlock rendering', function() {
                 var postXBlockRequest;
 
                 postXBlockRequest = function(requests, resources) {
                     var promise;
                     $.ajax({
-                        url: "test_url",
+                        url: 'test_url',
                         type: 'GET',
                         success: function(fragment) {
                             promise = xblockView.renderXBlockFragment(fragment, this.$el);
@@ -58,12 +58,12 @@ define(["jquery", "URI", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "c
 
                 it('can render an xblock with required CSS', function() {
                     var requests = AjaxHelpers.requests(this),
-                        mockCssText = "// Just a comment",
-                        mockCssUrl = "mock.css",
+                        mockCssText = '// Just a comment',
+                        mockCssUrl = 'mock.css',
                         headHtml;
                     postXBlockRequest(requests, [
-                        ["xblock_spec_hash1", { mimetype: "text/css", kind: "text", data: mockCssText }],
-                        ["xblock_spec_hash2", { mimetype: "text/css", kind: "url", data: mockCssUrl }]
+                        ['xblock_spec_hash1', {mimetype: 'text/css', kind: 'text', data: mockCssText}],
+                        ['xblock_spec_hash2', {mimetype: 'text/css', kind: 'url', data: mockCssUrl}]
                     ]);
                     headHtml = $('head').html();
                     expect(headHtml).toContain(mockCssText);
@@ -73,8 +73,8 @@ define(["jquery", "URI", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "c
                 it('can render an xblock with required JavaScript', function() {
                     var requests = AjaxHelpers.requests(this);
                     postXBlockRequest(requests, [
-                        ["xblock_spec_hash3", {
-                            mimetype: "application/javascript", kind: "text", data: "window.test = 100;"
+                        ['xblock_spec_hash3', {
+                            mimetype: 'application/javascript', kind: 'text', data: 'window.test = 100;'
                         }]
                     ]);
                     expect(window.test).toBe(100);
@@ -82,32 +82,32 @@ define(["jquery", "URI", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "c
 
                 it('can render an xblock with required HTML', function() {
                     var requests = AjaxHelpers.requests(this),
-                        mockHeadTag = "<title>Test Title</title>";
+                        mockHeadTag = '<title>Test Title</title>';
                     postXBlockRequest(requests, [
-                        ["xblock_spec_hash4", { mimetype: "text/html", placement: "head", data: mockHeadTag }]
+                        ['xblock_spec_hash4', {mimetype: 'text/html', placement: 'head', data: mockHeadTag}]
                     ]);
                     expect($('head').html()).toContain(mockHeadTag);
                 });
 
                 it('aborts rendering when a dependent script fails to load', function() {
                     var requests = AjaxHelpers.requests(this),
-                        missingJavaScriptUrl = "no_such_file.js",
+                        missingJavaScriptUrl = 'no_such_file.js',
                         promise;
                     spyOn(ViewUtils, 'loadJavaScript').and.returnValue($.Deferred().reject().promise());
                     promise = postXBlockRequest(requests, [
-                        ["xblock_spec_hash5", {
-                            mimetype: "application/javascript", kind: "url", data: missingJavaScriptUrl
+                        ['xblock_spec_hash5', {
+                            mimetype: 'application/javascript', kind: 'url', data: missingJavaScriptUrl
                         }]
                     ]);
-                    expect(promise.state()).toBe("rejected");
+                    expect(promise.state()).toBe('rejected');
                 });
 
-                it('Triggers an event to the runtime when a notification-action-button is clicked', function () {
-                    var notifySpy = spyOn(xblockView, "notifyRuntime").and.callThrough();
+                it('Triggers an event to the runtime when a notification-action-button is clicked', function() {
+                    var notifySpy = spyOn(xblockView, 'notifyRuntime').and.callThrough();
 
                     postXBlockRequest(AjaxHelpers.requests(this), []);
-                    xblockView.$el.find(".notification-action-button").click();
-                    expect(notifySpy).toHaveBeenCalledWith("add-missing-groups", model.get("id"));
+                    xblockView.$el.find('.notification-action-button').click();
+                    expect(notifySpy).toHaveBeenCalledWith('add-missing-groups', model.get('id'));
                 });
             });
         });

--- a/cms/static/js/spec/views/xblock_string_field_editor_spec.js
+++ b/cms/static/js/spec/views/xblock_string_field_editor_spec.js
@@ -1,20 +1,20 @@
-define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/js/spec_helpers/template_helpers",
-        "js/spec_helpers/edit_helpers", "js/models/xblock_info", "js/views/xblock_string_field_editor"],
-       function ($, AjaxHelpers, TemplateHelpers, EditHelpers, XBlockInfo, XBlockStringFieldEditor) {
-           describe("XBlockStringFieldEditorView", function () {
+define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/js/spec_helpers/template_helpers',
+        'js/spec_helpers/edit_helpers', 'js/models/xblock_info', 'js/views/xblock_string_field_editor'],
+       function($, AjaxHelpers, TemplateHelpers, EditHelpers, XBlockInfo, XBlockStringFieldEditor) {
+           describe('XBlockStringFieldEditorView', function() {
                var initialDisplayName, updatedDisplayName, getXBlockInfo, getFieldEditorView;
 
-               getXBlockInfo = function (displayName) {
+               getXBlockInfo = function(displayName) {
                    return new XBlockInfo(
                        {
                            display_name: displayName,
-                           id: "my_xblock"
+                           id: 'my_xblock'
                        },
-                       { parse: true }
+                       {parse: true}
                    );
                };
 
-               getFieldEditorView = function (xblockInfo) {
+               getFieldEditorView = function(xblockInfo) {
                    if (xblockInfo === undefined) {
                        xblockInfo = getXBlockInfo(initialDisplayName);
                    }
@@ -24,9 +24,9 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                    });
                };
 
-               beforeEach(function () {
-                   initialDisplayName = "Default Display Name";
-                   updatedDisplayName = "Updated Display Name";
+               beforeEach(function() {
+                   initialDisplayName = 'Default Display Name';
+                   updatedDisplayName = 'Updated Display Name';
                    TemplateHelpers.installTemplate('xblock-string-field-editor');
                    appendSetFixtures(
                            '<div class="wrapper-xblock-field incontext-editor is-editable"' +
@@ -38,10 +38,10 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                    );
                });
 
-               describe('Editing', function () {
+               describe('Editing', function() {
                    var expectPostedNewDisplayName, expectEditCanceled;
 
-                   expectPostedNewDisplayName = function (requests, displayName) {
+                   expectPostedNewDisplayName = function(requests, displayName) {
                        AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/my_xblock', {
                            metadata: {
                                display_name: displayName
@@ -49,13 +49,13 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                        });
                    };
 
-                   expectEditCanceled = function (test, fieldEditorView, options) {
+                   expectEditCanceled = function(test, fieldEditorView, options) {
                        var requests, initialRequests, displayNameInput;
                        requests = AjaxHelpers.requests(test);
                        displayNameInput = EditHelpers.inlineEdit(fieldEditorView.$el, options.newTitle);
                        if (options.pressEscape) {
-                           displayNameInput.simulate("keydown", { keyCode: $.simulate.keyCode.ESCAPE });
-                           displayNameInput.simulate("keyup", { keyCode: $.simulate.keyCode.ESCAPE });
+                           displayNameInput.simulate('keydown', {keyCode: $.simulate.keyCode.ESCAPE});
+                           displayNameInput.simulate('keyup', {keyCode: $.simulate.keyCode.ESCAPE});
                        } else if (options.clickCancel) {
                            fieldEditorView.$('button[name=cancel]').click();
                        } else {
@@ -67,7 +67,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                        expect(fieldEditorView.model.get('display_name')).toBe(initialDisplayName);
                    };
 
-                   it('can inline edit the display name', function () {
+                   it('can inline edit the display name', function() {
                        var requests, fieldEditorView;
                        requests = AjaxHelpers.requests(this);
                        fieldEditorView = getFieldEditorView().render();
@@ -77,11 +77,11 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                        // This is the response for the change operation.
                        AjaxHelpers.respondWithJson(requests, { });
                        // This is the response for the subsequent fetch operation.
-                       AjaxHelpers.respondWithJson(requests, {display_name:  updatedDisplayName});
+                       AjaxHelpers.respondWithJson(requests, {display_name: updatedDisplayName});
                        EditHelpers.verifyInlineEditChange(fieldEditorView.$el, updatedDisplayName);
                    });
 
-                   it('does not change the title when a display name update fails', function () {
+                   it('does not change the title when a display name update fails', function() {
                        var requests, fieldEditorView, initialRequests;
                        requests = AjaxHelpers.requests(this);
                        fieldEditorView = getFieldEditorView().render();
@@ -94,7 +94,7 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                        EditHelpers.verifyInlineEditChange(fieldEditorView.$el, initialDisplayName, updatedDisplayName);
                    });
 
-                   it('trims whitespace from the display name', function () {
+                   it('trims whitespace from the display name', function() {
                        var requests, fieldEditorView;
                        requests = AjaxHelpers.requests(this);
                        fieldEditorView = getFieldEditorView().render();
@@ -105,50 +105,50 @@ define(["jquery", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers", "common/j
                        // This is the response for the change operation.
                        AjaxHelpers.respondWithJson(requests, { });
                        // This is the response for the subsequent fetch operation.
-                       AjaxHelpers.respondWithJson(requests, {display_name:  updatedDisplayName.trim()});
+                       AjaxHelpers.respondWithJson(requests, {display_name: updatedDisplayName.trim()});
                        EditHelpers.verifyInlineEditChange(fieldEditorView.$el, updatedDisplayName.trim());
                    });
 
-                   it('does not change the title when input is the empty string', function () {
+                   it('does not change the title when input is the empty string', function() {
                        var fieldEditorView = getFieldEditorView().render();
                        expectEditCanceled(this, fieldEditorView, {newTitle: ''});
                    });
 
-                   it('does not change the title when input is whitespace-only', function () {
+                   it('does not change the title when input is whitespace-only', function() {
                        var fieldEditorView = getFieldEditorView().render();
                        expectEditCanceled(this, fieldEditorView, {newTitle: ' '});
                    });
 
-                   it('can cancel an inline edit by pressing escape', function () {
+                   it('can cancel an inline edit by pressing escape', function() {
                        var fieldEditorView = getFieldEditorView().render();
                        expectEditCanceled(this, fieldEditorView, {newTitle: updatedDisplayName, pressEscape: true});
                    });
 
-                   it('can cancel an inline edit by clicking cancel', function () {
+                   it('can cancel an inline edit by clicking cancel', function() {
                        var fieldEditorView = getFieldEditorView().render();
                        expectEditCanceled(this, fieldEditorView, {newTitle: updatedDisplayName, clickCancel: true});
                    });
                });
 
-               describe('Rendering', function () {
-                   var expectInputMatchesModelDisplayName = function (displayName) {
+               describe('Rendering', function() {
+                   var expectInputMatchesModelDisplayName = function(displayName) {
                        var fieldEditorView = getFieldEditorView(getXBlockInfo(displayName)).render();
                        expect(fieldEditorView.$('.xblock-field-input').val()).toBe(displayName);
                    };
 
-                   it('renders single quotes in input field', function () {
+                   it('renders single quotes in input field', function() {
                        expectInputMatchesModelDisplayName('Updated \'Display Name\'');
                    });
 
-                   it('renders double quotes in input field', function () {
+                   it('renders double quotes in input field', function() {
                        expectInputMatchesModelDisplayName('Updated "Display Name"');
                    });
 
-                   it('renders open angle bracket in input field', function () {
+                   it('renders open angle bracket in input field', function() {
                        expectInputMatchesModelDisplayName(updatedDisplayName + '<');
                    });
 
-                   it('renders close angle bracket in input field', function () {
+                   it('renders close angle bracket in input field', function() {
                        expectInputMatchesModelDisplayName('>' + updatedDisplayName);
                    });
                });

--- a/cms/static/js/spec/views/xblock_validation_spec.js
+++ b/cms/static/js/spec/views/xblock_validation_spec.js
@@ -1,14 +1,13 @@
 define(['jquery', 'js/models/xblock_validation', 'js/views/xblock_validation', 'common/js/spec_helpers/template_helpers'],
     function($, XBlockValidationModel, XBlockValidationView, TemplateHelpers) {
-
-        beforeEach(function () {
-           TemplateHelpers.installTemplate('xblock-validation-messages');
+        beforeEach(function() {
+            TemplateHelpers.installTemplate('xblock-validation-messages');
         });
 
         describe('XBlockValidationView helper methods', function() {
             var model, view;
 
-            beforeEach(function () {
+            beforeEach(function() {
                 model = new XBlockValidationModel({parse: true});
                 view = new XBlockValidationView({model: model});
                 view.render();
@@ -20,33 +19,33 @@ define(['jquery', 'js/models/xblock_validation', 'js/views/xblock_validation', '
                 expect(getIcon(model.WARNING)).toBe('fa-exclamation-triangle');
                 expect(getIcon(model.NOT_CONFIGURED)).toBe('fa-exclamation-triangle');
                 expect(getIcon(model.ERROR)).toBe('fa-exclamation-circle');
-                expect(getIcon("unknown")).toBeNull();
+                expect(getIcon('unknown')).toBeNull();
             });
 
             it('has a getDisplayName method', function() {
                 var getDisplayName = view.getDisplayName.bind(view);
 
-                expect(getDisplayName(model.WARNING)).toBe("Warning");
-                expect(getDisplayName(model.NOT_CONFIGURED)).toBe("Warning");
-                expect(getDisplayName(model.ERROR)).toBe("Error");
-                expect(getDisplayName("unknown")).toBeNull();
+                expect(getDisplayName(model.WARNING)).toBe('Warning');
+                expect(getDisplayName(model.NOT_CONFIGURED)).toBe('Warning');
+                expect(getDisplayName(model.ERROR)).toBe('Error');
+                expect(getDisplayName('unknown')).toBeNull();
             });
 
             it('can add additional classes', function() {
-                var noContainerContent = "no-container-content", notConfiguredModel, nonRootView, rootView;
+                var noContainerContent = 'no-container-content', notConfiguredModel, nonRootView, rootView;
 
-                expect(view.getAdditionalClasses()).toBe("");
+                expect(view.getAdditionalClasses()).toBe('');
                 expect(view.$('.validation')).not.toHaveClass(noContainerContent);
 
                 notConfiguredModel = new XBlockValidationModel({
-                     "empty": false, "summary": {"text": "Not configured", "type": model.NOT_CONFIGURED},
-                     "xblock_id": "id"
-                    },
+                    'empty': false, 'summary': {'text': 'Not configured', 'type': model.NOT_CONFIGURED},
+                    'xblock_id': 'id'
+                },
                     {parse: true}
                 );
                 nonRootView = new XBlockValidationView({model: notConfiguredModel});
                 nonRootView.render();
-                expect(nonRootView.getAdditionalClasses()).toBe("");
+                expect(nonRootView.getAdditionalClasses()).toBe('');
                 expect(view.$('.validation')).not.toHaveClass(noContainerContent);
 
                 rootView = new XBlockValidationView({model: notConfiguredModel, root: true});
@@ -54,28 +53,27 @@ define(['jquery', 'js/models/xblock_validation', 'js/views/xblock_validation', '
                 expect(rootView.getAdditionalClasses()).toBe(noContainerContent);
                 expect(rootView.$('.validation')).toHaveClass(noContainerContent);
             });
-
         });
 
         describe('XBlockValidationView rendering', function() {
             var model, view;
 
-            beforeEach(function () {
+            beforeEach(function() {
                 model = new XBlockValidationModel({
-                     "empty": false,
-                     "summary": {
-                         "text": "Summary message", "type": "error",
-                         "action_label": "Summary Action", "action_class": "edit-button"
-                     },
-                     "messages": [
-                         {
-                             "text": "First message", "type": "warning",
-                             "action_label": "First Message Action", "action_runtime_event": "fix-up"
-                         },
-                         {"text": "Second message", "type": "error"}
-                     ],
-                     "xblock_id": "id"
-                    });
+                    'empty': false,
+                    'summary': {
+                        'text': 'Summary message', 'type': 'error',
+                        'action_label': 'Summary Action', 'action_class': 'edit-button'
+                    },
+                    'messages': [
+                        {
+                            'text': 'First message', 'type': 'warning',
+                            'action_label': 'First Message Action', 'action_runtime_event': 'fix-up'
+                        },
+                         {'text': 'Second message', 'type': 'error'}
+                    ],
+                    'xblock_id': 'id'
+                });
                 view = new XBlockValidationView({model: model});
                 view.render();
             });
@@ -83,46 +81,46 @@ define(['jquery', 'js/models/xblock_validation', 'js/views/xblock_validation', '
             it('renders summary and detailed messages types', function() {
                 var details;
 
-                expect(view.$('.xblock-message')).toHaveClass("has-errors");
+                expect(view.$('.xblock-message')).toHaveClass('has-errors');
                 details = view.$('.xblock-message-item');
                 expect(details.length).toBe(2);
-                expect(details[0]).toHaveClass("warning");
-                expect(details[1]).toHaveClass("error");
+                expect(details[0]).toHaveClass('warning');
+                expect(details[1]).toHaveClass('error');
             });
 
             it('renders summary and detailed messages text', function() {
                 var details;
 
-                expect(view.$('.xblock-message').text()).toContain("Summary message");
+                expect(view.$('.xblock-message').text()).toContain('Summary message');
 
                 details = view.$('.xblock-message-item');
                 expect(details.length).toBe(2);
-                expect($(details[0]).text()).toContain("Warning");
-                expect($(details[0]).text()).toContain("First message");
-                expect($(details[1]).text()).toContain("Error");
-                expect($(details[1]).text()).toContain("Second message");
+                expect($(details[0]).text()).toContain('Warning');
+                expect($(details[0]).text()).toContain('First message');
+                expect($(details[1]).text()).toContain('Error');
+                expect($(details[1]).text()).toContain('Second message');
             });
 
             it('renders action info', function() {
-                expect(view.$('a.edit-button .action-button-text').text()).toContain("Summary Action");
+                expect(view.$('a.edit-button .action-button-text').text()).toContain('Summary Action');
 
                 expect(view.$('a.notification-action-button .action-button-text').text()).
-                    toContain("First Message Action");
-                expect(view.$('a.notification-action-button').data("notification-action")).toBe("fix-up");
+                    toContain('First Message Action');
+                expect(view.$('a.notification-action-button').data('notification-action')).toBe('fix-up');
             });
 
             it('renders a summary only', function() {
                 var summaryOnlyModel = new XBlockValidationModel({
-                     "empty": false,
-                     "summary": {"text": "Summary message", "type": "warning"},
-                     "xblock_id": "id"
+                        'empty': false,
+                        'summary': {'text': 'Summary message', 'type': 'warning'},
+                        'xblock_id': 'id'
                     }), summaryOnlyView, details;
 
                 summaryOnlyView = new XBlockValidationView({model: summaryOnlyModel});
                 summaryOnlyView.render();
 
-                expect(summaryOnlyView.$('.xblock-message')).toHaveClass("has-warnings");
-                expect(view.$('.xblock-message').text()).toContain("Summary message");
+                expect(summaryOnlyView.$('.xblock-message')).toHaveClass('has-warnings');
+                expect(view.$('.xblock-message').text()).toContain('Summary message');
 
                 details = summaryOnlyView.$('.xblock-message-item');
                 expect(details.length).toBe(0);

--- a/cms/static/js/spec_helpers/assertion_helpers.js
+++ b/cms/static/js/spec_helpers/assertion_helpers.js
@@ -1,21 +1,21 @@
 /**
  * Provides helper methods for invoking Studio modal windows in Jasmine tests.
  */
-define(["jquery", "common/js/components/views/feedback_notification", "common/js/components/views/feedback_prompt",
-        "common/js/spec_helpers/template_helpers"],
+define(['jquery', 'common/js/components/views/feedback_notification', 'common/js/components/views/feedback_prompt',
+        'common/js/spec_helpers/template_helpers'],
     function($, NotificationView, Prompt, TemplateHelpers) {
         var installViewTemplates, createFeedbackSpy, verifyFeedbackShowing,
             verifyFeedbackHidden, createNotificationSpy, verifyNotificationShowing,
             verifyNotificationHidden, createPromptSpy, confirmPrompt, inlineEdit, verifyInlineEditChange,
             installMockAnalytics, removeMockAnalytics, verifyPromptShowing, verifyPromptHidden;
 
-        assertDetailsView = function (view, text) {
+        assertDetailsView = function(view, text) {
             expect(view.$el).toContainText(text);
             expect(view.$el).toContainText('ID: 0');
             expect(view.$('.delete')).toExist();
         };
 
-        assertControllerView = function (view, detailsView, editView) {
+        assertControllerView = function(view, detailsView, editView) {
             // Details view by default
             expect(view.$(detailsView)).toExist();
             view.$('.action-edit .edit').click();
@@ -26,7 +26,7 @@ define(["jquery", "common/js/components/views/feedback_notification", "common/js
             expect(view.$(editView)).not.toExist();
         };
 
-        assertAndDeleteItemError = function (that, url, promptText) {
+        assertAndDeleteItemError = function(that, url, promptText) {
             var requests = AjaxHelpers.requests(that),
                 promptSpy = ViewHelpers.createPromptSpy(),
                 notificationSpy = ViewHelpers.createNotificationSpy();
@@ -40,7 +40,7 @@ define(["jquery", "common/js/components/views/feedback_notification", "common/js
             expect($(SELECTORS.itemView)).not.toExist();
         };
 
-        assertAndDeleteItemWithError = function (that, url, listItemView, promptText) {
+        assertAndDeleteItemWithError = function(that, url, listItemView, promptText) {
             var requests = AjaxHelpers.requests(that),
                 promptSpy = ViewHelpers.createPromptSpy(),
                 notificationSpy = ViewHelpers.createNotificationSpy();
@@ -53,14 +53,14 @@ define(["jquery", "common/js/components/views/feedback_notification", "common/js
             expect($(listItemView)).toExist();
         };
 
-        assertUnusedOptions = function (that) {
+        assertUnusedOptions = function(that) {
             that.model.set('usage', []);
             that.view.render();
             expect(that.view.$(SELECTORS.warningMessage)).not.toExist();
             expect(that.view.$(SELECTORS.warningIcon)).not.toExist();
         };
 
-        assertCannotDeleteUsed = function (that, toolTipText, warningText){
+        assertCannotDeleteUsed = function(that, toolTipText, warningText) {
             setUsageInfo(that.model);
             that.view.render();
             expect(that.view.$(SELECTORS.note)).toHaveAttr(

--- a/cms/static/js/spec_helpers/edit_helpers.js
+++ b/cms/static/js/spec_helpers/edit_helpers.js
@@ -1,11 +1,10 @@
 /**
  * Provides helper methods for invoking Studio editors in Jasmine tests.
  */
-define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers",
-        "common/js/spec_helpers/template_helpers", "js/spec_helpers/modal_helpers", "js/views/modals/edit_xblock",
-        "js/collections/component_template", "xmodule", "cms/js/main", "xblock/cms.runtime.v1"],
+define(['jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
+        'common/js/spec_helpers/template_helpers', 'js/spec_helpers/modal_helpers', 'js/views/modals/edit_xblock',
+        'js/collections/component_template', 'xmodule', 'cms/js/main', 'xblock/cms.runtime.v1'],
     function($, _, AjaxHelpers, TemplateHelpers, modal_helpers, EditXBlockModal, ComponentTemplates) {
-
         var installMockXBlock, uninstallMockXBlock, installMockXModule, uninstallMockXModule,
             mockComponentTemplates, installEditTemplates, showEditModal, verifyXBlockRequest;
 
@@ -41,30 +40,30 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
 
         mockComponentTemplates = new ComponentTemplates([
             {
-                "templates": [
+                'templates': [
                     {
-                        "category": "discussion",
-                        "display_name": "Discussion"
+                        'category': 'discussion',
+                        'display_name': 'Discussion'
                     }],
-                "type": "discussion",
-                "support_legend": {"show_legend": false}
+                'type': 'discussion',
+                'support_legend': {'show_legend': false}
             }, {
-                "templates": [
+                'templates': [
                     {
-                        "category": "html",
-                        "boilerplate_name": null,
-                        "display_name": "Text"
+                        'category': 'html',
+                        'boilerplate_name': null,
+                        'display_name': 'Text'
                     }, {
-                        "category": "html",
-                        "boilerplate_name": "announcement.yaml",
-                        "display_name": "Announcement"
+                        'category': 'html',
+                        'boilerplate_name': 'announcement.yaml',
+                        'display_name': 'Announcement'
                     }, {
-                        "category": "html",
-                        "boilerplate_name": "raw.yaml",
-                        "display_name": "Raw HTML"
+                        'category': 'html',
+                        'boilerplate_name': 'raw.yaml',
+                        'display_name': 'Raw HTML'
                     }],
-                "type": "html",
-                "support_legend": {"show_legend": false}
+                'type': 'html',
+                'support_legend': {'show_legend': false}
             }],
             {
                 parse: true
@@ -96,16 +95,16 @@ define(["jquery", "underscore", "edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
             modal.edit(xblockElement, model, options);
             AjaxHelpers.respondWithJson(requests, {
                 html: mockHtml,
-                "resources": []
+                'resources': []
             });
             return modal;
         };
 
-        verifyXBlockRequest = function (requests, expectedJson) {
+        verifyXBlockRequest = function(requests, expectedJson) {
             var request = AjaxHelpers.currentRequest(requests),
                 actualJson = JSON.parse(request.requestBody);
-            expect(request.url).toEqual("/xblock/");
-            expect(request.method).toEqual("POST");
+            expect(request.url).toEqual('/xblock/');
+            expect(request.method).toEqual('POST');
             expect(actualJson).toEqual(expectedJson);
         };
 

--- a/cms/static/js/spec_helpers/modal_helpers.js
+++ b/cms/static/js/spec_helpers/modal_helpers.js
@@ -1,9 +1,9 @@
 /**
  * Provides helper methods for invoking Studio modal windows in Jasmine tests.
  */
-define(["jquery", "common/js/spec_helpers/template_helpers", "common/js/spec_helpers/view_helpers"],
+define(['jquery', 'common/js/spec_helpers/template_helpers', 'common/js/spec_helpers/view_helpers'],
     function($, TemplateHelpers, ViewHelpers) {
-        var installModalTemplates, getModalElement, getModalWindow, getModalTitle, isShowingModal, 
+        var installModalTemplates, getModalElement, getModalWindow, getModalTitle, isShowingModal,
             hideModalIfShowing, pressModalButton, cancelModal, cancelModalIfShowing;
 
         installModalTemplates = function(append) {

--- a/cms/static/js/spec_helpers/validation_helpers.js
+++ b/cms/static/js/spec_helpers/validation_helpers.js
@@ -5,7 +5,7 @@ define(['jquery', 'js/spec_helpers/modal_helpers', 'common/js/spec_helpers/templ
     function($, ModalHelpers, TemplateHelpers) {
         var installValidationTemplates, checkErrorContents, undoChanges;
 
-        installValidationTemplates = function () {
+        installValidationTemplates = function() {
             ModalHelpers.installModalTemplates();
             TemplateHelpers.installTemplate('validation-error-modal');
         };
@@ -29,6 +29,6 @@ define(['jquery', 'js/spec_helpers/modal_helpers', 'common/js/spec_helpers/templ
         return $.extend(ModalHelpers, {
             'installValidationTemplates': installValidationTemplates,
             'checkErrorContents': checkErrorContents,
-            'undoChanges': undoChanges,
+            'undoChanges': undoChanges
         });
     });

--- a/cms/static/js/utils/cancel_on_escape.js
+++ b/cms/static/js/utils/cancel_on_escape.js
@@ -1,13 +1,13 @@
-define(["jquery"], function($) {
+define(['jquery'], function($) {
     var $body = $('body');
-    var checkForCancel = function (e) {
+    var checkForCancel = function(e) {
         if (e.which == 27) {
             $body.unbind('keyup', checkForCancel);
             e.data.$cancelButton.click();
         }
     };
 
-    var cancelOnEscape = function (cancelButton) {
+    var cancelOnEscape = function(cancelButton) {
         $body.bind('keyup', {
             $cancelButton: cancelButton
         }, checkForCancel);

--- a/cms/static/js/utils/change_on_enter.js
+++ b/cms/static/js/utils/change_on_enter.js
@@ -1,9 +1,9 @@
-define(["jquery"], function($) {
+define(['jquery'], function($) {
     // Trigger "Change" event on "Enter" keyup event
-    var triggerChangeEventOnEnter = function (e) {
-        if(e.which == 13)
+    var triggerChangeEventOnEnter = function(e) {
+        if (e.which == 13)
         {
-            $(this).trigger("change").blur();
+            $(this).trigger('change').blur();
         }
     };
 

--- a/cms/static/js/utils/date_utils.js
+++ b/cms/static/js/utils/date_utils.js
@@ -1,20 +1,20 @@
-define(["jquery", "date", "js/utils/change_on_enter", "jquery.ui", "jquery.timepicker"],
+define(['jquery', 'date', 'js/utils/change_on_enter', 'jquery.ui', 'jquery.timepicker'],
 function($, date, TriggerChangeEventOnEnter) {
     'use strict';
-    var setupDatePicker = function (fieldName, view, index) {
+    var setupDatePicker = function(fieldName, view, index) {
         var cacheModel;
         var div;
-        if (typeof index !== "undefined" && view.hasOwnProperty("collection")) {
+        if (typeof index !== 'undefined' && view.hasOwnProperty('collection')) {
             cacheModel = view.collection.models[index];
             div = view.$el.find('#' + view.collectionSelector(cacheModel.cid));
         } else {
             cacheModel = view.model;
             div = view.$el.find('#' + view.fieldToSelectorMap[fieldName]);
         }
-        var datefield = $(div).find("input.date");
-        var timefield = $(div).find("input.time");
+        var datefield = $(div).find('input.date');
+        var timefield = $(div).find('input.time');
         var cacheview = view;
-        var setfield = function (event) {
+        var setfield = function(event) {
             var newVal = getDate(datefield, timefield);
 
             // Setting to null clears the time as well, as date and time are linked.
@@ -25,7 +25,7 @@ function($, date, TriggerChangeEventOnEnter) {
         };
 
         // instrument as date and time pickers
-        timefield.timepicker({'timeFormat' : 'H:i'});
+        timefield.timepicker({'timeFormat': 'H:i'});
         datefield.datepicker();
 
         // Using the change event causes setfield to be triggered twice, but it is necessary
@@ -48,23 +48,23 @@ function($, date, TriggerChangeEventOnEnter) {
         }
     };
 
-    var getDate = function (datepickerInput, timepickerInput) {
+    var getDate = function(datepickerInput, timepickerInput) {
         // given a pair of inputs (datepicker and timepicker), return a JS Date
         // object that corresponds to the datetime.js that they represent. Assume
         // UTC timezone, NOT the timezone of the user's browser.
         var date = null, time = null;
         if (datepickerInput.length > 0) {
-            date = $(datepickerInput).datepicker("getDate");
+            date = $(datepickerInput).datepicker('getDate');
         }
         if (timepickerInput.length > 0) {
-            time = $(timepickerInput).timepicker("getTime");
+            time = $(timepickerInput).timepicker('getTime');
         }
-        if(date && time) {
+        if (date && time) {
             return new Date(Date.UTC(
                 date.getFullYear(), date.getMonth(), date.getDate(),
                 time.getHours(), time.getMinutes()
             ));
-        } else if (date) { 
+        } else if (date) {
             return new Date(Date.UTC(
                 date.getFullYear(), date.getMonth(), date.getDate()));
         } else {
@@ -72,14 +72,14 @@ function($, date, TriggerChangeEventOnEnter) {
         }
     };
 
-    var setDate = function (datepickerInput, timepickerInput, datetime) {
+    var setDate = function(datepickerInput, timepickerInput, datetime) {
         // given a pair of inputs (datepicker and timepicker) and the date as an
         // ISO-formatted date string.
         datetime = date.parse(datetime);
         if (datetime) {
-            $(datepickerInput).datepicker("setDate", datetime);
+            $(datepickerInput).datepicker('setDate', datetime);
             if (timepickerInput.length > 0) {
-                $(timepickerInput).timepicker("setTime", datetime);
+                $(timepickerInput).timepicker('setTime', datetime);
             }
         }
     };
@@ -90,12 +90,12 @@ function($, date, TriggerChangeEventOnEnter) {
         var date = new Date(dateArg);
         return date.toLocaleString(
             [],
-            {timeZone: "UTC", timeZoneName: "short"}
+            {timeZone: 'UTC', timeZoneName: 'short'}
         );
     };
 
-    var parseDateFromString = function(stringDate){
-        if (stringDate && typeof stringDate === "string"){
+    var parseDateFromString = function(stringDate) {
+        if (stringDate && typeof stringDate === 'string') {
             return new Date(stringDate);
         }
         else {
@@ -103,9 +103,9 @@ function($, date, TriggerChangeEventOnEnter) {
         }
     };
 
-    var convertDateStringsToObjects = function(obj, dateFields){
-        for (var i = 0; i < dateFields.length; i++){
-            if (obj[dateFields[i]]){
+    var convertDateStringsToObjects = function(obj, dateFields) {
+        for (var i = 0; i < dateFields.length; i++) {
+            if (obj[dateFields[i]]) {
                 obj[dateFields[i]] = parseDateFromString(obj[dateFields[i]]);
             }
         }

--- a/cms/static/js/utils/drag_and_drop.js
+++ b/cms/static/js/utils/drag_and_drop.js
@@ -1,24 +1,24 @@
-define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
-        "js/utils/module", "common/js/components/views/feedback_notification"],
-    function ($, ui, _, gettext, Draggabilly, ModuleUtils, NotificationView) {
+define(['jquery', 'jquery.ui', 'underscore', 'gettext', 'draggabilly',
+        'js/utils/module', 'common/js/components/views/feedback_notification'],
+    function($, ui, _, gettext, Draggabilly, ModuleUtils, NotificationView) {
         'use strict';
 
         var contentDragger = {
             droppableClasses: 'drop-target drop-target-prepend drop-target-before drop-target-after',
-            validDropClass: "valid-drop",
-            expandOnDropClass: "expand-on-drop",
-            collapsedClass: "is-collapsed",
+            validDropClass: 'valid-drop',
+            expandOnDropClass: 'expand-on-drop',
+            collapsedClass: 'is-collapsed',
 
             /*
              * Determine information about where to drop the currently dragged
              * element. Returns the element to attach to and the method of
              * attachment ('before', 'after', or 'prepend').
              */
-            findDestination: function (ele, yChange) {
+            findDestination: function(ele, yChange) {
                 var eleY = ele.offset().top;
                 var eleYEnd = eleY + ele.outerHeight();
                 var containers = $(ele.data('droppable-class'));
-                var isSibling = function () {
+                var isSibling = function() {
                     return $(this).data('locator') !== undefined && !$(this).is(ele);
                 };
 
@@ -32,7 +32,7 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
                     // position of the container
                     var parentList = container.parents(ele.data('parent-location-selector')).first();
                     if (parentList.hasClass(this.collapsedClass)) {
-                        var parentListTop =  parentList.offset().top;
+                        var parentListTop = parentList.offset().top;
                         // To make it easier to drop subsections into collapsed sections (which have
                         // a lot of visual padding around them), allow a fudge factor around the
                         // parent element.
@@ -148,7 +148,7 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
             // Information about the current drag.
             dragState: {},
 
-            onDragStart: function (draggable) {
+            onDragStart: function(draggable) {
                 var ele = $(draggable.element);
                 this.dragState = {
                     // Which element will be dropped into/onto on success
@@ -176,7 +176,7 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
                 ele.removeClass('was-dragging');
             },
 
-            onDragMove: function (draggable, event, pointer) {
+            onDragMove: function(draggable, event, pointer) {
                 // Handle scrolling of the browser.
                 var scrollAmount = 0;
                 var dragBuffer = 10;
@@ -220,7 +220,7 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
                 }
             },
 
-            onDragEnd: function (draggable, event, pointer) {
+            onDragEnd: function(draggable, event, pointer) {
                 var ele = $(draggable.element);
                 var destination = this.dragState.dropDestination;
 
@@ -260,11 +260,11 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
                 this.dragState = {};
             },
 
-            pointerInBounds: function (pointer, ele) {
+            pointerInBounds: function(pointer, ele) {
                 return pointer.clientX >= ele.offset().left && pointer.clientX < ele.offset().left + ele.outerWidth();
             },
 
-            expandElement: function (ele) {
+            expandElement: function(ele) {
                 // Verify all children of the element are rendered.
                 var ensureChildrenRendered = ele.data('ensureChildrenRendered');
                 if (_.isFunction(ensureChildrenRendered)) { ensureChildrenRendered(); }
@@ -276,7 +276,7 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
             /*
              * Find all parent-child changes and save them.
              */
-            handleReorder: function (element) {
+            handleReorder: function(element) {
                 var parentSelector = element.data('parent-location-selector'),
                     childrenSelector = element.data('child-selector'),
                     newParentEle = element.parents(parentSelector).first(),
@@ -284,14 +284,13 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
                     oldParentLocator = element.data('parent'),
                     oldParentEle, saving, refreshParent;
 
-                refreshParent = function (element) {
+                refreshParent = function(element) {
                     var refresh = element.data('refresh');
                     // If drop was into a collapsed parent, the parent will have been
                     // expanded. Views using this class may need to track the
                     // collapse/expand state, so send it with the refresh callback.
                     var collapsed = element.hasClass(contentDragger.collapsedClass);
                     if (_.isFunction(refresh)) { refresh(collapsed); }
-
                 };
                 saving = new NotificationView.Mini({
                     title: gettext('Saving')
@@ -299,10 +298,10 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
                 saving.show();
                 element.addClass('was-dropped');
                 // Timeout interval has to match what is in the CSS.
-                setTimeout(function () {
+                setTimeout(function() {
                     element.removeClass('was-dropped');
                 }, 1000);
-                this.saveItem(newParentEle, childrenSelector, function () {
+                this.saveItem(newParentEle, childrenSelector, function() {
                     saving.hide();
 
                     // Refresh new parent.
@@ -310,7 +309,7 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
 
                     // Refresh old parent.
                     if (newParentLocator !== oldParentLocator) {
-                        oldParentEle = $(parentSelector).filter(function () {
+                        oldParentEle = $(parentSelector).filter(function() {
                             return $(this).data('locator') === oldParentLocator;
                         });
                         refreshParent(oldParentEle);
@@ -324,11 +323,11 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
              * representing the parent item to save, a CSS selector to find
              * its children, and a success callback.
              */
-            saveItem: function (ele, childrenSelector, success) {
+            saveItem: function(ele, childrenSelector, success) {
                 // Find all current child IDs.
                 var children = _.map(
                     ele.find(childrenSelector),
-                    function (child) {
+                    function(child) {
                         return $(child).data('locator');
                     }
                 );
@@ -356,7 +355,7 @@ define(["jquery", "jquery.ui", "underscore", "gettext", "draggabilly",
              *   `refresh` - method that will be called after dragging to refresh
              *      views of the target and source xblocks.
              */
-            makeDraggable: function (element, options) {
+            makeDraggable: function(element, options) {
                 var draggable;
                 options = _.defaults({
                     type: undefined,

--- a/cms/static/js/utils/handle_iframe_binding.js
+++ b/cms/static/js/utils/handle_iframe_binding.js
@@ -1,26 +1,26 @@
-define(["jquery"], function($) {
-    var iframeBinding = function (e) {
+define(['jquery'], function($) {
+    var iframeBinding = function(e) {
         var target_element = null;
-        if (typeof(e) === "undefined") {
-            target_element = $("iframe, embed");
+        if (typeof(e) === 'undefined') {
+            target_element = $('iframe, embed');
         } else {
             if (typeof(e.nodeName) !== 'undefined') {
-                target_element = $(e).find("iframe, embed");
+                target_element = $(e).find('iframe, embed');
             } else {
-                target_element = e.$("iframe, embed");
+                target_element = e.$('iframe, embed');
             }
         }
         modifyTagContent(target_element);
     };
 
-    var modifyTagContent = function (target_element) {
+    var modifyTagContent = function(target_element) {
         target_element.each(function() {
             if ($(this).prop('tagName') === 'IFRAME') {
                 var ifr_source = $(this).attr('src');
 
                 // Modify iframe src only if it is not empty
                 if (ifr_source) {
-                    var wmode = "wmode=transparent";
+                    var wmode = 'wmode=transparent';
                     if (ifr_source.indexOf('?') !== -1) {
                         var getQString = ifr_source.split('?');
                         if (getQString[1].search('wmode=transparent') === -1) {
@@ -32,7 +32,7 @@ define(["jquery"], function($) {
                     // The TinyMCE editor is hosted in an iframe, and before the iframe is
                     // removed we execute this code. To avoid throwing an error when setting the
                     // attr, check that the source doesn't start with the value specified by TinyMCE ('javascript:""').
-                    else if (ifr_source.lastIndexOf("javascript:", 0) !== 0) {
+                    else if (ifr_source.lastIndexOf('javascript:', 0) !== 0) {
                         $(this).attr('src', ifr_source + '?' + wmode);
                     }
                 }
@@ -49,13 +49,13 @@ define(["jquery"], function($) {
     // tags in html string so both tags will attach to dom and don't create z-index problem for other popups
     // Note: embed tags should be modified before rendering as they are static objects as compared to iframes
     // Note: this method can modify unintended html (invalid tags) while converting to dom object
-    var iframeBindingHtml = function (html_string) {
-        if (html_string){
+    var iframeBindingHtml = function(html_string) {
+        if (html_string) {
             var target_element = null;
             var temp_content = document.createElement('div');
             $(temp_content).html(html_string);
-            target_element = $(temp_content).find("iframe, embed");
-            if (target_element.length > 0){
+            target_element = $(temp_content).find('iframe, embed');
+            if (target_element.length > 0) {
                 modifyTagContent(target_element);
                 html_string = $(temp_content).html();
             }

--- a/cms/static/js/utils/modal.js
+++ b/cms/static/js/utils/modal.js
@@ -1,4 +1,4 @@
-define(["jquery"], function($) {
+define(['jquery'], function($) {
     /**
      * Hides the modal and modal cover, using the standard selectors.
      * Note though that the class "is-fixed" on the modal cover
@@ -13,7 +13,7 @@ define(["jquery"], function($) {
 
         // Unit editors (module_edit) do not want the modal cover to hide when users click outside
         // of the editor. Users must press Cancel or Save to exit the editor.
-        if (!$modalCover.hasClass("is-fixed")) {
+        if (!$modalCover.hasClass('is-fixed')) {
             getModal().hide();
             hideModalCover($modalCover);
         }
@@ -25,19 +25,19 @@ define(["jquery"], function($) {
      *
      * This method also unbinds the click handler on the modal cover.
      */
-    var hideModalCover = function (modalCover) {
+    var hideModalCover = function(modalCover) {
         if (modalCover == undefined) {
             modalCover = getModalCover();
         }
         modalCover.hide();
-        modalCover.removeClass("is-fixed");
+        modalCover.removeClass('is-fixed');
         modalCover.unbind('click');
     };
 
     /**
      * Shows the modal and modal cover, using the standard selectors.
      */
-    var showModal = function () {
+    var showModal = function() {
         getModal().show();
         showModalCover();
     };
@@ -54,7 +54,7 @@ define(["jquery"], function($) {
         var $modalCover = getModalCover();
         $modalCover.show();
         if (addFixed) {
-            $modalCover.addClass("is-fixed");
+            $modalCover.addClass('is-fixed');
         }
         $modalCover.unbind('click');
         if (clickHandler) {
@@ -66,12 +66,12 @@ define(["jquery"], function($) {
         return $modalCover;
     };
 
-    var getModalCover = function () {
+    var getModalCover = function() {
         return $('.modal-cover');
     };
 
-    var getModal = function () {
-        return $(".modal, .showAsModal");
+    var getModal = function() {
+        return $('.modal, .showAsModal');
     };
 
     return {

--- a/cms/static/js/utils/module.js
+++ b/cms/static/js/utils/module.js
@@ -7,10 +7,10 @@
  * getUpdateUrl: a utility method that returns the xblock update URL, appending
  *               the location if passed in.
  */
-define(["underscore"], function (_) {
+define(['underscore'], function(_) {
     var urlRoot = '/xblock';
 
-    var getUpdateUrl = function (locator) {
+    var getUpdateUrl = function(locator) {
         if (_.isUndefined(locator)) {
             return urlRoot + '/';
         }

--- a/cms/static/js/utils/templates.js
+++ b/cms/static/js/utils/templates.js
@@ -1,15 +1,14 @@
-define(["jquery", "underscore"], function($, _) {
-
+define(['jquery', 'underscore'], function($, _) {
     /**
      * Loads the named template from the page, or logs an error if it fails.
      * @param name The name of the template.
      * @returns The loaded template.
      */
     var loadTemplate = function(name) {
-        var templateSelector = "#" + name + "-tpl",
+        var templateSelector = '#' + name + '-tpl',
             templateText = $(templateSelector).text();
         if (!templateText) {
-            console.error("Failed to load " + name + " template");
+            console.error('Failed to load ' + name + ' template');
         }
         return _.template(templateText);
     };

--- a/cms/static/js/views/abstract_editor.js
+++ b/cms/static/js/views/abstract_editor.js
@@ -1,13 +1,13 @@
 
-define(["js/views/baseview", "underscore"], function(BaseView, _) {
+define(['js/views/baseview', 'underscore'], function(BaseView, _) {
     var AbstractEditor = BaseView.extend({
 
         // Model is MetadataModel
-        initialize : function() {
+        initialize: function() {
             var self = this;
             var templateName = _.result(this, 'templateName');
             // Backbone model cid is only unique within the collection.
-            this.uniqueId = _.uniqueId(templateName + "_");
+            this.uniqueId = _.uniqueId(templateName + '_');
             this.template = this.loadTemplate(templateName);
             this.$el.html(this.template({model: this.model, uniqueId: this.uniqueId}));
             this.listenTo(this.model, 'change', this.render);
@@ -22,24 +22,24 @@ define(["js/views/baseview", "underscore"], function(BaseView, _) {
         /**
          * Returns the value currently displayed in the editor/view. Subclasses should implement this method.
          */
-        getValueFromEditor : function () {},
+        getValueFromEditor: function() {},
 
         /**
          * Sets the value currently displayed in the editor/view. Subclasses should implement this method.
          */
-        setValueInEditor : function (value) {},
+        setValueInEditor: function(value) {},
 
         /**
          * Sets the value in the model, using the value currently displayed in the view.
          */
-        updateModel: function () {
+        updateModel: function() {
             this.model.setValue(this.getValueFromEditor());
         },
 
         /**
          * Clears the value currently set in the model (reverting to the default).
          */
-        clear: function () {
+        clear: function() {
             this.model.clear();
         },
 
@@ -57,7 +57,7 @@ define(["js/views/baseview", "underscore"], function(BaseView, _) {
         /**
          * Returns the clear button.
          */
-        getClearButton: function () {
+        getClearButton: function() {
             return this.$el.find('.setting-clear');
         },
 
@@ -65,7 +65,7 @@ define(["js/views/baseview", "underscore"], function(BaseView, _) {
          * Renders the editor, updating the value displayed in the view, as well as the state of
          * the clear button.
          */
-        render: function () {
+        render: function() {
             if (!this.template) return;
 
             this.setValueInEditor(this.model.getDisplayValue());
@@ -88,10 +88,10 @@ define(["js/views/baseview", "underscore"], function(BaseView, _) {
          * @returns The loaded template.
          */
         loadTemplate: function(name) {
-            var templateSelector = "#" + name,
+            var templateSelector = '#' + name,
                 templateText = $(templateSelector).text();
             if (!templateText) {
-                console.error("Failed to load " + name + " template");
+                console.error('Failed to load ' + name + ' template');
             }
             return _.template(templateText);
         }

--- a/cms/static/js/views/active_video_upload.js
+++ b/cms/static/js/views/active_video_upload.js
@@ -1,27 +1,27 @@
 define(
-    ["js/models/active_video_upload", "js/views/baseview"],
+    ['js/models/active_video_upload', 'js/views/baseview'],
     function(ActiveVideoUpload, BaseView) {
-        "use strict";
+        'use strict';
 
         var STATUS_CLASSES = [
-            {status: ActiveVideoUpload.STATUS_QUEUED, cls: "queued"},
-            {status: ActiveVideoUpload.STATUS_COMPLETED, cls: "success"},
-            {status: ActiveVideoUpload.STATUS_FAILED, cls: "error"}
+            {status: ActiveVideoUpload.STATUS_QUEUED, cls: 'queued'},
+            {status: ActiveVideoUpload.STATUS_COMPLETED, cls: 'success'},
+            {status: ActiveVideoUpload.STATUS_FAILED, cls: 'error'}
         ];
 
         var ActiveVideoUploadView = BaseView.extend({
-            tagName: "li",
-            className: "active-video-upload",
+            tagName: 'li',
+            className: 'active-video-upload',
 
             initialize: function() {
-                this.template = this.loadTemplate("active-video-upload");
-                this.listenTo(this.model, "change", this.render);
+                this.template = this.loadTemplate('active-video-upload');
+                this.listenTo(this.model, 'change', this.render);
             },
 
             render: function() {
                 var $el = this.$el;
                 $el.html(this.template(this.model.attributes));
-                var status = this.model.get("status");
+                var status = this.model.get('status');
                 _.each(
                     STATUS_CLASSES,
                     function(statusClass) {
@@ -29,7 +29,7 @@ define(
                     }
                 );
                 return this;
-            },
+            }
         });
 
         return ActiveVideoUploadView;

--- a/cms/static/js/views/active_video_upload_list.js
+++ b/cms/static/js/views/active_video_upload_list.js
@@ -1,21 +1,21 @@
 define(
-    ["jquery", "underscore", "backbone", "js/models/active_video_upload", "js/views/baseview", "js/views/active_video_upload", "jquery.fileupload"],
+    ['jquery', 'underscore', 'backbone', 'js/models/active_video_upload', 'js/views/baseview', 'js/views/active_video_upload', 'jquery.fileupload'],
     function($, _, Backbone, ActiveVideoUpload, BaseView, ActiveVideoUploadView) {
-        "use strict";
+        'use strict';
 
         var ActiveVideoUploadListView = BaseView.extend({
-            tagName: "div",
+            tagName: 'div',
             events: {
-                "click .file-drop-area": "chooseFile",
-                "dragleave .file-drop-area": "dragleave",
-                "drop .file-drop-area": "dragleave"
+                'click .file-drop-area': 'chooseFile',
+                'dragleave .file-drop-area': 'dragleave',
+                'drop .file-drop-area': 'dragleave'
             },
 
             initialize: function(options) {
-                this.template = this.loadTemplate("active-video-upload-list");
+                this.template = this.loadTemplate('active-video-upload-list');
                 this.collection = new Backbone.Collection();
                 this.itemViews = [];
-                this.listenTo(this.collection, "add", this.addUpload);
+                this.listenTo(this.collection, 'add', this.addUpload);
                 this.concurrentUploadLimit = options.concurrentUploadLimit || 0;
                 this.postUrl = options.postUrl;
                 if (options.uploadButton) {
@@ -26,10 +26,10 @@ define(
             render: function() {
                 this.$el.html(this.template());
                 _.each(this.itemViews, this.renderUploadView.bind(this));
-                this.$uploadForm = this.$(".file-upload-form");
-                this.$dropZone = this.$uploadForm.find(".file-drop-area");
+                this.$uploadForm = this.$('.file-upload-form');
+                this.$dropZone = this.$uploadForm.find('.file-drop-area');
                 this.$uploadForm.fileupload({
-                    type: "PUT",
+                    type: 'PUT',
                     singleFileUploads: false,
                     limitConcurrentUploads: this.concurrentUploadLimit,
                     dropZone: this.$dropZone,
@@ -46,24 +46,24 @@ define(
                 var preventDefault = function(event) {
                     event.preventDefault();
                 };
-                $(window).on("dragover", preventDefault);
-                $(window).on("drop", preventDefault);
-                $(window).on("beforeunload", this.onBeforeUnload.bind(this));
+                $(window).on('dragover', preventDefault);
+                $(window).on('drop', preventDefault);
+                $(window).on('beforeunload', this.onBeforeUnload.bind(this));
 
                 return this;
             },
 
-            onBeforeUnload: function () {
+            onBeforeUnload: function() {
                 // Are there are uploads queued or in progress?
                 var uploading = this.collection.filter(function(model) {
-                    var stat = model.get("status");
-                    return (model.get("progress") < 1) &&
+                    var stat = model.get('status');
+                    return (model.get('progress') < 1) &&
                           ((stat === ActiveVideoUpload.STATUS_QUEUED ||
                            (stat === ActiveVideoUpload.STATUS_UPLOADING)));
                 });
                 // If so, show a warning message.
                 if (uploading.length) {
-                    return gettext("Your video uploads are not complete.");
+                    return gettext('Your video uploads are not complete.');
                 }
             },
 
@@ -74,22 +74,22 @@ define(
             },
 
             renderUploadView: function(view) {
-                this.$(".active-video-upload-list").append(view.render().$el);
+                this.$('.active-video-upload-list').append(view.render().$el);
             },
 
             chooseFile: function(event) {
                 event.preventDefault();
-                this.$uploadForm.find(".js-file-input").click();
+                this.$uploadForm.find('.js-file-input').click();
             },
 
             dragover: function(event) {
                 event.preventDefault();
-                this.$dropZone.addClass("is-dragged");
+                this.$dropZone.addClass('is-dragged');
             },
 
             dragleave: function(event) {
                 event.preventDefault();
-                this.$dropZone.removeClass("is-dragged");
+                this.$dropZone.removeClass('is-dragged');
             },
 
             // Each file is ultimately sent to a separate URL, but we want to make a
@@ -108,24 +108,24 @@ define(
                 } else {
                     $.ajax({
                         url: this.postUrl,
-                        contentType: "application/json",
+                        contentType: 'application/json',
                         data: JSON.stringify({
                             files: _.map(
                                 uploadData.files,
                                 function(file) {
-                                    return {"file_name": file.name, "content_type": file.type};
+                                    return {'file_name': file.name, 'content_type': file.type};
                                 }
                             )
                         }),
-                        dataType: "json",
-                        type: "POST"
+                        dataType: 'json',
+                        type: 'POST'
                     }).done(function(responseData) {
                         _.each(
-                            responseData["files"],
+                            responseData['files'],
                             function(file, index) {
-                                view.$uploadForm.fileupload("add", {
+                                view.$uploadForm.fileupload('add', {
                                     files: [uploadData.files[index]],
-                                    url: file["upload_url"],
+                                    url: file['upload_url'],
                                     multipart: false,
                                     global: false,  // Do not trigger global AJAX error handler
                                     redirected: true
@@ -137,12 +137,12 @@ define(
             },
 
             setStatus: function(cid, status) {
-                this.collection.get(cid).set("status", status);
+                this.collection.get(cid).set('status', status);
             },
 
             // progress should be a number between 0 and 1 (inclusive)
             setProgress: function(cid, progress) {
-                this.collection.get(cid).set("progress", progress);
+                this.collection.get(cid).set('progress', progress);
             },
 
             fileUploadSend: function(event, data) {

--- a/cms/static/js/views/asset.js
+++ b/cms/static/js/views/asset.js
@@ -1,94 +1,94 @@
-define(["js/views/baseview", "underscore", "gettext", "common/js/components/views/feedback_prompt",
-      "common/js/components/views/feedback_notification"],
+define(['js/views/baseview', 'underscore', 'gettext', 'common/js/components/views/feedback_prompt',
+      'common/js/components/views/feedback_notification'],
     function(BaseView, _, gettext, PromptView, NotificationView) {
-var AssetView = BaseView.extend({
-  initialize: function() {
-    this.template = this.loadTemplate("asset");
-    this.listenTo(this.model, "change:locked", this.updateLockState);
-  },
-  tagName: "tr",
-  events: {
-    "click .remove-asset-button": "confirmDelete",
-    "click .lock-checkbox": "lockAsset"
-  },
+        var AssetView = BaseView.extend({
+            initialize: function() {
+                this.template = this.loadTemplate('asset');
+                this.listenTo(this.model, 'change:locked', this.updateLockState);
+            },
+            tagName: 'tr',
+            events: {
+                'click .remove-asset-button': 'confirmDelete',
+                'click .lock-checkbox': 'lockAsset'
+            },
 
-  render: function() {
-    var uniqueId = _.uniqueId('lock_asset_');
-    this.$el.html(this.template({
-      display_name: this.model.get('display_name'),
-      thumbnail: this.model.get('thumbnail'),
-      date_added: this.model.get('date_added'),
-      url: this.model.get('url'),
-      external_url: this.model.get('external_url'),
-      portable_url: this.model.get('portable_url'),
-      asset_type: this.model.get_extension(),
-      uniqueId: uniqueId
-    }));
-    this.updateLockState();
-    return this;
-  },
+            render: function() {
+                var uniqueId = _.uniqueId('lock_asset_');
+                this.$el.html(this.template({
+                    display_name: this.model.get('display_name'),
+                    thumbnail: this.model.get('thumbnail'),
+                    date_added: this.model.get('date_added'),
+                    url: this.model.get('url'),
+                    external_url: this.model.get('external_url'),
+                    portable_url: this.model.get('portable_url'),
+                    asset_type: this.model.get_extension(),
+                    uniqueId: uniqueId
+                }));
+                this.updateLockState();
+                return this;
+            },
 
-  updateLockState: function () {
-    var locked_class = "is-locked";
+            updateLockState: function() {
+                var locked_class = 'is-locked';
 
     // Add a class of "locked" to the tr element if appropriate,
     // and toggle locked state of hidden checkbox.
-    if (this.model.get('locked')) {
-      this.$el.addClass(locked_class);
-      this.$el.find('.lock-checkbox').attr('checked','checked');
-    }
-    else {
-      this.$el.removeClass(locked_class);
-      this.$el.find('.lock-checkbox').removeAttr('checked');
-    }
-  },
-
-  confirmDelete: function(e) {
-    if(e && e.preventDefault) { e.preventDefault(); }
-    var asset = this.model, collection = this.model.collection;
-    new PromptView.Warning({
-      title: gettext("Delete File Confirmation"),
-      message: gettext("Are you sure you wish to delete this item. It cannot be reversed!\n\nAlso any content that links/refers to this item will no longer work (e.g. broken images and/or links)"),
-      actions: {
-        primary: {
-          text: gettext("Delete"),
-          click: function (view) {
-            view.hide();
-            asset.destroy({
-                wait: true, // Don't remove the asset from the collection until successful.
-                success: function () {
-                  new NotificationView.Confirmation({
-                    title: gettext("Your file has been deleted."),
-                    closeIcon: false,
-                    maxShown: 2000
-                  }).show();
+                if (this.model.get('locked')) {
+                    this.$el.addClass(locked_class);
+                    this.$el.find('.lock-checkbox').attr('checked', 'checked');
                 }
-            });
-          }
-        },
-        secondary: {
-          text: gettext("Cancel"),
-          click: function (view) {
-            view.hide();
-          }
-        }
-      }
-    }).show();
-  },
+                else {
+                    this.$el.removeClass(locked_class);
+                    this.$el.find('.lock-checkbox').removeAttr('checked');
+                }
+            },
 
-  lockAsset: function(e) {
-    var asset = this.model;
-    var saving = new NotificationView.Mini({
-      title: gettext("Saving")
-    }).show();
-    asset.save({'locked': !asset.get('locked')}, {
-      wait: true, // This means we won't re-render until we get back the success state.
-      success: function() {
-          saving.hide();
-      }
-    });
-    }
-});
+            confirmDelete: function(e) {
+                if (e && e.preventDefault) { e.preventDefault(); }
+                var asset = this.model, collection = this.model.collection;
+                new PromptView.Warning({
+                    title: gettext('Delete File Confirmation'),
+                    message: gettext('Are you sure you wish to delete this item. It cannot be reversed!\n\nAlso any content that links/refers to this item will no longer work (e.g. broken images and/or links)'),
+                    actions: {
+                        primary: {
+                            text: gettext('Delete'),
+                            click: function(view) {
+                                view.hide();
+                                asset.destroy({
+                                    wait: true, // Don't remove the asset from the collection until successful.
+                                    success: function() {
+                                        new NotificationView.Confirmation({
+                                            title: gettext('Your file has been deleted.'),
+                                            closeIcon: false,
+                                            maxShown: 2000
+                                        }).show();
+                                    }
+                                });
+                            }
+                        },
+                        secondary: {
+                            text: gettext('Cancel'),
+                            click: function(view) {
+                                view.hide();
+                            }
+                        }
+                    }
+                }).show();
+            },
 
-return AssetView;
-}); // end define()
+            lockAsset: function(e) {
+                var asset = this.model;
+                var saving = new NotificationView.Mini({
+                    title: gettext('Saving')
+                }).show();
+                asset.save({'locked': !asset.get('locked')}, {
+                    wait: true, // This means we won't re-render until we get back the success state.
+                    success: function() {
+                        saving.hide();
+                    }
+                });
+            }
+        });
+
+        return AssetView;
+    }); // end define()

--- a/cms/static/js/views/assets.js
+++ b/cms/static/js/views/assets.js
@@ -1,41 +1,40 @@
 define([
-        "jquery",
-        "underscore",
-        "gettext",
-        "edx-ui-toolkit/js/utils/html-utils",
-        "js/views/baseview",
-        "js/models/asset",
-        "js/views/paging",
-        "js/views/asset",
-        "js/views/paging_header",
-        "common/js/components/views/paging_footer",
-        "js/utils/modal",
-        "common/js/components/utils/view_utils",
-        "common/js/components/views/feedback_notification",
-        "text!templates/asset-library.underscore",
-        "jquery.fileupload-process",
-        "jquery.fileupload-validate"
-    ],
+    'jquery',
+    'underscore',
+    'gettext',
+    'edx-ui-toolkit/js/utils/html-utils',
+    'js/views/baseview',
+    'js/models/asset',
+    'js/views/paging',
+    'js/views/asset',
+    'js/views/paging_header',
+    'common/js/components/views/paging_footer',
+    'js/utils/modal',
+    'common/js/components/utils/view_utils',
+    'common/js/components/views/feedback_notification',
+    'text!templates/asset-library.underscore',
+    'jquery.fileupload-process',
+    'jquery.fileupload-validate'
+],
     function($, _, gettext, HtmlUtils, BaseView, AssetModel, PagingView, AssetView, PagingHeader, PagingFooter,
              ModalUtils, ViewUtils, NotificationView, asset_library_template) {
-
         var CONVERSION_FACTOR_MBS_TO_BYTES = 1000 * 1000;
 
         var AssetsView = BaseView.extend({
             // takes AssetCollection as model
 
-            events : {
-                "click .column-sort-link": "onToggleColumn",
-                "click .upload-button": "showUploadModal",
-                "click .filterable-column .nav-item": "onFilterColumn",
-                "click .filterable-column .column-filter-link": "toggleFilterColumn"
+            events: {
+                'click .column-sort-link': 'onToggleColumn',
+                'click .upload-button': 'showUploadModal',
+                'click .filterable-column .nav-item': 'onFilterColumn',
+                'click .filterable-column .column-filter-link': 'toggleFilterColumn'
             },
 
             typeData: ['Images', 'Documents'],
 
             allLabel: 'ALL',
 
-            initialize : function(options) {
+            initialize: function(options) {
                 options = options || {};
 
                 BaseView.prototype.initialize.call(this);
@@ -57,9 +56,9 @@ define([
             PagingAssetView: PagingView.extend({
                 renderPageItems: function() {
                     var self = this,
-                    assets = this.collection,
-                    hasAssets = this.collection.assetType !== '' || assets.length > 0,
-                    tableBody = this.getTableBody();
+                        assets = this.collection,
+                        hasAssets = this.collection.assetType !== '' || assets.length > 0,
+                        tableBody = this.getTableBody();
                     tableBody.empty();
                     if (hasAssets) {
                         assets.each(
@@ -138,7 +137,7 @@ define([
                 });
             },
 
-            addAsset: function (model) {
+            addAsset: function(model) {
                 // Switch the sort column back to the default (most recent date added) and show the first page
                 // so that the new asset is shown at the top of the page.
                 this.pagingView.setInitialSortColumn('js-asset-date-col');
@@ -161,18 +160,18 @@ define([
                 event.stopPropagation();
             },
 
-            hideModal: function (event) {
+            hideModal: function(event) {
                 if (event) {
                     event.preventDefault();
                 }
                 $('.file-input').unbind('change.startUpload');
                 ModalUtils.hideModal();
                 if (this.largeFileErrorMsg) {
-                  this.largeFileErrorMsg.hide();
+                    this.largeFileErrorMsg.hide();
                 }
             },
 
-            showUploadModal: function (event) {
+            showUploadModal: function(event) {
                 var self = this;
                 event.preventDefault();
                 self.resetUploadModal();
@@ -195,26 +194,26 @@ define([
                     },
                     processfail: function(event, data) {
                         var filename = data.files[data.index].name;
-                        var error = gettext("File {filename} exceeds maximum size of {maxFileSizeInMBs} MB")
-                                    .replace("{filename}", filename)
-                                    .replace("{maxFileSizeInMBs}", self.maxFileSizeInMBs)
+                        var error = gettext('File {filename} exceeds maximum size of {maxFileSizeInMBs} MB')
+                                    .replace('{filename}', filename)
+                                    .replace('{maxFileSizeInMBs}', self.maxFileSizeInMBs);
 
                         // disable second part of message for any falsy value,
                         // which can be null or an empty string
-                        if(self.maxFileSizeRedirectUrl) {
-                            var instructions = gettext("Please follow the instructions here to upload a file elsewhere and link to it: {maxFileSizeRedirectUrl}")
-                                    .replace("{maxFileSizeRedirectUrl}", self.maxFileSizeRedirectUrl);
-                            error = error + " " + instructions;
+                        if (self.maxFileSizeRedirectUrl) {
+                            var instructions = gettext('Please follow the instructions here to upload a file elsewhere and link to it: {maxFileSizeRedirectUrl}')
+                                    .replace('{maxFileSizeRedirectUrl}', self.maxFileSizeRedirectUrl);
+                            error = error + ' ' + instructions;
                         }
 
                         self.largeFileErrorMsg = new NotificationView.Error({
-                            "title": gettext("Your file could not be uploaded"),
-                            "message": error
+                            'title': gettext('Your file could not be uploaded'),
+                            'message': error
                         });
                         self.largeFileErrorMsg.show();
 
                         self.displayFailedUpload({
-                            "msg": gettext("Max file size exceeded")
+                            'msg': gettext('Max file size exceeded')
                         });
                     },
                     processdone: function(event, data) {
@@ -226,12 +225,12 @@ define([
             showFileSelectionMenu: function(event) {
                 event.preventDefault();
                 if (this.largeFileErrorMsg) {
-                  this.largeFileErrorMsg.hide();
+                    this.largeFileErrorMsg.hide();
                 }
                 $('.file-input').click();
             },
 
-            startUpload: function (event) {
+            startUpload: function(event) {
                 var file = event.target.value;
 
                 if (!this.largeFileErrorMsg) {
@@ -242,7 +241,7 @@ define([
                 }
             },
 
-            resetUploadModal: function () {
+            resetUploadModal: function() {
                 // Reset modal so it no longer displays information about previously
                 // completed uploads.
                 var percentVal = '0%',
@@ -262,7 +261,7 @@ define([
                 this.largeFileErrorMsg = null;
             },
 
-            showUploadFeedback: function (event, percentComplete) {
+            showUploadFeedback: function(event, percentComplete) {
                 var percentVal = percentComplete + '%',
                     $progressFill = $('.upload-modal .progress-fill');
 
@@ -278,9 +277,9 @@ define([
                 var $subnav = menu.find('.wrapper-nav-sub');
                 var $title = menu.find('.title');
                 var titleText = $title.find('.type-filter');
-                var assettype = selected ? selected.data('assetfilter'): false;
-                if(assettype) {
-                    if(assettype === this.allLabel) {
+                var assettype = selected ? selected.data('assetfilter') : false;
+                if (assettype) {
+                    if (assettype === this.allLabel) {
                         titleText.text(titleText.data('alllabel'));
                     }
                     else {
@@ -329,7 +328,7 @@ define([
                 this.toggleFilterColumnState($menu, element);
             },
 
-            displayFinishedUpload: function (resp) {
+            displayFinishedUpload: function(resp) {
                 var asset = resp.asset,
                     $progressFill = $('.upload-modal .progress-fill');
 
@@ -344,7 +343,7 @@ define([
                 this.addAsset(new AssetModel(asset));
             },
 
-            displayFailedUpload: function (resp) {
+            displayFailedUpload: function(resp) {
                 var $progressFill = $('.upload-modal .progress-fill');
 
                 $('.upload-modal h1').text(gettext('Upload New File'));

--- a/cms/static/js/views/baseview.js
+++ b/cms/static/js/views/baseview.js
@@ -1,6 +1,6 @@
-define(["jquery", "underscore", "backbone", "gettext", "js/utils/handle_iframe_binding", "js/utils/templates",
-        "common/js/components/utils/view_utils"],
-    function ($, _, Backbone, gettext, IframeUtils, TemplateUtils, ViewUtils) {
+define(['jquery', 'underscore', 'backbone', 'gettext', 'js/utils/handle_iframe_binding', 'js/utils/templates',
+        'common/js/components/utils/view_utils'],
+    function($, _, Backbone, gettext, IframeUtils, TemplateUtils, ViewUtils) {
         /*
          This view is extended from backbone to provide useful functionality for all Studio views.
          This functionality includes:
@@ -13,7 +13,7 @@ define(["jquery", "underscore", "backbone", "gettext", "js/utils/handle_iframe_b
 
         var BaseView = Backbone.View.extend({
             events: {
-                "click .ui-toggle-expansion": "toggleExpandCollapse"
+                'click .ui-toggle-expansion': 'toggleExpandCollapse'
             },
 
             options: {
@@ -23,7 +23,7 @@ define(["jquery", "underscore", "backbone", "gettext", "js/utils/handle_iframe_b
                 collapsedClass: 'collapsed'
             },
 
-            //override the constructor function
+            // override the constructor function
             constructor: function(options) {
                 _.bindAll(this, 'beforeRender', 'render', 'afterRender');
 
@@ -35,14 +35,14 @@ define(["jquery", "underscore", "backbone", "gettext", "js/utils/handle_iframe_b
                 this.options = options;
 
                 var _this = this;
-                this.render = _.wrap(this.render, function (render, options) {
+                this.render = _.wrap(this.render, function(render, options) {
                     _this.beforeRender();
                     render(options);
                     _this.afterRender();
                     return _this;
                 });
 
-                //call Backbone's own constructor
+                // call Backbone's own constructor
                 Backbone.View.prototype.constructor.apply(this, arguments);
             },
 

--- a/cms/static/js/views/components/add_xblock.js
+++ b/cms/static/js/views/components/add_xblock.js
@@ -1,9 +1,9 @@
 /**
  * This is a simple component that renders add buttons for all available XBlock template types.
  */
-define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/components/utils/view_utils",
-        "js/views/components/add_xblock_button", "js/views/components/add_xblock_menu"],
-    function ($, _, gettext, BaseView, ViewUtils, AddXBlockButton, AddXBlockMenu) {
+define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/components/utils/view_utils',
+        'js/views/components/add_xblock_button', 'js/views/components/add_xblock_menu'],
+    function($, _, gettext, BaseView, ViewUtils, AddXBlockButton, AddXBlockMenu) {
         var AddXBlockComponent = BaseView.extend({
             events: {
                 'click .new-component .new-component-type .multiple-templates': 'showComponentTemplates',
@@ -18,12 +18,12 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
                 this.template = this.loadTemplate('add-xblock-component');
             },
 
-            render: function () {
+            render: function() {
                 if (!this.$el.html()) {
                     var that = this;
                     this.$el.html(this.template({}));
                     this.collection.each(
-                        function (componentModel) {
+                        function(componentModel) {
                             var view, menu;
 
                             view = new AddXBlockButton({model: componentModel});
@@ -53,7 +53,6 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
                 this.$('.new-component').slideDown(250);
                 this.$('.new-component-templates').slideUp(250);
                 this.$('ul.new-component-type li button[data-type=' + type + ']').focus();
-
             },
 
             createNewComponent: function(event) {

--- a/cms/static/js/views/components/add_xblock_button.js
+++ b/cms/static/js/views/components/add_xblock_button.js
@@ -1,11 +1,10 @@
-define(["js/views/baseview"],
-    function (BaseView) {
-
+define(['js/views/baseview'],
+    function(BaseView) {
         return BaseView.extend({
-            tagName: "li",
-            initialize: function () {
+            tagName: 'li',
+            initialize: function() {
                 BaseView.prototype.initialize.call(this);
-                this.template = this.loadTemplate("add-xblock-component-button");
+                this.template = this.loadTemplate('add-xblock-component-button');
                 this.$el.html(
                     this.template({
                         type: this.model.type,
@@ -15,5 +14,4 @@ define(["js/views/baseview"],
                 );
             }
         });
-
     }); // end define();

--- a/cms/static/js/views/components/add_xblock_menu.js
+++ b/cms/static/js/views/components/add_xblock_menu.js
@@ -1,16 +1,15 @@
-define(["jquery", "js/views/baseview", 'edx-ui-toolkit/js/utils/html-utils'],
-    function ($, BaseView, HtmlUtils) {
-
+define(['jquery', 'js/views/baseview', 'edx-ui-toolkit/js/utils/html-utils'],
+    function($, BaseView, HtmlUtils) {
         return BaseView.extend({
-            className: function () {
-                return "new-component-templates new-component-" + this.model.type;
+            className: function() {
+                return 'new-component-templates new-component-' + this.model.type;
             },
-            initialize: function () {
+            initialize: function() {
                 BaseView.prototype.initialize.call(this);
-                var template_name = this.model.type === "problem" ? "add-xblock-component-menu-problem" :
-                    "add-xblock-component-menu";
-                var support_indicator_template = this.loadTemplate("add-xblock-component-support-level");
-                var support_legend_template = this.loadTemplate("add-xblock-component-support-legend");
+                var template_name = this.model.type === 'problem' ? 'add-xblock-component-menu-problem' :
+                    'add-xblock-component-menu';
+                var support_indicator_template = this.loadTemplate('add-xblock-component-support-level');
+                var support_legend_template = this.loadTemplate('add-xblock-component-support-legend');
                 this.template = this.loadTemplate(template_name);
                 HtmlUtils.setHtml(
                     this.$el,
@@ -26,5 +25,4 @@ define(["jquery", "js/views/baseview", 'edx-ui-toolkit/js/utils/html-utils'],
                 this.$('.tab-group').tabs();
             }
         });
-
     }); // end define();

--- a/cms/static/js/views/container.js
+++ b/cms/static/js/views/container.js
@@ -1,17 +1,17 @@
-define(["jquery", "underscore", "js/views/xblock", "js/utils/module", "gettext", "common/js/components/views/feedback_notification",
-    "jquery.ui"], // The container view uses sortable, which is provided by jquery.ui.
-    function ($, _, XBlockView, ModuleUtils, gettext, NotificationView) {
+define(['jquery', 'underscore', 'js/views/xblock', 'js/utils/module', 'gettext', 'common/js/components/views/feedback_notification',
+    'jquery.ui'], // The container view uses sortable, which is provided by jquery.ui.
+    function($, _, XBlockView, ModuleUtils, gettext, NotificationView) {
         var studioXBlockWrapperClass = '.studio-xblock-wrapper';
 
         var ContainerView = XBlockView.extend({
             // Store the request token of the first xblock on the page (which we know was rendered by Studio when
             // the page was generated). Use that request token to filter out user-defined HTML in any
             // child xblocks within the page.
-            requestToken: "",
+            requestToken: '',
 
             new_child_view: 'reorderable_container_child_preview',
 
-            xblockReady: function () {
+            xblockReady: function() {
                 XBlockView.prototype.xblockReady.call(this);
                 var reorderableClass, reorderableContainer,
                     newParent, oldParent, self = this;
@@ -23,13 +23,13 @@ define(["jquery", "underscore", "js/views/xblock", "js/utils/module", "gettext",
                 reorderableContainer.sortable({
                     handle: '.drag-handle',
 
-                    start: function (event, ui) {
+                    start: function(event, ui) {
                         // Necessary because of an open bug in JQuery sortable.
                         // http://bugs.jqueryui.com/ticket/4990
                         reorderableContainer.sortable('refreshPositions');
                     },
 
-                    stop: function (event, ui) {
+                    stop: function(event, ui) {
                         var saving, hideSaving, removeFromParent;
 
                         if (_.isUndefined(oldParent)) {
@@ -43,7 +43,7 @@ define(["jquery", "underscore", "js/views/xblock", "js/utils/module", "gettext",
                         });
                         saving.show();
 
-                        hideSaving = function () {
+                        hideSaving = function() {
                             saving.hide();
                         };
 
@@ -52,7 +52,7 @@ define(["jquery", "underscore", "js/views/xblock", "js/utils/module", "gettext",
                         // avoid creating an orphan if the addition fails.
                         if (newParent) {
                             removeFromParent = oldParent;
-                            self.updateChildren(newParent, function () {
+                            self.updateChildren(newParent, function() {
                                 self.updateChildren(removeFromParent, hideSaving);
                             });
                         } else {
@@ -63,7 +63,7 @@ define(["jquery", "underscore", "js/views/xblock", "js/utils/module", "gettext",
                         oldParent = undefined;
                         newParent = undefined;
                     },
-                    update: function (event, ui) {
+                    update: function(event, ui) {
                         // When dragging from one ol to another, this method
                         // will be called twice (once for each list). ui.sender will
                         // be null if the change is related to the list the element
@@ -78,31 +78,31 @@ define(["jquery", "underscore", "js/views/xblock", "js/utils/module", "gettext",
                             oldParent = parent;
                         }
                     },
-                    helper: "original",
+                    helper: 'original',
                     opacity: '0.5',
                     placeholder: 'component-placeholder',
                     forcePlaceholderSize: true,
                     axis: 'y',
                     items: '> .is-draggable',
                     connectWith: reorderableClass,
-                    tolerance: "pointer"
+                    tolerance: 'pointer'
 
                 });
             },
 
-            updateChildren: function (targetParent, successCallback) {
-                var children, childLocators, xblockInfo=this.model;
+            updateChildren: function(targetParent, successCallback) {
+                var children, childLocators, xblockInfo = this.model;
 
                 // Find descendants with class "studio-xblock-wrapper" whose parent === targetParent.
                 // This is necessary to filter our grandchildren, great-grandchildren, etc.
-                children = targetParent.find(studioXBlockWrapperClass).filter(function () {
+                children = targetParent.find(studioXBlockWrapperClass).filter(function() {
                     var parent = $(this).parent().closest(studioXBlockWrapperClass);
                     return parent.data('locator') === targetParent.data('locator');
                 });
 
                 childLocators = _.map(
                     children,
-                    function (child) {
+                    function(child) {
                         return $(child).data('locator');
                     }
                 );
@@ -114,7 +114,7 @@ define(["jquery", "underscore", "js/views/xblock", "js/utils/module", "gettext",
                     data: JSON.stringify({
                         children: childLocators
                     }),
-                    success: function () {
+                    success: function() {
                         // change data-parent on the element moved.
                         if (successCallback) {
                             successCallback();
@@ -125,7 +125,7 @@ define(["jquery", "underscore", "js/views/xblock", "js/utils/module", "gettext",
                 });
             },
 
-            acknowledgeXBlockDeletion: function(locator){
+            acknowledgeXBlockDeletion: function(locator) {
                 this.notifyRuntime('deleted-child', locator);
             },
 

--- a/cms/static/js/views/content_group_details.js
+++ b/cms/static/js/views/content_group_details.js
@@ -16,7 +16,7 @@ define([
             'click .hide-groups': 'hideContentGroupUsages'
         },
 
-        className: function () {
+        className: function() {
             var index = this.model.collection.indexOf(this.model);
 
             return [
@@ -36,7 +36,7 @@ define([
         },
 
         render: function(showContentGroupUsages) {
-           var attrs = $.extend({}, this.model.attributes, {
+            var attrs = $.extend({}, this.model.attributes, {
                 usageCountMessage: this.getUsageCountTitle(),
                 courseOutlineUrl: this.model.collection.parents[0].outlineUrl,
                 index: this.model.collection.indexOf(this.model),
@@ -57,7 +57,7 @@ define([
             this.render(false);
         },
 
-        getUsageCountTitle: function () {
+        getUsageCountTitle: function() {
             var count = this.model.get('usage').length;
 
             if (count === 0) {

--- a/cms/static/js/views/content_group_item.js
+++ b/cms/static/js/views/content_group_item.js
@@ -5,7 +5,7 @@
  * It is expected to be backed by a Group model.
  */
 define([
-    'js/views/list_item', 'js/views/content_group_editor', 'js/views/content_group_details', 'gettext', "common/js/components/utils/view_utils"
+    'js/views/list_item', 'js/views/content_group_editor', 'js/views/content_group_details', 'gettext', 'common/js/components/utils/view_utils'
 ], function(ListItemView, ContentGroupEditorView, ContentGroupDetailsView, gettext) {
     'use strict';
 
@@ -22,7 +22,7 @@ define([
 
         itemDisplayName: gettext('content group'),
 
-        attributes: function () {
+        attributes: function() {
             return {
                 'id': this.model.get('id'),
                 'tabindex': -1

--- a/cms/static/js/views/course_info_edit.js
+++ b/cms/static/js/views/course_info_edit.js
@@ -1,4 +1,4 @@
-define(["js/views/baseview", "js/views/course_info_update", "js/views/course_info_handout"],
+define(['js/views/baseview', 'js/views/course_info_update', 'js/views/course_info_handout'],
     function(BaseView, CourseInfoUpdateView, CourseInfoHandoutView) {
 /*  this view should own everything on the page which has controls effecting its operation
    generate other views for the individual editors.
@@ -6,27 +6,26 @@ define(["js/views/baseview", "js/views/course_info_update", "js/views/course_inf
    generate any html for the surrounding page.
 */
 
-var CourseInfoEdit = BaseView.extend({
+        var CourseInfoEdit = BaseView.extend({
   // takes CMS.Models.CourseInfo as model
-  tagName: 'div',
+            tagName: 'div',
 
-  render: function() {
+            render: function() {
     // instantiate the ClassInfoUpdateView and delegate the proper dom to it
-    new CourseInfoUpdateView({
-        el: $('body.updates'),
-        collection: this.model.get('updates'),
-        base_asset_url: this.model.get('base_asset_url'),
-        push_notification_enabled: this.options.push_notification_enabled
-    });
+                new CourseInfoUpdateView({
+                    el: $('body.updates'),
+                    collection: this.model.get('updates'),
+                    base_asset_url: this.model.get('base_asset_url'),
+                    push_notification_enabled: this.options.push_notification_enabled
+                });
 
-    new CourseInfoHandoutView({
-        el: this.$('#course-handouts-view'),
-        model: this.model.get('handouts'),
-        base_asset_url: this.model.get('base_asset_url')
-    });
-    return this;
-  }
-});
-return CourseInfoEdit;
-
-}); // end define()
+                new CourseInfoHandoutView({
+                    el: this.$('#course-handouts-view'),
+                    model: this.model.get('handouts'),
+                    base_asset_url: this.model.get('base_asset_url')
+                });
+                return this;
+            }
+        });
+        return CourseInfoEdit;
+    }); // end define()

--- a/cms/static/js/views/course_info_handout.js
+++ b/cms/static/js/views/course_info_handout.js
@@ -1,99 +1,98 @@
-define(["js/views/baseview", "codemirror", "common/js/components/views/feedback_notification", "js/views/course_info_helper", "js/utils/modal"],
+define(['js/views/baseview', 'codemirror', 'common/js/components/views/feedback_notification', 'js/views/course_info_helper', 'js/utils/modal'],
     function(BaseView, CodeMirror, NotificationView, CourseInfoHelper, ModalUtils) {
-
     // the handouts view is dumb right now; it needs tied to a model and all that jazz
-    var CourseInfoHandoutsView = BaseView.extend({
+        var CourseInfoHandoutsView = BaseView.extend({
         // collection is CourseUpdateCollection
-        events: {
-            "click .save-button" : "onSave",
-            "click .cancel-button" : "onCancel",
-            "click .edit-button" : "onEdit"
-        },
+            events: {
+                'click .save-button': 'onSave',
+                'click .cancel-button': 'onCancel',
+                'click .edit-button': 'onEdit'
+            },
 
-        initialize: function() {
-            this.template = this.loadTemplate('course_info_handouts');
-            var self = this;
-            this.model.fetch({
-                complete: function() {
-                    self.render();
-                },
-                reset: true
-            });
-        },
+            initialize: function() {
+                this.template = this.loadTemplate('course_info_handouts');
+                var self = this;
+                this.model.fetch({
+                    complete: function() {
+                        self.render();
+                    },
+                    reset: true
+                });
+            },
 
-        render: function () {
-            CourseInfoHelper.changeContentToPreview(
+            render: function() {
+                CourseInfoHelper.changeContentToPreview(
                 this.model, 'data', this.options['base_asset_url']);
 
-            this.$el.html(
+                this.$el.html(
                 $(this.template({
                     model: this.model
                 }))
             );
-            $('.handouts-content').html(this.model.get('data'));
-            this.$preview = this.$el.find('.handouts-content');
-            this.$form = this.$el.find(".edit-handouts-form");
-            this.$editor = this.$form.find('.handouts-content-editor');
-            this.$form.hide();
+                $('.handouts-content').html(this.model.get('data'));
+                this.$preview = this.$el.find('.handouts-content');
+                this.$form = this.$el.find('.edit-handouts-form');
+                this.$editor = this.$form.find('.handouts-content-editor');
+                this.$form.hide();
 
-            return this;
-        },
+                return this;
+            },
 
-        onEdit: function(event) {
-            var self = this;
-            this.$editor.val(this.$preview.html());
-            this.$form.show();
+            onEdit: function(event) {
+                var self = this;
+                this.$editor.val(this.$preview.html());
+                this.$form.show();
 
-            this.$codeMirror = CourseInfoHelper.editWithCodeMirror(
+                this.$codeMirror = CourseInfoHelper.editWithCodeMirror(
                 self.model, 'data', self.options['base_asset_url'], this.$editor.get(0));
 
-            ModalUtils.showModalCover(false, function() { self.closeEditor() });
-        },
+                ModalUtils.showModalCover(false, function() { self.closeEditor(); });
+            },
 
-        onSave: function(event) {
-            $('#handout_error').removeClass('is-shown');
-            $('.save-button').removeClass('is-disabled').attr('aria-disabled', false);
-            if ($('.CodeMirror-lines').find('.cm-error').length == 0){
-                this.model.set('data', this.$codeMirror.getValue());
-                var saving = new NotificationView.Mini({
-                    title: gettext('Saving')
-                });
-                saving.show();
-                this.model.save({}, {
-                    success: function() {
-                        saving.hide();
-                    }
-                });
-                this.render();
+            onSave: function(event) {
+                $('#handout_error').removeClass('is-shown');
+                $('.save-button').removeClass('is-disabled').attr('aria-disabled', false);
+                if ($('.CodeMirror-lines').find('.cm-error').length == 0) {
+                    this.model.set('data', this.$codeMirror.getValue());
+                    var saving = new NotificationView.Mini({
+                        title: gettext('Saving')
+                    });
+                    saving.show();
+                    this.model.save({}, {
+                        success: function() {
+                            saving.hide();
+                        }
+                    });
+                    this.render();
+                    this.$form.hide();
+                    this.closeEditor();
+
+                    analytics.track('Saved Course Handouts', {
+                        'course': course_location_analytics
+                    });
+                } else {
+                    $('#handout_error').addClass('is-shown');
+                    $('.save-button').addClass('is-disabled').attr('aria-disabled', true);
+                    event.preventDefault();
+                }
+            },
+
+            onCancel: function(event) {
+                $('#handout_error').removeClass('is-shown');
+                $('.save-button').removeClass('is-disabled').attr('aria-disabled', false);
                 this.$form.hide();
                 this.closeEditor();
+            },
 
-                analytics.track('Saved Course Handouts', {
-                    'course': course_location_analytics
-                });
-            }else{
-                $('#handout_error').addClass('is-shown');
-                $('.save-button').addClass('is-disabled').attr('aria-disabled', true);
-                event.preventDefault();
+            closeEditor: function() {
+                $('#handout_error').removeClass('is-shown');
+                $('.save-button').removeClass('is-disabled').attr('aria-disabled', false);
+                this.$form.hide();
+                ModalUtils.hideModalCover();
+                this.$form.find('.CodeMirror').remove();
+                this.$codeMirror = null;
             }
-        },
+        });
 
-        onCancel: function(event) {
-            $('#handout_error').removeClass('is-shown');
-            $('.save-button').removeClass('is-disabled').attr('aria-disabled', false);
-            this.$form.hide();
-            this.closeEditor();
-        },
-
-        closeEditor: function() {
-            $('#handout_error').removeClass('is-shown');
-            $('.save-button').removeClass('is-disabled').attr('aria-disabled', false);
-            this.$form.hide();
-            ModalUtils.hideModalCover();
-            this.$form.find('.CodeMirror').remove();
-            this.$codeMirror = null;
-        }
-    });
-
-    return CourseInfoHandoutsView;
-}); // end define()
+        return CourseInfoHandoutsView;
+    }); // end define()

--- a/cms/static/js/views/course_info_helper.js
+++ b/cms/static/js/views/course_info_helper.js
@@ -1,23 +1,23 @@
-define(["codemirror", 'js/utils/handle_iframe_binding', "utility"],
+define(['codemirror', 'js/utils/handle_iframe_binding', 'utility'],
     function(CodeMirror, IframeBinding) {
         var editWithCodeMirror = function(model, contentName, baseAssetUrl, textArea) {
             var content = rewriteStaticLinks(model.get(contentName), baseAssetUrl, '/static/');
             model.set(contentName, content);
             var $codeMirror = CodeMirror.fromTextArea(textArea, {
-                mode: "text/html",
+                mode: 'text/html',
                 lineNumbers: true,
                 lineWrapping: true,
                 autoCloseTags: true
             });
-            $codeMirror.on('change', function () {
-                    $('.save-button').removeClass('is-disabled').attr('aria-disabled', false);
+            $codeMirror.on('change', function() {
+                $('.save-button').removeClass('is-disabled').attr('aria-disabled', false);
             });
             $codeMirror.setValue(content);
             $codeMirror.clearHistory();
             return $codeMirror;
         };
 
-        var changeContentToPreview = function (model, contentName, baseAssetUrl) {
+        var changeContentToPreview = function(model, contentName, baseAssetUrl) {
             var content = rewriteStaticLinks(model.get(contentName), '/static/', baseAssetUrl);
             // Modify iframe (add wmode=transparent in url querystring) and embed (add wmode=transparent as attribute)
             // tags in html string (content) so both tags will attach to dom and don't create z-index problem for other popups

--- a/cms/static/js/views/course_info_update.js
+++ b/cms/static/js/views/course_info_update.js
@@ -1,324 +1,323 @@
-define(["js/views/validation", "codemirror", "js/models/course_update",
-        "common/js/components/views/feedback_prompt", "common/js/components/views/feedback_notification",
-        "js/views/course_info_helper", "js/utils/modal", "js/utils/date_utils"],
+define(['js/views/validation', 'codemirror', 'js/models/course_update',
+        'common/js/components/views/feedback_prompt', 'common/js/components/views/feedback_notification',
+        'js/views/course_info_helper', 'js/utils/modal', 'js/utils/date_utils'],
     function(ValidatingView, CodeMirror, CourseUpdateModel, PromptView, NotificationView,
         CourseInfoHelper, ModalUtils, DateUtils) {
-
-    'use strict';
-    var CourseInfoUpdateView = ValidatingView.extend({
+        'use strict';
+        var CourseInfoUpdateView = ValidatingView.extend({
 
         // collection is CourseUpdateCollection
-        events: {
-            "click .new-update-button" : "onNew",
-            "click .save-button" : "onSave",
-            "click .cancel-button" : "onCancel",
-            "click .post-actions > .edit-button" : "onEdit",
-            "click .post-actions > .delete-button" : "onDelete"
-        },
+            events: {
+                'click .new-update-button': 'onNew',
+                'click .save-button': 'onSave',
+                'click .cancel-button': 'onCancel',
+                'click .post-actions > .edit-button': 'onEdit',
+                'click .post-actions > .delete-button': 'onDelete'
+            },
 
-        initialize: function() {
-            this.template = this.loadTemplate('course_info_update');
-            this.render();
+            initialize: function() {
+                this.template = this.loadTemplate('course_info_update');
+                this.render();
             // when the client refetches the updates as a whole, re-render them
-            this.listenTo(this.collection, 'reset', this.render);
-            this.listenTo(this.collection, 'invalid', this.handleValidationError);
-        },
+                this.listenTo(this.collection, 'reset', this.render);
+                this.listenTo(this.collection, 'invalid', this.handleValidationError);
+            },
 
-        render: function () {
+            render: function() {
             // iterate over updates and create views for each using the template
-            var updateEle = this.$el.find("#course-update-list");
+                var updateEle = this.$el.find('#course-update-list');
             // remove and then add all children
-            $(updateEle).empty();
-            var self = this;
-            this.collection.each(function (update, index) {
-                try {
-                    CourseInfoHelper.changeContentToPreview(
+                $(updateEle).empty();
+                var self = this;
+                this.collection.each(function(update, index) {
+                    try {
+                        CourseInfoHelper.changeContentToPreview(
                         update, 'content', self.options['base_asset_url']);
                     // push notification is always disabled for existing updates
-                    var newEle = self.template({ updateModel : update, push_notification_enabled : false });
-                    $(updateEle).append(newEle);
-                    DateUtils.setupDatePicker("date", self, index);
-                    update.isValid();
-                } catch (e) {
+                        var newEle = self.template({updateModel: update, push_notification_enabled: false});
+                        $(updateEle).append(newEle);
+                        DateUtils.setupDatePicker('date', self, index);
+                        update.isValid();
+                    } catch (e) {
                     // ignore
-                }
-            });
-            this.$el.find(".new-update-form").hide();
-            return this;
-        },
-
-        collectionSelector: function(uid) {
-            return "course-update-list li[name=" + uid + "]";
-        },
-
-        setAndValidate: function(attr, value, event) {
-            if (attr === 'date') {
-                // If the value to be set was typed, validate that entry rather than the current datepicker value
-                if (this.dateEntry(event).length > 0) {
-                    value = DateUtils.parseDateFromString(this.dateEntry(event).val());
-                    if (value && isNaN(value.getTime())) {
-                        value = "";
                     }
-                }
-                value = $.datepicker.formatDate("MM d, yy", value);
-            }
-            var targetModel = this.collection.get(this.$currentPost.attr('name'));
-            var prevValue = targetModel.get(attr);
-            if (prevValue !== value) {
-                targetModel.set(attr, value);
-                this.validateModel(targetModel);
-            }
-        },
+                });
+                this.$el.find('.new-update-form').hide();
+                return this;
+            },
 
-        handleValidationError : function(model, error) {
-            var ele = this.$el.find('#course-update-list li[name=\"'+model.cid+'\"]');
-            $(ele).find('.message-error').remove();
-            for (var field in error) {
-                if (error.hasOwnProperty(field)) {
-                    $(ele).find('#update-date-'+model.cid).parent().append(
-                        this.errorTemplate({message : error[field]})
-                    );
-                    $(ele).find('.date-display').parent().append(this.errorTemplate({message : error[field]}));
-                }
-            }
-            $(ele).find('.save-button').addClass('is-disabled');
-        },
+            collectionSelector: function(uid) {
+                return 'course-update-list li[name=' + uid + ']';
+            },
 
-        validateModel: function(model) {
-            if (model.isValid()) {
+            setAndValidate: function(attr, value, event) {
+                if (attr === 'date') {
+                // If the value to be set was typed, validate that entry rather than the current datepicker value
+                    if (this.dateEntry(event).length > 0) {
+                        value = DateUtils.parseDateFromString(this.dateEntry(event).val());
+                        if (value && isNaN(value.getTime())) {
+                            value = '';
+                        }
+                    }
+                    value = $.datepicker.formatDate('MM d, yy', value);
+                }
+                var targetModel = this.collection.get(this.$currentPost.attr('name'));
+                var prevValue = targetModel.get(attr);
+                if (prevValue !== value) {
+                    targetModel.set(attr, value);
+                    this.validateModel(targetModel);
+                }
+            },
+
+            handleValidationError: function(model, error) {
                 var ele = this.$el.find('#course-update-list li[name=\"' + model.cid + '\"]');
                 $(ele).find('.message-error').remove();
-                $(ele).find('.save-button').removeClass('is-disabled');
-            }
-        },
+                for (var field in error) {
+                    if (error.hasOwnProperty(field)) {
+                        $(ele).find('#update-date-' + model.cid).parent().append(
+                        this.errorTemplate({message: error[field]})
+                    );
+                        $(ele).find('.date-display').parent().append(this.errorTemplate({message: error[field]}));
+                    }
+                }
+                $(ele).find('.save-button').addClass('is-disabled');
+            },
 
-        onNew: function(event) {
-            event.preventDefault();
-            var self = this;
+            validateModel: function(model) {
+                if (model.isValid()) {
+                    var ele = this.$el.find('#course-update-list li[name=\"' + model.cid + '\"]');
+                    $(ele).find('.message-error').remove();
+                    $(ele).find('.save-button').removeClass('is-disabled');
+                }
+            },
+
+            onNew: function(event) {
+                event.preventDefault();
+                var self = this;
             // create new obj, insert into collection, and render this one ele overriding the hidden attr
-            var newModel = new CourseUpdateModel();
-            this.collection.add(newModel, {at : 0});
+                var newModel = new CourseUpdateModel();
+                this.collection.add(newModel, {at: 0});
 
-            var $newForm = $(
+                var $newForm = $(
                 this.template({
-                    updateModel : newModel,
-                    push_notification_enabled : this.options.push_notification_enabled
+                    updateModel: newModel,
+                    push_notification_enabled: this.options.push_notification_enabled
                 })
             );
 
-            var updateEle = this.$el.find("#course-update-list");
-            $(updateEle).prepend($newForm);
+                var updateEle = this.$el.find('#course-update-list');
+                $(updateEle).prepend($newForm);
 
-            var $textArea = $newForm.find(".new-update-content").first();
-            this.$codeMirror = CodeMirror.fromTextArea($textArea.get(0), {
-                mode: "text/html",
-                lineNumbers: true,
-                lineWrapping: true
-            });
+                var $textArea = $newForm.find('.new-update-content').first();
+                this.$codeMirror = CodeMirror.fromTextArea($textArea.get(0), {
+                    mode: 'text/html',
+                    lineNumbers: true,
+                    lineWrapping: true
+                });
 
-            $newForm.addClass('editing');
-            this.$currentPost = $newForm.closest('li');
+                $newForm.addClass('editing');
+                this.$currentPost = $newForm.closest('li');
 
             // Variable stored for unit test.
-            this.$modalCover = ModalUtils.showModalCover(false, function() {
+                this.$modalCover = ModalUtils.showModalCover(false, function() {
                 // Binding empty function to prevent default hideModal.
-            });
+                });
 
-            DateUtils.setupDatePicker("date", this, 0);
-        },
+                DateUtils.setupDatePicker('date', this, 0);
+            },
 
-        onSave: function(event) {
-            event.preventDefault();
-            var targetModel = this.eventModel(event);
-            targetModel.set({
+            onSave: function(event) {
+                event.preventDefault();
+                var targetModel = this.eventModel(event);
+                targetModel.set({
                 // translate short-form date (for input) into long form date (for display)
-                date : $.datepicker.formatDate("MM d, yy", new Date(this.dateEntry(event).val())),
-                content : this.$codeMirror.getValue(),
-                push_notification_selected : this.push_notification_selected(event)
-            });
+                    date: $.datepicker.formatDate('MM d, yy', new Date(this.dateEntry(event).val())),
+                    content: this.$codeMirror.getValue(),
+                    push_notification_selected: this.push_notification_selected(event)
+                });
             // push change to display, hide the editor, submit the change
-            var saving = new NotificationView.Mini({
-                title: gettext('Saving')
-            });
-            saving.show();
-            var ele = this.modelDom(event);
-            targetModel.save({}, {
-                success: function() {
-                    saving.hide();
-                },
-                error: function() {
-                    ele.remove();
-                }
-            });
-            this.closeEditor(false);
+                var saving = new NotificationView.Mini({
+                    title: gettext('Saving')
+                });
+                saving.show();
+                var ele = this.modelDom(event);
+                targetModel.save({}, {
+                    success: function() {
+                        saving.hide();
+                    },
+                    error: function() {
+                        ele.remove();
+                    }
+                });
+                this.closeEditor(false);
 
-            analytics.track('Saved Course Update', {
-                'course': course_location_analytics,
-                'date': this.dateEntry(event).val(),
-                'push_notification_selected': this.push_notification_selected(event)
-            });
-        },
+                analytics.track('Saved Course Update', {
+                    'course': course_location_analytics,
+                    'date': this.dateEntry(event).val(),
+                    'push_notification_selected': this.push_notification_selected(event)
+                });
+            },
 
-        onCancel: function(event) {
-            event.preventDefault();
+            onCancel: function(event) {
+                event.preventDefault();
             // Since we're cancelling, the model should be using it's previous attributes
-            var targetModel = this.eventModel(event);
-            targetModel.set(targetModel.previousAttributes());
-            this.validateModel(targetModel);
+                var targetModel = this.eventModel(event);
+                targetModel.set(targetModel.previousAttributes());
+                this.validateModel(targetModel);
             // Hide the editor
-            $(this.editor(event)).hide();
+                $(this.editor(event)).hide();
             // targetModel will be lacking an id if it was newly created
-            this.closeEditor(!targetModel.id);
-        },
+                this.closeEditor(!targetModel.id);
+            },
 
-        onEdit: function(event) {
-            event.preventDefault();
-            var self = this;
-            this.$currentPost = $(event.target).closest('li');
-            this.$currentPost.addClass('editing');
+            onEdit: function(event) {
+                event.preventDefault();
+                var self = this;
+                this.$currentPost = $(event.target).closest('li');
+                this.$currentPost.addClass('editing');
 
-            $(this.editor(event)).show();
-            var $textArea = this.$currentPost.find(".new-update-content").first();
-            var targetModel = this.eventModel(event);
+                $(this.editor(event)).show();
+                var $textArea = this.$currentPost.find('.new-update-content').first();
+                var targetModel = this.eventModel(event);
             // translate long-form date (for viewing) into short-form date (for input)
-            if (targetModel.get('date') && targetModel.isValid()) {
-                $(this.dateEntry(event)).val($.datepicker.formatDate("mm/dd/yy", new Date(targetModel.get('date'))));
-            }
-            else {
-                $(this.dateEntry(event)).val("MM/DD/YY");
-            }
-            this.$codeMirror = CourseInfoHelper.editWithCodeMirror(
+                if (targetModel.get('date') && targetModel.isValid()) {
+                    $(this.dateEntry(event)).val($.datepicker.formatDate('mm/dd/yy', new Date(targetModel.get('date'))));
+                }
+                else {
+                    $(this.dateEntry(event)).val('MM/DD/YY');
+                }
+                this.$codeMirror = CourseInfoHelper.editWithCodeMirror(
                 targetModel, 'content', self.options['base_asset_url'], $textArea.get(0));
 
             // Variable stored for unit test.
-            this.$modalCover = ModalUtils.showModalCover(false,
+                this.$modalCover = ModalUtils.showModalCover(false,
                 function() {
                     self.closeEditor(false);
                 }
             );
 
             // Ensure validity is marked appropriately
-            targetModel.isValid();
-        },
+                targetModel.isValid();
+            },
 
-        onDelete: function(event) {
-            event.preventDefault();
+            onDelete: function(event) {
+                event.preventDefault();
 
-            var self = this;
-            var targetModel = this.eventModel(event);
-            var confirm = new PromptView.Warning({
-                title: gettext('Are you sure you want to delete this update?'),
-                message: gettext('This action cannot be undone.'),
-                actions: {
-                    primary: {
-                        text: gettext('OK'),
-                        click: function () {
-                            analytics.track('Deleted Course Update', {
-                                'course': course_location_analytics,
-                                'date': self.dateEntry(event).val()
-                            });
-                            self.modelDom(event).remove();
-                            var deleting = new NotificationView.Mini({
-                                title: gettext('Deleting')
-                            });
-                            deleting.show();
-                            targetModel.destroy({
-                                success: function (model, response) {
-                                    self.collection.fetch({
-                                        success: function() {
+                var self = this;
+                var targetModel = this.eventModel(event);
+                var confirm = new PromptView.Warning({
+                    title: gettext('Are you sure you want to delete this update?'),
+                    message: gettext('This action cannot be undone.'),
+                    actions: {
+                        primary: {
+                            text: gettext('OK'),
+                            click: function() {
+                                analytics.track('Deleted Course Update', {
+                                    'course': course_location_analytics,
+                                    'date': self.dateEntry(event).val()
+                                });
+                                self.modelDom(event).remove();
+                                var deleting = new NotificationView.Mini({
+                                    title: gettext('Deleting')
+                                });
+                                deleting.show();
+                                targetModel.destroy({
+                                    success: function(model, response) {
+                                        self.collection.fetch({
+                                            success: function() {
                                             self.render();
                                             deleting.hide();
                                         },
-                                        reset: true
-                                    });
-                                }
-                            });
-                            confirm.hide();
-                        }
-                    },
-                    secondary: {
-                        text: gettext('Cancel'),
-                        click: function() {
-                            confirm.hide();
+                                            reset: true
+                                        });
+                                    }
+                                });
+                                confirm.hide();
+                            }
+                        },
+                        secondary: {
+                            text: gettext('Cancel'),
+                            click: function() {
+                                confirm.hide();
+                            }
                         }
                     }
-                }
-            });
-            confirm.show();
-        },
+                });
+                confirm.show();
+            },
 
-        closeEditor: function(removePost) {
-            var targetModel = this.collection.get(this.$currentPost.attr('name'));
+            closeEditor: function(removePost) {
+                var targetModel = this.collection.get(this.$currentPost.attr('name'));
 
             // If the model was never created (user created a new update, then pressed Cancel),
             // we wish to remove it from the DOM.
-            if(removePost) {
-                this.$currentPost.remove();
-            }
-            else {
-                // close the modal and insert the appropriate data
-                this.$currentPost.removeClass('editing');
-                this.$currentPost.find('.date-display').html(targetModel.get('date'));
-                this.$currentPost.find('.date').val(targetModel.get('date'));
-
-                var content = CourseInfoHelper.changeContentToPreview(
-                    targetModel, 'content', this.options['base_asset_url']);
-                try {
-                    // just in case the content causes an error (embedded js errors)
-                    this.$currentPost.find('.update-contents').html(content);
-                    this.$currentPost.find('.new-update-content').val(content);
-                } catch (e) {
-                    // ignore but handle rest of page
+                if (removePost) {
+                    this.$currentPost.remove();
                 }
-                this.$currentPost.find('form').hide();
-                this.$currentPost.find('.CodeMirror').remove();
+                else {
+                // close the modal and insert the appropriate data
+                    this.$currentPost.removeClass('editing');
+                    this.$currentPost.find('.date-display').html(targetModel.get('date'));
+                    this.$currentPost.find('.date').val(targetModel.get('date'));
+
+                    var content = CourseInfoHelper.changeContentToPreview(
+                    targetModel, 'content', this.options['base_asset_url']);
+                    try {
+                    // just in case the content causes an error (embedded js errors)
+                        this.$currentPost.find('.update-contents').html(content);
+                        this.$currentPost.find('.new-update-content').val(content);
+                    } catch (e) {
+                    // ignore but handle rest of page
+                    }
+                    this.$currentPost.find('form').hide();
+                    this.$currentPost.find('.CodeMirror').remove();
 
                 // hide the push notification checkbox for subsequent edits to the Post
-                var push_notification_ele = this.$currentPost.find(".new-update-push-notification");
-                if (push_notification_ele) {
-                    push_notification_ele.hide();
+                    var push_notification_ele = this.$currentPost.find('.new-update-push-notification');
+                    if (push_notification_ele) {
+                        push_notification_ele.hide();
+                    }
                 }
-            }
 
-            ModalUtils.hideModalCover(this.$modalCover);
-            this.$codeMirror = null;
-        },
+                ModalUtils.hideModalCover(this.$modalCover);
+                this.$codeMirror = null;
+            },
 
         // Dereferencing from events to screen elements
-        eventModel: function(event) {
+            eventModel: function(event) {
             // not sure if it should be currentTarget or delegateTarget
-            return this.collection.get($(event.currentTarget).attr("name"));
-        },
+                return this.collection.get($(event.currentTarget).attr('name'));
+            },
 
-        modelDom: function(event) {
-            return $(event.currentTarget).closest("li");
-        },
+            modelDom: function(event) {
+                return $(event.currentTarget).closest('li');
+            },
 
-        editor: function(event) {
-            var li = $(event.currentTarget).closest("li");
-            if (li) {
-                return $(li).find("form").first();
-            }
-        },
+            editor: function(event) {
+                var li = $(event.currentTarget).closest('li');
+                if (li) {
+                    return $(li).find('form').first();
+                }
+            },
 
-        dateEntry: function(event) {
-            var li = $(event.currentTarget).closest("li");
-            if (li) {
-                return $(li).find(".date").first();
-            }
-        },
+            dateEntry: function(event) {
+                var li = $(event.currentTarget).closest('li');
+                if (li) {
+                    return $(li).find('.date').first();
+                }
+            },
 
-        push_notification_selected: function(event) {
-            var push_notification_checkbox;
-            var li = $(event.currentTarget).closest("li");
-            if (li) {
-                push_notification_checkbox = li.find(".new-update-push-notification .toggle-checkbox");
-                if (push_notification_checkbox) {
-                    return push_notification_checkbox.is(":checked");
+            push_notification_selected: function(event) {
+                var push_notification_checkbox;
+                var li = $(event.currentTarget).closest('li');
+                if (li) {
+                    push_notification_checkbox = li.find('.new-update-push-notification .toggle-checkbox');
+                    if (push_notification_checkbox) {
+                        return push_notification_checkbox.is(':checked');
+                    }
                 }
             }
-        }
-    });
+        });
 
-    return CourseInfoUpdateView;
-}); // end define()
+        return CourseInfoUpdateView;
+    }); // end define()

--- a/cms/static/js/views/course_outline.js
+++ b/cms/static/js/views/course_outline.js
@@ -8,13 +8,12 @@
  *  - changes cause a refresh of the entire section rather than just the view for the changed xblock
  *  - adding units will automatically redirect to the unit page rather than showing them inline
  */
-define(["jquery", "underscore", "js/views/xblock_outline", "common/js/components/utils/view_utils", "js/views/utils/xblock_utils",
-        "js/models/xblock_outline_info", "js/views/modals/course_outline_modals", "js/utils/drag_and_drop"],
+define(['jquery', 'underscore', 'js/views/xblock_outline', 'common/js/components/utils/view_utils', 'js/views/utils/xblock_utils',
+        'js/models/xblock_outline_info', 'js/views/modals/course_outline_modals', 'js/utils/drag_and_drop'],
     function(
         $, _, XBlockOutlineView, ViewUtils, XBlockViewUtils,
         XBlockOutlineInfo, CourseOutlineModalsFactory, ContentDragger
     ) {
-
         var CourseOutlineView = XBlockOutlineView.extend({
             // takes XBlockOutlineInfo as a model
 
@@ -67,7 +66,7 @@ define(["jquery", "underscore", "js/views/xblock_outline", "common/js/components
              * @param isCollapsed true if the element should be collapsed, else false
              */
             refreshWithCollapsedState: function(isCollapsed) {
-                var locator =  this.model.get('id');
+                var locator = this.model.get('id');
                 if (isCollapsed) {
                     this.expandedLocators.remove(locator);
                 }
@@ -192,7 +191,7 @@ define(["jquery", "underscore", "js/views/xblock_outline", "common/js/components
             },
 
             makeContentDraggable: function(element) {
-                if ($(element).hasClass("outline-section")) {
+                if ($(element).hasClass('outline-section')) {
                     ContentDragger.makeDraggable(element, {
                         type: '.outline-section',
                         handleClass: '.section-drag-handle',
@@ -202,7 +201,7 @@ define(["jquery", "underscore", "js/views/xblock_outline", "common/js/components
                         ensureChildrenRendered: this.ensureChildrenRendered.bind(this)
                     });
                 }
-                else if ($(element).hasClass("outline-subsection")) {
+                else if ($(element).hasClass('outline-subsection')) {
                     ContentDragger.makeDraggable(element, {
                         type: '.outline-subsection',
                         handleClass: '.subsection-drag-handle',
@@ -212,7 +211,7 @@ define(["jquery", "underscore", "js/views/xblock_outline", "common/js/components
                         ensureChildrenRendered: this.ensureChildrenRendered.bind(this)
                     });
                 }
-                else if ($(element).hasClass("outline-unit")) {
+                else if ($(element).hasClass('outline-unit')) {
                     ContentDragger.makeDraggable(element, {
                         type: '.outline-unit',
                         handleClass: '.unit-drag-handle',

--- a/cms/static/js/views/course_rerun.js
+++ b/cms/static/js/views/course_rerun.js
@@ -1,5 +1,5 @@
-define(["domReady", "jquery", "underscore", "js/views/utils/create_course_utils", "common/js/components/utils/view_utils"],
-    function (domReady, $, _, CreateCourseUtilsFactory, ViewUtils) {
+define(['domReady', 'jquery', 'underscore', 'js/views/utils/create_course_utils', 'common/js/components/utils/view_utils'],
+    function(domReady, $, _, CreateCourseUtilsFactory, ViewUtils) {
         var CreateCourseUtils = new CreateCourseUtilsFactory({
             name: '.rerun-course-name',
             org: '.rerun-course-org',
@@ -19,7 +19,7 @@ define(["domReady", "jquery", "underscore", "js/views/utils/create_course_utils"
             error: 'error'
         });
 
-        var saveRerunCourse = function (e) {
+        var saveRerunCourse = function(e) {
             e.preventDefault();
 
             if (CreateCourseUtils.hasInvalidRequiredFields()) {
@@ -41,7 +41,7 @@ define(["domReady", "jquery", "underscore", "js/views/utils/create_course_utils"
             };
 
             analytics.track('Reran a Course', course_info);
-            CreateCourseUtils.create(course_info, function (errorMessage) {
+            CreateCourseUtils.create(course_info, function(errorMessage) {
                 $('.wrapper-error').addClass('is-shown').removeClass('is-hidden');
                 $('#course_rerun_error').html('<p>' + errorMessage + '</p>');
                 $('.rerun-course-save').addClass('is-disabled').attr('aria-disabled', true).removeClass('is-processing').html(gettext('Create Re-run'));
@@ -55,7 +55,7 @@ define(["domReady", "jquery", "underscore", "js/views/utils/create_course_utils"
             $('.action-cancel').addClass('is-hidden');
         };
 
-        var cancelRerunCourse = function (e) {
+        var cancelRerunCourse = function(e) {
             e.preventDefault();
             // Clear out existing fields and errors
             $('.rerun-course-run').val('');
@@ -65,7 +65,7 @@ define(["domReady", "jquery", "underscore", "js/views/utils/create_course_utils"
             ViewUtils.redirect('/course/');
         };
 
-        var onReady = function () {
+        var onReady = function() {
             var $cancelButton = $('.rerun-course-cancel');
             var $courseRun = $('.rerun-course-run');
             $courseRun.focus().select();

--- a/cms/static/js/views/edit_chapter.js
+++ b/cms/static/js/views/edit_chapter.js
@@ -1,4 +1,4 @@
-/*global course */
+/* global course */
 
 define(['underscore', 'jquery', 'gettext', 'edx-ui-toolkit/js/utils/html-utils',
         'js/views/baseview', 'js/models/uploads', 'js/views/uploads', 'text!templates/edit-chapter.underscore'],
@@ -34,26 +34,26 @@ define(['underscore', 'jquery', 'gettext', 'edx-ui-toolkit/js/utils/html-utils',
                 'submit': 'uploadAsset'
             },
             changeName: function(e) {
-                if(e && e.preventDefault) { e.preventDefault(); }
+                if (e && e.preventDefault) { e.preventDefault(); }
                 this.model.set({
                     name: this.$('.chapter-name').val()
                 }, {silent: true});
                 return this;
             },
             changeAssetPath: function(e) {
-                if(e && e.preventDefault) { e.preventDefault(); }
+                if (e && e.preventDefault) { e.preventDefault(); }
                 this.model.set({
                     asset_path: this.$('.chapter-asset-path').val()
                 }, {silent: true});
                 return this;
             },
             removeChapter: function(e) {
-                if(e && e.preventDefault) { e.preventDefault(); }
+                if (e && e.preventDefault) { e.preventDefault(); }
                 this.model.collection.remove(this.model);
                 return this.remove();
             },
             openUploadDialog: function(e) {
-                if(e && e.preventDefault) { e.preventDefault(); }
+                if (e && e.preventDefault) { e.preventDefault(); }
                 this.model.set({
                     name: this.$('input.chapter-name').val(),
                     asset_path: this.$('input.chapter-asset-path').val()

--- a/cms/static/js/views/edit_textbook.js
+++ b/cms/static/js/views/edit_textbook.js
@@ -1,94 +1,94 @@
-define(["js/views/baseview", "underscore", "jquery", "js/views/edit_chapter", "common/js/components/views/feedback_notification"],
+define(['js/views/baseview', 'underscore', 'jquery', 'js/views/edit_chapter', 'common/js/components/views/feedback_notification'],
         function(BaseView, _, $, EditChapterView, NotificationView) {
-    var EditTextbook = BaseView.extend({
-        initialize: function() {
-            this.template = this.loadTemplate('edit-textbook');
-            this.listenTo(this.model, "invalid", this.render);
-            var chapters = this.model.get('chapters');
-            this.listenTo(chapters, "add", this.addOne);
-            this.listenTo(chapters, "reset", this.addAll);
-            this.listenTo(chapters, "all", this.render);
-        },
-        tagName: "section",
-        className: "textbook",
-        render: function() {
-            this.$el.html(this.template({
-                name: this.model.get('name'),
-                error: this.model.validationError
-            }));
-            this.addAll();
-            return this;
-        },
-        events: {
-            "change input[name=textbook-name]": "setName",
-            "submit": "setAndClose",
-            "click .action-cancel": "cancel",
-            "click .action-add-chapter": "createChapter"
-        },
-        addOne: function(chapter) {
-            var view = new EditChapterView({model: chapter});
-            this.$("ol.chapters").append(view.render().el);
-            return this;
-        },
-        addAll: function() {
-            this.model.get('chapters').each(this.addOne, this);
-        },
-        createChapter: function(e) {
-            if(e && e.preventDefault) { e.preventDefault(); }
-            this.setValues();
-            this.model.get('chapters').add([{}]);
-        },
-        setName: function(e) {
-            if(e && e.preventDefault) { e.preventDefault(); }
-            this.model.set("name", this.$("#textbook-name-input").val(), {silent: true});
-        },
-        setValues: function() {
-            this.setName();
-            var that = this;
-            _.each(this.$("li"), function(li, i) {
-                var chapter = that.model.get('chapters').at(i);
-                if(!chapter) { return; }
-                chapter.set({
-                    "name": $(".chapter-name", li).val(),
-                    "asset_path": $(".chapter-asset-path", li).val()
-                });
-            });
-            return this;
-        },
-        setAndClose: function(e) {
-            if(e && e.preventDefault) { e.preventDefault(); }
-            this.setValues();
-            if(!this.model.isValid()) { return; }
-            var saving = new NotificationView.Mini({
-                title: gettext("Saving")
-            }).show();
-            var that = this;
-            this.model.save({}, {
-                success: function() {
-                    that.model.setOriginalAttributes();
-                    that.close();
+            var EditTextbook = BaseView.extend({
+                initialize: function() {
+                    this.template = this.loadTemplate('edit-textbook');
+                    this.listenTo(this.model, 'invalid', this.render);
+                    var chapters = this.model.get('chapters');
+                    this.listenTo(chapters, 'add', this.addOne);
+                    this.listenTo(chapters, 'reset', this.addAll);
+                    this.listenTo(chapters, 'all', this.render);
                 },
-                complete: function() {
-                    saving.hide();
+                tagName: 'section',
+                className: 'textbook',
+                render: function() {
+                    this.$el.html(this.template({
+                        name: this.model.get('name'),
+                        error: this.model.validationError
+                    }));
+                    this.addAll();
+                    return this;
+                },
+                events: {
+                    'change input[name=textbook-name]': 'setName',
+                    'submit': 'setAndClose',
+                    'click .action-cancel': 'cancel',
+                    'click .action-add-chapter': 'createChapter'
+                },
+                addOne: function(chapter) {
+                    var view = new EditChapterView({model: chapter});
+                    this.$('ol.chapters').append(view.render().el);
+                    return this;
+                },
+                addAll: function() {
+                    this.model.get('chapters').each(this.addOne, this);
+                },
+                createChapter: function(e) {
+                    if (e && e.preventDefault) { e.preventDefault(); }
+                    this.setValues();
+                    this.model.get('chapters').add([{}]);
+                },
+                setName: function(e) {
+                    if (e && e.preventDefault) { e.preventDefault(); }
+                    this.model.set('name', this.$('#textbook-name-input').val(), {silent: true});
+                },
+                setValues: function() {
+                    this.setName();
+                    var that = this;
+                    _.each(this.$('li'), function(li, i) {
+                        var chapter = that.model.get('chapters').at(i);
+                        if (!chapter) { return; }
+                        chapter.set({
+                            'name': $('.chapter-name', li).val(),
+                            'asset_path': $('.chapter-asset-path', li).val()
+                        });
+                    });
+                    return this;
+                },
+                setAndClose: function(e) {
+                    if (e && e.preventDefault) { e.preventDefault(); }
+                    this.setValues();
+                    if (!this.model.isValid()) { return; }
+                    var saving = new NotificationView.Mini({
+                        title: gettext('Saving')
+                    }).show();
+                    var that = this;
+                    this.model.save({}, {
+                        success: function() {
+                            that.model.setOriginalAttributes();
+                            that.close();
+                        },
+                        complete: function() {
+                            saving.hide();
+                        }
+                    });
+                },
+                cancel: function(e) {
+                    if (e && e.preventDefault) { e.preventDefault(); }
+                    this.model.reset();
+                    return this.close();
+                },
+                close: function() {
+                    var textbooks = this.model.collection;
+                    this.remove();
+                    if (this.model.isNew()) {
+                // if the textbook has never been saved, remove it
+                        textbooks.remove(this.model);
+                    }
+            // don't forget to tell the model that it's no longer being edited
+                    this.model.set('editing', false);
+                    return this;
                 }
             });
-        },
-        cancel: function(e) {
-            if(e && e.preventDefault) { e.preventDefault(); }
-            this.model.reset();
-            return this.close();
-        },
-        close: function() {
-            var textbooks = this.model.collection;
-            this.remove();
-            if(this.model.isNew()) {
-                // if the textbook has never been saved, remove it
-                textbooks.remove(this.model);
-            }
-            // don't forget to tell the model that it's no longer being edited
-            this.model.set("editing", false);
-            return this;
-        }
-    });
-    return EditTextbook;
-});
+            return EditTextbook;
+        });

--- a/cms/static/js/views/experiment_group_edit.js
+++ b/cms/static/js/views/experiment_group_edit.js
@@ -43,7 +43,7 @@ function(BaseView, _, str, gettext, groupEditTemplate) {
             if (event && event.preventDefault) { event.preventDefault(); }
             this.model.set({
                 name: this.$('.group-name').val()
-            }, { silent: true });
+            }, {silent: true});
 
             return this;
         },
@@ -58,11 +58,11 @@ function(BaseView, _, str, gettext, groupEditTemplate) {
             return Math.floor(100 / this.model.collection.length);
         },
 
-        onFocus: function () {
+        onFocus: function() {
             this.$el.closest('.groups-fields').addClass('is-focused');
         },
 
-        onBlur: function () {
+        onBlur: function() {
             this.$el.closest('.groups-fields').removeClass('is-focused');
         }
     });

--- a/cms/static/js/views/group_configuration_details.js
+++ b/cms/static/js/views/group_configuration_details.js
@@ -16,7 +16,7 @@ function(BaseView, _, gettext, str, StringUtils, HtmlUtils) {
             'click .hide-groups': 'hideGroups'
         },
 
-        className: function () {
+        className: function() {
             var index = this.model.collection.indexOf(this.model);
 
             return [
@@ -59,7 +59,7 @@ function(BaseView, _, gettext, str, StringUtils, HtmlUtils) {
             this.model.set('showGroups', false);
         },
 
-        getGroupsCountTitle: function () {
+        getGroupsCountTitle: function() {
             var count = this.model.get('groups').length,
                 /* globals ngettext */
                 message = ngettext(
@@ -71,10 +71,10 @@ function(BaseView, _, gettext, str, StringUtils, HtmlUtils) {
                     count
                 );
 
-            return StringUtils.interpolate(message, { count: count });
+            return StringUtils.interpolate(message, {count: count});
         },
 
-        getUsageCountTitle: function () {
+        getUsageCountTitle: function() {
             var count = this.model.get('usage').length;
 
             if (count === 0) {

--- a/cms/static/js/views/group_configuration_editor.js
+++ b/cms/static/js/views/group_configuration_editor.js
@@ -20,7 +20,7 @@ function(ListItemEditorView, _, $, gettext, ExperimentGroupEditView) {
             'click .action-cancel': 'cancel'
         },
 
-        className: function () {
+        className: function() {
             var index = this.model.collection.indexOf(this.model);
 
             return [
@@ -63,7 +63,7 @@ function(ListItemEditorView, _, $, gettext, ExperimentGroupEditView) {
         },
 
         onAddItem: function(group) {
-            var view = new ExperimentGroupEditView({ model: group });
+            var view = new ExperimentGroupEditView({model: group});
             this.$('ol.groups').append(view.render().el);
 
             return this;
@@ -86,7 +86,7 @@ function(ListItemEditorView, _, $, gettext, ExperimentGroupEditView) {
             if (event && event.preventDefault) { event.preventDefault(); }
             this.model.set(
                 'name', this.$('.collection-name-input').val(),
-                { silent: true }
+                {silent: true}
             );
         },
 
@@ -95,7 +95,7 @@ function(ListItemEditorView, _, $, gettext, ExperimentGroupEditView) {
             this.model.set(
                 'description',
                 this.$('.group-configuration-description-input').val(),
-                { silent: true }
+                {silent: true}
             );
         },
 

--- a/cms/static/js/views/group_configuration_item.js
+++ b/cms/static/js/views/group_configuration_item.js
@@ -25,7 +25,7 @@ define([
         // Translators: this refers to a collection of groups.
         itemDisplayName: gettext('group configuration'),
 
-        attributes: function () {
+        attributes: function() {
             return {
                 'id': this.model.get('id'),
                 'tabindex': -1

--- a/cms/static/js/views/import.js
+++ b/cms/static/js/views/import.js
@@ -2,12 +2,11 @@
  * Course import-related js.
  */
 define(
-    ["jquery", "underscore", "gettext", "moment", "jquery.cookie"],
+    ['jquery', 'underscore', 'gettext', 'moment', 'jquery.cookie'],
     function($, _, gettext, moment) {
+        'use strict';
 
-        "use strict";
-
-        /********** Private properties ****************************************/
+        /** ******** Private properties ****************************************/
 
         var COOKIE_NAME = 'lastimportupload';
 
@@ -15,35 +14,35 @@ define(
             'UPLOADING': 0,
             'UNPACKING': 1,
             'VERIFYING': 2,
-            'UPDATING' : 3,
-            'SUCCESS'  : 4
+            'UPDATING': 3,
+            'SUCCESS': 4
         };
 
         var STATE = {
-            'READY'      : 1,
+            'READY': 1,
             'IN_PROGRESS': 2,
-            'SUCCESS'    : 3,
-            'ERROR'      : 4
+            'SUCCESS': 3,
+            'ERROR': 4
         };
 
-        var current = { stage: 0, state: STATE.READY };
+        var current = {stage: 0, state: STATE.READY};
         var deferred = null;
-        var file = { name: null, url: null };
-        var timeout = { id: null, delay: 1000 };
+        var file = {name: null, url: null};
+        var timeout = {id: null, delay: 1000};
         var $dom = {
             stages: $('ol.status-progress').children(),
             successStage: $('.item-progresspoint-success'),
             wrapper: $('div.wrapper-status')
         };
 
-        /********** Private functions *****************************************/
+        /** ******** Private functions *****************************************/
 
         /**
          * Destroys any event listener Import might have needed
          * during the process the import
          *
          */
-        var destroyEventListeners = function () {
+        var destroyEventListeners = function() {
             $(window).off('beforeunload.import');
         };
 
@@ -51,7 +50,7 @@ define(
          * Makes Import feedback status list visible
          *
          */
-        var displayFeedbackList = function () {
+        var displayFeedbackList = function() {
             $dom.wrapper.removeClass('is-hidden');
         };
 
@@ -65,7 +64,7 @@ define(
          * @param {string} msg Error message to display.
          * @param {int} [stage=current.stage] Stage of import process at which error occurred.
          */
-        var error = function (msg, stage) {
+        var error = function(msg, stage) {
             current.stage = Math.abs(stage || current.stage); // Could be negative
             current.state = STATE.ERROR;
 
@@ -80,8 +79,8 @@ define(
          * Initializes the event listeners
          *
          */
-        var initEventListeners = function () {
-            $(window).on('beforeunload.import', function () {
+        var initEventListeners = function() {
+            $(window).on('beforeunload.import', function() {
                 if (current.stage <= STAGE.UNPACKING) {
                     return gettext('Your import is in progress; navigating away will abort it.');
                 }
@@ -93,7 +92,7 @@ define(
          *
          * @param {boolean} [completed=false] If the import has been completed or not
          */
-        var storeImport = function (completed) {
+        var storeImport = function(completed) {
             $.cookie(COOKIE_NAME, JSON.stringify({
                 file: file,
                 date: moment().valueOf(),
@@ -107,7 +106,7 @@ define(
          * If it wasn't already, marks the stored import as "completed",
          * and updates its date timestamp
          */
-        var success = function () {
+        var success = function() {
             current.state = STATE.SUCCESS;
 
             if (CourseImport.storedImport().completed !== true) {
@@ -126,7 +125,7 @@ define(
          * @param {string} [currStageMsg=''] The message to show on the
          *   current stage (for now only in case of error)
          */
-        var updateFeedbackList = function (currStageMsg) {
+        var updateFeedbackList = function(currStageMsg) {
             var $checkmark, $curr, $prev, $next;
             var date, successUnix, time;
 
@@ -135,8 +134,8 @@ define(
 
             function completeStage(stage) {
                 $(stage)
-                    .removeClass("is-not-started is-started")
-                    .addClass("is-complete");
+                    .removeClass('is-not-started is-started')
+                    .addClass('is-complete');
             }
 
             function errorStage(stage) {
@@ -146,57 +145,57 @@ define(
                         .addClass('has-error')
                         .find('p.copy')
                         .hide()
-                        .after("<p class='copy error'>" + currStageMsg + "</p>");
+                        .after("<p class='copy error'>" + currStageMsg + '</p>');
                 }
             }
 
             function resetStage(stage) {
                 $(stage)
-                    .removeClass("is-complete is-started has-error")
-                    .addClass("is-not-started")
+                    .removeClass('is-complete is-started has-error')
+                    .addClass('is-not-started')
                     .find('p.error').remove().end()
                     .find('p.copy').show();
             }
 
             switch (current.state) {
-                case STATE.READY:
-                    _.map($dom.stages, resetStage);
+            case STATE.READY:
+                _.map($dom.stages, resetStage);
 
-                    break;
+                break;
 
-                case STATE.IN_PROGRESS:
-                    $prev = $dom.stages.slice(0, current.stage);
-                    $curr = $dom.stages.eq(current.stage);
+            case STATE.IN_PROGRESS:
+                $prev = $dom.stages.slice(0, current.stage);
+                $curr = $dom.stages.eq(current.stage);
 
-                    _.map($prev, completeStage);
-                    $curr.removeClass("is-not-started").addClass("is-started");
+                _.map($prev, completeStage);
+                $curr.removeClass('is-not-started').addClass('is-started');
 
-                    break;
+                break;
 
-                case STATE.SUCCESS:
-                    successUnix = CourseImport.storedImport().date;
-                    date = moment(successUnix).utc().format('MM/DD/YYYY');
-                    time = moment(successUnix).utc().format('HH:mm');
+            case STATE.SUCCESS:
+                successUnix = CourseImport.storedImport().date;
+                date = moment(successUnix).utc().format('MM/DD/YYYY');
+                time = moment(successUnix).utc().format('HH:mm');
 
-                    _.map($dom.stages, completeStage);
+                _.map($dom.stages, completeStage);
 
-                    $dom.successStage
+                $dom.successStage
                         .find('.item-progresspoint-success-date')
                         .html('(' + date + ' at ' + time + ' UTC)');
 
-                    break;
+                break;
 
-                case STATE.ERROR:
+            case STATE.ERROR:
                     // Make all stages up to, and including, the error stage 'complete'.
-                    $prev = $dom.stages.slice(0, current.stage + 1);
-                    $curr = $dom.stages.eq(current.stage);
-                    $next = $dom.stages.slice(current.stage + 1);
+                $prev = $dom.stages.slice(0, current.stage + 1);
+                $curr = $dom.stages.eq(current.stage);
+                $next = $dom.stages.slice(current.stage + 1);
 
-                    _.map($prev, completeStage);
-                    _.map($next, resetStage);
-                    errorStage($curr);
+                _.map($prev, completeStage);
+                _.map($next, resetStage);
+                errorStage($curr);
 
-                    break;
+                break;
             }
 
             if (current.state === STATE.SUCCESS) {
@@ -206,7 +205,7 @@ define(
             }
         };
 
-        /********** Public functions ******************************************/
+        /** ******** Public functions ******************************************/
 
         var CourseImport = {
 
@@ -216,7 +215,7 @@ define(
              * @param {string} msg Error message to display.
              * @param {int} stage Stage of import process at which error occurred.
              */
-            cancel: function (msg, stage) {
+            cancel: function(msg, stage) {
                 error(msg, stage);
             },
 
@@ -228,7 +227,7 @@ define(
              *
              * @param {int} [stage=0] Starting stage.
              */
-            pollStatus: function (stage) {
+            pollStatus: function(stage) {
                 if (current.state !== STATE.IN_PROGRESS) {
                     return;
                 }
@@ -238,12 +237,12 @@ define(
                 if (current.stage === STAGE.SUCCESS) {
                     success();
                 } else if (current.stage < STAGE.UPLOADING) { // Failed
-                    error(gettext("Error importing course"));
+                    error(gettext('Error importing course'));
                 } else { // In progress
                     updateFeedbackList();
 
-                    $.getJSON(file.url, function (data) {
-                        timeout.id = setTimeout(function () {
+                    $.getJSON(file.url, function(data) {
+                        timeout.id = setTimeout(function() {
                             this.pollStatus(data.ImportStatus);
                         }.bind(this), timeout.delay);
                     }.bind(this));
@@ -254,7 +253,7 @@ define(
              * Resets the Import internally and visually
              *
              */
-            reset: function () {
+            reset: function() {
                 current.stage = STAGE.UPLOADING;
                 current.state = STATE.READY;
 
@@ -268,11 +267,11 @@ define(
              *
              * @return {jQuery promise}
              */
-            resume: function () {
+            resume: function() {
                 deferred = $.Deferred();
                 file = this.storedImport().file;
 
-                $.getJSON(file.url, function (data) {
+                $.getJSON(file.url, function(data) {
                     current.stage = data.ImportStatus;
 
                     displayFeedbackList();
@@ -283,7 +282,7 @@ define(
                         this.pollStatus(current.stage);
                     } else {
                         // An import in the upload stage cannot be resumed
-                        error(gettext("There was an error with the upload"));
+                        error(gettext('There was an error with the upload'));
                     }
                 }.bind(this));
 
@@ -299,7 +298,7 @@ define(
              *     about the import status
              * @return {jQuery promise}
              */
-            start: function (fileName, fileUrl) {
+            start: function(fileName, fileUrl) {
                 current.state = STATE.IN_PROGRESS;
                 deferred = $.Deferred();
 
@@ -319,7 +318,7 @@ define(
              *
              * @return {JSON} the data of the previous import
              */
-            storedImport: function () {
+            storedImport: function() {
                 return JSON.parse($.cookie(COOKIE_NAME));
             }
         };

--- a/cms/static/js/views/instructor_info.js
+++ b/cms/static/js/views/instructor_info.js
@@ -1,26 +1,26 @@
 // Backbone Application View: Instructor Information
 
 define([
-        'jquery',
-        'underscore',
-        'backbone',
-        'gettext',
-        'js/utils/templates',
-        "js/models/uploads",
-        "js/views/uploads"
-    ],
-    function ($, _, Backbone, gettext, TemplateUtils, FileUploadModel, FileUploadDialog) {
+    'jquery',
+    'underscore',
+    'backbone',
+    'gettext',
+    'js/utils/templates',
+    'js/models/uploads',
+    'js/views/uploads'
+],
+    function($, _, Backbone, gettext, TemplateUtils, FileUploadModel, FileUploadDialog) {
         'use strict';
         var InstructorInfoView = Backbone.View.extend({
 
-             events : {
-                 'click .remove-instructor-data': 'removeInstructor',
-                 'click .action-upload-instructor-image': "uploadInstructorImage"
-             },
+            events: {
+                'click .remove-instructor-data': 'removeInstructor',
+                'click .action-upload-instructor-image': 'uploadInstructorImage'
+            },
 
             initialize: function() {
                 // Set up the initial state of the attributes set for this model instance
-                 _.bindAll(this, 'render');
+                _.bindAll(this, 'render');
                 this.template = this.loadTemplate('course-instructor-details');
                 this.listenTo(this.model, 'change:instructor_info', this.render);
             },
@@ -32,9 +32,9 @@ define([
 
             render: function() {
                 // Assemble the render view for this model.
-                $(".course-instructor-details-fields").empty();
+                $('.course-instructor-details-fields').empty();
                 var self = this;
-                $.each(this.model.get('instructor_info').instructors, function( index, data ) {
+                $.each(this.model.get('instructor_info').instructors, function(index, data) {
                     $(self.el).append(self.template({
                         data: data,
                         index: index
@@ -71,8 +71,8 @@ define([
                     instructor = instructors[index];
 
                 var upload = new FileUploadModel({
-                    title: gettext("Upload instructor image."),
-                    message: gettext("Files must be in JPEG or PNG format."),
+                    title: gettext('Upload instructor image.'),
+                    message: gettext('Files must be in JPEG or PNG format.'),
                     mimeTypes: ['image/jpeg', 'image/png']
                 });
                 var self = this;

--- a/cms/static/js/views/learning_info.js
+++ b/cms/static/js/views/learning_info.js
@@ -7,17 +7,17 @@ define([
     'gettext',
     'js/utils/templates'
 ],
-function ($, _, Backbone, gettext, TemplateUtils) {
+function($, _, Backbone, gettext, TemplateUtils) {
     'use strict';
     var LearningInfoView = Backbone.View.extend({
 
         events: {
-            'click .delete-course-learning-info': "removeLearningInfo"
+            'click .delete-course-learning-info': 'removeLearningInfo'
         },
 
         initialize: function() {
             // Set up the initial state of the attributes set for this model instance
-             _.bindAll(this, 'render');
+            _.bindAll(this, 'render');
             this.template = this.loadTemplate('course-settings-learning-fields');
             this.listenTo(this.model, 'change:learning_info', this.render);
         },
@@ -29,11 +29,11 @@ function ($, _, Backbone, gettext, TemplateUtils) {
 
         render: function() {
              // rendering for this model
-            $("li.course-settings-learning-fields").empty();
+            $('li.course-settings-learning-fields').empty();
             var self = this;
             var learning_information = this.model.get('learning_info');
-            $.each(learning_information, function( index, info ) {
-                $(self.el).append(self.template({index: index, info: info, info_count: learning_information.length }));
+            $.each(learning_information, function(index, info) {
+                $(self.el).append(self.template({index: index, info: info, info_count: learning_information.length}));
             });
         },
 

--- a/cms/static/js/views/library_container.js
+++ b/cms/static/js/views/library_container.js
@@ -1,5 +1,5 @@
-define(["js/views/paged_container"],
-    function (PagedContainerView) {
+define(['js/views/paged_container'],
+    function(PagedContainerView) {
         // To be extended with Library-specific features later.
         var LibraryContainerView = PagedContainerView;
         return LibraryContainerView;

--- a/cms/static/js/views/license.js
+++ b/cms/static/js/views/license.js
@@ -1,59 +1,59 @@
 define([
-    "js/views/baseview",
-    "underscore",
-    "text!templates/license-selector.underscore"
+    'js/views/baseview',
+    'underscore',
+    'text!templates/license-selector.underscore'
 ], function(BaseView, _, licenseSelectorTemplate) {
     var defaultLicenseInfo = {
-        "all-rights-reserved": {
-            "name": gettext("All Rights Reserved"),
-            "tooltip": gettext("You reserve all rights for your work")
+        'all-rights-reserved': {
+            'name': gettext('All Rights Reserved'),
+            'tooltip': gettext('You reserve all rights for your work')
         },
-        "creative-commons": {
-            "name": gettext("Creative Commons"),
-            "tooltip": gettext("You waive some rights for your work, such that others can use it too"),
-            "url": "https://creativecommons.org/about",
-            "options": {
-                "ver": {
-                    "name": gettext("Version"),
-                    "type": "string",
-                    "default": "4.0",
+        'creative-commons': {
+            'name': gettext('Creative Commons'),
+            'tooltip': gettext('You waive some rights for your work, such that others can use it too'),
+            'url': 'https://creativecommons.org/about',
+            'options': {
+                'ver': {
+                    'name': gettext('Version'),
+                    'type': 'string',
+                    'default': '4.0'
                 },
-                "BY": {
-                    "name": gettext("Attribution"),
-                    "type": "boolean",
-                    "default": true,
-                    "help": gettext("Allow others to copy, distribute, display and perform your copyrighted work but only if they give credit the way you request. Currently, this option is required."),
-                    "disabled": true,
+                'BY': {
+                    'name': gettext('Attribution'),
+                    'type': 'boolean',
+                    'default': true,
+                    'help': gettext('Allow others to copy, distribute, display and perform your copyrighted work but only if they give credit the way you request. Currently, this option is required.'),
+                    'disabled': true
                 },
-                "NC": {
-                    "name": gettext("Noncommercial"),
-                    "type": "boolean",
-                    "default": true,
-                    "help": gettext("Allow others to copy, distribute, display and perform your work - and derivative works based upon it - but for noncommercial purposes only."),
+                'NC': {
+                    'name': gettext('Noncommercial'),
+                    'type': 'boolean',
+                    'default': true,
+                    'help': gettext('Allow others to copy, distribute, display and perform your work - and derivative works based upon it - but for noncommercial purposes only.')
                 },
-                "ND": {
-                    "name": gettext("No Derivatives"),
-                    "type": "boolean",
-                    "default": true,
-                    "help": gettext("Allow others to copy, distribute, display and perform only verbatim copies of your work, not derivative works based upon it. This option is incompatible with \"Share Alike\"."),
-                    "conflictsWith": ["SA"]
+                'ND': {
+                    'name': gettext('No Derivatives'),
+                    'type': 'boolean',
+                    'default': true,
+                    'help': gettext('Allow others to copy, distribute, display and perform only verbatim copies of your work, not derivative works based upon it. This option is incompatible with "Share Alike".'),
+                    'conflictsWith': ['SA']
                 },
-                "SA": {
-                    "name": gettext("Share Alike"),
-                    "type": "boolean",
-                    "default": false,
-                    "help": gettext("Allow others to distribute derivative works only under a license identical to the license that governs your work. This option is incompatible with \"No Derivatives\"."),
-                    "conflictsWith": ["ND"]
+                'SA': {
+                    'name': gettext('Share Alike'),
+                    'type': 'boolean',
+                    'default': false,
+                    'help': gettext('Allow others to distribute derivative works only under a license identical to the license that governs your work. This option is incompatible with "No Derivatives".'),
+                    'conflictsWith': ['ND']
                 }
             },
-            "option_order": ["BY", "NC", "ND", "SA"]
+            'option_order': ['BY', 'NC', 'ND', 'SA']
         }
-    }
+    };
 
     var LicenseView = BaseView.extend({
         events: {
-            "click ul.license-types li button" : "onLicenseClick",
-            "click ul.license-options li": "onOptionClick"
+            'click ul.license-types li button': 'onLicenseClick',
+            'click ul.license-options li': 'onOptionClick'
         },
 
         initialize: function(options) {
@@ -77,43 +77,43 @@ define([
             var defaults = {};
             _.each(this.licenseInfo[licenseType].options, function(value, key) {
                 defaults[key] = value.default;
-            })
+            });
             return defaults;
         },
 
         render: function() {
             this.$el.html(_.template(licenseSelectorTemplate)({
                 model: this.model.attributes,
-                licenseString: this.model.toString() || "",
+                licenseString: this.model.toString() || '',
                 licenseInfo: this.licenseInfo,
                 showPreview: this.showPreview,
-                previewButton: false,
+                previewButton: false
             }));
             return this;
         },
 
         onLicenseClick: function(e) {
             var $li = $(e.srcElement || e.target).closest('li');
-            var licenseType = $li.data("license");
+            var licenseType = $li.data('license');
 
-	    // Check that we've selected a different license type than what's currently selected
-	    if (licenseType != this.model.attributes.type) {
-		this.model.set({
-                    "type": licenseType,
-                    "options": this.getDefaultOptionsForLicenseType(licenseType)
-		});
-		// Fire the change event manually
-		this.model.trigger("change change:type")
-	    }
-	    e.preventDefault();
+            // Check that we've selected a different license type than what's currently selected
+            if (licenseType != this.model.attributes.type) {
+                this.model.set({
+                    type: licenseType,
+                    options: this.getDefaultOptionsForLicenseType(licenseType)
+                });
+                // Fire the change event manually
+                this.model.trigger('change change:type');
+            }
+            e.preventDefault();
         },
 
         onOptionClick: function(e) {
-            var licenseType = this.model.get("type"),
-                licenseOptions = $.extend({}, this.model.get("options")),
+            var licenseType = this.model.get('type'),
+                licenseOptions = $.extend({}, this.model.get('options')),
                 $li = $(e.srcElement || e.target).closest('li');
 
-            var optionKey = $li.data("option")
+            var optionKey = $li.data('option');
             var licenseInfo = this.licenseInfo[licenseType];
             var optionInfo = licenseInfo.options[optionKey];
             if (optionInfo.disabled) {
@@ -121,25 +121,25 @@ define([
                 return;
             }
             var currentOptionValue = licenseOptions[optionKey];
-            if (optionInfo.type === "boolean") {
+            if (optionInfo.type === 'boolean') {
                 // toggle current value
                 currentOptionValue = !currentOptionValue;
                 licenseOptions[optionKey] = currentOptionValue;
             }
             // check for conflicts
             if (currentOptionValue && optionInfo.conflictsWith) {
-		var conflicts = optionInfo.conflictsWith;
-		for (var i=0; i<conflicts.length; i++) {
-		    // Uncheck all conflicts
-		    licenseOptions[conflicts[i]] = false;
-		    console.log(licenseOptions);
-		}
+                var conflicts = optionInfo.conflictsWith;
+                for (var i = 0; i < conflicts.length; i++) {
+                    // Uncheck all conflicts
+                    licenseOptions[conflicts[i]] = false;
+                    console.log(licenseOptions);
+                }
             }
 
-            this.model.set({"options": licenseOptions})
+            this.model.set({'options': licenseOptions});
             // Backbone has trouble identifying when objects change, so we'll
             // fire the change event manually.
-            this.model.trigger("change change:options")
+            this.model.trigger('change change:options');
             e.preventDefault();
         }
 

--- a/cms/static/js/views/list.js
+++ b/cms/static/js/views/list.js
@@ -71,7 +71,7 @@ define([
             }
         },
 
-        addNewItemView: function (model) {
+        addNewItemView: function(model) {
             var view = this.createItemView({model: model});
 
             // If items already exist, just append one new.
@@ -101,7 +101,7 @@ define([
             this.collection.add({editing: true}, this.newModelOptions);
         },
 
-        onRemoveItem: function () {
+        onRemoveItem: function() {
             if (this.collection.length === 0) {
                 this.render();
             }

--- a/cms/static/js/views/list_item.js
+++ b/cms/static/js/views/list_item.js
@@ -12,7 +12,7 @@
  *   to the DOM.
  */
 define([
-    'js/views/baseview', 'jquery', "gettext", "common/js/components/utils/view_utils"
+    'js/views/baseview', 'jquery', 'gettext', 'common/js/components/utils/view_utils'
 ], function(
     BaseView, $, gettext, ViewUtils
 ) {
@@ -26,7 +26,7 @@ define([
             this.listenTo(this.model, 'remove', this.remove);
         },
 
-        className: function () {
+        className: function() {
             var index = this.model.collection.indexOf(this.model);
 
             return [
@@ -59,7 +59,7 @@ define([
                 function() {
                     return ViewUtils.runOperationShowingMessage(
                         gettext('Deleting'),
-                        function () {
+                        function() {
                             return model.destroy({wait: true});
                         }
                     );

--- a/cms/static/js/views/list_item_editor.js
+++ b/cms/static/js/views/list_item_editor.js
@@ -36,7 +36,7 @@ define([
 
             ViewUtils.runOperationShowingMessage(
                 gettext('Saving'),
-                function () {
+                function() {
                     var dfd = $.Deferred();
                     var actionableModel = this.getSaveableModel();
 

--- a/cms/static/js/views/list_textbooks.js
+++ b/cms/static/js/views/list_textbooks.js
@@ -1,51 +1,51 @@
-define(["js/views/baseview", "jquery", "js/views/edit_textbook", "js/views/show_textbook", "common/js/components/utils/view_utils"],
+define(['js/views/baseview', 'jquery', 'js/views/edit_textbook', 'js/views/show_textbook', 'common/js/components/utils/view_utils'],
         function(BaseView, $, EditTextbookView, ShowTextbookView, ViewUtils) {
-    var ListTextbooks = BaseView.extend({
-        initialize: function() {
-            this.emptyTemplate = this.loadTemplate('no-textbooks');
-            this.listenTo(this.collection, 'all', this.render);
-            this.listenTo(this.collection, 'destroy', this.handleDestroy);
-        },
-        tagName: "div",
-        className: "textbooks-list",
-        render: function() {
-            var textbooks = this.collection;
-            if(textbooks.length === 0) {
-                this.$el.html(this.emptyTemplate());
-            } else {
-                this.$el.empty();
-                var that = this;
-                textbooks.each(function(textbook) {
-                    var view;
-                    if (textbook.get("editing")) {
-                        view = new EditTextbookView({model: textbook});
+            var ListTextbooks = BaseView.extend({
+                initialize: function() {
+                    this.emptyTemplate = this.loadTemplate('no-textbooks');
+                    this.listenTo(this.collection, 'all', this.render);
+                    this.listenTo(this.collection, 'destroy', this.handleDestroy);
+                },
+                tagName: 'div',
+                className: 'textbooks-list',
+                render: function() {
+                    var textbooks = this.collection;
+                    if (textbooks.length === 0) {
+                        this.$el.html(this.emptyTemplate());
                     } else {
-                        view = new ShowTextbookView({model: textbook});
+                        this.$el.empty();
+                        var that = this;
+                        textbooks.each(function(textbook) {
+                            var view;
+                            if (textbook.get('editing')) {
+                                view = new EditTextbookView({model: textbook});
+                            } else {
+                                view = new ShowTextbookView({model: textbook});
+                            }
+                            that.$el.append(view.render().el);
+                        });
                     }
-                    that.$el.append(view.render().el);
-                });
-            }
-            return this;
-        },
-        events: {
-            "click .new-button": "addOne"
-        },
-        addOne: function(e) {
-            var $sectionEl, $inputEl;
-            if(e && e.preventDefault) { e.preventDefault(); }
-            this.collection.add([{editing: true}]); // (render() call triggered here)
+                    return this;
+                },
+                events: {
+                    'click .new-button': 'addOne'
+                },
+                addOne: function(e) {
+                    var $sectionEl, $inputEl;
+                    if (e && e.preventDefault) { e.preventDefault(); }
+                    this.collection.add([{editing: true}]); // (render() call triggered here)
             // find the outer 'section' tag for the newly added textbook
-            $sectionEl = this.$el.find('section:last');
+                    $sectionEl = this.$el.find('section:last');
             // scroll to put this at top of viewport
-            ViewUtils.setScrollOffset($sectionEl, 0);
+                    ViewUtils.setScrollOffset($sectionEl, 0);
             // find the first input element in this section
-            $inputEl = $sectionEl.find('input:first');
+                    $inputEl = $sectionEl.find('input:first');
             // activate the text box (so user can go ahead and start typing straight away)
-            $inputEl.focus().select();
-        },
-        handleDestroy: function(model, collection, options) {
-            collection.remove(model);
-        }
-    });
-    return ListTextbooks;
-});
+                    $inputEl.focus().select();
+                },
+                handleDestroy: function(model, collection, options) {
+                    collection.remove(model);
+                }
+            });
+            return ListTextbooks;
+        });

--- a/cms/static/js/views/manage_users_and_roles.js
+++ b/cms/static/js/views/manage_users_and_roles.js
@@ -1,13 +1,13 @@
 /*
  Code for editing users and assigning roles within a course or library team context.
  */
-define(['jquery', 'underscore', 'gettext', "js/views/baseview",
+define(['jquery', 'underscore', 'gettext', 'js/views/baseview',
         'common/js/components/views/feedback_prompt', 'common/js/components/utils/view_utils'],
-    function ($, _, gettext, BaseView, PromptView, ViewUtils) {
+    function($, _, gettext, BaseView, PromptView, ViewUtils) {
         'use strict';
         var default_messages = {
             defaults: {
-                confirmation: gettext("Ok"),
+                confirmation: gettext('Ok'),
                 changeRoleError: gettext("There was an error changing the user's role"),
                 unknown: gettext('Unknown')
             },
@@ -22,7 +22,7 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
             },
             alreadyMember: {
                 title: gettext('Already a member'),
-                messageTpl: gettext("{email} is already on the {container} team. Recheck the email address if you want to add a new member."),
+                messageTpl: gettext('{email} is already on the {container} team. Recheck the email address if you want to add a new member.'),
                 primaryAction: gettext('Return to team listing')
             },
             deleteUser: {
@@ -40,7 +40,7 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                 actions: {
                     primary: {
                         text: messages.invalidEmail.primaryAction,
-                        click: function (view) {
+                        click: function(view) {
                             view.hide();
                             $('#user-email-input').focus();
                         }
@@ -60,7 +60,7 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                 actions: {
                     primary: {
                         text: messages.alreadyMember.primaryAction,
-                        click: function (view) {
+                        click: function(view) {
                             view.hide();
                             $('#user-email-input').focus();
                         }
@@ -76,7 +76,7 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                 actions: {
                     primary: {
                         text: messages.defaults.confirmation,
-                        click: function (view) {
+                        click: function(view) {
                             view.hide();
                             onErrorCallback();
                         }
@@ -90,13 +90,13 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
         }
 
         var ManageUsersAndRoles = BaseView.extend({
-            events: function () {
+            events: function() {
                 var baseEvents = {
-                    'click .create-user-button': "addUserHandler",
-                    'submit #create-user-form': "createUserFormSubmit",
-                    'click .action-cancel': "cancelEditHandler",
-                    'keyup': "keyUpHandler",
-                    'click .remove-user': "removeUserHandler"
+                    'click .create-user-button': 'addUserHandler',
+                    'submit #create-user-form': 'createUserFormSubmit',
+                    'click .action-cancel': 'cancelEditHandler',
+                    'keyup': 'keyUpHandler',
+                    'click .remove-user': 'removeUserHandler'
                 };
                 var roleEvents = {};
                 var self = this;
@@ -104,14 +104,14 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                     var role_name = self.options.roles[i].key;
                     var role_selector = 'click .user-actions .make-' + role_name;
 
-                    (function (role) {
-                        roleEvents[role_selector] = function (event) { self.handleRoleButtonClick(event.target, role); };
+                    (function(role) {
+                        roleEvents[role_selector] = function(event) { self.handleRoleButtonClick(event.target, role); };
                     })(role_name);
                 }
                 return _.extend(baseEvents, roleEvents);
             },
 
-            initialize: function (options) {
+            initialize: function(options) {
                 BaseView.prototype.initialize.call(this);
                 this.containerName = options.containerName;
                 this.tplUserURL = options.tplUserURL;
@@ -124,7 +124,7 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                 this.initial_role = this.roles[0];
                 this.admin_role = this.roles[this.roles.length - 1];
 
-                var message_mod = options.messages_modifier || function (messages) { return messages; };
+                var message_mod = options.messages_modifier || function(messages) { return messages; };
                 this.messages = message_mod(default_messages);
 
                 this.$userEmailInput = this.$el.find('#user-email-input');
@@ -134,13 +134,13 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                 this.$userList = this.$el.find('#user-list');
             },
 
-            render: function () {
+            render: function() {
                 this.$userList.empty();
-                var templateFn = this.loadTemplate("team-member"),
-                    roles = _.object(_.pluck(this.roles, 'key'), _.pluck(this.roles, "name")),
+                var templateFn = this.loadTemplate('team-member'),
+                    roles = _.object(_.pluck(this.roles, 'key'), _.pluck(this.roles, 'name')),
                     adminRoleCount = this.getAdminRoleCount(),
                     viewHelpers = {
-                        format: function (template, data) {
+                        format: function(template, data) {
                             return _.template(template, {interpolate: /\{(.+?)}/g})(data);
                         }
                     };
@@ -161,14 +161,14 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                 }
             },
 
-            getAdminRoleCount: function () {
+            getAdminRoleCount: function() {
                 var self = this;
-                return _.filter(this.users, function (user) { return user.role === self.admin_role.key; }).length;
+                return _.filter(this.users, function(user) { return user.role === self.admin_role.key; }).length;
             },
 
-            getPossibleRoleChangesForRole: function (role, adminRoleCount) {
+            getPossibleRoleChangesForRole: function(role, adminRoleCount) {
                 var result = [],
-                    role_names = _.map(this.roles, function (role) { return role.key });
+                    role_names = _.map(this.roles, function(role) { return role.key; });
                 if (role === this.admin_role.key && adminRoleCount === 1) {
                     result.push({notoggle: true});
                 }
@@ -181,15 +181,15 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                         result.push({
                             to_role: other_role.key,
                             label: (i < currentRoleIdx) ? this.roles[currentRoleIdx].name : other_role.name,
-                            direction: (i < currentRoleIdx) ? "remove" : "add"
+                            direction: (i < currentRoleIdx) ? 'remove' : 'add'
                         });
                     }
                 }
                 return result;
             },
 
-            checkEmail: function (email) {
-                var allUsersEmails = _.map(this.users, function (user) { return user.email; });
+            checkEmail: function(email) {
+                var allUsersEmails = _.map(this.users, function(user) { return user.email; });
 
                 if (!email) {
                     return {valid: false, msg: makeInvalidEmailMessage(this.messages)};
@@ -202,12 +202,12 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
             },
 
             // Our helper method that calls the RESTful API to add/remove/change user roles:
-            changeRole: function (email, newRole, opts) {
+            changeRole: function(email, newRole, opts) {
                 var self = this;
                 var url = this.tplUserURL.replace('@@EMAIL@@', email);
                 var errMessage = opts.errMessage || this.messages.defaults.changeRoleError;
-                var onSuccess = opts.onSuccess || function (data) { ViewUtils.reload(); };
-                var onError = opts.onError || function () {};
+                var onSuccess = opts.onSuccess || function(data) { ViewUtils.reload(); };
+                var onError = opts.onError || function() {};
                 $.ajax({
                     url: url,
                     type: newRole ? 'POST' : 'DELETE',
@@ -215,7 +215,7 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                     contentType: 'application/json',
                     data: JSON.stringify({role: newRole}),
                     success: onSuccess,
-                    error: function (jqXHR, textStatus, errorThrown) {
+                    error: function(jqXHR, textStatus, errorThrown) {
                         var message, prompt;
                         try {
                             message = JSON.parse(jqXHR.responseText).error || self.messages.defaults.unknown;
@@ -228,11 +228,11 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                 });
             },
 
-            handleRoleButtonClick: function (button, role) {
+            handleRoleButtonClick: function(button, role) {
                 this.changeRole(getEmail(button), role, {});
             },
 
-            addUserHandler: function (event) {
+            addUserHandler: function(event) {
                 event.preventDefault();
                 this.$createUserButton
                     .toggleClass('is-disabled')
@@ -241,7 +241,7 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                 this.$userEmailInput.focus();
             },
 
-            cancelEditHandler: function (event) {
+            cancelEditHandler: function(event) {
                 event.preventDefault();
                 this.$createUserButton
                     .toggleClass('is-disabled')
@@ -250,7 +250,7 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                 this.$userEmailInput.val('');
             },
 
-            createUserFormSubmit: function (event) {
+            createUserFormSubmit: function(event) {
                 event.preventDefault();
                 var self = this;
                 var email = this.$userEmailInput.val().trim();
@@ -267,18 +267,18 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                     this.initial_role.key,
                     {
                         errMessage: this.messages.errors.addUser,
-                        onError: function () { self.$userEmailInput.focus(); }
+                        onError: function() { self.$userEmailInput.focus(); }
                     }
                 );
             },
 
-            keyUpHandler: function (event) {
+            keyUpHandler: function(event) {
                 if (event.which === jQuery.ui.keyCode.ESCAPE && this.$createUserFormWrapper.is('.is-shown')) {
                     this.$cancelButton.click();
                 }
             },
 
-            removeUserHandler: function (event) {
+            removeUserHandler: function(event) {
                 event.preventDefault();
                 var self = this;
                 var email = getEmail(event.target);
@@ -292,7 +292,7 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                     actions: {
                         primary: {
                             text: self.messages.deleteUser.primaryAction,
-                            click: function (view) {
+                            click: function(view) {
                                 view.hide();
                                 // Use the REST API to delete the user:
                                 self.changeRole(email, null, {errMessage: self.messages.errors.deleteUser});
@@ -300,7 +300,7 @@ define(['jquery', 'underscore', 'gettext', "js/views/baseview",
                         },
                         secondary: {
                             text: self.messages.deleteUser.secondaryAction,
-                            click: function (view) { view.hide(); }
+                            click: function(view) { view.hide(); }
                         }
                     }
                 });

--- a/cms/static/js/views/metadata.js
+++ b/cms/static/js/views/metadata.js
@@ -1,10 +1,10 @@
 define(
     [
-        "js/views/baseview", "underscore", "js/models/metadata", "js/views/abstract_editor",
-        "js/models/uploads", "js/views/uploads",
-        "js/models/license", "js/views/license",
-        "js/views/video/transcripts/metadata_videolist",
-        "js/views/video/translations_editor"
+        'js/views/baseview', 'underscore', 'js/models/metadata', 'js/views/abstract_editor',
+        'js/models/uploads', 'js/views/uploads',
+        'js/models/license', 'js/views/license',
+        'js/views/video/transcripts/metadata_videolist',
+        'js/views/video/translations_editor'
     ],
 function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
          LicenseModel, LicenseView, VideoList, VideoTranslations) {
@@ -13,7 +13,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
     Metadata.Editor = BaseView.extend({
 
         // Model is CMS.Models.MetadataCollection,
-        initialize : function() {
+        initialize: function() {
             var self = this,
                 counter = 0,
                 locator = self.$el.closest('[data-locator]').data('locator'),
@@ -23,7 +23,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             this.$el.html(this.template({numEntries: this.collection.length}));
 
             this.collection.each(
-                function (model) {
+                function(model) {
                     var data = {
                             el: self.$el.find('.metadata_entry')[counter++],
                             courseKey: courseKey,
@@ -53,10 +53,10 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
         /**
          * Returns just the modified metadata values, in the format used to persist to the server.
          */
-        getModifiedMetadataValues: function () {
+        getModifiedMetadataValues: function() {
             var modified_values = {};
             this.collection.each(
-                function (model) {
+                function(model) {
                     if (model.isModified()) {
                         modified_values[model.getFieldName()] = model.getValue();
                     }
@@ -70,10 +70,10 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
          * if there is a metadata entry called 'display_name', and if so, it returns its value. If there
          * is no such entry, or if display_name does not have a value set, it returns an empty string.
          */
-        getDisplayName: function () {
+        getDisplayName: function() {
             var displayName = '';
             this.collection.each(
-                function (model) {
+                function(model) {
                     if (model.get('field_name') === 'display_name') {
                         var displayNameValue = model.get('value');
                         // It is possible that there is no display name value set. In that case, return empty string.
@@ -90,15 +90,15 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
 
     Metadata.String = AbstractEditor.extend({
 
-        events : {
-            "change input" : "updateModel",
-            "keypress .setting-input" : "showClearButton",
-            "click .setting-clear" : "clear"
+        events: {
+            'change input': 'updateModel',
+            'keypress .setting-input': 'showClearButton',
+            'click .setting-clear': 'clear'
         },
 
-        templateName: "metadata-string-entry",
+        templateName: 'metadata-string-entry',
 
-        render: function () {
+        render: function() {
             AbstractEditor.prototype.render.apply(this);
 
             // If the model has property `non editable` equals `true`,
@@ -111,33 +111,33 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             }
         },
 
-        getValueFromEditor : function () {
+        getValueFromEditor: function() {
             return this.$el.find('#' + this.uniqueId).val();
         },
 
-        setValueInEditor : function (value) {
+        setValueInEditor: function(value) {
             this.$el.find('input').val(value);
         }
     });
 
     Metadata.Number = AbstractEditor.extend({
 
-        events : {
-            "change input" : "updateModel",
-            "keypress .setting-input" : "keyPressed",
-            "change .setting-input" : "changed",
-            "click .setting-clear" : "clear"
+        events: {
+            'change input': 'updateModel',
+            'keypress .setting-input': 'keyPressed',
+            'change .setting-input': 'changed',
+            'click .setting-clear': 'clear'
         },
 
-        render: function () {
+        render: function() {
             AbstractEditor.prototype.render.apply(this);
             if (!this.initialized) {
-                var numToString = function (val) {
+                var numToString = function(val) {
                     return val.toFixed(4);
                 };
-                var min = "min";
-                var max = "max";
-                var step = "step";
+                var min = 'min';
+                var max = 'max';
+                var step = 'step';
                 var options = this.model.getOptions();
                 if (options.hasOwnProperty(min)) {
                     this.min = Number(options[min]);
@@ -153,7 +153,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
                     stepValue = numToString(Number(options[step]));
                 }
                 else if (this.isIntegerField()) {
-                    stepValue = "1";
+                    stepValue = '1';
                 }
                 if (stepValue !== undefined) {
                     this.$el.find('input').attr(step, stepValue);
@@ -171,24 +171,24 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             return this;
         },
 
-        templateName: "metadata-number-entry",
+        templateName: 'metadata-number-entry',
 
-        getValueFromEditor : function () {
+        getValueFromEditor: function() {
             return this.$el.find('#' + this.uniqueId).val();
         },
 
-        setValueInEditor : function (value) {
+        setValueInEditor: function(value) {
             this.$el.find('input').val(value);
         },
 
         /**
          * Returns true if this view is restricted to integers, as opposed to floating points values.
          */
-        isIntegerField : function () {
+        isIntegerField: function() {
             return this.model.getType() === 'Integer';
         },
 
-        keyPressed: function (e) {
+        keyPressed: function(e) {
             this.showClearButton();
             // This first filtering if statement is take from polyfill to prevent
             // non-numeric input (for browsers that don't use polyfill because they DO have a number input type).
@@ -204,7 +204,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             }
         },
 
-        changed: function () {
+        changed: function() {
             // Limit value to the range specified by min and max (necessary for browsers that aren't using polyfill).
             // Prevent integer/float fields value to be empty (set them to their defaults)
             var value = this.getValueFromEditor();
@@ -225,17 +225,17 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
 
     Metadata.Option = AbstractEditor.extend({
 
-        events : {
-            "change select" : "updateModel",
-            "click .setting-clear" : "clear"
+        events: {
+            'change select': 'updateModel',
+            'click .setting-clear': 'clear'
         },
 
-        templateName: "metadata-option-entry",
+        templateName: 'metadata-option-entry',
 
-        getValueFromEditor : function () {
-            var selectedText = this.$el.find('#' + this.uniqueId).find(":selected").text();
+        getValueFromEditor: function() {
+            var selectedText = this.$el.find('#' + this.uniqueId).find(':selected').text();
             var selectedValue;
-            _.each(this.model.getOptions(), function (modelValue) {
+            _.each(this.model.getOptions(), function(modelValue) {
                 if (modelValue === selectedText) {
                     selectedValue = modelValue;
                 }
@@ -246,15 +246,15 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             return selectedValue;
         },
 
-        setValueInEditor : function (value) {
+        setValueInEditor: function(value) {
             // Value here is the json value as used by the field. The choice may instead be showing display names.
             // Find the display name matching the value passed in.
-            _.each(this.model.getOptions(), function (modelValue) {
+            _.each(this.model.getOptions(), function(modelValue) {
                 if (modelValue['value'] === value) {
                     value = modelValue['display_name'];
                 }
             });
-            this.$el.find('#' + this.uniqueId + " option").filter(function() {
+            this.$el.find('#' + this.uniqueId + ' option').filter(function() {
                 return $(this).text() === value;
             }).prop('selected', true);
         }
@@ -262,25 +262,25 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
 
     Metadata.List = AbstractEditor.extend({
 
-        events : {
-            "click .setting-clear" : "clear",
-            "keypress .setting-input" : "showClearButton",
-            "change input" : "updateModel",
-            "input input" : "enableAdd",
-            "click .create-setting" : "addEntry",
-            "click .remove-setting" : "removeEntry"
+        events: {
+            'click .setting-clear': 'clear',
+            'keypress .setting-input': 'showClearButton',
+            'change input': 'updateModel',
+            'input input': 'enableAdd',
+            'click .create-setting': 'addEntry',
+            'click .remove-setting': 'removeEntry'
         },
 
-        templateName: "metadata-list-entry",
+        templateName: 'metadata-list-entry',
 
-        getValueFromEditor: function () {
+        getValueFromEditor: function() {
             return _.map(
                 this.$el.find('li input'),
-                function (ele) { return ele.value.trim(); }
+                function(ele) { return ele.value.trim(); }
             ).filter(_.identity);
         },
 
-        setValueInEditor: function (value) {
+        setValueInEditor: function(value) {
             var list = this.$el.find('ol');
 
             list.empty();
@@ -332,22 +332,22 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
         maxTimeInSeconds: 86399,
 
         events: {
-            "focus input" : "addSelection",
-            "mouseup input" : "mouseUpHandler",
-            "change input" : "updateModel",
-            "keypress .setting-input" : "showClearButton"  ,
-            "click .setting-clear" : "clear"
+            'focus input': 'addSelection',
+            'mouseup input': 'mouseUpHandler',
+            'change input': 'updateModel',
+            'keypress .setting-input': 'showClearButton',
+            'click .setting-clear': 'clear'
         },
 
-        templateName: "metadata-string-entry",
+        templateName: 'metadata-string-entry',
 
-        getValueFromEditor: function () {
+        getValueFromEditor: function() {
             var $input = this.$el.find('#' + this.uniqueId);
 
             return $input.val();
         },
 
-        updateModel: function () {
+        updateModel: function() {
             var value = this.getValueFromEditor(),
                 time = this.parseRelativeTime(value);
 
@@ -365,10 +365,10 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             }
         },
 
-        parseRelativeTime: function (value) {
+        parseRelativeTime: function(value) {
             // This function ensure you have two-digits
-            var pad = function (number) {
-                    return (number < 10) ? "0" + number : number;
+            var pad = function(number) {
+                    return (number < 10) ? '0' + number : number;
                 },
                 // Removes all white-spaces and splits by `:`.
                 list = value.replace(/\s+/g, '').split(':'),
@@ -392,7 +392,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             ].join(':');
         },
 
-        setValueInEditor: function (value) {
+        setValueInEditor: function(value) {
             if (!value) {
                 value = this.defaultValue;
             }
@@ -400,11 +400,11 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             this.$el.find('input').val(value);
         },
 
-        addSelection: function (event) {
+        addSelection: function(event) {
             $(event.currentTarget).select();
         },
 
-        mouseUpHandler: function (event) {
+        mouseUpHandler: function(event) {
             // Prevents default behavior to make works selection in WebKit
             // browsers
             event.preventDefault();
@@ -414,17 +414,17 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
     Metadata.Dict = AbstractEditor.extend({
 
         events: {
-            "click .setting-clear" : "clear",
-            "keypress .setting-input" : "showClearButton",
-            "change input" : "updateModel",
-            "input input" : "enableAdd",
-            "click .create-setting" : "addEntry",
-            "click .remove-setting" : "removeEntry"
+            'click .setting-clear': 'clear',
+            'keypress .setting-input': 'showClearButton',
+            'change input': 'updateModel',
+            'input input': 'enableAdd',
+            'click .create-setting': 'addEntry',
+            'click .remove-setting': 'removeEntry'
         },
 
-        templateName: "metadata-dict-entry",
+        templateName: 'metadata-dict-entry',
 
-        getValueFromEditor: function () {
+        getValueFromEditor: function() {
             var dict = {};
 
             _.each(this.$el.find('li'), function(li, index) {
@@ -446,7 +446,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             return dict;
         },
 
-        setValueInEditor: function (value) {
+        setValueInEditor: function(value) {
             var list = this.$el.find('ol'),
                 frag = document.createDocumentFragment();
 
@@ -503,24 +503,24 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
      */
     Metadata.FileUploader = AbstractEditor.extend({
 
-        events : {
-            "click .upload-setting" : "upload",
-            "click .setting-clear" : "clear"
+        events: {
+            'click .upload-setting': 'upload',
+            'click .setting-clear': 'clear'
         },
 
-        templateName: "metadata-file-uploader-entry",
-        templateButtonsName: "metadata-file-uploader-item",
+        templateName: 'metadata-file-uploader-entry',
+        templateButtonsName: 'metadata-file-uploader-item',
 
-        initialize: function () {
+        initialize: function() {
             this.buttonTemplate = this.loadTemplate(this.templateButtonsName);
             AbstractEditor.prototype.initialize.apply(this);
         },
 
-        getValueFromEditor: function () {
+        getValueFromEditor: function() {
             return this.$('#' + this.uniqueId).val();
         },
 
-        setValueInEditor: function (value) {
+        setValueInEditor: function(value) {
             var html = this.buttonTemplate({
                 model: this.model,
                 uniqueId: this.uniqueId
@@ -530,18 +530,18 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             this.$('.wrapper-uploader-actions').html(html);
         },
 
-        upload: function (event) {
+        upload: function(event) {
             var self = this,
                 target = $(event.currentTarget),
                 url = '/assets/' + this.options.courseKey + '/',
                 model = new FileUpload({
-                    title: gettext('Upload File'),
+                    title: gettext('Upload File')
                 }),
                 view = new UploadDialog({
                     model: model,
                     url: url,
                     parentElement: target.closest('.xblock-editor'),
-                    onSuccess: function (response) {
+                    onSuccess: function(response) {
                         if (response['asset'] && response['asset']['url']) {
                             self.model.setValue(response['asset']['url']);
                         }
@@ -555,7 +555,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
     Metadata.License = AbstractEditor.extend({
 
         initialize: function(options) {
-            this.licenseModel = new LicenseModel({"asString": this.model.getValue()});
+            this.licenseModel = new LicenseModel({'asString': this.model.getValue()});
             this.licenseView = new LicenseView({model: this.licenseModel});
 
             // Rerender when the license model changes
@@ -564,7 +564,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
         },
 
         render: function() {
-            this.licenseView.render().$el.css("display", "inline");
+            this.licenseView.render().$el.css('display', 'inline');
             this.licenseView.undelegateEvents();
             this.$el.empty().append(this.licenseView.el);
             // restore event bindings
@@ -574,7 +574,7 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
 
         setLicense: function() {
             this.model.setValue(this.licenseModel.toString());
-            this.render()
+            this.render();
         }
 
     });

--- a/cms/static/js/views/modals/base_modal.js
+++ b/cms/static/js/views/modals/base_modal.js
@@ -19,10 +19,10 @@
  *   addSaveButton: A boolean indicating whether to include a save
  *     button on the modal.
  */
-define(["jquery", "underscore", "gettext", "js/views/baseview"],
+define(['jquery', 'underscore', 'gettext', 'js/views/baseview'],
     function($, _, gettext, BaseView) {
         var BaseModal = BaseView.extend({
-            events : {
+            events: {
                 'click .action-cancel': 'cancel'
             },
 

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -18,7 +18,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         ContentVisibilityEditor, VerificationAccessEditor, TimedExaminationPreferenceEditor, AccessEditor;
 
     CourseOutlineXBlockModal = BaseModal.extend({
-        events : _.extend({}, BaseModal.prototype.events, {
+        events: _.extend({}, BaseModal.prototype.events, {
             'click .action-save': 'save'
         }),
 
@@ -37,13 +37,13 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             this.options.title = this.getTitle();
         },
 
-        afterRender: function () {
+        afterRender: function() {
             BaseModal.prototype.afterRender.call(this);
             this.initializeEditors();
         },
 
-        initializeEditors: function () {
-            this.options.editors = _.map(this.options.editors, function (Editor) {
+        initializeEditors: function() {
+            this.options.editors = _.map(this.options.editors, function(Editor) {
                 return new Editor({
                     parentElement: this.$('.modal-section'),
                     model: this.model,
@@ -54,11 +54,11 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             }, this);
         },
 
-        getTitle: function () {
+        getTitle: function() {
             return '';
         },
 
-        getIntroductionMessage: function () {
+        getIntroductionMessage: function() {
             return '';
         },
 
@@ -69,7 +69,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         save: function(event) {
             event.preventDefault();
             var requestData = this.getRequestData();
-            if (!_.isEqual(requestData, { metadata: {} })) {
+            if (!_.isEqual(requestData, {metadata: {}})) {
                 XBlockViewUtils.updateXBlockFields(this.model, requestData, {
                     success: this.options.onSave
                 });
@@ -81,7 +81,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
          * Return context for the modal.
          * @return {Object}
          */
-        getContext: function () {
+        getContext: function() {
             return $.extend({
                 xblockInfo: this.model,
                 introductionMessage: this.getIntroductionMessage(),
@@ -94,8 +94,8 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
          * Return request data.
          * @return {Object}
          */
-        getRequestData: function () {
-            var requestData = _.map(this.options.editors, function (editor) {
+        getRequestData: function() {
+            var requestData = _.map(this.options.editors, function(editor) {
                 return editor.getRequestData();
             });
 
@@ -105,26 +105,26 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
 
     SettingsXBlockModal = CourseOutlineXBlockModal.extend({
 
-        getTitle: function () {
+        getTitle: function() {
             return StringUtils.interpolate(
                 gettext('{display_name} Settings'),
-                { display_name: this.model.get('display_name') }
+                {display_name: this.model.get('display_name')}
             );
         },
 
-        getIntroductionMessage: function () {
+        getIntroductionMessage: function() {
             var message = '';
             var tabs = this.options.tabs;
             if (!tabs || tabs.length < 2) {
                 message = StringUtils.interpolate(
                     gettext('Change the settings for {display_name}'),
-                    { display_name: this.model.get('display_name') }
+                    {display_name: this.model.get('display_name')}
                 );
             }
             return message;
         },
 
-        initializeEditors: function () {
+        initializeEditors: function() {
             var tabs = this.options.tabs;
             if (tabs && tabs.length > 0) {
                 if (tabs.length > 1) {
@@ -133,7 +133,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                     _.each(this.options.tabs, function(tab) {
                         this.options.editors.push.apply(
                             this.options.editors,
-                            _.map(tab.editors, function (Editor) {
+                            _.map(tab.editors, function(Editor) {
                                 return new Editor({
                                     parent: this,
                                     parentElement: this.$('.modal-section .' + tab.name),
@@ -164,19 +164,19 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
          * Return request data.
          * @return {Object}
          */
-        getRequestData: function () {
-            var requestData = _.map(this.options.editors, function (editor) {
+        getRequestData: function() {
+            var requestData = _.map(this.options.editors, function(editor) {
                 return editor.getRequestData();
             });
             return $.extend.apply(this, [true, {}].concat(requestData));
         },
 
-        handleShowTab: function (event) {
+        handleShowTab: function(event) {
             event.preventDefault();
             this.showTab($(event.target).data('tab'));
         },
 
-        showTab: function (tab) {
+        showTab: function(tab) {
             this.$('.modal-section .settings-tab-button').removeClass('active');
             this.$('.modal-section .settings-tab-button[data-tab="' + tab + '"]').addClass('active');
             this.$('.modal-section .settings-tab').hide();
@@ -186,7 +186,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
 
 
     PublishXBlockModal = CourseOutlineXBlockModal.extend({
-        events : _.extend({}, CourseOutlineXBlockModal.prototype.events, {
+        events: _.extend({}, CourseOutlineXBlockModal.prototype.events, {
             'click .action-publish': 'save'
         }),
 
@@ -197,17 +197,17 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             }
         },
 
-        getTitle: function () {
+        getTitle: function() {
             return StringUtils.interpolate(
                 gettext('Publish {display_name}'),
-                { display_name: this.model.get('display_name') }
+                {display_name: this.model.get('display_name')}
             );
         },
 
-        getIntroductionMessage: function () {
+        getIntroductionMessage: function() {
             return StringUtils.interpolate(
                 gettext('Publish all unpublished changes for this {item}?'),
-                { item: this.options.xblockType }
+                {item: this.options.xblockType}
             );
         },
 
@@ -227,7 +227,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             this.render();
         },
 
-        render: function () {
+        render: function() {
             var html = this.template($.extend({}, {
                 xblockInfo: this.model,
                 xblockType: this.options.xblockType,
@@ -239,11 +239,11 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             this.parentElement.append(this.$el);
         },
 
-        getContext: function () {
+        getContext: function() {
             return {};
         },
 
-        getRequestData: function () {
+        getRequestData: function() {
             return {};
         }
     });
@@ -252,15 +252,15 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         // Attribute name in the model, should be defined in children classes.
         fieldName: null,
 
-        events : {
+        events: {
             'click .clear-date': 'clearValue'
         },
 
-        afterRender: function () {
+        afterRender: function() {
             AbstractEditor.prototype.afterRender.call(this);
             this.$('input.date').datepicker({'dateFormat': 'm/d/yy'});
             this.$('input.time').timepicker({
-                'timeFormat' : 'H:i',
+                'timeFormat': 'H:i',
                 'forceRoundTime': false
             });
             if (this.model.get(this.fieldName)) {
@@ -277,16 +277,16 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         templateName: 'due-date-editor',
         className: 'modal-section-content has-actions due-date-input grading-due-date',
 
-        getValue: function () {
+        getValue: function() {
             return DateUtils.getDate(this.$('#due_date'), this.$('#due_time'));
         },
 
-        clearValue: function (event) {
+        clearValue: function(event) {
             event.preventDefault();
             this.$('#due_time, #due_date').val('');
         },
 
-        getRequestData: function () {
+        getRequestData: function() {
             return {
                 metadata: {
                     'due': this.getValue()
@@ -301,23 +301,23 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         className: 'edit-settings-release scheduled-date-input',
         startingReleaseDate: null,
 
-        afterRender: function () {
+        afterRender: function() {
             BaseDateEditor.prototype.afterRender.call(this);
             // Store the starting date and time so that we can determine if the user
             // actually changed it when "Save" is pressed.
             this.startingReleaseDate = this.getValue();
         },
 
-        getValue: function () {
+        getValue: function() {
             return DateUtils.getDate(this.$('#start_date'), this.$('#start_time'));
         },
 
-        clearValue: function (event) {
+        clearValue: function(event) {
             event.preventDefault();
             this.$('#start_time, #start_date').val('');
         },
 
-        getRequestData: function () {
+        getRequestData: function() {
             var newReleaseDate = this.getValue();
             if (JSON.stringify(newReleaseDate) === JSON.stringify(this.startingReleaseDate)) {
                 return {};
@@ -333,19 +333,19 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
     TimedExaminationPreferenceEditor = AbstractEditor.extend({
         templateName: 'timed-examination-preference-editor',
         className: 'edit-settings-timed-examination',
-        events : {
+        events: {
             'change input.no_special_exam': 'notTimedExam',
             'change input.timed_exam': 'setTimedExam',
             'change input.practice_exam': 'setPracticeExam',
             'change input.proctored_exam': 'setProctoredExam',
             'focusout .field-time-limit input': 'timeLimitFocusout'
         },
-        notTimedExam: function (event) {
+        notTimedExam: function(event) {
             event.preventDefault();
             this.$('.exam-options').hide();
             this.$('.field-time-limit input').val('00:00');
         },
-        selectSpecialExam: function (showRulesField) {
+        selectSpecialExam: function(showRulesField) {
             this.$('.exam-options').show();
             this.$('.field-time-limit').show();
             if (!this.isValidTimeLimit(this.$('.field-time-limit input').val())) {
@@ -358,15 +358,15 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 this.$('.field-exam-review-rules').hide();
             }
         },
-        setTimedExam: function (event) {
+        setTimedExam: function(event) {
             event.preventDefault();
             this.selectSpecialExam(false);
         },
-        setPracticeExam: function (event) {
+        setPracticeExam: function(event) {
             event.preventDefault();
             this.selectSpecialExam(false);
         },
-        setProctoredExam: function (event) {
+        setProctoredExam: function(event) {
             event.preventDefault();
             this.selectSpecialExam(true);
         },
@@ -374,13 +374,13 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             event.preventDefault();
             var selectedTimeLimit = $(event.currentTarget).val();
             if (!this.isValidTimeLimit(selectedTimeLimit)) {
-                $(event.currentTarget).val("00:30");
+                $(event.currentTarget).val('00:30');
             }
         },
-        afterRender: function () {
+        afterRender: function() {
             AbstractEditor.prototype.afterRender.call(this);
             this.$('input.time').timepicker({
-                'timeFormat' : 'H:i',
+                'timeFormat': 'H:i',
                 'minTime': '00:30',
                 'maxTime': '24:00',
                 'forceRoundTime': false
@@ -421,48 +421,48 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             var time = this.convertTimeLimitMinutesToString(value);
             this.$('.field-time-limit input').val(time);
         },
-        setReviewRules: function (value) {
+        setReviewRules: function(value) {
             this.$('.field-exam-review-rules textarea').val(value);
         },
         isValidTimeLimit: function(time_limit) {
             var pattern = new RegExp('^\\d{1,2}:[0-5][0-9]$');
-            return pattern.test(time_limit) && time_limit !== "00:00";
+            return pattern.test(time_limit) && time_limit !== '00:00';
         },
-        getExamTimeLimit: function () {
+        getExamTimeLimit: function() {
             return this.$('.field-time-limit input').val();
         },
-        convertTimeLimitMinutesToString: function (timeLimitMinutes) {
-            var hoursStr = "" + Math.floor(timeLimitMinutes / 60);
-            var actualMinutesStr = "" + (timeLimitMinutes % 60);
-            hoursStr = "00".substring(0, 2 - hoursStr.length) + hoursStr;
-            actualMinutesStr = "00".substring(0, 2 - actualMinutesStr.length) + actualMinutesStr;
-            return hoursStr + ":" + actualMinutesStr;
+        convertTimeLimitMinutesToString: function(timeLimitMinutes) {
+            var hoursStr = '' + Math.floor(timeLimitMinutes / 60);
+            var actualMinutesStr = '' + (timeLimitMinutes % 60);
+            hoursStr = '00'.substring(0, 2 - hoursStr.length) + hoursStr;
+            actualMinutesStr = '00'.substring(0, 2 - actualMinutesStr.length) + actualMinutesStr;
+            return hoursStr + ':' + actualMinutesStr;
         },
-        convertTimeLimitToMinutes: function (time_limit) {
+        convertTimeLimitToMinutes: function(time_limit) {
             var time = time_limit.split(':');
             var total_time = (parseInt(time[0]) * 60) + parseInt(time[1]);
             return total_time;
         },
-        getRequestData: function () {
+        getRequestData: function() {
             var is_time_limited;
             var is_practice_exam;
             var is_proctored_exam;
             var time_limit = this.getExamTimeLimit();
             var exam_review_rules = this.$('.field-exam-review-rules textarea').val();
 
-            if (this.$('input.no_special_exam').is(':checked')){
+            if (this.$('input.no_special_exam').is(':checked')) {
                 is_time_limited = false;
                 is_practice_exam = false;
                 is_proctored_exam = false;
-            } else if (this.$('input.timed_exam').is(':checked')){
+            } else if (this.$('input.timed_exam').is(':checked')) {
                 is_time_limited = true;
                 is_practice_exam = false;
                 is_proctored_exam = false;
-            } else if (this.$('input.proctored_exam').is(':checked')){
+            } else if (this.$('input.proctored_exam').is(':checked')) {
                 is_time_limited = true;
                 is_practice_exam = false;
                 is_proctored_exam = true;
-            } else if (this.$('input.practice_exam').is(':checked')){
+            } else if (this.$('input.practice_exam').is(':checked')) {
                 is_time_limited = true;
                 is_practice_exam = true;
                 is_proctored_exam = true;
@@ -488,11 +488,11 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
     AccessEditor = AbstractEditor.extend({
         templateName: 'access-editor',
         className: 'edit-settings-access',
-        events : {
+        events: {
             'change #prereq': 'handlePrereqSelect',
             'keyup #prereq_min_score': 'validateMinScore'
         },
-        afterRender: function () {
+        afterRender: function() {
             AbstractEditor.prototype.afterRender.call(this);
             var prereq = this.model.get('prereq') || '';
             var prereq_min_score = this.model.get('prereq_min_score') || '';
@@ -501,11 +501,11 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             this.$('#prereq_min_score').val(prereq_min_score);
             this.$('#prereq_min_score_input').toggle(prereq.length > 0);
         },
-        handlePrereqSelect: function () {
+        handlePrereqSelect: function() {
             var showPrereqInput = this.$('#prereq option:selected').val().length > 0;
             this.$('#prereq_min_score_input').toggle(showPrereqInput);
         },
-        validateMinScore: function () {
+        validateMinScore: function() {
             var minScore = this.$('#prereq_min_score').val().trim();
             var minScoreInt = parseInt(minScore);
             // minScore needs to be an integer between 0 and 100
@@ -525,7 +525,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 BaseModal.prototype.enableActionButton.call(this.parent, 'save');
             }
         },
-        getRequestData: function () {
+        getRequestData: function() {
             var minScore = this.$('#prereq_min_score').val();
             if (minScore) {
                 minScore = minScore.trim();
@@ -537,31 +537,31 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             };
         }
     });
-    
+
     GradingEditor = AbstractEditor.extend({
         templateName: 'grading-editor',
         className: 'edit-settings-grading',
 
-        afterRender: function () {
+        afterRender: function() {
             AbstractEditor.prototype.afterRender.call(this);
             this.setValue(this.model.get('format') || 'notgraded');
         },
 
-        setValue: function (value) {
+        setValue: function(value) {
             this.$('#grading_type').val(value);
         },
 
-        getValue: function () {
+        getValue: function() {
             return this.$('#grading_type').val();
         },
 
-        getRequestData: function () {
+        getRequestData: function() {
             return {
                 'graderType': this.getValue()
             };
         },
 
-        getContext: function () {
+        getContext: function() {
             return {
                 graderTypes: this.model.get('course_graders')
             };
@@ -571,7 +571,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
     PublishEditor = AbstractEditor.extend({
         templateName: 'publish-editor',
         className: 'edit-settings-publish',
-        getRequestData: function () {
+        getRequestData: function() {
             return {
                 publish: 'make_public'
             };
@@ -579,7 +579,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
     });
 
     AbstractVisibilityEditor = AbstractEditor.extend({
-        afterRender: function () {
+        afterRender: function() {
             AbstractEditor.prototype.afterRender.call(this);
         },
 
@@ -591,7 +591,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             return this.model.get('ancestor_has_staff_lock');
         },
 
-        getContext: function () {
+        getContext: function() {
             return {
                 hasExplicitStaffLock: this.isModelLocked(),
                 ancestorLocked: this.isAncestorLocked()
@@ -602,7 +602,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
     StaffLockEditor = AbstractVisibilityEditor.extend({
         templateName: 'staff-lock-editor',
         className: 'edit-staff-lock',
-        afterRender: function () {
+        afterRender: function() {
             AbstractVisibilityEditor.prototype.afterRender.call(this);
             this.setLock(this.isModelLocked());
         },
@@ -630,7 +630,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             } else {
                 return {};
             }
-        },
+        }
     });
 
     ContentVisibilityEditor = AbstractVisibilityEditor.extend({
@@ -650,14 +650,14 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             }
         },
 
-        afterRender: function () {
+        afterRender: function() {
             AbstractVisibilityEditor.prototype.afterRender.call(this);
             this.setVisibility(this.modelVisibility());
             this.$('input[name=content-visibility]:checked').change();
         },
 
         setVisibility: function(value) {
-            this.$('input[name=content-visibility][value='+value+']').prop('checked', true);
+            this.$('input[name=content-visibility][value=' + value + ']').prop('checked', true);
         },
 
         currentVisibility: function() {
@@ -708,11 +708,11 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             }
         },
 
-        getContext: function () {
+        getContext: function() {
             return $.extend(
                 {},
                 AbstractVisibilityEditor.prototype.getContext.call(this),
-                { hide_after_due: this.modelVisibility() === 'hide_after_due'}
+                {hide_after_due: this.modelVisibility() === 'hide_after_due'}
             );
         }
     });
@@ -726,11 +726,11 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         ALLOW_GROUP_ID: 1,
 
         getSelectedPartition: function() {
-            var hasRestrictions = $("#verification-access-checkbox").is(":checked"),
+            var hasRestrictions = $('#verification-access-checkbox').is(':checked'),
                 selectedPartitionID = null;
 
             if (hasRestrictions) {
-                selectedPartitionID = $("#verification-partition-select").val();
+                selectedPartitionID = $('#verification-partition-select').val();
             }
 
             return parseInt(selectedPartitionID, 10);
@@ -765,7 +765,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             // Otherwise, all groups in the partition have access.
             //
             _.each(userPartitions, function(partition) {
-                if (partition.scheme === "verification") {
+                if (partition.scheme === 'verification') {
                     if (selectedPartition === partition.id) {
                         groupAccess[partition.id] = [that.ALLOW_GROUP_ID];
                     } else {
@@ -784,13 +784,13 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             return hasChanges ? {
                 publish: 'republish',
                 metadata: {
-                    group_access: groupAccess,
+                    group_access: groupAccess
                 }
             } : {};
         },
 
         getContext: function() {
-            var partitions = this.model.get("user_partitions"),
+            var partitions = this.model.get('user_partitions'),
                 hasRestrictions = false,
                 verificationPartitions = [],
                 isSelected = false;
@@ -801,27 +801,27 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             // To avoid searching all the groups, we're assuming that the editor
             // either sets the ALLOW group or doesn't set any groups (implicitly allow all).
             _.each(partitions, function(item) {
-                if (item.scheme === "verification") {
-                    isSelected = _.any(_.pluck(item.groups, "selected"));
+                if (item.scheme === 'verification') {
+                    isSelected = _.any(_.pluck(item.groups, 'selected'));
                     hasRestrictions = hasRestrictions || isSelected;
 
                     verificationPartitions.push({
-                        "id": item.id,
-                        "name": item.name,
-                        "selected": isSelected,
+                        'id': item.id,
+                        'name': item.name,
+                        'selected': isSelected
                     });
                 }
             });
 
             return {
-                "hasVerificationRestrictions": hasRestrictions,
-                "verificationPartitions": verificationPartitions,
+                'hasVerificationRestrictions': hasRestrictions,
+                'verificationPartitions': verificationPartitions
             };
         }
     });
 
     return {
-        getModal: function (type, xblockInfo, options) {
+        getModal: function(type, xblockInfo, options) {
             if (type === 'edit') {
                 return this.getEditModal(xblockInfo, options);
             } else if (type === 'publish') {
@@ -829,8 +829,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             }
         },
 
-        getEditModal: function (xblockInfo, options) {
-
+        getEditModal: function(xblockInfo, options) {
             var tabs = [];
             var editors = [];
             if (xblockInfo.isVertical()) {
@@ -872,7 +871,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             /* globals course */
             if (course.get('self_paced')) {
                 editors = _.without(editors, ReleaseDateEditor, DueDateEditor);
-                _.each(tabs, function (tab) {
+                _.each(tabs, function(tab) {
                     tab.editors = _.without(tab.editors, ReleaseDateEditor, DueDateEditor);
                 });
             }
@@ -884,7 +883,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             }, options));
         },
 
-        getPublishModal: function (xblockInfo, options) {
+        getPublishModal: function(xblockInfo, options) {
             return new PublishXBlockModal($.extend({
                 editors: [PublishEditor],
                 model: xblockInfo

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -3,15 +3,15 @@
  * It is invoked using the edit method which is passed an existing rendered xblock,
  * and upon save an optional refresh function can be invoked to update the display.
  */
-define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "common/js/components/utils/view_utils",
-    "js/models/xblock_info", "js/views/xblock_editor"],
+define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'common/js/components/utils/view_utils',
+    'js/models/xblock_info', 'js/views/xblock_editor'],
     function($, _, gettext, BaseModal, ViewUtils, XBlockInfo, XBlockEditorView) {
-        "strict mode";
+        'strict mode';
 
         var EditXBlockModal = BaseModal.extend({
             events: _.extend({}, BaseModal.prototype.events, {
-                "click .action-save": "save",
-                "click .action-modes a": "changeMode"
+                'click .action-save': 'save',
+                'click .action-modes a': 'changeMode'
             }),
 
             options: $.extend({}, BaseModal.prototype.options, {
@@ -20,7 +20,7 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "common
                 view: 'studio_view',
                 viewSpecificClasses: 'modal-editor confirm',
                 // Translators: "title" is the name of the current component being edited.
-                titleFormat: gettext("Editing: %(title)s")
+                titleFormat: gettext('Editing: %(title)s')
             }),
 
             initialize: function() {
@@ -121,7 +121,7 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "common
                 if (!displayName) {
                     displayName = gettext('Component');
                 }
-                return interpolate(this.options.titleFormat, { title: displayName }, true);
+                return interpolate(this.options.titleFormat, {title: displayName}, true);
             },
 
             addDefaultModes: function() {

--- a/cms/static/js/views/modals/validation_error_modal.js
+++ b/cms/static/js/views/modals/validation_error_modal.js
@@ -32,31 +32,29 @@ define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal'],
                 this.response = json_object;
             },
 
-            /* Create the content HTML for this modal by passing necessary 
+            /* Create the content HTML for this modal by passing necessary
              * parameters to template (validation-error-modal) */
             getContentHtml: function() {
-
                 return this.template({
                     response: this.response,
                     num_errors: this.response.length
                 });
             },
 
-            /* Receive calback function from the view, so that it can be 
+            /* Receive calback function from the view, so that it can be
              * invoked when the user clicks the reset button */
             setResetCallback: function(reset_callback) {
                 this.reset_callback = reset_callback;
             },
 
-            /* Upon receiving a user's clicking event on the reset button, 
+            /* Upon receiving a user's clicking event on the reset button,
              * resets all setting changes, and hide the modal */
             resetAction: function() {
-
                 // reset page content
                 this.reset_callback();
 
                 // hide the modal
-                BaseModal.prototype.hide.call(this); 
+                BaseModal.prototype.hide.call(this);
             }
         });
 

--- a/cms/static/js/views/module_edit.js
+++ b/cms/static/js/views/module_edit.js
@@ -21,91 +21,88 @@
     define(['jquery', 'underscore', 'gettext', 'xblock/runtime.v1', 'js/views/xblock', 'js/views/modals/edit_xblock'],
         function($, _, gettext, XBlock, XBlockView, EditXBlockModal) {
             var ModuleEdit = (function(_super) {
+                __extends(ModuleEdit, _super);
 
-            __extends(ModuleEdit, _super);
-
-            function ModuleEdit() {
-                return ModuleEdit.__super__.constructor.apply(this, arguments);
-            }
-
-            ModuleEdit.prototype.tagName = 'li';
-
-            ModuleEdit.prototype.className = 'component';
-
-            ModuleEdit.prototype.editorMode = 'editor-mode';
-
-            ModuleEdit.prototype.events = {
-                'click .edit-button': 'clickEditButton',
-                'click .delete-button': 'onDelete'
-            };
-
-            ModuleEdit.prototype.initialize = function() {
-                this.onDelete = this.options.onDelete;
-                return this.render();
-            };
-
-            ModuleEdit.prototype.loadDisplay = function() {
-                var xblockElement;
-                xblockElement = this.$el.find('.xblock-student_view');
-                if (xblockElement.length > 0) {
-                    return XBlock.initializeBlock(xblockElement);
+                function ModuleEdit() {
+                    return ModuleEdit.__super__.constructor.apply(this, arguments);
                 }
-            };
 
-            ModuleEdit.prototype.createItem = function(parent, payload, callback) {
-                var _this = this;
-                if (_.isNull(callback)) {
-                    callback = function() {};
-                }
-                payload.parent_locator = parent;
-                return $.postJSON(this.model.urlRoot + '/', payload, function(data) {
-                    _this.model.set({
-                        id: data.locator
+                ModuleEdit.prototype.tagName = 'li';
+
+                ModuleEdit.prototype.className = 'component';
+
+                ModuleEdit.prototype.editorMode = 'editor-mode';
+
+                ModuleEdit.prototype.events = {
+                    'click .edit-button': 'clickEditButton',
+                    'click .delete-button': 'onDelete'
+                };
+
+                ModuleEdit.prototype.initialize = function() {
+                    this.onDelete = this.options.onDelete;
+                    return this.render();
+                };
+
+                ModuleEdit.prototype.loadDisplay = function() {
+                    var xblockElement;
+                    xblockElement = this.$el.find('.xblock-student_view');
+                    if (xblockElement.length > 0) {
+                        return XBlock.initializeBlock(xblockElement);
+                    }
+                };
+
+                ModuleEdit.prototype.createItem = function(parent, payload, callback) {
+                    var _this = this;
+                    if (_.isNull(callback)) {
+                        callback = function() {};
+                    }
+                    payload.parent_locator = parent;
+                    return $.postJSON(this.model.urlRoot + '/', payload, function(data) {
+                        _this.model.set({
+                            id: data.locator
+                        });
+                        _this.$el.data('locator', data.locator);
+                        _this.$el.data('courseKey', data.courseKey);
+                        return _this.render();
+                    }).success(callback);
+                };
+
+                ModuleEdit.prototype.loadView = function(viewName, target, callback) {
+                    var _this = this;
+                    if (this.model.id) {
+                        return $.ajax({
+                            url: '' + (decodeURIComponent(this.model.url())) + '/' + viewName,
+                            type: 'GET',
+                            cache: false,
+                            headers: {
+                                Accept: 'application/json'
+                            },
+                            success: function(fragment) {
+                                return _this.renderXBlockFragment(fragment, target).done(callback);
+                            }
+                        });
+                    }
+                };
+
+                ModuleEdit.prototype.render = function() {
+                    var _this = this;
+                    return this.loadView('student_view', this.$el, function() {
+                        _this.loadDisplay();
+                        return _this.delegateEvents();
                     });
-                    _this.$el.data('locator', data.locator);
-                    _this.$el.data('courseKey', data.courseKey);
-                    return _this.render();
-                }).success(callback);
-            };
+                };
 
-            ModuleEdit.prototype.loadView = function(viewName, target, callback) {
-                var _this = this;
-                if (this.model.id) {
-                    return $.ajax({
-                        url: '' + (decodeURIComponent(this.model.url())) + '/' + viewName,
-                        type: 'GET',
-                        cache: false,
-                        headers: {
-                            Accept: 'application/json'
-                        },
-                        success: function(fragment) {
-                            return _this.renderXBlockFragment(fragment, target).done(callback);
-                        }
+                ModuleEdit.prototype.clickEditButton = function(event) {
+                    var modal;
+                    event.preventDefault();
+                    modal = new EditXBlockModal();
+                    return modal.edit(this.$el, this.model, {
+                        refresh: _.bind(this.render, this)
                     });
-                }
-            };
+                };
 
-            ModuleEdit.prototype.render = function() {
-                var _this = this;
-                return this.loadView('student_view', this.$el, function() {
-                    _this.loadDisplay();
-                    return _this.delegateEvents();
-                });
-            };
-
-            ModuleEdit.prototype.clickEditButton = function(event) {
-                var modal;
-                event.preventDefault();
-                modal = new EditXBlockModal();
-                return modal.edit(this.$el, this.model, {
-                    refresh: _.bind(this.render, this)
-                });
-            };
-
+                return ModuleEdit;
+            })(XBlockView);
             return ModuleEdit;
-
-        })(XBlockView);
-        return ModuleEdit;
-    });
-
+        });
 }).call(this);

--- a/cms/static/js/views/paged_container.js
+++ b/cms/static/js/views/paged_container.js
@@ -1,6 +1,6 @@
-define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/views/container", "js/utils/module", "gettext",
-        "common/js/components/views/feedback_notification", "js/views/paging_header", "common/js/components/views/paging_footer"],
-    function ($, _, ViewUtils, ContainerView, ModuleUtils, gettext, NotificationView, PagingHeader, PagingFooter) {
+define(['jquery', 'underscore', 'common/js/components/utils/view_utils', 'js/views/container', 'js/utils/module', 'gettext',
+        'common/js/components/views/feedback_notification', 'js/views/paging_header', 'common/js/components/views/paging_footer'],
+    function($, _, ViewUtils, ContainerView, ModuleUtils, gettext, NotificationView, PagingHeader, PagingFooter) {
         var PagedContainerView = ContainerView.extend({
 
             initialize: function(options) {
@@ -17,7 +17,7 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                     currentPage: 0,
                     totalPages: 0,
                     totalCount: 0,
-                    sortDirection: "desc",
+                    sortDirection: 'desc',
                     start: 0,
                     _size: 0,
                     // Paging header and footer expect this to be a Backbone model they can listen to for changes, but
@@ -31,11 +31,11 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
 
                     // PagingFooter expects to be able to control paging through the collection instead of the view,
                     // so we just make these functions act as pass-throughs
-                    setPage: function (page) {
+                    setPage: function(page) {
                         self.setPage(page - 1);
                     },
 
-                    nextPage: function () {
+                    nextPage: function() {
                         self.nextPage();
                     },
 
@@ -43,31 +43,31 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                         self.previousPage();
                     },
 
-                    getPage: function () {
+                    getPage: function() {
                         return self.collection.currentPage + 1;
                     },
 
-                    hasPreviousPage: function () {
+                    hasPreviousPage: function() {
                         return self.collection.currentPage > 0;
                     },
 
-                    hasNextPage: function () {
+                    hasNextPage: function() {
                         return self.collection.currentPage < self.collection.totalPages - 1;
                     },
 
-                    getTotalPages: function () {
+                    getTotalPages: function() {
                         return this.totalPages;
                     },
 
-                    getPageNumber: function () {
+                    getPageNumber: function() {
                         return this.getPage();
                     },
 
-                    getTotalRecords: function () {
+                    getTotalRecords: function() {
                         return this.totalCount;
                     },
 
-                    getPageSize: function () {
+                    getPageSize: function() {
                         return self.page_size;
                     }
                 };
@@ -77,7 +77,7 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
 
             render: function(options) {
                 options = options || {};
-                options.page_number = typeof options.page_number !== "undefined"
+                options.page_number = typeof options.page_number !== 'undefined'
                     ? options.page_number
                     : this.collection.currentPage;
                 return this.renderPage(options);
@@ -90,14 +90,14 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                     xblockUrl = xblockInfo.url();
 
                 return $.ajax({
-                    url: decodeURIComponent(xblockUrl) + "/" + view,
+                    url: decodeURIComponent(xblockUrl) + '/' + view,
                     type: 'GET',
                     cache: false,
                     data: this.getRenderParameters(options.page_number, options.force_render),
-                    headers: { Accept: 'application/json' },
+                    headers: {Accept: 'application/json'},
                     success: function(fragment) {
                         self.handleXBlockFragment(fragment, options);
-                        self.processPaging({ requested_page: options.page_number });
+                        self.processPaging({requested_page: options.page_number});
                         self.page.updatePreviewButton(self.collection.showChildrenPreviews);
                         self.page.renderAddXBlockComponents();
                         if (options.force_render) {
@@ -149,7 +149,7 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                 }
             },
 
-            processPaging: function(options){
+            processPaging: function(options) {
                 // We have the Django template sneak us the pagination information,
                 // and we load it from a div here.
                 var $element = this.$el.find('.xblock-container-paging-parameters'),
@@ -168,7 +168,7 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                 this.processPagingHeaderAndFooter();
             },
 
-            processPagingHeaderAndFooter: function(){
+            processPagingHeaderAndFooter: function() {
                 // Rendering the container view detaches the header and footer from the DOM.
                 // It's just as easy to recreate them as it is to try to shove them back into the tree.
                 if (this.pagingHeader)
@@ -191,24 +191,24 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
 
             refresh: function(xblockView, block_added, is_duplicate) {
                 if (!block_added) {
-                    return
+                    return;
                 }
                 if (is_duplicate) {
                     // Duplicated blocks can be inserted onto the current page.
-                    var xblock = xblockView.xblock.element.parents(".studio-xblock-wrapper").first();
-                    var all_xblocks = xblock.parent().children(".studio-xblock-wrapper");
+                    var xblock = xblockView.xblock.element.parents('.studio-xblock-wrapper').first();
+                    var all_xblocks = xblock.parent().children('.studio-xblock-wrapper');
                     var index = all_xblocks.index(xblock);
                     if ((index + 1 <= this.page_size) && (all_xblocks.length > this.page_size)) {
                         // Pop the last XBlock off the bottom.
                         all_xblocks[all_xblocks.length - 1].remove();
-                        return
+                        return;
                     }
                 }
                 this.collection.totalCount += 1;
-                this.collection._size +=1;
+                this.collection._size += 1;
                 if (this.collection.totalCount == 1) {
                     this.render();
-                    return
+                    return;
                 }
                 this.collection.totalPages = this.getPageCount(this.collection.totalCount);
                 var target_page = this.collection.totalPages - 1;
@@ -223,14 +223,13 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                         target_page,
                         {force_render: force_render}
                     );
-
                 } else {
                     this.pagingHeader.render();
                     this.pagingFooter.render();
                 }
             },
 
-            acknowledgeXBlockDeletion: function (locator){
+            acknowledgeXBlockDeletion: function(locator) {
                 this.notifyRuntime('deleted-child', locator);
                 this.collection._size -= 1;
                 this.collection.totalCount -= 1;
@@ -241,10 +240,10 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                 if ((current_page + 1) > total_pages) {
                     // The number of total pages has changed. Move down.
                     // Also, be mindful of the off-by-one.
-                    this.setPage(total_pages - 1)
+                    this.setPage(total_pages - 1);
                 } else if ((current_page + 1) != total_pages) {
                     // Refresh page to get any blocks shifted from the next page.
-                    this.setPage(current_page)
+                    this.setPage(current_page);
                 } else {
                     // We're on the last page, just need to update the numbers in the
                     // pagination interface.
@@ -254,17 +253,17 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
             },
 
             sortDisplayName: function() {
-                return gettext("Date added");  // TODO add support for sorting
+                return gettext('Date added');  // TODO add support for sorting
             },
 
-            togglePreviews: function(){
+            togglePreviews: function() {
                 var self = this,
                     xblockUrl = this.model.url();
                 return $.ajax({
                     // No runtime, so can't get this via the handler() call.
-                    url: '/preview' + decodeURIComponent(xblockUrl) + "/handler/trigger_previews",
+                    url: '/preview' + decodeURIComponent(xblockUrl) + '/handler/trigger_previews',
                     type: 'POST',
-                    data: JSON.stringify({ showChildrenPreviews: !this.collection.showChildrenPreviews}),
+                    data: JSON.stringify({showChildrenPreviews: !this.collection.showChildrenPreviews}),
                     dataType: 'json'
                 })
                 .then(self.render).promise();

--- a/cms/static/js/views/pages/base_page.js
+++ b/cms/static/js/views/pages/base_page.js
@@ -2,7 +2,7 @@
  * This is the base view that all Studio pages extend from.
  */
 define(['jquery', 'js/views/baseview'],
-    function ($, BaseView) {
+    function($, BaseView) {
         var BasePage = BaseView.extend({
 
             initialize: function() {

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -2,11 +2,11 @@
  * XBlockContainerPage is used to display Studio's container page for an xblock which has children.
  * This page allows the user to understand and manipulate the xblock and its children.
  */
-define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "common/js/components/utils/view_utils",
-        "js/views/container", "js/views/xblock", "js/views/components/add_xblock", "js/views/modals/edit_xblock",
-        "js/models/xblock_info", "js/views/xblock_string_field_editor", "js/views/pages/container_subviews",
-        "js/views/unit_outline", "js/views/utils/xblock_utils"],
-    function ($, _, gettext, BasePage, ViewUtils, ContainerView, XBlockView, AddXBlockComponent,
+define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'common/js/components/utils/view_utils',
+        'js/views/container', 'js/views/xblock', 'js/views/components/add_xblock', 'js/views/modals/edit_xblock',
+        'js/models/xblock_info', 'js/views/xblock_string_field_editor', 'js/views/pages/container_subviews',
+        'js/views/unit_outline', 'js/views/utils/xblock_utils'],
+    function($, _, gettext, BasePage, ViewUtils, ContainerView, XBlockView, AddXBlockComponent,
               EditXBlockModal, XBlockInfo, XBlockStringFieldEditor, ContainerSubviews, UnitOutlineView,
               XBlockUtils) {
         'use strict';
@@ -14,11 +14,11 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "common/j
             // takes XBlockInfo as a model
 
             events: {
-                "click .edit-button": "editXBlock",
-                "click .visibility-button": "editVisibilitySettings",
-                "click .duplicate-button": "duplicateXBlock",
-                "click .delete-button": "deleteXBlock",
-                "click .new-component-button": "scrollToNewComponentButtons"
+                'click .edit-button': 'editXBlock',
+                'click .visibility-button': 'editVisibilitySettings',
+                'click .duplicate-button': 'duplicateXBlock',
+                'click .delete-button': 'deleteXBlock',
+                'click .new-component-button': 'scrollToNewComponentButtons'
             },
 
             options: {
@@ -82,15 +82,15 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "common/j
                 }
             },
 
-            getViewParameters: function () {
+            getViewParameters: function() {
                 return {
                     el: this.$('.wrapper-xblock'),
                     model: this.model,
                     view: this.view
-                }
+                };
             },
 
-            getXBlockView: function(){
+            getXBlockView: function() {
                 return new this.viewClass(this.getViewParameters());
             },
 
@@ -99,7 +99,7 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "common/j
                     xblockView = this.xblockView,
                     loadingElement = this.$('.ui-loading'),
                     unitLocationTree = this.$('.unit-location'),
-                    hiddenCss='is-hidden';
+                    hiddenCss = 'is-hidden';
 
                 loadingElement.removeClass(hiddenCss);
 
@@ -180,7 +180,7 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "common/j
                 this.editXBlock(event, {
                     view: 'visibility_view',
                     // Translators: "title" is the name of the current component being edited.
-                    titleFormat: gettext("Editing visibility for: %(title)s"),
+                    titleFormat: gettext('Editing visibility for: %(title)s'),
                     viewSpecificClasses: '',
                     modalSize: 'med'
                 });
@@ -197,7 +197,7 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "common/j
             },
 
             createPlaceholderElement: function() {
-                return $("<div/>", { class: "studio-xblock-wrapper" });
+                return $('<div/>', {class: 'studio-xblock-wrapper'});
             },
 
             createComponent: function(template, target) {

--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -1,11 +1,11 @@
 /**
  * Subviews (usually small side panels) for XBlockContainerPage.
  */
-define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/components/utils/view_utils",
-    "js/views/utils/xblock_utils"],
-    function ($, _, gettext, BaseView, ViewUtils, XBlockViewUtils) {
+define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/components/utils/view_utils',
+    'js/views/utils/xblock_utils'],
+    function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils) {
         var VisibilityState = XBlockViewUtils.VisibilityState,
-            disabledCss = "is-disabled";
+            disabledCss = 'is-disabled';
 
         /**
          * A view that refreshes the view when certain values in the XBlockInfo have changed
@@ -20,7 +20,7 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
 
             onSync: function(model) {
                 if (this.shouldRefresh(model)) {
-                   this.render();
+                    this.render();
                 }
             },
 
@@ -32,7 +32,7 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
         });
 
         var MessageView = ContainerStateListenerView.extend({
-            initialize: function () {
+            initialize: function() {
                 ContainerStateListenerView.prototype.initialize.call(this);
                 this.template = this.loadTemplate('container-message');
             },
@@ -84,7 +84,7 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
 
             // takes XBlockInfo as a model
 
-            initialize: function () {
+            initialize: function() {
                 BaseView.prototype.initialize.call(this);
                 this.template = this.loadTemplate('publish-xblock');
                 this.model.on('sync', this.onSync, this);
@@ -96,11 +96,11 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
                     'has_changes', 'published', 'edited_on', 'edited_by', 'visibility_state',
                     'has_explicit_staff_lock', 'has_content_group_components'
                 ])) {
-                   this.render();
+                    this.render();
                 }
             },
 
-            render: function () {
+            render: function() {
                 this.$el.html(this.template({
                     visibilityState: this.model.get('visibility_state'),
                     visibilityClass: XBlockViewUtils.getXBlockVisibilityClass(this.model.get('visibility_state')),
@@ -116,50 +116,50 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
                     hasExplicitStaffLock: this.model.get('has_explicit_staff_lock'),
                     staffLockFrom: this.model.get('staff_lock_from'),
                     hasContentGroupComponents: this.model.get('has_content_group_components'),
-                    course: window.course,
+                    course: window.course
                 }));
 
                 return this;
             },
 
-            publish: function (e) {
+            publish: function(e) {
                 var xblockInfo = this.model;
                 if (e && e.preventDefault) {
                     e.preventDefault();
                 }
                 ViewUtils.runOperationShowingMessage(gettext('Publishing'),
-                    function () {
+                    function() {
                         return xblockInfo.save({publish: 'make_public'}, {patch: true});
                     }).always(function() {
-                        xblockInfo.set("publish", null);
-                    }).done(function () {
+                        xblockInfo.set('publish', null);
+                    }).done(function() {
                         xblockInfo.fetch();
                     });
             },
 
-            discardChanges: function (e) {
+            discardChanges: function(e) {
                 var xblockInfo = this.model, renderPage = this.renderPage;
                 if (e && e.preventDefault) {
                     e.preventDefault();
                 }
-                ViewUtils.confirmThenRunOperation(gettext("Discard Changes"),
-                    gettext("Are you sure you want to revert to the last published version of the unit? You cannot undo this action."),
-                    gettext("Discard Changes"),
-                    function () {
+                ViewUtils.confirmThenRunOperation(gettext('Discard Changes'),
+                    gettext('Are you sure you want to revert to the last published version of the unit? You cannot undo this action.'),
+                    gettext('Discard Changes'),
+                    function() {
                         ViewUtils.runOperationShowingMessage(gettext('Discarding Changes'),
-                            function () {
+                            function() {
                                 return xblockInfo.save({publish: 'discard_changes'}, {patch: true});
                             }).always(function() {
-                                xblockInfo.set("publish", null);
-                            }).done(function () {
+                                xblockInfo.set('publish', null);
+                            }).done(function() {
                                 renderPage();
                             });
                     }
                 );
             },
 
-            toggleStaffLock: function (e) {
-                var xblockInfo = this.model, self=this, enableStaffLock, hasInheritedStaffLock,
+            toggleStaffLock: function(e) {
+                var xblockInfo = this.model, self = this, enableStaffLock, hasInheritedStaffLock,
                     saveAndPublishStaffLock, revertCheckBox;
                 if (e && e.preventDefault) {
                     e.preventDefault();
@@ -179,8 +179,8 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
                         metadata: {visible_to_staff_only: enableStaffLock ? true : null}},
                         {patch: true}
                     ).always(function() {
-                        xblockInfo.set("publish", null);
-                    }).done(function () {
+                        xblockInfo.set('publish', null);
+                    }).done(function() {
                         xblockInfo.fetch();
                     }).fail(function() {
                         revertCheckBox();
@@ -198,9 +198,9 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
                     ViewUtils.runOperationShowingMessage(gettext('Inheriting Student Visibility'),
                         _.bind(saveAndPublishStaffLock, self));
                 } else {
-                    ViewUtils.confirmThenRunOperation(gettext("Make Visible to Students"),
-                        gettext("If the unit was previously published and released to students, any changes you made to the unit when it was hidden will now be visible to students. Do you want to proceed?"),
-                        gettext("Make Visible to Students"),
+                    ViewUtils.confirmThenRunOperation(gettext('Make Visible to Students'),
+                        gettext('If the unit was previously published and released to students, any changes you made to the unit when it was hidden will now be visible to students. Do you want to proceed?'),
+                        gettext('Make Visible to Students'),
                         function() {
                             ViewUtils.runOperationShowingMessage(gettext('Making Visible to Students'),
                                 _.bind(saveAndPublishStaffLock, self));
@@ -225,7 +225,7 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
         var PublishHistory = BaseView.extend({
             // takes XBlockInfo as a model
 
-            initialize: function () {
+            initialize: function() {
                 BaseView.prototype.initialize.call(this);
                 this.template = this.loadTemplate('publish-history');
                 this.model.on('sync', this.onSync, this);
@@ -233,11 +233,11 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
 
             onSync: function(model) {
                 if (ViewUtils.hasChangedAttributes(model, ['published', 'published_on', 'published_by'])) {
-                   this.render();
+                    this.render();
                 }
             },
 
-            render: function () {
+            render: function() {
                 this.$el.html(this.template({
                     published: this.model.get('published'),
                     published_on: this.model.get('published_on'),

--- a/cms/static/js/views/pages/course_outline.js
+++ b/cms/static/js/views/pages/course_outline.js
@@ -1,17 +1,17 @@
 /**
  * This page is used to show the user an outline of the course.
  */
-define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views/utils/xblock_utils",
-        "js/views/course_outline", "common/js/components/utils/view_utils", "common/js/components/views/feedback_alert",
-        "common/js/components/views/feedback_notification"],
-    function ($, _, gettext, BasePage, XBlockViewUtils, CourseOutlineView, ViewUtils, AlertView, NoteView) {
+define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'js/views/utils/xblock_utils',
+        'js/views/course_outline', 'common/js/components/utils/view_utils', 'common/js/components/views/feedback_alert',
+        'common/js/components/views/feedback_notification'],
+    function($, _, gettext, BasePage, XBlockViewUtils, CourseOutlineView, ViewUtils, AlertView, NoteView) {
         var expandedLocators, CourseOutlinePage;
 
         CourseOutlinePage = BasePage.extend({
             // takes XBlockInfo as a model
 
             events: {
-                "click .button-toggle-expand-collapse": "toggleExpandCollapse"
+                'click .button-toggle-expand-collapse': 'toggleExpandCollapse'
             },
 
             options: {
@@ -29,7 +29,7 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
                     self.handleReIndexEvent(event);
                 });
                 this.model.on('change', this.setCollapseExpandVisibility, this);
-                $('.dismiss-button').bind('click', ViewUtils.deleteNotificationHandler(function () {
+                $('.dismiss-button').bind('click', ViewUtils.deleteNotificationHandler(function() {
                     $('.wrapper-alert-announcement').removeClass('is-shown').addClass('is-hidden');
                 }));
             },
@@ -45,7 +45,7 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
             },
 
             renderPage: function() {
-                var setInitialExpandState = function (xblockInfo, expandedLocators) {
+                var setInitialExpandState = function(xblockInfo, expandedLocators) {
                     if (xblockInfo.isCourse() || xblockInfo.isChapter()) {
                         expandedLocators.add(xblockInfo.get('id'));
                     }
@@ -55,8 +55,8 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
                 this.expandedLocators = expandedLocators;
                 this.expandedLocators.clear();
                 if (this.model.get('child_info')) {
-                    _.each(this.model.get('child_info').children, function (childXBlockInfo) {
-                       setInitialExpandState(childXBlockInfo, this.expandedLocators);
+                    _.each(this.model.get('child_info').children, function(childXBlockInfo) {
+                        setInitialExpandState(childXBlockInfo, this.expandedLocators);
                     }, this);
                 }
                 setInitialExpandState(this.model, this.expandedLocators);
@@ -95,7 +95,7 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
                     }
                 });
                 if (this.model.get('child_info')) {
-                    _.each(this.model.get('child_info').children, function (childXBlockInfo) {
+                    _.each(this.model.get('child_info').children, function(childXBlockInfo) {
                         if (collapse) {
                             this.expandedLocators.remove(childXBlockInfo.get('id'));
                         }
@@ -112,34 +112,34 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
                 var target = $(event.currentTarget);
                 target.css('cursor', 'wait');
                 this.startReIndex(target.attr('href'))
-                    .done(function(data) {self.onIndexSuccess(data);})
-                    .fail(function(data) {self.onIndexError(data);})
-                    .always(function() {target.css('cursor', 'pointer');});
+                    .done(function(data) { self.onIndexSuccess(data); })
+                    .fail(function(data) { self.onIndexError(data); })
+                    .always(function() { target.css('cursor', 'pointer'); });
             },
 
             startReIndex: function(reindex_url) {
                 return $.ajax({
-                        url: reindex_url,
-                        method: 'GET',
-                        global: false,
-                        contentType: "application/json; charset=utf-8",
-                        dataType: "json"
-                    });
+                    url: reindex_url,
+                    method: 'GET',
+                    global: false,
+                    contentType: 'application/json; charset=utf-8',
+                    dataType: 'json'
+                });
             },
 
             onIndexSuccess: function(data) {
                 var msg = new AlertView.Announcement({
-                        title: gettext('Course Index'),
-                        message: data.user_message
-                    });
+                    title: gettext('Course Index'),
+                    message: data.user_message
+                });
                 msg.show();
             },
 
             onIndexError: function(data) {
                 var msg = new NoteView.Error({
-                        title: gettext('There were errors reindexing course.'),
-                        message: data.user_message
-                    });
+                    title: gettext('There were errors reindexing course.'),
+                    message: data.user_message
+                });
                 msg.show();
             }
         });
@@ -153,9 +153,9 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
             /**
              * Add the locator to the set if it is not already present.
              */
-            add: function (locator) {
+            add: function(locator) {
                 if (!this.contains(locator)) {
-                   this.locators.push(locator);
+                    this.locators.push(locator);
                 }
             },
 
@@ -171,7 +171,7 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
             /**
              * Remove the locator from the set if it is present.
              */
-            remove: function (locator) {
+            remove: function(locator) {
                 var index = this.locators.indexOf(locator);
                 if (index >= 0) {
                     this.locators.splice(index, 1);
@@ -181,14 +181,14 @@ define(["jquery", "underscore", "gettext", "js/views/pages/base_page", "js/views
             /**
              * Returns true iff the locator is present in the set.
              */
-            contains: function (locator) {
+            contains: function(locator) {
                 return this.locators.indexOf(locator) >= 0;
             },
 
             /**
              * Clears all expanded locators from the set.
              */
-            clear: function () {
+            clear: function() {
                 this.locators = [];
             }
         };

--- a/cms/static/js/views/pages/group_configurations.js
+++ b/cms/static/js/views/pages/group_configurations.js
@@ -2,7 +2,7 @@ define([
     'jquery', 'underscore', 'gettext', 'js/views/pages/base_page',
     'js/views/group_configurations_list', 'js/views/content_group_list'
 ],
-function ($, _, gettext, BasePage, GroupConfigurationsListView, ContentGroupListView) {
+function($, _, gettext, BasePage, GroupConfigurationsListView, ContentGroupListView) {
     'use strict';
     var GroupConfigurationsPage = BasePage.extend({
         initialize: function(options) {
@@ -34,11 +34,11 @@ function ($, _, gettext, BasePage, GroupConfigurationsListView, ContentGroupList
             return $.Deferred().resolve().promise();
         },
 
-        addWindowActions: function () {
+        addWindowActions: function() {
             $(window).on('beforeunload', this.onBeforeUnload.bind(this));
         },
 
-        onBeforeUnload: function () {
+        onBeforeUnload: function() {
             var dirty = this.contentGroupConfiguration.isDirty() ||
                 (this.experimentsEnabled && this.experimentGroupConfigurations.find(function(configuration) {
                     return configuration.isDirty();
@@ -61,7 +61,7 @@ function ($, _, gettext, BasePage, GroupConfigurationsListView, ContentGroupList
          * Focus on and expand group configuration with peculiar id.
          * @param {String|Number} Id of the group configuration.
          */
-        expandConfiguration: function (id) {
+        expandConfiguration: function(id) {
             var groupConfig = this.experimentsEnabled && this.experimentGroupConfigurations.findWhere({
                 id: parseInt(id)
             });

--- a/cms/static/js/views/pages/paged_container.js
+++ b/cms/static/js/views/pages/paged_container.js
@@ -1,8 +1,8 @@
 /**
  * PagedXBlockContainerPage is a variant of XBlockContainerPage that supports Pagination.
  */
-define(["jquery", "underscore", "gettext", "js/views/pages/container", "js/views/paged_container"],
-    function ($, _, gettext, XBlockContainerPage, PagedContainerView) {
+define(['jquery', 'underscore', 'gettext', 'js/views/pages/container', 'js/views/paged_container'],
+    function($, _, gettext, XBlockContainerPage, PagedContainerView) {
         'use strict';
         var PagedXBlockContainerPage = XBlockContainerPage.extend({
 
@@ -13,17 +13,17 @@ define(["jquery", "underscore", "gettext", "js/views/pages/container", "js/views
             defaultViewClass: PagedContainerView,
             components_on_init: false,
 
-            initialize: function (options) {
+            initialize: function(options) {
                 this.page_size = options.page_size || 10;
                 this.showChildrenPreviews = options.showChildrenPreviews || true;
                 XBlockContainerPage.prototype.initialize.call(this, options);
             },
 
-            getViewParameters: function () {
-               return  _.extend(XBlockContainerPage.prototype.getViewParameters.call(this), {
-                   page_size: this.page_size,
-                   page: this
-               });
+            getViewParameters: function() {
+                return _.extend(XBlockContainerPage.prototype.getViewParameters.call(this), {
+                    page_size: this.page_size,
+                    page: this
+                });
             },
 
             refreshXBlock: function(element, block_added, is_duplicate) {
@@ -41,12 +41,12 @@ define(["jquery", "underscore", "gettext", "js/views/pages/container", "js/views
                 this.xblockView.togglePreviews();
             },
 
-            updatePreviewButton: function(show_previews){
+            updatePreviewButton: function(show_previews) {
                 var text = (show_previews) ? gettext('Hide Previews') : gettext('Show Previews'),
                     button = $('.nav-actions .button-toggle-preview');
 
-                this.$(".preview-text", button).text(text);
-                this.$('.toggle-preview-button').removeClass("is-hidden");
+                this.$('.preview-text', button).text(text);
+                this.$('.toggle-preview-button').removeClass('is-hidden');
             }
         });
         return PagedXBlockContainerPage;

--- a/cms/static/js/views/paging.js
+++ b/cms/static/js/views/paging.js
@@ -1,8 +1,7 @@
-;(function (define) {
+(function(define) {
     'use strict';
-    define(["underscore", "backbone", "gettext"],
+    define(['underscore', 'backbone', 'gettext'],
         function(_, Backbone, gettext) {
-
             var PagingView = Backbone.View.extend({
                 // takes a Backbone Paginator as a model
 
@@ -19,7 +18,7 @@
                     collection.bind('remove', _.bind(this.onPageRefresh, this));
                     collection.bind('reset', _.bind(this.onPageRefresh, this));
                     collection.bind('error', _.bind(this.onError, this));
-                    collection.bind('page_changed', function () { window.scrollTo(0, 0); });
+                    collection.bind('page_changed', function() { window.scrollTo(0, 0); });
                 },
 
                 onPageRefresh: function() {
@@ -33,15 +32,15 @@
                     // Do nothing by default
                 },
 
-                setPage: function (page) {
+                setPage: function(page) {
                     this.collection.setPage(page);
                 },
 
-                nextPage: function () {
+                nextPage: function() {
                     this.collection.nextPage();
                 },
 
-                previousPage: function () {
+                previousPage: function() {
                     this.collection.previousPage();
                 },
 

--- a/cms/static/js/views/paging_header.js
+++ b/cms/static/js/views/paging_header.js
@@ -6,128 +6,128 @@ define([
     'edx-ui-toolkit/js/utils/string-utils',
     'text!templates/paging-header.underscore'
 ], function(_, Backbone, gettext, HtmlUtils, StringUtils, pagingHeaderTemplate) {
-        'use strict';
-        var PagingHeader = Backbone.View.extend({
-            events : {
-                'click .next-page-link': 'nextPage',
-                'click .previous-page-link': 'previousPage'
-            },
+    'use strict';
+    var PagingHeader = Backbone.View.extend({
+        events: {
+            'click .next-page-link': 'nextPage',
+            'click .previous-page-link': 'previousPage'
+        },
 
-            initialize: function(options) {
-                var view = options.view,
-                    collection = view.collection;
-                this.view = view;
-                collection.bind('add', _.bind(this.render, this));
-                collection.bind('remove', _.bind(this.render, this));
-                collection.bind('reset', _.bind(this.render, this));
-            },
+        initialize: function(options) {
+            var view = options.view,
+                collection = view.collection;
+            this.view = view;
+            collection.bind('add', _.bind(this.render, this));
+            collection.bind('remove', _.bind(this.render, this));
+            collection.bind('reset', _.bind(this.render, this));
+        },
 
-            render: function() {
-                var view = this.view,
-                    collection = view.collection,
-                    currentPage = collection.getPageNumber(),
-                    lastPage = collection.getTotalPages(),
-                    messageHtml = this.messageHtml(),
-                    isNextDisabled = lastPage === 0 || currentPage === lastPage;
+        render: function() {
+            var view = this.view,
+                collection = view.collection,
+                currentPage = collection.getPageNumber(),
+                lastPage = collection.getTotalPages(),
+                messageHtml = this.messageHtml(),
+                isNextDisabled = lastPage === 0 || currentPage === lastPage;
 
-                HtmlUtils.setHtml(this.$el, HtmlUtils.template(pagingHeaderTemplate)({messageHtml: messageHtml}));
-                this.$('.previous-page-link')
+            HtmlUtils.setHtml(this.$el, HtmlUtils.template(pagingHeaderTemplate)({messageHtml: messageHtml}));
+            this.$('.previous-page-link')
                     .toggleClass('is-disabled', currentPage === 1)
                     .attr('aria-disabled', currentPage === 1);
-                this.$('.next-page-link')
+            this.$('.next-page-link')
                     .toggleClass('is-disabled', isNextDisabled)
                     .attr('aria-disabled', isNextDisabled);
 
-                return this;
-            },
+            return this;
+        },
 
-            messageHtml: function() {
-                var message = '',
-                    assetType = false;
+        messageHtml: function() {
+            var message = '',
+                assetType = false;
 
-                if (this.view.collection.assetType) {
-                    if (this.view.collection.sortDirection === 'asc') {
+            if (this.view.collection.assetType) {
+                if (this.view.collection.sortDirection === 'asc') {
                         // Translators: sample result:
                         // "Showing 0-9 out of 25 total, filtered by Images, sorted by Date Added ascending"
-                        message = gettext('Showing {currentItemRange} out of {totalItemsCount}, filtered by {assetType}, sorted by {sortName} ascending');  // eslint-disable-line max-len
-                    } else {
+                    message = gettext('Showing {currentItemRange} out of {totalItemsCount}, filtered by {assetType}, sorted by {sortName} ascending');  // eslint-disable-line max-len
+                } else {
                         // Translators: sample result:
                         // "Showing 0-9 out of 25 total, filtered by Images, sorted by Date Added descending"
-                        message = gettext('Showing {currentItemRange} out of {totalItemsCount}, filtered by {assetType}, sorted by {sortName} descending');  // eslint-disable-line max-len
-                    }
-                    assetType = this.filterNameLabel();
-                } else {
-                    if (this.view.collection.sortDirection === 'asc') {
+                    message = gettext('Showing {currentItemRange} out of {totalItemsCount}, filtered by {assetType}, sorted by {sortName} descending');  // eslint-disable-line max-len
+                }
+                assetType = this.filterNameLabel();
+            } else {
+                if (this.view.collection.sortDirection === 'asc') {
                         // Translators: sample result:
                         // "Showing 0-9 out of 25 total, sorted by Date Added ascending"
-                        message = gettext('Showing {currentItemRange} out of {totalItemsCount}, sorted by {sortName} ascending');  // eslint-disable-line max-len
-                    } else {
+                    message = gettext('Showing {currentItemRange} out of {totalItemsCount}, sorted by {sortName} ascending');  // eslint-disable-line max-len
+                } else {
                         // Translators: sample result:
                         // "Showing 0-9 out of 25 total, sorted by Date Added descending"
-                        message = gettext('Showing {currentItemRange} out of {totalItemsCount}, sorted by {sortName} descending');  // eslint-disable-line max-len
-                    }
+                    message = gettext('Showing {currentItemRange} out of {totalItemsCount}, sorted by {sortName} descending');  // eslint-disable-line max-len
                 }
+            }
 
-                return HtmlUtils.interpolateHtml(message, {
-                    currentItemRange: this.currentItemRangeLabel(),
-                    totalItemsCount: this.totalItemsCountLabel(),
-                    assetType: assetType,
-                    sortName: this.sortNameLabel()
-                });
-            },
+            return HtmlUtils.interpolateHtml(message, {
+                currentItemRange: this.currentItemRangeLabel(),
+                totalItemsCount: this.totalItemsCountLabel(),
+                assetType: assetType,
+                sortName: this.sortNameLabel()
+            });
+        },
 
-            currentItemRangeLabel: function() {
-                var view = this.view,
-                    collection = view.collection,
-                    start = (collection.getPageNumber() - 1) * collection.getPageSize(),
-                    count = collection.size(),
-                    end = start + count,
-                    htmlMessage = HtmlUtils.HTML('<span class="count-current-shown">{start}-{end}</span>');
+        currentItemRangeLabel: function() {
+            var view = this.view,
+                collection = view.collection,
+                start = (collection.getPageNumber() - 1) * collection.getPageSize(),
+                count = collection.size(),
+                end = start + count,
+                htmlMessage = HtmlUtils.HTML('<span class="count-current-shown">{start}-{end}</span>');
 
-                return HtmlUtils.interpolateHtml(htmlMessage, {
-                    start: Math.min(start + 1, end),
-                    end: end
-                });
-            },
+            return HtmlUtils.interpolateHtml(htmlMessage, {
+                start: Math.min(start + 1, end),
+                end: end
+            });
+        },
 
-            totalItemsCountLabel: function() {
-                var totalItemsLabel,
-                    htmlMessage = HtmlUtils.HTML('<span class="count-total">{totalItemsLabel}</span>');
+        totalItemsCountLabel: function() {
+            var totalItemsLabel,
+                htmlMessage = HtmlUtils.HTML('<span class="count-total">{totalItemsLabel}</span>');
 
                 // Translators: turns into "25 total" to be used in other sentences, e.g. "Showing 0-9 out of 25 total".
-                totalItemsLabel = StringUtils.interpolate(gettext('{totalItems} total'), {
-                    totalItems: this.view.collection.getTotalRecords()
-                });
+            totalItemsLabel = StringUtils.interpolate(gettext('{totalItems} total'), {
+                totalItems: this.view.collection.getTotalRecords()
+            });
 
-                return HtmlUtils.interpolateHtml(htmlMessage, {
-                    totalItemsLabel: totalItemsLabel
-                });
-            },
+            return HtmlUtils.interpolateHtml(htmlMessage, {
+                totalItemsLabel: totalItemsLabel
+            });
+        },
 
-            sortNameLabel: function() {
-                var htmlMessage = HtmlUtils.HTML('<span class="sort-order">{sortName}</span>');
+        sortNameLabel: function() {
+            var htmlMessage = HtmlUtils.HTML('<span class="sort-order">{sortName}</span>');
 
-                return HtmlUtils.interpolateHtml(htmlMessage, {
-                    sortName: this.view.sortDisplayName()
-                });
-            },
+            return HtmlUtils.interpolateHtml(htmlMessage, {
+                sortName: this.view.sortDisplayName()
+            });
+        },
 
-            filterNameLabel: function() {
-                var htmlMessage = HtmlUtils.HTML('<span class="filter-column">{filterName}</span>');
+        filterNameLabel: function() {
+            var htmlMessage = HtmlUtils.HTML('<span class="filter-column">{filterName}</span>');
 
-                return HtmlUtils.interpolateHtml(htmlMessage, {
-                    filterName: this.view.filterDisplayName()
-                });
-            },
+            return HtmlUtils.interpolateHtml(htmlMessage, {
+                filterName: this.view.filterDisplayName()
+            });
+        },
 
-            nextPage: function() {
-                this.view.nextPage();
-            },
+        nextPage: function() {
+            this.view.nextPage();
+        },
 
-            previousPage: function() {
-                this.view.previousPage();
-            }
-        });
-
-        return PagingHeader;
+        previousPage: function() {
+            this.view.previousPage();
+        }
     });
+
+    return PagingHeader;
+});

--- a/cms/static/js/views/previous_video_upload.js
+++ b/cms/static/js/views/previous_video_upload.js
@@ -1,31 +1,31 @@
 define(
-    ["gettext", "js/utils/date_utils", "js/views/baseview"],
+    ['gettext', 'js/utils/date_utils', 'js/views/baseview'],
     function(gettext, DateUtils, BaseView) {
-        "use strict";
+        'use strict';
 
         var PreviousVideoUploadView = BaseView.extend({
-            tagName: "tr",
+            tagName: 'tr',
 
             initialize: function() {
-                this.template = this.loadTemplate("previous-video-upload");
+                this.template = this.loadTemplate('previous-video-upload');
             },
 
             renderDuration: function(seconds) {
-                var minutes = Math.floor(seconds/ 60);
+                var minutes = Math.floor(seconds / 60);
                 var seconds = Math.floor(seconds - minutes * 60);
 
-                return minutes + ":" + (seconds < 10 ? "0" : "") + seconds;
+                return minutes + ':' + (seconds < 10 ? '0' : '') + seconds;
             },
 
             render: function() {
-                var duration = this.model.get("duration");
+                var duration = this.model.get('duration');
                 var renderedAttributes = {
                     // Translators: This is listed as the duration for a video
                     // that has not yet reached the point in its processing by
                     // the servers where its duration is determined.
-                    duration: duration > 0 ? this.renderDuration(duration) : gettext("Pending"),
-                    created: DateUtils.renderDate(this.model.get("created")),
-                    status: this.model.get("status")
+                    duration: duration > 0 ? this.renderDuration(duration) : gettext('Pending'),
+                    created: DateUtils.renderDate(this.model.get('created')),
+                    status: this.model.get('status')
                 };
                 this.$el.html(
                     this.template(_.extend({}, this.model.attributes, renderedAttributes))

--- a/cms/static/js/views/previous_video_upload_list.js
+++ b/cms/static/js/views/previous_video_upload_list.js
@@ -1,13 +1,13 @@
 define(
-    ["jquery", "underscore", "backbone", "js/views/baseview", "js/views/previous_video_upload"],
+    ['jquery', 'underscore', 'backbone', 'js/views/baseview', 'js/views/previous_video_upload'],
     function($, _, Backbone, BaseView, PreviousVideoUploadView) {
-        "use strict";
+        'use strict';
         var PreviousVideoUploadListView = BaseView.extend({
-            tagName: "section",
-            className: "wrapper-assets",
+            tagName: 'section',
+            className: 'wrapper-assets',
 
             initialize: function(options) {
-                this.template = this.loadTemplate("previous-video-upload-list");
+                this.template = this.loadTemplate('previous-video-upload-list');
                 this.encodingsDownloadUrl = options.encodingsDownloadUrl;
                 this.itemViews = this.collection.map(function(model) {
                     return new PreviousVideoUploadView({model: model});
@@ -17,12 +17,12 @@ define(
             render: function() {
                 var $el = this.$el;
                 $el.html(this.template({encodingsDownloadUrl: this.encodingsDownloadUrl}));
-                var $tabBody = $el.find(".js-table-body");
+                var $tabBody = $el.find('.js-table-body');
                 _.each(this.itemViews, function(view) {
                     $tabBody.append(view.render().$el);
                 });
                 return this;
-            },
+            }
         });
 
         return PreviousVideoUploadListView;

--- a/cms/static/js/views/settings/advanced.js
+++ b/cms/static/js/views/settings/advanced.js
@@ -1,172 +1,171 @@
-define(["js/views/validation",
-        "jquery",
-        "underscore",
-        "gettext",
-        "codemirror",
-        "js/views/modals/validation_error_modal",
+define(['js/views/validation',
+        'jquery',
+        'underscore',
+        'gettext',
+        'codemirror',
+        'js/views/modals/validation_error_modal',
         'edx-ui-toolkit/js/utils/html-utils'],
     function(ValidatingView, $, _, gettext, CodeMirror, ValidationErrorModal, HtmlUtils) {
-
-var AdvancedView = ValidatingView.extend({
-    error_saving : "error_saving",
-    successful_changes: "successful_changes",
-    render_deprecated: false,
+        var AdvancedView = ValidatingView.extend({
+            error_saving: 'error_saving',
+            successful_changes: 'successful_changes',
+            render_deprecated: false,
 
     // Model class is CMS.Models.Settings.Advanced
-    events : {
-        'focus :input' : "focusInput",
-        'blur :input' : "blurInput"
+            events: {
+                'focus :input': 'focusInput',
+                'blur :input': 'blurInput'
         // TODO enable/disable save based on validation (currently enabled whenever there are changes)
-    },
-    initialize : function() {
-        this.template = HtmlUtils.template(
-            $("#advanced_entry-tpl").text()
+            },
+            initialize: function() {
+                this.template = HtmlUtils.template(
+            $('#advanced_entry-tpl').text()
         );
-        this.listenTo(this.model, 'invalid', this.handleValidationError);
-        this.render();
-    },
-    render: function() {
+                this.listenTo(this.model, 'invalid', this.handleValidationError);
+                this.render();
+            },
+            render: function() {
         // catch potential outside call before template loaded
-        if (!this.template) return this;
+                if (!this.template) return this;
 
-        var listEle$ = this.$el.find('.course-advanced-policy-list');
-        listEle$.empty();
+                var listEle$ = this.$el.find('.course-advanced-policy-list');
+                listEle$.empty();
 
         // b/c we've deleted all old fields, clear the map and repopulate
-        this.fieldToSelectorMap = {};
-        this.selectorToField = {};
+                this.fieldToSelectorMap = {};
+                this.selectorToField = {};
 
         // iterate through model and produce key : value editors for each property in model.get
-        var self = this;
-        _.each(_.sortBy(_.keys(this.model.attributes), function(key) { return self.model.get(key).display_name; }),
+                var self = this;
+                _.each(_.sortBy(_.keys(this.model.attributes), function(key) { return self.model.get(key).display_name; }),
             function(key) {
                 if (self.render_deprecated || !self.model.get(key).deprecated) {
                     HtmlUtils.append(listEle$, self.renderTemplate(key, self.model.get(key)));
                 }
             });
 
-        var policyValues = listEle$.find('.json');
-        _.each(policyValues, this.attachJSONEditor, this);
-        return this;
-    },
-    attachJSONEditor : function (textarea) {
+                var policyValues = listEle$.find('.json');
+                _.each(policyValues, this.attachJSONEditor, this);
+                return this;
+            },
+            attachJSONEditor: function(textarea) {
         // Since we are allowing duplicate keys at the moment, it is possible that we will try to attach
         // JSON Editor to a value that already has one. Therefore only attach if no CodeMirror peer exists.
-        if ( $(textarea).siblings().hasClass('CodeMirror')) {
-            return;
-        }
+                if ($(textarea).siblings().hasClass('CodeMirror')) {
+                    return;
+                }
 
-        var self = this;
-        var oldValue = $(textarea).val();
-        var cm = CodeMirror.fromTextArea(textarea, {
-            mode: "application/json",
-            lineNumbers: false,
-            lineWrapping: false});
-        cm.on('change', function(instance, changeobj) {
-                instance.save();
+                var self = this;
+                var oldValue = $(textarea).val();
+                var cm = CodeMirror.fromTextArea(textarea, {
+                    mode: 'application/json',
+                    lineNumbers: false,
+                    lineWrapping: false});
+                cm.on('change', function(instance, changeobj) {
+                    instance.save();
                 // this event's being called even when there's no change :-(
-                if (instance.getValue() !== oldValue) {
-                    var message = gettext("Your changes will not take effect until you save your progress. Take care with key and value formatting, as validation is not implemented.");
-                    self.showNotificationBar(message,
+                    if (instance.getValue() !== oldValue) {
+                        var message = gettext('Your changes will not take effect until you save your progress. Take care with key and value formatting, as validation is not implemented.');
+                        self.showNotificationBar(message,
                                              _.bind(self.saveView, self),
                                              _.bind(self.revertView, self));
-                }
-            });
-        cm.on('focus', function(mirror) {
-              $(textarea).parent().children('label').addClass("is-focused");
-            });
-        cm.on('blur', function (mirror) {
-                $(textarea).parent().children('label').removeClass("is-focused");
-                var key = $(mirror.getWrapperElement()).closest('.field-group').children('.key').attr('id');
-                var stringValue = $.trim(mirror.getValue());
+                    }
+                });
+                cm.on('focus', function(mirror) {
+                    $(textarea).parent().children('label').addClass('is-focused');
+                });
+                cm.on('blur', function(mirror) {
+                    $(textarea).parent().children('label').removeClass('is-focused');
+                    var key = $(mirror.getWrapperElement()).closest('.field-group').children('.key').attr('id');
+                    var stringValue = $.trim(mirror.getValue());
                 // update CodeMirror to show the trimmed value.
-                mirror.setValue(stringValue);
-                var JSONValue = undefined;
-                try {
-                    JSONValue = JSON.parse(stringValue);
-                } catch (e) {
+                    mirror.setValue(stringValue);
+                    var JSONValue = undefined;
+                    try {
+                        JSONValue = JSON.parse(stringValue);
+                    } catch (e) {
                     // If it didn't parse, try converting non-arrays/non-objects to a String.
                     // But don't convert single-quote strings, which are most likely errors.
-                    var firstNonWhite = stringValue.substring(0, 1);
-                    if (firstNonWhite !== "{" && firstNonWhite !== "[" && firstNonWhite !== "'") {
-                        try {
-                            stringValue = '"'+stringValue +'"';
-                            JSONValue = JSON.parse(stringValue);
-                            mirror.setValue(stringValue);
-                        } catch(quotedE) {
+                        var firstNonWhite = stringValue.substring(0, 1);
+                        if (firstNonWhite !== '{' && firstNonWhite !== '[' && firstNonWhite !== "'") {
+                            try {
+                                stringValue = '"' + stringValue + '"';
+                                JSONValue = JSON.parse(stringValue);
+                                mirror.setValue(stringValue);
+                            } catch (quotedE) {
                             // TODO: validation error
                             // console.log("Error with JSON, even after converting to String.");
                             // console.log(quotedE);
-                            JSONValue = undefined;
+                                JSONValue = undefined;
+                            }
                         }
                     }
-                }
-                if (JSONValue !== undefined) {
-                    var modelVal = self.model.get(key);
-                    modelVal.value = JSONValue;
-                    self.model.set(key, modelVal);
-                }
-            });
-    },
-    saveView : function() {
+                    if (JSONValue !== undefined) {
+                        var modelVal = self.model.get(key);
+                        modelVal.value = JSONValue;
+                        self.model.set(key, modelVal);
+                    }
+                });
+            },
+            saveView: function() {
         // TODO one last verification scan:
         //    call validateKey on each to ensure proper format
         //    check for dupes
-        var self = this;
-        this.model.save({}, {
-            success : function() {
-                var title = gettext("Your policy changes have been saved.");
-                var message = gettext('No validation is performed on policy keys or value pairs. If you are having difficulties, check your formatting.');  // eslint-disable-line max-len
-                self.render();
-                self.showSavedBar(title, message);
-                analytics.track('Saved Advanced Settings', {
-                    'course': course_location_analytics
-                });
-            },
-            silent: true,
-            error: function(model, response, options) {
-                var json_response, reset_callback, err_modal;
+                var self = this;
+                this.model.save({}, {
+                    success: function() {
+                        var title = gettext('Your policy changes have been saved.');
+                        var message = gettext('No validation is performed on policy keys or value pairs. If you are having difficulties, check your formatting.');  // eslint-disable-line max-len
+                        self.render();
+                        self.showSavedBar(title, message);
+                        analytics.track('Saved Advanced Settings', {
+                            'course': course_location_analytics
+                        });
+                    },
+                    silent: true,
+                    error: function(model, response, options) {
+                        var json_response, reset_callback, err_modal;
 
                 /* Check that the server came back with a bad request error*/
-                if (response.status === 400) {
-                    json_response = $.parseJSON(response.responseText);
-                    reset_callback = function() {
-                        self.revertView();
-                    };
+                        if (response.status === 400) {
+                            json_response = $.parseJSON(response.responseText);
+                            reset_callback = function() {
+                                self.revertView();
+                            };
 
                     /* initialize and show validation error modal */
-                    err_modal = new ValidationErrorModal();
-                    err_modal.setContent(json_response);
-                    err_modal.setResetCallback(reset_callback);
-                    err_modal.show();
-                }
-            }
-        });
-    },
-    revertView: function() {
-        var self = this;
-        this.model.fetch({
-            success: function() { self.render(); },
-            reset: true
-        });
-    },
-    renderTemplate: function (key, model) {
-        var newKeyId = _.uniqueId('policy_key_'),
-        newEle = this.template({ key: key, display_name : model.display_name, help: model.help,
-            value : JSON.stringify(model.value, null, 4), deprecated: model.deprecated,
+                            err_modal = new ValidationErrorModal();
+                            err_modal.setContent(json_response);
+                            err_modal.setResetCallback(reset_callback);
+                            err_modal.show();
+                        }
+                    }
+                });
+            },
+            revertView: function() {
+                var self = this;
+                this.model.fetch({
+                    success: function() { self.render(); },
+                    reset: true
+                });
+            },
+            renderTemplate: function(key, model) {
+                var newKeyId = _.uniqueId('policy_key_'),
+                    newEle = this.template({key: key, display_name: model.display_name, help: model.help,
+            value: JSON.stringify(model.value, null, 4), deprecated: model.deprecated,
             keyUniqueId: newKeyId, valueUniqueId: _.uniqueId('policy_value_')});
 
-        this.fieldToSelectorMap[key] = newKeyId;
-        this.selectorToField[newKeyId] = key;
-        return newEle;
-    },
-    focusInput : function(event) {
-        $(event.target).prev().addClass("is-focused");
-    },
-    blurInput : function(event) {
-        $(event.target).prev().removeClass("is-focused");
-    }
-});
+                this.fieldToSelectorMap[key] = newKeyId;
+                this.selectorToField[newKeyId] = key;
+                return newEle;
+            },
+            focusInput: function(event) {
+                $(event.target).prev().addClass('is-focused');
+            },
+            blurInput: function(event) {
+                $(event.target).prev().removeClass('is-focused');
+            }
+        });
 
-return AdvancedView;
-});
+        return AdvancedView;
+    });

--- a/cms/static/js/views/settings/grader.js
+++ b/cms/static/js/views/settings/grader.js
@@ -1,81 +1,79 @@
-define(["js/views/validation",
+define(['js/views/validation',
         'gettext',
         'edx-ui-toolkit/js/utils/string-utils',
-        "edx-ui-toolkit/js/utils/html-utils",
-        "underscore",
-        "jquery"],
+        'edx-ui-toolkit/js/utils/html-utils',
+        'underscore',
+        'jquery'],
     function(ValidatingView, gettext, StringUtils, HtmlUtils, _, $) {
-
-var GraderView = ValidatingView.extend({
+        var GraderView = ValidatingView.extend({
     // Model class is CMS.Models.Settings.CourseGrader
-    events : {
-        "input input" : "updateModel",
-        "input textarea" : "updateModel",
+            events: {
+                'input input': 'updateModel',
+                'input textarea': 'updateModel',
         // Leaving change in as fallback for older browsers
-        "change input" : "updateModel",
-        "change textarea" : "updateModel",
-        "click .remove-grading-data" : "deleteModel",
+                'change input': 'updateModel',
+                'change textarea': 'updateModel',
+                'click .remove-grading-data': 'deleteModel',
         // would love to move to a general superclass, but event hashes don't inherit in backbone :-(
-        'focus :input' : "inputFocus",
-        'blur :input' : "inputUnfocus"
-    },
-    initialize : function() {
-        this.listenTo(this.model, 'invalid', this.handleValidationError);
-        this.selectorToField = _.invert(this.fieldToSelectorMap);
-        this.render();
-    },
+                'focus :input': 'inputFocus',
+                'blur :input': 'inputUnfocus'
+            },
+            initialize: function() {
+                this.listenTo(this.model, 'invalid', this.handleValidationError);
+                this.selectorToField = _.invert(this.fieldToSelectorMap);
+                this.render();
+            },
 
-    render: function() {
-        return this;
-    },
-    fieldToSelectorMap : {
-        'type' : 'course-grading-assignment-name',
-        'short_label' : 'course-grading-assignment-shortname',
-        'min_count' : 'course-grading-assignment-totalassignments',
-        'drop_count' : 'course-grading-assignment-droppable',
-        'weight' : 'course-grading-assignment-gradeweight'
-    },
-    updateModel: function(event) {
+            render: function() {
+                return this;
+            },
+            fieldToSelectorMap: {
+                'type': 'course-grading-assignment-name',
+                'short_label': 'course-grading-assignment-shortname',
+                'min_count': 'course-grading-assignment-totalassignments',
+                'drop_count': 'course-grading-assignment-droppable',
+                'weight': 'course-grading-assignment-gradeweight'
+            },
+            updateModel: function(event) {
         // HACK to fix model sometimes losing its pointer to the collection [I think I fixed this but leaving
         // this in out of paranoia. If this error ever happens, the user will get a warning that they cannot
         // give 2 assignments the same name.]
-        if (!this.model.collection) {
-            this.model.collection = this.collection;
-        }
+                if (!this.model.collection) {
+                    this.model.collection = this.collection;
+                }
 
-        switch (event.currentTarget.id) {
-        case 'course-grading-assignment-totalassignments':
-            this.$el.find('#course-grading-assignment-droppable').attr('max', $(event.currentTarget).val());
-            this.setField(event);
-            break;
-        case 'course-grading-assignment-name':
+                switch (event.currentTarget.id) {
+                case 'course-grading-assignment-totalassignments':
+                    this.$el.find('#course-grading-assignment-droppable').attr('max', $(event.currentTarget).val());
+                    this.setField(event);
+                    break;
+                case 'course-grading-assignment-name':
             // Keep the original name, until we save
-            this.oldName = this.oldName === undefined ? this.model.get('type') : this.oldName;
+                    this.oldName = this.oldName === undefined ? this.model.get('type') : this.oldName;
             // If the name has changed, alert the user to change all subsection names.
-            if (this.setField(event) != this.oldName && !_.isEmpty(this.oldName)) {
+                    if (this.setField(event) != this.oldName && !_.isEmpty(this.oldName)) {
                 // overload the error display logic
-                this._cacheValidationErrors.push(event.currentTarget);
-                var message = StringUtils.interpolate(
+                        this._cacheValidationErrors.push(event.currentTarget);
+                        var message = StringUtils.interpolate(
                     gettext('For grading to work, you must change all {oldName} subsections to {newName}.'),
-                    {
-                        oldName: this.oldName,
-                        newName: this.model.get('type')
-                    }
+                            {
+                                oldName: this.oldName,
+                                newName: this.model.get('type')
+                            }
                 );
-                HtmlUtils.append($(event.currentTarget).parent(), this.errorTemplate({message : message}));
+                        HtmlUtils.append($(event.currentTarget).parent(), this.errorTemplate({message: message}));
+                    }
+                    break;
+                default:
+                    this.setField(event);
+                    break;
+                }
+            },
+            deleteModel: function(e) {
+                e.preventDefault();
+                this.collection.remove(this.model);
             }
-            break;
-        default:
-            this.setField(event);
-        break;
-        }
-    },
-    deleteModel : function(e) {
-        e.preventDefault();
-        this.collection.remove(this.model);
-    }
-});
+        });
 
-return GraderView;
-
-}); // end define()
+        return GraderView;
+    }); // end define()

--- a/cms/static/js/views/settings/grading.js
+++ b/cms/static/js/views/settings/grading.js
@@ -1,144 +1,143 @@
-define(["js/views/validation",
-        "underscore",
-        "jquery",
-        "jquery.ui",
-        "js/views/settings/grader",
+define(['js/views/validation',
+        'underscore',
+        'jquery',
+        'jquery.ui',
+        'js/views/settings/grader',
         'edx-ui-toolkit/js/utils/string-utils',
-        'edx-ui-toolkit/js/utils/html-utils',
+        'edx-ui-toolkit/js/utils/html-utils'
     ],
     function(ValidatingView, _, $, ui, GraderView, StringUtils, HtmlUtils) {
-
-var GradingView = ValidatingView.extend({
+        var GradingView = ValidatingView.extend({
     // Model class is CMS.Models.Settings.CourseGradingPolicy
-    events : {
-        "input input" : "updateModel",
-        "input textarea" : "updateModel",
+            events: {
+                'input input': 'updateModel',
+                'input textarea': 'updateModel',
         // Leaving change in as fallback for older browsers
-        "change input" : "updateModel",
-        "change textarea" : "updateModel",
-        "input span[contenteditable=true]" : "updateDesignation",
-        "click .settings-extra header" : "showSettingsExtras",
-        "click .new-grade-button" : "addNewGrade",
-        "click .remove-button" : "removeGrade",
-        "click .add-grading-data" : "addAssignmentType",
+                'change input': 'updateModel',
+                'change textarea': 'updateModel',
+                'input span[contenteditable=true]': 'updateDesignation',
+                'click .settings-extra header': 'showSettingsExtras',
+                'click .new-grade-button': 'addNewGrade',
+                'click .remove-button': 'removeGrade',
+                'click .add-grading-data': 'addAssignmentType',
         // would love to move to a general superclass, but event hashes don't inherit in backbone :-(
-        'focus :input' : "inputFocus",
-        'blur :input' : "inputUnfocus"
-    },
-    initialize : function() {
+                'focus :input': 'inputFocus',
+                'blur :input': 'inputUnfocus'
+            },
+            initialize: function() {
         //  load template for grading view
-        var self = this;
-        this.template = HtmlUtils.template(
-            $("#course_grade_policy-tpl").text()
+                var self = this;
+                this.template = HtmlUtils.template(
+            $('#course_grade_policy-tpl').text()
         );
-        this.gradeCutoffTemplate = HtmlUtils.template(
-            $("#course_grade_cutoff-tpl").text()
+                this.gradeCutoffTemplate = HtmlUtils.template(
+            $('#course_grade_cutoff-tpl').text()
         );
-        this.setupCutoffs();
+                this.setupCutoffs();
 
-        this.listenTo(this.model, 'invalid', this.handleValidationError);
-        this.listenTo(this.model, 'change', this.showNotificationBar);
-        this.model.get('graders').on('reset', this.render, this);
-        this.model.get('graders').on('add', this.render, this);
-        this.selectorToField = _.invert(this.fieldToSelectorMap);
-        this.render();
-    },
+                this.listenTo(this.model, 'invalid', this.handleValidationError);
+                this.listenTo(this.model, 'change', this.showNotificationBar);
+                this.model.get('graders').on('reset', this.render, this);
+                this.model.get('graders').on('add', this.render, this);
+                this.selectorToField = _.invert(this.fieldToSelectorMap);
+                this.render();
+            },
 
-    render: function() {
-        this.clearValidationErrors();
+            render: function() {
+                this.clearValidationErrors();
 
-        this.renderGracePeriod();
-        this.renderMinimumGradeCredit();
+                this.renderGracePeriod();
+                this.renderMinimumGradeCredit();
 
         // Create and render the grading type subs
-        var self = this;
-        var gradelist = this.$el.find('.course-grading-assignment-list');
+                var self = this;
+                var gradelist = this.$el.find('.course-grading-assignment-list');
         // Undo the double invocation error. At some point, fix the double invocation
-        $(gradelist).empty();
-        var gradeCollection = this.model.get('graders');
+                $(gradelist).empty();
+                var gradeCollection = this.model.get('graders');
         // We need to bind these events here (rather than in
         // initialize), or else we can only press the delete button
         // once due to the graders collection changing when we cancel
         // our changes.
-        _.each(['change', 'remove', 'add'],
-               function (event) {
+                _.each(['change', 'remove', 'add'],
+               function(event) {
                    gradeCollection.on(event, function() {
                        this.showNotificationBar();
                        // Since the change event gets fired every time
                        // we type in an input field, we don't need to
                        // (and really shouldn't) rerender the whole view.
-                       if(event !== 'change') {
+                       if (event !== 'change') {
                            this.render();
                        }
                    }, this);
                },
                this);
-        gradeCollection.each(function(gradeModel) {
-            HtmlUtils.append(gradelist, self.template({model : gradeModel }));
-            var newEle = gradelist.children().last();
-            var newView = new GraderView({el: newEle,
-                model : gradeModel, collection : gradeCollection });
+                gradeCollection.each(function(gradeModel) {
+                    HtmlUtils.append(gradelist, self.template({model: gradeModel}));
+                    var newEle = gradelist.children().last();
+                    var newView = new GraderView({el: newEle,
+                model: gradeModel, collection: gradeCollection});
             // Listen in order to rerender when the 'cancel' button is
             // pressed
-            self.listenTo(newView, 'revert', _.bind(self.render, self));
-        });
+                    self.listenTo(newView, 'revert', _.bind(self.render, self));
+                });
 
         // render the grade cutoffs
-        this.renderCutoffBar();
+                this.renderCutoffBar();
 
-        return this;
-    },
-    addAssignmentType : function(e) {
-        e.preventDefault();
-        this.model.get('graders').push({});
-    },
-    fieldToSelectorMap : {
-        'grace_period' : 'course-grading-graceperiod',
-        'minimum_grade_credit' : 'course-minimum_grade_credit'
-    },
-    renderGracePeriod: function() {
-        var format = function(time) {
-            return time >= 10 ? time.toString() : '0' + time;
-        };
-        var grace_period = this.model.get('grace_period');
-        this.$el.find('#course-grading-graceperiod').val(
+                return this;
+            },
+            addAssignmentType: function(e) {
+                e.preventDefault();
+                this.model.get('graders').push({});
+            },
+            fieldToSelectorMap: {
+                'grace_period': 'course-grading-graceperiod',
+                'minimum_grade_credit': 'course-minimum_grade_credit'
+            },
+            renderGracePeriod: function() {
+                var format = function(time) {
+                    return time >= 10 ? time.toString() : '0' + time;
+                };
+                var grace_period = this.model.get('grace_period');
+                this.$el.find('#course-grading-graceperiod').val(
             format(grace_period.hours) + ':' + format(grace_period.minutes)
         );
-    },
-    renderMinimumGradeCredit: function() {
-        var minimum_grade_credit = this.model.get('minimum_grade_credit');
-        this.$el.find('#course-minimum_grade_credit').val(
+            },
+            renderMinimumGradeCredit: function() {
+                var minimum_grade_credit = this.model.get('minimum_grade_credit');
+                this.$el.find('#course-minimum_grade_credit').val(
             Math.round(parseFloat(minimum_grade_credit) * 100)
         );
-    },
-    setGracePeriod : function(event) {
-        this.clearValidationErrors();
-        var newVal = this.model.parseGracePeriod($(event.currentTarget).val());
-        this.model.set('grace_period', newVal, {validate: true});
-    },
-    setMinimumGradeCredit : function(event) {
-        this.clearValidationErrors();
+            },
+            setGracePeriod: function(event) {
+                this.clearValidationErrors();
+                var newVal = this.model.parseGracePeriod($(event.currentTarget).val());
+                this.model.set('grace_period', newVal, {validate: true});
+            },
+            setMinimumGradeCredit: function(event) {
+                this.clearValidationErrors();
         // get field value in float
-        var newVal = this.model.parseMinimumGradeCredit($(event.currentTarget).val()) / 100;
-        this.model.set('minimum_grade_credit', newVal, {validate: true});
-    },
-    updateModel : function(event) {
-        if (!this.selectorToField[event.currentTarget.id]) return;
+                var newVal = this.model.parseMinimumGradeCredit($(event.currentTarget).val()) / 100;
+                this.model.set('minimum_grade_credit', newVal, {validate: true});
+            },
+            updateModel: function(event) {
+                if (!this.selectorToField[event.currentTarget.id]) return;
 
-        switch (this.selectorToField[event.currentTarget.id]) {
-        case 'grace_period':
-            this.setGracePeriod(event);
-            break;
+                switch (this.selectorToField[event.currentTarget.id]) {
+                case 'grace_period':
+                    this.setGracePeriod(event);
+                    break;
 
-        case 'minimum_grade_credit':
-            this.setMinimumGradeCredit(event);
-            break;
+                case 'minimum_grade_credit':
+                    this.setMinimumGradeCredit(event);
+                    break;
 
-        default:
-            this.setField(event);
-            break;
-        }
-    },
+                default:
+                    this.setField(event);
+                    break;
+                }
+            },
 
     // Grade sliders attributes and methods
     // Grade bars are li's ordered A -> F with A taking whole width, B overlaying it with its paint, ...
@@ -148,252 +147,251 @@ var GradingView = ValidatingView.extend({
 
     // A does not have a drag bar (cannot change its upper limit)
     // Need to insert new bars in right place.
-    GRADES : ['A', 'B', 'C', 'D'],	// defaults for new grade designators
-    descendingCutoffs : [],  // array of { designation : , cutoff : }
-    gradeBarWidth : null, // cache of value since it won't change (more certain)
+            GRADES: ['A', 'B', 'C', 'D'],	// defaults for new grade designators
+            descendingCutoffs: [],  // array of { designation : , cutoff : }
+            gradeBarWidth: null, // cache of value since it won't change (more certain)
 
-    renderCutoffBar: function() {
-        var gradeBar = this.$el.find('.grade-bar');
-        this.gradeBarWidth = gradeBar.width();
-        var gradelist = gradeBar.children('.grades');
+            renderCutoffBar: function() {
+                var gradeBar = this.$el.find('.grade-bar');
+                this.gradeBarWidth = gradeBar.width();
+                var gradelist = gradeBar.children('.grades');
         // HACK fixing a duplicate call issue by undoing previous call effect. Need to figure out why called 2x
-        gradelist.empty();
-        var nextWidth = 100; // first width is 100%
+                gradelist.empty();
+                var nextWidth = 100; // first width is 100%
         // Can probably be simplified to one variable now.
-        var removable = false;
-        var draggable = false; // first and last are not removable, first is not draggable
-        _.each(this.descendingCutoffs, function(cutoff) {
-            HtmlUtils.append(gradelist,  this.gradeCutoffTemplate({
-                descriptor : cutoff.designation,
-                width : nextWidth,
-                contenteditable: true,
-                removable : removable})
+                var removable = false;
+                var draggable = false; // first and last are not removable, first is not draggable
+                _.each(this.descendingCutoffs, function(cutoff) {
+                    HtmlUtils.append(gradelist, this.gradeCutoffTemplate({
+                        descriptor: cutoff.designation,
+                        width: nextWidth,
+                        contenteditable: true,
+                        removable: removable})
             );
-            if (draggable) {
-                var newBar = gradelist.children().last(); // get the dom object not the unparsed string
-                newBar.resizable({
-                    handles: "e",
-                    containment : "parent",
-                    start : this.startMoveClosure(),
-                    resize : this.moveBarClosure(),
-                    stop : this.stopDragClosure()
-                });
-            }
+                    if (draggable) {
+                        var newBar = gradelist.children().last(); // get the dom object not the unparsed string
+                        newBar.resizable({
+                            handles: 'e',
+                            containment: 'parent',
+                            start: this.startMoveClosure(),
+                            resize: this.moveBarClosure(),
+                            stop: this.stopDragClosure()
+                        });
+                    }
             // prepare for next
-            nextWidth = cutoff.cutoff;
-            removable = true; // first is not removable, all others are
-            draggable = true;
-        },
+                    nextWidth = cutoff.cutoff;
+                    removable = true; // first is not removable, all others are
+                    draggable = true;
+                },
         this);
         // Add fail which is not in data
-        HtmlUtils.append(gradelist, this.gradeCutoffTemplate({
-            descriptor : this.failLabel(),
-            width : nextWidth,
-            contenteditable: false,
-            removable : false
-        }));
-        gradelist.children().last().resizable({
-            handles: "e",
-            containment : "parent",
-            start : this.startMoveClosure(),
-            resize : this.moveBarClosure(),
-            stop : this.stopDragClosure()
-        });
+                HtmlUtils.append(gradelist, this.gradeCutoffTemplate({
+                    descriptor: this.failLabel(),
+                    width: nextWidth,
+                    contenteditable: false,
+                    removable: false
+                }));
+                gradelist.children().last().resizable({
+                    handles: 'e',
+                    containment: 'parent',
+                    start: this.startMoveClosure(),
+                    resize: this.moveBarClosure(),
+                    stop: this.stopDragClosure()
+                });
 
-        this.renderGradeRanges();
-    },
+                this.renderGradeRanges();
+            },
 
-    showSettingsExtras : function(event) {
-        $(event.currentTarget).toggleClass('active');
-        $(event.currentTarget).siblings.toggleClass('is-shown');
-    },
+            showSettingsExtras: function(event) {
+                $(event.currentTarget).toggleClass('active');
+                $(event.currentTarget).siblings.toggleClass('is-shown');
+            },
 
 
-    startMoveClosure : function() {
+            startMoveClosure: function() {
         // set min/max widths
-        var cachethis = this;
-        var widthPerPoint = cachethis.gradeBarWidth / 100;
-        return function(event, ui) {
-            var barIndex = ui.element.index();
+                var cachethis = this;
+                var widthPerPoint = cachethis.gradeBarWidth / 100;
+                return function(event, ui) {
+                    var barIndex = ui.element.index();
             // min and max represent limits not labels (note, can's make smaller than 3 points wide)
-            var min = (barIndex < cachethis.descendingCutoffs.length ? cachethis.descendingCutoffs[barIndex]['cutoff'] + 3 : 3);
+                    var min = (barIndex < cachethis.descendingCutoffs.length ? cachethis.descendingCutoffs[barIndex]['cutoff'] + 3 : 3);
             // minus 2 b/c minus 1 is the element we're effecting. It's max is just shy of the next one above it
-            var max = (barIndex >= 2 ? cachethis.descendingCutoffs[barIndex - 2]['cutoff'] - 3 : 97);
-            ui.element.resizable("option",{minWidth : min * widthPerPoint, maxWidth : max * widthPerPoint});
-        };
-    },
+                    var max = (barIndex >= 2 ? cachethis.descendingCutoffs[barIndex - 2]['cutoff'] - 3 : 97);
+                    ui.element.resizable('option', {minWidth: min * widthPerPoint, maxWidth: max * widthPerPoint});
+                };
+            },
 
-    moveBarClosure : function() {
+            moveBarClosure: function() {
         // 0th ele doesn't have a bar; so, will never invoke this
-        var cachethis = this;
-        return function(event, ui) {
-            var barIndex = ui.element.index();
+                var cachethis = this;
+                return function(event, ui) {
+                    var barIndex = ui.element.index();
             // min and max represent limits not labels (note, can's make smaller than 3 points wide)
-            var min = (barIndex < cachethis.descendingCutoffs.length ? cachethis.descendingCutoffs[barIndex]['cutoff'] + 3 : 3);
+                    var min = (barIndex < cachethis.descendingCutoffs.length ? cachethis.descendingCutoffs[barIndex]['cutoff'] + 3 : 3);
             // minus 2 b/c minus 1 is the element we're effecting. It's max is just shy of the next one above it
-            var max = (barIndex >= 2 ? cachethis.descendingCutoffs[barIndex - 2]['cutoff'] - 3 : 100);
-            var percentage = Math.min(Math.max(ui.size.width / cachethis.gradeBarWidth * 100, min), max);
-            cachethis.descendingCutoffs[barIndex - 1]['cutoff'] = Math.round(percentage);
-            cachethis.renderGradeRanges();
-        };
-    },
+                    var max = (barIndex >= 2 ? cachethis.descendingCutoffs[barIndex - 2]['cutoff'] - 3 : 100);
+                    var percentage = Math.min(Math.max(ui.size.width / cachethis.gradeBarWidth * 100, min), max);
+                    cachethis.descendingCutoffs[barIndex - 1]['cutoff'] = Math.round(percentage);
+                    cachethis.renderGradeRanges();
+                };
+            },
 
-    renderGradeRanges: function() {
+            renderGradeRanges: function() {
         // the labels showing the range e.g., 71-80
-        var cutoffs = this.descendingCutoffs;
-        this.$el.find('.range').each(function(i) {
-            var min = (i < cutoffs.length ? cutoffs[i]['cutoff'] : 0);
-            var max = (i > 0 ? cutoffs[i - 1]['cutoff'] : 100);
-            $(this).text(min + '-' + max);
-        });
-    },
+                var cutoffs = this.descendingCutoffs;
+                this.$el.find('.range').each(function(i) {
+                    var min = (i < cutoffs.length ? cutoffs[i]['cutoff'] : 0);
+                    var max = (i > 0 ? cutoffs[i - 1]['cutoff'] : 100);
+                    $(this).text(min + '-' + max);
+                });
+            },
 
-    stopDragClosure: function() {
-        var cachethis = this;
-        return function(event, ui) {
+            stopDragClosure: function() {
+                var cachethis = this;
+                return function(event, ui) {
             // for some reason the resize is setting height to 0
-            cachethis.saveCutoffs();
-        };
-    },
+                    cachethis.saveCutoffs();
+                };
+            },
 
-    renderGradeLabels: function(){
+            renderGradeLabels: function() {
         // When a grade is removed, keep the remaining grades consistent.
-        var _this = this;
-        if (_this.descendingCutoffs.length === 1 && _this.descendingCutoffs[0]['designation'] === _this.GRADES[0]) {
-            _this.descendingCutoffs[0]['designation'] = 'Pass';
-            _this.setTopGradeLabel();
-        } else {
-            _.each(_this.descendingCutoffs, function(cutoff, index) {
-                cutoff['designation'] = _this.GRADES[index];
-            });
-            _this.updateDomGradeLabels();
-        }
-    },
-    updateDomGradeLabels: function(){
+                var _this = this;
+                if (_this.descendingCutoffs.length === 1 && _this.descendingCutoffs[0]['designation'] === _this.GRADES[0]) {
+                    _this.descendingCutoffs[0]['designation'] = 'Pass';
+                    _this.setTopGradeLabel();
+                } else {
+                    _.each(_this.descendingCutoffs, function(cutoff, index) {
+                        cutoff['designation'] = _this.GRADES[index];
+                    });
+                    _this.updateDomGradeLabels();
+                }
+            },
+            updateDomGradeLabels: function() {
         // Update the DOM elements (Grades)
-        var _this = this;
-        var gradeElements = this.$el.find('.grades .letter-grade[contenteditable=true]');
-        _.each(gradeElements, function(element, index) {
-            if (index !== 0 ) $(element).text(_this.GRADES[index])
-        });
-    },
+                var _this = this;
+                var gradeElements = this.$el.find('.grades .letter-grade[contenteditable=true]');
+                _.each(gradeElements, function(element, index) {
+                    if (index !== 0) $(element).text(_this.GRADES[index]);
+                });
+            },
 
-    saveCutoffs: function() {
-        this.model.set('grade_cutoffs',
+            saveCutoffs: function() {
+                this.model.set('grade_cutoffs',
                 _.reduce(this.descendingCutoffs,
                         function(object, cutoff) {
-                    object[cutoff['designation']] = cutoff['cutoff'] / 100.0;
-                    return object;
-                },
+                            object[cutoff['designation']] = cutoff['cutoff'] / 100.0;
+                            return object;
+                        },
                 {}),
                 {validate: true});
-    },
+            },
 
-    addNewGrade: function(e) {
-        e.preventDefault();
-        var gradeLength = this.descendingCutoffs.length; // cutoffs doesn't include fail/f so this is only the passing grades
-        if(gradeLength > 3) {
+            addNewGrade: function(e) {
+                e.preventDefault();
+                var gradeLength = this.descendingCutoffs.length; // cutoffs doesn't include fail/f so this is only the passing grades
+                if (gradeLength > 3) {
             // TODO shouldn't we disable the button
-            return;
-        }
-        var failBarWidth = this.descendingCutoffs[gradeLength - 1]['cutoff'];
+                    return;
+                }
+                var failBarWidth = this.descendingCutoffs[gradeLength - 1]['cutoff'];
         // going to split the grade above the insertion point in half leaving fail in same place
-        var nextGradeTop = (gradeLength > 1 ? this.descendingCutoffs[gradeLength - 2]['cutoff'] : 100);
-        var targetWidth = failBarWidth + ((nextGradeTop - failBarWidth) / 2);
-        this.descendingCutoffs.push({designation: this.GRADES[gradeLength], cutoff: failBarWidth});
-        this.descendingCutoffs[gradeLength - 1]['cutoff'] = Math.round(targetWidth);
+                var nextGradeTop = (gradeLength > 1 ? this.descendingCutoffs[gradeLength - 2]['cutoff'] : 100);
+                var targetWidth = failBarWidth + ((nextGradeTop - failBarWidth) / 2);
+                this.descendingCutoffs.push({designation: this.GRADES[gradeLength], cutoff: failBarWidth});
+                this.descendingCutoffs[gradeLength - 1]['cutoff'] = Math.round(targetWidth);
 
-        var newGradeHtml = this.gradeCutoffTemplate({
-            descriptor : this.GRADES[gradeLength],
-            width : targetWidth,
-            contenteditable: true,
-            removable : true });
-        var gradeDom = this.$el.find('.grades');
-        gradeDom.children().last().before(HtmlUtils.ensureHtml(newGradeHtml).toString());
-        var newEle = gradeDom.children()[gradeLength];
-        $(newEle).resizable({
-            handles: "e",
-            containment : "parent",
-            start : this.startMoveClosure(),
-            resize : this.moveBarClosure(),
-            stop : this.stopDragClosure()
-        });
+                var newGradeHtml = this.gradeCutoffTemplate({
+                    descriptor: this.GRADES[gradeLength],
+                    width: targetWidth,
+                    contenteditable: true,
+                    removable: true});
+                var gradeDom = this.$el.find('.grades');
+                gradeDom.children().last().before(HtmlUtils.ensureHtml(newGradeHtml).toString());
+                var newEle = gradeDom.children()[gradeLength];
+                $(newEle).resizable({
+                    handles: 'e',
+                    containment: 'parent',
+                    start: this.startMoveClosure(),
+                    resize: this.moveBarClosure(),
+                    stop: this.stopDragClosure()
+                });
 
         // Munge existing grade labels?
         // If going from Pass/Fail to 3 levels, change to Pass to A
-        if (gradeLength === 1 && this.descendingCutoffs[0].designation === 'Pass') {
-            this.descendingCutoffs[0].designation = this.GRADES[0];
-            this.setTopGradeLabel();
-        }
-        this.setFailLabel();
+                if (gradeLength === 1 && this.descendingCutoffs[0].designation === 'Pass') {
+                    this.descendingCutoffs[0].designation = this.GRADES[0];
+                    this.setTopGradeLabel();
+                }
+                this.setFailLabel();
 
-        this.renderGradeRanges();
-        this.saveCutoffs();
-    },
+                this.renderGradeRanges();
+                this.saveCutoffs();
+            },
 
-    removeGrade: function(e) {
-        e.preventDefault();
-        var domElement = $(e.currentTarget).closest('li');
-        var index = domElement.index();
+            removeGrade: function(e) {
+                e.preventDefault();
+                var domElement = $(e.currentTarget).closest('li');
+                var index = domElement.index();
         // copy the boundary up to the next higher grade then remove
-        this.descendingCutoffs[index - 1]['cutoff'] = this.descendingCutoffs[index]['cutoff'];
-        this.descendingCutoffs.splice(index, 1);
-        domElement.remove();
+                this.descendingCutoffs[index - 1]['cutoff'] = this.descendingCutoffs[index]['cutoff'];
+                this.descendingCutoffs.splice(index, 1);
+                domElement.remove();
 
-        this.setFailLabel();
-        this.renderGradeRanges();
-        this.renderGradeLabels();
-        this.saveCutoffs();
-    },
+                this.setFailLabel();
+                this.renderGradeRanges();
+                this.renderGradeLabels();
+                this.saveCutoffs();
+            },
 
-    updateDesignation: function(e) {
-        var index = $(e.currentTarget).closest('li').index();
-        this.descendingCutoffs[index]['designation'] = $(e.currentTarget).html();
-        this.saveCutoffs();
-    },
+            updateDesignation: function(e) {
+                var index = $(e.currentTarget).closest('li').index();
+                this.descendingCutoffs[index]['designation'] = $(e.currentTarget).html();
+                this.saveCutoffs();
+            },
 
-    failLabel: function() {
-        if (this.descendingCutoffs.length === 1) return 'Fail';
-        else return 'F';
-    },
-    setFailLabel: function() {
-        this.$el.find('.grades .letter-grade').last().text(this.failLabel());
-    },
-    setTopGradeLabel: function() {
-        this.$el.find('.grades .letter-grade').first().text(this.descendingCutoffs[0].designation);
-    },
-    setupCutoffs: function() {
+            failLabel: function() {
+                if (this.descendingCutoffs.length === 1) return 'Fail';
+                else return 'F';
+            },
+            setFailLabel: function() {
+                this.$el.find('.grades .letter-grade').last().text(this.failLabel());
+            },
+            setTopGradeLabel: function() {
+                this.$el.find('.grades .letter-grade').first().text(this.descendingCutoffs[0].designation);
+            },
+            setupCutoffs: function() {
         // Instrument grading scale
         // convert cutoffs to inversely ordered list
-        var modelCutoffs = this.model.get('grade_cutoffs');
-        for (var cutoff in modelCutoffs) {
-            this.descendingCutoffs.push({designation: cutoff, cutoff: Math.round(modelCutoffs[cutoff] * 100)});
-        }
-        this.descendingCutoffs = _.sortBy(this.descendingCutoffs,
-                                          function (gradeEle) { return -gradeEle['cutoff']; });
-    },
-    revertView: function() {
-        var self = this;
-        this.model.fetch({
-            success: function() {
-                self.descendingCutoffs = [];
-                self.setupCutoffs();
-                self.render();
-                self.renderCutoffBar();
+                var modelCutoffs = this.model.get('grade_cutoffs');
+                for (var cutoff in modelCutoffs) {
+                    this.descendingCutoffs.push({designation: cutoff, cutoff: Math.round(modelCutoffs[cutoff] * 100)});
+                }
+                this.descendingCutoffs = _.sortBy(this.descendingCutoffs,
+                                          function(gradeEle) { return -gradeEle['cutoff']; });
             },
-            reset: true,
-            silent: true});
-    },
-    showNotificationBar: function() {
+            revertView: function() {
+                var self = this;
+                this.model.fetch({
+                    success: function() {
+                        self.descendingCutoffs = [];
+                        self.setupCutoffs();
+                        self.render();
+                        self.renderCutoffBar();
+                    },
+                    reset: true,
+                    silent: true});
+            },
+            showNotificationBar: function() {
         // We always call showNotificationBar with the same args, just
         // delegate to superclass
-        ValidatingView.prototype.showNotificationBar.call(this,
+                ValidatingView.prototype.showNotificationBar.call(this,
                                                           this.save_message,
                                                           _.bind(this.saveView, this),
                                                           _.bind(this.revertView, this));
-    }
-});
+            }
+        });
 
-return GradingView;
-
-}); // end define()
+        return GradingView;
+    }); // end define()

--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -1,463 +1,461 @@
-define(["js/views/validation", "codemirror", "underscore", "jquery", "jquery.ui", "js/utils/date_utils",
-    "js/models/uploads", "js/views/uploads", "js/views/license", "js/models/license",
-    "common/js/components/views/feedback_notification", "jquery.timepicker", "date", "gettext",
-    "js/views/learning_info", "js/views/instructor_info", "edx-ui-toolkit/js/utils/string-utils"],
+define(['js/views/validation', 'codemirror', 'underscore', 'jquery', 'jquery.ui', 'js/utils/date_utils',
+    'js/models/uploads', 'js/views/uploads', 'js/views/license', 'js/models/license',
+    'common/js/components/views/feedback_notification', 'jquery.timepicker', 'date', 'gettext',
+    'js/views/learning_info', 'js/views/instructor_info', 'edx-ui-toolkit/js/utils/string-utils'],
        function(ValidatingView, CodeMirror, _, $, ui, DateUtils, FileUploadModel,
                 FileUploadDialog, LicenseView, LicenseModel, NotificationView,
                 timepicker, date, gettext, LearningInfoView, InstructorInfoView, StringUtils) {
-
-var DetailsView = ValidatingView.extend({
+           var DetailsView = ValidatingView.extend({
     // Model class is CMS.Models.Settings.CourseDetails
-    events : {
-        "input input" : "updateModel",
-        "input textarea" : "updateModel",
+               events: {
+                   'input input': 'updateModel',
+                   'input textarea': 'updateModel',
         // Leaving change in as fallback for older browsers
-        "change input" : "updateModel",
-        "change textarea" : "updateModel",
-        "change select" : "updateModel",
-        'click .remove-course-introduction-video' : "removeVideo",
-        'focus #course-overview' : "codeMirrorize",
-        'mouseover .timezone' : "updateTime",
+                   'change input': 'updateModel',
+                   'change textarea': 'updateModel',
+                   'change select': 'updateModel',
+                   'click .remove-course-introduction-video': 'removeVideo',
+                   'focus #course-overview': 'codeMirrorize',
+                   'mouseover .timezone': 'updateTime',
         // would love to move to a general superclass, but event hashes don't inherit in backbone :-(
-        'focus :input' : "inputFocus",
-        'blur :input' : "inputUnfocus",
-        'click .action-upload-image': "uploadImage",
-        'click .add-course-learning-info': "addLearningFields",
-        'click .add-course-instructor-info': "addInstructorFields"
-    },
+                   'focus :input': 'inputFocus',
+                   'blur :input': 'inputUnfocus',
+                   'click .action-upload-image': 'uploadImage',
+                   'click .add-course-learning-info': 'addLearningFields',
+                   'click .add-course-instructor-info': 'addInstructorFields'
+               },
 
-    initialize : function(options) {
-        options = options || {};
+               initialize: function(options) {
+                   options = options || {};
         // fill in fields
-        this.$el.find("#course-language").val(this.model.get('language'));
-        this.$el.find("#course-organization").val(this.model.get('org'));
-        this.$el.find("#course-number").val(this.model.get('course_id'));
-        this.$el.find("#course-name").val(this.model.get('run'));
-        this.$el.find('.set-date').datepicker({ 'dateFormat': 'm/d/yy' });
+                   this.$el.find('#course-language').val(this.model.get('language'));
+                   this.$el.find('#course-organization').val(this.model.get('org'));
+                   this.$el.find('#course-number').val(this.model.get('course_id'));
+                   this.$el.find('#course-name').val(this.model.get('run'));
+                   this.$el.find('.set-date').datepicker({'dateFormat': 'm/d/yy'});
 
         // Avoid showing broken image on mistyped/nonexistent image
-        this.$el.find('img').error(function() {
-            $(this).hide();
-        });
-        this.$el.find('img').load(function() {
-            $(this).show();
-        });
+                   this.$el.find('img').error(function() {
+                       $(this).hide();
+                   });
+                   this.$el.find('img').load(function() {
+                       $(this).show();
+                   });
 
-        this.listenTo(this.model, 'invalid', this.handleValidationError);
-        this.listenTo(this.model, 'change', this.showNotificationBar);
-        this.selectorToField = _.invert(this.fieldToSelectorMap);
+                   this.listenTo(this.model, 'invalid', this.handleValidationError);
+                   this.listenTo(this.model, 'change', this.showNotificationBar);
+                   this.selectorToField = _.invert(this.fieldToSelectorMap);
         // handle license separately, to avoid reimplementing view logic
-        this.licenseModel = new LicenseModel({"asString": this.model.get('license')});
-        this.licenseView = new LicenseView({
-            model: this.licenseModel,
-            el: this.$("#course-license-selector").get(),
-            showPreview: true
-        });
-        this.listenTo(this.licenseModel, 'change', this.handleLicenseChange);
+                   this.licenseModel = new LicenseModel({'asString': this.model.get('license')});
+                   this.licenseView = new LicenseView({
+                       model: this.licenseModel,
+                       el: this.$('#course-license-selector').get(),
+                       showPreview: true
+                   });
+                   this.listenTo(this.licenseModel, 'change', this.handleLicenseChange);
 
-        if (options.showMinGradeWarning || false) {
-            new NotificationView.Warning({
-                title: gettext("Course Credit Requirements"),
-                message: gettext("The minimum grade for course credit is not set."),
-                closeIcon: true
-            }).show();
-        }
+                   if (options.showMinGradeWarning || false) {
+                       new NotificationView.Warning({
+                           title: gettext('Course Credit Requirements'),
+                           message: gettext('The minimum grade for course credit is not set.'),
+                           closeIcon: true
+                       }).show();
+                   }
 
-        this.learning_info_view = new LearningInfoView({
-            el: $(".course-settings-learning-fields"),
-            model: this.model
-        });
+                   this.learning_info_view = new LearningInfoView({
+                       el: $('.course-settings-learning-fields'),
+                       model: this.model
+                   });
 
-        this.instructor_info_view = new InstructorInfoView({
-            el: $(".course-instructor-details-fields"),
-            model: this.model
-        });
-    },
+                   this.instructor_info_view = new InstructorInfoView({
+                       el: $('.course-instructor-details-fields'),
+                       model: this.model
+                   });
+               },
 
-    render: function() {
+               render: function() {
         // Clear any image preview timeouts set in this.updateImagePreview
-        clearTimeout(this.imageTimer);
+                   clearTimeout(this.imageTimer);
 
-        DateUtils.setupDatePicker('start_date', this);
-        DateUtils.setupDatePicker('end_date', this);
-        DateUtils.setupDatePicker('enrollment_start', this);
-        DateUtils.setupDatePicker('enrollment_end', this);
+                   DateUtils.setupDatePicker('start_date', this);
+                   DateUtils.setupDatePicker('end_date', this);
+                   DateUtils.setupDatePicker('enrollment_start', this);
+                   DateUtils.setupDatePicker('enrollment_end', this);
 
-        this.$el.find('#' + this.fieldToSelectorMap['overview']).val(this.model.get('overview'));
-        this.codeMirrorize(null, $('#course-overview')[0]);
+                   this.$el.find('#' + this.fieldToSelectorMap['overview']).val(this.model.get('overview'));
+                   this.codeMirrorize(null, $('#course-overview')[0]);
 
-        if (this.model.get('title') !== '') {
-            this.$el.find('#' + this.fieldToSelectorMap.title).val(this.model.get('title'));
-        } else {
-            var displayName = this.$el.find('#' + this.fieldToSelectorMap.title).attr('data-display-name');
-            this.$el.find('#' + this.fieldToSelectorMap.title).val(displayName);
-        }
-        this.$el.find('#' + this.fieldToSelectorMap.subtitle).val(this.model.get('subtitle'));
-        this.$el.find('#' + this.fieldToSelectorMap.duration).val(this.model.get('duration'));
-        this.$el.find('#' + this.fieldToSelectorMap.description).val(this.model.get('description'));
+                   if (this.model.get('title') !== '') {
+                       this.$el.find('#' + this.fieldToSelectorMap.title).val(this.model.get('title'));
+                   } else {
+                       var displayName = this.$el.find('#' + this.fieldToSelectorMap.title).attr('data-display-name');
+                       this.$el.find('#' + this.fieldToSelectorMap.title).val(displayName);
+                   }
+                   this.$el.find('#' + this.fieldToSelectorMap.subtitle).val(this.model.get('subtitle'));
+                   this.$el.find('#' + this.fieldToSelectorMap.duration).val(this.model.get('duration'));
+                   this.$el.find('#' + this.fieldToSelectorMap.description).val(this.model.get('description'));
 
-        this.$el.find('#' + this.fieldToSelectorMap['short_description']).val(this.model.get('short_description'));
+                   this.$el.find('#' + this.fieldToSelectorMap['short_description']).val(this.model.get('short_description'));
 
-        this.$el.find('.current-course-introduction-video iframe').attr('src', this.model.videosourceSample());
-        this.$el.find('#' + this.fieldToSelectorMap['intro_video']).val(this.model.get('intro_video') || '');
-        if (this.model.has('intro_video')) {
-            this.$el.find('.remove-course-introduction-video').show();
-        }
-        else this.$el.find('.remove-course-introduction-video').hide();
+                   this.$el.find('.current-course-introduction-video iframe').attr('src', this.model.videosourceSample());
+                   this.$el.find('#' + this.fieldToSelectorMap['intro_video']).val(this.model.get('intro_video') || '');
+                   if (this.model.has('intro_video')) {
+                       this.$el.find('.remove-course-introduction-video').show();
+                   }
+                   else this.$el.find('.remove-course-introduction-video').hide();
 
-        this.$el.find('#' + this.fieldToSelectorMap['effort']).val(this.model.get('effort'));
+                   this.$el.find('#' + this.fieldToSelectorMap['effort']).val(this.model.get('effort'));
 
-        var courseImageURL = this.model.get('course_image_asset_path');
-        this.$el.find('#course-image-url').val(courseImageURL);
-        this.$el.find('#course-image').attr('src', courseImageURL);
+                   var courseImageURL = this.model.get('course_image_asset_path');
+                   this.$el.find('#course-image-url').val(courseImageURL);
+                   this.$el.find('#course-image').attr('src', courseImageURL);
 
-        var bannerImageURL = this.model.get('banner_image_asset_path');
-        this.$el.find('#banner-image-url').val(bannerImageURL);
-        this.$el.find('#banner-image').attr('src', bannerImageURL);
+                   var bannerImageURL = this.model.get('banner_image_asset_path');
+                   this.$el.find('#banner-image-url').val(bannerImageURL);
+                   this.$el.find('#banner-image').attr('src', bannerImageURL);
 
-        var videoThumbnailImageURL = this.model.get('video_thumbnail_image_asset_path');
-        this.$el.find('#video-thumbnail-image-url').val(videoThumbnailImageURL);
-        this.$el.find('#video-thumbnail-image').attr('src', videoThumbnailImageURL);
+                   var videoThumbnailImageURL = this.model.get('video_thumbnail_image_asset_path');
+                   this.$el.find('#video-thumbnail-image-url').val(videoThumbnailImageURL);
+                   this.$el.find('#video-thumbnail-image').attr('src', videoThumbnailImageURL);
 
-        var pre_requisite_courses = this.model.get('pre_requisite_courses');
-        pre_requisite_courses = pre_requisite_courses.length > 0 ? pre_requisite_courses : '';
-        this.$el.find('#' + this.fieldToSelectorMap['pre_requisite_courses']).val(pre_requisite_courses);
+                   var pre_requisite_courses = this.model.get('pre_requisite_courses');
+                   pre_requisite_courses = pre_requisite_courses.length > 0 ? pre_requisite_courses : '';
+                   this.$el.find('#' + this.fieldToSelectorMap['pre_requisite_courses']).val(pre_requisite_courses);
 
-        if (this.model.get('entrance_exam_enabled') == 'true') {
-            this.$('#' + this.fieldToSelectorMap['entrance_exam_enabled']).attr('checked', this.model.get('entrance_exam_enabled'));
-            this.$('.div-grade-requirements').show();
-        }
-        else {
-            this.$('#' + this.fieldToSelectorMap['entrance_exam_enabled']).removeAttr('checked');
-            this.$('.div-grade-requirements').hide();
-        }
-        this.$('#' + this.fieldToSelectorMap['entrance_exam_minimum_score_pct']).val(this.model.get('entrance_exam_minimum_score_pct'));
+                   if (this.model.get('entrance_exam_enabled') == 'true') {
+                       this.$('#' + this.fieldToSelectorMap['entrance_exam_enabled']).attr('checked', this.model.get('entrance_exam_enabled'));
+                       this.$('.div-grade-requirements').show();
+                   }
+                   else {
+                       this.$('#' + this.fieldToSelectorMap['entrance_exam_enabled']).removeAttr('checked');
+                       this.$('.div-grade-requirements').hide();
+                   }
+                   this.$('#' + this.fieldToSelectorMap['entrance_exam_minimum_score_pct']).val(this.model.get('entrance_exam_minimum_score_pct'));
 
-        var selfPacedButton = this.$('#course-pace-self-paced'),
-            instructorPacedButton = this.$('#course-pace-instructor-paced'),
-            paceToggleTip = this.$('#course-pace-toggle-tip');
-        (this.model.get('self_paced') ? selfPacedButton : instructorPacedButton).attr('checked', true);
-        if (this.model.canTogglePace()) {
-            selfPacedButton.removeAttr('disabled');
-            instructorPacedButton.removeAttr('disabled');
-            paceToggleTip.text('');
-        }
-        else {
-            selfPacedButton.attr('disabled', true);
-            instructorPacedButton.attr('disabled', true);
-            paceToggleTip.text(gettext('Course pacing cannot be changed once a course has started.'));
-        }
+                   var selfPacedButton = this.$('#course-pace-self-paced'),
+                       instructorPacedButton = this.$('#course-pace-instructor-paced'),
+                       paceToggleTip = this.$('#course-pace-toggle-tip');
+                   (this.model.get('self_paced') ? selfPacedButton : instructorPacedButton).attr('checked', true);
+                   if (this.model.canTogglePace()) {
+                       selfPacedButton.removeAttr('disabled');
+                       instructorPacedButton.removeAttr('disabled');
+                       paceToggleTip.text('');
+                   }
+                   else {
+                       selfPacedButton.attr('disabled', true);
+                       instructorPacedButton.attr('disabled', true);
+                       paceToggleTip.text(gettext('Course pacing cannot be changed once a course has started.'));
+                   }
 
-        this.licenseView.render();
-        this.learning_info_view.render();
-        this.instructor_info_view.render();
+                   this.licenseView.render();
+                   this.learning_info_view.render();
+                   this.instructor_info_view.render();
 
-        return this;
-    },
-    fieldToSelectorMap : {
-        'language' : 'course-language',
-        'start_date' : "course-start",
-        'end_date' : 'course-end',
-        'enrollment_start' : 'enrollment-start',
-        'enrollment_end' : 'enrollment-end',
-        'overview' : 'course-overview',
-        'title': 'course-title',
-        'subtitle': 'course-subtitle',
-        'duration': 'course-duration',
-        'description': 'course-description',
-        'short_description' : 'course-short-description',
-        'intro_video' : 'course-introduction-video',
-        'effort' : "course-effort",
-        'course_image_asset_path': 'course-image-url',
-        'banner_image_asset_path': 'banner-image-url',
-        'video_thumbnail_image_asset_path': 'video-thumbnail-image-url',
-        'pre_requisite_courses': 'pre-requisite-course',
-        'entrance_exam_enabled': 'entrance-exam-enabled',
-        'entrance_exam_minimum_score_pct': 'entrance-exam-minimum-score-pct',
-        'course_settings_learning_fields': 'course-settings-learning-fields',
-        'add_course_learning_info': 'add-course-learning-info',
-        'add_course_instructor_info': 'add-course-instructor-info',
-        'course_learning_info': 'course-learning-info'
-    },
+                   return this;
+               },
+               fieldToSelectorMap: {
+                   'language': 'course-language',
+                   'start_date': 'course-start',
+                   'end_date': 'course-end',
+                   'enrollment_start': 'enrollment-start',
+                   'enrollment_end': 'enrollment-end',
+                   'overview': 'course-overview',
+                   'title': 'course-title',
+                   'subtitle': 'course-subtitle',
+                   'duration': 'course-duration',
+                   'description': 'course-description',
+                   'short_description': 'course-short-description',
+                   'intro_video': 'course-introduction-video',
+                   'effort': 'course-effort',
+                   'course_image_asset_path': 'course-image-url',
+                   'banner_image_asset_path': 'banner-image-url',
+                   'video_thumbnail_image_asset_path': 'video-thumbnail-image-url',
+                   'pre_requisite_courses': 'pre-requisite-course',
+                   'entrance_exam_enabled': 'entrance-exam-enabled',
+                   'entrance_exam_minimum_score_pct': 'entrance-exam-minimum-score-pct',
+                   'course_settings_learning_fields': 'course-settings-learning-fields',
+                   'add_course_learning_info': 'add-course-learning-info',
+                   'add_course_instructor_info': 'add-course-instructor-info',
+                   'course_learning_info': 'course-learning-info'
+               },
 
-    addLearningFields: function() {
+               addLearningFields: function() {
         /*
         * Add new course learning fields.
         * */
-        var existingInfo = _.clone(this.model.get('learning_info'));
-        existingInfo.push('');
-        this.model.set('learning_info', existingInfo);
-    },
+                   var existingInfo = _.clone(this.model.get('learning_info'));
+                   existingInfo.push('');
+                   this.model.set('learning_info', existingInfo);
+               },
 
-    addInstructorFields: function() {
+               addInstructorFields: function() {
         /*
         * Add new course instructor fields.
         * */
-        var instructors = this.model.get('instructor_info').instructors.slice(0);
-        instructors.push({
-            name: '',
-            title: '',
-            organization: '',
-            image: '',
-            bio: ''
-        });
-        this.model.set('instructor_info', {instructors: instructors});
-    },
+                   var instructors = this.model.get('instructor_info').instructors.slice(0);
+                   instructors.push({
+                       name: '',
+                       title: '',
+                       organization: '',
+                       image: '',
+                       bio: ''
+                   });
+                   this.model.set('instructor_info', {instructors: instructors});
+               },
 
-    updateTime : function(e) {
-        var now = new Date(),
-            hours = now.getUTCHours(),
-            minutes = now.getUTCMinutes(),
-            currentTimeText = StringUtils.interpolate(
+               updateTime: function(e) {
+                   var now = new Date(),
+                       hours = now.getUTCHours(),
+                       minutes = now.getUTCMinutes(),
+                       currentTimeText = StringUtils.interpolate(
                 gettext('{hours}:{minutes} (current UTC time)'),
-                {
-                    'hours': hours,
-                    'minutes': minutes
-                }
+                           {
+                               'hours': hours,
+                               'minutes': minutes
+                           }
             );
 
-        $(e.currentTarget).attr('title', currentTimeText);
-    },
-    updateModel: function(event) {
-        var value;
-        var index = event.currentTarget.getAttribute('data-index');
-        switch (event.currentTarget.id) {
-        case 'course-learning-info-' + index:
-            value = $(event.currentTarget).val();
-            var learningInfo = this.model.get('learning_info');
-            learningInfo[index] = value;
-            this.showNotificationBar();
-            break;
-        case 'course-instructor-name-' + index:
-        case 'course-instructor-title-' + index:
-        case 'course-instructor-organization-' + index:
-        case 'course-instructor-bio-' + index:
-            value = $(event.currentTarget).val();
-            var field = event.currentTarget.getAttribute('data-field'),
-                instructors = this.model.get('instructor_info').instructors.slice(0);
-            instructors[index][field] = value;
-            this.model.set('instructor_info', {instructors: instructors});
-            this.showNotificationBar();
-            break;
-        case 'course-instructor-image-' + index:
-            instructors = this.model.get('instructor_info').instructors.slice(0);
-            instructors[index].image = $(event.currentTarget).val();
-            this.model.set('instructor_info', {instructors: instructors});
-            this.showNotificationBar();
-            this.updateImagePreview(event.currentTarget, '#course-instructor-image-preview-' + index);
-            break;
-        case 'course-image-url':
-            this.updateImageField(event, 'course_image_name', '#course-image');
-            break;
-        case 'banner-image-url':
-            this.updateImageField(event, 'banner_image_name', '#banner-image');
-            break;
-        case 'video-thumbnail-image-url':
-            this.updateImageField(event, 'video_thumbnail_image_name', '#video-thumbnail-image');
-            break;
-        case 'entrance-exam-enabled':
-            if($(event.currentTarget).is(":checked")){
-                this.$('.div-grade-requirements').show();
-            }else{
-                this.$('.div-grade-requirements').hide();
-            }
-            this.setField(event);
-            break;
-        case 'entrance-exam-minimum-score-pct':
+                   $(e.currentTarget).attr('title', currentTimeText);
+               },
+               updateModel: function(event) {
+                   var value;
+                   var index = event.currentTarget.getAttribute('data-index');
+                   switch (event.currentTarget.id) {
+                   case 'course-learning-info-' + index:
+                       value = $(event.currentTarget).val();
+                       var learningInfo = this.model.get('learning_info');
+                       learningInfo[index] = value;
+                       this.showNotificationBar();
+                       break;
+                   case 'course-instructor-name-' + index:
+                   case 'course-instructor-title-' + index:
+                   case 'course-instructor-organization-' + index:
+                   case 'course-instructor-bio-' + index:
+                       value = $(event.currentTarget).val();
+                       var field = event.currentTarget.getAttribute('data-field'),
+                           instructors = this.model.get('instructor_info').instructors.slice(0);
+                       instructors[index][field] = value;
+                       this.model.set('instructor_info', {instructors: instructors});
+                       this.showNotificationBar();
+                       break;
+                   case 'course-instructor-image-' + index:
+                       instructors = this.model.get('instructor_info').instructors.slice(0);
+                       instructors[index].image = $(event.currentTarget).val();
+                       this.model.set('instructor_info', {instructors: instructors});
+                       this.showNotificationBar();
+                       this.updateImagePreview(event.currentTarget, '#course-instructor-image-preview-' + index);
+                       break;
+                   case 'course-image-url':
+                       this.updateImageField(event, 'course_image_name', '#course-image');
+                       break;
+                   case 'banner-image-url':
+                       this.updateImageField(event, 'banner_image_name', '#banner-image');
+                       break;
+                   case 'video-thumbnail-image-url':
+                       this.updateImageField(event, 'video_thumbnail_image_name', '#video-thumbnail-image');
+                       break;
+                   case 'entrance-exam-enabled':
+                       if ($(event.currentTarget).is(':checked')) {
+                           this.$('.div-grade-requirements').show();
+                       } else {
+                           this.$('.div-grade-requirements').hide();
+                       }
+                       this.setField(event);
+                       break;
+                   case 'entrance-exam-minimum-score-pct':
             // If the val is an empty string then update model with default value.
-            if ($(event.currentTarget).val() === '') {
-                this.model.set('entrance_exam_minimum_score_pct', this.model.defaults.entrance_exam_minimum_score_pct);
-            }
-            else {
-                this.setField(event);
-            }
-            break;
-        case 'pre-requisite-course':
-            var value = $(event.currentTarget).val();
-            value = value == "" ? [] : [value];
-            this.model.set('pre_requisite_courses', value);
-            break;
+                       if ($(event.currentTarget).val() === '') {
+                           this.model.set('entrance_exam_minimum_score_pct', this.model.defaults.entrance_exam_minimum_score_pct);
+                       }
+                       else {
+                           this.setField(event);
+                       }
+                       break;
+                   case 'pre-requisite-course':
+                       var value = $(event.currentTarget).val();
+                       value = value == '' ? [] : [value];
+                       this.model.set('pre_requisite_courses', value);
+                       break;
         // Don't make the user reload the page to check the Youtube ID.
         // Wait for a second to load the video, avoiding egregious AJAX calls.
-        case 'course-introduction-video':
-            this.clearValidationErrors();
-            var previewsource = this.model.set_videosource($(event.currentTarget).val());
-            clearTimeout(this.videoTimer);
-            this.videoTimer = setTimeout(_.bind(function() {
-                this.$el.find(".current-course-introduction-video iframe").attr("src", previewsource);
-                if (this.model.has('intro_video')) {
-                    this.$el.find('.remove-course-introduction-video').show();
-                }
-                else {
-                    this.$el.find('.remove-course-introduction-video').hide();
-                }
-            }, this), 1000);
-            break;
-        case 'course-pace-self-paced':
+                   case 'course-introduction-video':
+                       this.clearValidationErrors();
+                       var previewsource = this.model.set_videosource($(event.currentTarget).val());
+                       clearTimeout(this.videoTimer);
+                       this.videoTimer = setTimeout(_.bind(function() {
+                           this.$el.find('.current-course-introduction-video iframe').attr('src', previewsource);
+                           if (this.model.has('intro_video')) {
+                               this.$el.find('.remove-course-introduction-video').show();
+                           }
+                           else {
+                               this.$el.find('.remove-course-introduction-video').hide();
+                           }
+                       }, this), 1000);
+                       break;
+                   case 'course-pace-self-paced':
             // Fallthrough to handle both radio buttons
-        case 'course-pace-instructor-paced':
-            this.model.set('self_paced', JSON.parse(event.currentTarget.value));
-            break;
-        case 'course-language':
-        case 'course-effort':
-        case 'course-title':
-        case 'course-subtitle':
-        case 'course-duration':
-        case 'course-description':
-        case 'course-short-description':
-            this.setField(event);
-            break;
-        default: // Everything else is handled by datepickers and CodeMirror.
-            break;
-        }
-    },
-    updateImageField: function(event, image_field, selector) {
-        this.setField(event);
-        var url = $(event.currentTarget).val();
-        var image_name = _.last(url.split('/'));
+                   case 'course-pace-instructor-paced':
+                       this.model.set('self_paced', JSON.parse(event.currentTarget.value));
+                       break;
+                   case 'course-language':
+                   case 'course-effort':
+                   case 'course-title':
+                   case 'course-subtitle':
+                   case 'course-duration':
+                   case 'course-description':
+                   case 'course-short-description':
+                       this.setField(event);
+                       break;
+                   default: // Everything else is handled by datepickers and CodeMirror.
+                       break;
+                   }
+               },
+               updateImageField: function(event, image_field, selector) {
+                   this.setField(event);
+                   var url = $(event.currentTarget).val();
+                   var image_name = _.last(url.split('/'));
         // If image path is entered directly, we need to strip the asset prefix
-        image_name = _.last(image_name.split('block@'));
-        this.model.set(image_field, image_name);
-        this.updateImagePreview(event.currentTarget, selector);
-    },
-    updateImagePreview: function(imagePathInputElement, previewSelector) {
+                   image_name = _.last(image_name.split('block@'));
+                   this.model.set(image_field, image_name);
+                   this.updateImagePreview(event.currentTarget, selector);
+               },
+               updateImagePreview: function(imagePathInputElement, previewSelector) {
         // Wait to set the image src until the user stops typing
-        clearTimeout(this.imageTimer);
-        this.imageTimer = setTimeout(function() {
-            $(previewSelector).attr('src', $(imagePathInputElement).val());
-        }, 1000);
-    },
-    removeVideo: function(event) {
-        event.preventDefault();
-        if (this.model.has('intro_video')) {
-            this.model.set_videosource(null);
-            this.$el.find(".current-course-introduction-video iframe").attr("src", "");
-            this.$el.find('#' + this.fieldToSelectorMap['intro_video']).val("");
-            this.$el.find('.remove-course-introduction-video').hide();
-        }
-    },
-    codeMirrors : {},
-    codeMirrorize: function (e, forcedTarget) {
-        var thisTarget;
-        if (forcedTarget) {
-            thisTarget = forcedTarget;
-            thisTarget.id = $(thisTarget).attr('id');
-        } else if (e !== null) {
-            thisTarget = e.currentTarget;
-        } else
+                   clearTimeout(this.imageTimer);
+                   this.imageTimer = setTimeout(function() {
+                       $(previewSelector).attr('src', $(imagePathInputElement).val());
+                   }, 1000);
+               },
+               removeVideo: function(event) {
+                   event.preventDefault();
+                   if (this.model.has('intro_video')) {
+                       this.model.set_videosource(null);
+                       this.$el.find('.current-course-introduction-video iframe').attr('src', '');
+                       this.$el.find('#' + this.fieldToSelectorMap['intro_video']).val('');
+                       this.$el.find('.remove-course-introduction-video').hide();
+                   }
+               },
+               codeMirrors: {},
+               codeMirrorize: function(e, forcedTarget) {
+                   var thisTarget;
+                   if (forcedTarget) {
+                       thisTarget = forcedTarget;
+                       thisTarget.id = $(thisTarget).attr('id');
+                   } else if (e !== null) {
+                       thisTarget = e.currentTarget;
+                   } else
         {
             // e and forcedTarget can be null so don't deference it
             // This is because in cases where we have a marketing site
             // we don't display the codeMirrors for editing the marketing
             // materials, except we do need to show the 'set course image'
             // workflow. So in this case e = forcedTarget = null.
-            return;
-        }
+                       return;
+                   }
 
-        if (!this.codeMirrors[thisTarget.id]) {
-            var cachethis = this;
-            var field = this.selectorToField[thisTarget.id];
-            this.codeMirrors[thisTarget.id] = CodeMirror.fromTextArea(thisTarget, {
-                mode: "text/html", lineNumbers: true, lineWrapping: true});
-            this.codeMirrors[thisTarget.id].on('change', function (mirror) {
-                    mirror.save();
-                    cachethis.clearValidationErrors();
-                    var newVal = mirror.getValue();
-                    if (cachethis.model.get(field) != newVal) {
-                        cachethis.setAndValidate(field, newVal);
-                    }
-            });
-        }
-    },
+                   if (!this.codeMirrors[thisTarget.id]) {
+                       var cachethis = this;
+                       var field = this.selectorToField[thisTarget.id];
+                       this.codeMirrors[thisTarget.id] = CodeMirror.fromTextArea(thisTarget, {
+                           mode: 'text/html', lineNumbers: true, lineWrapping: true});
+                       this.codeMirrors[thisTarget.id].on('change', function(mirror) {
+                           mirror.save();
+                           cachethis.clearValidationErrors();
+                           var newVal = mirror.getValue();
+                           if (cachethis.model.get(field) != newVal) {
+                               cachethis.setAndValidate(field, newVal);
+                           }
+                       });
+                   }
+               },
 
-    revertView: function() {
+               revertView: function() {
         // Make sure that the CodeMirror instance has the correct
         // data from its corresponding textarea
-        var self = this;
-        this.model.fetch({
-            success: function() {
-                self.render();
-                _.each(self.codeMirrors, function(mirror) {
-                    var ele = mirror.getTextArea();
-                    var field = self.selectorToField[ele.id];
-                    mirror.setValue(self.model.get(field));
-                });
-                self.licenseModel.setFromString(self.model.get("license"), {silent: true});
-                self.licenseView.render()
-            },
-            reset: true,
-            silent: true});
-    },
-    setAndValidate: function(attr, value) {
+                   var self = this;
+                   this.model.fetch({
+                       success: function() {
+                           self.render();
+                           _.each(self.codeMirrors, function(mirror) {
+                               var ele = mirror.getTextArea();
+                               var field = self.selectorToField[ele.id];
+                               mirror.setValue(self.model.get(field));
+                           });
+                           self.licenseModel.setFromString(self.model.get('license'), {silent: true});
+                           self.licenseView.render();
+                       },
+                       reset: true,
+                       silent: true});
+               },
+               setAndValidate: function(attr, value) {
         // If we call model.set() with {validate: true}, model fields
         // will not be set if validation fails. This puts the UI and
         // the model in an inconsistent state, and causes us to not
         // see the right validation errors the next time validate() is
         // called on the model. So we set *without* validating, then
         // call validate ourselves.
-        this.model.set(attr, value);
-        this.model.isValid();
-    },
+                   this.model.set(attr, value);
+                   this.model.isValid();
+               },
 
-    showNotificationBar: function() {
+               showNotificationBar: function() {
         // We always call showNotificationBar with the same args, just
         // delegate to superclass
-        ValidatingView.prototype.showNotificationBar.call(this,
+                   ValidatingView.prototype.showNotificationBar.call(this,
                                                           this.save_message,
                                                           _.bind(this.saveView, this),
                                                           _.bind(this.revertView, this));
-    },
+               },
 
-    uploadImage: function(event) {
-        event.preventDefault();
-        var title = "", selector = "", image_key = "", image_path_key = "";
-        switch (event.currentTarget.id) {
-            case 'upload-course-image':
-                title = gettext("Upload your course image.");
-                selector = "#course-image";
-                image_key = 'course_image_name';
-                image_path_key = 'course_image_asset_path';
-                break;
-            case 'upload-banner-image':
-                title = gettext("Upload your banner image.");
-                selector = "#banner-image";
-                image_key = 'banner_image_name';
-                image_path_key = 'banner_image_asset_path';
-                break;
-            case 'upload-video-thumbnail-image':
-                title = gettext("Upload your video thumbnail image.");
-                selector = "#video-thumbnail-image";
-                image_key = 'video_thumbnail_image_name';
-                image_path_key = 'video_thumbnail_image_asset_path';
-                break;
-        }
+               uploadImage: function(event) {
+                   event.preventDefault();
+                   var title = '', selector = '', image_key = '', image_path_key = '';
+                   switch (event.currentTarget.id) {
+                   case 'upload-course-image':
+                       title = gettext('Upload your course image.');
+                       selector = '#course-image';
+                       image_key = 'course_image_name';
+                       image_path_key = 'course_image_asset_path';
+                       break;
+                   case 'upload-banner-image':
+                       title = gettext('Upload your banner image.');
+                       selector = '#banner-image';
+                       image_key = 'banner_image_name';
+                       image_path_key = 'banner_image_asset_path';
+                       break;
+                   case 'upload-video-thumbnail-image':
+                       title = gettext('Upload your video thumbnail image.');
+                       selector = '#video-thumbnail-image';
+                       image_key = 'video_thumbnail_image_name';
+                       image_path_key = 'video_thumbnail_image_asset_path';
+                       break;
+                   }
 
-        var upload = new FileUploadModel({
-            title: title,
-            message: gettext("Files must be in JPEG or PNG format."),
-            mimeTypes: ['image/jpeg', 'image/png']
-        });
-        var self = this;
-        var modal = new FileUploadDialog({
-            model: upload,
-            onSuccess: function(response) {
-                var options = {};
-                options[image_key] = response.asset.display_name;
-                options[image_path_key] = response.asset.url;
-                self.model.set(options);
-                self.render();
-                $(selector).attr('src', self.model.get(image_path_key));
-            }
-        });
-        modal.show();
-    },
+                   var upload = new FileUploadModel({
+                       title: title,
+                       message: gettext('Files must be in JPEG or PNG format.'),
+                       mimeTypes: ['image/jpeg', 'image/png']
+                   });
+                   var self = this;
+                   var modal = new FileUploadDialog({
+                       model: upload,
+                       onSuccess: function(response) {
+                           var options = {};
+                           options[image_key] = response.asset.display_name;
+                           options[image_path_key] = response.asset.url;
+                           self.model.set(options);
+                           self.render();
+                           $(selector).attr('src', self.model.get(image_path_key));
+                       }
+                   });
+                   modal.show();
+               },
 
-    handleLicenseChange: function() {
-        this.showNotificationBar();
-        this.model.set("license", this.licenseModel.toString());
-    }
-});
+               handleLicenseChange: function() {
+                   this.showNotificationBar();
+                   this.model.set('license', this.licenseModel.toString());
+               }
+           });
 
-return DetailsView;
-
-}); // end define()
+           return DetailsView;
+       }); // end define()

--- a/cms/static/js/views/show_textbook.js
+++ b/cms/static/js/views/show_textbook.js
@@ -1,70 +1,70 @@
-define(["js/views/baseview", "underscore", "gettext", "common/js/components/views/feedback_notification",
-        "common/js/components/views/feedback_prompt"],
+define(['js/views/baseview', 'underscore', 'gettext', 'common/js/components/views/feedback_notification',
+        'common/js/components/views/feedback_prompt'],
         function(BaseView, _, gettext, NotificationView, PromptView) {
-    var ShowTextbook = BaseView.extend({
-        initialize: function() {
-            this.template = _.template($("#show-textbook-tpl").text());
-            this.listenTo(this.model, "change", this.render);
-        },
-        tagName: "section",
-        className: "textbook",
-        events: {
-            "click .edit": "editTextbook",
-            "click .delete": "confirmDelete",
-            "click .show-chapters": "showChapters",
-            "click .hide-chapters": "hideChapters"
-        },
-        render: function() {
-            var attrs = $.extend({}, this.model.attributes);
-            attrs.bookindex = this.model.collection.indexOf(this.model);
-            attrs.course = window.course.attributes;
-            this.$el.html(this.template(attrs));
-            return this;
-        },
-        editTextbook: function(e) {
-            if(e && e.preventDefault) { e.preventDefault(); }
-            this.model.set("editing", true);
-        },
-        confirmDelete: function(e) {
-            if(e && e.preventDefault) { e.preventDefault(); }
-            var textbook = this.model;
-            new PromptView.Warning({
-                title: _.template(gettext("Delete “<%= name %>”?"))(
+            var ShowTextbook = BaseView.extend({
+                initialize: function() {
+                    this.template = _.template($('#show-textbook-tpl').text());
+                    this.listenTo(this.model, 'change', this.render);
+                },
+                tagName: 'section',
+                className: 'textbook',
+                events: {
+                    'click .edit': 'editTextbook',
+                    'click .delete': 'confirmDelete',
+                    'click .show-chapters': 'showChapters',
+                    'click .hide-chapters': 'hideChapters'
+                },
+                render: function() {
+                    var attrs = $.extend({}, this.model.attributes);
+                    attrs.bookindex = this.model.collection.indexOf(this.model);
+                    attrs.course = window.course.attributes;
+                    this.$el.html(this.template(attrs));
+                    return this;
+                },
+                editTextbook: function(e) {
+                    if (e && e.preventDefault) { e.preventDefault(); }
+                    this.model.set('editing', true);
+                },
+                confirmDelete: function(e) {
+                    if (e && e.preventDefault) { e.preventDefault(); }
+                    var textbook = this.model;
+                    new PromptView.Warning({
+                        title: _.template(gettext('Delete “<%= name %>”?'))(
                     {name: textbook.get('name')}
                 ),
-                message: gettext("Deleting a textbook cannot be undone and once deleted any reference to it in your courseware's navigation will also be removed."),
-                actions: {
-                    primary: {
-                        text: gettext("Delete"),
-                        click: function(view) {
-                            view.hide();
-                            var delmsg = new NotificationView.Mini({
-                                title: gettext("Deleting")
-                            }).show();
-                            textbook.destroy({
-                                complete: function() {
-                                    delmsg.hide();
+                        message: gettext("Deleting a textbook cannot be undone and once deleted any reference to it in your courseware's navigation will also be removed."),
+                        actions: {
+                            primary: {
+                                text: gettext('Delete'),
+                                click: function(view) {
+                                    view.hide();
+                                    var delmsg = new NotificationView.Mini({
+                                        title: gettext('Deleting')
+                                    }).show();
+                                    textbook.destroy({
+                                        complete: function() {
+                                            delmsg.hide();
+                                        }
+                                    });
                                 }
-                            });
+                            },
+                            secondary: {
+                                text: gettext('Cancel'),
+                                click: function(view) {
+                                    view.hide();
+                                }
+                            }
                         }
-                    },
-                    secondary: {
-                        text: gettext("Cancel"),
-                        click: function(view) {
-                            view.hide();
-                        }
-                    }
+                    }).show();
+                },
+                showChapters: function(e) {
+                    if (e && e.preventDefault) { e.preventDefault(); }
+                    this.model.set('showChapters', true);
+                },
+                hideChapters: function(e) {
+                    if (e && e.preventDefault) { e.preventDefault(); }
+                    this.model.set('showChapters', false);
                 }
-            }).show();
-        },
-        showChapters: function(e) {
-            if(e && e.preventDefault) { e.preventDefault(); }
-            this.model.set('showChapters', true);
-        },
-        hideChapters: function(e) {
-            if(e && e.preventDefault) { e.preventDefault(); }
-            this.model.set('showChapters', false);
-        }
-    });
-    return ShowTextbook;
-});
+            });
+            return ShowTextbook;
+        });

--- a/cms/static/js/views/tabs.js
+++ b/cms/static/js/views/tabs.js
@@ -26,7 +26,6 @@
         function(_, $, ui, Backbone, PromptView, NotificationView, ModuleEditView, ModuleModel, ModuleUtils) {
             var TabsEdit;
             TabsEdit = (function(_super) {
-
                 __extends(TabsEdit, _super);
 
                 function TabsEdit() {
@@ -197,7 +196,6 @@
                 };
 
                 return TabsEdit;
-
             })(Backbone.View);
             return TabsEdit;
         });

--- a/cms/static/js/views/unit_outline.js
+++ b/cms/static/js/views/unit_outline.js
@@ -26,7 +26,7 @@ define(['underscore', 'js/views/xblock_outline', 'js/views/unit_outline_child'],
                     // Note: the ancestors are processed in reverse order because the tree wants to
                     // start at the root, but the ancestors are ordered by closeness to the unit,
                     // i.e. subsection and then section.
-                    for (i=ancestors.length - 1; i >= 0; i--) {
+                    for (i = ancestors.length - 1; i >= 0; i--) {
                         ancestor = ancestors[i];
                         ancestorView = this.createChildView(
                             ancestor,

--- a/cms/static/js/views/uploads.js
+++ b/cms/static/js/views/uploads.js
@@ -1,9 +1,9 @@
-define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "jquery.form"],
+define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'jquery.form'],
     function($, _, gettext, BaseModal) {
         var UploadDialog = BaseModal.extend({
             events: _.extend({}, BaseModal.prototype.events, {
-                "change input[type=file]": "selectFile",
-                "click .action-upload": "upload"
+                'change input[type=file]': 'selectFile',
+                'click .action-upload': 'upload'
             }),
 
             options: $.extend({}, BaseModal.prototype.options, {
@@ -15,20 +15,20 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "jquery
 
             initialize: function() {
                 BaseModal.prototype.initialize.call(this);
-                this.template = this.loadTemplate("upload-dialog");
-                this.listenTo(this.model, "change", this.renderContents);
+                this.template = this.loadTemplate('upload-dialog');
+                this.listenTo(this.model, 'change', this.renderContents);
                 this.options.title = this.model.get('title');
             },
 
             addActionButtons: function() {
-                this.addActionButton('upload', gettext("Upload"), true);
+                this.addActionButton('upload', gettext('Upload'), true);
                 BaseModal.prototype.addActionButtons.call(this);
             },
 
             renderContents: function() {
                 var isValid = this.model.isValid(),
                     selectedFile = this.model.get('selectedFile'),
-                    oldInput = this.$("input[type=file]").get(0);
+                    oldInput = this.$('input[type=file]').get(0);
                 BaseModal.prototype.renderContents.call(this);
                 // Ideally, we'd like to tell the browser to pre-populate the
                 // <input type="file"> with the selectedFile if we have one -- but
@@ -38,7 +38,7 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "jquery
                 // this if the selected file is valid: if it isn't, we want to render
                 // a blank input to prompt the user to upload a different (valid) file.
                 if (selectedFile && isValid) {
-                    $(oldInput).removeClass("error");
+                    $(oldInput).removeClass('error');
                     this.$('input[type=file]').replaceWith(oldInput);
                     this.$('.action-upload').removeClass('disabled');
                 } else {
@@ -67,7 +67,7 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "jquery
                 });
                 // This change event triggering necessary for FireFox, because the browser don't
                 // consider change of File object (file input field) as a change in model.
-                if (selectedFile && $.isEmptyObject(this.model.changed)){
+                if (selectedFile && $.isEmptyObject(this.model.changed)) {
                     this.model.trigger('change');
                 }
             },
@@ -75,7 +75,7 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "jquery
             upload: function(e) {
                 if (e && e.preventDefault) { e.preventDefault(); }
                 this.model.set('uploading', true);
-                this.$("form").ajaxSubmit({
+                this.$('form').ajaxSubmit({
                     success: _.bind(this.success, this),
                     error: _.bind(this.error, this),
                     uploadProgress: _.bind(this.progress, this),
@@ -89,8 +89,8 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "jquery
 
             progress: function(event, position, total) {
                 this.model.set({
-                    "uploadedBytes": position,
-                    "totalBytes": total
+                    'uploadedBytes': position,
+                    'totalBytes': total
                 });
             },
 
@@ -110,9 +110,9 @@ define(["jquery", "underscore", "gettext", "js/views/modals/base_modal", "jquery
 
             error: function() {
                 this.model.set({
-                    "uploading": false,
-                    "uploadedBytes": 0,
-                    "title": gettext("We're sorry, there was an error")
+                    'uploading': false,
+                    'uploadedBytes': 0,
+                    'title': gettext("We're sorry, there was an error")
                 });
             }
         });

--- a/cms/static/js/views/utils/create_course_utils.js
+++ b/cms/static/js/views/utils/create_course_utils.js
@@ -1,29 +1,29 @@
 /**
  * Provides utilities for validating courses during creation, for both new courses and reruns.
  */
-define(["jquery", "gettext", "common/js/components/utils/view_utils", "js/views/utils/create_utils_base"],
-    function ($, gettext, ViewUtils, CreateUtilsFactory) {
-        "use strict";
-        return function (selectors, classes) {
-            var keyLengthViolationMessage = gettext("The combined length of the organization, course number, and course run fields cannot be more than <%=limit%> characters.");
+define(['jquery', 'gettext', 'common/js/components/utils/view_utils', 'js/views/utils/create_utils_base'],
+    function($, gettext, ViewUtils, CreateUtilsFactory) {
+        'use strict';
+        return function(selectors, classes) {
+            var keyLengthViolationMessage = gettext('The combined length of the organization, course number, and course run fields cannot be more than <%=limit%> characters.');
             var keyFieldSelectors = [selectors.org, selectors.number, selectors.run];
             var nonEmptyCheckFieldSelectors = [selectors.name, selectors.org, selectors.number, selectors.run];
 
             CreateUtilsFactory.call(this, selectors, classes, keyLengthViolationMessage, keyFieldSelectors, nonEmptyCheckFieldSelectors);
 
-            this.setupOrgAutocomplete = function(){
-                $.getJSON('/organizations', function (data) {
+            this.setupOrgAutocomplete = function() {
+                $.getJSON('/organizations', function(data) {
                     $(selectors.org).autocomplete({
                         source: data
                     });
                 });
             };
 
-            this.create = function (courseInfo, errorHandler) {
+            this.create = function(courseInfo, errorHandler) {
                 $.postJSON(
                     '/course/',
                     courseInfo,
-                    function (data) {
+                    function(data) {
                         if (data.url !== undefined) {
                             ViewUtils.redirect(data.url);
                         } else if (data.ErrMsg !== undefined) {

--- a/cms/static/js/views/utils/create_library_utils.js
+++ b/cms/static/js/views/utils/create_library_utils.js
@@ -1,21 +1,21 @@
 /**
  * Provides utilities for validating libraries during creation.
  */
-define(["jquery", "gettext", "common/js/components/utils/view_utils", "js/views/utils/create_utils_base"],
-    function ($, gettext, ViewUtils, CreateUtilsFactory) {
-        "use strict";
-        return function (selectors, classes) {
-            var keyLengthViolationMessage = gettext("The combined length of the organization and library code fields cannot be more than <%=limit%> characters.")
+define(['jquery', 'gettext', 'common/js/components/utils/view_utils', 'js/views/utils/create_utils_base'],
+    function($, gettext, ViewUtils, CreateUtilsFactory) {
+        'use strict';
+        return function(selectors, classes) {
+            var keyLengthViolationMessage = gettext('The combined length of the organization and library code fields cannot be more than <%=limit%> characters.');
             var keyFieldSelectors = [selectors.org, selectors.number];
             var nonEmptyCheckFieldSelectors = [selectors.name, selectors.org, selectors.number];
 
             CreateUtilsFactory.call(this, selectors, classes, keyLengthViolationMessage, keyFieldSelectors, nonEmptyCheckFieldSelectors);
 
-            this.create = function (libraryInfo, errorHandler) {
+            this.create = function(libraryInfo, errorHandler) {
                 $.postJSON(
                     '/library/',
                     libraryInfo
-                ).done(function (data) {
+                ).done(function(data) {
                     ViewUtils.redirect(data.url);
                 }).fail(function(jqXHR, textStatus, errorThrown) {
                     var reason = errorThrown;
@@ -29,6 +29,6 @@ define(["jquery", "gettext", "common/js/components/utils/view_utils", "js/views/
                     }
                     errorHandler(reason);
                 });
-            }
+            };
         };
     });

--- a/cms/static/js/views/utils/create_utils_base.js
+++ b/cms/static/js/views/utils/create_utils_base.js
@@ -1,9 +1,9 @@
 /**
  * Mixin class for creation of things like courses and libraries.
  */
-define(["jquery", "underscore", "gettext", "common/js/components/utils/view_utils"],
-    function ($, _, gettext, ViewUtils) {
-        return function (selectors, classes, keyLengthViolationMessage, keyFieldSelectors, nonEmptyCheckFieldSelectors) {
+define(['jquery', 'underscore', 'gettext', 'common/js/components/utils/view_utils'],
+    function($, _, gettext, ViewUtils) {
+        return function(selectors, classes, keyLengthViolationMessage, keyFieldSelectors, nonEmptyCheckFieldSelectors) {
             var self = this;
 
             this.selectors = selectors;
@@ -16,12 +16,12 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
             // Fields that must not be empty on your model.
             this.nonEmptyCheckFieldSelectors = nonEmptyCheckFieldSelectors;
 
-            this.create = function (courseInfo, errorHandler) {
+            this.create = function(courseInfo, errorHandler) {
                 // Replace this with a function that will make a request to create the object.
             };
 
             // Ensure that key fields passes checkTotalKeyLengthViolations check
-            this.validateTotalKeyLength = function () {
+            this.validateTotalKeyLength = function() {
                 ViewUtils.checkTotalKeyLengthViolations(
                     self.selectors, self.classes,
                     self.keyFieldSelectors,
@@ -29,12 +29,12 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
                 );
             };
 
-            this.toggleSaveButton = function (is_enabled) {
+            this.toggleSaveButton = function(is_enabled) {
                 var is_disabled = !is_enabled;
                 $(self.selectors.save).toggleClass(self.classes.disabled, is_disabled).attr('aria-disabled', is_disabled);
             };
 
-            this.setFieldInErr = function (element, message) {
+            this.setFieldInErr = function(element, message) {
                 if (message) {
                     element.addClass(self.classes.error);
                     element.children(self.selectors.tipError).addClass(self.classes.showing).removeClass(self.classes.hiding).text(message);
@@ -51,10 +51,10 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
             };
 
             // One final check for empty values
-            this.hasInvalidRequiredFields = function () {
+            this.hasInvalidRequiredFields = function() {
                 return _.reduce(
                     self.nonEmptyCheckFieldSelectors,
-                    function (acc, element) {
+                    function(acc, element) {
                         var $element = $(element);
                         var error = self.validateRequiredField($element.val());
                         self.setFieldInErr($element.parent(), error);
@@ -65,10 +65,10 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
             };
 
             // Ensure that all fields are not empty
-            this.validateFilledFields = function () {
+            this.validateFilledFields = function() {
                 return _.reduce(
                     self.nonEmptyCheckFieldSelectors,
-                    function (acc, element) {
+                    function(acc, element) {
                         var $element = $(element);
                         return $element.val().length !== 0 ? acc : false;
                     },
@@ -77,12 +77,12 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
             };
 
             // Handle validation asynchronously
-            this.configureHandlers = function () {
+            this.configureHandlers = function() {
                 _.each(
                     self.keyFieldSelectors,
-                    function (element) {
+                    function(element) {
                         var $element = $(element);
-                        $element.on('keyup', function (event) {
+                        $element.on('keyup', function(event) {
                             // Don't bother showing "required field" error when
                             // the user tabs into a new field; this is distracting
                             // and unnecessary
@@ -100,7 +100,7 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
                 );
 
                 var $name = $(self.selectors.name);
-                $name.on('keyup', function () {
+                $name.on('keyup', function() {
                     var error = self.validateRequiredField($name.val());
                     self.setFieldInErr($name.parent(), error);
                     self.validateTotalKeyLength();
@@ -118,6 +118,6 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
                 validateFilledFields: self.validateFilledFields,
                 configureHandlers: self.configureHandlers
             };
-        }
+        };
     }
 );

--- a/cms/static/js/views/utils/xblock_utils.js
+++ b/cms/static/js/views/utils/xblock_utils.js
@@ -1,7 +1,7 @@
 /**
  * Provides utilities for views to work with xblocks.
  */
-define(["jquery", "underscore", "gettext", "common/js/components/utils/view_utils", "js/utils/module"],
+define(['jquery', 'underscore', 'gettext', 'common/js/components/utils/view_utils', 'js/utils/module'],
     function($, _, gettext, ViewUtils, ModuleUtils) {
         var addXBlock, deleteXBlock, createUpdateRequestData, updateXBlockField, VisibilityState,
             getXBlockVisibilityClass, getXBlockListTypeClass, updateXBlockFields;
@@ -90,7 +90,7 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
             xblockType = xblockType || 'component';
             messageBody = interpolate(
                     gettext('Deleting this %(xblock_type)s is permanent and cannot be undone.'),
-                    { xblock_type: xblockType },
+                    {xblock_type: xblockType},
                     true
                 );
 
@@ -99,13 +99,13 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
                 ViewUtils.confirmThenRunOperation(
                     interpolate(
                         gettext('Delete this %(xblock_type)s (and prerequisite)?'),
-                        { xblock_type: xblockType },
+                        {xblock_type: xblockType},
                         true
                     ),
                     messageBody,
                     interpolate(
                         gettext('Yes, delete this %(xblock_type)s'),
-                        { xblock_type: xblockType },
+                        {xblock_type: xblockType},
                         true
                     ),
                     operation
@@ -114,13 +114,13 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
                 ViewUtils.confirmThenRunOperation(
                     interpolate(
                         gettext('Delete this %(xblock_type)s?'),
-                        { xblock_type: xblockType },
+                        {xblock_type: xblockType},
                         true
                     ),
                     messageBody,
                     interpolate(
                         gettext('Yes, delete this %(xblock_type)s'),
-                        { xblock_type: xblockType },
+                        {xblock_type: xblockType},
                         true
                     ),
                     operation
@@ -148,7 +148,7 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
             var requestData = createUpdateRequestData(fieldName, newValue);
             return ViewUtils.runOperationShowingMessage(gettext('Saving'),
                 function() {
-                    return xblockInfo.save(requestData, { patch: true });
+                    return xblockInfo.save(requestData, {patch: true});
                 });
         };
 
@@ -160,7 +160,7 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
          * @returns {jQuery promise} A promise representing the updating of the xblock values.
          */
         updateXBlockFields = function(xblockInfo, xblockData, options) {
-            options = _.extend({}, { patch: true }, options);
+            options = _.extend({}, {patch: true}, options);
             return ViewUtils.runOperationShowingMessage(gettext('Saving'),
                 function() {
                     return xblockInfo.save(xblockData, options);
@@ -190,7 +190,7 @@ define(["jquery", "underscore", "gettext", "common/js/components/utils/view_util
             return '';
         };
 
-        getXBlockListTypeClass = function (xblockType) {
+        getXBlockListTypeClass = function(xblockType) {
             var listType = 'list-unknown';
             if (xblockType === 'course') {
                 listType = 'list-sections';

--- a/cms/static/js/views/validation.js
+++ b/cms/static/js/views/validation.js
@@ -1,178 +1,176 @@
-define(["edx-ui-toolkit/js/utils/html-utils",
-        "js/views/baseview",
-        "underscore",
-        "jquery",
-        "gettext",
-        "common/js/components/views/feedback_notification",
-        "common/js/components/views/feedback_alert",
-        "js/views/baseview",
-        "jquery.smoothScroll"],
+define(['edx-ui-toolkit/js/utils/html-utils',
+        'js/views/baseview',
+        'underscore',
+        'jquery',
+        'gettext',
+        'common/js/components/views/feedback_notification',
+        'common/js/components/views/feedback_alert',
+        'js/views/baseview',
+        'jquery.smoothScroll'],
     function(HtmlUtils, BaseView, _, $, gettext, NotificationView, AlertView) {
-
-var ValidatingView = BaseView.extend({
+        var ValidatingView = BaseView.extend({
     // Intended as an abstract class which catches validation errors on the model and
     // decorates the fields. Needs wiring per class, but this initialization shows how
     // either have your init call this one or copy the contents
-    initialize : function() {
-        this.listenTo(this.model, 'invalid', this.handleValidationError);
-        this.selectorToField = _.invert(this.fieldToSelectorMap);
-    },
+            initialize: function() {
+                this.listenTo(this.model, 'invalid', this.handleValidationError);
+                this.selectorToField = _.invert(this.fieldToSelectorMap);
+            },
 
-    errorTemplate : HtmlUtils.template('<span class="message-error"><%- message %></span>'),
+            errorTemplate: HtmlUtils.template('<span class="message-error"><%- message %></span>'),
 
-    save_title: gettext("You've made some changes"),
-    save_message: gettext("Your changes will not take effect until you save your progress."),
-    error_title: gettext("You've made some changes, but there are some errors"),
-    error_message: gettext("Please address the errors on this page first, and then save your progress."),
+            save_title: gettext("You've made some changes"),
+            save_message: gettext('Your changes will not take effect until you save your progress.'),
+            error_title: gettext("You've made some changes, but there are some errors"),
+            error_message: gettext('Please address the errors on this page first, and then save your progress.'),
 
-    events : {
-        "change input" : "clearValidationErrors",
-        "change textarea" : "clearValidationErrors"
-    },
-    fieldToSelectorMap : {
+            events: {
+                'change input': 'clearValidationErrors',
+                'change textarea': 'clearValidationErrors'
+            },
+            fieldToSelectorMap: {
         // Your subclass must populate this w/ all of the model keys and dom selectors
         // which may be the subjects of validation errors
-    },
-    _cacheValidationErrors : [],
+            },
+            _cacheValidationErrors: [],
 
-    handleValidationError : function(model, error) {
-        this.clearValidationErrors();
+            handleValidationError: function(model, error) {
+                this.clearValidationErrors();
         // error is object w/ fields and error strings
-        for (var field in error) {
-            var ele = this.$el.find('#' + this.fieldToSelectorMap[field]);
-            this._cacheValidationErrors.push(ele);
-            this.getInputElements(ele).addClass('error');
-            HtmlUtils.append($(ele).parent(), this.errorTemplate({message : error[field]}));
-        }
-        $('.wrapper-notification-warning').addClass('wrapper-notification-warning-w-errors');
-        $('.action-save').addClass('is-disabled');
+                for (var field in error) {
+                    var ele = this.$el.find('#' + this.fieldToSelectorMap[field]);
+                    this._cacheValidationErrors.push(ele);
+                    this.getInputElements(ele).addClass('error');
+                    HtmlUtils.append($(ele).parent(), this.errorTemplate({message: error[field]}));
+                }
+                $('.wrapper-notification-warning').addClass('wrapper-notification-warning-w-errors');
+                $('.action-save').addClass('is-disabled');
         // TODO: (pfogg) should this text fade in/out on change?
-        $('#notification-warning-title').text(this.error_title);
-        $('#notification-warning-description').text(this.error_message);
-    },
+                $('#notification-warning-title').text(this.error_title);
+                $('#notification-warning-description').text(this.error_message);
+            },
 
-    clearValidationErrors : function() {
+            clearValidationErrors: function() {
         // error is object w/ fields and error strings
-        while (this._cacheValidationErrors.length > 0) {
-            var ele = this._cacheValidationErrors.pop();
-            this.getInputElements(ele).removeClass('error');
-            $(ele).nextAll('.message-error').remove();
-        }
-        $('.wrapper-notification-warning').removeClass('wrapper-notification-warning-w-errors');
-        $('.action-save').removeClass('is-disabled');
-        $('#notification-warning-title').text(this.save_title);
-        $('#notification-warning-description').text(this.save_message);
-    },
+                while (this._cacheValidationErrors.length > 0) {
+                    var ele = this._cacheValidationErrors.pop();
+                    this.getInputElements(ele).removeClass('error');
+                    $(ele).nextAll('.message-error').remove();
+                }
+                $('.wrapper-notification-warning').removeClass('wrapper-notification-warning-w-errors');
+                $('.action-save').removeClass('is-disabled');
+                $('#notification-warning-title').text(this.save_title);
+                $('#notification-warning-description').text(this.save_message);
+            },
 
-    setField : function(event) {
+            setField: function(event) {
         // Set model field and return the new value.
-        this.clearValidationErrors();
-        var field = this.selectorToField[event.currentTarget.id];
-        var newVal = '';
-        if(event.currentTarget.type == 'checkbox'){
-            newVal = $(event.currentTarget).is(":checked").toString();
-        }else{
-            newVal = $(event.currentTarget).val();
-        }
-        this.model.set(field, newVal);
-        this.model.isValid();
-        return newVal;
-    },
+                this.clearValidationErrors();
+                var field = this.selectorToField[event.currentTarget.id];
+                var newVal = '';
+                if (event.currentTarget.type == 'checkbox') {
+                    newVal = $(event.currentTarget).is(':checked').toString();
+                } else {
+                    newVal = $(event.currentTarget).val();
+                }
+                this.model.set(field, newVal);
+                this.model.isValid();
+                return newVal;
+            },
     // these should perhaps go into a superclass but lack of event hash inheritance demotivates me
-    inputFocus : function(event) {
-        $("label[for='" + event.currentTarget.id + "']").addClass("is-focused");
-    },
-    inputUnfocus : function(event) {
-        $("label[for='" + event.currentTarget.id + "']").removeClass("is-focused");
-    },
+            inputFocus: function(event) {
+                $("label[for='" + event.currentTarget.id + "']").addClass('is-focused');
+            },
+            inputUnfocus: function(event) {
+                $("label[for='" + event.currentTarget.id + "']").removeClass('is-focused');
+            },
 
-    getInputElements: function(ele) {
-        var inputElements = 'input, textarea';
-        if ($(ele).is(inputElements)) {
-            return $(ele);
-        }
-        else {
+            getInputElements: function(ele) {
+                var inputElements = 'input, textarea';
+                if ($(ele).is(inputElements)) {
+                    return $(ele);
+                }
+                else {
             // put error on the contained inputs
-            return $(ele).find(inputElements);
-        }
-    },
+                    return $(ele).find(inputElements);
+                }
+            },
 
-    showNotificationBar: function(message, primaryClick, secondaryClick) {
+            showNotificationBar: function(message, primaryClick, secondaryClick) {
         // Show a notification with message. primaryClick is called on
         // pressing the save button, and secondaryClick (if it's
         // passed, which it may not be) will be called on
         // cancel. Takes care of hiding the notification bar at the
         // appropriate times.
-        if(this.notificationBarShowing) {
-            return;
-        }
+                if (this.notificationBarShowing) {
+                    return;
+                }
         // If we've already saved something, hide the alert.
-        if(this.saved) {
-            this.saved.hide();
-        }
-        var self = this;
-        this.confirmation = new NotificationView.Warning({
-            title: this.save_title,
-            message: message,
-            actions: {
-                primary: {
-                    "text": gettext("Save Changes"),
-                    "class": "action-save",
-                    "click": function() {
-                        primaryClick();
-                        self.confirmation.hide();
-                        self.notificationBarShowing = false;
-                    }
-                },
-                secondary: [{
-                    "text": gettext("Cancel"),
-                    "class": "action-cancel",
-                    "click": function() {
-                        if(secondaryClick) {
-                            secondaryClick();
-                        }
-                        self.model.clear({silent : true});
-                        self.confirmation.hide();
-                        self.notificationBarShowing = false;
-                    }
-                }]
-            }});
-        this.notificationBarShowing = true;
-        this.confirmation.show();
+                if (this.saved) {
+                    this.saved.hide();
+                }
+                var self = this;
+                this.confirmation = new NotificationView.Warning({
+                    title: this.save_title,
+                    message: message,
+                    actions: {
+                        primary: {
+                            'text': gettext('Save Changes'),
+                            'class': 'action-save',
+                            'click': function() {
+                                primaryClick();
+                                self.confirmation.hide();
+                                self.notificationBarShowing = false;
+                            }
+                        },
+                        secondary: [{
+                            'text': gettext('Cancel'),
+                            'class': 'action-cancel',
+                            'click': function() {
+                                if (secondaryClick) {
+                                    secondaryClick();
+                                }
+                                self.model.clear({silent: true});
+                                self.confirmation.hide();
+                                self.notificationBarShowing = false;
+                            }
+                        }]
+                    }});
+                this.notificationBarShowing = true;
+                this.confirmation.show();
         // Make sure the bar is in the right state
-        this.model.isValid();
-    },
+                this.model.isValid();
+            },
 
-    showSavedBar: function(title, message) {
-        var defaultTitle = gettext('Your changes have been saved.');
-        this.saved = new AlertView.Confirmation({
-            title: title || defaultTitle,
-            message: message,
-            closeIcon: false
-        });
-        this.saved.show();
-        $.smoothScroll({
-            offset: 0,
-            easing: 'swing',
-            speed: 1000
-        });
-    },
+            showSavedBar: function(title, message) {
+                var defaultTitle = gettext('Your changes have been saved.');
+                this.saved = new AlertView.Confirmation({
+                    title: title || defaultTitle,
+                    message: message,
+                    closeIcon: false
+                });
+                this.saved.show();
+                $.smoothScroll({
+                    offset: 0,
+                    easing: 'swing',
+                    speed: 1000
+                });
+            },
 
-    saveView: function() {
-        var self = this;
-        this.model.save(
+            saveView: function() {
+                var self = this;
+                this.model.save(
             {},
-            {
-                success: function() {
-                    self.showSavedBar();
-                    self.render();
-                },
-                silent: true
-            }
+                    {
+                        success: function() {
+                            self.showSavedBar();
+                            self.render();
+                        },
+                        silent: true
+                    }
         );
-    }
-});
+            }
+        });
 
-return ValidatingView;
-
-}); // end define()
+        return ValidatingView;
+    }); // end define()

--- a/cms/static/js/views/video/transcripts/editor.js
+++ b/cms/static/js/views/video/transcripts/editor.js
@@ -1,17 +1,16 @@
 define(
     [
-        "jquery", "backbone", "underscore",
-        "js/views/video/transcripts/utils",
-        "js/views/metadata", "js/collections/metadata",
-        "js/views/video/transcripts/metadata_videolist"
+        'jquery', 'backbone', 'underscore',
+        'js/views/video/transcripts/utils',
+        'js/views/metadata', 'js/collections/metadata',
+        'js/views/video/transcripts/metadata_videolist'
     ],
 function($, Backbone, _, Utils, MetadataView, MetadataCollection) {
-
     var Editor = Backbone.View.extend({
 
         tagName: 'div',
 
-        initialize: function () {
+        initialize: function() {
             // prepare data for MetadataView.Editor
 
             var metadata = this.$el.data('metadata'),
@@ -45,7 +44,7 @@ function($, Backbone, _, Utils, MetadataView, MetadataCollection) {
         * toModels(metadata) // => [{.1.}, {.2.}]
         *
         */
-        toModels: function (data) {
+        toModels: function(data) {
             var metadata = (_.isString(data)) ? JSON.parse(data) : data,
                 models = [];
 
@@ -69,7 +68,7 @@ function($, Backbone, _, Utils, MetadataView, MetadataCollection) {
         *                                    setting editors in `Advanced` tab.
         *
         */
-        syncBasicTab: function (metadataCollection, metadataView) {
+        syncBasicTab: function(metadataCollection, metadataView) {
             var result = [],
                 getField = Utils.getField,
                 component_locator = this.$el.closest('[data-locator]').data('locator'),
@@ -87,8 +86,8 @@ function($, Backbone, _, Utils, MetadataView, MetadataCollection) {
 
             modifiedValues = metadataView.getModifiedMetadataValues();
 
-            var isSubsModified = (function (values) {
-                var isSubsChanged = subs.hasChanged("value");
+            var isSubsModified = (function(values) {
+                var isSubsChanged = subs.hasChanged('value');
 
                 return Boolean(
                     isSubsChanged &&
@@ -124,7 +123,7 @@ function($, Backbone, _, Utils, MetadataView, MetadataCollection) {
 
             values.youtube = getField(metadataCollection, 'youtube_id_1_0').getDisplayValue();
 
-            values.html5Sources = _.filter(html5Sources, function (value) {
+            values.html5Sources = _.filter(html5Sources, function(value) {
                 var link = Utils.parseLink(value),
                     mode = link && link.mode;
 
@@ -150,7 +149,7 @@ function($, Backbone, _, Utils, MetadataView, MetadataCollection) {
             // Synchronize other fields that has the same `field_name` property.
             Utils.syncCollections(metadataCollection, this.collection);
 
-            if (isSubsModified){
+            if (isSubsModified) {
                 // When `sub` field is changed, clean Storage to avoid overwriting.
                 Utils.Storage.remove('sub');
 
@@ -173,7 +172,7 @@ function($, Backbone, _, Utils, MetadataView, MetadataCollection) {
         *                                    setting editors in `Advanced` tab.
         *
         */
-        syncAdvancedTab: function (metadataCollection, metadataView) {
+        syncAdvancedTab: function(metadataCollection, metadataView) {
             var getField = Utils.getField,
                 subsValue = Utils.Storage.get('sub'),
                 subs = getField(metadataCollection, 'sub'),
@@ -213,7 +212,7 @@ function($, Backbone, _, Utils, MetadataView, MetadataCollection) {
             // }
             result = _.groupBy(
                 videoUrlValue,
-                function (value) {
+                function(value) {
                     return Utils.parseLink(value).mode;
                 }
             );

--- a/cms/static/js/views/video/transcripts/file_uploader.js
+++ b/cms/static/js/views/video/transcripts/file_uploader.js
@@ -1,7 +1,7 @@
 define(
     [
-        "jquery", "backbone", "underscore",
-        "js/views/video/transcripts/utils"
+        'jquery', 'backbone', 'underscore',
+        'js/views/video/transcripts/utils'
     ],
 function($, Backbone, _, Utils) {
     var FileUploader = Backbone.View.extend({
@@ -17,7 +17,7 @@ function($, Backbone, _, Utils) {
 
         uploadTpl: '#file-upload',
 
-        initialize: function (options) {
+        initialize: function(options) {
             _.bindAll(this,
                 'changeHandler', 'clickHandler', 'xhrResetProgressBar', 'xhrProgressHandler', 'xhrCompleteHandler',
                 'render'
@@ -27,7 +27,7 @@ function($, Backbone, _, Utils) {
             this.render();
         },
 
-        render: function () {
+        render: function() {
             var tpl = $(this.uploadTpl).text(),
                 tplContainer = this.$el.find('.transcripts-file-uploader'),
                 videoList = this.options.videoListObject.getVideoObjectsList();
@@ -58,7 +58,7 @@ function($, Backbone, _, Utils) {
         * Uploads file to the server. Get file from the `file` property.
         *
         */
-        upload: function () {
+        upload: function() {
             if (!this.file) {
                 return;
             }
@@ -78,7 +78,7 @@ function($, Backbone, _, Utils) {
         * @param {object} event Event object.
         *
         */
-        clickHandler: function (event) {
+        clickHandler: function(event) {
             event.preventDefault();
 
             this.$input
@@ -95,7 +95,7 @@ function($, Backbone, _, Utils) {
         * @param {object} event Event object.
         *
         */
-        changeHandler: function (event) {
+        changeHandler: function(event) {
             event.preventDefault();
 
             this.options.messenger.hideError();
@@ -122,7 +122,7 @@ function($, Backbone, _, Utils) {
         *                    extension.
         *
         */
-        checkExtValidity: function (file) {
+        checkExtValidity: function(file) {
             if (!file.name) {
                 return void(0);
             }
@@ -145,7 +145,7 @@ function($, Backbone, _, Utils) {
         * Resets progress bar.
         *
         */
-        xhrResetProgressBar: function () {
+        xhrResetProgressBar: function() {
             var percentVal = '0%';
 
             this.$progress
@@ -169,7 +169,7 @@ function($, Backbone, _, Utils) {
         * @param {integer} percentComplete Object with information about file.
         *
         */
-        xhrProgressHandler: function (event, position, total, percentComplete) {
+        xhrProgressHandler: function(event, position, total, percentComplete) {
             var percentVal = percentComplete + '%';
 
             this.$progress
@@ -183,7 +183,7 @@ function($, Backbone, _, Utils) {
         * Handle complete uploading.
         *
         */
-        xhrCompleteHandler: function (xhr) {
+        xhrCompleteHandler: function(xhr) {
             var resp = JSON.parse(xhr.responseText),
                 err = resp.status || gettext('Error: Uploading failed.'),
                 sub = resp.subs;

--- a/cms/static/js/views/video/transcripts/message_manager.js
+++ b/cms/static/js/views/video/transcripts/message_manager.js
@@ -1,8 +1,8 @@
 define(
     [
-        "jquery", "backbone", "underscore",
-        "js/views/video/transcripts/utils", "js/views/video/transcripts/file_uploader",
-        "gettext"
+        'jquery', 'backbone', 'underscore',
+        'js/views/video/transcripts/utils', 'js/views/video/transcripts/file_uploader',
+        'gettext'
     ],
 function($, Backbone, _, Utils, FileUploader, gettext) {
     var MessageManager = Backbone.View.extend({
@@ -22,13 +22,13 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
             not_found: '#transcripts-not-found',
             found: '#transcripts-found',
             import: '#transcripts-import',
-            replace:  '#transcripts-replace',
-            uploaded:  '#transcripts-uploaded',
+            replace: '#transcripts-replace',
+            uploaded: '#transcripts-uploaded',
             use_existing: '#transcripts-use-existing',
             choose: '#transcripts-choose'
         },
 
-        initialize: function (options) {
+        initialize: function(options) {
             _.bindAll(this,
                 'importHandler', 'replaceHandler', 'chooseHandler', 'useExistingHandler', 'showError', 'hideError'
             );
@@ -45,7 +45,7 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
             });
         },
 
-        render: function (template_id, params) {
+        render: function(template_id, params) {
             var tplHtml = $(this.templates[template_id]).text(),
                 videoList = this.options.parent.getVideoObjectsList(),
             // Change list representation format to more convenient and group
@@ -62,7 +62,7 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
             // }
                 groupedList = _.groupBy(
                     videoList,
-                    function (value) {
+                    function(value) {
                         return value.video;
                     }
                 ),
@@ -83,7 +83,7 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
                     component_locator: encodeURIComponent(this.component_locator),
                     html5_list: html5List,
                     grouped_list: groupedList,
-                    subs_id: (params) ? params.subs: ''
+                    subs_id: (params) ? params.subs : ''
                 }));
 
             this.fileUploader.render();
@@ -101,7 +101,7 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
         * @param {boolean} hideButtons Hide buttons
         *
         */
-        showError: function (err, hideButtons) {
+        showError: function(err, hideButtons) {
             var $error = this.$el.find('.transcripts-error-message');
 
             if (err) {
@@ -125,7 +125,7 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
         * Hides error message.
         *
         */
-        hideError: function () {
+        hideError: function() {
             this.$el.find('.transcripts-error-message')
                 .addClass(this.invisibleClass);
 
@@ -141,7 +141,7 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
         * @params {object} event Event object.
         *
         */
-        importHandler: function (event) {
+        importHandler: function(event) {
             event.preventDefault();
 
             this.processCommand('replace', gettext('Error: Import failed.'));
@@ -155,7 +155,7 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
         * @params {object} event Event object.
         *
         */
-        replaceHandler: function (event) {
+        replaceHandler: function(event) {
             event.preventDefault();
 
             this.processCommand('replace', gettext('Error: Replacing failed.'));
@@ -169,7 +169,7 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
         * @params {object} event Event object.
         *
         */
-        chooseHandler: function (event) {
+        chooseHandler: function(event) {
             event.preventDefault();
 
             var videoId = $(event.currentTarget).data('video-id');
@@ -185,7 +185,7 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
         * @params {object} event Event object.
         *
         */
-        useExistingHandler: function (event) {
+        useExistingHandler: function(event) {
             event.preventDefault();
 
             this.processCommand('rename', gettext('Error: Choosing failed.'));
@@ -206,24 +206,24 @@ function($, Backbone, _, Utils, FileUploader, gettext) {
         *                          to the server
         *
         */
-        processCommand: function (action, errorMessage, videoId) {
+        processCommand: function(action, errorMessage, videoId) {
             var self = this,
                 component_locator = this.component_locator,
                 videoList = this.options.parent.getVideoObjectsList(),
                 extraParam, xhr;
 
             if (videoId) {
-                extraParam = { html5_id: videoId };
+                extraParam = {html5_id: videoId};
             }
 
             xhr = Utils.command(action, component_locator, videoList, extraParam)
-                .done(function (resp) {
-                        var sub = resp.subs;
+                .done(function(resp) {
+                    var sub = resp.subs;
 
-                        self.render('found', resp);
-                        Utils.Storage.set('sub', sub);
+                    self.render('found', resp);
+                    Utils.Storage.set('sub', sub);
                 })
-                .fail(function (resp) {
+                .fail(function(resp) {
                     var message = resp.status || errorMessage;
                     self.showError(message);
                 });

--- a/cms/static/js/views/video/transcripts/metadata_videolist.js
+++ b/cms/static/js/views/video/transcripts/metadata_videolist.js
@@ -10,10 +10,10 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
         // Time that we wait since the last time user typed.
         inputDelay: 300,
 
-        events : {
-            'click .setting-clear' : 'clear',
-            'keypress .setting-input' : 'showClearButton',
-            'click .collapse-setting' : 'toggleExtraVideosBar'
+        events: {
+            'click .setting-clear': 'clear',
+            'keypress .setting-input': 'showClearButton',
+            'click .collapse-setting': 'toggleExtraVideosBar'
         },
 
         templateName: 'metadata-videolist-entry',
@@ -25,7 +25,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
             'youtube': 'http://youtube.com/'
         },
 
-        initialize: function (options) {
+        initialize: function(options) {
             // Initialize MessageManager that is responsible for
             // status messages and errors.
             this.options = _.extend({}, options);
@@ -51,17 +51,17 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
                                                             .data('locator');
         },
 
-        render: function () {
+        render: function() {
             // Call inherited `render` method.
             AbstractEditor.prototype.render
                 .apply(this, arguments);
 
             var self = this,
-                component_locator =  this.$el.closest('[data-locator]')
+                component_locator = this.$el.closest('[data-locator]')
                                                             .data('locator'),
                 videoList = this.getVideoObjectsList(),
 
-                showServerError = function (response) {
+                showServerError = function(response) {
                     var errorMessage = response.status ||
                         gettext('Error: Connection with server failed.');
 
@@ -88,7 +88,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
 
             // Check current state of Timed Transcripts.
             Utils.command('check', component_locator, videoList)
-                .done(function (resp) {
+                .done(function(resp) {
                     var params = resp,
                         len = videoList.length,
                         mode = (len === 1) ? videoList[0].mode : false;
@@ -113,10 +113,10 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * Returns the values currently displayed in the editor/view.
          * @return {Array} List of non-empty values.
          */
-        getValueFromEditor: function () {
+        getValueFromEditor: function() {
             return _.map(
                 this.$el.find('.input'),
-                function (ele) {
+                function(ele) {
                     return ele.value.trim();
                 }
             ).filter(_.identity);
@@ -142,7 +142,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          *     ]
          *
          */
-        getVideoObjectsList: function () {
+        getVideoObjectsList: function() {
             var links = this.getValueFromEditor();
 
             return Utils.getVideoList(links);
@@ -152,12 +152,12 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * Sets the values currently displayed in the editor/view.
          * @param {Array} value List of values.
          */
-        setValueInEditor: function (value) {
+        setValueInEditor: function(value) {
             var list = this.$el.find('.input'),
                 val = value.filter(_.identity),
                 placeholders = this.getPlaceholders(val);
 
-            list.each(function (index) {
+            list.each(function(index) {
                 $(this)
                     .val(val[index] || null)
                     .attr('placeholder', placeholders[index]);
@@ -170,14 +170,14 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * editor/view.
          * @return {Array} List of placeholders.
          */
-        getPlaceholders: function (value) {
+        getPlaceholders: function(value) {
             var parseLink = Utils.parseLink,
                 placeholders = _.clone(this.placeholders);
 
             // Returned list should have the same size as a count of editors.
             return _.map(
                 this.$el.find('.input'),
-                function (element, index) {
+                function(element, index) {
                     var linkInfo = parseLink(value[index]),
                         type = (linkInfo) ? linkInfo.type : null,
                         label;
@@ -189,7 +189,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
                         label = placeholders[type];
                         delete placeholders[type];
                     } else {
-                        if ( !($.isArray(placeholders)) ) {
+                        if (!($.isArray(placeholders))) {
                             placeholders = _.values(placeholders);
                         }
 
@@ -205,7 +205,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * Opens video sources box.
          * @param {Object} event Event object.
          */
-        openExtraVideosBar: function (event) {
+        openExtraVideosBar: function(event) {
             if (event && event.preventDefault) {
                 event.preventDefault();
             }
@@ -217,7 +217,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * Closes video sources box.
          * @param {Object} event Event object.
          */
-        closeExtraVideosBar: function (event) {
+        closeExtraVideosBar: function(event) {
             if (event && event.preventDefault) {
                 event.preventDefault();
             }
@@ -229,7 +229,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * Toggles video sources box.
          * @param {Object} event Event object.
          */
-        toggleExtraVideosBar: function (event) {
+        toggleExtraVideosBar: function(event) {
             if (event && event.preventDefault) {
                 event.preventDefault();
             }
@@ -245,7 +245,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * Handle `input` event.
          * @param {Object} event Event object.
          */
-        inputHandler: function (event) {
+        inputHandler: function(event) {
             if (event && event.preventDefault) {
                 event.preventDefault();
             }
@@ -282,7 +282,6 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
                 $inputs
                     .prop('disabled', false).attr('aria-disabled', false)
                     .removeClass('is-disabled');
-
             } else {
                 // If any error occurs, disable all inputs except the current.
                 // User cannot change other inputs before putting valid value in
@@ -307,10 +306,10 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * @return {Boolean} Boolean value that indicate if video types are
          * unique.
          */
-        isUniqVideoTypes: function (videoList) {
+        isUniqVideoTypes: function(videoList) {
             // Extract a list of "type" property values.
             // => ex: ['webm', 'mp4', 'mp4']
-            var arr = _.pluck(videoList, 'type').filter(function (item) {
+            var arr = _.pluck(videoList, 'type').filter(function(item) {
                     return item !== 'other';
                 }),
                 // Produces a duplicate-free version of the array.
@@ -325,10 +324,10 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * @return {Boolean} Boolean value that indicate if video types are
          * unique.
          */
-        isUniqOtherVideos: function (videoList) {
+        isUniqOtherVideos: function(videoList) {
             // Returns list of video objects with "type" equal "other" or
             // "youtube".
-            var otherLinksList = videoList.filter(function (item) {
+            var otherLinksList = videoList.filter(function(item) {
                     return item.type === 'other';
                 }),
                 // Extract a list of "video" property values.
@@ -347,7 +346,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * @param {String} message Error message.
          * @return {Boolean}
          */
-        checkIsValid: function (validator, list, message) {
+        checkIsValid: function(validator, list, message) {
             var videoList = list || this.getVideoObjectsList(),
                 isValid = true;
 
@@ -365,7 +364,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * values currently displayed in the editor.
          * @return {Boolean}
          */
-        checkIsUniqVideoTypes: function (list) {
+        checkIsUniqVideoTypes: function(list) {
             return this.checkIsValid(
                 this.isUniqVideoTypes, list, gettext('Link types should be unique.')
             );
@@ -378,7 +377,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * values currently displayed in the editor.
          * @return {Boolean}
          */
-        checkIsUniqOtherVideos: function (list) {
+        checkIsUniqOtherVideos: function(list) {
             return this.checkIsValid(
                 this.isUniqOtherVideos, list, gettext('Links should be unique.')
             );
@@ -392,7 +391,7 @@ function($, Backbone, _, AbstractEditor, Utils, MessageManager) {
          * @param {Boolean} showErrorModeMessage Disable mode validation
          * @return {Boolean} Boolean value that indicate if value is valid.
          */
-        checkValidity: function (data, showErrorModeMessage) {
+        checkValidity: function(data, showErrorModeMessage) {
             var videoList = this.getVideoObjectsList(),
                 isUniqTypes = this.checkIsUniqVideoTypes.bind(this),
                 isUniqOtherVideos = this.checkIsUniqOtherVideos.bind(this);

--- a/cms/static/js/views/video/transcripts/utils.js
+++ b/cms/static/js/views/video/transcripts/utils.js
@@ -1,7 +1,7 @@
 define(['jquery', 'underscore', 'jquery.ajaxQueue'], function($) {
-'use strict';
-return (function () {
-    var Storage = {};
+    'use strict';
+    return (function() {
+        var Storage = {};
 
     /**
      * Adds some data to the Storage object. If data with existent `data_id`
@@ -11,10 +11,10 @@ return (function () {
      * @param {Any} data Data that should be stored.
      * @return {Object} Object itself for chaining.
      */
-    Storage.set = function (data_id, data) {
-        Storage[data_id] = data;
-        return this;
-    };
+        Storage.set = function(data_id, data) {
+            Storage[data_id] = data;
+            return this;
+        };
 
     /**
      * Return data from the Storage object by identifier.
@@ -22,9 +22,9 @@ return (function () {
      * @param {String} data_id Unique identifier of the data.
      * @return {Any} Stored data.
      */
-    Storage.get= function (data_id) {
-        return Storage[data_id];
-    };
+        Storage.get = function(data_id) {
+            return Storage[data_id];
+        };
 
     /**
      * Deletes data from the Storage object by identifier.
@@ -32,9 +32,9 @@ return (function () {
      * @param {String} data_id Unique identifier of the data.
      * @return {Boolean} Boolean value that indicate if data is removed.
      */
-    Storage.remove = function (data_id) {
-        return (delete Storage[data_id]);
-    };
+        Storage.remove = function(data_id) {
+            return (delete Storage[data_id]);
+        };
 
     /**
      * Returns model from collection by 'field_name' property.
@@ -47,17 +47,17 @@ return (function () {
      *    Undefined:     When model doesn't exist.
      * }
      */
-    var _getField = function (collection, field_name) {
-        var model;
+        var _getField = function(collection, field_name) {
+            var model;
 
-        if (collection && field_name) {
-            model = collection.findWhere({
-                field_name: field_name
-            });
-        }
+            if (collection && field_name) {
+                model = collection.findWhere({
+                    field_name: field_name
+                });
+            }
 
-        return model;
-    };
+            return model;
+        };
 
     /**
      * Parses Youtube link and return video id.
@@ -77,25 +77,25 @@ return (function () {
      *                   non-string, video id's length is not equal 11.
      * }
      */
-    var _youtubeParser = (function () {
-        var cache = {},
-            regExp = /(?:http|https|)(?:\:\/\/|)(?:www.|)(?:youtu\.be\/|youtube\.com(?:\/embed\/|\/v\/|\/watch\?v=|\/ytscreeningroom\?v=|\/feeds\/api\/videos\/|\/user\S*[^\w\-\s]|\S*[^\w\-\s]))([\w\-]+)/i;
+        var _youtubeParser = (function() {
+            var cache = {},
+                regExp = /(?:http|https|)(?:\:\/\/|)(?:www.|)(?:youtu\.be\/|youtube\.com(?:\/embed\/|\/v\/|\/watch\?v=|\/ytscreeningroom\?v=|\/feeds\/api\/videos\/|\/user\S*[^\w\-\s]|\S*[^\w\-\s]))([\w\-]+)/i;
 
-        return function (url) {
-            if (typeof url !== 'string') {
-                return void(0);
-            }
+            return function(url) {
+                if (typeof url !== 'string') {
+                    return void(0);
+                }
 
-            if (cache[url]) {
+                if (cache[url]) {
+                    return cache[url];
+                }
+
+                var match = url.match(regExp);
+                cache[url] = (match) ? match[1] : void(0);
+
                 return cache[url];
-            }
-
-            var match = url.match(regExp);
-            cache[url] = (match) ? match[1] : void(0);
-
-            return cache[url];
-        };
-    }());
+            };
+        }());
 
     /**
      * Parses links with html5 video sources in mp4 or webm formats.
@@ -108,47 +108,46 @@ return (function () {
      *                   non-string.
      * }
      */
-    var _videoLinkParser = (function () {
-        var cache = {};
+        var _videoLinkParser = (function() {
+            var cache = {};
 
-        return function (url) {
-            if (typeof url !== 'string') {
+            return function(url) {
+                if (typeof url !== 'string') {
+                    return void(0);
+                }
 
-                return void(0);
-            }
+                if (cache[url]) {
+                    return cache[url];
+                }
 
-            if (cache[url]) {
-                return cache[url];
-            }
+                var link = document.createElement('a'),
+                    match;
 
-            var link = document.createElement('a'),
-                match;
-
-            link.href = url;
+                link.href = url;
             // The regular expression try catches file name and file extension.
             // '[scheme://hostname/pathname/]filename.extension[?query#hash]'
-            match = link.pathname.match(/\/{1}([^\/]+)\.([^\/]+)$/);
-            if (match) {
-                cache[url] = {
-                    video: match[1],
-                    type: match[2]
-                };
-            } else {
-                // Links like http://goo.gl/pxxZrg
-                // The regular expression try catches file name.
-                // '[scheme://hostname/pathname/]filename[?query#hash]'
-                match = link.pathname.match(/\/{1}([^\/\.]+)$/);
+                match = link.pathname.match(/\/{1}([^\/]+)\.([^\/]+)$/);
                 if (match) {
                     cache[url] = {
                         video: match[1],
-                        type: 'other'
+                        type: match[2]
                     };
+                } else {
+                // Links like http://goo.gl/pxxZrg
+                // The regular expression try catches file name.
+                // '[scheme://hostname/pathname/]filename[?query#hash]'
+                    match = link.pathname.match(/\/{1}([^\/\.]+)$/);
+                    if (match) {
+                        cache[url] = {
+                            video: match[1],
+                            type: 'other'
+                        };
+                    }
                 }
-            }
 
-            return cache[url];
-        };
-    }());
+                return cache[url];
+            };
+        }());
 
     /**
      * Facade function that parses html5 and youtube links.
@@ -164,36 +163,36 @@ return (function () {
      *    undefined:     when argument is non-string.
      * }
      */
-    var _linkParser = function (url) {
-        var youtubeIdLength = 11,
-            result;
+        var _linkParser = function(url) {
+            var youtubeIdLength = 11,
+                result;
 
-        if (typeof url !== 'string') {
-            return void(0);
-        }
+            if (typeof url !== 'string') {
+                return void(0);
+            }
 
-        if (_youtubeParser(url)) {
-            if (_youtubeParser(url).length === youtubeIdLength) {
-                result = {
-                    mode: 'youtube',
-                    video: _youtubeParser(url),
-                    type: 'youtube'
-                };
+            if (_youtubeParser(url)) {
+                if (_youtubeParser(url).length === youtubeIdLength) {
+                    result = {
+                        mode: 'youtube',
+                        video: _youtubeParser(url),
+                        type: 'youtube'
+                    };
+                } else {
+                    result = {
+                        mode: 'incorrect'
+                    };
+                }
+            } else if (_videoLinkParser(url)) {
+                result = $.extend({mode: 'html5'}, _videoLinkParser(url));
             } else {
                 result = {
                     mode: 'incorrect'
                 };
             }
-        } else if (_videoLinkParser(url)) {
-            result = $.extend({mode: 'html5'}, _videoLinkParser(url));
-        } else {
-            result = {
-                mode: 'incorrect'
-            };
-        }
 
-        return result;
-    };
+            return result;
+        };
 
     /**
      * Returns short-hand youtube url.
@@ -203,9 +202,9 @@ return (function () {
      * @examples
      * _getYoutubeLink('OEoXaMPEzfM'); => 'http://youtu.be/OEoXaMPEzfM'
      */
-    var _getYoutubeLink = function (video_id) {
-        return 'http://youtu.be/' + video_id;
-    };
+        var _getYoutubeLink = function(video_id) {
+            return 'http://youtu.be/' + video_id;
+        };
 
     /**
      * Returns list of objects with information about the passed links.
@@ -226,22 +225,22 @@ return (function () {
      *       {mode: `html5`, type: `webm`, ...}
      *     ]
      */
-    var _getVideoList = function (links) {
-        if ($.isArray(links)) {
-            var arr = [],
-                data;
+        var _getVideoList = function(links) {
+            if ($.isArray(links)) {
+                var arr = [],
+                    data;
 
-            for (var i = 0, len = links.length; i < len; i += 1) {
-                data = _linkParser(links[i]);
+                for (var i = 0, len = links.length; i < len; i += 1) {
+                    data = _linkParser(links[i]);
 
-                if (data.mode !== 'incorrect') {
-                    arr.push(data);
+                    if (data.mode !== 'incorrect') {
+                        arr.push(data);
+                    }
                 }
-            }
 
-            return arr;
-        }
-    };
+                return arr;
+            }
+        };
 
     /**
      * Synchronizes 2 Backbone collections by 'field_name' property.
@@ -250,17 +249,17 @@ return (function () {
      * happens.
      * @param {Object} toCollection Collection which will synchronized.
      */
-    var _syncCollections = function (fromCollection, toCollection) {
-        fromCollection.each(function (m) {
-            var model = toCollection.findWhere({
+        var _syncCollections = function(fromCollection, toCollection) {
+            fromCollection.each(function(m) {
+                var model = toCollection.findWhere({
                     field_name: m.getFieldName()
                 });
 
-            if (model) {
-                model.setValue(m.getDisplayValue());
-            }
-        });
-    };
+                if (model) {
+                    model.setValue(m.getDisplayValue());
+                }
+            });
+        };
 
     /**
      * Sends Ajax requests in appropriate format.
@@ -275,57 +274,57 @@ return (function () {
      * attach callbacks to AJAX request events (for example on 'done',
      * 'fail', etc.).
      */
-    var _command = (function () {
+        var _command = (function() {
         // We will store the XMLHttpRequest object that $.ajax() function
         // returns, to abort an ongoing AJAX request (if necessary) upon
         // subsequent invocations of _command() function.
         //
         // A new AJAX request will be made on each invocation of the
         // _command() function.
-        var xhr = null;
+            var xhr = null;
 
-        return function (action, locator, videoList, extraParams) {
-            var params, data;
+            return function(action, locator, videoList, extraParams) {
+                var params, data;
 
-            if (extraParams) {
-                if ($.isPlainObject(extraParams)) {
-                    params = extraParams;
-                } else {
-                    params = {params: extraParams};
+                if (extraParams) {
+                    if ($.isPlainObject(extraParams)) {
+                        params = extraParams;
+                    } else {
+                        params = {params: extraParams};
+                    }
                 }
-            }
 
-            data = $.extend(
-                { locator: locator },
-                { videos: videoList },
+                data = $.extend(
+                {locator: locator},
+                {videos: videoList},
                 params
             );
 
-            xhr = $.ajaxQueue({
-                url: '/transcripts/' + action,
-                data: { data: JSON.stringify(data) },
-                notifyOnError: false,
-                type: 'get'
-            });
+                xhr = $.ajaxQueue({
+                    url: '/transcripts/' + action,
+                    data: {data: JSON.stringify(data)},
+                    notifyOnError: false,
+                    type: 'get'
+                });
 
-            return xhr;
+                return xhr;
+            };
+        }());
+
+        return {
+            getField: _getField,
+            parseYoutubeLink: _youtubeParser,
+            parseHTML5Link: _videoLinkParser,
+            parseLink: _linkParser,
+            getYoutubeLink: _getYoutubeLink,
+            syncCollections: _syncCollections,
+            command: _command,
+            getVideoList: _getVideoList,
+            Storage: {
+                set: Storage.set,
+                get: Storage.get,
+                remove: Storage.remove
+            }
         };
     }());
-
-    return {
-        getField: _getField,
-        parseYoutubeLink: _youtubeParser,
-        parseHTML5Link: _videoLinkParser,
-        parseLink: _linkParser,
-        getYoutubeLink: _getYoutubeLink,
-        syncCollections: _syncCollections,
-        command: _command,
-        getVideoList: _getVideoList,
-        Storage: {
-            set: Storage.set,
-            get: Storage.get,
-            remove: Storage.remove
-        }
-    };
-}());
 });

--- a/cms/static/js/views/video/translations_editor.js
+++ b/cms/static/js/views/video/translations_editor.js
@@ -1,39 +1,39 @@
 define(
     [
-        "jquery", "underscore",
-        "js/views/abstract_editor", "js/models/uploads", "js/views/uploads"
+        'jquery', 'underscore',
+        'js/views/abstract_editor', 'js/models/uploads', 'js/views/uploads'
 
     ],
 function($, _, AbstractEditor, FileUpload, UploadDialog) {
-    "use strict";
+    'use strict';
 
     var VideoUploadDialog = UploadDialog.extend({
         error: function() {
             this.model.set({
-                "uploading": false,
-                "uploadedBytes": 0,
-                "title": gettext("Sorry, there was an error parsing the subtitles that you uploaded. Please check the format and try again.")
+                'uploading': false,
+                'uploadedBytes': 0,
+                'title': gettext('Sorry, there was an error parsing the subtitles that you uploaded. Please check the format and try again.')
             });
         }
     });
 
     var Translations = AbstractEditor.extend({
-        events : {
-            "click .setting-clear" : "clear",
-            "click .create-setting" : "addEntry",
-            "click .remove-setting" : "removeEntry",
-            "click .upload-setting" : "upload",
-            "change select" : "onChangeHandler"
+        events: {
+            'click .setting-clear': 'clear',
+            'click .create-setting': 'addEntry',
+            'click .remove-setting': 'removeEntry',
+            'click .upload-setting': 'upload',
+            'change select': 'onChangeHandler'
         },
 
-        templateName: "metadata-translations-entry",
-        templateItemName: "metadata-translations-item",
+        templateName: 'metadata-translations-entry',
+        templateItemName: 'metadata-translations-item',
 
-        initialize: function () {
+        initialize: function() {
             var templateName = _.result(this, 'templateItemName'),
                 tpl = document.getElementById(templateName).text;
 
-            if(!tpl) {
+            if (!tpl) {
                 console.error("Couldn't load template for item: " + templateName);
             }
 
@@ -41,16 +41,16 @@ function($, _, AbstractEditor, FileUpload, UploadDialog) {
             AbstractEditor.prototype.initialize.apply(this, arguments);
         },
 
-        getDropdown: function () {
+        getDropdown: function() {
             var dropdown,
-                disableOptions = function (element, values) {
+                disableOptions = function(element, values) {
                     var dropdown = $(element).clone();
 
                     _.each(values, function(value, key) {
                         // Note: IE may raise an exception if key is an empty string,
                         // while other browsers return null as excepted. So coerce it
                         // into null for browser consistency.
-                        if (key === "") {
+                        if (key === '') {
                             key = null;
                         }
 
@@ -64,7 +64,7 @@ function($, _, AbstractEditor, FileUpload, UploadDialog) {
                     return dropdown;
                 };
 
-            return function (values) {
+            return function(values) {
                 if (dropdown) {
                     return disableOptions(dropdown, values);
                 }
@@ -84,7 +84,7 @@ function($, _, AbstractEditor, FileUpload, UploadDialog) {
             };
         }(),
 
-        getValueFromEditor: function () {
+        getValueFromEditor: function() {
             var dict = {},
                 items = this.$el.find('ol').find('.list-settings-item');
 
@@ -108,17 +108,17 @@ function($, _, AbstractEditor, FileUpload, UploadDialog) {
         },
 
         // @TODO: Use backbone render patterns.
-        setValueInEditor: function (values) {
+        setValueInEditor: function(values) {
             var self = this,
                 frag = document.createDocumentFragment(),
                 dropdown = self.getDropdown(values);
 
             _.each(values, function(value, key) {
                 var html = $(self.templateItem({
-                        'lang': key,
-                        'value': value,
-                        'url': self.model.get('urlRoot') + '/' + key
-                    })).prepend(dropdown.clone().val(key))[0];
+                    'lang': key,
+                    'value': value,
+                    'url': self.model.get('urlRoot') + '/' + key
+                })).prepend(dropdown.clone().val(key))[0];
 
                 frag.appendChild(html);
             });
@@ -145,7 +145,7 @@ function($, _, AbstractEditor, FileUpload, UploadDialog) {
             this.$el.find('.create-setting').removeClass('is-disabled').attr('aria-disabled', false);
         },
 
-        upload: function (event) {
+        upload: function(event) {
             event.preventDefault();
 
             var self = this,
@@ -159,7 +159,7 @@ function($, _, AbstractEditor, FileUpload, UploadDialog) {
                     model: model,
                     url: self.model.get('urlRoot') + '/' + lang,
                     parentElement: target.closest('.xblock-editor'),
-                    onSuccess: function (response) {
+                    onSuccess: function(response) {
                         if (!response['filename']) { return; }
 
                         var dict = $.extend(true, {}, self.model.get('value'));
@@ -183,7 +183,7 @@ function($, _, AbstractEditor, FileUpload, UploadDialog) {
             }
         },
 
-        onChangeHandler: function (event) {
+        onChangeHandler: function(event) {
             this.showClearButton();
             this.enableAdd();
             this.updateModel();

--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -1,12 +1,12 @@
-define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/views/baseview", "xblock/runtime.v1"],
-    function ($, _, ViewUtils, BaseView, XBlock) {
+define(['jquery', 'underscore', 'common/js/components/utils/view_utils', 'js/views/baseview', 'xblock/runtime.v1'],
+    function($, _, ViewUtils, BaseView, XBlock) {
         'use strict';
 
         var XBlockView = BaseView.extend({
             // takes XBlockInfo as a model
 
             events: {
-                "click .notification-action-button": "fireNotificationActionEvent"
+                'click .notification-action-button': 'fireNotificationActionEvent'
             },
 
             initialize: function() {
@@ -20,10 +20,10 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                     xblockInfo = this.model,
                     xblockUrl = xblockInfo.url();
                 return $.ajax({
-                    url: decodeURIComponent(xblockUrl) + "/" + view,
+                    url: decodeURIComponent(xblockUrl) + '/' + view,
                     type: 'GET',
                     cache: false,
-                    headers: { Accept: 'application/json' },
+                    headers: {Accept: 'application/json'},
                     success: function(fragment) {
                         self.handleXBlockFragment(fragment, options);
                     }
@@ -54,10 +54,10 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                         self.xblock = self.initRuntimeData(xblock, options);
                         self.xblockReady(self.xblock);
                         self.$('.xblock_asides-v1').each(function() {
-                             if (!$(this).hasClass('xblock-initialized')) {
-                                 var aside = XBlock.initializeBlock($(this));
-                                 self.initRuntimeData(aside, options);
-                             }
+                            if (!$(this).hasClass('xblock-initialized')) {
+                                var aside = XBlock.initializeBlock($(this));
+                                self.initRuntimeData(aside, options);
+                            }
                         });
                         if (successCallback) {
                             successCallback(xblock);
@@ -92,7 +92,7 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                 } else if (this.xblock) {
                     var xblock_children = this.xblock.element && $(this.xblock.element).prop('xblock_children');
                     if (xblock_children) {
-                        $(xblock_children).each(function () {
+                        $(xblock_children).each(function() {
                             if (this.runtime) {
                                 this.runtime.notify(eventName, data);
                             }
@@ -134,7 +134,7 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                 try {
                     this.updateHtml(element, html);
                     return this.addXBlockFragmentResources(resources);
-                } catch(e) {
+                } catch (e) {
                     console.error(e.stack);
                     return $.Deferred().resolve();
                 }
@@ -202,20 +202,20 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
                     kind = resource.kind,
                     placement = resource.placement,
                     data = resource.data;
-                if (mimetype === "text/css") {
-                    if (kind === "text") {
-                        head.append("<style type='text/css'>" + data + "</style>");
-                    } else if (kind === "url") {
+                if (mimetype === 'text/css') {
+                    if (kind === 'text') {
+                        head.append("<style type='text/css'>" + data + '</style>');
+                    } else if (kind === 'url') {
                         head.append("<link rel='stylesheet' href='" + data + "' type='text/css'>");
                     }
-                } else if (mimetype === "application/javascript") {
-                    if (kind === "text") {
-                        head.append("<script>" + data + "</script>");
-                    } else if (kind === "url") {
+                } else if (mimetype === 'application/javascript') {
+                    if (kind === 'text') {
+                        head.append('<script>' + data + '</script>');
+                    } else if (kind === 'url') {
                         return ViewUtils.loadJavaScript(data);
                     }
-                } else if (mimetype === "text/html") {
-                    if (placement === "head") {
+                } else if (mimetype === 'text/html') {
+                    if (placement === 'head') {
                         head.append(data);
                     }
                 }
@@ -224,10 +224,10 @@ define(["jquery", "underscore", "common/js/components/utils/view_utils", "js/vie
             },
 
             fireNotificationActionEvent: function(event) {
-                var eventName = $(event.currentTarget).data("notification-action");
+                var eventName = $(event.currentTarget).data('notification-action');
                 if (eventName) {
                     event.preventDefault();
-                    this.notifyRuntime(eventName, this.model.get("id"));
+                    this.notifyRuntime(eventName, this.model.get('id'));
                 }
             }
         });

--- a/cms/static/js/views/xblock_editor.js
+++ b/cms/static/js/views/xblock_editor.js
@@ -2,10 +2,9 @@
  * XBlockEditorView displays the authoring view of an xblock, and allows the user to switch between
  * the available modes.
  */
-define(["jquery", "underscore", "gettext", "js/views/xblock", "js/views/metadata", "js/collections/metadata",
-        "jquery.inputnumber"],
-    function ($, _, gettext, XBlockView, MetadataView, MetadataCollection) {
-
+define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata', 'js/collections/metadata',
+        'jquery.inputnumber'],
+    function($, _, gettext, XBlockView, MetadataView, MetadataCollection) {
         var XBlockEditorView = XBlockView.extend({
             // takes XBlockInfo as a model
 
@@ -40,8 +39,8 @@ define(["jquery", "underscore", "gettext", "js/views/xblock", "js/views/metadata
 
             getDefaultModes: function() {
                 return [
-                    { id: 'editor', name: gettext("Editor")},
-                    { id: 'settings', name: gettext("Settings")}
+                    {id: 'editor', name: gettext('Editor')},
+                    {id: 'settings', name: gettext('Settings')}
                 ];
             },
 
@@ -134,7 +133,7 @@ define(["jquery", "underscore", "gettext", "js/views/xblock", "js/views/metadata
                 metadataNameElements = this.$('[data-metadata-name]');
                 for (i = 0; i < metadataNameElements.length; i++) {
                     element = metadataNameElements[i];
-                    metadataName = $(element).data("metadata-name");
+                    metadataName = $(element).data('metadata-name');
                     metadata[metadataName] = element.value;
                 }
                 return metadata;

--- a/cms/static/js/views/xblock_outline.js
+++ b/cms/static/js/views/xblock_outline.js
@@ -13,10 +13,9 @@
  *  - scroll_offset - the scroll offset to use for the locator being shown
  *  - edit_display_name - true if the shown xblock's display name should be in inline edit mode
  */
-define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/components/utils/view_utils",
-        "js/views/utils/xblock_utils", "js/views/xblock_string_field_editor"],
+define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/components/utils/view_utils',
+        'js/views/utils/xblock_utils', 'js/views/xblock_string_field_editor'],
     function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, XBlockStringFieldEditor) {
-
         var XBlockOutlineView = BaseView.extend({
             // takes XBlockInfo as a model
 
@@ -49,7 +48,7 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
                 // need to add the current model's id/locator to the set of expanded locators
                 if (this.model.get('is_header_visible') !== null && !this.model.get('is_header_visible')) {
                     var locator = this.model.get('id');
-                    if(!_.isUndefined(this.expandedLocators) && !this.expandedLocators.contains(locator)) {
+                    if (!_.isUndefined(this.expandedLocators) && !this.expandedLocators.contains(locator)) {
                         this.expandedLocators.add(locator);
                         this.refresh();
                     }
@@ -216,7 +215,7 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
 
             onSync: function(event) {
                 if (ViewUtils.hasChangedAttributes(this.model, ['visibility_state', 'child_info', 'display_name'])) {
-                   this.onXBlockChange();
+                    this.onXBlockChange();
                 }
             },
 
@@ -246,7 +245,7 @@ define(["jquery", "underscore", "gettext", "js/views/baseview", "common/js/compo
                     if (locatorElement.length > 0) {
                         ViewUtils.setScrollOffset(locatorElement, scrollOffset);
                     } else {
-                        console.error("Failed to show item with locator " + locatorToShow + "");
+                        console.error('Failed to show item with locator ' + locatorToShow + '');
                     }
                     if (editDisplayName) {
                         locatorElement.find('> div[class$="header"] .xblock-field-value-edit').click();

--- a/cms/static/js/views/xblock_string_field_editor.js
+++ b/cms/static/js/views/xblock_string_field_editor.js
@@ -5,9 +5,8 @@
  * XBlock field's value if it has been changed. If the user presses Escape, then any changes will
  * be removed and the input hidden again.
  */
-define(["js/views/baseview", "js/views/utils/xblock_utils"],
-    function (BaseView, XBlockViewUtils) {
-
+define(['js/views/baseview', 'js/views/utils/xblock_utils'],
+    function(BaseView, XBlockViewUtils) {
         var XBlockStringFieldEditor = BaseView.extend({
             events: {
                 'click .xblock-field-value-edit': 'showInput',
@@ -42,7 +41,7 @@ define(["js/views/baseview", "js/views/utils/xblock_utils"],
                 return this.$('.xblock-field-value');
             },
 
-            getInput: function () {
+            getInput: function() {
                 return this.$('.xblock-field-input');
             },
 

--- a/cms/static/js/views/xblock_validation.js
+++ b/cms/static/js/views/xblock_validation.js
@@ -1,5 +1,5 @@
-define(["jquery", "underscore", "js/views/baseview", "gettext"],
-    function ($, _, BaseView, gettext) {
+define(['jquery', 'underscore', 'js/views/baseview', 'gettext'],
+    function($, _, BaseView, gettext) {
         /**
          * View for xblock validation messages as displayed in Studio.
          */
@@ -12,7 +12,7 @@ define(["jquery", "underscore", "js/views/baseview", "gettext"],
                 this.root = options.root;
             },
 
-            render: function () {
+            render: function() {
                 this.$el.html(this.template({
                     validation: this.model,
                     additionalClasses: this.getAdditionalClasses(),
@@ -27,7 +27,7 @@ define(["jquery", "underscore", "js/views/baseview", "gettext"],
              * @param messageType
              * @returns string representation of css class that will render the correct icon, or null if unknown type
              */
-            getIcon: function (messageType) {
+            getIcon: function(messageType) {
                 if (messageType === this.model.ERROR) {
                     return 'fa-exclamation-circle';
                 }
@@ -42,16 +42,16 @@ define(["jquery", "underscore", "js/views/baseview", "gettext"],
              * @param messageType
              * @returns string display name (translated)
              */
-            getDisplayName: function (messageType) {
+            getDisplayName: function(messageType) {
                 if (messageType === this.model.WARNING || messageType === this.model.NOT_CONFIGURED) {
                     // Translators: This message will be added to the front of messages of type warning,
                     // e.g. "Warning: this component has not been configured yet".
-                    return gettext("Warning");
+                    return gettext('Warning');
                 }
                 else if (messageType === this.model.ERROR) {
                     // Translators: This message will be added to the front of messages of type error,
                     // e.g. "Error: required field is missing".
-                    return gettext("Error");
+                    return gettext('Error');
                 }
                 return null;
             },
@@ -62,13 +62,12 @@ define(["jquery", "underscore", "js/views/baseview", "gettext"],
              *
              * @returns string of additional css classes (or empty string)
              */
-            getAdditionalClasses: function () {
-                if (this.root && this.model.get("summary").type === this.model.NOT_CONFIGURED &&
-                    this.model.get("messages").length === 0) {
-
-                    return "no-container-content";
+            getAdditionalClasses: function() {
+                if (this.root && this.model.get('summary').type === this.model.NOT_CONFIGURED &&
+                    this.model.get('messages').length === 0) {
+                    return 'no-container-content';
                 }
-                return "";
+                return '';
             }
         });
 

--- a/cms/static/js/xblock/authoring.js
+++ b/cms/static/js/xblock/authoring.js
@@ -21,7 +21,7 @@
 
             // Cohort partitions (user is allowed to select more than one)
             element.find('.field-visibility-content-group input:checked').each(function(index, input) {
-                checkboxValues = $(input).val().split("-");
+                checkboxValues = $(input).val().split('-');
                 partitionId = parseInt(checkboxValues[0], 10);
                 groupId = parseInt(checkboxValues[1], 10);
 
@@ -61,7 +61,7 @@
     VisibilityEditorView.prototype.collectFieldData = function collectFieldData() {
         return {
             metadata: {
-                "group_access": this.getGroupAccess()
+                'group_access': this.getGroupAccess()
             }
         };
     };

--- a/cms/static/js/xblock_asides/structured_tags.js
+++ b/cms/static/js/xblock_asides/structured_tags.js
@@ -2,10 +2,9 @@
     'use strict';
 
     function StructuredTagsView(runtime, element) {
-
         var $element = $(element);
 
-        $element.find("select").each(function() {
+        $element.find('select').each(function() {
             var loader = this;
             var sts = $(this).attr('structured-tags-select-init');
 

--- a/cms/static/karma_cms_squire.conf.js
+++ b/cms/static/karma_cms_squire.conf.js
@@ -41,6 +41,6 @@ var options = {
     ]
 };
 
-module.exports = function (config) {
+module.exports = function(config) {
     configModule.configure(config, options);
 };


### PR DESCRIPTION
### Description

Part of the great trinity of ESLint autofix PRs (#13171, #13172, #13173) - all children of [FEDX-221](https://openedx.atlassian.net/browse/FEDX-221)
- Runs `$(npm bin)/eslint --fix lms` to take ESLint violations from 48128 to 40741
- Remove an auto-added semicolon from the last line of `cms/static/cms/js/build.js` because it breaks the requirejs optimizer (??!)
### Reviewers
- [x] @andy-armstrong 
- [x] @jzoldak 

FYI @benpatterson @cpennington 

Note: This PR won't pass the quality check, because it's failing diff-quality. `eslint --fix` knows how to fix simple lint violations but not complex ones, and there are often complex ones left on lines dirtied by the autofixer, so diff-quality fails.
