### PR TITLE
Add Logging for CohortMembership

### DIFF
--- a/lms/djangoapps/verified_track_content/models.py
+++ b/lms/djangoapps/verified_track_content/models.py
@@ -49,6 +49,8 @@ def move_to_verified_cohort(sender, instance, **kwargs):  # pylint: disable=unus
                     'verified_cohort_name': verified_cohort_name,
                     'default_cohort_name': random_cohort.name
                 }
+                log.info("Queuing automatic cohorting for user '%s' in course '%s'", instance.user.username, course_key)
+
                 # Do the update with a 3-second delay in hopes that the CourseEnrollment transaction has been
                 # completed before the celery task runs. We want a reasonably short delay in case the learner
                 # immediately goes to the courseware.

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -90,6 +90,8 @@ class CohortMembership(models.Model):
     def save(self, *args, **kwargs):
         self.full_clean(validate_unique=False)
 
+        log.info("Saving CohortMembership for '%s' (id=%s) in '%s'", self.user.username, self.user.id, self.course_id)
+
         # Avoid infinite recursion if creating from get_or_create() call below.
         # This block also allows middleware to use CohortMembership.get_or_create without worrying about outer_atomic
         if 'force_insert' in kwargs and kwargs['force_insert'] is True:


### PR DESCRIPTION
Diagnostics for https://openedx.atlassian.net/browse/TNL-5181. We'd like to get this into next week's release to speed up debugging and hopefully have an intelligent fix for next week's rc.

@macdiesel @cahrens 

This is how the messages appear in the logs:
2016-08-05 22:14:27,448 INFO 13098 [verified_track_content.models] models.py:52 - Queuing automatic cohorting for user 'christina' in course 'course-v1:demo+demo+demo'
2016-08-05 22:14:27,652 INFO 13098 [openedx.core.djangoapps.course_groups.models] models.py:93 - Saving CohortMembership for 'christina' (id=11) in 'course-v1:demo+demo+demo'
