### PR TITLE
Ignore IntegrityErrors upon set_many update save().

### DIFF
--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -139,7 +139,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         # to discover if something other than the DjangoXBlockUserStateClient
         # has written to the StudentModule (such as UserStateCache setting the score
         # on the StudentModule).
-        with self.assertNumQueries(2, using='default'):
+        with self.assertNumQueries(4, using='default'):
             with self.assertNumQueries(1, using='student_module_history'):
                 self.kvs.set(user_state_key('a_field'), 'new_value')
         self.assertEquals(1, StudentModule.objects.all().count())
@@ -152,7 +152,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         # to discover if something other than the DjangoXBlockUserStateClient
         # has written to the StudentModule (such as UserStateCache setting the score
         # on the StudentModule).
-        with self.assertNumQueries(2, using='default'):
+        with self.assertNumQueries(4, using='default'):
             with self.assertNumQueries(1, using='student_module_history'):
                 self.kvs.set(user_state_key('not_a_field'), 'new_value')
         self.assertEquals(1, StudentModule.objects.all().count())
@@ -206,7 +206,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         # We also need to read the database to discover if something other than the
         # DjangoXBlockUserStateClient has written to the StudentModule (such as
         # UserStateCache setting the score on the StudentModule).
-        with self.assertNumQueries(2, using="default"):
+        with self.assertNumQueries(4, using="default"):
             with self.assertNumQueries(1, using="student_module_history"):
                 self.kvs.set_many(kv_dict)
 

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -234,7 +234,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                     # The UPDATE above failed. Log information - but ignore the error.
                     # See https://openedx.atlassian.net/browse/TNL-5365
                     log.warning("set_many: IntegrityError for student {} - course_id {} - usage key {}".format(
-                        user, usage_key.course_key, usage_key
+                        user, repr(unicode(usage_key.course_key)), usage_key
                     ))
                     log.warning("set_many: All {} block keys: {}".format(
                         len(block_keys_to_state), block_keys_to_state.keys()


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-5365

This PR will remove the customer-facing 500 errors. However, the fix should not be considered complete until we understand enough about the errors to add an appropriate test.

I have tested this locally and caused the logging code in the IntegrityError block to execute.

@feanil @nasthagiri @adampalay @jzoldak @efischer19 Please review.
