### PR TITLE
Update to deal with flaky test

### DIFF
--- a/common/test/acceptance/pages/studio/course_info.py
+++ b/common/test/acceptance/pages/studio/course_info.py
@@ -38,6 +38,7 @@ class CourseUpdatesPage(CoursePage):
         Clicks the new-update button.
         """
         click_css(self, '.new-update-button', require_notification=False)
+        self.wait_for_element_visibility('.CodeMirror', 'Waiting for .CodeMirror')
 
     def submit_update(self, message):
         """

--- a/common/test/acceptance/tests/studio/test_studio_course_info.py
+++ b/common/test/acceptance/tests/studio/test_studio_course_info.py
@@ -1,8 +1,6 @@
 """
 Acceptance Tests for Course Information
 """
-from flaky import flaky
-
 from common.test.acceptance.pages.studio.course_info import CourseUpdatesPage
 from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
 
@@ -108,7 +106,6 @@ class UsersCanAddUpdatesTest(StudioCourseTest):
         self.course_updates_page.click_new_update_save_button()
         self.assertTrue(self.course_updates_page.is_first_update_date('June 1, 2013'))
 
-    @flaky  # TODO fix this, see TNL-5298
     def test_outside_tag_preserved(self):
         """
         Scenario: Text outside of tags is preserved


### PR DESCRIPTION
TNL-5298
- [x] @jzoldak 
- [x] @cahrens 

This PR will correct issues with the flaky tests mentioned in https://openedx.atlassian.net/browse/TNL-5298

I have run this 100 times here: 
https://build.testeng.edx.org/view/edx-platform-specific-tests/job/edx-platform-specific-tests/279/

runs 276-279
