### PR TITLE
MA-2663: Donot mark thread unread on any action but creation

### DIFF
--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -916,6 +916,11 @@ def update_thread(request, thread_id, update_data):
         thread_edited.send(sender=None, user=request.user, post=cc_thread)
     api_thread = serializer.data
     _do_extra_actions(api_thread, cc_thread, update_data.keys(), actions_form, context, request)
+
+    # always return read as True (and therefore unread_comment_count=0) as reasonably
+    # accurate shortcut, rather than adding additional processing.
+    api_thread['read'] = True
+    api_thread['unread_comment_count'] = 0
     return api_thread
 
 

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -2047,7 +2047,7 @@ class UpdateThreadTest(
             "endorsed_comment_list_url": None,
             "non_endorsed_comment_list_url": None,
             "editable_fields": ["abuse_flagged", "following", "raw_body", "read", "title", "topic_id", "type", "voted"],
-            'read': False,
+            'read': True,
             'has_endorsed': False,
             'response_count': 0
         }

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -833,7 +833,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
 
     def test_basic(self):
         self.register_get_user_response(self.user)
-        self.register_thread({"created_at": "Test Created Date", "updated_at": "Test Updated Date"})
+        self.register_thread({"created_at": "Test Created Date", "updated_at": "Test Updated Date", "read": True})
         request_data = {"raw_body": "Edited body"}
         response = self.request_patch(request_data)
         self.assertEqual(response.status_code, 200)
@@ -849,6 +849,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
                 "created_at": "Test Created Date",
                 "updated_at": "Test Updated Date",
                 "comment_count": 1,
+                "read": True,
             })
         )
         self.assertEqual(
@@ -864,7 +865,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
                 "anonymous_to_peers": ["False"],
                 "closed": ["False"],
                 "pinned": ["False"],
-                "read": ["False"],
+                "read": ["True"],
             }
         )
 


### PR DESCRIPTION
## [MA-2663](https://openedx.atlassian.net/browse/MA-2663)

Do not mark thread back to unread on any of the following action:
- follow
- endorse
- mark as answer
- vote
- edit 
- delete
- report
### Sandbox
- [x] https://wjia-dapi.sandbox.edx.org/
### Testing
- [x] Unit
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @jcdyer 
- [x] Code review: @robrap 
### Post-review
- [x] Squash commits
