### PR TITLE
Fix extremely minor box corner issue in Discussions

### DIFF
--- a/lms/static/sass/discussion/elements/_navigation.scss
+++ b/lms/static/sass/discussion/elements/_navigation.scss
@@ -154,6 +154,7 @@
     padding-left: 0;
     overflow-y: scroll;
     list-style: none;
+    border-radius: 0 0 3px 3px;
 
     .forum-nav-thread-labels {
         margin: 5px 0 0;


### PR DESCRIPTION
This is _so_ minor, but something was bugging me with the topic/thread list box in Discussions - if you zoom way in you can see that the inner liner doesn't have a border-radius while the outer box does, leading the inner box to cut into the inside of the rounded corner.

Before:
![](https://i.bjacobel.com/20160908-ky7ay.png)
(look at the bottom right corner)

After:
![](https://i.bjacobel.com/20160908-qloy1.png)

Still not perfect, because we're positioning and sizing this box with JavaScript based on your scroll position (... ? why.) so there's unpredictable sub-pixel height stuff going on here.

No ticket.
- [x] @alisan617 
- [ ] @chris-mike 
- [ ] @marcotuts 
