### PR TITLE
Sync npm dependencies from pa11ycrawler

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "underscore.string": "~3.3.4"
   },
   "devDependencies": {
+    "bootstrap": "3.3.7",
+    "bootstrap-table": "1.11.0",
     "edx-custom-a11y-rules": "0.1.2",
     "eslint": "^2.13.1",
     "eslint-config-edx": "^1.2.1",
@@ -32,8 +34,7 @@
     "karma-junit-reporter": "^0.4.1",
     "karma-requirejs": "^0.2.6",
     "karma-spec-reporter": "^0.0.20",
-    "pa11y": "3.6.0",
-    "pa11y-reporter-1.0-json": "1.0.2",
+    "pa11y": "4.0.1",
     "plato": "1.2.2"
   }
 }


### PR DESCRIPTION
[pa11ycrawler](https://github.com/edx/pa11ycrawler) was recently [updated to version 1.4.0](https://github.com/edx/edx-platform/pull/13353), which puts more dependencies into `npm`. When running on Jenkins, [it appears that these dependencies weren't installed](https://build.testeng.edx.org/job/edx-platform-accessibility-master/3126/console), or at least can't be found at runtime. This is a quick-fix to try to get these dependencies working again on Jenkins -- if this doesn't work, I can re-commit the assets to the pa11ycrawler repo again.

This also begs the question of why pa11ycrawler is able to find the `pa11y` command, but can't find the assets that are installed in the same way...
