### PR TITLE
Updated the Reset button to focus on the title and also added a test …

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -28,7 +28,6 @@ class @Problem
     problem_prefix = @element_id.replace(/problem_/,'')
     @inputs = @$("[id^='input_#{problem_prefix}_']")
     @$('div.action button').click @refreshAnswers
-    @questionTitle = @$(".problem-header")
     @reviewButton = @$('div.action .review-btn')
     @reviewButton.click @scroll_to_problem_meta
     @checkButton = @$('div.action button.check')
@@ -243,6 +242,7 @@ class @Problem
 
   # Scroll to problem metadata and next focus is problem input
   scroll_to_problem_meta: =>
+    @questionTitle = @$(".problem-header")
     if @questionTitle.length > 0
       $('html, body').animate({
         scrollTop: @questionTitle.offset().top
@@ -365,9 +365,10 @@ class @Problem
   reset_internal: =>
     Logger.log 'problem_reset', @answers
     $.postWithPrefix "#{@url}/problem_reset", id: @id, (response) =>
-        @el.trigger('contentChanged', [@id, response.html])
-        @render(response.html)
-        @updateProgress response
+      @el.trigger('contentChanged', [@id, response.html])
+      @render(response.html)
+      @updateProgress response
+      @scroll_to_problem_meta()
 
   # TODO this needs modification to deal with javascript responses; perhaps we
   # need something where responsetypes can define their own behavior when show

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -2,6 +2,7 @@
 Problem Page.
 """
 from bok_choy.page_object import PageObject
+from common.test.acceptance.pages.common.utils import click_css
 
 
 class ProblemPage(PageObject):
@@ -127,8 +128,7 @@ class ProblemPage(PageObject):
         """
         Click the Reset button.
         """
-        self.q(css='div.problem button.reset').click()
-        self.wait_for_ajax()
+        click_css(self, '.problem .reset', require_notification=False)
 
     def click_show(self):
         """
@@ -136,6 +136,10 @@ class ProblemPage(PageObject):
         """
         self.q(css='.problem .show').click()
         self.wait_for_ajax()
+
+    def is_reset_button_present(self):
+        """ Check for the presence of the reset button. """
+        return self.q(css='.problem .reset').present
 
     def is_focus_on_problem_meta(self):
         """

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -245,6 +245,31 @@ class ProblemTypeTestMixin(object):
         self.problem_page.click_show()
         self.assertTrue(self.problem_page.is_focus_on_problem_meta())
 
+    @attr(shard=7)
+    def test_reset_clears_answer_and_focus(self):
+        """
+        Scenario: Reset will clear answers and focus on problem meta
+        If I select an answer
+        and then reset the problem
+        There should be no answer selected
+        And the focus should shift appropriately
+        """
+        self.problem_page.wait_for(
+            lambda: self.problem_page.problem_name == self.problem_name,
+            "Make sure the correct problem is on the page"
+        )
+        self.wait_for_status('unanswered')
+        # Set an answer
+        self.answer_problem(correct=True)
+        self.problem_page.click_check()
+        self.wait_for_status('correct')
+        # clear the answers
+        self.problem_page.click_reset()
+        # Focus should change to meta
+        self.assertTrue(self.problem_page.is_focus_on_problem_meta())
+        # Answer should be reset
+        self.wait_for_status('unanswered')
+
     @attr('a11y')
     def test_problem_type_a11y(self):
         """
@@ -285,7 +310,6 @@ class AnnotationProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
     factory = AnnotationResponseXMLFactory()
 
     can_submit_blank = True
-
     factory_kwargs = {
         'title': 'Annotation Problem',
         'text': 'The text being annotated',
@@ -728,6 +752,13 @@ class CodeProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         """
         pass
 
+    def wait_for_status(self, status):
+        """
+        Overridden for script test because the testing grader always responds
+        with "correct"
+        """
+        pass
+
 
 class ChoiceTextProbelmTypeTestBase(ProblemTypeTestBase):
     """
@@ -803,7 +834,6 @@ class CheckboxTextProblemTypeTest(ChoiceTextProbelmTypeTestBase, ProblemTypeTest
     problem_name = 'CHECKBOX TEXT TEST PROBLEM'
     problem_type = 'checkbox_text'
     choice_type = 'checkbox'
-
     factory = ChoiceTextResponseXMLFactory()
 
     factory_kwargs = {


### PR DESCRIPTION
…to ensure focus shifted

TNL-4882
### Description

[TNL-4882](https://openedx.atlassian.net/browse/TNL-4882)

Updated the Reset button to focus on the Problem title while waiting on the problem meta changes. Also, added a test for the focus change when reset is clicked.
### Sandbox

LMS: https://staubina-reset.sandbox.edx.org
CMS: https://studio-staubina-reset.sandbox.edx.org
- [x] Build a sandbox for your branch and add a link here
### Testing
- [x] safecommit shows 0 violations
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @alisan617 
### Post-review
- [x] Squash commits
