### PR TITLE
add partners url

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -198,6 +198,8 @@ urlpatterns += (
         {'template': 'media-kit.html'}, name="media-kit"),
     url(r'^copyright$', 'static_template_view.views.render',
         {'template': 'copyright.html'}, name="copyright"),
+    url(r'^partners$', 'static_template_view.views.render',
+        {'template': 'partners.html'}, name="partners"),
 
     # Press releases
     url(r'^press/([_a-zA-Z0-9-]+)$', 'static_template_view.views.render_press_release', name='press_release'),


### PR DESCRIPTION
Add partners URL in lms to allow white label sites to have a partners.html template.
