### PR TITLE
Fix discussions error with unabortable jqXHRs

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_view.js
@@ -213,7 +213,10 @@
             };
 
             DiscussionThreadView.prototype.cleanup = function() {
-                if (this.responsesRequest) {
+                // jQuery.ajax after 1.5 returns a jqXHR which doesn't implement .abort
+                // but I don't feel confident enough about what's going on here to remove this code
+                // so just check to make sure we can abort before we try to
+                if (this.responsesRequest && this.responsesRequest.abort) {
                     return this.responsesRequest.abort();
                 }
             };


### PR DESCRIPTION
### Description

[TNL-5173](https://openedx.atlassian.net/browse/TNL-5173)

My understanding of this code is that following the jQuery upgrade to 2.2, these requests no longer implement the `.abort()` interface. But I am reluctant to remove this method completely given how legacy this code is. So my fix for this is just to always check that `.abort` is a valid method on the request before trying to call it.

Note: This was merged to the discussions feature branch [here](https://github.com/edx/edx-platform/pull/13044/files#diff-77350d20b34f7b55e97efbcf19fdd49dR216), I would really prefer to merge this as-is to reduce merge conflicts.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @andy-armstrong 
- [x] @dianakhuang 
- [x] @robrap 

FYI @mushtaqak
### Post-review
- [x] Squash commits
