### PR TITLE
Fix TNL-5249: inconsistent state in discussions UI

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_view.js
@@ -91,7 +91,6 @@
                     id = self.model.get('id');
                     if (collection.get(id)) {
                         self.model = collection.get(id);
-                        self.rerender();
                     }
                 });
                 this.createShowView();


### PR DESCRIPTION
### Description

[TNL-5249](https://openedx.atlassian.net/browse/TNL-5249)

Fixes the following four (related) bugs in Discussions:

**bug 1** (reported by Jennifer Akana):
- load discussions
- click on "All Discussions"
- click on a thread with > 2 responses
- click on "Load More" (there must be >25 threads for pagination to show)
- Expected: thread should not change, "Load More" should only load new threads
- Observed: "Load More" would replace the responses in the currently viewed thread with responses from a thread on the second page of results that you hadn't clicked

**bug 2** (reported by @attiyaIshaque)
- Go to the forum, load "all discussions" from the left-hand top menu.
- On the right side of the forum (on the discussion page), select any thread which has two or more responses. 
- After that click on the "Add a Post", and submit the post.
- Expected: You should see the thread you just made, with no responses yet
- Observed: You can see the responses of the previously selected thread as responses to your newly created thread.

**bug 3** (reported by @attiyaIshaque)
- Go to the forum, load "all discussions" from the left-hand top menu.
- On Discussion page, select any thread which has two or more responses.
- Then Add a new post, submit the post.
- Add the new responses.
- Click the previously selected thread.
- Expected: you should see the responses to the original, pre-existing post displayed
- Observed: you can see the responses of the newly added post in this thread.

**bug 4** (reported by @attiyaIshaque)
- Go to the forum, load "all discussions" from the left-hand top menu.
- Select any thread which has two or more responses.
- Then Add a new post, submit the post. Click "Add a Response" and then Click Submit, the reply is visible, and the "number of votes" counter on the thread immediately updates. 
- Then add another fpost and add a response. the reply is visible and the "number of votes" on the thread didn't update. 
- but on the other hand, click the previously selected thread before adding the "new posts",  you can see the responses of the newly added post in this thread.
- All the new posts responses added after selecting this thread, you will see comments in this thread.

Originally started as a branch off of #13270, the fixes @attiyaIshaque put in for this issue, but I later realized it was a one-line fix so I made a new branch instead.
### Sandbox
- [x] https://bjacobel-5249.sandbox.edx.org (will be live ~15:00 EST 8/26)
### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit violation code review process
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [x] Database migrations are backwards-compatible
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @attiyaIshaque
- [x] Code review: @dianakhuang 

FYI: @marcotuts @adampalay @awaisdar001 
### Post-review
- [ ] Rebase and squash commits
