### PR TITLE
Hotfix: edx-opaque-keys 0.3.3, OpaqueKeyField newline usage log, fix inline JS for CCX navigation

### DIFF
--- a/common/djangoapps/xmodule_django/models.py
+++ b/common/djangoapps/xmodule_django/models.py
@@ -110,8 +110,8 @@ class OpaqueKeyField(models.CharField):
             if value.endswith('\n'):
                 # An opaque key with a trailing newline has leaked into the DB.
                 # Log and strip the value.
-                log.warning('{}:{}:{}:to_python: Invalid key: {}. Removing trailing newline.'.format(
-                    self.model._meta.db_table,
+                log.warning(u'{}:{}:{}:to_python: Invalid key: {}. Removing trailing newline.'.format(
+                    self.model._meta.db_table,  # pylint: disable=protected-access
                     self.name,
                     self.KEY_CLASS.__name__,
                     repr(value)
@@ -140,8 +140,8 @@ class OpaqueKeyField(models.CharField):
         if serialized_key.endswith('\n'):
             # An opaque key object serialized to a string with a trailing newline.
             # Log the value - but do not modify it.
-            log.warning('{}:{}:{}:get_prep_value: Invalid key: {}.'.format(
-                self.model._meta.db_table,
+            log.warning(u'{}:{}:{}:get_prep_value: Invalid key: {}.'.format(
+                self.model._meta.db_table,  # pylint: disable=protected-access
                 self.name,
                 self.KEY_CLASS.__name__,
                 repr(serialized_key)

--- a/lms/djangoapps/courseware/features/navigation.feature
+++ b/lms/djangoapps/courseware/features/navigation.feature
@@ -4,10 +4,11 @@ Feature: LMS.Navigate Course
     In order to access courseware
     I want to be able to navigate through the content
 
-    Scenario: I can navigate to a section
-        Given I am viewing a course with multiple sections
-        When I navigate to a section
-        Then I see the content of the section
+# This scenario is flaky: See TNL-5315
+#    Scenario: I can navigate to a section
+#        Given I am viewing a course with multiple sections
+#        When I navigate to a section
+#        Then I see the content of the section
 
     Scenario: I can navigate to subsections
         Given I am viewing a section with multiple subsections

--- a/lms/templates/ccx/coach_dashboard.html
+++ b/lms/templates/ccx/coach_dashboard.html
@@ -89,9 +89,9 @@ from openedx.core.djangolib.js_utils import (
 
 <script>
   function setup_tabs() {
-    $(".instructor-nav a").on("click", function(event) {
+    $(".instructor-nav .btn-link").on("click", function(event) {
         event.preventDefault();
-        $(".instructor-nav a").removeClass("active-section");
+        $(".instructor-nav .btn-link").removeClass("active-section");
         var section_sel = "#" + $(this).attr("data-section");
         $("section.idash-section").hide();
         $(section_sel).show();
@@ -101,12 +101,12 @@ from openedx.core.djangolib.js_utils import (
     var url = document.URL,
         hashbang = url.indexOf('#!');
     if (hashbang != -1) {
-      var selector = '.instructor-nav a[data-section=' +
+      var selector = '.instructor-nav [data-section=' +
         url.substr(hashbang + 2) + ']';
       $(selector).click();
     }
     else {
-      $(".instructor-nav a").first().click();
+      $(".instructor-nav .btn-link").first().click();
     }
   }
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -44,7 +44,7 @@ edx-lint==0.4.3
 edx-django-oauth2-provider==1.1.1
 edx-django-sites-extensions==2.0.1
 edx-oauth2-provider==1.1.3
-edx-opaque-keys==0.2.1
+edx-opaque-keys==0.3.3
 edx-organizations==0.4.1
 edx-rest-api-client==1.2.1
 edx-search==0.1.2


### PR DESCRIPTION
# Hotfix 2016-08-24
## CCX dashboard JS fix

https://openedx.atlassian.net/browse/TNL-5369
Thumbs were given in a PR before it became a hotfix.
https://github.com/edx/edx-platform/pull/13304
## Opaque keys update

x
x
x
## Comment out flaky lettuce test.

https://openedx.atlassian.net/browse/TNL-5315
Already merged to master via #13289

---
- [x] @feanil 
- [x] @jzoldak 
