### PR TITLE
capa answer feedback explanation text font size

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -84,6 +84,7 @@ h2 {
 
 %feedback-hint {
   margin-top: ($baseline / 4);
+
   .icon {
     @include margin-right($baseline / 4);
   }
@@ -1007,10 +1008,13 @@ div.problem {
     border: 1px solid $gray-l3;
   }
 
+  .message {
+    font-size: inherit;
+  }
+
   .detailed-solution {
     > p {
       margin: 0;
-      font-size: $medium-font-size;
 
       &:first-child {
         @extend %t-strong;
@@ -1024,7 +1028,6 @@ div.problem {
   .detailed-targeted-feedback-correct {
     > p {
         margin: 0;
-        font-size: $medium-font-size;
         font-weight: normal;
 
         &:first-child {


### PR DESCRIPTION
Answer feedback / explanation / solution via Show Answer font size falls back to regular text -- base font size 16px

[Sandbox](https://alisan617.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/1414ffd5143b4b508f739b563ab468b7/workflow/2?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40vertical_f04afeac0131)
## Reviewers
- [x] Code review: @staubina 
- [x] Code review: @cahrens 
- [x] UX review: @chris-mike
