### PR TITLE
Avoid to use an unsupported '/' operand between two unicode strings

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -345,7 +345,7 @@ class Courses(SysadminDashboardView):
         # Try the data dir, then try to find it in the git import dir
         if not gdir.exists():
             git_repo_dir = getattr(settings, 'GIT_REPO_DIR', git_import.DEFAULT_GIT_REPO_DIR)
-            gdir = path(git_repo_dir + "/" + cdir)
+            gdir = path(git_repo_dir) / cdir
             if not gdir.exists():
                 return info
 

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -345,7 +345,7 @@ class Courses(SysadminDashboardView):
         # Try the data dir, then try to find it in the git import dir
         if not gdir.exists():
             git_repo_dir = getattr(settings, 'GIT_REPO_DIR', git_import.DEFAULT_GIT_REPO_DIR)
-            gdir = path(git_repo_dir / cdir)
+            gdir = path(git_repo_dir + "/" + cdir)
             if not gdir.exists():
                 return info
 


### PR DESCRIPTION
This line

`gdir = path(git_repo_dir / cdir)
`

in file:   /edx/app/edxapp/edx-platform/lms/djangoapps/dashboard/sysadmin.py , method git_info_for_course,

yields a 500 CODE error when opening http://0.0.0.0:8000/sysadmin/courses (Courses tab)

Specifically, it throws a TypeError exception:

  unsupported operand type(s) for /: 'unicode' and 'unicode'

This PR fixes that error.
