### PR TITLE
Fix sysadmin writing csv

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -98,7 +98,8 @@ class SysadminDashboardView(TemplateView):
         def csv_data():
             """Generator for handling potentially large CSVs"""
             for row in data:
-                writer.writerow(row)
+                encoded_row = [unicode(s).encode('utf-8') for s in row]
+                writer.writerow(encoded_row)
             csv_data = read_and_flush()
             yield csv_data
         response = HttpResponse(csv_data(), content_type='text/csv')


### PR DESCRIPTION
# Scenario:
## LMS - SysAdmin

When trying to download CSV file with Staff and Superuser users, server respond with 500 code when there is some user with fullname with special characters as á, é, í,...

`
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/dashboard/sysadmin.py", line 110, in csv_data
    writer.writerow(row)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfa' in position 11: ordinal not in range(128)
`
# Fix

I've used the same fix used in downloading CSV student profiles:

https://github.com/edx/edx-platform/blob/master/lms/djangoapps/instructor_analytics/csvs.py#L34-L35
