### PR TITLE
SOL-2076: check settings.DEFAULT_SITE_THEME to be not None before applying default theme

### DIFF
--- a/openedx/core/djangoapps/theming/middleware.py
+++ b/openedx/core/djangoapps/theming/middleware.py
@@ -18,5 +18,7 @@ class CurrentSiteThemeMiddleware(object):
         """
         fetch Site Theme for the current site and add it to the request object.
         """
-        default_theme = SiteTheme(site=request.site, theme_dir_name=settings.DEFAULT_SITE_THEME)
+        default_theme = None
+        if settings.DEFAULT_SITE_THEME:
+            default_theme = SiteTheme(site=request.site, theme_dir_name=settings.DEFAULT_SITE_THEME)
         request.site_theme = SiteTheme.get_theme(request.site, default=default_theme)

--- a/openedx/core/djangoapps/theming/tests/test_middleware.py
+++ b/openedx/core/djangoapps/theming/tests/test_middleware.py
@@ -1,0 +1,43 @@
+"""
+    Tests for middleware for comprehensive themes.
+"""
+from mock import Mock
+from django.test import TestCase, override_settings
+from django.contrib.sites.models import Site
+
+from openedx.core.djangoapps.theming.middleware import CurrentSiteThemeMiddleware
+
+
+class TestCurrentSiteThemeMiddlewareLMS(TestCase):
+    """
+    Test theming middleware.
+    """
+    def setUp(self):
+        """
+        Initialize middleware and related objects
+        """
+        super(TestCurrentSiteThemeMiddlewareLMS, self).setUp()
+
+        self.site_theme_middleware = CurrentSiteThemeMiddleware()
+        self.request = Mock()
+        self.request.site, __ = Site.objects.get_or_create(domain="test", name="test")
+        self.request.session = {}
+
+    @override_settings(DEFAULT_SITE_THEME="test-theme")
+    def test_default_site_theme(self):
+        """
+        Test that request.site_theme returns theme defined by DEFAULT_SITE_THEME setting
+        when there is no theme associated with the current site.
+        """
+        self.assertEqual(self.site_theme_middleware.process_request(self.request), None)
+        self.assertIsNotNone(self.request.site_theme)
+        self.assertEqual(self.request.site_theme.theme_dir_name, "test-theme")
+
+    @override_settings(DEFAULT_SITE_THEME=None)
+    def test_default_site_theme_2(self):
+        """
+        Test that request.site_theme returns None when there is no theme associated with
+        the current site and DEFAULT_SITE_THEME is also None.
+        """
+        self.assertEqual(self.site_theme_middleware.process_request(self.request), None)
+        self.assertIsNone(self.request.site_theme)


### PR DESCRIPTION
Hi @mattdrayer , @asadiqbal08 

Kindly take a look at this PR, it removes the condition that causes unnecessary logs to appear on devstack when no default theme is applied.
