### PR TITLE
Revert pa11ycrawler back to 1.3.0

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -69,7 +69,7 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 
 # Used for testing
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
-git+https://github.com/edx/pa11ycrawler.git@1.4.0#egg=pa11ycrawler==1.4.0
+git+https://github.com/edx/pa11ycrawler.git@1.3.0#egg=pa11ycrawler==1.3.0
 
 # Our libraries:
 git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12


### PR DESCRIPTION
1.4.0 doesn't work with edx-platform. I believe it's because we need a newer version of node: edx-platform is currently on node 0.10.37. This pull request gets the pa11ycrawler working again on Jenkins, so that it continues running while we investigate upgrading node.

@benpatterson, can you review this?
