### PR TITLE
Fix bug in grade retrieval

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -71,7 +71,7 @@ class ProgressSummary(object):
         if location in self.weighted_scores:
             score = self.weighted_scores[location]
             return score.earned, score.possible
-        children = self.locations_to_children[location]
+        children = self.locations_to_children(location)
         earned = 0.0
         possible = 0.0
         for child in children:

--- a/lms/djangoapps/courseware/tests/test_grades.py
+++ b/lms/djangoapps/courseware/tests/test_grades.py
@@ -226,8 +226,9 @@ class TestProgressSummary(TestCase):
             self.loc_k: [],
             self.loc_m: [],
         }
+        locations_function = lambda location: locations_to_scored_children[location]
         self.progress_summary = ProgressSummary(
-            None, weighted_scores, locations_to_scored_children
+            None, weighted_scores, locations_function
         )
 
     def create_score(self, earned, possible):


### PR DESCRIPTION
self.locations_to_children was updated to be a function rather than a dict,
and this reference to the object was not updated accordingly.

@nasthagiri @nedbat Could you be my reviewers? The bug was introduced in https://github.com/edx/edx-platform/commit/02e6925275eaec386a8acc86a665843c4a0c626b#diff-01ee3bebb0bc1e8d54c64a405a816b43L144, and that code has changed drastically since eucalyptus was cut so there's no need to make this fix against master as well.

@nedbat Also let me know if there's anything else I need to do to get this into the eucalyptus release.

FYI @sambapete @robrap 
