### PR TITLE
Ensure correct aria-valid-attr-value for discussions

### DIFF
--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -456,7 +456,6 @@ class DiscussionTabMultipleThreadTest(BaseDiscussionTestCase):
         self.thread_page_1.a11y_audit.config.set_rules({
             "ignore": [
                 'section',  # TODO: AC-491
-                'aria-valid-attr-value',  # TNL-4638
                 'color-contrast',  # TNL-4639
                 'icon-aria-hidden',  # TNL-4641
             ]
@@ -467,7 +466,6 @@ class DiscussionTabMultipleThreadTest(BaseDiscussionTestCase):
         self.thread_page_2.a11y_audit.config.set_rules({
             "ignore": [
                 'section',  # TODO: AC-491
-                'aria-valid-attr-value',  # TNL-4638
                 'color-contrast',  # TNL-4639
                 'icon-aria-hidden',  # TNL-4641
             ]
@@ -530,7 +528,6 @@ class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
         page.a11y_audit.config.set_rules({
             'ignore': [
                 'section',  # TODO: AC-491
-                'aria-valid-attr-value',  # TNL-4643
                 'color-contrast',  # TNL-4644
                 'icon-aria-hidden',  # TNL-4645
             ]
@@ -541,7 +538,6 @@ class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
         page.a11y_audit.config.set_rules({
             'ignore': [
                 'section',  # TODO: AC-491
-                'aria-valid-attr-value',  # TNL-4643
                 'color-contrast',  # TNL-4644
                 'icon-aria-hidden',  # TNL-4645
             ]
@@ -829,7 +825,6 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
         page.a11y_audit.config.set_rules({
             'ignore': [
                 'section',  # TODO: AC-491
-                'aria-valid-attr-value',  # TNL-4638
                 'color-contrast',  # TNL-4644
                 'icon-aria-hidden',  # TNL-4645
                 'duplicate-id',  # TNL-4647
@@ -930,7 +925,6 @@ class DiscussionCommentEditTest(BaseDiscussionTestCase):
         page.a11y_audit.config.set_rules({
             'ignore': [
                 'section',  # TODO: AC-491
-                'aria-valid-attr-value',  # TNL-4643
                 'color-contrast',  # TNL-4644
                 'icon-aria-hidden',  # TNL-4645
             ]


### PR DESCRIPTION
### Description

[TNL-4638](https://openedx.atlassian.net/browse/TNL-4638) , [TNL-4643](https://openedx.atlassian.net/browse/TNL-4643)

To improve the accessibility of discussions, this change removes all `aria-valid-attr-value` rules from the discussions bokchoy a11y tests.

We don't need to change any template as this was fixed recently in @andy-armstrong 's [PR](https://github.com/edx/edx-platform/pull/13345/files#diff-eee7cbb81135859a2dfdebdd4175bcc8R6) which fixed the code : `aria-controls="action-menu-<%= contentType %>"`.
### Reviewers
- [x] Code review: @muzaffaryousaf 
- [x] Code review: @andy-armstrong 

FYI: Tag anyone who might be interested in this PR here.
