### PR TITLE
Update Vector Drawing XBlock to the latest version.

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -34,5 +34,5 @@ git+https://github.com/open-craft/problem-builder.git@v2.0.4#egg=xblock-problem-
 ubcpi-xblock==0.5.3
 
 # Vector Drawing and ActiveTable XBlocks (Davidson)
--e git+https://github.com/open-craft/xblock-vectordraw.git@ded76fc8f6c99ba4949ed57a7bf62a1f12e44683#egg=xblock-vectordraw
+-e git+https://github.com/open-craft/xblock-vectordraw.git@v0.2#egg=xblock-vectordraw==0.2
 -e git+https://github.com/open-craft/xblock-activetable.git@1786a2c8fc06ca3ecfac1972464048982bd486ff#egg=xblock-activetable


### PR DESCRIPTION
This PR updates xblock-vectordraw from v0.1 to v0.2. The new version includes changes from the following PRs:
- https://github.com/open-craft/xblock-vectordraw/pull/9 (Ensure "templates" dir is present in non-editable installs)
- https://github.com/open-craft/xblock-vectordraw/pull/10 (Ensure any vector can be drawn using mouse)
- https://github.com/open-craft/xblock-vectordraw/pull/11 (Fix flaky/unregistered clicking when dragging using a mobile device)
- https://github.com/open-craft/xblock-vectordraw/pull/12 (Disable scroll during draw)

Please refer to the individual PRs for test instructions and relevant discussions.
