### PR TITLE
Unifying calls to helper values

### DIFF
--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1105,7 +1105,7 @@ class SubmitPhotosView(View):
 
         subject = _("Verification photos received")
         message = render_to_string('emails/photo_submission_confirmation.txt', context)
-        from_address = configuration_helpers.get_value('default_from_email', settings.DEFAULT_FROM_EMAIL)
+        from_address = configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
         to_address = user.email
 
         try:


### PR DESCRIPTION
### Description

In all the repo code [every time](https://github.com/edx/edx-platform/search?p=2&q=DEFAULT_FROM_EMAIL&utf8=%E2%9C%93) we use the `settings.DEFAULT_FROM_EMAIL` we allow the extension of the value using the sites model by calling `configuration_helpers.get_value`. Only this time we do it with a different key. This PR fixes that.

There is no jira ticket for this, but it would fit into the bit-sized category.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review:
- [ ] Code review:

FYI: Tag anyone who might be interested in this PR here. 

@mattdrayer, @saleem-latif 

I guess you two could be reviewers of this, please check the boxes if you approve it.
