### PR TITLE
Update coverage version to 4.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -144,7 +144,7 @@ django_debug_toolbar==1.5
 before_after==0.1.3
 bok-choy==0.5.3
 chrono==1.0.2
-coverage==4.0.2
+coverage==4.2
 ddt==0.8.0
 diff-cover==0.9.8
 django-crum==0.5


### PR DESCRIPTION
Updating the coverage version for 2 reasons:
- to keep up to date with the latest
- because we are having issues counting coverage. See [TE-1672](https://openedx.atlassian.net/browse/TE-1672). This may or may not fix the issue but shouldn't hurt.

I have reviewed the release notes, and there is one item that will not affect us but warrants specific mention. Nothing else in the notes raised any concerns.
- 4.2 has a BACKWARD INCOMPATIBILITY: the `coverage combine` command now ignores an existing .coverage data file
- We do use the `coverage combine` command. However whenever we use it, we never use an existing .coverage data file for input. Actually we always use that filename for output.

@nedbat @edx/testeng please review.
