### PR TITLE
Printing fixes

### DIFF
--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -625,7 +625,7 @@ html.video-fullscreen {
   }
 }
 
-div.course-wrapper
+div.course-wrapper {
   @media print {
     border: 0;
     background: transparent !important;

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -591,7 +591,7 @@ html.video-fullscreen {
     }
 
     @media print {
-      padding: 4mm 2mm 0;
+      padding: 6mm 2mm 0;
       background: transparent !important;
     }
   }
@@ -623,7 +623,9 @@ html.video-fullscreen {
       width: flex-grid(11.5) + flex-gutter();
     }
   }
+}
 
+div.course-wrapper
   @media print {
     border: 0;
     background: transparent !important;
@@ -669,7 +671,7 @@ section.self-assessment {
  */
 
 .CodeMirror {
-    
+
     .CodeMirror-linenumber.CodeMirror-gutter-elt {
         color: $gray-d3 !important;
     }

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -2,6 +2,7 @@
     @include transition( all .2s $ease-in-out-quad 0s);
     @include border-right(1px solid $border-color-2);
     @include border-radius(3px, 0, 0, 3px);
+    @extend %ui-print-excluded;
     display: table-cell; // needed to extend the sidebar the full height of the area
 
     // provides sufficient contrast for all screen reader-only elements

--- a/lms/static/sass/views/_bookmarks.scss
+++ b/lms/static/sass/views/_bookmarks.scss
@@ -141,6 +141,7 @@
 
   // Rules for bookmark button's different styles
   .bookmark-button-wrapper {
+    @extend %ui-print-excluded;
     text-align: right;
     margin-bottom: 10px;
   }


### PR DESCRIPTION
Some UI changes were recently made without concern for how they would print. This PR updates some printing CSS to make things print prettily again.

Before:
![screen shot 2016-08-19 at 12 08 12 am](https://cloud.githubusercontent.com/assets/6232546/17798731/0e4c3f1c-65a2-11e6-97d6-d425cd3f6c16.png)

After:
![screen shot 2016-08-19 at 12 08 55 am](https://cloud.githubusercontent.com/assets/6232546/17798736/12dc2e02-65a2-11e6-93d2-271c56a35a37.png)

In particular:
- Bookmark button should not print
- Sidebar should not print
- Box around courseware should not print. This was in the CSS already, but had been superseded by new code (edx-platform/lms/static/sass/course/base/_base.scss line 27)
- Due to the addition of the location of the content at the top of each vertical, padding needed to be changed so that the text wasn't being drawn on top of a border

@pdpinch 
