### PR TITLE
Updates help links to point to Open edX Euc versions

### DIFF
--- a/docs/cms_config.ini
+++ b/docs/cms_config.ini
@@ -1,13 +1,13 @@
 # below are the server-wide settings for documentation
 [help_settings]
-url_base = http://edx.readthedocs.org/projects/edx-partner-course-staff
-version = latest
+url_base = http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course
+version = open-release-eucalyptus.master
 
 
 # below are the pdf settings for the pdf file
 [pdf_settings]
-pdf_base = https://media.readthedocs.org/pdf/edx-partner-course-staff
-pdf_file = edx-partner-course-staff.pdf
+pdf_base = https://media.readthedocs.org/pdf/open-edx-building-and-running-a-course
+pdf_file = open-edx-building-and-running-a-course.pdf
 
 
 # below are the sub-paths to the documentation for the various pages

--- a/docs/lms_config.ini
+++ b/docs/lms_config.ini
@@ -1,8 +1,7 @@
 # below are the server-wide settings for documentation
 [help_settings]
 url_base = http://edx.readthedocs.io/projects/open-edx-learner-guide
-version = latest
-
+version = open-release-eucalyptus.master
 
 # below are the pdf settings for the pdf file
 [pdf_settings]

--- a/lms/templates/instructor/instructor_dashboard_2/cohort-group-header.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort-group-header.underscore
@@ -12,10 +12,10 @@
     <div class="setup-value">
         <% if (cohort.get('assignment_type') == "manual") { %>
             <%- gettext("Learners are added to this cohort only when you provide their email addresses or usernames on this page.") %>
-            <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohort_config.html#assign-learners-to-cohorts-manually" class="incontext-help action-secondary action-help" target="_blank"><%- gettext("What does this mean?") %></a>
+            <a href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-eucalyptus.master/course_features/cohorts/cohort_config.html#assign-learners-to-cohorts-manually" class="incontext-help action-secondary action-help" target="_blank"><%- gettext("What does this mean?") %></a>
         <% } else { %>
             <%- gettext("Learners are added to this cohort automatically.") %>
-            <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohorts_overview.html#all-automated-assignment" class="incontext-help action-secondary action-help" target="_blank"><%- gettext("What does this mean?") %></a>
+            <a href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-eucalyptus.master/course_features/cohorts/cohorts_overview.html#all-automated-assignment" class="incontext-help action-secondary action-help" target="_blank"><%- gettext("What does this mean?") %></a>
         <% } %>
     </div>
 </div>


### PR DESCRIPTION
## [DOC-3228](https://openedx.atlassian.net/browse/DOC-3228)

Updates the help links from the default (partner versions, latest) to the Open edX Eucalyptus versions.
### Date Needed

25 August
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @nedbat 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check): @pdesjardins @catong 
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Sandbox (optional)
- [ ] Point to or build a sandbox for the software change and add a link here
### Post-review
- [ ] Squash commits
