### PR TITLE
test_acceptance paver command option fasttest should not recompile sass

### DIFF
--- a/docs/en_us/internal/testing.rst
+++ b/docs/en_us/internal/testing.rst
@@ -609,7 +609,7 @@ To start the debugger on failure, pass the ``--pdb`` option to the paver command
 
     paver test_acceptance -s lms --pdb --extra_args="lms/djangoapps/courseware/features/problems.feature"
 
-To run tests faster by not collecting static files, you can use
+To run tests faster by not collecting static files or compiling sass, you can use
 ``paver test_acceptance -s lms --fasttest`` and
 ``paver test_acceptance -s cms --fasttest``.
 

--- a/pavelib/utils/test/suites/acceptance_suite.py
+++ b/pavelib/utils/test/suites/acceptance_suite.py
@@ -80,7 +80,8 @@ class AcceptanceTest(TestSuite):
     def __enter__(self):
         super(AcceptanceTest, self).__enter__()
         self.report_dir.makedirs_p()
-        self._update_assets()
+        if not self.fasttest:
+            self._update_assets()
 
     def __exit__(self, exc_type, exc_value, traceback):
         super(AcceptanceTest, self).__exit__(exc_type, exc_value, traceback)
@@ -109,10 +110,6 @@ class AcceptanceTest(TestSuite):
         Internal helper method to manage asset compilation
         """
         args = [self.system, '--settings=acceptance']
-
-        if self.fasttest:
-            args.append('--skip-collect')
-
         call_task('pavelib.assets.update_assets', args=args)
 
 


### PR DESCRIPTION
@cpennington @benpatterson 
