### PR TITLE
Silence expected IntegrityErrors.

### DIFF
--- a/lms/djangoapps/verified_track_content/models.py
+++ b/lms/djangoapps/verified_track_content/models.py
@@ -49,7 +49,11 @@ def move_to_verified_cohort(sender, instance, **kwargs):  # pylint: disable=unus
                     'verified_cohort_name': verified_cohort_name,
                     'default_cohort_name': random_cohort.name
                 }
-                log.info("Queuing automatic cohorting for user '%s' in course '%s'", instance.user.username, course_key)
+                log.info(
+                    "Queuing automatic cohorting for user '%s' in course '%s' "
+                    "due to change in enrollment mode from '%s' to '%s'.",
+                    instance.user.id, course_key, instance._old_mode, instance.mode  # pylint: disable=protected-access
+                )
 
                 # Do the update with a 3-second delay in hopes that the CourseEnrollment transaction has been
                 # completed before the celery task runs. We want a reasonably short delay in case the learner

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -90,7 +90,7 @@ class CohortMembership(models.Model):
     def save(self, *args, **kwargs):
         self.full_clean(validate_unique=False)
 
-        log.info("Saving CohortMembership for '%s' (id=%s) in '%s'", self.user.username, self.user.id, self.course_id)
+        log.info("Saving CohortMembership for user '%s' in '%s'", self.user.id, self.course_id)
 
         # Avoid infinite recursion if creating from get_or_create() call below.
         # This block also allows middleware to use CohortMembership.get_or_create without worrying about outer_atomic


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-5181

@efischer19 This is the change that I'm thinking of (will change to be against master once the release branch is merged back in).

With the retry logic already in the release, we will retry on IntegrityErrors. However, those celery Retry exceptions still appear in New Relic, and I think it is better to silence them if possible since we expect a steady stream of them.

I need to do some testing of this, and also will verify after tomorrow's release goes out that the behavior we see in prod matches what we saw today in staging.

Code reviews:
- [x] @efischer19
- [x] @staubina 

Sandbox (with verified track cohorting enabled, "honor" mode instead of "audit": https://cahrens.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course

See #13193 for original discussion about this change.
