### PR TITLE
Add auto-generated discussion css files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ cms/static/sass/*.css
 cms/static/sass/*.css.map
 cms/static/themed_sass/
 themes/**/css/*.css
+themes/**/css/discussion/*.css
 
 ### Logging artifacts
 log/


### PR DESCRIPTION
@mattdrayer , @staubina, @douglashall  I think the problem with yesterday release was because of the reason that css files for discussion were not added in the `.gitignore` file. I had same problem on sandbox while running update command.

[Here](https://github.com/edx/edx-themes/pull/135) is a link to corresponding `edx-themes` PR.
