### PR TITLE
Fix discussion markdown previews

### DIFF
--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -321,7 +321,8 @@
             imageUploadUrl = this.urlFor('upload');
             _processor = function(self) {
                 return function(text) {
-                    return self.postMathJaxProcessor(text);
+                    // HTML returned by Markdown is assumed to be safe to render
+                    return self.postMathJaxProcessor(edx.HtmlUtils.HTML(text)).toString();
                 };
             };
             editor = Markdown.makeWmdEditor(elem, appended_id, imageUploadUrl, _processor(this));

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -723,3 +723,17 @@ class DiscussionTabHomePage(CoursePage, DiscussionPageMixin):
         """
         elements = self.q(css=".forum-new-post-form")
         return elements[0] if elements.visible and len(elements) == 1 else None
+
+    def set_new_post_editor_value(self, new_body):
+        """
+        Set the Discussions new post editor (wmd) with the content in new_body
+        """
+        self.q(css=".wmd-input").fill(new_body)
+
+    def get_new_post_preview_value(self):
+        """
+        Get the rendered preview of the contents of the Discussions new post editor
+        Waits for content to appear, as the preview is triggered on debounced/delayed onchange
+        """
+        self.wait_for_element_visibility(".wmd-preview > *", "WMD preview pane has contents", timeout=10)
+        return self.q(css=".wmd-preview").html[0]

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -838,6 +838,40 @@ class DiscussionCommentEditTest(BaseDiscussionTestCase):
 
 
 @attr(shard=2)
+class DiscussionEditorPreviewTest(UniqueCourseTest):
+    def setUp(self):
+        super(DiscussionEditorPreviewTest, self).setUp()
+        CourseFixture(**self.course_info).install()
+        AutoAuthPage(self.browser, course_id=self.course_id).visit()
+        self.page = DiscussionTabHomePage(self.browser, self.course_id)
+        self.page.visit()
+        self.page.click_new_post_button()
+
+    def test_text_rendering(self):
+        """When I type plain text into the editor, it should be rendered as plain text in the preview box"""
+        self.page.set_new_post_editor_value("Some plain text")
+        self.assertEqual(self.page.get_new_post_preview_value(), "<p>Some plain text</p>")
+
+    def test_markdown_rendering(self):
+        """When I type Markdown into the editor, it should be rendered as formatted Markdown in the preview box"""
+        self.page.set_new_post_editor_value(
+            "Some markdown\n"
+            "\n"
+            "- line 1\n"
+            "- line 2"
+        )
+
+        self.assertEqual(self.page.get_new_post_preview_value(), (
+            "<p>Some markdown</p>\n"
+            "\n"
+            "<ul>\n"
+            "<li>line 1</li>\n"
+            "<li>line 2</li>\n"
+            "</ul>"
+        ))
+
+
+@attr(shard=2)
 class InlineDiscussionTest(UniqueCourseTest, DiscussionResponsePaginationTestMixin):
     """
     Tests for inline discussions


### PR DESCRIPTION
### Description

[TNL-5198](https://openedx.atlassian.net/browse/TNL-5198)

Previews of markdown posts/responses in Discussions were not being rendered due to over-aggressive HTML escaping.

(I don't know if this will pass the safe template linter, but I tried to XSS it and am fairly confident all the nasty kinds of input are escaped.)
### Sandbox
- [x] https://bjacobel-tnl-5198.sandbox.edx.org (updated as of Thursday morning)
### Testing
- [x] safecommit violation code review process
- [ ] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @andy-armstrong 
- [x] Code review: @robrap 
### Post-review
- [ ] Squash commits
