### PR TITLE
Fix grade push back for non-components through LTI

### DIFF
--- a/lms/djangoapps/grades/new/course_grade.py
+++ b/lms/djangoapps/grades/new/course_grade.py
@@ -155,7 +155,7 @@ class CourseGrade(object):
         all scored problems that are children of the chosen location.
         """
         if location in self.locations_to_weighted_scores:
-            score = self.locations_to_weighted_scores[location]
+            score, _ = self.locations_to_weighted_scores[location]
             return score.earned, score.possible
         children = self.course_structure.get_children(location)
         earned = 0.0

--- a/lms/djangoapps/grades/tests/test_grades.py
+++ b/lms/djangoapps/grades/tests/test_grades.py
@@ -187,11 +187,11 @@ class TestProgressSummary(TestCase):
         self.loc_n = self.create_location('problem', 'n')
 
         weighted_scores = {
-            self.loc_h: self.create_score(2, 5),
-            self.loc_i: self.create_score(3, 5),
-            self.loc_j: self.create_score(0, 1),
-            self.loc_l: self.create_score(1, 3),
-            self.loc_n: self.create_score(3, 10),
+            self.loc_h: (self.create_score(2, 5), 1),
+            self.loc_i: (self.create_score(3, 5), 1),
+            self.loc_j: (self.create_score(0, 1), 1),
+            self.loc_l: (self.create_score(1, 3), 1),
+            self.loc_n: (self.create_score(3, 10), 1),
         }
         locations_to_scored_children = {
             self.loc_a: [self.loc_h, self.loc_i, self.loc_j, self.loc_l, self.loc_n],


### PR DESCRIPTION
**Background**: 
We noticed the grade is not being passed back for non-components integrations, e.g. units, sequence. Did some digging and found the issue:
There is a bug introduced in this commit:
https://github.com/edx/edx-platform/commit/22046d4067595f785365554b430fad1fc9d85000#diff-32687833c38e231b51a8f27a76c72a56R119
The return value of the locations_to_weighted_scores[location] is
changed from `Score` object to a tuple `(Score, weight)`. However, the
left side of assignment didn't get updated. So an error is raised and
the Celery task failed to continue. Thus, no grade is being passed back.

**Impact**: All courses using LTI grade passback on non-component integration

**Test**:
- Setup edX as LTI tool provider: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/lti/
- Create a graded problem in a unit
- Find out course ID and unit usage ID (not the problem usage ID): http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/lti/lti_address_content.html
- Setup Tool consumer (I'm using http://lti.tools/test/tc.php as example)
  - Launch URL: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/lti/lti_address_content.html#constructing-the-lti-url. If using a local edx environment, the URL should be something like: `http://localhost:8000/lti_provider/courses/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@vertical+block@2152d4a4aadc4cb0af5256394a3d1fc7`. 
  - Consumer Key and Secret: make sure they matches the one in first step (setup LTI tool provider). Otherwise, you will get 403 error.
  - Click Save data button and launch TP.
  - You should see the problem being populated
  - Complete the problem and wait for grade to pass back (up to 15 mins delay)
  - Click on "gradebook" button to see the grade.

/cc @smagoun 
