### PR TITLE
A11Y fixes for discussions markdown editor

### DIFF
--- a/lms/static/coffee/src/customwmd.coffee
+++ b/lms/static/coffee/src/customwmd.coffee
@@ -126,7 +126,7 @@ if Markdown?
       $elem.empty()
       _append = appended_id || ""
       wmdInputId = "wmd-input#{_append}"
-      $wmdPreviewContainer = $("<div>").addClass("wmd-preview-container")
+      $wmdPreviewContainer = $("<div>").addClass("wmd-preview-container").attr("aria-label", "HTML preview of post")
           .append($("<div>").addClass("wmd-preview-label").text(gettext("Preview")))
           .append($("<div>").attr("id", "wmd-preview#{_append}").addClass("wmd-panel wmd-preview"))
       $wmdPanel = $("<div>").addClass("wmd-panel")

--- a/lms/static/coffee/src/customwmd.coffee
+++ b/lms/static/coffee/src/customwmd.coffee
@@ -126,7 +126,9 @@ if Markdown?
       $elem.empty()
       _append = appended_id || ""
       wmdInputId = "wmd-input#{_append}"
-      $wmdPreviewContainer = $("<div>").addClass("wmd-preview-container").attr("aria-label", "HTML preview of post")
+      $wmdPreviewContainer = $("<div>").addClass("wmd-preview-container")
+          .attr("role", "region")
+          .attr("aria-label", gettext("HTML preview of post"))
           .append($("<div>").addClass("wmd-preview-label").text(gettext("Preview")))
           .append($("<div>").attr("id", "wmd-preview#{_append}").addClass("wmd-panel wmd-preview"))
       $wmdPanel = $("<div>").addClass("wmd-panel")

--- a/lms/static/js/Markdown.Editor.js
+++ b/lms/static/js/Markdown.Editor.js
@@ -1434,8 +1434,7 @@
             buttonRow = buttonBar.appendChild(buttonRow);
             var xPosition = 0;
             var makeButton = function(id, title, XShift, textOp) {
-                var button = document.createElement('span');
-                button.setAttribute('role', 'button');
+                var button = document.createElement('button');
                 button.tabIndex = 0;
                 button.className = 'wmd-button';
                 button.style.left = xPosition + 'px';

--- a/lms/static/sass/discussion/_discussion.scss
+++ b/lms/static/sass/discussion/_discussion.scss
@@ -143,15 +143,15 @@ body.discussion {
   }
 
   .wmd-button {
-    @include padding-right(3px);
-    @include padding-left(3px);
     position: absolute;
     display: inline-block;
     width: 20px;
     height: 20px;
+    border: none;
     background: none;
     list-style: none;
     cursor: pointer;
+    padding: 0;
   }
 
   .wmd-button > span {
@@ -336,10 +336,6 @@ body.discussion {
   .discussion-submit-post {
     @include blue-button;
     @include float(left);
-  }
-
-  .wmd-button {
-    width: 15px;
   }
 }
 

--- a/lms/static/sass/discussion/elements/_editor.scss
+++ b/lms/static/sass/discussion/elements/_editor.scss
@@ -87,13 +87,18 @@
   .wmd-button {
     position: absolute;
     display: inline-block;
-    padding-right: 3px;
-    padding-left: 2px;
     width: 20px;
     height: 20px;
+    border: none;
     background: none;
     list-style: none;
     cursor: pointer;
+    padding: 0;
+  }
+
+  .wmd-button:hover {
+    background: none;
+    box-shadow: none;
   }
 
   .wmd-button > span {


### PR DESCRIPTION
### Description

[TNL-5161](https://openedx.atlassian.net/browse/TNL-5161)
[TNL-5168](https://openedx.atlassian.net/browse/TNL-5168)

Fixes two issues with the accessibility of the discussions markdown editor.

Note that we plan on imminently retiring this editor, so certain things going on here (edited vendor files, duplicated Sass) are Very Bad and that's OK, this is just a band-aid to pass our audit.
### Sandbox
- [x] https://bjacobel-pagedown-a11y.sandbox.edx.org (launched Wed Aug 17 16:18:59 EDT 2016, should be ready ~1hr after)
### Testing
- [ ] i18n
- [ ] RTL
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @dianakhuang 
- [x] Accessibility review: @edx/edx-accessibility 

FYI: @marcotuts 
### Post-review
- [ ] Squash commits
