### PR TITLE
Fix typo in class name, remove incorrect class.

### DIFF
--- a/cms/static/sass/elements/_header.scss
+++ b/cms/static/sass/elements/_header.scss
@@ -367,7 +367,7 @@ body.course.view-updates .nav-course-courseware-updates,
 body.course.view-static-pages .nav-course-courseware-pages,
 body.course.view-uploads .nav-course-courseware-uploads,
 body.course.view-textbooks .nav-course-courseware-textbooks,
-body.course.view-video-uploads .nav-course-courseware-video,
+body.course.view-video-uploads .nav-course-courseware-videos,
 
 // course settings
 body.course.schedule .nav-course-settings .title,

--- a/cms/templates/videos_index.html
+++ b/cms/templates/videos_index.html
@@ -6,7 +6,7 @@
   from django.utils.translation import ugettext as _
 %>
 <%block name="title">${_("Video Uploads")}</%block>
-<%block name="bodyclass">is-signedin course view-uploads view-video-uploads</%block>
+<%block name="bodyclass">is-signedin course view-video-uploads</%block>
 
 <%namespace name='static' file='static_content.html'/>
 


### PR DESCRIPTION
[TNL-5101](https://openedx.atlassian.net/browse/TNL-5101)

Two things needed to be fixed--
1. Correct the classname to match the HTML
2. Remove the "extra" class that was causing File & Uploads to also be selected.

Note the name of the class in HTML--

![image](https://cloud.githubusercontent.com/assets/484484/17341962/166fce6e-58c5-11e6-92b6-d951473fef2e.png)

No sandbox because it is a pain to enable the video pipeline settings (which I hacked on my devstack). However, I offer a screenshot of proof that it works.

![image](https://cloud.githubusercontent.com/assets/484484/17676591/47791636-62fd-11e6-9104-6fa42b8723cb.png)

Please review:
- [ ] @nasthagiri 
- [x] @clrux 

I am re-running Lettuce due to a flaky (unrelated) test
