### PR TITLE
ENT-16 Make SSO configurable per Site

### DIFF
--- a/common/djangoapps/config_models/models.py
+++ b/common/djangoapps/config_models/models.py
@@ -42,7 +42,7 @@ class ConfigurationModelManager(models.Manager):
         assert self.model.KEY_FIELDS != (), "Just use model.current() if there are no KEY_FIELDS"
         return self.get_queryset().extra(           # pylint: disable=no-member
             where=["{table_name}.id IN ({subquery})".format(
-                table_name=self.model._meta.db_table,  # pylint: disable=protected-access
+                table_name=self.model._meta.db_table,  # pylint: disable=protected-access, no-member
                 subquery=self._current_ids_subquery(),
             )],
             select={'is_active': 1},  # This annotation is used by the admin changelist. sqlite requires '1', not 'True'
@@ -57,15 +57,15 @@ class ConfigurationModelManager(models.Manager):
             subquery = self._current_ids_subquery()
             return self.get_queryset().extra(           # pylint: disable=no-member
                 select={'is_active': "{table_name}.id IN ({subquery})".format(
-                    table_name=self.model._meta.db_table,  # pylint: disable=protected-access
+                    table_name=self.model._meta.db_table,  # pylint: disable=protected-access, no-member
                     subquery=subquery,
                 )}
             )
         else:
             return self.get_queryset().extra(           # pylint: disable=no-member
                 select={'is_active': "{table_name}.id = {pk}".format(
-                    table_name=self.model._meta.db_table,  # pylint: disable=protected-access
-                    pk=self.model.current().pk,
+                    table_name=self.model._meta.db_table,  # pylint: disable=protected-access, no-member
+                    pk=self.model.current().pk,  # pylint: disable=no-member
                 )}
             )
 
@@ -145,9 +145,15 @@ class ConfigurationModel(models.Model):
         return current
 
     @classmethod
-    def is_enabled(cls):
-        """Returns True if this feature is configured as enabled, else False."""
-        return cls.current().enabled
+    def is_enabled(cls, *key_fields):
+        """
+        Returns True if this feature is configured as enabled, else False.
+
+        Arguments:
+            key_fields: The positional arguments are the KEY_FIELDS used to identify the
+                configuration to be checked.
+        """
+        return cls.current(*key_fields).enabled
 
     @classmethod
     def key_values_cache_key_name(cls, *key_fields):

--- a/common/djangoapps/config_models/models.py
+++ b/common/djangoapps/config_models/models.py
@@ -41,7 +41,10 @@ class ConfigurationModelManager(models.Manager):
         """
         assert self.model.KEY_FIELDS != (), "Just use model.current() if there are no KEY_FIELDS"
         return self.get_queryset().extra(           # pylint: disable=no-member
-            where=["id IN ({subquery})".format(subquery=self._current_ids_subquery())],
+            where=["{table_name}.id IN ({subquery})".format(
+                table_name=self.model._meta.db_table,  # pylint: disable=protected-access
+                subquery=self._current_ids_subquery(),
+            )],
             select={'is_active': 1},  # This annotation is used by the admin changelist. sqlite requires '1', not 'True'
         )
 
@@ -53,11 +56,17 @@ class ConfigurationModelManager(models.Manager):
         if self.model.KEY_FIELDS:
             subquery = self._current_ids_subquery()
             return self.get_queryset().extra(           # pylint: disable=no-member
-                select={'is_active': "id IN ({subquery})".format(subquery=subquery)}
+                select={'is_active': "{table_name}.id IN ({subquery})".format(
+                    table_name=self.model._meta.db_table,  # pylint: disable=protected-access
+                    subquery=subquery,
+                )}
             )
         else:
             return self.get_queryset().extra(           # pylint: disable=no-member
-                select={'is_active': "id = {pk}".format(pk=self.model.current().pk)}
+                select={'is_active': "{table_name}.id = {pk}".format(
+                    table_name=self.model._meta.db_table,  # pylint: disable=protected-access
+                    pk=self.model.current().pk,
+                )}
             )
 
 

--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -33,7 +33,7 @@ class OAuth2ProviderConfigAdmin(KeyedConfigurationModelAdmin):
     def get_list_display(self, request):
         """ Don't show every single field in the admin change list """
         return (
-            'name', 'enabled', 'backend_name', 'secondary', 'skip_registration_form',
+            'name', 'enabled', 'site', 'backend_name', 'secondary', 'skip_registration_form',
             'skip_email_verification', 'change_date', 'changed_by', 'edit_link',
         )
 
@@ -52,7 +52,7 @@ class SAMLProviderConfigAdmin(KeyedConfigurationModelAdmin):
     def get_list_display(self, request):
         """ Don't show every single field in the admin change list """
         return (
-            'name', 'enabled', 'backend_name', 'entity_id', 'metadata_source',
+            'name', 'enabled', 'site', 'backend_name', 'entity_id', 'metadata_source',
             'has_data', 'mode', 'change_date', 'changed_by', 'edit_link',
         )
 
@@ -86,13 +86,13 @@ class SAMLProviderConfigAdmin(KeyedConfigurationModelAdmin):
 admin.site.register(SAMLProviderConfig, SAMLProviderConfigAdmin)
 
 
-class SAMLConfigurationAdmin(ConfigurationModelAdmin):
+class SAMLConfigurationAdmin(KeyedConfigurationModelAdmin):
     """ Django Admin class for SAMLConfiguration """
     def get_list_display(self, request):
         """ Shorten the public/private keys in the change view """
         return (
-            'change_date', 'changed_by', 'enabled', 'entity_id',
-            'org_info_str', 'key_summary',
+            'site', 'change_date', 'changed_by', 'enabled', 'entity_id',
+            'org_info_str', 'key_summary', 'edit_link',
         )
 
     def key_summary(self, inst):
@@ -136,6 +136,7 @@ class LTIProviderConfigAdmin(KeyedConfigurationModelAdmin):
         return (
             'name',
             'enabled',
+            'site',
             'lti_consumer_key',
             'lti_max_timestamp_age',
             'change_date',

--- a/common/djangoapps/third_party_auth/lti.py
+++ b/common/djangoapps/third_party_auth/lti.py
@@ -198,9 +198,9 @@ class LTIAuthBackend(BaseAuth):
         """
         from .models import LTIProviderConfig
         provider_config = LTIProviderConfig.current(lti_consumer_key)
-        if provider_config and provider_config.enabled:
+        if provider_config and provider_config.enabled_for_current_site:
             return (
-                provider_config.enabled,
+                provider_config.enabled_for_current_site,
                 provider_config.get_lti_consumer_secret(),
                 provider_config.lti_max_timestamp_age,
             )

--- a/common/djangoapps/third_party_auth/migrations/0005_add_site_field.py
+++ b/common/djangoapps/third_party_auth/migrations/0005_add_site_field.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations, models
+
+
+def fill_oauth2_slug(apps, schema_editor):
+    """
+    Fill in the provider_slug to be the same as backend_name for backwards compatability.
+    """
+    OAuth2ProviderConfig = apps.get_model('third_party_auth', 'OAuth2ProviderConfig')
+    for config in OAuth2ProviderConfig.objects.all():
+        config.provider_slug = config.backend_name
+        config.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sites', '0001_initial'),
+        ('third_party_auth', '0004_add_visible_field'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='provider_slug',
+            field=models.SlugField(
+                default='temp',
+                help_text=b'A short string uniquely identifying this provider. Cannot contain spaces and should be a usable as a CSS class. Examples: "ubc", "mit-staging"',
+                max_length=30
+            ),
+            preserve_default=False,
+        ),
+        migrations.RunPython(fill_oauth2_slug, reverse_code=migrations.RunPython.noop),
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='site',
+            field=models.ForeignKey(
+                related_name='ltiproviderconfigs',
+                default=settings.SITE_ID,
+                to='sites.Site',
+                help_text='The Site that this provider configuration belongs to.'
+            ),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='site',
+            field=models.ForeignKey(
+                related_name='oauth2providerconfigs',
+                default=settings.SITE_ID,
+                to='sites.Site',
+                help_text='The Site that this provider configuration belongs to.'
+            ),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='site',
+            field=models.ForeignKey(
+                related_name='samlproviderconfigs',
+                default=settings.SITE_ID,
+                to='sites.Site',
+                help_text='The Site that this provider configuration belongs to.'
+            ),
+        ),
+        migrations.AddField(
+            model_name='samlconfiguration',
+            name='site',
+            field=models.ForeignKey(
+                related_name='samlconfigurations',
+                default=settings.SITE_ID,
+                to='sites.Site',
+                help_text='The Site that this SAML configuration belongs to.'
+            ),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/provider.py
+++ b/common/djangoapps/third_party_auth/provider.py
@@ -1,6 +1,9 @@
 """
 Third-party auth provider configuration API.
 """
+from django.contrib.sites.models import Site
+from openedx.core.djangoapps.theming.helpers import get_current_request
+
 from .models import (
     OAuth2ProviderConfig, SAMLConfiguration, SAMLProviderConfig, LTIProviderConfig,
     _PSA_OAUTH2_BACKENDS, _PSA_SAML_BACKENDS, _LTI_BACKENDS,
@@ -15,20 +18,23 @@ class Registry(object):
     """
     @classmethod
     def _enabled_providers(cls):
-        """ Helper method to iterate over all providers """
+        """
+        Helper method that returns a generator used to iterate over all providers
+        of the current site.
+        """
         for backend_name in _PSA_OAUTH2_BACKENDS:
             provider = OAuth2ProviderConfig.current(backend_name)
-            if provider.enabled:
+            if provider.enabled_for_current_site:
                 yield provider
-        if SAMLConfiguration.is_enabled():
+        if SAMLConfiguration.is_enabled(Site.objects.get_current(get_current_request())):
             idp_slugs = SAMLProviderConfig.key_values('idp_slug', flat=True)
             for idp_slug in idp_slugs:
                 provider = SAMLProviderConfig.current(idp_slug)
-                if provider.enabled and provider.backend_name in _PSA_SAML_BACKENDS:
+                if provider.enabled_for_current_site and provider.backend_name in _PSA_SAML_BACKENDS:
                     yield provider
         for consumer_key in LTIProviderConfig.key_values('lti_consumer_key', flat=True):
             provider = LTIProviderConfig.current(consumer_key)
-            if provider.enabled and provider.backend_name in _LTI_BACKENDS:
+            if provider.enabled_for_current_site and provider.backend_name in _LTI_BACKENDS:
                 yield provider
 
     @classmethod
@@ -69,7 +75,7 @@ class Registry(object):
     @classmethod
     def get_enabled_by_backend_name(cls, backend_name):
         """Generator returning all enabled providers that use the specified
-        backend.
+        backend on the current site.
 
         Example:
             >>> list(get_enabled_by_backend_name("tpa-saml"))
@@ -84,16 +90,17 @@ class Registry(object):
         """
         if backend_name in _PSA_OAUTH2_BACKENDS:
             provider = OAuth2ProviderConfig.current(backend_name)
-            if provider.enabled:
+            if provider.enabled_for_current_site:
                 yield provider
-        elif backend_name in _PSA_SAML_BACKENDS and SAMLConfiguration.is_enabled():
+        elif backend_name in _PSA_SAML_BACKENDS and SAMLConfiguration.is_enabled(
+                Site.objects.get_current(get_current_request())):
             idp_names = SAMLProviderConfig.key_values('idp_slug', flat=True)
             for idp_name in idp_names:
                 provider = SAMLProviderConfig.current(idp_name)
-                if provider.backend_name == backend_name and provider.enabled:
+                if provider.backend_name == backend_name and provider.enabled_for_current_site:
                     yield provider
         elif backend_name in _LTI_BACKENDS:
             for consumer_key in LTIProviderConfig.key_values('lti_consumer_key', flat=True):
                 provider = LTIProviderConfig.current(consumer_key)
-                if provider.backend_name == backend_name and provider.enabled:
+                if provider.backend_name == backend_name and provider.enabled_for_current_site:
                     yield provider

--- a/common/djangoapps/third_party_auth/strategy.py
+++ b/common/djangoapps/third_party_auth/strategy.py
@@ -26,7 +26,7 @@ class ConfigurationModelStrategy(DjangoStrategy):
         """
         if isinstance(backend, OAuthAuth):
             provider_config = OAuth2ProviderConfig.current(backend.name)
-            if not provider_config.enabled:
+            if not provider_config.enabled_for_current_site:
                 raise Exception("Can't fetch setting of a disabled backend/provider.")
             try:
                 return provider_config.get_setting(name)

--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -36,16 +36,13 @@ def fetch_saml_metadata():
         num_failed: Number of providers that could not be updated
         num_total: Total number of providers whose metadata was fetched
     """
-    if not SAMLConfiguration.is_enabled():
-        return (0, 0, 0)  # Nothing to do until SAML is enabled.
-
     num_changed, num_failed = 0, 0
 
     # First make a list of all the metadata XML URLs:
     url_map = {}
     for idp_slug in SAMLProviderConfig.key_values('idp_slug', flat=True):
         config = SAMLProviderConfig.current(idp_slug)
-        if not config.enabled:
+        if not config.enabled or not SAMLConfiguration.is_enabled(config.site):
             continue
         url = config.metadata_source
         if url not in url_map:

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -1,9 +1,14 @@
 """Unit tests for provider.py."""
 
+from django.contrib.sites.models import Site
 from mock import Mock, patch
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from third_party_auth import provider
 from third_party_auth.tests import testutil
 import unittest
+
+SITE_DOMAIN_A = 'professionalx.example.com'
+SITE_DOMAIN_B = 'somethingelse.example.com'
 
 
 @unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
@@ -83,6 +88,22 @@ class RegistryTest(testutil.TestCase):
         self.assertNotIn(disabled_provider.provider_id, provider_ids)
         self.assertNotIn(no_log_in_provider.provider_id, provider_ids)
         self.assertIn(normal_provider.provider_id, provider_ids)
+
+    def test_provider_enabled_for_current_site(self):
+        """
+        Verify that enabled_for_current_site returns True when the provider matches the current site.
+        """
+        prov = self.configure_google_provider(visible=True, enabled=True, site=Site.objects.get_current())
+        self.assertEqual(prov.enabled_for_current_site, True)
+
+    @with_site_configuration(SITE_DOMAIN_A)
+    def test_provider_disabled_for_mismatching_site(self):
+        """
+        Verify that enabled_for_current_site returns False when the provider is configured for a different site.
+        """
+        site_b = Site.objects.get_or_create(domain=SITE_DOMAIN_B, name=SITE_DOMAIN_B)[0]
+        prov = self.configure_google_provider(visible=True, enabled=True, site=site_b)
+        self.assertEqual(prov.enabled_for_current_site, False)
 
     def test_get_returns_enabled_provider(self):
         google_provider = self.configure_google_provider(enabled=True)

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -7,6 +7,7 @@ Used by Django and non-Django tests; must not have Django deps.
 from contextlib import contextmanager
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from provider.oauth2.models import Client as OAuth2Client
 from provider import constants
 import django.test
@@ -76,13 +77,17 @@ class ThirdPartyAuthTestMixin(object):
     @staticmethod
     def configure_oauth_provider(**kwargs):
         """ Update the settings for an OAuth2-based third party auth provider """
+        kwargs.setdefault('provider_slug', kwargs['backend_name'])
         obj = OAuth2ProviderConfig(**kwargs)
         obj.save()
         return obj
 
     def configure_saml_provider(self, **kwargs):
         """ Update the settings for a SAML-based third party auth provider """
-        self.assertTrue(SAMLConfiguration.is_enabled(), "SAML Provider Configuration only works if SAML is enabled.")
+        self.assertTrue(
+            SAMLConfiguration.is_enabled(Site.objects.get_current()),
+            "SAML Provider Configuration only works if SAML is enabled."
+        )
         obj = SAMLProviderConfig(**kwargs)
         obj.save()
         return obj

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -36,7 +36,7 @@ def saml_metadata_view(request):
     Get the Service Provider metadata for this edx-platform instance.
     You must send this XML to any Shibboleth Identity Provider that you wish to use.
     """
-    if not SAMLConfiguration.is_enabled():
+    if not SAMLConfiguration.is_enabled(request.site):
         raise Http404
     complete_url = reverse('social:complete', args=("tpa-saml", ))
     if settings.APPEND_SLASH and not complete_url.endswith('/'):

--- a/common/test/db_fixtures/third_party_auth.json
+++ b/common/test/db_fixtures/third_party_auth.json
@@ -10,8 +10,10 @@
       "icon_class": "fa-google-plus",
       "icon_image": null,
       "backend_name": "google-oauth2",
+      "provider_slug": "google-oauth2",
       "key": "test",
       "secret": "test",
+      "site": 2,
       "other_settings": "{}",
       "visible": true
     }
@@ -27,8 +29,10 @@
       "icon_class": "fa-facebook",
       "icon_image": null,
       "backend_name": "facebook",
+      "provider_slug": "facebook",
       "key": "test",
       "secret": "test",
+      "site": 2,
       "other_settings": "{}",
       "visible": true
     }
@@ -44,8 +48,10 @@
       "icon_class": "",
       "icon_image": "test-icon.png",
       "backend_name": "dummy",
+      "provider_slug": "dummy",
       "key": "",
       "secret": "",
+      "site": 2,
       "other_settings": "{}",
       "visible": true
     }

--- a/openedx/core/djangoapps/site_configuration/tests/test_util.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_util.py
@@ -37,7 +37,8 @@ def with_site_configuration(domain="test.localhost", configuration=None):
             with patch('openedx.core.djangoapps.site_configuration.helpers.get_current_site_configuration',
                        return_value=site_configuration):
                 with patch('openedx.core.djangoapps.theming.helpers.get_current_site', return_value=site):
-                    return func(*args, **kwargs)
+                    with patch('django.contrib.sites.models.SiteManager.get_current', return_value=site):
+                        return func(*args, **kwargs)
         return _decorated
     return _decorator
 
@@ -63,4 +64,5 @@ def with_site_configuration_context(domain="test.localhost", configuration=None)
     with patch('openedx.core.djangoapps.site_configuration.helpers.get_current_site_configuration',
                return_value=site_configuration):
         with patch('openedx.core.djangoapps.theming.helpers.get_current_site', return_value=site):
-            yield
+            with patch('django.contrib.sites.models.SiteManager.get_current', return_value=site):
+                yield


### PR DESCRIPTION
This change adds a Site field to the ProviderConfig models and enforces each SSO integration to only work for a specific Site (or no Site if unset).

**JIRA tickets**: Implements [ENT-16](https://openedx.atlassian.net/browse/ENT-16).

**Discussions**: This was initially discussed in the comments of [ENT-13](https://openedx.atlassian.net/browse/ENT-13) and formed into it's own ticket: [ENT-16](https://openedx.atlassian.net/browse/ENT-16).

**Sandbox URL**:

SITE 1: http://pr13474.sandbox.opencraft.hosting/
SITE 2: http://pr13474.sandbox.bdero.me/

**Testing instructions**:
1. Navigate to both [this sandbox login](http://pr13474.sandbox.opencraft.hosting/login) and [this second sandbox login](http://pr13474.sandbox.bdero.me/login) in separate tabs. Notice that they're the same sandbox, but the two URLs are configured to forge different Sites.
   
   Observe that the first Site only shows the normal login screen, while the second one shows a "TestShib College" login.
2. Login using "TestShib College". Observe that it still works.
3. As a superuser, navigate to http://pr13474.sandbox.bdero.me/admin/third_party_auth/samlconfiguration/.
4. Note that the SAML Configuration admin view shows the `Site` and `Update` columns, as well as the filter section (which shows up for keyed models).
   
   ![](http://i.imgur.com/t613Bx5.png)
5. Navigate to http://pr13474.sandbox.opencraft.hosting/auth/saml/metadata.xml and http://pr13474.sandbox.bdero.me/auth/saml/metadata.xml.
   - Observe that the entityID within the EntityDescriptor corresponds with the entityID of the `SAMLConfiguration` models for the different Sites.
   - Observe that the certificates are different.
   - Observe that in both cases, the domain of the URI in the `Location` attribute of `AssertionCustomerService` matches the domain of the current URL.

**Merge deadline**: **9/22/2016**

**Author notes and concerns**:

Making it configurable by site and having only the current Site's login options show up was trivial, but I couldn't find an sane universal way to disable `/auth/login/<backend>` redirects, but users trying to login using the wrong Site's provider shouldn't be able to make it all the way through the login process (and OAuth2/LTI require a matching callback to the referrer).

**Reviewers**
- [x] @e-kolpakov 
- [ ] edX reviewer: @douglashall 

**Settings**

``` yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
  ENABLE_THIRD_PARTY_AUTH: true
```
