### PR TITLE
AC-578 fixing link in label on logistration form

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -337,7 +337,7 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
         # Verify that the expected errors are displayed.
         errors = self.register_page.wait_for_errors()
         self.assertIn(u'Please enter your Public username.', errors)
-        self.assertIn(u'You must agree to the edX Terms of Service and Honor Code.', errors)
+        self.assertIn(u'You must agree to the edX Terms of Service and Honor Code', errors)
         self.assertIn(u'Please select your Country.', errors)
         self.assertIn(u'Please tell us your favorite movie.', errors)
 

--- a/lms/static/js/spec/student_account/register_spec.js
+++ b/lms/static/js/spec/student_account/register_spec.js
@@ -162,7 +162,7 @@
                             {
                                 placeholder: '',
                                 name: 'honor_code',
-                                label: 'I agree to the <a href="/honor">Terms of Service and Honor Code</a>',
+                                label: 'I agree to the Terms of Service and Honor Code',
                                 defaultValue: '',
                                 type: 'checkbox',
                                 required: true,

--- a/lms/static/js/student_account/views/FormView.js
+++ b/lms/static/js/student_account/views/FormView.js
@@ -85,7 +85,9 @@
 
                         html.push(_.template(fieldTpl)($.extend(data[i], {
                             form: this.formType,
-                            requiredStr: this.requiredStr
+                            requiredStr: this.requiredStr,
+                            supplementalText: data[i].supplementalText || '',
+                            supplementalLink: data[i].supplementalLink || ''
                         })));
                     }
 

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -244,8 +244,9 @@
             &.error {
                 color: $red;
             }
-
-            &[for="register-honor_code"], &[for="register-terms_of_service"] {
+            
+            &[for="register-honor_code"],
+            &[for="register-terms_of_service"] {
                 display: inline-block;
                 margin: 5px 5px 0 0;
                 width: 90%;
@@ -254,10 +255,6 @@
 
             &[for="login-remember"] {
                 display: inline-block;
-            }
-
-            a {
-                font-family: $sans-serif;
             }
         }
 
@@ -603,4 +600,8 @@
     #finish-auth-status li:last-child {
         font-weight: bold;
     }
+}
+
+.supplemental-link {
+    margin: 1rem 0;
 }

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -4,6 +4,11 @@
             <%= label %>
             <% if ( required && requiredStr ) { %> <%= requiredStr %></label><% } %>
         </label>
+        <% if (supplementalLink && supplementalText) { %>
+            <div class="supplemental-link">
+                <a href="<%- supplementalLink %>"><%- supplementalText %></a>
+            </div>
+        <% } %>
     <% } %>
 
     <% if ( type === 'select' ) { %>
@@ -24,6 +29,11 @@
         <% }); %>
         </select>
         <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
+        <% if (supplementalLink && supplementalText) { %>
+            <div class="supplemental-link">
+                <a href="<%- supplementalLink %>"><%- supplementalText %></a>
+            </div>
+        <% } %>
     <% } else if ( type === 'textarea' ) { %>
         <textarea id="<%= form %>-<%= name %>"
             type="<%= type %>"
@@ -41,6 +51,11 @@
             } %>
             <% if ( required ) { %> aria-required="true" required<% } %> ></textarea>
             <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
+            <% if (supplementalLink && supplementalText) { %>
+                <div class="supplemental-link">
+                    <a href="<%- supplementalLink %>"><%- supplementalText %></a>
+                </div>
+            <% } %>
     <% } else { %>
         <input id="<%= form %>-<%= name %>"
            type="<%= type %>"
@@ -49,7 +64,7 @@
             <% if ( instructions ) { %> aria-describedby="<%= form %>-<%= name %>-desc" <% } %>
             <% if ( restrictions.min_length ) { %> minlength="<%= restrictions.min_length %>"<% } %>
             <% if ( restrictions.max_length ) { %> maxlength="<%= restrictions.max_length %>"<% } %>
-            <% if ( required ) { %> aria-required="true" required<% } %>
+            <% if ( required ) { %> required<% } %>
             <% if ( typeof errorMessages !== 'undefined' ) {
                 _.each(errorMessages, function( msg, type ) {%>
                     data-errormsg-<%= type %>="<%= msg %>"
@@ -65,6 +80,11 @@
             </label>
         <% } %>
         <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
+        <% if (supplementalLink && supplementalText) { %>
+            <div class="supplemental-link">
+                <a href="<%- supplementalLink %>"><%- supplementalText %></a>
+            </div>
+        <% } %>
     <% } %>
 
     <% if( form === 'login' && name === 'password' ) { %>

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -138,7 +138,7 @@ class FormDescription(object):
     OVERRIDE_FIELD_PROPERTIES = [
         "label", "type", "defaultValue", "placeholder",
         "instructions", "required", "restrictions",
-        "options"
+        "options", "supplementalLink", "supplementalText"
     ]
 
     def __init__(self, method, submit_url):
@@ -158,6 +158,7 @@ class FormDescription(object):
             self, name, label=u"", field_type=u"text", default=u"",
             placeholder=u"", instructions=u"", required=True, restrictions=None,
             options=None, include_default_option=False, error_messages=None,
+            supplementalLink=u"", supplementalText=u""
     ):
         """Add a field to the form description.
 
@@ -198,6 +199,12 @@ class FormDescription(object):
                 that the messages should be displayed if the user does
                 not provide a value for a required field.
 
+            supplementalLink (unicode): A qualified URL to provide supplemental information
+                for the form field. An example may be a link to documentation for creating
+                strong passwords.
+
+            supplementalText (unicode): The visible text for the supplemental link above.
+
         Raises:
             InvalidFieldError
 
@@ -219,6 +226,8 @@ class FormDescription(object):
             "required": required,
             "restrictions": {},
             "errorMessages": {},
+            "supplementalLink": supplementalLink,
+            "supplementalText": supplementalText
         }
 
         if field_type == "select":

--- a/openedx/core/djangoapps/user_api/tests/test_helpers.py
+++ b/openedx/core/djangoapps/user_api/tests/test_helpers.py
@@ -88,7 +88,9 @@ class FormDescriptionTest(TestCase):
             },
             error_messages={
                 "required": "You must provide a value!"
-            }
+            },
+            supplementalLink="",
+            supplementalText="",
         )
 
         self.assertEqual(desc.to_json(), json.dumps({
@@ -109,7 +111,9 @@ class FormDescriptionTest(TestCase):
                     },
                     "errorMessages": {
                         "required": "You must provide a value!"
-                    }
+                    },
+                    "supplementalLink": "",
+                    "supplementalText": ""
                 }
             ]
         }))

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -596,6 +596,8 @@ class LoginSessionViewTest(UserAPITestCase):
                     "max_length": EMAIL_MAX_LENGTH
                 },
                 "errorMessages": {},
+                "supplementalText": "",
+                "supplementalLink": "",
             },
             {
                 "name": "password",
@@ -610,6 +612,8 @@ class LoginSessionViewTest(UserAPITestCase):
                     "max_length": PASSWORD_MAX_LENGTH
                 },
                 "errorMessages": {},
+                "supplementalText": "",
+                "supplementalLink": "",
             },
             {
                 "name": "remember",
@@ -621,6 +625,8 @@ class LoginSessionViewTest(UserAPITestCase):
                 "instructions": "",
                 "restrictions": {},
                 "errorMessages": {},
+                "supplementalText": "",
+                "supplementalLink": "",
             },
         ])
 
@@ -758,6 +764,8 @@ class PasswordResetViewTest(UserAPITestCase):
                     "max_length": EMAIL_MAX_LENGTH
                 },
                 "errorMessages": {},
+                "supplementalText": "",
+                "supplementalLink": "",
             }
         ])
 
@@ -1173,22 +1181,22 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
     )
     @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": True})
     def test_registration_honor_code_mktg_site_enabled(self):
-        link_html = '<a href=\"https://www.test.com/honor\">Terms of Service and Honor Code</a>'
+        link_label = 'Terms of Service and Honor Code'
         self._assert_reg_field(
             {"honor_code": "required"},
             {
-                "label": "I agree to the {platform_name} {link_html}.".format(
+                "label": "I agree to the {platform_name} {link_label}".format(
                     platform_name=settings.PLATFORM_NAME,
-                    link_html=link_html
+                    link_label=link_label
                 ),
                 "name": "honor_code",
                 "defaultValue": False,
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": "You must agree to the {platform_name} {link_html}.".format(
+                    "required": "You must agree to the {platform_name} {link_label}".format(
                         platform_name=settings.PLATFORM_NAME,
-                        link_html=link_html
+                        link_label=link_label
                     )
                 }
             }
@@ -1197,22 +1205,22 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
     @override_settings(MKTG_URLS_LINK_MAP={"HONOR": "honor"})
     @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": False})
     def test_registration_honor_code_mktg_site_disabled(self):
-        link_html = '<a href=\"/honor\">Terms of Service and Honor Code</a>'
+        link_label = 'Terms of Service and Honor Code'
         self._assert_reg_field(
             {"honor_code": "required"},
             {
-                "label": "I agree to the {platform_name} {link_html}.".format(
+                "label": "I agree to the {platform_name} {link_label}".format(
                     platform_name=settings.PLATFORM_NAME,
-                    link_html=link_html
+                    link_label=link_label
                 ),
                 "name": "honor_code",
                 "defaultValue": False,
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": "You must agree to the {platform_name} {link_html}.".format(
+                    "required": "You must agree to the {platform_name} {link_label}".format(
                         platform_name=settings.PLATFORM_NAME,
-                        link_html=link_html
+                        link_label=link_label
                     )
                 }
             }
@@ -1227,44 +1235,44 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
     def test_registration_separate_terms_of_service_mktg_site_enabled(self):
         # Honor code field should say ONLY honor code,
         # not "terms of service and honor code"
-        link_html = '<a href=\"https://www.test.com/honor\">Honor Code</a>'
+        link_label = 'Honor Code'
         self._assert_reg_field(
             {"honor_code": "required", "terms_of_service": "required"},
             {
-                "label": "I agree to the {platform_name} {link_html}.".format(
+                "label": "I agree to the {platform_name} {link_label}".format(
                     platform_name=settings.PLATFORM_NAME,
-                    link_html=link_html
+                    link_label=link_label
                 ),
                 "name": "honor_code",
                 "defaultValue": False,
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": "You must agree to the {platform_name} {link_html}.".format(
+                    "required": "You must agree to the {platform_name} {link_label}".format(
                         platform_name=settings.PLATFORM_NAME,
-                        link_html=link_html
+                        link_label=link_label
                     )
                 }
             }
         )
 
         # Terms of service field should also be present
-        link_html = '<a href=\"https://www.test.com/tos\">Terms of Service</a>'
+        link_label = 'Terms of Service'
         self._assert_reg_field(
             {"honor_code": "required", "terms_of_service": "required"},
             {
-                "label": "I agree to the {platform_name} {link_html}.".format(
+                "label": "I agree to the {platform_name} {link_label}".format(
                     platform_name=settings.PLATFORM_NAME,
-                    link_html=link_html
+                    link_label=link_label
                 ),
                 "name": "terms_of_service",
                 "defaultValue": False,
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": "You must agree to the {platform_name} {link_html}.".format(
+                    "required": "You must agree to the {platform_name} {link_label}".format(
                         platform_name=settings.PLATFORM_NAME,
-                        link_html=link_html
+                        link_label=link_label
                     )
                 }
             }
@@ -1278,7 +1286,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
         self._assert_reg_field(
             {"honor_code": "required", "terms_of_service": "required"},
             {
-                "label": "I agree to the {platform_name} <a href=\"/honor\">Honor Code</a>.".format(
+                "label": "I agree to the {platform_name} Honor Code".format(
                     platform_name=settings.PLATFORM_NAME
                 ),
                 "name": "honor_code",
@@ -1286,7 +1294,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": "You must agree to the {platform_name} <a href=\"/honor\">Honor Code</a>.".format(
+                    "required": "You must agree to the {platform_name} Honor Code".format(
                         platform_name=settings.PLATFORM_NAME
                     )
                 }
@@ -1297,7 +1305,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
         self._assert_reg_field(
             {"honor_code": "required", "terms_of_service": "required"},
             {
-                "label": "I agree to the {platform_name} <a href=\"/tos\">Terms of Service</a>.".format(
+                "label": "I agree to the {platform_name} Terms of Service".format(
                     platform_name=settings.PLATFORM_NAME
                 ),
                 "name": "terms_of_service",
@@ -1305,7 +1313,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": "You must agree to the {platform_name} <a href=\"/tos\">Terms of Service</a>.".format(
+                    "required": "You must agree to the {platform_name} Terms of Service".format(  # pylint: disable=line-too-long
                         platform_name=settings.PLATFORM_NAME
                     )
                 }

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -755,31 +755,30 @@ class RegistrationView(APIView):
         """
         # Separate terms of service and honor code checkboxes
         if self._is_field_visible("terms_of_service"):
-            terms_text = _(u"Honor Code")
+            terms_label = _(u"Honor Code")
+            terms_link = marketing_link("HONOR")
+            terms_text = _(u"Review the Honor Code")
 
         # Combine terms of service and honor code checkboxes
         else:
             # Translators: This is a legal document users must agree to
             # in order to register a new account.
-            terms_text = _(u"Terms of Service and Honor Code")
+            terms_label = _(u"Terms of Service and Honor Code")
+            terms_link = marketing_link("HONOR")
+            terms_text = _(u"Review the Terms of Service and Honor Code")
 
-        terms_link = u"<a href=\"{url}\">{terms_text}</a>".format(
-            url=marketing_link("HONOR"),
-            terms_text=terms_text
+        # Translators: "Terms of Service" is a legal document users must agree to
+        # in order to register a new account.
+        label = _(u"I agree to the {platform_name} {terms_of_service}").format(
+            platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
+            terms_of_service=terms_label
         )
 
         # Translators: "Terms of Service" is a legal document users must agree to
         # in order to register a new account.
-        label = _(u"I agree to the {platform_name} {terms_of_service}.").format(
+        error_msg = _(u"You must agree to the {platform_name} {terms_of_service}").format(
             platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
-            terms_of_service=terms_link
-        )
-
-        # Translators: "Terms of Service" is a legal document users must agree to
-        # in order to register a new account.
-        error_msg = _(u"You must agree to the {platform_name} {terms_of_service}.").format(
-            platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
-            terms_of_service=terms_link
+            terms_of_service=terms_label
         )
 
         form_desc.add_field(
@@ -790,7 +789,9 @@ class RegistrationView(APIView):
             required=required,
             error_messages={
                 "required": error_msg
-            }
+            },
+            supplementalLink=terms_link,
+            supplementalText=terms_text
         )
 
     def _add_terms_of_service_field(self, form_desc, required=True):
@@ -805,24 +806,22 @@ class RegistrationView(APIView):
         """
         # Translators: This is a legal document users must agree to
         # in order to register a new account.
-        terms_text = _(u"Terms of Service")
-        terms_link = u"<a href=\"{url}\">{terms_text}</a>".format(
-            url=marketing_link("TOS"),
-            terms_text=terms_text
+        terms_label = _(u"Terms of Service")
+        terms_link = marketing_link("TIS")
+        terms_text = _(u"Review the Terms of Service")
+
+        # Translators: "Terms of service" is a legal document users must agree to
+        # in order to register a new account.
+        label = _(u"I agree to the {platform_name} {terms_of_service}").format(
+            platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
+            terms_of_service=terms_label
         )
 
         # Translators: "Terms of service" is a legal document users must agree to
         # in order to register a new account.
-        label = _(u"I agree to the {platform_name} {terms_of_service}.").format(
+        error_msg = _(u"You must agree to the {platform_name} {terms_of_service}").format(
             platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
-            terms_of_service=terms_link
-        )
-
-        # Translators: "Terms of service" is a legal document users must agree to
-        # in order to register a new account.
-        error_msg = _(u"You must agree to the {platform_name} {terms_of_service}.").format(
-            platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
-            terms_of_service=terms_link
+            terms_of_service=terms_label
         )
 
         form_desc.add_field(
@@ -833,7 +832,9 @@ class RegistrationView(APIView):
             required=required,
             error_messages={
                 "required": error_msg
-            }
+            },
+            supplementalLink=terms_link,
+            supplementalText=terms_text
         )
 
     def _apply_third_party_auth_overrides(self, request, form_desc):


### PR DESCRIPTION
# [AC-578](https://openedx.atlassian.net/browse/AC-578)

A recent bug filed indicated that the link for "terms and services" contained within the label on the registration/login form could not be found. This work corrects that by moving the link outside of the label, but resizing things so that the link appears as part of the label.
## Background

Because form fields are navigated by pressing Tab or Up/Down, the link that was contained within the label wasn't accessible. The text was announced, but the link itself wasn't able to be accessed. Because of this, the Terms and Conditions and Privacy information was never able to be viewed by screenreader users prior to registration in the system.

The code now looks something like the following:

```
<input />
<label>I agree to the <span class="sr">Terms and Conditions</span></label>
<div>
<a href>Terms and Conditions</a>
</div>
```
## Screenshot

<img width="678" alt="screen shot 2016-09-12 at 1 34 55 pm" src="https://cloud.githubusercontent.com/assets/2112024/18445899/c8236d44-78ed-11e6-8ddf-003afeeaa379.png">
## Sandbox

[https://clrux-ac-578.sandbox.edx.org](https://clrux-ac-578.sandbox.edx.org/register)
## Future work

Safe lint. Lots of issues. I made [a ticket to correct this](https://openedx.atlassian.net/browse/AC-580) for future work.
## Reviewers
- [x] @cptvitamin 
- [x] @cahrens or @andy-armstrong 
- [x] @lamagnifica FYI
