### PR TITLE
LMS context sensitive help minor fixes

### DIFF
--- a/docs/lms_config.ini
+++ b/docs/lms_config.ini
@@ -17,8 +17,7 @@ pdf_file = open-edx-learner-guide.pdf
 [pages]
 default = index.html
 
-
-instructor = index.html
+instructor = SFD_instructor_dash_help.html
 
 course = index.html
 
@@ -32,10 +31,17 @@ progress = SFD_check_progress.html
 
 learneraccountsettings = sfd_dashboard_profile/SFD_dashboard_settings_profile.html#exploring-the-account-settings-page
 
-learnerdashboard = sfd_dashboard_profile/SFD_dashboard_settings_profile.html#exploring-the-learner-dashboard
+learnerdashboard = sfd_dashboard_profile/SFD_dashboard_settings_profile.html#exploring-the-dashboard
+
+programs = SFD_enrolling.html#programs
 
 bookmarks = SFD_bookmarks.html
 
+notes = SFD_notes.html
+
+wiki = SFD_wiki.html
+
+discussions = sfd_discussions/index.html
 
 # below are the language directory names for the different locales
 [locales]

--- a/lms/djangoapps/discussion/templates/discussion/discussion_board.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_board.html
@@ -5,6 +5,7 @@
 <%page expression_filter="h"/>
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
+<%def name="online_help_token()"><% return "discussions" %></%def>
 <%!
 import json
 from django.utils.translation import ugettext as _

--- a/lms/templates/edxnotes/edxnotes.html
+++ b/lms/templates/edxnotes/edxnotes.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
-
+<%def name="online_help_token()"><% return "notes" %></%def>
 <%!
 from django.utils.translation import ugettext as _
 from edxnotes.helpers import NoteJSONEncoder

--- a/lms/templates/learner_dashboard/programs.html
+++ b/lms/templates/learner_dashboard/programs.html
@@ -4,6 +4,7 @@
 <%page expression_filter="h"/>
 <%inherit file="../main.html" />
 <%namespace name='static' file='../static_content.html'/>
+<%def name="online_help_token()"><% return "programs" %></%def>
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import (


### PR DESCRIPTION
## [DOC-3322](https://openedx.atlassian.net/browse/DOC-3322), [DOC-3323](https://openedx.atlassian.net/browse/DOC-3323), [DOC-3324](https://openedx.atlassian.net/browse/DOC-3324)

Makes the following changes to LMS context sensitive help.
- Corrects the token for the Dashboard/Course list page/Courses tab (DOC-3322)
- Adds more specific links to Programs, Wiki, Discussions, and Notes pages (DOC-3323)
- Updates the instructor token to point to a new, hidden page in the learner's guide that will lead users to relevant Instructor Dashboard topics in the course authors' guide (DOC-3324)
### 9/16/16 12:00 PM

We want to get this into the release for next week.
### Reviewers
- [x] Subject matter expert: @andy-armstrong
- [x] Subject matter expert: @nasthagiri 
- [x] Subject matter expert: @efischer19 
- [x] Doc team review: @edx/doc 
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
