### PR TITLE
TNL-5404: Default to not requesting responses when grabbing a single thread.

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -294,6 +294,7 @@ def single_thread(request, course_key, discussion_id, thread_id):
     # the comments service.
     try:
         thread = cc.Thread.find(thread_id).retrieve(
+            with_responses=True,
             recursive=request.is_ajax(),
             user_id=request.user.id,
             response_skip=request.GET.get("resp_skip"),

--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -96,6 +96,7 @@ def _get_thread_and_context(request, thread_id, retrieve_kwargs=None):
     """
     retrieve_kwargs = retrieve_kwargs or {}
     try:
+        retrieve_kwargs["with_responses"] = True
         if "mark_as_read" not in retrieve_kwargs:
             retrieve_kwargs["mark_as_read"] = False
         cc_thread = Thread(id=thread_id).retrieve(**retrieve_kwargs)

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -631,6 +631,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
             "page": ["1"],
             "per_page": ["1"],
             "recursive": ["False"],
+            "with_responses": ["True"],
             "commentable_ids": ["topic_x,topic_meow"]
         })
 
@@ -644,6 +645,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
             "page": ["6"],
             "per_page": ["14"],
             "recursive": ["False"],
+            "with_responses": ["True"],
         })
 
     def test_thread_content(self):
@@ -857,6 +859,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
             "page": ["1"],
             "per_page": ["10"],
             "recursive": ["False"],
+            "with_responses": ["True"],
             "text": ["test search string"],
         })
 
@@ -923,6 +926,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
             "per_page": ["11"],
             "recursive": ["False"],
             query: ["true"],
+            "with_responses": ["True"],
         })
 
     @ddt.data(
@@ -965,6 +969,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
             "page": ["1"],
             "per_page": ["11"],
             "recursive": ["False"],
+            "with_responses": ["True"],
         })
 
     @ddt.data("asc", "desc")
@@ -995,6 +1000,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
             "page": ["1"],
             "per_page": ["11"],
             "recursive": ["False"],
+            "with_responses": ["True"],
         })
 
 
@@ -1181,6 +1187,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
                 "mark_as_read": ["False"],
                 "resp_skip": ["70"],
                 "resp_limit": ["14"],
+                "with_responses": ["True"]
             }
         )
 

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -432,6 +432,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
             "page": ["1"],
             "per_page": ["10"],
             "recursive": ["False"],
+            "with_responses": ["True"],
         })
 
     @ddt.data("unread", "unanswered")
@@ -452,6 +453,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
             "sort_key": ["activity"],
             "sort_order": ["desc"],
             "recursive": ["False"],
+            "with_responses": ["True"],
             "page": ["1"],
             "per_page": ["10"],
             query: ["true"],
@@ -477,6 +479,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
             "page": ["18"],
             "per_page": ["4"],
             "recursive": ["False"],
+            "with_responses": ["True"],
         })
 
     def test_text_search(self):
@@ -504,6 +507,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
             "page": ["1"],
             "per_page": ["10"],
             "recursive": ["False"],
+            "with_responses": ["True"],
             "text": ["test search string"],
         })
 
@@ -598,6 +602,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
             "page": ["1"],
             "per_page": ["10"],
             "sort_key": [cc_query],
+            "with_responses": ["True"],
         })
 
     @ddt.data("asc", "desc")
@@ -620,6 +625,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
             "page": ["1"],
             "per_page": ["10"],
             "sort_order": [query],
+            "with_responses": ["True"],
         })
 
     def test_mutually_exclusive(self):
@@ -1130,6 +1136,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
                 "resp_limit": ["10"],
                 "user_id": [str(self.user.id)],
                 "mark_as_read": ["False"],
+                "with_responses": ["True"],
             }
         )
 
@@ -1163,6 +1170,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
                 "resp_limit": ["4"],
                 "user_id": [str(self.user.id)],
                 "mark_as_read": ["False"],
+                "with_responses": ["True"],
             }
         )
 

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -734,7 +734,7 @@ class ViewsTestCase(
                 ('get', '{prefix}/threads/518d4237b023791dca00000d'.format(prefix=CS_PREFIX)),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False},
                     'headers': ANY,
                     'timeout': 5
                 }
@@ -752,7 +752,7 @@ class ViewsTestCase(
                 ('get', '{prefix}/threads/518d4237b023791dca00000d'.format(prefix=CS_PREFIX)),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False},
                     'headers': ANY,
                     'timeout': 5
                 }
@@ -812,7 +812,7 @@ class ViewsTestCase(
                 ('get', '{prefix}/threads/518d4237b023791dca00000d'.format(prefix=CS_PREFIX)),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False},
                     'headers': ANY,
                     'timeout': 5
                 }
@@ -830,7 +830,7 @@ class ViewsTestCase(
                 ('get', '{prefix}/threads/518d4237b023791dca00000d'.format(prefix=CS_PREFIX)),
                 {
                     'data': None,
-                    'params': {'mark_as_read': True, 'request_id': ANY},
+                    'params': {'mark_as_read': True, 'request_id': ANY, 'with_responses': False},
                     'headers': ANY,
                     'timeout': 5
                 }

--- a/lms/lib/comment_client/thread.py
+++ b/lms/lib/comment_client/thread.py
@@ -48,7 +48,8 @@ class Thread(models.Model):
         default_params = {'page': 1,
                           'per_page': 20,
                           'course_id': query_params['course_id'],
-                          'recursive': False}
+                          'recursive': False,
+                          'with_responses': True}
         params = merge_dict(default_params, strip_blank(strip_none(query_params)))
 
         if query_params.get('text'):
@@ -131,6 +132,7 @@ class Thread(models.Model):
         url = self.url(action='get', params=self.attributes)
         request_params = {
             'recursive': kwargs.get('recursive'),
+            'with_responses': kwargs.get('with_responses', False),
             'user_id': kwargs.get('user_id'),
             'mark_as_read': kwargs.get('mark_as_read', True),
             'resp_skip': kwargs.get('response_skip'),


### PR DESCRIPTION
### Description

[TNL-5404](https://openedx.atlassian.net/browse/TNL-5404)

This is a duplicate and replacement of the earlier PR from Toby:
https://github.com/edx/edx-platform/pull/13349

We're often grabbing the metadata of a specific thread to then be able
to perform other operations, but we never need the actual responses or
comments of a thread unless we're displaying it in the normal forum
view.

This change sets a default of with_responses=False, which instructs the
comment service to not send back the responses/comments for the given
thread.  We only ask for responses in the case of rendering a single
thread or inline discussion.
### Sandbox
- [x] [https://robrap.sandbox.edx.org](https://robrap.sandbox.edx.org)

NOTE: Beware of bug creating new posts without a topic id.  It is being fixed here https://github.com/edx/edx-platform/pull/13418
### Testing
- [X] Mobile app test (completed manually - see comment)
- [X] safecommit violation code review process
- [X] Unit, integration, acceptance tests as appropriate
- [X] Performance
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [X] Code review: @robrap (FYI: Commit was from @tobz and was already reviewed in https://github.com/edx/edx-platform/pull/13418)
- [x] Code review: @jcdyer
  ### Post-review
- [x] Rebase and squash commits
