### PR TITLE
edx-ora2 1.1.7 version bump

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -77,7 +77,7 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@1.1.6#egg=ora2==1.1.6
+git+https://github.com/edx/edx-ora2.git@1.1.7#egg=ora2==1.1.7
 -e git+https://github.com/edx/edx-submissions.git@1.1.1#egg=edx-submissions==1.1.1
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.3.2#egg=i18n-tools==v0.3.2


### PR DESCRIPTION
Version bump of edx-ora2 to 1.1.7, mainly includes accessibility fixes.

Diff:
https://github.com/edx/edx-ora2/compare/1.1.6...1.1.7

Accessibility tests:
http://jenkins.edx.org:8080/view/ora2/job/ora2-acceptance-tests/994/
(waiting to finish)

FYI @cahrens 
