### PR TITLE
Hide 'Reset Attempts' and 'Rescore Problem' on unsupported blocks.

### DIFF
--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -68,12 +68,16 @@ ${block_content}
       </div>
       <div data-location="${location | h}" data-location-name="${location.name | h}">
         [
+        % if can_reset_attempts:
         <a href="#" class="staff-debug-reset">${_('Reset Student Attempts')}</a>
-        % if has_instructor_access:
         |
+        % endif
+        % if has_instructor_access:
         <a href="#" class="staff-debug-sdelete">${_('Delete Student State')}</a>
+        % if can_rescore_problem:
         |
         <a href="#" class="staff-debug-rescore">${_('Rescore Student Submission')}</a>
+        % endif
         % endif
         ]
       </div>

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -87,16 +87,17 @@ ${block_content}
     <div class="staff_info" style="display:block">
 is_released = ${is_released}
 location = ${location.to_deprecated_string() | h}
+
 <table summary="${_('Module Fields')}">
   <tr><th>${_('Module Fields')}</th></tr>
   %for name, field in fields:
-  <tr><td>${name}</td><td><pre style="display:inline-block; margin: 0;">${field | h}</pre></td></tr>
+  <tr><td style="width:25%">${name}</td><td><pre style="display:inline-block; margin: 0;">${field | h}</pre></td></tr>
   %endfor
 </table>
 <table>
   <tr><th>${_('XML attributes')}</th></tr>
   %for name, field in xml_attributes.items():
-  <tr><td>${name}</td><td><pre style="display:inline-block; margin: 0;">${field | h}</pre></td></tr>
+  <tr><td style="width:25%">${name}</td><td><pre style="display:inline-block; margin: 0;">${field | h}</pre></td></tr>
   %endfor
 </table>
 category = ${category | h}

--- a/openedx/core/lib/xblock_utils.py
+++ b/openedx/core/lib/xblock_utils.py
@@ -382,6 +382,8 @@ def add_staff_markup(user, has_instructor_access, disable_staff_debug_info, bloc
         'block_content': frag.content,
         'is_released': is_released,
         'has_instructor_access': has_instructor_access,
+        'can_reset_attempts': 'attempts' in block.fields,
+        'can_rescore_problem': hasattr(block, 'rescore_problem'),
         'disable_staff_debug_info': disable_staff_debug_info,
     }
     return wrap_fragment(frag, render_to_string("staff_problem_info.html", staff_context))


### PR DESCRIPTION
CAPA problems have the "Staff Debug Info" button, which allows instructors to "Reset Attempts" and "Rescore problem" for any individual student.

XBlocks, such as Drag and Drop v2 do not support those, though the UI was still present. Clicking any of those links would result in an "Unknown Error Occurred" message.

This patch hides the two buttons if the associated block does not support them.

**JIRA tickets**: https://openedx.atlassian.net/browse/SOL-1809

**Dependencies**: None

**Screenshots**:

<img width="1114" alt="screen shot 2016-08-09 at 18 09 19" src="https://cloud.githubusercontent.com/assets/32585/17512923/cdfc3efe-5e5c-11e6-9de2-cbe6f251d3be.png">

<img width="1115" alt="screen shot 2016-08-09 at 18 09 36" src="https://cloud.githubusercontent.com/assets/32585/17512862/85c0a3aa-5e5c-11e6-9156-9cb1714f0b06.png">

**Sandbox URL** (installed version 32fb5517c01da29fa63b8a70d935ce74bb88ffe5):
- LMS: http://pr13194.sandbox.opencraft.hosting/
- Studio: http://studio-pr13194.sandbox.opencraft.hosting/

You may want to check this unit which includes one CAPA problem and one Drag and Drop v2 problem:
http://pr13194.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/9fca584977d04885bc911ea76a9ef29e/07bc32474380492cb34f76e5f9d9a135/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%4045c7cedb4bfe46f4a68c78787151cfb5

**Testing instructions**:
1. Log into the LMS with staff access.
2. Navigate to a unit with a CAPA problem and click .
3. Click "Staff Debug Info".
4. You should see all these three buttons/links in the popup: "Reset Student Attempts", "Delete Student State", "Rescore Student Submission".
5. Navigate to a unit with a pure XBlock problem (such as Drag and Drop v2).
6. Click "Staff Debug Info".
7. You should see the "Delete Student State" button, but not the other two.

**Reviewers**
- [x] OpenCraft: @e-kolpakov  
- [x] edX reviewer[s]: @cahrens 
