### PR TITLE
TNL-4970 Make CAPA dropdown problems accessible

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_crud.py
+++ b/cms/djangoapps/contentstore/tests/test_crud.py
@@ -35,8 +35,8 @@ class TemplateTests(ModuleStoreTestCase):
         self.assertIsNotNone(dropdown)
         self.assertIn('markdown', dropdown['metadata'])
         self.assertIn('data', dropdown)
-        self.assertRegexpMatches(dropdown['metadata']['markdown'], r'^Dropdown.*')
-        self.assertRegexpMatches(dropdown['data'], r'<problem>\s*<optionresponse>\s*<p>Dropdown.*')
+        self.assertRegexpMatches(dropdown['metadata']['markdown'], r'.*dropdown problems.*')
+        self.assertRegexpMatches(dropdown['data'], r'<problem>\s*<optionresponse>\s*<p>.*dropdown problems.*')
 
     def test_get_some_templates(self):
         self.assertEqual(len(SequenceDescriptor.templates()), 0)

--- a/common/lib/capa/capa/templates/optioninput.html
+++ b/common/lib/capa/capa/templates/optioninput.html
@@ -1,11 +1,19 @@
 <% doinline = "inline" if inline else "" %>
 
 <form class="inputtype option-input ${doinline}">
-   <select name="input_${id}" id="input_${id}" aria-label="${response_data['label']}" ${describedby}>
+  <label class="problem-group-label" for="input_${id}">
+    ${response_data['label']}
+  </label>
+
+  % for description_id, description_text in response_data['descriptions'].items():
+    <p class="question-description" id="${description_id}">${description_text}</p>
+  % endfor
+
+   <select name="input_${id}" id="input_${id}" ${describedby}>
       <option value="option_${id}_dummy_default">  </option>
       % for option_id, option_description in options:
           <option value="${option_id}"
-          % if (option_id==value or option_id==answervariable):
+          % if (option_id == value or option_id == answervariable):
         	selected="true"
           % endif
           > ${option_description}</option>
@@ -16,12 +24,11 @@
     <span class="status ${status.classname}"
         id="status_${id}"
         aria-describedby="input_${id}" data-tooltip="${status.display_tooltip}">
-      <span class="sr">${value|h} - ${status.display_tooltip}</span>
+        <span class="sr">${value|h} - ${status.display_tooltip}</span>
     </span>
   </div>
   <p class="answer" id="answer_${id}"></p>
   % if msg:
       <span class="message">${msg|n}</span>
   % endif
-
 </form>

--- a/common/lib/capa/capa/tests/test_input_templates.py
+++ b/common/lib/capa/capa/tests/test_input_templates.py
@@ -813,15 +813,15 @@ class OptionInputTemplateTest(TemplateTestCase):
 
     def test_label(self):
         xml = self.render_to_xml(self.context)
-        xpath = "//select[@aria-label='%s']" % self.context['response_data']['label']
-        self.assert_has_xpath(xml, xpath, self.context)
+        xpath = "//label[@class='problem-group-label']"
+        self.assert_has_xpath(xml, xpath, self.RESPONSE_DATA['label'])
 
     def test_description(self):
         """
         Test that correct description information is set on desired elements.
         """
         xpaths = ['//select/@aria-describedby']
-        self.assert_description(xpaths, descriptions=False)
+        self.assert_description(xpaths)
         self.assert_describedby_attribute(xpaths)
 
 

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -156,6 +156,13 @@ div.problem {
   .question-description {
     @include margin(($baseline*0.75), 0);
   }
+
+  form > label {
+    display: block;
+    margin-bottom: $baseline;
+    font: inherit;
+    color: inherit;
+  }
 }
 
 // +Problem - Choice Group

--- a/common/lib/xmodule/xmodule/templates/problem/optionresponse.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/optionresponse.yaml
@@ -2,33 +2,23 @@
 metadata:
     display_name: Dropdown
     markdown: |
-         Dropdown problems allow learners to select only one option from a list of options.
-
-         When you add the problem, be sure to select Settings to specify a Display Name and other values that apply.
-
-         You can use the following example problem as a model.
-
-         >>Which of the following countries celebrates its independence on August 15?||You can select only one option.<<
-
-         [[(India), Spain, China, Bermuda]]
-
-         [explanation]
-         India became an independent nation on August 15, 1947.
-         [explanation]
+         You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown problems. Edit this component to replace this template with your own assessment.
+         >>Add the question text, or prompt, here. This text is required.||You can add an optional tip or note related to the prompt like this. <<
+         [[
+         an incorrect answer
+         (the correct answer)
+         an incorrect answer
+         ]]
 data:   |
         <problem>
             <optionresponse>
-                <p>Dropdown problems allow learners to select only one option from a list of options.</p>
-                <p>When you add the problem, be sure to select Settings to specify a Display Name and other values that apply.</p>
-                <p>You can use the following example problem as a model.</p>
-                <label>Which of the following countries celebrates its independence on August 15?</label>
-                <description>You can select only one option.</description>
-                <optioninput options="('India','Spain','China','Bermuda')" correct="India"/>
-                <solution>
-                    <div class="detailed-solution">
-                        <p>Explanation</p>
-                        <p>India became an independent nation on August 15, 1947.</p>
-                    </div>
-                </solution>
+                <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown problems. Edit this component to replace this template with your own assessment.</p>
+                <label>Add the question text, or prompt, here. This text is required.</label>
+                <description>You can add an optional tip or note related to the prompt like this. </description>
+                <optioninput>
+                    <option correct="False">an incorrect answer</option>
+                    <option correct="True">the correct answer</option>
+                    <option correct="False">an incorrect answer</option>
+                </optioninput>
             </optionresponse>
         </problem>

--- a/common/lib/xmodule/xmodule/templates/problem/optionresponse_hint.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/optionresponse_hint.yaml
@@ -2,55 +2,34 @@
 metadata:
     display_name: Dropdown with Hints and Feedback
     markdown: |
-
-        You can provide feedback for each available option in a dropdown problem.
-
-        You can also add hints for learners.
-
-        Be sure to select Settings to specify a Display Name and other values that apply.
-
-        Use the following example problem as a model.
-
-        >> A/an ________ is a vegetable.||You can select only one option.<<
-
+        You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown with hints and feedback problems. Edit this component to replace this template with your own assessment.
+        >>Add the question text, or prompt, here. This text is required.||You can add an optional tip or note related to the prompt
+        like this. <<
         [[
-            apple {{An apple is the fertilized ovary that comes from an apple tree and contains seeds, meaning it is a fruit.}}
-            pumpkin {{A pumpkin is the fertilized ovary of a squash plant and contains seeds, meaning it is a fruit.}}
-            (potato) {{A potato is an edible part of a plant in tuber form and is a vegetable.}}
-            tomato {{Many people mistakenly think a tomato is a vegetable. However, because a tomato is the fertilized ovary of a tomato plant and contains seeds, it is a fruit.}}
+        an incorrect answer {{You can specify optional feedback like this, which appears after this answer is submitted.}}
+        (the correct answer)
+        an incorrect answer {{You can specify optional feedback for none, a subset, or all of the answers.}}
         ]]
 
-        ||A fruit is the fertilized ovary from a flower.||
-        ||A fruit contains seeds of the plant.||
+        ||You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.||
+        ||If you add more than one hint, a different hint appears each time learners select the hint button.||
 
 hinted: true
 data:   |
         <problem>
             <optionresponse>
-                <p>You can provide feedback for each available option in a dropdown problem.</p>
-                <p>You can also add hints for learners.</p>
-                <p>Be sure to select Settings to specify a Display Name and other values that apply.</p>
-                <p>Use the following example problem as a model.</p>
-                <label>A/an ________ is a vegetable.</label>
-                <description>You can select only one option.</description>
+                <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
+                <label>Add the question text, or prompt, here. This text is required.</label>
+                <description>You can add an optional tip or note related to the prompt
+                like this. </description>
                 <optioninput>
-                    <option correct="False">apple
-                        <optionhint>An apple is the fertilized ovary that comes from an apple tree and contains seeds, meaning it is a fruit.</optionhint>
-                    </option>
-                    <option correct="False">pumpkin
-                        <optionhint>A pumpkin is the fertilized ovary of a squash plant and contains seeds, meaning it is a fruit.</optionhint>
-                    </option>
-                    <option correct="True">potato
-                        <optionhint>A potato is an edible part of a plant in tuber form and is a vegetable.</optionhint>
-                    </option>
-                    <option correct="False">tomato
-                        <optionhint>Many people mistakenly think a tomato is a vegetable. However, because a tomato is the fertilized ovary of a tomato plant and contains seeds, it is a fruit.</optionhint>
-                    </option>
+                    <option correct="False">an incorrect answer <optionhint>You can specify optional feedback like this, which appears after this answer is submitted.</optionhint></option>
+                    <option correct="True">the correct answer</option>
+                    <option correct="False">an incorrect answer <optionhint>You can specify optional feedback for none, a subset, or all of the answers.</optionhint></option>
                 </optioninput>
             </optionresponse>
-
             <demandhint>
-                <hint>A fruit is the fertilized ovary from a flower.</hint>
-                <hint>A fruit contains seeds of the plant.</hint>
+              <hint>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</hint>
+              <hint>If you add more than one hint, a different hint appears each time learners select the hint button.</hint>
             </demandhint>
         </problem>

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -535,3 +535,29 @@ class ProblemTextInputA11yTest(CAPAProblemA11yBaseTestMixin, ProblemsTest):
             </stringresponse>
         </problem>""")
         return XBlockFixtureDesc('problem', 'TEXTINPUT PROBLEM', data=xml)
+
+
+@attr('a11y')
+class CAPAProblemDropDownA11yTest(CAPAProblemA11yBaseTestMixin, ProblemsTest):
+    """TestCase Class to verify accessibility for dropdowns(optioninput) CAPA problems."""
+
+    def get_problem(self):
+        """
+        Problem structure.
+        """
+        xml = dedent("""
+        <problem>
+            <optionresponse>
+                <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for
+                 dropdown problems. Edit this component to replace this template with your own assessment.</p>
+                <label>Which of the following is a fruit</label>
+                <description>Choose wisely</description>
+                <optioninput>
+                    <option correct="False">radish</option>
+                    <option correct="True">appple</option>
+                    <option correct="False">carrot</option>
+                </optioninput>
+            </optionresponse>
+        </problem>
+        """)
+        return XBlockFixtureDesc('problem', 'Problem A11Y TEST', data=xml)

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -462,12 +462,6 @@ class DropDownProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         Additional setup for DropDownProblemTypeTest
         """
         super(DropDownProblemTypeTest, self).setUp(*args, **kwargs)
-        self.problem_page.a11y_audit.config.set_rules({
-            'ignore': [
-                'section',  # TODO: AC-491
-                'label',  # TODO: AC-291
-            ]
-        })
 
     def answer_problem(self, correct):
         """


### PR DESCRIPTION
These changes make the dropdown problems accessible.
## Related Story

https://openedx.atlassian.net/browse/TNL-4970
## Sandbox Link

https://drop-down.sandbox.edx.org/
## Post-review
- [ ] Squash commits into discrete sets of changes with descriptive commit messages.
## Reviewers
- [x] @muzaffaryousaf 
- [x] @muhammad-ammar 
- [ ] @cptvitamin 

@muzaffaryousaf FYI
