### PR TITLE
Register block_structure djangoapp.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -876,7 +876,8 @@ INSTALLED_APPS = (
     'edx_jsme',    # Molecular Structure
 
     'openedx.core.djangoapps.content.course_overviews',
-    'openedx.core.djangoapps.content.course_structures',
+    'openedx.core.djangoapps.content.course_structures.apps.CourseStructuresConfig',
+    'openedx.core.djangoapps.content.block_structure.apps.BlockStructureConfig',
 
     # Credit courses
     'openedx.core.djangoapps.credit',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2033,7 +2033,8 @@ INSTALLED_APPS = (
 
     # Course data caching
     'openedx.core.djangoapps.content.course_overviews',
-    'openedx.core.djangoapps.content.course_structures',
+    'openedx.core.djangoapps.content.course_structures.apps.CourseStructuresConfig',
+    'openedx.core.djangoapps.content.block_structure.apps.BlockStructureConfig',
     'lms.djangoapps.course_blocks',
 
     # Old course structure API

--- a/openedx/core/djangoapps/content/__init__.py
+++ b/openedx/core/djangoapps/content/__init__.py
@@ -1,5 +1,0 @@
-"""
-Setup the signals on startup.
-"""
-import openedx.core.djangoapps.content.course_structures.signals
-import openedx.core.djangoapps.content.block_structure.signals

--- a/openedx/core/djangoapps/content/block_structure/apps.py
+++ b/openedx/core/djangoapps/content/block_structure/apps.py
@@ -1,0 +1,23 @@
+"""
+Configuration for block_structure djangoapp
+"""
+
+from django.apps import AppConfig
+
+
+class BlockStructureConfig(AppConfig):
+    """
+    block_structure django app.
+    """
+    name = u'openedx.core.djangoapps.content.block_structure'
+
+    def ready(self):
+        """
+        Define tasks to perform at app loading time
+
+        * Connect signal handlers
+        * Register celery tasks
+
+        These happen at import time.  Hence the unused imports
+        """
+        from . import signals, tasks  # pylint: disable=unused-variable

--- a/openedx/core/djangoapps/content/course_structures/apps.py
+++ b/openedx/core/djangoapps/content/course_structures/apps.py
@@ -1,0 +1,19 @@
+"""
+Django Application Configuration for course_structures app.
+"""
+from django.apps import AppConfig
+
+
+class CourseStructuresConfig(AppConfig):
+    """
+    Custom AppConfig for openedx.core.djangoapps.content.course_structures
+    """
+    name = u'openedx.core.djangoapps.content.course_structures'
+
+    def ready(self):
+        """
+        Define tasks to perform at app loading time:
+
+        * Connect signal handlers
+        """
+        from . import signals  # pylint: disable=unused-variable


### PR DESCRIPTION
## [TNL-5274: djangoapps.content.block_structure should be in INSTALLED_APPS](https://openedx.atlassian.net/browse/TNL-5274)

`block_structure` should be included as an INSTALLED_APP.   

This ticket does it the new way, using a django AppConfig object, which imports signals and tasks. This ensures the tasks are always available.  They were available before, but only because other code happened to import them.  `course_structures` is also given an AppConfig in this PR, so its signal handlers can be connected at `AppConfig.ready()` time, instead of at first import (which can sometimes cause issues with app import order).
## Reviewers
- [x] @nasthagiri 
- [x] @sanfordstudent 

FYI @jmbowman -- Do these appconfigs look good to you?
## TODO
- [x] Squash commits
