### PR TITLE
AC-570 courseware search contrast enhancement

### DIFF
--- a/cms/static/sass/partials/_variables.scss
+++ b/cms/static/sass/partials/_variables.scss
@@ -42,7 +42,7 @@ $transparent: rgba(0,0,0,0); // used when color value is needed for UI width/tra
 // +Colors - UXPL new pattern library colors
 // ====================
 $uxpl-blue-base: rgb(0, 117, 180); // wcag2a compliant
-$uxpl-blue-hover-active: rgb(41, 145, 195); // wcag2a compliant
+$uxpl-blue-hover-active: rgb(6, 86, 131); // wcag2a compliant
 
 $uxpl-green-base: rgb(0, 129, 0); // wcag2a compliant
 $uxpl-green-hover-active: rgb(0, 155, 0); // wcag2a compliant

--- a/common/test/test-theme/cms/static/sass/partials/_variables.scss
+++ b/common/test/test-theme/cms/static/sass/partials/_variables.scss
@@ -88,7 +88,7 @@ $blue-t2: rgba($blue, 0.50);
 $blue-t3: rgba($blue, 0.75);
 
 $uxpl-blue-base: rgb(0, 117, 180); // wcag2a compliant
-$uxpl-blue-hover-active: rgb(41, 145, 195); // wcag2a compliant
+$uxpl-blue-hover-active: rgb(6, 86, 131); // wcag2a compliant
 
 $uxpl-green-base: rgb(0, 129, 0); // wcag2a compliant
 $uxpl-green-hover-active: rgb(0, 155, 0); // wcag2a compliant

--- a/lms/static/js/fixtures/search/course_search_form.html
+++ b/lms/static/js/fixtures/search/course_search_form.html
@@ -2,9 +2,7 @@
     <form>
         <label for="course-search-input" class="sr">Course Search</label>
         <input id="course-search-input" type="text" class="search-field"/>
-        <button type="submit" class="search-button">
-          search <span class="icon fa fa-search" aria-hidden="true"></span>
-        </button>
+        <button type="submit" class="search-button">Search</button>
         <button type="button" class="cancel-button" title="Clear search">
           <span class="icon fa fa-remove" aria-hidden="true"></span>
         </button>

--- a/lms/static/sass/partials/base/_variables.scss
+++ b/lms/static/sass/partials/base/_variables.scss
@@ -160,7 +160,7 @@ $blue-t2: rgba($blue, 0.50);
 $blue-t3: rgba($blue, 0.75);
 
 $uxpl-blue-base: rgb(0, 117, 180); // wcag2a compliant
-$uxpl-blue-hover-active: rgb(41, 145, 195); // wcag2a compliant
+$uxpl-blue-hover-active: rgb(6, 86, 131); // wcag2a compliant
 
 $uxpl-green-base: rgb(0, 129, 0); // wcag2a compliant
 $uxpl-green-hover-active: rgb(0, 155, 0); // wcag2a compliant

--- a/lms/static/sass/search/_search.scss
+++ b/lms/static/sass/search/_search.scss
@@ -13,30 +13,39 @@
     top: 5px;
     width: 100%;
     border-radius: 4px;
-    background: $white-t1;
-    &.is-active {
-      background: $white;
-    }
+    background: $white;
   }
 
-  .search-button, .cancel-button,
-  .search-button:hover, .cancel-button:hover {
-    @extend %t-icon6;
+  .search-button,
+  .cancel-button,
+  .search-button:hover,
+  .cancel-button:hover {
     @extend %t-regular;
     @include box-sizing(border-box);
-    @include right(12px);
+    @include right(0);
     display: block;
     position: absolute;
     top: 0;
     border: none;
-    background: transparent;
-    padding: 0;
+    border-radius: 0;
+    @include border-top-right-radius(3px);
+    @include border-bottom-right-radius(3px);
+    background: $uxpl-blue-base;
+    padding: 0 10px;
     height: 35px;
-    color: $gray-l1;
+    color: $white;
     box-shadow: none;
-    line-height: 35px;
+    line-height: 33px;
     text-shadow: none;
     text-transform: none;
+    
+    &:hover,
+    &:focus,
+    &:active {
+        background: $uxpl-blue-hover-active;
+        box-shadow: none;
+        border: none;
+    }
   }
 
   .cancel-button {
@@ -171,4 +180,3 @@
     }
   }
 }
-

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -126,9 +126,7 @@ ${HTML(fragment.foot_html())}
                 <label for="course-search-input" class="sr">${_('Course Search')}</label>
                 <div class="search-field-wrapper">
                   <input id="course-search-input" type="text" class="search-field"/>
-                  <button type="submit" class="search-button">
-                    ${_('search')} <span class="icon fa fa-search" aria-hidden="true"></span>
-                  </button>
+                  <button type="submit" class="search-button">${_('Search')}</button>
                   <button type="button" class="cancel-button" title="${_('Clear search')}">
                     <span class="icon fa fa-remove" aria-hidden="true"></span>
                   </button>


### PR DESCRIPTION
# [AC-570](https://openedx.atlassian.net/browse/AC-570)

This adjusts the courseware search button to provide more contrast. While darkening the button text I realized that it began to look like normal text, and decided to make it look more like a button - or something separate from entered text - so I restyled the button a little to add clarity to the action.

<img width="186" alt="screen shot 2016-08-30 at 12 53 02 pm" src="https://cloud.githubusercontent.com/assets/2112024/18098569/c95dc674-6eb0-11e6-9b60-4598d56d29c5.png">
_Normal_

<img width="191" alt="screen shot 2016-08-30 at 12 53 07 pm" src="https://cloud.githubusercontent.com/assets/2112024/18098573/cf2b3adc-6eb0-11e6-86d6-ea83550ff0a0.png">
_Hover/Focus_

<img width="191" alt="screen shot 2016-08-30 at 12 53 13 pm" src="https://cloud.githubusercontent.com/assets/2112024/18098576/d366e95c-6eb0-11e6-8f33-377f8a03772f.png">
_Active_
## Sandbox

Setting up forums requires hoops, so just take a peek at the screenshots and let me know. Feel free to stand this up locally.
## Reviewers
- [x] @andy-armstrong  
- [x] @marcotuts 
- [x] @cptvitamin 
