### PR TITLE
Update pa11ycrawler to 1.1.2

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -69,7 +69,7 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 
 # Used for testing
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
-git+https://github.com/edx/pa11ycrawler.git@1.0.0#egg=pa11ycrawler==1.0.0
+git+https://github.com/edx/pa11ycrawler.git@1.1.2#egg=pa11ycrawler==1.1.2
 
 # Our libraries:
 git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12


### PR DESCRIPTION
This is to get https://github.com/edx/pa11ycrawler/pull/12 in. @benpatterson, you want to thumb this real quick?
