### PR TITLE
Enable Persistent Grades in unit tests

### DIFF
--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -36,6 +36,7 @@ from openedx.core.djangoapps.content.block_structure.api import get_course_in_ca
     'django.conf.settings.FEATURES',
     {
         'ENABLE_XBLOCK_VIEW_ENDPOINT': True,
+        'PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS': False  # disable persistent grades until TNL-5458 (reduces queries)
     }
 )
 @ddt.ddt

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1345,6 +1345,8 @@ class ProgressPageTests(ModuleStoreTestCase):
         )
         self.assertContains(resp, u"Download Your Certificate")
 
+    # disable persistent grades until TNL-5458 (reduces query counts)
+    @patch.dict(settings.FEATURES, {'PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS': False})
     @ddt.data(
         *itertools.product(((39, 4, True), (39, 4, False)), (True, False))
     )

--- a/lms/djangoapps/grades/config/models.py
+++ b/lms/djangoapps/grades/config/models.py
@@ -3,6 +3,7 @@ Models for configuration of the feature flags
 controlling persistent grades.
 """
 from config_models.models import ConfigurationModel
+from django.conf import settings
 from django.db.models import BooleanField
 from xmodule_django.models import CourseKeyField
 
@@ -29,6 +30,8 @@ class PersistentGradesEnabledFlag(ConfigurationModel):
         If the flag is enabled and no course ID is given,
             we return True since the global setting is enabled.
         """
+        if settings.FEATURES.get('PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS'):
+            return True
         if not PersistentGradesEnabledFlag.is_enabled():
             return False
         elif not PersistentGradesEnabledFlag.current().enabled_for_all_courses and course_id:

--- a/lms/djangoapps/grades/config/tests/test_models.py
+++ b/lms/djangoapps/grades/config/tests/test_models.py
@@ -3,6 +3,9 @@ Tests for the models that control the
 persistent grading feature.
 """
 import ddt
+from django.conf import settings
+import itertools
+from mock import patch
 
 from django.test import TestCase
 from opaque_keys.edx.locator import CourseLocator
@@ -10,6 +13,7 @@ from lms.djangoapps.grades.config.models import PersistentGradesEnabledFlag
 from lms.djangoapps.grades.config.tests.utils import persistent_grades_feature_flags
 
 
+@patch.dict(settings.FEATURES, {'PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS': False})
 @ddt.ddt
 class PersistentGradesFeatureFlagTests(TestCase):
     """
@@ -21,16 +25,11 @@ class PersistentGradesFeatureFlagTests(TestCase):
         self.course_id_1 = CourseLocator(org="edx", course="course", run="run")
         self.course_id_2 = CourseLocator(org="edx", course="course2", run="run")
 
-    @ddt.data(
-        (True, True, True),
-        (True, True, False),
-        (True, False, True),
-        (True, False, False),
-        (False, True, True),
-        (False, False, True),
-        (False, True, False),
-        (False, False, False),
-    )
+    @ddt.data(*itertools.product(
+        (True, False),
+        (True, False),
+        (True, False),
+    ))
     @ddt.unpack
     def test_persistent_grades_feature_flags(self, global_flag, enabled_for_all_courses, enabled_for_course_1):
         with persistent_grades_feature_flags(

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -43,8 +43,6 @@ def submissions_score_set_handler(sender, **kwargs):  # pylint: disable=unused-a
     usage_id = kwargs['item_id']
     user = user_by_anonymous_id(kwargs['anonymous_user_id'])
 
-    # If any of the kwargs were missing, at least one of the following values
-    # will be None.
     SCORE_CHANGED.send(
         sender=None,
         points_possible=points_possible,
@@ -73,8 +71,6 @@ def submissions_score_reset_handler(sender, **kwargs):  # pylint: disable=unused
     usage_id = kwargs['item_id']
     user = user_by_anonymous_id(kwargs['anonymous_user_id'])
 
-    # If any of the kwargs were missing, at least one of the following values
-    # will be None.
     SCORE_CHANGED.send(
         sender=None,
         points_possible=0,

--- a/lms/djangoapps/grades/tests/test_signals.py
+++ b/lms/djangoapps/grades/tests/test_signals.py
@@ -3,6 +3,7 @@ Tests for the score change signals defined in the courseware models module.
 """
 
 import ddt
+from django.conf import settings
 from django.test import TestCase
 from mock import patch, MagicMock
 from unittest import skip
@@ -169,6 +170,7 @@ class SubmissionSignalRelayTest(TestCase):
         self.signal_mock.assert_not_called()
 
 
+@patch.dict(settings.FEATURES, {'PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS': False})
 @ddt.ddt
 class ScoreChangedUpdatesSubsectionGradeTest(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1641,6 +1641,8 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
         super(TestCertificateGeneration, self).setUp()
         self.initialize_course()
 
+    # disable persistent grades until TNL-5458 (reduces query counts)
+    @patch.dict(settings.FEATURES, {'PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS': False})
     def test_certificate_generation_for_students(self):
         """
         Verify that certificates generated for all eligible students enrolled in a course.

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -298,6 +298,9 @@ OIDC_COURSE_HANDLER_CACHE_TIMEOUT = 0
 FEATURES['ENABLE_MOBILE_REST_API'] = True
 FEATURES['ENABLE_VIDEO_ABSTRACTION_LAYER_API'] = True
 
+########################### Grades #################################
+FEATURES['PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS'] = True
+
 ###################### Payment ##############################3
 # Enable fake payment processing page
 FEATURES['ENABLE_PAYMENT_FAKE'] = True


### PR DESCRIPTION
### Description

[TNL-5475](https://openedx.atlassian.net/browse/TNL-5475)

This PR enables Persistent Subsection Grades in all unit and lettuce tests.  As we roll-out these Grading changes, we want to ensure the feature doesn't break existing functionality that is already being tested by existing tests.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @sanfordstudent 
- [ ] Code review: @jcdyer or @efischer19 
### Post-review
- [ ] Rebase and squash commits
