### PR TITLE
Fix bug where new posts were not assigned a topic ID and would fail to post

### DIFF
--- a/common/static/common/js/discussion/views/discussion_topic_menu_view.js
+++ b/common/static/common/js/discussion/views/discussion_topic_menu_view.js
@@ -46,7 +46,7 @@
                         '[data-discussion-id="' + this.getCurrentTopicId() + '"]')
                     );
                 } else {
-                    this.setTopic(this.$('.topic-title').first());
+                    this.setTopic(this.$('button.topic-title').first());
                 }
                 return this.$el;
             },

--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -177,7 +177,7 @@
                 DiscussionUtil.clearFormErrors(this.$('.post-errors'));
                 this.$('.wmd-preview p').html('');
                 if (this.isTabMode()) {
-                    return this.topicView.setTopic(this.$('.topic-title').first());
+                    return this.topicView.setTopic(this.$('button.topic-title').first());
                 }
             };
 

--- a/common/static/common/js/spec/discussion/view/discussion_topic_menu_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/discussion_topic_menu_view_spec.js
@@ -135,7 +135,7 @@
             var dropdownText;
             this.createTopicView();
             this.view.maxNameWidth = this.selectedOptionText.length + 100;
-            this.view.$el.find('.topic-title').first().click();
+            this.view.$el.find('button.topic-title').first().click();
             dropdownText = this.view.$el.find('.js-selected-topic').text();
             expect(dropdownText.indexOf('/ span>')).toEqual(-1);
         });
@@ -150,6 +150,15 @@
             this.view.render();
             dropdownText = this.view.$el.find('.js-selected-topic').text();
             expect(completeText).toEqual(dropdownText);
+        });
+
+        it("defaults to the first topic if you don't click one", function() {
+            this.createTopicView();
+            expect(
+                this.view.$el.find('.js-selected-topic').text()
+            ).toMatch(
+                this.view.$el.find('.topic-menu-entry')[0].innerHTML
+            );
         });
 
         it('click outside of the dropdown close it', function() {

--- a/lms/static/sass/discussion/views/_create-edit-post.scss
+++ b/lms/static/sass/discussion/views/_create-edit-post.scss
@@ -257,7 +257,7 @@
     font-size: $forum-base-font-size;
   }
 
-  a.topic-title {
+  button.topic-title {
     @include transition(none);
 
     &:hover, &:focus {


### PR DESCRIPTION
### Description

[TNL-5442](https://openedx.atlassian.net/browse/TNL-5442)

[This change](https://github.com/edx/edx-platform/commit/f1bad0721fba08eba2a96b50153deaae3463e88d) moved a link to a button, and removed the `a` from a jQuery selector searching for that link (so it wold match the button) - unfortunately there was a `span` higher in the document sharing the class name of the button we were looking for, and the newly broadened selector matched that span instead.
### Sandbox
- [x] https://bjacobel.sandbox.edx.org
### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit violation code review process
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @robrap
### Post-review
- [ ] Rebase and squash commits
