### PR TITLE
Heperlink changed to button to be accessed with keyboard users

### DIFF
--- a/lms/static/sass/views/_decoupled-verification.scss
+++ b/lms/static/sass/views/_decoupled-verification.scss
@@ -147,9 +147,14 @@
 
         .retake-photos {
             color: $blue;
+            background:none!important;
+            border:0!important;
+            padding:0!important;
+            box-shadow: none;
+            cursor: pointer;
 
-            &:hover {
-                cursor: pointer;
+          &:hover, &:focus {
+              text-decoration: underline;
             }
         }
 

--- a/lms/templates/verify_student/review_photos_step.underscore
+++ b/lms/templates/verify_student/review_photos_step.underscore
@@ -49,9 +49,9 @@
           <div class="copy">
             <p>
               <%- gettext( "Photos don't meet the requirements?" ) %>
-              <a id="retake_photos_button" class="retake-photos">
+              <button id="retake_photos_button" class="retake-photos">
                 <%- gettext( "Retake Your Photos" ) %>
-              </a>
+              </button>
             </p>
           </div>
         </div>


### PR DESCRIPTION
[ECOM-5301](https://openedx.atlassian.net/browse/ECOM-5301)
- changed `a` tag to `button` to be accessible by keyboard users.
- changed its `css` so that button will still looks like hyperlink.

@ahsan-ul-haq, @cptvitamin  Please review this.
