### PR TITLE
RC fixup for student notes button

### DIFF
--- a/lms/static/sass/course/_student-notes.scss
+++ b/lms/static/sass/course/_student-notes.scss
@@ -160,6 +160,14 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
           @extend %shame-link-text;
           display: inline;
           @include margin-left($baseline/4);
+          border: 0;
+          background: transparent;
+          padding: 0;
+          
+          &:active {
+              background: transparent;
+              box-shadow: none;
+          }
         }
 
         // note - comment made on highlighted content


### PR DESCRIPTION
I had to do verification for student notes links/buttons on stage as I couldn't get student notes up locally. Just one small change to styling. This should get in with this release.
## Screenshots of changes

<img width="172" alt="screen shot 2016-08-22 at 8 55 06 am" src="https://cloud.githubusercontent.com/assets/2112024/17855343/471becf6-6846-11e6-9c2f-0087cbe2869e.png">
_Before_

<img width="138" alt="screen shot 2016-08-22 at 8 56 01 am" src="https://cloud.githubusercontent.com/assets/2112024/17855346/4ca60a30-6846-11e6-88f3-f0db04b49270.png">
_After_
## Reviewers
- [x] @alisan617 
- [x] @jzoldak  
