### PR TITLE
Fix width of 'Load More' button in Discussions

### DIFF
--- a/lms/static/sass/discussion/elements/_navigation.scss
+++ b/lms/static/sass/discussion/elements/_navigation.scss
@@ -322,6 +322,7 @@
 .forum-nav-load-more-link {
     @extend %forum-nav-load-more-content;
     color: $link-color;
+    width: 100%;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
When the "Load More" link was converted to a button it started showing up at a smaller width - it should expand to fill this box.

Before, when it was a link: 
![](https://i.bjacobel.com/20160908-v0zhk.png)

After, as a button (current master):
![](https://i.bjacobel.com/20160908-dncbw.png)

With these changes:
![](https://i.bjacobel.com/20160908-y5tnq.png)
- [x] @andy-armstrong 
- [X] @robrap
