### PR TITLE
TNL-4945 – Prioritize Library defaults over the fields coming from parent blocks.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -2517,7 +2517,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 del new_block_info.defaults['markdown']
             # </workaround>
 
-            new_block_info.fields = existing_block_info.fields  # Preserve any existing overrides
+            # Preserve any existing overrides
+            new_block_info.fields = existing_block_info.fields
+
             if 'children' in new_block_info.defaults:
                 del new_block_info.defaults['children']  # Will be set later
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_mongo_kvs.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_mongo_kvs.py
@@ -136,7 +136,7 @@ class SplitMongoKVS(InheritanceKeyValueStore):
 
     def has(self, key):
         """
-        Is the given field explicitly set in this kvs (not inherited nor default)
+        Is the given field explicitly set in this kvs (neither inherited nor default)
         """
         # handle any special cases
         if key.scope not in self.VALID_SCOPES:
@@ -157,6 +157,12 @@ class SplitMongoKVS(InheritanceKeyValueStore):
             # it's not clear whether inherited values should return True. Right now they don't
             # if someone changes it so that they do, then change any tests of field.name in xx._field_data
             return key.field_name in self._fields
+
+    def has_default_value(self, field_name):
+        """
+        Is the given field has default value in this kvs
+        """
+        return field_name in self._defaults
 
     def default(self, key):
         """


### PR DESCRIPTION
[TNL-4945](https://openedx.atlassian.net/browse/TNL-4945), [TNL-4858](https://openedx.atlassian.net/browse/TNL-4858)

In case, block's parent is of type `library_content`, bypass inheritance and use kvs' default instead of reusing `field` set on parent, as `_copy_from_templates` puts fields into defaults while constructing destination block from source library block.

Sandbox: https://studio-tnl4945.sandbox.edx.org
