### PR TITLE
Explicit grade values so saved grades are immune to subsection graded

### DIFF
--- a/lms/djangoapps/grades/new/subsection_grade.py
+++ b/lms/djangoapps/grades/new/subsection_grade.py
@@ -11,6 +11,7 @@ from courseware.model_data import ScoresClient
 from lms.djangoapps.grades.scores import get_score, possibly_scored
 from lms.djangoapps.grades.models import BlockRecord, PersistentSubsectionGrade
 from lms.djangoapps.grades.config.models import PersistentGradesEnabledFlag
+from lms.djangoapps.grades.transformer import GradesTransformer
 from student.models import anonymous_id_for_user, User
 from submissions import api as submissions_api
 from traceback import format_exc
@@ -173,7 +174,7 @@ class SubsectionGrade(object):
                 #
                 # Cannot grade a problem with a denominator of 0.
                 # TODO: None > 0 is not python 3 compatible.
-                block_graded = block.graded if possible > 0 else False
+                block_graded = self._get_explicit_graded(block, course_structure) if possible > 0 else False
 
                 self.locations_to_weighted_scores[block.location] = (
                     Score(
@@ -185,6 +186,22 @@ class SubsectionGrade(object):
                     ),
                     weight,
                 )
+
+    def _get_explicit_graded(self, block, course_structure):
+        """
+        Returns the explicit graded field value for the given block
+        """
+        field_value = course_structure.get_transformer_block_field(
+            block.location,
+            GradesTransformer,
+            GradesTransformer.EXPLICIT_GRADED_FIELD_NAME
+        )
+
+        # Set to True if grading is not explicitly disabled for
+        # this block.  This allows us to include the block's score
+        # in the aggregated self.graded_total, regardless of the
+        # inherited graded value from the subsection. (TNL-5560)
+        return True if field_value is None else field_value
 
     def _persisted_model_params(self, student):
         """

--- a/lms/djangoapps/grades/transformer.py
+++ b/lms/djangoapps/grades/transformer.py
@@ -2,10 +2,11 @@
 Grades Transformer
 """
 from django.test.client import RequestFactory
+from functools import reduce as functools_reduce
 
 from courseware.model_data import FieldDataCache
 from courseware.module_render import get_module_for_descriptor
-from lms.djangoapps.course_blocks.transformers.utils import collect_unioned_set_field
+from lms.djangoapps.course_blocks.transformers.utils import collect_unioned_set_field, get_field_on_block
 from openedx.core.lib.block_structure.transformer import BlockStructureTransformer
 from openedx.core.djangoapps.util.user_utils import SystemUser
 
@@ -17,8 +18,8 @@ class GradesTransformer(BlockStructureTransformer):
 
     No runtime transformations are performed.
 
-    The following values are stored as xblock_fields on their respective blocks in the
-    block structure:
+    The following values are stored as xblock_fields on their respective blocks
+    in the block structure:
 
         due: (datetime) when the problem is due.
         format: (string) what type of problem it is
@@ -26,13 +27,15 @@ class GradesTransformer(BlockStructureTransformer):
         has_score: (boolean)
         weight: (numeric)
 
-    Additionally, the following value is calculated and stored as a transformer_block_field
-    for each block:
+    Additionally, the following value is calculated and stored as a
+    transformer_block_field for each block:
 
         max_score: (numeric)
     """
-    VERSION = 3
+    VERSION = 4
     FIELDS_TO_COLLECT = [u'due', u'format', u'graded', u'has_score', u'weight', u'course_version', u'subtree_edited_on']
+
+    EXPLICIT_GRADED_FIELD_NAME = 'explicit_graded'
 
     @classmethod
     def name(cls):
@@ -56,12 +59,51 @@ class GradesTransformer(BlockStructureTransformer):
             merged_field_name='subsections',
             filter_by=lambda block_key: block_key.block_type == 'sequential',
         )
+        cls._collect_explicit_graded(block_structure)
 
     def transform(self, block_structure, usage_context):
         """
         Perform no transformations.
         """
         pass
+
+    @classmethod
+    def _collect_explicit_graded(cls, block_structure):
+        """
+        Collect the 'explicit_graded' field for every block.
+        """
+        def _set_field(block_key, field_value):
+            """
+            Sets the explicit graded field to the given value for the
+            given block.
+            """
+            block_structure.set_transformer_block_field(block_key, cls, cls.EXPLICIT_GRADED_FIELD_NAME, field_value)
+
+        def _get_field(block_key):
+            """
+            Gets the explicit graded field to the given value for the
+            given block.
+            """
+            return block_structure.get_transformer_block_field(block_key, cls, cls.EXPLICIT_GRADED_FIELD_NAME)
+
+        block_types_to_ignore = {'course', 'chapter', 'sequential'}
+
+        for block_key in block_structure.topological_traversal():
+            if block_key.block_type in block_types_to_ignore:
+                _set_field(block_key, None)
+            else:
+                explicit_field_on_block = get_field_on_block(block_structure.get_xblock(block_key), 'graded')
+                if explicit_field_on_block is not None:
+                    _set_field(block_key, explicit_field_on_block)
+                else:
+                    values_from_parents = [
+                        _get_field(parent)
+                        for parent in block_structure.get_parents(block_key)
+                        if parent.block_type not in block_types_to_ignore
+                    ]
+                    non_null_values_from_parents = [value for value in values_from_parents if not None]
+                    explicit_from_parents = functools_reduce(lambda x, y: x or y, non_null_values_from_parents, None)
+                    _set_field(block_key, explicit_from_parents)
 
     @classmethod
     def _collect_max_scores(cls, block_structure):
@@ -83,8 +125,8 @@ class GradesTransformer(BlockStructureTransformer):
     @staticmethod
     def _iter_scorable_xmodules(block_structure):
         """
-        Loop through all the blocks locators in the block structure, and retrieve
-        the module (XModule or XBlock) associated with that locator.
+        Loop through all the blocks locators in the block structure, and
+        retrieve the module (XModule or XBlock) associated with that locator.
 
         For implementation reasons, we need to pull the max_score from the
         XModule, even though the data is not user specific.  Here we bind the


### PR DESCRIPTION
[TNL-5560](https://openedx.atlassian.net/browse/TNL-5560)
### Description
#### Problem

When a subsection's `graded` field value changes from ungraded to graded, we want the aggregated course grade to automatically reflect this change.  Theoretically, as long as the saved subsection's scores are an aggregated computation of its descendants, then its own `graded` designation should not impact this aggregated score.  And so when its own `graded` value changes, it's already computed scores should just be included (or not) in the overall course grade.

However, we had found that when the subsection's scores are computed, the `graded_total` scores didn't include the descendants' scores when the subsection is marked ungraded.  The reason is because the descendants' own `graded` value was being inherited from the subsection's.  
#### Solution

So this PR introduces a new `explicit-graded` field on the block that is computed during the `collect` phase of the `GradesTransformer`.  This new field is then used by the grading code to determine whether to include the block's score in the `graded_total`.

If the block's `graded` field is not explicitly set by any component below the subsection, then we assume that the block's score is included in the grades when calculating `graded_total`.  Then, whenever the course's grade is calculated, the subsection's `graded` value comes into play to determine whether to include its already aggregated `graded_total` in the course's grade.
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @sanfordstudent 
### Post-review
- [ ] Rebase with target branch
- [x] Squash commits
