### PR TITLE
Complete the LMS help link - add it to edx.org theme, adjust Sass styling for the theme and for pattern library pages

### DIFF
--- a/lms/static/sass/shared-v2/_header.scss
+++ b/lms/static/sass/shared-v2/_header.scss
@@ -129,3 +129,15 @@
         }
     }
 }
+
+.doc-link {
+    @include float(right);
+    @include margin(($baseline*0.75), ($baseline*0.75), ($baseline*0.75), ($baseline*0.75));
+    font-size: 14px;
+    font-weight: bold;
+    color: $base-font-color;
+
+    &:visited {
+      color: $base-font-color;
+    }
+}

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -10,30 +10,6 @@
   width: 100%;
   height: 76px;
 
-  .doc-link {
-    position: relative;
-    @include float(right);
-    @include margin(($baseline*0.75), ($baseline*0.75), ($baseline*0.75), ($baseline*0.75));
-    padding: 0;
-    text-transform: none;
-    font-size: 14px;
-    font-weight: bold;
-    letter-spacing: 0;
-    color: $base-font-color;
-    text-decoration: none;
-
-    &:hover,
-    &:focus {
-      text-decoration: none;
-      color: $base-font-color;
-    }
-
-    &:visited {
-      text-decoration: none;
-      color: $base-font-color;
-    }
-  }
-
   .wrapper-header {
     @include clearfix();
     height: 40px;
@@ -905,4 +881,16 @@
     text-decoration: none;
     color: $link-color !important;
   }
+}
+
+.doc-link {
+    @include float(right);
+    @include margin(($baseline*0.75), ($baseline*0.75), ($baseline*0.75), ($baseline*0.75));
+    font-size: 14px;
+    font-weight: bold;
+    color: $base-font-color;
+
+    &:visited {
+      color: $base-font-color;
+    }
 }

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -104,6 +104,10 @@ site_status_msg = get_site_status_msg(course_id)
 
       <%include file="user_dropdown.html"/>
 
+      <a href="${get_online_help_info(online_help_token)['doc_url']}" 
+         target="_blank"
+         class="doc-link">${_("Help")}</a>
+
       % if should_display_shopping_cart_func(): # see shoppingcart.context_processor.user_has_cart_context_processor
         <ul class="user">
           <li class="primary">


### PR DESCRIPTION
## [DOC-3296](https://openedx.atlassian.net/browse/DOC-3296)

This PR completes the LMS help link that was introduced in https://github.com/edx/edx-platform/pull/13215. I didn't realize that the link would also need to be in the edx.org theme, which overrides the lms/templates/navigation.html template on edx.org (seems obvious now). This PR makes the following changes.
- Add the help link to the header template in the edx.org theme, so that it will appear on edx.org.
- Adds the sass styling for the help link (doc-link class) to the v2 sass files used by the pattern library pages. (The help link was not styled on the discussions page, which uses the pattern library.)
- Moves the .doc-link styling to the top level of the sass file, so that it selects the link wherever it appears in the page DOM. This is because the hierarchy is different in the edx.org theme and the default template. There's only one help link, so we don't need to be specific about when we style it.

Product, accessibility, devops, and UX reviews were done for https://github.com/edx/edx-platform/pull/13215. This PR only fixes a problem with the execution, so I am only tagging development review here.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @andy-armstrong 
- [ ] Doc team review (sanity check): @edx/doc 
### Sandbox (optional)
- [ ] https://pdesjardins.sandbox.edx.org/dashboard
### Post-review
- [ ] Add description to release notes task as a comment
- [ ] Squash commits
