### PR TITLE
common.py incorrect moment.js for locales

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1539,7 +1539,7 @@ PIPELINE_JS = {
             [
                 'js/sticky_filter.js',
                 'js/query-params.js',
-                'js/vendor/moment.min.js',
+                'js/vendor/moment-with-locales.min.js',
             ]
         ),
         'output_filename': 'js/lms-application.js',
@@ -1687,7 +1687,7 @@ REQUIRE_ENVIRONMENT = "node"
 REQUIRE_JS_PATH_OVERRIDES = {
     'js/bookmarks/views/bookmark_button': 'js/bookmarks/views/bookmark_button.js',
     'js/views/message_banner': 'js/views/message_banner.js',
-    'moment': 'js/vendor/moment.min.js',
+    'moment': 'js/vendor/moment-with-locales.min.js',
     'jquery.url': 'js/vendor/url.min.js',
     'js/courseware/course_home_events': 'js/courseware/course_home_events.js',
     'js/courseware/accordion_events': 'js/courseware/accordion_events.js',


### PR DESCRIPTION
replacing 'js/vendor/moment.min.js' with 'js/vendor/moment-with-locales.min.js' in common.py

if not, the dates stay in English by default.
