### PR TITLE
Update to latest `django-debug-toolbar`

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -77,6 +77,9 @@ from lms.envs.common import (
     REDIRECT_CACHE_KEY_PREFIX,
 
     JWT_AUTH,
+
+    # django-debug-toolbar
+    DEBUG_TOOLBAR_PATCH_SETTINGS,
 )
 from path import Path as path
 from warnings import simplefilter
@@ -709,15 +712,6 @@ REQUIRE_EXCLUDE = ("build.txt",)
 # require.environments.Environment and defines some "args" function that
 # returns a list with the command arguments to execute.
 REQUIRE_ENVIRONMENT = "node"
-
-
-########################## DJANGO DEBUG TOOLBAR ###############################
-
-# We don't enable Django Debug Toolbar universally, but whenever we do, we want
-# to avoid patching settings.  Patched settings can cause circular import
-# problems: http://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup
-
-DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 ################################# CELERY ######################################
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1706,6 +1706,15 @@ REQUIRE_JS_PATH_OVERRIDES = {
     'js/groups/views/cohorts_dashboard_factory': 'js/groups/views/cohorts_dashboard_factory.js',
     'draggabilly': 'js/vendor/draggabilly.js'
 }
+
+########################## DJANGO DEBUG TOOLBAR ###############################
+
+# We don't enable Django Debug Toolbar universally, but whenever we do, we want
+# to avoid patching settings.  Patched settings can cause circular import
+# problems: http://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup
+
+DEBUG_TOOLBAR_PATCH_SETTINGS = False
+
 ################################# CELERY ######################################
 
 # Celery's task autodiscovery won't find tasks nested in a tasks package.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -138,7 +138,7 @@ ipaddr==2.1.11
 django-cors-headers==1.1.0
 
 # Debug toolbar
-django_debug_toolbar==1.3.2
+django_debug_toolbar==1.5
 
 # Used for testing
 before_after==0.1.3


### PR DESCRIPTION
We are two minor versions behind in `django-debug-toolbar` ("DDT"). Older versions also had the problem of not pinning its `sqlparse` requirements which causes issues if requirements are installed from scratch.

If we don't want to upgrade to the latest DDT, then we should pin the version of sqlparse we use per PR #13346.

Also make sure we set the recommended settings according to
https://django-debug-toolbar.readthedocs.io/en/stable/installation.html#explicit-setup.

/cc @edx/devops 
