### PR TITLE
Reduce the number of retries.

### DIFF
--- a/lms/djangoapps/verified_track_content/tasks.py
+++ b/lms/djangoapps/verified_track_content/tasks.py
@@ -15,7 +15,7 @@ from openedx.core.djangoapps.course_groups.cohorts import (
 LOGGER = get_task_logger(__name__)
 
 
-@task(bind=True, default_retry_delay=60, max_retries=4)
+@task(bind=True, default_retry_delay=60, max_retries=2)
 def sync_cohort_with_mode(self, course_id, user_id, verified_cohort_name, default_cohort_name):
     """
     If the learner's mode does not match their assigned cohort, move the learner into the correct cohort.


### PR DESCRIPTION
This task will get run twice, 5 minutes apart (that's pre-existing code because we can't be sure when the enrollment change will be committed to the database). Because of that, it can run up to 6 times with max_retries set to 2.

@efischer19 FYI, I'm going to reduce the number of retries before this gets into production. Since retry exceptions do get raised in New Relic, I'm worried about potentially a large number.
