### PR TITLE
Fix: Send one email when unenrolling from Instructor

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -167,6 +167,8 @@ def unenroll_email(course_id, student_email, email_students=False, email_params=
 
     if previous_state.allowed:
         CourseEnrollmentAllowed.objects.get(course_id=course_id, email=student_email).delete()
+
+    if previous_state.allowed and not previous_state.enrollment:
         if email_students:
             email_params['message'] = 'allowed_unenroll'
             email_params['email_address'] = student_email


### PR DESCRIPTION
# Scenario:
## LMS: Instructor, unenroll student.

In a given course, into the Instructor section. When an instructor auto-enorlls a student with an email that is not registered in the platform, the student receives an email with the invitation to register into the platform. Once the student is registered into the platform and activates his/her account, this student is automatically registered into the course.

Later on, when the instructor decides to unenroll this same student from the Instructor section, this student will receive two emails to be notified. The first received email will notified him/her as if the student would never be registered into the platform (this is not true as the student has registered his/her account). The sencond email will notified the student that he/she is no longer registered in the given course and that the rest of his/her courses he/she is registered in will not be affected.
# Error:

The student should receive only the second email, not the first one.
# Solution:

This commit fixes the first sent email. The first email will be sent only if the student is not registered in the course.
