### PR TITLE
logging

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -258,7 +258,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
             self.user_id,
             self.course_version,
             self.usage_key,
-            self.visible_blocks.hashed,
+            self.visible_blocks_id,
             self.earned_graded,
             self.possible_graded,
             self.earned_all,
@@ -273,6 +273,7 @@ class PersistentSubsectionGrade(TimeStampedModel):
         """
         user_id = kwargs.pop('user_id')
         usage_key = kwargs.pop('usage_key')
+
         try:
             with transaction.atomic():
                 grade, is_created = cls.objects.get_or_create(
@@ -281,8 +282,17 @@ class PersistentSubsectionGrade(TimeStampedModel):
                     usage_key=usage_key,
                     defaults=kwargs,
                 )
+                log.info(u"Persistent Grades: Grade model saved: {0}".format(grade))
         except IntegrityError:
             cls.update_grade(user_id=user_id, usage_key=usage_key, **kwargs)
+            log.warning(
+                u"Persistent Grades: Integrity error trying to save grade for user: {0}, usage key: {1}, defaults: {2}"
+                .format(
+                    user_id,
+                    usage_key,
+                    **kwargs
+                )
+            )
         else:
             if not is_created:
                 grade.update(**kwargs)
@@ -368,3 +378,4 @@ class PersistentSubsectionGrade(TimeStampedModel):
         self.possible_graded = possible_graded
         self.visible_blocks_id = visible_blocks_hash  # pylint: disable=attribute-defined-outside-init
         self.save()
+        log.info(u"Persistent Grades: Grade model updated: {0}".format(self))

--- a/lms/djangoapps/grades/new/course_grade.py
+++ b/lms/djangoapps/grades/new/course_grade.py
@@ -40,6 +40,10 @@ class CourseGrade(object):
                     graded_total = subsection_grade.graded_total
                     if graded_total.possible > 0:
                         subsections_by_format[subsection_grade.format].append(graded_total)
+        log.info(u"Persistent Grades: Calculated subsections_by_format. course id: {0}, user: {1}".format(
+            self.course.location,
+            self.student.id
+        ))
         return subsections_by_format
 
     @lazy
@@ -51,6 +55,10 @@ class CourseGrade(object):
         for chapter in self.chapter_grades:
             for subsection_grade in chapter['sections']:
                 locations_to_weighted_scores.update(subsection_grade.locations_to_weighted_scores)
+        log.info(u"Persistent Grades: Calculated locations_to_weighted_scores. course id: {0}, user: {1}".format(
+            self.course.id,
+            self.student.id
+        ))
         return locations_to_weighted_scores
 
     @lazy
@@ -60,10 +68,15 @@ class CourseGrade(object):
         """
         # Grading policy might be overriden by a CCX, need to reset it
         self.course.set_grading_policy(self.course.grading_policy)
-        return self.course.grader.grade(
+        grade_value = self.course.grader.grade(
             self.subsection_grade_totals_by_format,
             generate_random_scores=settings.GENERATE_PROFILE_SCORES
         )
+        log.info(u"Persistent Grades: Calculated grade_value. course id: {0}, user: {1}".format(
+            self.course.location,
+            self.student.id
+        ))
+        return grade_value
 
     @property
     def has_access_to_course(self):
@@ -107,7 +120,6 @@ class CourseGrade(object):
         # doesn't get displayed differently than it gets grades
         grade_summary['percent'] = self.percent
         grade_summary['grade'] = self.letter_grade
-
         grade_summary['totaled_scores'] = self.subsection_grade_totals_by_format
         grade_summary['raw_scores'] = list(self.locations_to_weighted_scores.itervalues())
 

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -173,10 +173,10 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
             "usage_key": self.usage_key,
             "course_version": "deadbeef",
             "subtree_edited_timestamp": "2016-08-01 18:53:24.354741",
-            "earned_all": 6,
-            "possible_all": 12,
-            "earned_graded": 6,
-            "possible_graded": 8,
+            "earned_all": 6.0,
+            "possible_all": 12.0,
+            "earned_graded": 6.0,
+            "possible_graded": 8.0,
             "visible_blocks": [self.record_a, self.record_b],
         }
 
@@ -212,15 +212,21 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
         with self.assertRaises(PersistentSubsectionGrade.DoesNotExist):
             PersistentSubsectionGrade.update_grade(**self.params)
         PersistentSubsectionGrade.objects.create(**self.params)
-        self.params['earned_all'] = 12
-        self.params['earned_graded'] = 8
-        PersistentSubsectionGrade.update_grade(**self.params)
-        read_grade = PersistentSubsectionGrade.read_grade(
-            user_id=self.params["user_id"],
-            usage_key=self.params["usage_key"],
-        )
-        self.assertEqual(read_grade.earned_all, 12)
-        self.assertEqual(read_grade.earned_graded, 8)
+        self.params['earned_all'] = 12.0
+        self.params['earned_graded'] = 8.0
+
+        with patch('lms.djangoapps.grades.models.log') as log_mock:
+            PersistentSubsectionGrade.update_grade(**self.params)
+            read_grade = PersistentSubsectionGrade.read_grade(
+                user_id=self.params["user_id"],
+                usage_key=self.params["usage_key"],
+            )
+            log_mock.info.assert_called_with(
+                u"Persistent Grades: Grade model updated: {0}".format(read_grade)
+            )
+
+        self.assertEqual(read_grade.earned_all, 12.0)
+        self.assertEqual(read_grade.earned_graded, 8.0)
 
     @ddt.data(True, False)
     def test_save(self, already_created):
@@ -235,3 +241,14 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
                 PersistentSubsectionGrade.save_grade(**self.params)
                 self.assertTrue(mock_get_or_create.called)
                 self.assertEqual(mock_update.called, already_created)
+
+    def test_logging_for_save(self):
+        with patch('lms.djangoapps.grades.models.log') as log_mock:
+            PersistentSubsectionGrade.save_grade(**self.params)
+            read_grade = PersistentSubsectionGrade.read_grade(
+                user_id=self.params["user_id"],
+                usage_key=self.params["usage_key"],
+            )
+            log_mock.info.assert_called_with(
+                u"Persistent Grades: Grade model saved: {0}".format(read_grade)
+            )


### PR DESCRIPTION
@jcdyer @nasthagiri @efischer19 let me know what logging cases you can think of and I will add them. Once this PR is finalized I'll document the logging we've added on the wiki (I think it's easier to find than the ticket and can be colocated with the testing wiki page).
### Added in this PR so far:

**Warning level (available in Splunk**
- When a lazy property gets calculated
- When a saved grade is retrieved  (in subsection_grade.py)
- When a saved grade cannot be retrieved because it does not exist  (in subsection_grade.py)
- When a grade is saved (in subsection_grade.py)

**Info level (available in logs on sandbox, etc.)**
- When we attempt to save a grade  (in subsection_grade.py)
- When a lazy property is accessed
- Model-level changes for persisted grades (grade updated/created, integrity error, etc. in models.py)

Logs for saving/retrieving grades include:
- Course id
- Course version
- Subsection location
- All/graded correct/total (where available).
### Questions

Do we want logging for course grade functionality even though we don't currently persist the grade?
