### PR TITLE
Removing unused variable from recent word cloud updates

### DIFF
--- a/common/lib/xmodule/xmodule/word_cloud_module.py
+++ b/common/lib/xmodule/xmodule/word_cloud_module.py
@@ -242,7 +242,6 @@ class WordCloudModule(WordCloudFields, XModule):
         context = {
             'ajax_url': self.system.ajax_url,
             'display_name': self.display_name,
-            'display_name_default': WordCloudFields.display_name.default,
             'instructions': self.instructions,
             'element_class': self.location.category,
             'element_id': self.location.html_id(),

--- a/lms/djangoapps/courseware/tests/test_word_cloud.py
+++ b/lms/djangoapps/courseware/tests/test_word_cloud.py
@@ -246,7 +246,6 @@ class TestWordCloud(BaseTestXmodule):
         expected_context = {
             'ajax_url': self.item_descriptor.xmodule_runtime.ajax_url,
             'display_name': self.item_descriptor.display_name,
-            'display_name_default': 'Word cloud',
             'instructions': self.item_descriptor.instructions,
             'element_class': self.item_descriptor.location.category,
             'element_id': self.item_descriptor.location.html_id(),


### PR DESCRIPTION
This removes an unused variable from the word cloud after recent updates. Cleanup.
- [x] @cahrens 
