### PR TITLE
Adjustments to course dashboard visual styles 

### DIFF
--- a/lms/static/sass/elements/_system-feedback.scss
+++ b/lms/static/sass/elements/_system-feedback.scss
@@ -168,10 +168,8 @@
   @include box-sizing(border-box);
   @extend %t-strong;
   display: none;
-  border-bottom: 2px solid $yellow-d2;
   margin: 0 0 $baseline 0;
   padding: ($baseline/2) $baseline;
-  background: $yellow-d1;
   color: $white;
 
   .feedback-symbol {

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -24,7 +24,6 @@
       @include clearfix();
       box-sizing: border-box;
       padding: $baseline;
-      background-color: $body-bg;
       border: 1px solid $border-color-l3;
       .advertise-message {
         @include font-size(12);
@@ -196,7 +195,6 @@
         @include clearfix();
         box-sizing: border-box;
         padding: $baseline;
-        background-color: $body-bg;
         border: 1px solid $border-color-l3;
 
         .list--nav {
@@ -275,11 +273,10 @@
 
       .course-item {
         margin-bottom: $baseline;
-        border-bottom: 4px solid $border-color-l4;
         padding-bottom: $baseline;
 
         .course-container {
-          border: 1px solid $border-color-l4;
+          border: 2px solid $border-color-l4;
           border-radius: 3px;
         }
 
@@ -600,8 +597,7 @@
         display: none;
         margin: $baseline 0 ($baseline/2) 0;
         padding: ($baseline/2) $baseline;
-        background: $gray-l5;
-        border: 1px solid $gray-l4;
+        border-top: 1px solid $gray-l4;
         color: $base-font-color; // Overrides the normal white color in this one case
 
         // STATE: shown
@@ -795,11 +791,6 @@
           .message-copy {
             @extend %t-copy-sub1;
             margin: 0;
-
-            .grade-value {
-              font-size: 1.2rem;
-              font-weight: bold;
-            }
           }
 
           .credit-action {

--- a/lms/static/sass/partials/base/_variables.scss
+++ b/lms/static/sass/partials/base/_variables.scss
@@ -5,6 +5,7 @@
 // #UNITS:          Basic units of measurement
 // #GRID:           Grid and layout variables
 // #COLORS:         Base, palette and theme color definitions + application
+// #COLORS-EDX-SPECIFIC: edX specific colors not yet refactored to use updated color scheme
 // #TYPOGRAPHY:     Font definitions and scales
 // #DEPTH:          UI depth-based scale
 // #SPACING:        General UI spacing variables and scale
@@ -219,7 +220,13 @@ $alert-color: rgb(212, 64, 64) !default;
 $warning-color: rgb(237, 189, 60) !default;
 $success-color: rgb(37, 184, 90) !default;
 
-// newer color variables
+
+// ----------------------------
+// #COLORS- EDX-SPECIFIC
+// ----------------------------
+
+// old color variables
+// DEPRECATED: Do not continue to use these colors, instead use pattern libary and base colors above.
 $dark-gray1: rgb(74,74,74);
 $light-gray1: rgb(242,242,242);
 $light-gray2: rgb(171,171,171);
@@ -232,6 +239,7 @@ $green1: rgb(97,161,46);
 $red1: rgb(208,2,27);
 
 // edx-specific: marketing site variables
+// DEPRECATED: Do not continue to use these colors, instead use pattern libary and base colors above.
 $m-gray: rgb(138,140,143); //C8F
 $m-gray-l1: rgb(151,153,155);
 $m-gray-l2: rgb(164,166,168);


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-5561

_Description_
The follow PR is a small cleanup of items that were not addressed prior to merge of related dashboard improvements. The goal of this set of changes is to improve readability and visual clarity on the dashboard of the items being rendered. No content changes are included in the scope of this PR. 

_Details_
- Removes gray background on sidebar dashboard cards that went from nearly-white to a light-gray with recent UXPL changes. These are ok to be white instead of gray. 
- Removed visual separator between course cards that is a carry over from before course cards very visually bounded as cards.
- Added comments / notes to _variables.scss color files to note older marketing site variables that we should not continue to use (cleanup is a separate effort). 
- Removed special font-sizing for grade status on final course grade message, and removed dark yellow background for this message as well. 
- Messages using white background instead of bounded gray message to better emulate the pattern introduced in the Program Details page.

_Current_
![image](https://cloud.githubusercontent.com/assets/2023680/18359967/2ed0581c-75ca-11e6-9772-fa0253ee5fd3.png)

_With Changes_
![image](https://cloud.githubusercontent.com/assets/2023680/18359927/0813f670-75ca-11e6-944c-a1918d965482.png)

_To-Do_
- [x] Ensure system feedback style changes (removal of yellow-d1) is ok in the other places it is rendered / used. 

_Sandbox_
Coming Soon

_Reviewers_
- [ ] Lauren Holliday
- [ ] @sstack22 
- [x] @roderickmorales
