### PR TITLE
Fix mongo store's has_course with a split course key

### DIFF
--- a/cms/djangoapps/maintenance/tests.py
+++ b/cms/djangoapps/maintenance/tests.py
@@ -182,6 +182,23 @@ class TestForcePublish(MaintenanceViewTestCase):
             error_message='Force publishing course is not supported with old mongo courses.'
         )
 
+    def test_mongo_course_with_split_course_key(self):
+        """
+        Test that we get an error message `course_key_not_found` for a provided split course key
+        if we already have an old mongo course.
+        """
+        # validate non split error message
+        course = CourseFactory.create(org='e', number='d', run='X', default_store=ModuleStoreEnum.Type.mongo)
+        self.verify_error_message(
+            data={'course-id': unicode(course.id)},
+            error_message='Force publishing course is not supported with old mongo courses.'
+        )
+        # Now search for the course key in split version.
+        self.verify_error_message(
+            data={'course-id': 'course-v1:e+d+X'},
+            error_message=COURSE_KEY_ERROR_MESSAGES['course_key_not_found']
+        )
+
     def test_already_published(self):
         """
         Test that when a course is forcefully publish, we get a 'course is already published' message.

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1118,6 +1118,11 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         otherwise, do a case sensitive search
         """
         assert isinstance(course_key, CourseKey)
+
+        if not course_key.deprecated:  # split course_key
+            # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
+            return False
+
         if isinstance(course_key, LibraryLocator):
             return None  # Libraries require split mongo
         course_key = self.fill_in_run(course_key)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -300,6 +300,14 @@ class TestMongoModuleStore(TestMongoModuleStoreBase):
         with self.assertRaises(ItemNotFoundError):
             self.draft_store.get_course(course_key)
 
+    def test_has_mongo_course_with_split_course_key(self):
+        """
+        Test `has course` using split course key would return False.
+        """
+        course_key = CourseKey.from_string('course-v1:edX+simple+2012_Fall')
+
+        self.assertFalse(self.draft_store.has_course(course_key))
+
     def test_has_course_with_library(self):
         """
         Test that has_course() returns False when called with a LibraryLocator.


### PR DESCRIPTION
Fix when checking in mongo store, `has_course` with a split course key returns False

[SUST-57](https://openedx.atlassian.net/browse/SUST-57)
