### PR TITLE
UX changes for capa demand hints

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -111,7 +111,6 @@ h2 {
 }
 
 .problem-hint {
-  color: $color-copy-tip;
   margin-bottom: 20px;
 }
 
@@ -274,7 +273,6 @@ div.problem {
       @include padding-left($baseline*1.75);
       position: relative;
       font-size: $base-font-size;
-      line-height: $base-line-height;
     }
 
     input[type="radio"],
@@ -1056,19 +1054,35 @@ div.problem {
 
   .notification {
     margin-top: $baseline / 2;
-    padding: ($baseline * 0.4) ($baseline / 2);
+    padding: ($baseline * 0.4) ($baseline / 2) ($baseline / 5);
+    line-height: 1.5em;
     min-width: auto;
+
     &.success {
       @include notification-by-type($success-color);
     }
     &.error {
       @include notification-by-type($error-color);
     }
-    &.info {
-      @include notification-by-type($info-color);
-    }
     &.warning {
       @include notification-by-type($warning-color);
+    }
+    &.hint {
+      border: 1px solid $uxpl-gray-background;
+      border-radius: 6px;
+
+      .icon {
+        @include margin-right(3 * $baseline / 4);
+        color: $uxpl-gray-dark;
+      }
+
+      li {
+        color: $uxpl-gray-base;
+
+        strong {
+          color: $uxpl-gray-dark;
+        }
+      }
     }
     .icon {
       position: relative;
@@ -1078,6 +1092,19 @@ div.problem {
     .notification-message {
       display: inline-block;
       width: flex-grid(8,10);
+      // Make notification tall enough that when the "Review" button is displayed,
+      // the notification does not grow in height.
+      margin-bottom: 8px;
+
+      ol {
+        list-style: none outside none;
+        padding: 0;
+        margin: 0;
+
+        li:not(:last-child) {
+          margin-bottom: $baseline / 4;
+        }
+      }
     }
     .notification-btn-wrapper {
       @include float(right);

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1211,6 +1211,7 @@ class CapaModuleTest(unittest.TestCase):
         self.assertEqual(bool(context['should_enable_submit_button']), enable_submit_button)
         self.assertEqual(bool(context['reset_button']), show_reset_button)
         self.assertEqual(bool(context['save_button']), show_save_button)
+        self.assertFalse(context['demand_hint_possible'])
 
         # Assert that the encapsulated html contains the original html
         self.assertIn(html, html_encapsulated)
@@ -1238,17 +1239,29 @@ class CapaModuleTest(unittest.TestCase):
         module.get_problem_html()  # ignoring html result
         context = module.system.render_template.call_args[0][1]
         self.assertEqual(context['demand_hint_possible'], True)
+        self.assertIsNone(context['hint_notification_message'])
 
         # Check the AJAX call that gets the hint by index
         result = module.get_demand_hint(0)
-        self.assertEqual(result['contents'], u'Hint (1 of 2): Demand 1')
+        context = module.system.render_template.call_args[0][1]
+        self.assertIn(u'<strong>Hint (1 of 2): </strong>Demand 1', unicode(context['hint_notification_message']))
+        self.assertNotIn(u'<strong>Hint (2 of 2): </strong>Demand 2', unicode(context['hint_notification_message']))
         self.assertEqual(result['hint_index'], 0)
+        self.assertTrue(context['should_enable_next_hint'])
+
         result = module.get_demand_hint(1)
-        self.assertEqual(result['contents'], u'Hint (2 of 2): Demand 2')
+        context = module.system.render_template.call_args[0][1]
+        self.assertIn(u'<strong>Hint (1 of 2): </strong>Demand 1', unicode(context['hint_notification_message']))
+        self.assertIn(u'<strong>Hint (2 of 2): </strong>Demand 2', unicode(context['hint_notification_message']))
         self.assertEqual(result['hint_index'], 1)
+        self.assertFalse(context['should_enable_next_hint'])
+
         result = module.get_demand_hint(2)  # here the server wraps around to index 0
-        self.assertEqual(result['contents'], u'Hint (1 of 2): Demand 1')
+        context = module.system.render_template.call_args[0][1]
+        self.assertIn(u'<strong>Hint (1 of 2): </strong>Demand 1', unicode(context['hint_notification_message']))
+        self.assertNotIn(u'<strong>Hint (2 of 2): </strong>Demand 2', unicode(context['hint_notification_message']))
         self.assertEqual(result['hint_index'], 0)
+        self.assertTrue(context['should_enable_next_hint'])
 
     def test_demand_hint_logging(self):
         module = CapaFactory.create(xml=self.demand_xml)

--- a/common/static/sass/edx-pattern-library-shims/base/_variables.scss
+++ b/common/static/sass/edx-pattern-library-shims/base/_variables.scss
@@ -133,12 +133,15 @@ $uxpl-blue-hover-active: darken($uxpl-blue-base, 7%); // wcag2a compliant
 $uxpl-green-base: rgba(0, 129, 0, 1); // wcag2a compliant
 $uxpl-green-hover-active: lighten($uxpl-green-base, 7%); // wcag2a compliant
 
+$uxpl-gray-dark: rgb(17, 17, 17);
+$uxpl-gray-base: rgb(65, 65, 65);
+$uxpl-gray-background: rgb(217, 217, 217);
+
 
 // Alert styles
 $error-color: rgb(203, 7, 18) !default;
 $success-color: rgb(0, 155, 0) !default;
 $warning-color: rgb(255, 192 ,31) !default;
-$info-color: rgb(0, 134, 206) !default;
 
 
 // BUTTONS
@@ -212,7 +215,7 @@ $btn-small-padding-horizontal: spacing-horizontal(small);
 @mixin notification-by-type($color) {
   border-top: 3px solid $color;
   .icon {
-    @include margin-right($baseline / 2);
+    @include margin-right(3 * $baseline/ 4);
     color: $color;
   }
 }

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -50,14 +50,15 @@ class ProblemPage(PageObject):
         """
         Return the "hint" text of the problem from html
         """
-        return self.q(css="div.problem div.problem-hint").html[0].split(' <', 1)[0]
+        hints_html = self.q(css="div.problem .notification-hint .notification-message li").html
+        return [hint_html.split(' <span', 1)[0] for hint_html in hints_html]
 
     @property
     def hint_text(self):
         """
         Return the "hint" text of the problem from its div.
         """
-        return self.q(css="div.problem div.problem-hint").text[0]
+        return self.q(css="div.problem .notification-hint .notification-message").text[0]
 
     def verify_mathjax_rendered_in_problem(self):
         """
@@ -232,8 +233,21 @@ class ProblemPage(PageObject):
         """
         Click the Hint button.
         """
-        self.q(css='div.problem button.hint-button').click()
-        self.wait_for_ajax()
+        click_css(self, '.problem .hint-button', require_notification=False)
+        self.wait_for_focus_on_hint_notification()
+
+    def wait_for_focus_on_hint_notification(self):
+        """
+        Wait for focus to be on the hint notification.
+        """
+        self.wait_for(
+            lambda: self.q(css='.notification-hint').focused,
+            'Waiting for the focus to be on the hint notification'
+        )
+
+    def get_hint_button_disabled_attr(self):
+        """ Return the disabled attribute of all hint buttons (once hints are visible, there will be two). """
+        return self.q(css='.problem .hint-button').attrs('disabled')
 
     def click_choice(self, choice_value):
         """

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -16,12 +16,22 @@ from openedx.core.djangolib.markup import HTML
   <div class="action">
     <input type="hidden" name="problem_id" value="${ problem['name'] }" />
     % if demand_hint_possible:
-    <div class="problem-hint" aria-live="polite"></div>
+    <div class="problem-hint">
+        % if hint_notification_message is not None:
+            <%include file="problem_notifications.html" args="
+             notification_name='hint',
+             notification_type='hint',
+             notification_icon='question',
+             notification_message=hint_notification_message,
+             should_enable_next_hint=should_enable_next_hint"
+           />
+        % endif
+        </div>
     % endif
     <div class="problem-action-buttons-wrapper">
     % if demand_hint_possible:
     <span class="problem-action-button-wrapper">
-        <button class="hint-button problem-action-btn btn-default btn-small" data-value="${_('Hint')}"><span class="icon fa fa-question" aria-hidden="true"></span>${_('Hint')}</button>
+        <button class="hint-button problem-action-btn btn-default btn-small" data-value="${_('Hint')}" ${'' if should_enable_next_hint else 'disabled'}><span class="icon fa fa-question" aria-hidden="true"></span>${_('Hint')}</button>
     </span>
     % endif
     % if save_button:
@@ -63,7 +73,7 @@ from openedx.core.djangolib.markup import HTML
                 notification_type='success',
                 notification_icon='check',
                 notification_name='submit',
-                notification_message= answer_notification_message"
+                notification_message=answer_notification_message"
             />
         % endif
         % if 'incorrect' == answer_notification_type:
@@ -71,7 +81,7 @@ from openedx.core.djangolib.markup import HTML
                 notification_type='error',
                 notification_icon='close',
                 notification_name='submit',
-                notification_message= answer_notification_message"
+                notification_message=answer_notification_message"
             />
         % endif
         % if 'partially-correct' == answer_notification_type:
@@ -79,7 +89,7 @@ from openedx.core.djangolib.markup import HTML
                 notification_type='success',
                 notification_icon='asterisk',
                 notification_name='submit',
-                notification_message= answer_notification_message"
+                notification_message=answer_notification_message"
             />
         % endif
     % endif

--- a/lms/templates/problem_notifications.html
+++ b/lms/templates/problem_notifications.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h" args="notification_name, notification_type, notification_icon,
-                                   notification_message"/>
+                                   notification_message, should_enable_next_hint"/>
 <%! from django.utils.translation import ugettext as _ %>
 
 <div class="notification ${notification_type} ${'notification-'}${notification_name}"
@@ -9,7 +9,7 @@
     </span>
     <div class="notification-btn-wrapper">
         % if notification_name is 'hint':
-        <button class="btn btn-default btn-small notification-btn">${_('Next Hint')}</button>
+        <button class="btn btn-default btn-small notification-btn hint-button" ${'' if should_enable_next_hint else 'disabled'}>${_('Next Hint')}</button>
         % endif
         <button class="btn btn-default btn-small notification-btn review-btn sr">${_('Review')}</button>
     </div>


### PR DESCRIPTION
## [TNL-4934](https://openedx.atlassian.net/browse/TNL-4934)
### Description

Change demand hints to use a notification area above the "Submit" button.
Hints now build up instead of only displaying the last one, and the "Hint" and "Next Hint" buttons disable when no more hints exist.
### Sandbox
- [x] https://cahrens.sandbox.edx.org/courses/course-v1:capa+capa+capa/courseware/710113305c5743b195f4f602e45cc8fb/f5289da3f1d643eab704a29805a80b22/
### Testing
- [x] i18n
- [x] RTL
- [x] safecommit violation code review process
- [x] Unit, integration, acceptance tests as appropriate
- [x] Analytics
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @staubina 
- [x] Code review: @alisan617 
- [ ] Doc Review: @catong (FYI)
- [x] UX review: @chris-mike 
- [ ] Accessibility review: @cptvitamin (FYI)
- [x] Product review: @sstack22 
### Post-review
- [ ] Rebase and squash commits

@chris-mike wondering what color you want for the font. Also notice that when there is a single-line hint, the hint box has to grow vertically when you tab to "Review".

For @chris-mike and @sstack22, some of the interactions of when various "notifications" disappear is a bit hard to understand. Hints will go away whenever any rendering of the problem occurs, which doesn't seem horrible since you can easily get them back, but it might be confusing.
