### PR TITLE
AC-566 fixing contrast for copyright

### DIFF
--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -58,42 +58,46 @@ html.video-fullscreen {
 
 .content-wrapper {
 
-  .course-license,
-  .xblock-license {
-    @include text-align(right);
-    @extend %t-title7;
-    display: block;
-    width: auto;
-    padding: ($baseline/4) 0;
-    color: $gray-d1;
+    .course-license,
+    .xblock-license {
+        @include text-align(right);
+        @extend %t-title7;
+        display: block;
+        width: auto;
+        padding: ($baseline/4) 0;
+        color: $base-font-color;
 
-    span {
-      color: inherit;
-    }
+        span {
+            color: inherit;
+        }
 
-    a:link, a:visited {
-      color: $gray;
-    }
-    a:active, a:hover {
-      color: $uxpl-blue-base;
-    }
+        a:link,
+        a:visited {
+            color: $base-font-color;
+        }
 
-    .license-label,
-    .license-value,
-    .license-actions {
-      display: inline-block;
-      vertical-align: middle;
-      margin-bottom: 0;
-    }
+        a:active,
+        a:hover {
+            color: $uxpl-blue-base;
+        }
 
-    i {
-      font-style: normal;
-    }
+        .license-label,
+        .license-value,
+        .license-actions {
+            display: inline-block;
+            vertical-align: middle;
+            margin-bottom: 0;
+        }
 
-    img {
-      display: inline;
+        i,
+        em {
+            font-style: normal;
+        }
+
+        img {
+            display: inline;
+        }
     }
-  }
 }
 
 // TO-DO should this be content wrapper?


### PR DESCRIPTION
# [AC-566](https://openedx.atlassian.net/browse/AC-566)

This darkens the copyright badge under the course for better contrast.

<img width="232" alt="screen shot 2016-08-25 at 1 34 04 pm" src="https://cloud.githubusercontent.com/assets/2112024/17979518/04001250-6ac9-11e6-9683-fd8d29fe06c9.png">
<img width="306" alt="screen shot 2016-08-25 at 1 34 21 pm" src="https://cloud.githubusercontent.com/assets/2112024/17979517/03fb4978-6ac9-11e6-994e-2887760e5968.png">
## Sandbox

https://clrux-ac-566.sandbox.edx.org (building...)
## Reviewers
- [x] @cptvitamin 
- [x] @alisan617 
