### PR TITLE
Updated copyright year for LMS / CMS

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -49,7 +49,7 @@ from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 PLATFORM_NAME = "Your Platform Name Here"
 CC_MERCHANT_NAME = PLATFORM_NAME
 # Shows up in the platform footer, eg "(c) COPYRIGHT_YEAR"
-COPYRIGHT_YEAR = "2015"
+COPYRIGHT_YEAR = "2016"
 
 PLATFORM_FACEBOOK_ACCOUNT = "http://www.facebook.com/YourPlatformFacebookAccount"
 PLATFORM_TWITTER_ACCOUNT = "@YourPlatformTwitterAccount"

--- a/themes/edx.org/lms/templates/footer.html
+++ b/themes/edx.org/lms/templates/footer.html
@@ -35,7 +35,7 @@
               % endfor
           </nav>
           <p class="copyright">${_(
-          u"\u00A9 edX Inc.  All rights reserved except where noted.  "
+          u"\u00A9 2016 edX Inc.  All rights reserved except where noted.  "
           u"EdX, Open edX and the edX and Open EdX logos are registered trademarks "
           u"or trademarks of edX Inc."
           )}


### PR DESCRIPTION
Goal
Updates footer to list 2016 as the copyright year by updating the copyright setting. 

JIRA:
TNL-5151
https://openedx.atlassian.net/browse/TNL-5141

Tasks:
- [ ] confirm LMS footer behavior
- [ ] confirm CMS footer behavior

Reviewer:
@adampalay 

Sandbox:
http://TNL5141.sandbox.edx.org
