### PR TITLE
Allow for site override of EDITABLE_SHORT_DESCRIPTION setting

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -990,7 +990,11 @@ def settings_handler(request, course_key_string):
 
             about_page_editable = not marketing_site_enabled
             enrollment_end_editable = GlobalStaff().has_user(request.user) or not marketing_site_enabled
-            short_description_editable = settings.FEATURES.get('EDITABLE_SHORT_DESCRIPTION', True)
+            short_description_editable = configuration_helpers.get_value_for_org(
+                course_module.location.org,
+                'EDITABLE_SHORT_DESCRIPTION',
+                settings.FEATURES.get('EDITABLE_SHORT_DESCRIPTION', True)
+            )
             self_paced_enabled = SelfPacedConfiguration.current().enabled
 
             settings_context = {


### PR DESCRIPTION
@mattdrayer @saleem-latif @ibrahimahmed443 

This enables us to override the `EDITABLE_SHORT_DESCRIPTION` feature setting on a per-site basis. We need the ability to do this so that we can make the short description field visible on the Studio: Schedule & Details page for select sites.
