### PR TITLE
Handle scoreable blocks without defined weight

### DIFF
--- a/lms/djangoapps/grades/new/subsection_grade.py
+++ b/lms/djangoapps/grades/new/subsection_grade.py
@@ -131,7 +131,7 @@ class SubsectionGrade(object):
 
             # There's a chance that the value of weight is not the same value used when the problem was scored,
             # since we can get the value from either block_structure or CSM/submissions.
-            weight = block.weight
+            weight = getattr(block, 'weight', 1.0)
             if persisted_values:
                 possible = persisted_values.get('possible', possible)
                 weight = persisted_values.get('weight', weight)


### PR DESCRIPTION
Default weight to 1.0.

[TNL-5410](https://openedx.atlassian.net/browse/TNL-5410)
## Reviewers:
- [x] @adampalay 
- [x] @nasthagiri 
