### PR TITLE
WIP WL-589 Upgrade to edx-django-sites-extensions 2.1.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -42,7 +42,7 @@ edx-ccx-keys==0.1.2
 edx-drf-extensions==0.5.1
 edx-lint==0.4.3
 edx-django-oauth2-provider==1.1.1
-edx-django-sites-extensions==2.0.1
+edx-django-sites-extensions==2.1.1
 edx-oauth2-provider==1.1.3
 edx-opaque-keys==0.3.3
 edx-organizations==0.4.1


### PR DESCRIPTION
Upgrade to edx-django-sites-extensions 2.1.1 to take advantage of site cache timeout.

**Related PR:** https://github.com/edx/edx-django-sites-extensions/pull/8

Note that tests will not pass on this PR until the related PR above has been merged and the new version of edx-django-sites-extensions has been pushed to PyPi.
