### PR TITLE
TNL-5240: Cache comment thread.

### DIFF
--- a/lms/lib/comment_client/comment.py
+++ b/lms/lib/comment_client/comment.py
@@ -27,9 +27,15 @@ class Comment(models.Model):
     base_url = "{prefix}/comments".format(prefix=settings.PREFIX)
     type = 'comment'
 
+    def __init__(self, *args, **kwargs):
+        super(Comment, self).__init__(*args, **kwargs)
+        self._cached_thread = None
+
     @property
     def thread(self):
-        return Thread(id=self.thread_id, type='thread')
+        if not self._cached_thread:
+            self._cached_thread = Thread(id=self.thread_id, type='thread')
+        return self._cached_thread
 
     @property
     def context(self):


### PR DESCRIPTION
### Description

[TNL-5240](https://openedx.atlassian.net/browse/TNL-5240)

The point of this ticket was to get rid of some redundant calls to GET thread while creating a comment.  Originally, there were 3 calls.  This change gets it down to 2, which now matches the Discussion API for the same.  

FYI: The final redundancy comes from an outside call getting the permissions, and seems like it would be difficult to remove (or reuse).  Note that these GET thread calls already should be far more performant now that they are not requesting responses when not needed.
### Sandbox
- [X] https://robrap.sandbox.edx.org
### Testing
- [X] Unit, integration, acceptance tests as appropriate
- [X] Performance
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @jcdyer 
- [x] Code review: @dianakhuang 
### Post-review
- [x] Rebase and squash commits
