### PR TITLE
Toolbarmageddon! (TNL-5105)

### DIFF
--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -309,7 +309,7 @@
             var appended_id, editor, elem, id, imageUploadUrl, placeholder, _processor;
             elem = $local('.' + cls_identifier);
             placeholder = elem.data('placeholder');
-            id = elem.attr('data-id');
+            id = elem.data('id');
             appended_id = '-' + cls_identifier + '-' + id;
             imageUploadUrl = this.urlFor('upload');
             _processor = function(self) {

--- a/common/static/common/js/discussion/views/thread_response_view.js
+++ b/common/static/common/js/discussion/views/thread_response_view.js
@@ -72,7 +72,7 @@
                     container = $('.discussion-module');
                 }
                 templateData = _.extend(this.model.toJSON(), {
-                    wmdId: (_ref = this.model.id) !== null ? _ref : (new Date()).getTime(),
+                    wmdId: typeof(this.model.id) !== 'undefined' ? this.model.id : (new Date()).getTime(),
                     create_sub_comment: container.data('user-create-subcomment'),
                     readOnly: this.readOnly
                 });

--- a/common/static/common/js/spec/discussion/view/thread_response_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/thread_response_view_spec.js
@@ -1,4 +1,4 @@
-/* globals DiscussionSpecHelper, ResponseCommentView, Thread, ThreadResponseView, ThreadResponseShowView */
+/* globals DiscussionSpecHelper, ResponseCommentView, Thread, ThreadResponseView, ThreadResponseShowView, _ */
 (function() {
     'use strict';
     describe('ThreadResponseView', function() {
@@ -89,6 +89,25 @@
                     return expect(this.view.$('.action-show-comments')).not.toBeVisible();
                 }
             );
+            it('calls renderTemplate with a temporary id if the model lacks one', function() {
+                this.view = new ThreadResponseView({
+                    model: this.response,
+                    el: $('#fixture-element'),
+                    collapseComments: true
+                });
+                spyOn(_, 'extend').and.callThrough();
+                spyOn(window, 'Date').and.callFake(function() {
+                    return {
+                        getTime: function() {
+                            return 1;
+                        }
+                    };
+                });
+                this.view.render();
+                expect(_.extend).toHaveBeenCalledWith(jasmine.any(Object), jasmine.objectContaining({
+                    wmdId: 1
+                }));
+            });
             it('populates commentViews and binds events', function() {
                 this.view.createEditView();
                 spyOn(this.view, 'cancelEdit');


### PR DESCRIPTION
### Description

[TNL-5105](https://openedx.atlassian.net/browse/TNL-5105)
Under certain circumstances (see repro steps in ticket), posting a response to a discussion thread could lead to a different comment having two WMD editors displayed above it (and to infinite stacking of toolbars, if you continue to post).

This was a super weird bug to track down.... the template wasn't getting the id of the comment object due to a funky ternary statement, so a data prop wasn't being set, so the function that hides the WMD editor was being called on the wrong element. Been around since these files were converted from Coffeescript, as far as I can tell.
### Sandbox
- [x] https://bjacobel-toolbarmageddon.sandbox.edx.org
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @alisan617 
- [ ] Doc Review: @catong 

FYI: @robrap 
### Post-review
- [ ] Rebase and squash commits
