### PR TITLE
replaced static with dynamically generated copyright year

### DIFF
--- a/docs/en_us/enrollment_api/source/conf.py
+++ b/docs/en_us/enrollment_api/source/conf.py
@@ -95,5 +95,4 @@ extensions = [
 exclude_patterns = ['build', 'links.rst']
 
 
-project = u'edX Enrollment API Version 1'
-copyright = u'2015, edX'
+project = 'edX Enrollment API Version 1'

--- a/docs/en_us/platform_api/source/conf.py
+++ b/docs/en_us/platform_api/source/conf.py
@@ -241,7 +241,6 @@ extensions = [
     'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.pngmath',
     'sphinx.ext.mathjax', 'sphinx.ext.viewcode', 'sphinxcontrib.napoleon']
 
-project = u'Open edX Platform APIs'
-copyright = u'2016, edX Inc. and licensed under a Creative Commons Attribution-ShareAlike 4.0 International License unless otherwise specified'
+project = 'Open edX Platform APIs'
 
 exclude_patterns = ['build', 'links.rst']

--- a/docs/shared/conf.py
+++ b/docs/shared/conf.py
@@ -22,6 +22,7 @@
 # -----------------------------------------------------------------------------
 
 import os
+import datetime
 
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -63,8 +64,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'edX'
-copyright = u'2013, EdX Doc Team'
+project = 'edX'
+copyright = '{year}, edX Inc. and licensed under a Creative Commons Attribution-ShareAlike 4.0 International License unless otherwise specified'.format(year=datetime.datetime.now().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DOC-3212
with reference to the [outreachy page](https://openedx.atlassian.net/wiki/display/COMM/Outreachy+Round+13)
