### PR TITLE
Grades models explicit app label

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -128,6 +128,9 @@ class VisibleBlocks(models.Model):
 
     objects = VisibleBlocksQuerySet.as_manager()
 
+    class Meta(object):
+        app_label = "grades"
+
     def __unicode__(self):
         """
         String representation of this model.
@@ -182,6 +185,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
     """
 
     class Meta(object):
+        app_label = "grades"
         unique_together = [
             # * Specific grades can be pulled using all three columns,
             # * Progress page can pull all grades for a given (course_id, user_id)


### PR DESCRIPTION
Small change to silence a warning that appears on my devstack after the data model PR landed.

```
/edx/app/edxapp/edx-platform/lms/djangoapps/grades/models.py:117: RemovedInDjango19Warning: Model class lms.djangoapps.grades.models.VisibleBlocks doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class VisibleBlocks(models.Model):

2016-08-18 14:38:44,522 WARNING 14306 [py.warnings] base.py:116 - /edx/app/edxapp/edx-platform/lms/djangoapps/grades/models.py:117: RemovedInDjango19Warning: Model class lms.djangoapps.grades.models.VisibleBlocks doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class VisibleBlocks(models.Model):

/edx/app/edxapp/edx-platform/lms/djangoapps/grades/models.py:179: RemovedInDjango19Warning: Model class lms.djangoapps.grades.models.PersistentSubsectionGrade doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class PersistentSubsectionGrade(TimeStampedModel):

2016-08-18 14:38:44,526 WARNING 14306 [py.warnings] base.py:116 - /edx/app/edxapp/edx-platform/lms/djangoapps/grades/models.py:179: RemovedInDjango19Warning: Model class lms.djangoapps.grades.models.PersistentSubsectionGrade doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class PersistentSubsectionGrade(TimeStampedModel):
```

@jcdyer @sanfordstudent Could you give this a quick review?
