### PR TITLE
Don't show error in studio when fetching YouTube metadata fails.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -1,3 +1,4 @@
+/* eslint no-console:0 */
 /**
  * @file Initialize module works with the JSON config, and sets up various
  * settings, parameters, variables. After all setup actions are performed, it
@@ -13,8 +14,8 @@
 (function(requirejs, require, define) {
     define(
 'video/01_initialize.js',
-['video/03_video_player.js', 'video/00_i18n.js', 'moment'],
-function(VideoPlayer, i18n, moment) {
+['video/03_video_player.js', 'video/00_i18n.js', 'moment', 'underscore'],
+function(VideoPlayer, i18n, moment, _) {
     var moment = moment || window.moment;
     /**
      * @function
@@ -698,7 +699,14 @@ function(VideoPlayer, i18n, moment) {
             return $.ajax({
                 url: [this.config.ytMetadataUrl, '?id=', url, '&part=contentDetails&key=', this.config.ytKey].join(''),
                 timeout: this.config.ytTestTimeout,
-                success: _.isFunction(callback) ? callback : null
+                success: _.isFunction(callback) ? callback : null,
+                error: function() {
+                    console.warn(
+                        'YouTube API request failed - usually this means the YouTube API key is invalid. ' +
+                            'Some video metadata may be unavailable.'
+                    );
+                },
+                notifyOnError: false
             });
         } else {
             return $.Deferred().reject().promise();


### PR DESCRIPTION
If the YouTube API key was not set correctly, a very confusing error message ("Studio is having trouble saving your work [object Object]") would pop up in the Studio when loading a unit containing at least one YouTube video.

The YouTube API key is not strictly necessary - YouTube videos continue to work correctly without a valid API key. The only thing that the API key is used for is fetching the length of the video prior to playing the video. Without the API key, the duration of the video is displayed as 0:00. If you start playing the video, the duration gets set to the correct value though.

This simple patch suppresses the error message in the Studio and logs a warning to the JS console instead.

![screen shot 2016-09-15 at 12 13 44](https://cloud.githubusercontent.com/assets/32585/18555090/ce0dece0-7b66-11e6-9e74-72b6f287011a.png)

**JIRA tickets**: https://openedx.atlassian.net/browse/OSPR-1450

**Dependencies**: None

**Sandbox URL**: http://studio-pr13475.sandbox.opencraft.hosting/

**Testing instructions**:
1. Open unit containing a YouTube video in the Studio (for example http://studio-pr13475.sandbox.opencraft.hosting/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@4f6c1b4e316a419ab5b6bf30e6c708e9)
2. Observe that the "Studio is having trouble saving your work [object Object]" is not show, even though the YouTube v3 data API request fails. A warning is logged to the JS console instead:

![screen shot 2016-09-18 at 12 15 46](https://cloud.githubusercontent.com/assets/32585/18614950/b7871b92-7d99-11e6-8436-35cd34a00530.png)

**Reviewers**
- [x] OpenCraft: @itsjeyd
- [ ] edX: @sstack22
