### PR TITLE
capa show answer cleanup

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -65,7 +65,7 @@ describe 'Problem', ->
       expect($('div.action button.reset')).toHandleWith 'click', @problem.reset
 
     it 'bind the show button', ->
-      expect($('div.action button.show')).toHandleWith 'click', @problem.show
+      expect($('.action .show')).toHandleWith 'click', @problem.show
 
     it 'bind the save button', ->
       expect($('div.action button.save')).toHandleWith 'click', @problem.save
@@ -425,6 +425,7 @@ describe 'Problem', ->
     describe 'when the answer has not yet shown', ->
       beforeEach ->
         @problem.el.removeClass 'showed'
+        expect(@problem.el.find('.show').attr('disabled')).not.toEqual('disabled')
 
       it 'log the problem_show event', ->
         @problem.show()
@@ -444,30 +445,28 @@ describe 'Problem', ->
         expect($('#answer_1_1')).toHaveHtml 'One'
         expect($('#answer_1_2')).toHaveHtml 'Two'
 
-      it 'toggle the show answer button', ->
+      it 'sends the answers when text to the SR element', ->
         spyOn($, 'postWithPrefix').and.callFake (url, callback) -> callback(answers: {})
         @problem.show()
-        expect($('.show .show-label')).toHaveText 'Hide Answer'
         expect(window.SR.readElts).toHaveBeenCalled()
-
-      it 'toggle the show answer button, answers are strings', ->
+ 
+      it 'sends the answers when elements to the SR element, answers are strings', ->
         spyOn($, 'postWithPrefix').and.callFake (url, callback) -> callback(answers: '1_1': 'One', '1_2': 'Two')
         @problem.show()
-        expect($('.show .show-label')).toHaveText 'Hide Answer'
         expect(window.SR.readElts).toHaveBeenCalledWith ['<p>Answer: One</p>', '<p>Answer: Two</p>']
 
-      it 'toggle the show answer button, answers are elements', ->
+      it 'sends the answers when elements to the SR element, answers are elements', ->
         answer1 = '<div><span class="detailed-solution">one</span></div>'
         answer2 = '<div><span class="detailed-solution">two</span></div>'
         spyOn($, 'postWithPrefix').and.callFake (url, callback) -> callback(answers: '1_1': answer1, '1_2': answer2)
         @problem.show()
-        expect($('.show .show-label')).toHaveText 'Hide Answer'
         expect(window.SR.readElts).toHaveBeenCalledWith [jasmine.any(jQuery), jasmine.any(jQuery)]
 
       it 'add the showed class to element', ->
         spyOn($, 'postWithPrefix').and.callFake (url, callback) -> callback(answers: {})
         @problem.show()
         expect(@problem.el).toHaveClass 'showed'
+        expect(@problem.el.find('.show').attr('disabled')).toEqual('disabled')
 
       it 'reads the answers', (done) ->
         deferred = $.Deferred()
@@ -700,20 +699,6 @@ describe 'Problem', ->
         '''
         $('#answer_1_1').html('One')
         $('#answer_1_2').html('Two')
-
-      it 'hide the answers', ->
-        @problem.show()
-        expect($('#answer_1_1')).toHaveHtml ''
-        expect($('#answer_1_2')).toHaveHtml ''
-        expect($('label[for="input_1_1_1"]')).not.toHaveAttr 'correct_answer'
-
-      it 'toggle the show answer button', ->
-        @problem.show()
-        expect($('.show .show-label')).toHaveText 'Show Answer'
-
-      it 'remove the showed class from element', ->
-        @problem.show()
-        expect(@problem.el).not.toHaveClass 'showed'
 
   describe 'save', ->
     beforeEach ->

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -30,7 +30,7 @@ class @Problem
     @$('div.action button').click @refreshAnswers
     @questionTitle = @$(".problem-header")
     @reviewButton = @$('div.action .review-btn')
-    @reviewButton.click @review_question_click
+    @reviewButton.click @scroll_to_problem_meta
     @checkButton = @$('div.action button.check')
     @checkButtonLabel = @$('div.action button.check span.check-label')
     @checkButtonCheckText = @checkButtonLabel.text()
@@ -241,12 +241,13 @@ class @Problem
         flag = false
     return flag
 
-  # Review button click brings user back to top of problem
-  review_question_click: =>
-    $('html, body').animate({
-      scrollTop: @questionTitle.offset().top
-    }, 500);
-    @questionTitle.focus();
+  # Scroll to problem metadata and next focus is problem input
+  scroll_to_problem_meta: =>
+    if @questionTitle.length > 0
+      $('html, body').animate({
+        scrollTop: @questionTitle.offset().top
+      }, 500);
+      @questionTitle.focus()
 
   ###
   # 'check_fd' uses FormData to allow file submissions in the 'problem_check' dispatch,
@@ -417,25 +418,11 @@ class @Problem
           @el.find('.problem > div').each (index, element) =>
             MathJax.Hub.Queue ["Typeset", MathJax.Hub, element]
 
-        `// Translators: the word Answer here refers to the answer to a problem the student must solve.`
-        @$('.show-label').text gettext('Hide Answer')
         @el.addClass 'showed'
+        @el.find('.show').attr('disabled', 'disabled')
         @updateProgress response
         window.SR.readElts(answer_text)
-    else
-      @$('[id^=answer_], [id^=solution_]').text ''
-      @$('[correct_answer]').attr correct_answer: null
-      @el.removeClass 'showed'
-      `// Translators: the word Answer here refers to the answer to a problem the student must solve.`
-      @$('.show-label').text gettext('Show Answer')
-      window.SR.readText(gettext('Answer hidden'))
-
-      @el.find(".capa_inputtype").each (index, inputtype) =>
-        display = @inputtypeDisplays[$(inputtype).attr('id')]
-        classes = $(inputtype).attr('class').split(' ')
-        for cls in classes
-          hideMethod = @inputtypeHideAnswerMethods[cls]
-          hideMethod(inputtype, display) if hideMethod?
+        @scroll_to_problem_meta()
 
   gentle_alert: (msg) =>
     if @el.find('.capa_alert').length

--- a/common/static/sass/edx-pattern-library-shims/_buttons.scss
+++ b/common/static/sass/edx-pattern-library-shims/_buttons.scss
@@ -25,8 +25,8 @@
 
   // Display: block, one button per line, full width
   &.block {
-      display: block;
-      width: 100%;
+    display: block;
+    width: 100%;
   }
 
   // STATE: is disabled

--- a/common/static/sass/edx-pattern-library-shims/base/_variables.scss
+++ b/common/static/sass/edx-pattern-library-shims/base/_variables.scss
@@ -123,7 +123,7 @@ $font-sizes: (
 // +Colors - UXPL new pattern library colors
 // ====================
 $uxpl-blue-base: rgba(0, 116, 180, 1); // wcag2a compliant
-$uxpl-blue-hover-active: lighten($uxpl-blue-base, 7%); // wcag2a compliant
+$uxpl-blue-hover-active: darken($uxpl-blue-base, 7%); // wcag2a compliant
 
 $uxpl-green-base: rgba(0, 129, 0, 1); // wcag2a compliant
 $uxpl-green-hover-active: lighten($uxpl-green-base, 7%); // wcag2a compliant

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -130,10 +130,18 @@ class ProblemPage(PageObject):
         self.q(css='div.problem button.reset').click()
         self.wait_for_ajax()
 
-    def click_show_hide_button(self):
-        """ Click the Show/Hide button. """
-        self.q(css='div.problem div.action .show').click()
+    def click_show(self):
+        """
+        Click the Show Answer button.
+        """
+        self.q(css='.problem .show').click()
         self.wait_for_ajax()
+
+    def is_focus_on_problem_meta(self):
+        """
+        Check for focus problem meta.
+        """
+        return self.q(css='.problem-header').focused
 
     def wait_for_status_icon(self):
         """

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -231,6 +231,20 @@ class ProblemTypeTestMixin(object):
         )
         self.assertIn('is-disabled', self.problem_page.q(css='div.problem button.check').attrs('class')[0])
 
+    @attr(shard=7)
+    def test_can_show_answer(self):
+        """
+        Scenario: Verifies that show answer button is working as expected.
+
+        Given that I am on courseware page
+        And I can see a CAPA problem with show answer button
+        When I click "Show Answer" button
+        And I should see question's solution
+        And I should see the problem title is focused
+        """
+        self.problem_page.click_show()
+        self.assertTrue(self.problem_page.is_focus_on_problem_meta())
+
     @attr('a11y')
     def test_problem_type_a11y(self):
         """
@@ -344,29 +358,21 @@ class CheckboxProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         else:
             self.problem_page.click_choice("choice_1")
 
-    @attr('shard_7')
-    def test_can_show_hide_answer(self):
+    @attr(shard=7)
+    def test_can_show_answer(self):
         """
-        Scenario: Verifies that show/hide answer button is working as expected.
+        Scenario: Verifies that show answer button is working as expected.
 
         Given that I am on courseware page
         And I can see a CAPA problem with show answer button
         When I click "Show Answer" button
-        Then I should see "Hide Answer" text on button
         And I should see question's solution
         And I should see correct choices highlighted
-        When I click "Hide Answer" button
-        Then I should see "Show Answer" text on button
-        And I should not see question's solution
-        And I should not see correct choices highlighted
         """
-        self.problem_page.click_show_hide_button()
+        self.problem_page.click_show()
         self.assertTrue(self.problem_page.is_solution_tag_present())
         self.assertTrue(self.problem_page.is_correct_choice_highlighted(correct_choices=[1, 3]))
-
-        self.problem_page.click_show_hide_button()
-        self.assertFalse(self.problem_page.is_solution_tag_present())
-        self.assertFalse(self.problem_page.is_correct_choice_highlighted(correct_choices=[1, 3]))
+        self.assertTrue(self.problem_page.is_focus_on_problem_meta())
 
 
 class MultipleChoiceProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):

--- a/lms/djangoapps/courseware/features/problems.feature
+++ b/lms/djangoapps/courseware/features/problems.feature
@@ -108,14 +108,10 @@ Feature: LMS.Answer problems
         When I answer a "multiple choice" problem "correctly"
         Then The "Reset" button does not appear
 
-    Scenario: I can view and hide the answer if the problem has it:
+    Scenario: I can view the answer if the problem has it:
         Given I am viewing a "numerical" that shows the answer "always"
         When I press the button with the label "Show Answer"
-        Then the Show/Hide button label is "Hide Answer"
         And I should see "4.14159" somewhere in the page
-        When I press the button with the label "Hide Answer"
-        Then the Show/Hide button label is "Show Answer"
-        And I should not see "4.14159" anywhere on the page
 
     Scenario: I can see my score on a problem when I answer it and after I reset it
         Given I am viewing a "<ProblemType>" problem

--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -147,14 +147,6 @@ def action_button_present(_step, buttonname, doesnt_appear):
         assert world.is_css_present(button_css)
 
 
-@step(u'the Show/Hide button label is "([^"]*)"$')
-def show_hide_label_is(_step, label_name):
-    # The label text is changed by static/xmodule_js/src/capa/display.js
-    # so give it some time to change on the page.
-    label_css = 'button.show.btn-default.btn-small span.show-label'
-    world.wait_for(lambda _: world.css_has_text(label_css, label_name))
-
-
 @step(u'I should see a score of "([^"]*)"$')
 def see_score(_step, score):
     # The problem progress is changed by

--- a/lms/static/sass/partials/base/_variables.scss
+++ b/lms/static/sass/partials/base/_variables.scss
@@ -210,13 +210,13 @@ $shadow-d1: rgba(0,0,0,0.4) !default;
 $shadow-d2: rgba($black, 0.6) !default;
 
 // system feedback-based colors
-$error-color: rgb(253, 87, 87) !default;
-$warning-color: rgb(181,42,103) !default;
+$error-color: rgb(203, 7, 18) !default;
+$warning-color: rgb(255, 192 ,31) !default;
 $confirm-color: rgb(0, 132, 1) !default;
 $active-color: $blue !default;
 $highlight-color: rgb(255,255,0) !default;
 $alert-color: rgb(212, 64, 64) !default;
-$success-color: rgb(37, 184, 90) !default;
+$success-color: rgb(0, 155, 0) !default;
 
 // newer color variables
 $dark-gray1: rgb(74,74,74);

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -36,7 +36,9 @@ from openedx.core.djangolib.markup import HTML
     % endif
     % if answer_available:
     <span class="problem-action-button-wrapper">
-        <button class="show problem-action-btn btn-default btn-small"><span class="icon fa fa-exclamation-triangle" aria-hidden="true"></span><span class="show-label">${_('Show Answer')}</span></button>
+        <button class="show problem-action-btn btn-default btn-small" aria-describedby="${ id }-problem-title">
+            <span class="icon fa fa-exclamation-triangle" aria-hidden="true"></span><span class="show-label">${_('Show Answer')}</span>
+        </button>
     </span>
     % endif
     </div>
@@ -47,7 +49,7 @@ from openedx.core.djangolib.markup import HTML
     % endif
     % if attempts_allowed :
     <div class="submission_feedback" aria-live="polite">
-      ${_("You have used {num_used} of {num_total} attempts").format(num_used=attempts_used, num_total=attempts_allowed)}
+        ${_("You have used {num_used} of {num_total} attempts").format(num_used=attempts_used, num_total=attempts_allowed)}
     </div>
     % endif
     ## <%include file="problem_notifications.html" args="notification_type=notification_type,notification_icon=notification_icon,notification_message=notification_message,hint_notification=hint_notification"/>


### PR DESCRIPTION
[TNL-4936](https://openedx.atlassian.net/browse/TNL-4936)
## Description

CAPA
- Add Show Answer tooltip **ACTUALLY NOT-- THIS HAS BEEN REMOVED**
- Remove Hide Answer, Disable Show Answer after it is pressed until reload.
## Sandbox is rebuilding (got 500 error for some reason)

[example 1](https://alisan617.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/)

[example 2](https://alisan617.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/1414ffd5143b4b508f739b563ab468b7/workflow/)
## Testing Checklist
- [x] Manually test responsive behavior.
- [x] Manually test right-to-left behavior.
- [ ] Manually test a11y support.
## Reviewers
- [x] Code review: @cahrens 
- [x] Code review: @staubina 
- [x] UX review: @chris-mike 
