### PR TITLE
Remove placeholders in discussion new post form

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_edit_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_edit_view.js
@@ -36,7 +36,7 @@
                 this.$('#' + formId + '-post-type-' + this.threadType).attr('checked', true);
                 // Only allow the topic field for course threads, as standalone threads
                 // cannot be moved.
-                if (this.context === 'course') {
+                if (this.isTabMode()) {
                     this.topicView = new DiscussionTopicMenuView({
                         topicId: this.topicId,
                         course_settings: this.course_settings

--- a/common/static/common/js/spec/discussion/view/discussion_thread_edit_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/discussion_thread_edit_view_spec.js
@@ -30,11 +30,16 @@
             };
         });
 
-        testUpdate = function(view, thread, newTopicId, newTopicName) {
+        testUpdate = function(view, thread, newTopicId, newTopicName, mode) {
+            var discussionMode = mode || 'tab';
+
+
             spyOn($, 'ajax').and.callFake(function(params) {
                 expect(params.url.path()).toEqual(DiscussionUtil.urlFor('update_thread', 'dummy_id'));
                 expect(params.data.thread_type).toBe('discussion');
-                expect(params.data.commentable_id).toBe(newTopicId);
+                if (discussionMode !== 'inline') {
+                    expect(params.data.commentable_id).toBe(newTopicId);
+                }
                 expect(params.data.title).toBe('changed thread title');
                 params.success();
                 return {
@@ -47,14 +52,18 @@
                 return $(el).data('discussionId') === newTopicId;
             }).click(); // set new topic
             view.$('.edit-post-title').val('changed thread title'); // set new title
-            view.$("label[for$='post-type-discussion']").click(); // set new thread type
+            if (discussionMode !== 'inline') {
+                view.$("label[for$='post-type-discussion']").click(); // set new thread type
+            }
             view.$('.post-update').click();
             expect($.ajax).toHaveBeenCalled();
 
             expect(thread.get('title')).toBe('changed thread title');
             expect(thread.get('thread_type')).toBe('discussion');
-            expect(thread.get('commentable_id')).toBe(newTopicId);
-            expect(thread.get('courseware_title')).toBe(newTopicName);
+            if (discussionMode !== 'inline') {
+                expect(thread.get('commentable_id')).toBe(newTopicId);
+                expect(thread.get('courseware_title')).toBe(newTopicName);
+            }
             expect(view.$('.edit-post-title')).toHaveValue('');
             expect(view.$('.wmd-preview p')).toHaveText('');
         };
@@ -66,7 +75,7 @@
 
         it('can save new data correctly in inline mode', function() {
             this.createEditView({'mode': 'inline'});
-            testUpdate(this.view, this.thread, 'other_topic', 'Other Topic');
+            testUpdate(this.view, this.thread, 'other_topic', 'Other Topic', 'inline');
         });
 
         testCancel = function(view) {

--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -20,13 +20,16 @@
     <% } %>
     <div class="post-field">
         <label class="field-label">
-            <span class="sr"><%- gettext("Title:") %></span>
-            <input aria-describedby="field_help_title" type="text" class="field-input js-post-title" name="title" placeholder="<%- gettext('Title') %>">
+            <span class="field-label-text"><%- gettext("Title:") %></span><input aria-describedby="field_help_title" type="text" class="js-post-title field-input" name="title">
         </label><span class="field-help" id="field_help_title">
             <%- gettext("Add a clear and descriptive title to encourage participation.") %>
         </span>
     </div>
-    <div class="post-field js-post-body editor" name="body" data-placeholder="<%- gettext('Enter your question or comment') %>"></div>
+
+    <div class="post-field">
+        <p class="sr-only field-help" id="new-post-editor-description"><%- gettext('Enter your question or comment.') %></p>
+        <div class="js-post-body editor" aria-describedby="new-post-editor-description" name="body"></div>
+    </div>
     <div class="post-options">
         <label class="post-option is-enabled">
             <input type="checkbox" name="follow" class="post-option-input js-follow" checked>

--- a/common/static/common/templates/discussion/thread-edit.underscore
+++ b/common/static/common/templates/discussion/thread-edit.underscore
@@ -1,12 +1,16 @@
 <h1><%- gettext("Editing post") %></h1>
 <ul class="post-errors"></ul>
 <div class="forum-edit-post-form-wrapper"></div>
-<div class="form-row">
-  <label class="sr" for="edit-post-title"><%- gettext("Edit post title") %></label>
-  <input type="text" id="edit-post-title" class="edit-post-title" name="title" value="<%-title %>" placeholder="<%- gettext('Title') %>">
+<div class="post-field">
+    <label class="field-label">
+        <span class="field-label-text"><%- gettext("Title:") %></span><input aria-describedby="field_help_title" type="text" class="edit-post-title field-input" name="title" value="<%- title %>">
+    </label><span class="field-help" id="field_help_title">
+        <%- gettext("Add a clear and descriptive title to encourage participation.") %>
+    </span>
 </div>
-<div class="form-row">
-  <div class="edit-post-body" name="body"><%- body %></div>
+<div class="form-row post-field">
+    <p class="sr-only field-help" id="edit-post-editor-description"><%- gettext('Edit your post below.') %></p>
+    <div class="edit-post-body" aria-describedby="edit-post-editor-description" name="body"><%- body %></div>
 </div>
 <button type="submit" id="edit-post-submit" class="btn-brand submit post-update"><%- gettext("Update post") %></button>
 <button class="btn post-cancel"><%- gettext("Cancel") %></button>

--- a/common/static/common/templates/discussion/thread-type.underscore
+++ b/common/static/common/templates/discussion/thread-type.underscore
@@ -3,7 +3,8 @@
         <span class="field-label-text">
             <% // Translators: This is the label for a control to select a forum post type %>
             <%- gettext("Post type:") %>
-        </span><fieldset class="field-input"><legend class="sr"><%- gettext("Post type:") %></legend>
+        </span><fieldset class="field-input">
+            <legend class="sr"><%- gettext("Post type:") %></legend>
             <input aria-describedby="field_help_post_type" type="radio" name="<%= form_id %>-post-type" class="post-type-input" id="<%= form_id %>-post-type-question" value="question">
             <label for="<%= form_id %>-post-type-question" class="post-type-label">
                 <span class="icon fa fa-question" aria-hidden="true"></span>

--- a/lms/static/sass/discussion/_discussion.scss
+++ b/lms/static/sass/discussion/_discussion.scss
@@ -8,6 +8,7 @@ body.discussion {
     @include clearfix();
     box-sizing: border-box;
     width: 100%;
+    padding-top: 0;
 
     h1 {
       font-size: $forum-x-large-font-size;
@@ -19,14 +20,12 @@ body.discussion {
 
     .post-cancel {
       @include float(left);
-      margin: ($baseline/2) 0 0 ($baseline*0.75);
+      @include margin($baseline/2, 0, 0, $baseline*0.75);
     }
 
     .post-update {
       @include float(left);
       margin-top: ($baseline/2);
-      padding-bottom: ($baseline/10);
-      height: 37px;
 
       &:hover, &:focus {
         border-color: #222;
@@ -350,7 +349,6 @@ section.discussion {
 
 .new-post-article {
   display: none;
-  margin-top: $baseline;
 
   .inner-wrapper {
     max-width: 1180px;

--- a/lms/static/sass/discussion/_layouts.scss
+++ b/lms/static/sass/discussion/_layouts.scss
@@ -31,4 +31,8 @@
 
 .discussion-column {
     min-height: 500px;
+
+    .new-post-article {
+        margin-top: -$baseline;
+    }
 }

--- a/lms/static/sass/discussion/views/_create-edit-post.scss
+++ b/lms/static/sass/discussion/views/_create-edit-post.scss
@@ -25,7 +25,9 @@
         width: 100%;
         vertical-align: top;
         border-width: 0;
-        padding: 0 ($baseline/2);
+        &:not([type="text"]) {
+          padding: 0;
+        }
       }
 
       .field-label-text {
@@ -49,6 +51,9 @@
       width: 50%;
       font-size: $forum-small-font-size;
 
+      &#new-post-editor-description {
+          @include padding-left(0);
+      }
     }
   }
 
@@ -100,6 +105,11 @@
     color: $gray-d3;
     font-weight: 600;
     line-height: 36px;
+    @include float(left);
+
+    &:last-of-type {
+      @include float(right);
+    }
 
     .icon {
       @include margin-right($baseline/4);


### PR DESCRIPTION
### Description

[TNL-5166](https://openedx.atlassian.net/browse/TNL-5166)

Remove placeholders in favor of visible labels in the new post form in teams, inline discussions and discussion forums.

**discussion tab**:
![](https://i.bjacobel.com/20160831-txq9x.png)

**teams**:
![](https://i.bjacobel.com/20160831-hg0aj.png)

**Inline**:
![](https://i.bjacobel.com/20160831-j5xs8.png)
### Sandbox
- [x] https://discussion-title-placeholder.sandbox.edx.org (updated @ Fri Sep  2 10:52:07 EDT 2016)
### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit violation code review process
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @robrap 
- [ ] Doc Review: @catong 
- [ ] UX review: @chris-mike 
- [ ] Accessibility review: @edx/edx-accessibility 
- [x] Product review: @marcotuts 
### Post-review
- [x] Rebase and squash commits
