### PR TITLE
PLAT-1046 – update library content block's children on branches

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -753,11 +753,18 @@ def _update_and_import_module(
         # if library exists, update source_library_version and children
         # according to this existing library and library content block.
         if store.get_library(block.source_library_key):
-            LibraryToolsService(store).update_children(
-                block,
-                user_id,
-                version=block.source_library_version
-            )
+
+            # Update library content block's children on draft branch
+            with store.branch_setting(branch_setting=ModuleStoreEnum.Branch.draft_preferred):
+                LibraryToolsService(store).update_children(
+                    block,
+                    user_id,
+                    version=block.source_library_version
+                )
+
+            # Publish it if importing the course for branch setting published_only.
+            if store.get_branch_setting() == ModuleStoreEnum.Branch.published_only:
+                store.publish(block.location, user_id)
 
     return block
 


### PR DESCRIPTION
That's follow up work of #12813.

Implementation in previos PR wasn't working for the following scenario while importing course containing library content blocks:
1. Exported a course with published randomize content block.
2. Imported it in any course.
3. Problem name was "Blank Advanced Problem".

Issue was with the problem block from xml modulestore(this block doesn't have updated fields). In the above scenerio, with #12813, `library_content` block's children were updated for `published-only` branch. Outdated problem block from xml modulestore, was being populated on `draft-branch` then it was being published causing the above scenario – [source link](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py#L555-L557).

Current commit refactors #12813 to address the issue and tests.

Sandbox is building on: http://jenkins.edx.org:8080/view/Ansible/job/ansible-provision/
Domain: http://studio-plat1046lib.sandbox.edx.org
