### PR TITLE
Wait for the transcript file chooser input field to be visible

### DIFF
--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -639,6 +639,8 @@ class VideoComponentPage(VideoPage):
         # Show the Browse Button
         self.browser.execute_script("$('form.file-chooser').show()")
         asset_file_path = self.file_path(transcript_filename)
-        self.q(css=CLASS_SELECTORS['attach_transcript']).results[0].send_keys(asset_file_path)
+        attach_css = CLASS_SELECTORS['attach_transcript']
+        self.wait_for_element_visibility(attach_css, "The file chooser's input field is visible.")
+        self.q(css=attach_css).results[0].send_keys(asset_file_path)
         # confirm upload completion
-        self._wait_for(lambda: not self.q(css=CLASS_SELECTORS['attach_transcript']).visible, 'Upload Completed')
+        self._wait_for(lambda: not self.q(css=attach_css).visible, 'Upload Completed')


### PR DESCRIPTION
This should fix the intermittent failure on this bok-choy test: common.test.acceptance.tests.v​ideo.test_studio_video_module.​CMSVideoA11yTest.test_video_pl​ayer_a11y

It would manifest with this error message and stacktrace:

**Error Message**

```
list index out of range
-------------------- >> begin captured logging << --------------------
bok_choy.browser: INFO: Using local browser: firefox [Default is firefox]
--------------------- >> end captured logging << ---------------------
```

**Stacktrace**

```
  File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/home/jenkins/workspace/edx-platform-accessibility-master/edx-platform/common/test/acceptance/tests/video/test_studio_video_module.py", line 351, in test_video_player_a11y
    self.video.upload_transcript('english_single_transcript.srt')
  File "/home/jenkins/edx-venv/local/lib/python2.7/site-packages/bok_choy/page_object.py", line 88, in wrapper
    return method(self, *args, **kwargs)
  File "/home/jenkins/workspace/edx-platform-accessibility-master/edx-platform/common/test/acceptance/pages/studio/video/video.py", line 642, in upload_transcript
    self.q(css=CLASS_SELECTORS['attach_transcript']).results[0].send_keys(asset_file_path)
'list index out of range\n-------------------- >> begin captured logging << --------------------\nbok_choy.browser: INFO: Using local browser: firefox [Default is firefox]\n--------------------- >> end captured logging << ---------------------'
```
