### PR TITLE
Fix Discussion blackout date still has Add a Response text box

### DIFF
--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -108,6 +108,12 @@ class DiscussionThreadPage(PageObject, DiscussionPageMixin):
         """Returns true if the add response button is visible, false otherwise"""
         return self.is_element_visible(".add-response-btn")
 
+    def has_discussion_reply_editor(self):
+        """
+        Returns true if the discussion reply editor is is visible
+        """
+        return self.is_element_visible(".discussion-reply-new")
+
     def click_add_response_button(self):
         """
         Clicks the add response button and ensures that the response text
@@ -151,6 +157,13 @@ class DiscussionThreadPage(PageObject, DiscussionPageMixin):
         """Returns true if the edit response button is present, false otherwise"""
         with self.secondary_action_menu_open(".response_{} .discussion-response".format(response_id)):
             return self.is_element_visible(".response_{} .discussion-response .action-edit".format(response_id))
+
+    def is_response_deletable(self, response_id):
+        """
+        Returns true if the delete response button is present, false otherwise
+        """
+        with self.secondary_action_menu_open(".response_{} .discussion-response".format(response_id)):
+            return self.is_element_visible(".response_{} .discussion-response .action-delete".format(response_id))
 
     def get_response_body(self, response_id):
         return self._get_element_text(".response_{} .response-body".format(response_id))

--- a/common/test/acceptance/pages/lms/tab_nav.py
+++ b/common/test/acceptance/pages/lms/tab_nav.py
@@ -104,3 +104,10 @@ class TabNavPage(PageObject):
             lambda: self._is_on_tab(tab_name),
             "{0} is the current tab".format(tab_name)
         )
+
+    def has_new_post_button_visible_on_tab(self):
+        """
+        Check if new post button present and visible on course tab page
+        """
+        new_post_btn = self.q(css='ol.course-tabs .new-post-btn')
+        return new_post_btn.present and new_post_btn.visible

--- a/lms/djangoapps/discussion/templates/discussion/discussion_board.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_board.html
@@ -6,6 +6,7 @@
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%!
+import json
 from django.utils.translation import ugettext as _
 from django.template.defaultfilters import escapejs
 from django.core.urlresolvers import reverse
@@ -48,11 +49,11 @@ DiscussionBoardFactory({
 <%block name="content">
 <section class="discussion discussion-board container" id="discussion-container"
          data-course-id="${course_id}"
-         data-user-create-comment="${can_create_comment}"
-         data-user-create-subcomment="${can_create_subcomment}"
+         data-user-create-comment="${json.dumps(can_create_comment)}"
+         data-user-create-subcomment="${json.dumps(can_create_subcomment)}"
          data-read-only="false"
          data-sort-preference="${sort_preference}"
-         data-flag-moderator="${flag_moderator}"
+         data-flag-moderator="${json.dumps(flag_moderator)}"
          data-user-cohort-id="${user_cohort}">
     <header class="page-header has-secondary">
         ## Breadcrumb navigation


### PR DESCRIPTION
### Discussion blackout date still has Add a Response text box

Course teams believe that their blackout dates have not taken effect since the Add a Response text box is still visible within each thread. Although new posts/responses will not save, this is confusing to course teams and potentially learners.
#### Expected behavior:

Add a Response text box will not be visible
#### Actual behavior:

Add a Response text box is visible.

[TNL-5111](https://openedx.atlassian.net/browse/TNL-5111)
