### PR TITLE
Make edX logo in edx.org footer more accessible

### DIFF
--- a/themes/edx.org/lms/templates/footer.html
+++ b/themes/edx.org/lms/templates/footer.html
@@ -18,7 +18,9 @@
     <h2 class="sr footer-about-title">${_("About edX")}</h2>
     <div class="footer-content-wrapper">
       <div class="footer-logo">
-          <img alt="edX logo" src="${footer['logo_image']}">
+          <a href="${marketing_link('ROOT')}">
+            <img alt="edX Home Page" src="${footer['logo_image']}">
+          </a>
       </div>
 
       <div class="site-details">


### PR DESCRIPTION
The logo in the edx.org footer now links to the edX home page, consistent with the logo in the header. ECOM-4117.

@edx/ecommerce please review.
