### PR TITLE
Add font awesome loading spinner to CAPA problems

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -1523,3 +1523,10 @@ div.problem .annotation-input {
     background: url('#{$static-path}/images/partially-correct-icon.png') center center no-repeat;
   }
 }
+
+// Loading Spinner
+// ====================
+.problems-wrapper .loading-spinner {
+  text-align: center;
+  color: $gray-d1;
+}

--- a/lms/templates/problem_ajax.html
+++ b/lms/templates/problem_ajax.html
@@ -1,1 +1,7 @@
-<div id="problem_${element_id}" class="problems-wrapper" data-problem-id="${id}" data-url="${ajax_url}" data-progress_status="${progress_status}" data-progress_detail="${progress_detail}" data-content="${content | h}"></div>
+<%! from django.utils.translation import ugettext as _ %>
+<div id="problem_${element_id}" class="problems-wrapper" data-problem-id="${id}" data-url="${ajax_url}" data-progress_status="${progress_status}" data-progress_detail="${progress_detail}" data-content="${content | h}">
+    <p class="loading-spinner">
+        <span class="icon fa fa-spinner fa-pulse fa-2x fa-fw" aria-hidden="true"></span>
+        <span class="sr">${_('Loading')}</span>
+    </p>
+</div>


### PR DESCRIPTION
- loading spinner is automatically replaced by the content when AJAX problem_get returns

@marcotuts & @cptvitamin - here's the loading spinner OSPR

here's a quick screenshot of what it would look like:

![screen shot 2016-08-11 at 11 30 29 am](https://cloud.githubusercontent.com/assets/3364609/17600149/15299dfc-5fb7-11e6-9d9b-322457212317.png)
