### PR TITLE
Revert "Bump opaque-keys version to 0.3.2"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -44,7 +44,7 @@ edx-lint==0.4.3
 edx-django-oauth2-provider==1.1.1
 edx-django-sites-extensions==2.0.1
 edx-oauth2-provider==1.1.3
-edx-opaque-keys==0.3.2
+edx-opaque-keys==0.2.1
 edx-organizations==0.4.1
 edx-rest-api-client==1.2.1
 edx-search==0.1.2


### PR DESCRIPTION
This reverts commit 5d150a39eb546369c846912b764b8b6994564d14.

See ECOM-5345 for more details.

@cpennington @ormsbee @doctoryes @adampalay @rlucioni 
