### PR TITLE
AC-581 using UXPL values for course types on dashboard

### DIFF
--- a/lms/static/sass/partials/base/_variables.scss
+++ b/lms/static/sass/partials/base/_variables.scss
@@ -246,7 +246,7 @@ $m-gray-t1: rgba($m-gray,0.25);
 $m-gray-t2: rgba($m-gray,0.50);
 $m-gray-t3: rgba($m-gray,0.75);
 
-$m-blue: rgb(26,161,222);
+$m-blue: $uxpl-blue-base;  // uxpl blue base
 $m-blue-l1: rgb(43,172,230);
 $m-blue-l2: rgb(66,181,233);
 $m-blue-l3: rgb(89,190,236);
@@ -264,7 +264,7 @@ $m-blue-t1: rgba($m-blue,0.25);
 $m-blue-t2: rgba($m-blue,0.50);
 $m-blue-t3: rgba($m-blue,0.75);
 
-$m-pink: rgb(181,42,103);
+$m-pink: $uxpl-pink-base; // uxpl pink base
 $m-pink-l1: rgb(202,47,115);
 $m-pink-l2: rgb(211,63,128);
 $m-pink-l3: rgb(215,84,142);
@@ -274,7 +274,7 @@ $m-pink-d1: rgb(160,37,91);
 $m-pink-d2: rgb(140,32,79);
 $m-pink-d3: rgb(119,28,68);
 
-$m-green: rgb(0, 136, 1);
+$m-green: $uxpl-green-base; // uxpl green base
 $m-green-s1: rgb(96, 188, 97);
 $m-green-l1: tint($m-green,20%);
 $m-green-l2: tint($m-green,40%);
@@ -305,7 +305,7 @@ $professional-color-lvl4: $m-pink-l3;
 $professional-color-lvl5: $m-pink-l4;
 
 // edx-specific: honor code
-$honorcode-color-lvl1: rgb(50, 165, 217);
+$honorcode-color-lvl1: $m-blue;
 $honorcode-color-lvl2: tint($honorcode-color-lvl1, 33%);
 
 // edx-specific: audit


### PR DESCRIPTION
# [AC-581](https://openedx.atlassian.net/browse/AC-581)

This corrects color contrast failures on the dashboard for the course types (honor, professional, verified, etc.). I've chosen to use colors from our pattern library to bring some consistency along with ensured accessibility and contrast. The blue, green and pink are slightly darker, but barely noticeable.

Because this changes higher-level color variables, there may be other color shifts elsewhere in the platform. However, if this is the case, know that those colors are UX and a11y approved.
## Screenshots

<img width="211" alt="screen shot 2016-09-12 at 3 04 31 pm" src="https://cloud.githubusercontent.com/assets/2112024/18448767/56ad7b02-78fa-11e6-9ba2-ae06bdb79264.png"><img width="210" alt="screen shot 2016-09-12 at 3 05 16 pm" src="https://cloud.githubusercontent.com/assets/2112024/18448766/56a8727e-78fa-11e6-88e9-3ff5a9dce8bd.png">

<img width="210" alt="screen shot 2016-09-12 at 3 06 34 pm" src="https://cloud.githubusercontent.com/assets/2112024/18448830/8d4d98d6-78fa-11e6-8500-940f6bc69f20.png"><img width="211" alt="screen shot 2016-09-12 at 3 06 41 pm" src="https://cloud.githubusercontent.com/assets/2112024/18448829/8d4d93c2-78fa-11e6-83c5-857e9ef4636b.png">

<img width="211" alt="screen shot 2016-09-12 at 3 09 11 pm" src="https://cloud.githubusercontent.com/assets/2112024/18448907/ec0c10b4-78fa-11e6-86d8-a94383cba03f.png"><img width="210" alt="screen shot 2016-09-12 at 3 09 19 pm" src="https://cloud.githubusercontent.com/assets/2112024/18448908/ec2443d2-78fa-11e6-8c37-330d9db78851.png">
## Sandbox

I can't for the life of me figure out how to get the "badges" to show up on my sandbox so see the screenshots above using my style updates with existing classes from stage.

http://clrux-ac-581.sandbox.edx.org/dashboard
## Reviewers
- [x] @sstack22 
- [x] @cptvitamin 
