### PR TITLE
Disable debug-toolbar ProfilingPanel

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -79,7 +79,12 @@ DEBUG_TOOLBAR_PANELS = (
 )
 
 DEBUG_TOOLBAR_CONFIG = {
-    'SHOW_TOOLBAR_CALLBACK': 'cms.envs.devstack.should_show_debug_toolbar'
+    # Profile panel is incompatible with wrapped views
+    # See https://github.com/jazzband/django-debug-toolbar/issues/792
+    'DISABLE_PANELS': (
+        'debug_toolbar.panels.profiling.ProfilingPanel',
+    ),
+    'SHOW_TOOLBAR_CALLBACK': 'cms.envs.devstack.should_show_debug_toolbar',
 }
 
 


### PR DESCRIPTION
There's a [bug](https://github.com/jazzband/django-debug-toolbar/issues/792) that prevents wrapped views from working properly with the profiling panel. Let's disable it by default.

In order to test this, you need to remove cookies associated with the django-debug-toolbar. For Chrome, see https://support.google.com/chrome/answer/95647?co=GENIE.Platform%3DDesktop&hl=en.

/cc @nedbat 
