### PR TITLE
Update opaque-keys and ccx-keys versions.

### DIFF
--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -55,7 +55,7 @@ setup(
         'capa',
         'path.py',
         'webob',
-        'edx-opaque-keys>=0.2.1,<1.0.0',
+        'edx-opaque-keys>=0.3.4,<1.0.0',
     ],
     package_data={
         'xmodule': ['js/module/*'],

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -38,13 +38,13 @@ git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc432894737119
 django==1.8.14
 djangorestframework-jwt==1.8.0
 djangorestframework-oauth==1.1.0
-edx-ccx-keys==0.1.2
+edx-ccx-keys==0.2.1
 edx-drf-extensions==0.5.1
 edx-lint==0.4.3
 edx-django-oauth2-provider==1.1.1
 edx-django-sites-extensions==2.1.1
 edx-oauth2-provider==1.1.3
-edx-opaque-keys==0.3.3
+edx-opaque-keys==0.3.4
 edx-organizations==0.4.1
 edx-rest-api-client==1.2.1
 edx-search==0.1.2


### PR DESCRIPTION
Update both the opaque-keys and ccx-keys repos to the versions that reject keys/locators with trailing newlines.
