### PR TITLE
Icon updated to use information icon

### DIFF
--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -40,7 +40,7 @@ from openedx.core.djangolib.markup import HTML
     % endif
     % if answer_available:
     <span class="problem-action-button-wrapper">
-        <button class="show problem-action-btn btn-default btn-small" aria-describedby="${ id }-problem-title"><span class="icon fa fa-exclamation-triangle" aria-hidden="true"></span><span class="show-label">${_('Show Answer')}</span></button>
+        <button class="show problem-action-btn btn-default btn-small" aria-describedby="${ id }-problem-title"><span class="icon fa fa-info-circle" aria-hidden="true"></span><span class="show-label">${_('Show Answer')}</span></button>
     </span>
     % endif
     </div>


### PR DESCRIPTION
https://studio-staubina.sandbox.edx.org
### Description

[TNL-5544](https://openedx.atlassian.net/browse/TNL-5544)

Changed the Icon for Show Answer to be more informational.
### Screenshot

<img width="551" alt="screen shot 2016-09-15 at 3 02 29 pm" src="https://cloud.githubusercontent.com/assets/2854941/18563407/85558564-7b55-11e6-9e92-1cbd39f752ff.png">
### Testing
- [x] safecommit shows 0 violations
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @alisan617 
- [x] Code review: @cahrens  
- [x] UX review: @chris-mike 
- [x] Product review: @sstack22 
### Post-review
- [x] Squash commits
