### PR TITLE
Lower ESLint thresholds post-autofix

### DIFF
--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -12,7 +12,7 @@ set -e
 
 # Violations thresholds for failing the build
 export PYLINT_THRESHOLD=3750
-export ESLINT_THRESHOLD=48129
+export ESLINT_THRESHOLD=10162
 
 SAFELINT_THRESHOLDS=`cat scripts/safelint_thresholds.json`
 export SAFELINT_THRESHOLDS=${SAFELINT_THRESHOLDS//[[:space:]]/}


### PR DESCRIPTION
Lowers the ESLint violations threshold from ~48k to 10,162. Accomplished by doing the autofixes in merged PRs #13171, #13172, #13173 and by ignoring `schematic.js`.
- [x] @aphanse
- [x] @jzoldak 
