### PR TITLE
Disabling the "View Unit in Studio" button to CCX courses

### DIFF
--- a/common/test/acceptance/pages/lms/ccx_dashboard_page.py
+++ b/common/test/acceptance/pages/lms/ccx_dashboard_page.py
@@ -40,3 +40,9 @@ class CoachDashboardPage(CoursePage):
             lambda: self.q(css=create_ccx_button).present, "Create a new Custom Course for edX"
         ).fulfill()
         self.q(css=create_ccx_button).click()
+
+    def is_button_view_unit_in_studio_visible(self):
+        """
+        check if the View Unit in Studio button is on the page
+        """
+        return self.q(css='instructor-info-action').present

--- a/common/test/acceptance/tests/lms/test_ccx.py
+++ b/common/test/acceptance/tests/lms/test_ccx.py
@@ -56,3 +56,7 @@ class CreateCCXCoachTest(EventsTestMixin, UniqueCourseTest):
 
         # Assert that new ccx is created and we are on ccx dashboard/enrollment tab.
         self.assertTrue(self.coach_dashboard_page.is_browser_on_enrollment_page())
+
+        # Assert that the user cannot click in the "View Unit in Studio" button,
+        # which means the user cannot edit the ccx course in studio
+        self.assertFalse(self.coach_dashboard_page.is_button_view_unit_in_studio_visible())

--- a/lms/djangoapps/ccx/overrides.py
+++ b/lms/djangoapps/ccx/overrides.py
@@ -88,6 +88,12 @@ def get_override_for_ccx(ccx, block, name, default=None):
     clean_ccx_key = _clean_ccx_key(block.location)
 
     block_overrides = overrides.get(clean_ccx_key, {})
+
+    # Hardcode the course_edit_method to be None instead of 'Studio', so,
+    # the LMS never tries to link back to Studio. CCX courses
+    # can't be edited in Studio.
+    block_overrides['course_edit_method'] = None
+
     if name in block_overrides:
         try:
             return block.fields[name].from_json(block_overrides[name])


### PR DESCRIPTION
It's about this ticket: [https://openedx.atlassian.net/browse/OSPR-1383](https://openedx.atlassian.net/browse/OSPR-1383)

The idea is to remove the "View Unit in Studio" button when the user is "viewing" a CCX course, because CCX courses are not editable.

A screenshot when you're viewing a "normal" course
![screen shot 2016-08-17 at 12 25 41 am](https://cloud.githubusercontent.com/assets/1590527/17723521/27f9587e-6411-11e6-8e7b-8e50d16e465a.png)

A screenshot when you're viewing a CCX course
![screen shot 2016-08-17 at 12 25 35 am](https://cloud.githubusercontent.com/assets/1590527/17723523/2aee2ab4-6411-11e6-80a7-874a107ea46a.png)

I put the validation on the openedx/core/lib/xblock_utils.py file, but I don't know if it's a good idea, because the code from rendering the view gets coupled with the database. Instead of calling the CustomCourseForEdX model directly on the xblock_utils.py file, I could add a method on the lms/djangoapps/ccx/utils.py file that does it.

However, I don't know what is the best decision. I guess that this kind of decision it's up to you guys, even that I read the documentation about Developing at devstack, it doesn't cover this kind of thing (I also think that it shouldn't).

Also, I can't find any tests that coverage this behavior.

I added the tag (WIP) in the title, because I didn't write a test to this PR, maybe if someone give me a direction about where I could find some test as an example, it would be awesome.

Furthermore, when I run the test suite on my computer it takes more than 25 minutes to run it all, some tip about running it faster? (I used the --disable-migration option).
