### PR TITLE
Deserialize BlockRecord.locator into a real BlockUsageLocator

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -17,6 +17,7 @@ from django.db.utils import IntegrityError
 from model_utils.models import TimeStampedModel
 
 from coursewarehistoryextended.fields import UnsignedBigIntAutoField
+from opaque_keys.edx.locator import BlockUsageLocator
 from xmodule_django.models import CourseKeyField, UsageKeyField
 
 
@@ -62,7 +63,14 @@ class BlockRecordSet(frozenset):
         Return a BlockRecordSet from a json list.
         """
         block_dicts = json.loads(blockrecord_json)
-        record_generator = (BlockRecord(**block) for block in block_dicts)
+        record_generator = (
+            BlockRecord(
+                locator=BlockUsageLocator.from_string(block["locator"]),
+                weight=block["weight"],
+                max_score=block["max_score"],
+            )
+            for block in block_dicts
+        )
         return cls(record_generator)
 
     def to_hash(self):

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -36,8 +36,8 @@ class GradesModelTestCase(TestCase):
             block_type='problem',
             block_id='block_id_b'
         )
-        self.record_a = BlockRecord(unicode(self.locator_a), 1, 10)
-        self.record_b = BlockRecord(unicode(self.locator_b), 1, 10)
+        self.record_a = BlockRecord(self.locator_a, 1, 10)
+        self.record_b = BlockRecord(self.locator_b, 1, 10)
 
 
 @ddt.ddt
@@ -89,7 +89,10 @@ class VisibleBlocksTest(GradesModelTestCase):
         Happy path test to ensure basic create functionality works as expected.
         """
         vblocks = VisibleBlocks.objects.create_from_blockrecords([self.record_a])
-        expected_json = json.dumps([self.record_a._asdict()], separators=(',', ':'), sort_keys=True)
+        list_of_block_dicts = [self.record_a._asdict()]
+        for block_dict in list_of_block_dicts:
+            block_dict['locator'] = unicode(block_dict['locator'])  # BlockUsageLocator is not json-serializable
+        expected_json = json.dumps(list_of_block_dicts, separators=(',', ':'), sort_keys=True)
         expected_hash = b64encode(sha1(expected_json).digest())
         self.assertEqual(expected_json, vblocks.blocks_json)
         self.assertEqual(expected_hash, vblocks.hashed)


### PR DESCRIPTION
A few small changes notes while debugging the progress page locally.
    ~~-invalidate the "scores" lazy property when data changes~~
    -use a BlockUsageLocator when loading persisted scores

@sanfordstudent @nasthagiri - can you review when you get a chance?
