### PR TITLE
Upgrading django-storage-swift module to take advantage of pending PR

### DIFF
--- a/requirements/edx/openstack.txt
+++ b/requirements/edx/openstack.txt
@@ -3,4 +3,4 @@
 #
 
 # OpenStack swift backend for django storage API
-django-storage-swift==1.2.10
+django-storage-swift==1.2.12


### PR DESCRIPTION
While troubleshooting a distinct issue, we encountered a problem with Swift storage as currently implemented. Specifically, the module sometimes re-prepends a path prefix onto a filename that's being requested. As a result, links that are created by the module may be inaccurate if the filename that was passed to it already included the path prefix, as is typical, since the module returns the name with the prefix included.

This update points OpenEdX to a branch of the module that has two main differences: makes the prepending of a path prefix constant, and also removes the path prefix from any return value, so the path prefix for a given file is used in a completely transparent way. This branch has been submitted as a pull request to the upstream repository, and we'll submit another pull request to revert to the canonical source once that pull request has been accepted.

**Dependencies**: Depends on edx/configuration#3349 for Swift storage to provision correctly on Eucalyptus

**Sandbox URL**: http://pr-13323.opencraft.hosting/ (username/password: staff/edx)

**Testing instructions**:
1. Using the sandbox, which is provisioned with Swift storage, upload an image to the forums for the demo course. Observe that the image is embedded correctly, with an accurate path, pointing to a Swift storage location, and that viewing the forum once posted shows that image inline. Prior to this change, the path prefix was incorrectly re-prepended to the filename before the link was generated, resulting in the link not working.

**Reviewers**
- [ ] @itsjeyd 
- [x] edX reviewer[s] @e0d
