### PR TITLE
Aj/save tnl 4935

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -601,7 +601,7 @@ class CapaMixin(CapaFields):
             'hint_index': hint_index
         }
 
-    def get_problem_html(self, encapsulate=True):
+    def get_problem_html(self, encapsulate=True, save_notification_message=None):
         """
         Return html for the problem.
 
@@ -697,6 +697,7 @@ class CapaMixin(CapaFields):
             'attempts_used': self.attempts,
             'attempts_allowed': self.max_attempts,
             'demand_hint_possible': demand_hint_possible,
+            'save_notification_message': save_notification_message,
             'answer_notification_type': answer_notification_type,
             'answer_notification_message': answer_notification_message,
         }
@@ -1448,7 +1449,7 @@ class CapaMixin(CapaFields):
         return {
             'success': True,
             'msg': msg,
-            'html': self.get_problem_html(encapsulate=False),
+            'html': self.get_problem_html(encapsulate=False, save_notification_message=msg),
         }
 
     def reset_problem(self, _data):

--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -724,33 +724,14 @@ describe 'Problem', ->
       expect($.postWithPrefix).toHaveBeenCalledWith '/problem/Problem1/problem_save',
           'foo=1&bar=2', jasmine.any(Function)
 
-    it 'reads the save message', (done) ->
-      deferred = $.Deferred()
-
-      runs = ->
-        spyOn($, 'postWithPrefix').and.callFake (url, answers, callback) ->
-          promise = undefined
-          callback success: 'OK'
-          promise = always: (callable) ->
-            callable()
-        @problem.save()
-        if jQuery.active == 0
-          deferred.resolve()
-        deferred.promise()
-
-      runs.call(this).then(->
-        expect(window.SR.readElts).toHaveBeenCalled()
-        return
-      ).always done
-
     it 'tests if all the buttons are disabled and the text of submit button does not change while saving.', (done) ->
       deferred = $.Deferred()
       self = this
-
+      curr_html = @problem.el.html()
       runs = ->
         spyOn($, 'postWithPrefix').and.callFake (url, answers, callback) ->
           promise = undefined
-          callback success: 'OK'
+          callback(success: 'correct', html: curr_html)
           promise = always: (callable) ->
             callable()
         spyOn @problem, 'enableAllButtons'

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -120,8 +120,7 @@ class ProblemPage(PageObject):
         """
         Click the Save button.
         """
-        self.q(css='div.problem button.save').click()
-        self.wait_for_ajax()
+        click_css(self, '.problem .save', require_notification=False)
 
     def click_reset(self):
         """
@@ -136,9 +135,28 @@ class ProblemPage(PageObject):
         self.q(css='.problem .show').click()
         self.wait_for_ajax()
 
+    def is_save_notification_visible(self):
+        """
+        Is the Save Notification Visible?
+        """
+        return self.q(css='.notification.warning.notification-save').visible
+
+    def wait_for_save_notification(self):
+        """
+        Wait for the Save Notification to be present
+        """
+        self.wait_for_element_visibility('.notification.warning.notification-save',
+                                         'Waiting for Save notification to be visible')
+        self.wait_for(lambda: self.q(css='.notification.warning.notification-save').focused,
+                      'Waiting for the focus to be on the save notification')
+
     def is_reset_button_present(self):
         """ Check for the presence of the reset button. """
         return self.q(css='.problem .reset').present
+
+    def is_save_button_enabled(self):
+        """ Check for the visibility of the Save button """
+        return not self.q(css='.action .save').attrs('disabled') is None
 
     def is_focus_on_problem_meta(self):
         """

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -763,7 +763,7 @@ class ProblemStateOnNavigationTest(UniqueCourseTest):
         # Update problem 1's content state by clicking save button.
         self.problem_page.click_choice('choice_choice_1')
         self.problem_page.click_save()
-        self.problem_page.wait_for_expected_status('div.capa_alert', 'saved')
+        self.problem_page.wait_for_save_notification()
 
         # Save problem 1's content state as we're about to switch units in the sequence.
         problem1_content_before_switch = self.problem_page.problem_content

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -137,6 +137,7 @@ class ProblemTypeTestMixin(object):
     Test cases shared amongst problem types.
     """
     can_submit_blank = False
+    can_update_save_notification = True
 
     @attr(shard=7)
     def test_answer_correctly(self):
@@ -252,6 +253,35 @@ class ProblemTypeTestMixin(object):
         self.assertTrue(self.problem_page.is_focus_on_problem_meta())
 
     @attr(shard=7)
+    def test_save_reaction(self):
+        """
+        Scenario: Verify that the save button performs as expected with problem types
+
+        Given that I am on a problem page
+        And I can see a CAPA problem with the Save button present
+        When I select and answer and click the "Save" button
+        Then I should see the Save notification
+        And the Save button should not be disabled
+        And if I change the answer selected
+        And the Save notification should be removed
+        """
+        self.problem_page.wait_for(
+            lambda: self.problem_page.problem_name == self.problem_name,
+            "Make sure the correct problem is on the page"
+        )
+        self.problem_page.wait_for_page()
+        self.answer_problem(correctness='correct')
+        self.assertTrue(self.problem_page.is_save_button_enabled())
+        self.problem_page.click_save()
+        # Ensure "Save" button is enabled after save is complete.
+        self.assertTrue(self.problem_page.is_save_button_enabled())
+        self.problem_page.wait_for_save_notification()
+        self.answer_problem(correctness='incorrect')
+        if self.can_update_save_notification:
+            # Not all problems will detect the change and remove the save notification
+            self.assertFalse(self.problem_page.is_save_notification_visible())
+
+    @attr(shard=7)
     def test_reset_clears_answer_and_focus(self):
         """
         Scenario: Reset will clear answers and focus on problem meta
@@ -337,6 +367,7 @@ class AnnotationProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
     partially_correct = True
 
     can_submit_blank = True
+    can_update_save_notification = False
     factory_kwargs = {
         'title': 'Annotation Problem',
         'text': 'The text being annotated',
@@ -722,7 +753,7 @@ class CodeProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
     problem_name = 'CODE TEST PROBLEM'
     problem_type = 'code'
     partially_correct = False
-
+    can_update_save_notification = False
     factory = CodeResponseXMLFactory()
 
     factory_kwargs = {
@@ -787,6 +818,7 @@ class ChoiceTextProbelmTypeTestBase(ProblemTypeTestBase):
     """
     choice_type = None
     partially_correct = False
+    can_update_save_notification = False
 
     def _select_choice(self, input_num):
         """
@@ -824,6 +856,7 @@ class RadioTextProblemTypeTest(ChoiceTextProbelmTypeTestBase, ProblemTypeTestMix
     problem_type = 'radio_text'
     choice_type = 'radio'
     partially_correct = False
+    can_update_save_notification = False
 
     factory = ChoiceTextResponseXMLFactory()
 
@@ -858,6 +891,7 @@ class CheckboxTextProblemTypeTest(ChoiceTextProbelmTypeTestBase, ProblemTypeTest
     choice_type = 'checkbox'
     factory = ChoiceTextResponseXMLFactory()
     partially_correct = False
+    can_update_save_notification = False
 
     factory_kwargs = {
         'question_text': 'The correct answer is Choice 0 and input 8',
@@ -886,6 +920,7 @@ class ImageProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
     factory = ImageResponseXMLFactory()
 
     can_submit_blank = True
+    can_update_save_notification = False
 
     factory_kwargs = {
         'src': '/static/images/placeholder-image.png',

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -26,7 +26,11 @@ from openedx.core.djangolib.markup import HTML
     % endif
     % if save_button:
     <span class="problem-action-button-wrapper">
-        <button class="save problem-action-btn btn-default btn-small" data-value="${_('Save')}"><span class="icon fa fa-floppy-o" aria-hidden="true"></span><span aria-hidden="true">${_('Save')}</span><span class="sr">${_("Save your answer")}</span></button>
+        <button class="save problem-action-btn btn-default btn-small" data-value="${_('Save')}">
+            <span class="icon fa fa-floppy-o" aria-hidden="true"></span>
+            <span aria-hidden="true">${_('Save')}</span>
+            <span class="sr">${_("Save your answer")}</span>
+        </button>
     </span>
     % endif
     % if reset_button:
@@ -58,26 +62,34 @@ from openedx.core.djangolib.markup import HTML
             <%include file="problem_notifications.html" args="
                 notification_type='success',
                 notification_icon='check',
-                notification_message=answer_notification_message,
-                hint_notification=hint_notification"
+                notification_name='submit',
+                notification_message= answer_notification_message"
             />
         % endif
         % if 'incorrect' == answer_notification_type:
             <%include file="problem_notifications.html" args="
                 notification_type='error',
                 notification_icon='close',
-                notification_message=answer_notification_message,
-                hint_notification=hint_notification"
+                notification_name='submit',
+                notification_message= answer_notification_message"
             />
         % endif
         % if 'partially-correct' == answer_notification_type:
             <%include file="problem_notifications.html" args="
                 notification_type='success',
                 notification_icon='asterisk',
-                notification_message=answer_notification_message,
-                hint_notification=hint_notification"
+                notification_name='submit',
+                notification_message= answer_notification_message"
             />
         % endif
+    % endif
+    % if save_notification_message:
+      <%include file="problem_notifications.html" args="
+        notification_type='warning',
+        notification_icon='save',
+        notification_name='save',
+        notification_message=save_notification_message"
+      />
     % endif
 
   </div>

--- a/lms/templates/problem_notifications.html
+++ b/lms/templates/problem_notifications.html
@@ -1,12 +1,14 @@
-<%page expression_filter="h" args="notification_type, notification_icon, notification_message, hint_notification"/>
+<%page expression_filter="h" args="notification_name, notification_type, notification_icon,
+                                   notification_message"/>
 <%! from django.utils.translation import ugettext as _ %>
 
-<div class="notification ${notification_type} ${'notification-hint' if hint_notification else 'notification-submit'}" tabindex="-1">
+<div class="notification ${notification_type} ${'notification-'}${notification_name}"
+     tabindex="-1">
     <span class="icon fa fa-${notification_icon}" aria-hidden="true"></span>
     <span class="notification-message" aria-describedby="${ id }-problem-title">${notification_message}
     </span>
     <div class="notification-btn-wrapper">
-        % if hint_notification:
+        % if notification_name is 'hint':
         <button class="btn btn-default btn-small notification-btn">${_('Next Hint')}</button>
         % endif
         <button class="btn btn-default btn-small notification-btn review-btn sr">${_('Review')}</button>


### PR DESCRIPTION
### Description

This PR updates the Save button to meet accessibility needs, including updated focus, notifications and screen reader changes.

[TNL-4935](https://openedx.atlassian.net/browse/TNL-4935)
### Sandbox

[https://staubina-save.sandbox.edx.org](https://staubina-save.sandbox.edx.org)
- [x] Build a sandbox for your branch and add a link here
### Testing
- [x] i18n
- [x] RTL
- [x] safecommit shows 0 violations
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @alisan617 
- [x] UX review: @chris-mike 
- [x] Product review: @sstack22 
### Post-review
- [x] Squash commits
