### PR TITLE
trailing text remove its parent class that doesn not exist in python …

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -818,10 +818,8 @@ div.problem {
     }
   }
 
-  .capa_inputtype.textline.text-input-dynamath, .inputtype.formulaequationinput {
-    .trailing_text {
-      display: inline-block;
-    }
+  .trailing_text {
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION
[TNL-5289](https://openedx.atlassian.net/browse/TNL-5289)
## Description

Due to the fact that a legacy span style applies to all input types, and the last fix for trailing text, the parent class the trailing text has does not exist in Python Eval Input, and it ends up pushing the Answer to a new line. The answer should be inline, if room allows. So removing the parent class makes it cleaner for all num/text input types, including Python Eval Input, under class "problem"
## Sandbox

[example](https://alisan-tnl-5289.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/1414ffd5143b4b508f739b563ab468b7/workflow/2?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40vertical_f04afeac0131)
## Reviewers
- [x] Code review: @cahrens 
- [x] Code review: @staubina 
