### PR TITLE
Remove duplicate-id rule for a11y discussions

### DIFF
--- a/common/static/common/templates/discussion/thread-response.underscore
+++ b/common/static/common/templates/discussion/thread-response.underscore
@@ -11,8 +11,8 @@
         <% if (create_sub_comment && !readOnly) { %>
             <form class="comment-form" data-id="<%- wmdId %>">
                 <ul class="discussion-errors"></ul>
-                <label class="sr" for="add-new-comment"><%- gettext("Add a comment") %></label>
-                <div class="comment-body" id="add-new-comment" data-id="<%- wmdId %>"
+                <label class="sr" for="add-new-comment-<%- wmdId %>"><%- gettext("Add a comment") %></label>
+                <div class="comment-body" id="add-new-comment-<%- wmdId %>" data-id="<%- wmdId %>"
                 data-placeholder="<%- gettext('Add a comment') %>"></div>
                 <div class="comment-post-control">
                     <button class="btn-brand discussion-submit-comment control-button"><%- gettext("Submit") %></button>

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -827,7 +827,6 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
                 'section',  # TODO: AC-491
                 'color-contrast',  # TNL-4644
                 'icon-aria-hidden',  # TNL-4645
-                'duplicate-id',  # TNL-4647
             ]
         })
         page.visit()


### PR DESCRIPTION
### Description

[TNL-4647](https://openedx.atlassian.net/browse/TNL-4647)

To improve the accessibility of discussions, this change removes all `duplicate-id` rules from the discussions bokchoy a11y tests.
### Reviewers
- [x] Code review: @muzaffaryousaf 
- [x] Code review: @dianakhuang / @andy-armstrong or anyone from forums team

FYI: @andy-armstrong since this involves discussions template, you might be interested to look at this.
