### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -185,4 +185,4 @@ pynliner==0.5.2
 sailthru-client==2.2.3
 
 # Release utils for the edx release pipeline
-edx-django-release-util==0.0.4
+edx-django-release-util==0.1.0


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.1.0.

@edx/pipeline-team  Please review and tag appropriate parties.
