### PR TITLE
Fix create user from sysadmin

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -196,6 +196,20 @@ class Users(SysadminDashboardView):
                 uname = uname.replace('.', '_')
             new_password = password
 
+        if User.objects.filter(email=email):
+            msg += _('Oops, failed to create user {user}, {error}').format(
+                user=email,
+                error="IntegrityError: email exists"
+            )
+            return msg
+
+        if User.objects.filter(username=uname):
+            msg += _('Oops, failed to create user {user}, {error}').format(
+                user=email,
+                error="IntegrityError: username exists"
+            )
+            return msg
+
         user = User(username=uname, email=email, is_active=True)
         user.set_password(new_password)
         try:

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -190,6 +190,10 @@ class Users(SysadminDashboardView):
                 return msg
             else:
                 uname = email.replace('@', '_')
+            if '+' in uname:
+                uname = uname.replace('+', '_')
+            if '.' in uname:
+                uname = uname.replace('.', '_')
             new_password = password
 
         user = User(username=uname, email=email, is_active=True)

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -188,6 +188,8 @@ class Users(SysadminDashboardView):
             if '@' not in email:
                 msg += _('email address required (not username)')
                 return msg
+            else:
+                uname = email.replace('@', '_')
             new_password = password
 
         user = User(username=uname, email=email, is_active=True)


### PR DESCRIPTION
# Scenario
## LMS - Sysadmin dashboard

When creating a user from sysadmin dashboard, the email is used to create the username. So, if the email is 'user@mail.com' the username is 'user@mail.com'. The user is created succesfully.

EDIT: When creating a new user from sysadmin, if this user already exists, the error is given at the second trial, not the first one. Added fix for this one too.
# Error

When the user logs in and tries to access to the Profile or Account settings sections in the right top menu, a 500 error is given.
# Solution

I propose to keep using the email as username but changing the char '@' to undersocore char '_'.

EDIT: Also change '+' and '.' characters in username.
