### PR TITLE
Update xblock-utils dependency to v1.0.3.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -87,7 +87,7 @@ git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd3
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/pmitros/DoneXBlock.git@release-2016-08-10#egg=done-xblock
 git+https://github.com/edx/edx-milestones.git@v0.1.10#egg=edx-milestones==0.1.10
-git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
+git+https://github.com/edx/xblock-utils.git@v1.0.3#egg=xblock-utils==1.0.3
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1


### PR DESCRIPTION
New version includes fixes from https://github.com/edx/xblock-utils/pull/38 and https://github.com/edx/xblock-utils/pull/39.

Follow-up PR for [OC-1819](https://tasks.opencraft.com/browse/OC-1819) (OpenCraft recruitment task).

**Reviewers**
- [x] OpenCraft: @bradenmacdonald 
- [x] edX: @doctoryes 
