### PR TITLE
Don't delete question p-tag if children.

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -951,7 +951,13 @@ class LoncapaProblem(object):
 
                 if p_tag and p_tag[0].text == inputfields[0].attrib['label']:
                     label = p_tag[0].text
-                    element_to_be_deleted = p_tag[0]
+
+                    p_tag_children = list(p_tag[0])
+                    if len(p_tag_children) == 0:
+                        element_to_be_deleted = p_tag[0]
+                    else:
+                        # Delete the text from the p-tag, but leave the children.
+                        p_tag[0].text = ''
             else:
                 # In this case the problems don't have tag or label attribute inside the responsetype
                 # so we will get the first preceding label tag w.r.t to this responsetype.

--- a/common/lib/capa/capa/tests/test_capa_problem.py
+++ b/common/lib/capa/capa/tests/test_capa_problem.py
@@ -424,6 +424,39 @@ class CAPAProblemTest(unittest.TestCase):
         self.assert_question_tag(question1, question2, tag='label', label_attr=False)
         self.assert_question_tag(question1, question2, tag='p', label_attr=True)
 
+    def test_question_tag_child_left(self):
+        """
+        If the "old" question tag has children, don't delete the children when
+        transforming to the new label tag.
+        """
+        xml = """
+            <problem>
+                <p>Question<img src='img/src'/></p>
+                <choiceresponse>
+                    <checkboxgroup label="Question">
+                        <choice correct="true">choice1</choice>
+                        <choice correct="false">choice2</choice>
+                    </checkboxgroup>
+                </choiceresponse>
+            </problem>
+            """
+
+        problem = new_loncapa_problem(xml)
+        self.assertEqual(
+            problem.problem_data,
+            {
+                '1_2_1':
+                    {
+                        'label': "Question",
+                        'descriptions': {}
+                    }
+            }
+        )
+        # img tag is still present within the paragraph, but p text has been deleted
+        self.assertEqual(len(problem.tree.xpath('//p')), 1)
+        self.assertEqual(problem.tree.xpath('//p')[0].text, '')
+        self.assertEqual(len(problem.tree.xpath('//p/img')), 1)
+
 
 @ddt.ddt
 class CAPAMultiInputProblemTest(unittest.TestCase):


### PR DESCRIPTION
[TNL-5510](https://openedx.atlassian.net/browse/TNL-5510)

Sandbox: https://cahrens.sandbox.edx.org/courses/course-v1:disappeared+ouch+bug/courseware/71b1751a65794e00a8582f61767523a4/9a70834ddfd54e9aa0c09b155e08367f/

The first problem on the page is how their problems would look (paragraph text matches label). The child elements remain, but the paragraph text is transformed into the legend.

Second problem is what happens when the paragraph text does NOT match the label (no change from master).

Third problem is when paragraph text matches label and there are no child elements (no change from master).

@staubina @cptvitamin and @sstack22 please review.
