### PR TITLE
Fix discussion dropdown padding issue.

### DIFF
--- a/lms/static/sass/discussion/views/_create-edit-post.scss
+++ b/lms/static/sass/discussion/views/_create-edit-post.scss
@@ -213,7 +213,6 @@
     position: absolute;
     top: 40px;
     left: 0;
-    border: 1px solid $forum-color-border;
     width: 100%;
     background: $forum-color-background;
     box-shadow: 0 2px 1px $shadow;
@@ -221,12 +220,12 @@
 
   .topic-filter-label {
     border-bottom: 1px solid $forum-color-border;
-    padding: ($baseline/4);
   }
 
   .topic-filter-input {
     box-sizing: border-box;
-    border: 1px solid $forum-color-border;
+    border: none;
+    border-bottom: 1px solid $forum-color-border;
     padding: 0 15px;
     width: 100%;
     height: 30px;
@@ -239,17 +238,17 @@
     overflow-y: scroll;
     max-height: 400px;
     list-style: none;
+    margin-left: ($baseline/2);
   }
 
   .topic-submenu {
-    padding-left: $baseline;
     list-style: none;
+    margin-left: $baseline;
   }
 
   .topic-title {
     display: block;
-    border-bottom: 1px solid $forum-color-border;
-    padding: ($baseline/2);
+    padding: ($baseline/4) ($baseline/2);
     font-size: 14px;
   }
 


### PR DESCRIPTION
### Description

[TNL-4864](https://openedx.atlassian.net/browse/TNL-4864)

Removed extra padding such that the 'filter topics' box is no longer misaligned. I did not change the sizing of the drop-down relative to the topic area button.

Before:
https://openedx.atlassian.net/secure/attachment/35509/TabDiscussions.png

After:
 https://dl.dropboxusercontent.com/u/386585530/dropdown.png
### Sandbox
- [ ] https://filter-topic-list.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @andy-armstrong
- [x] Code review: @bjacobel  
### Post-review
- [ ] Squash commits
