### PR TITLE
AC-577 login form contrast and invalid aria cleanup

### DIFF
--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -335,7 +335,7 @@
             @extend %t-copy-sub2;
             display: block;
             margin: 0 0 ($baseline/2) 0;
-            color: $m-gray-l1;
+            color: $base-font-color;
         }
         /** FROM _accounts.scss - end **/
     }

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -10,7 +10,9 @@
         <select id="<%= form %>-<%= name %>"
             name="<%= name %>"
             class="input-inline"
+            <% if ( instructions ) { %>
             aria-describedby="<%= form %>-<%= name %>-desc"
+            <% } %>
             <% if ( typeof errorMessages !== 'undefined' ) {
                 _.each(errorMessages, function( msg, type ) {%>
                     data-errormsg-<%= type %>="<%= msg %>"
@@ -27,7 +29,9 @@
             type="<%= type %>"
             name="<%= name %>"
             class="input-block"
+            <% if ( instructions ) { %>
             aria-describedby="<%= form %>-<%= name %>-desc"
+            <% } %>
             <% if ( restrictions.min_length ) { %> minlength="<%= restrictions.min_length %>"<% } %>
             <% if ( restrictions.max_length ) { %> maxlength="<%= restrictions.max_length %>"<% } %>
             <% if ( typeof errorMessages !== 'undefined' ) {
@@ -42,7 +46,7 @@
            type="<%= type %>"
            name="<%= name %>"
            class="input-block <% if ( type === 'checkbox' ) { %>checkbox<% } %>"
-            <% if ( type !== 'password' ) { %> aria-describedby="<%= form %>-<%= name %>-desc" <% } %>
+            <% if ( instructions ) { %> aria-describedby="<%= form %>-<%= name %>-desc" <% } %>
             <% if ( restrictions.min_length ) { %> minlength="<%= restrictions.min_length %>"<% } %>
             <% if ( restrictions.max_length ) { %> maxlength="<%= restrictions.max_length %>"<% } %>
             <% if ( required ) { %> aria-required="true" required<% } %>


### PR DESCRIPTION
# [AC-577](https://openedx.atlassian.net/browse/AC-577)

This work corrects three minor things on the main login form for LMS:
- two contrast failures for the help/tips
- one invalid aria attribute for the "Remember me" checkbox that referenced an ID that wasn't present
## Details

The contrast fixes are pretty straightforward: the tip text was too light. I set it to the base font color. The "Remember me" checkbox had an `aria-describedby` value that referenced an ID that's not on the page. This is because the template displays that attribute _only if_ it's not a password field. A password field may need that attribute so I updated the conditional to only display the attribute if the Python `instructions` object is defined.
## Sandbox

https://clrux-ac-577.sandbox.edx.org/login
## Reviewers
- [x] @cptvitamin 
- [x] @edx/ecommerce 

FYI @lamagnifica 
