### PR TITLE
Removed incorrect aria tag from ID photo submission button

### DIFF
--- a/lms/templates/verify_student/id_photo_step.underscore
+++ b/lms/templates/verify_student/id_photo_step.underscore
@@ -48,7 +48,7 @@
 
     <% if ( nextStepTitle ) { %>
     <nav class="nav-wizard" id="face_next_button_nav">
-      <button id="next_step_button" class="next action-primary is-disabled right" aria-hidden="true" title="Next">
+      <button id="next_step_button" class="next action-primary right" disabled title="Next">
         <%- _.sprintf(
           gettext( "Next: %(nextStepTitle)s" ),
           { nextStepTitle: nextStepTitle }


### PR DESCRIPTION
ECOM-5184
- `aria-hidden` removed from the button which was preventing user to submit photos through screenreader. 
