### PR TITLE
Pin sqlparse to older version due to API change

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -138,6 +138,9 @@ ipaddr==2.1.11
 django-cors-headers==1.1.0
 
 # Debug toolbar
+# We need to pin to an older version of sqlparse due to API changes
+# See https://github.com/andialbrecht/sqlparse/blob/master/CHANGELOG#L41
+sqlparse==0.1.19
 django_debug_toolbar==1.3.2
 
 # Used for testing


### PR DESCRIPTION
**NOTE**: This is an alternate solution to PR #13352 in which we just upgrade `django-debug-toolbar` itself.

By default, Django Debug Toolbar installed the latest version of `sqlparse`, which doesn't work with the version of toolbar we require.

Due to an API change in `sqlparse`, we need to pin our requirements to an older version.

See https://github.com/andialbrecht/sqlparse/blob/master/CHANGELOG#L41 for more details.

/cc @edx/devops 
