### PR TITLE
Added in the error/gentle_alert notification and the logic to udpate

### DIFF
--- a/common/lib/xmodule/xmodule/js/fixtures/matlabinput_problem.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/matlabinput_problem.html
@@ -1,43 +1,46 @@
 <div class="problem">
-    <div aria-live="polite">
-        <div>
-  <span>
-    <p>
-    <p></p>
-  </span>
-  <span><section id="textbox_test_matlab_plot1_2_1" class="capa_inputtype cminput">
-    <textarea rows="10" cols="80" name="input_i4x-MITx-2_01x-problem-test_matlab_plot1_2_1" aria-describedby="answer_i4x-MITx-2_01x-problem-test_matlab_plot1_2_1" id="input_i4x-MITx-2_01x-problem-test_matlab_plot1_2_1" data-tabsize="4" data-mode="octave" data-linenums="true" style="display: none;">This is the MATLAB input, whatever that may be.</textarea>
+  <div>
+    <span>
+      <section id="textbox_test_matlab_plot1_2_1" class="capa_inputtype cminput">
+        <textarea rows="10" cols="80" name="input_i4x-MITx-2_01x-problem-test_matlab_plot1_2_1"
+                  aria-describedby="answer_i4x-MITx-2_01x-problem-test_matlab_plot1_2_1"
+                  id="input_i4x-MITx-2_01x-problem-test_matlab_plot1_2_1" data-tabsize="4" data-mode="octave"
+                  data-linenums="true" style="display: none;">This is the MATLAB input, whatever that may be.
+        </textarea>
 
-  <div class="grader-status" tabindex="-1">
-      <span id="status_test_matlab_plot1_2_1" class="processing" aria-describedby="input_test_matlab_plot1_2_1">
-          <span class="status sr">processing</span>
-      </span>
-      <span style="display:none;" class="xqueue" id="test_matlab_plot1_2_1">1</span>
+        <div class="grader-status" tabindex="-1">
+          <span id="status_test_matlab_plot1_2_1" class="processing" aria-describedby="input_test_matlab_plot1_2_1">
+              <span class="status sr">processing</span>
+          </span>
+          <span style="display:none;" class="xqueue" id="test_matlab_plot1_2_1">1</span>
+          <p class="debug">processing</p>
+        </div>
+        <span id="answer_test_matlab_plot1_2_1"></span>
 
+        <div class="external-grader-message" aria-live="polite">
+          Submitted. As soon as a response is returned, this message will be replaced by that feedback.
+        </div>
+        <div class="ungraded-matlab-result" aria-live="polite">
+        </div>
 
-    <p class="debug">processing</p>
+        <div class="plot-button">
+          <input type="button" class="save" name="plot-button" id="plot_test_matlab_plot1_2_1" value="Run Code">
+        </div>
+      </section>
+    </span>
   </div>
-
-  <span id="answer_test_matlab_plot1_2_1"></span>
-
-  <div class="external-grader-message" aria-live="polite">
-    Submitted. As soon as a response is returned, this message will be replaced by that feedback.
-  </div>
-  <div class="ungraded-matlab-result" aria-live="polite">
-    
-  </div>
-
-  <div class="plot-button">
-      <input type="button" class="save" name="plot-button" id="plot_test_matlab_plot1_2_1" value="Run Code">
-  </div>
-
-  
-</section></span>
-</div>
-    </div>
   <div class="action">
     <input type="hidden" name="problem_id" value="Plot a straight line">
     <button class="reset" data-value="Reset">Reset<span class="sr"> your answer</span></button>
     <button class="show"><span class="show-label">Show Answer</span> </button>
+  </div>
+
+  <div class="notification warning notification-gentle-alert is-hidden" tabindex="-1">
+    <span class="icon fa fa-exclamation-circle" aria-hidden="true"></span>
+    <span class="notification-message" aria-describedby="title">
+    </span>
+    <div class="notification-btn-wrapper">
+        <button class="btn btn-default btn-small notification-btn review-btn sr">Review</button>
+    </div>
   </div>
 </div>

--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -453,7 +453,7 @@ describe 'Problem', ->
         spyOn($, 'postWithPrefix').and.callFake (url, callback) -> callback(answers: {})
         @problem.show()
         expect(window.SR.readElts).toHaveBeenCalled()
- 
+
       it 'sends the answers when elements to the SR element, answers are strings', ->
         spyOn($, 'postWithPrefix').and.callFake (url, callback) -> callback(answers: '1_1': 'One', '1_2': 'Two')
         @problem.show()
@@ -841,4 +841,4 @@ describe 'Problem', ->
       jasmine.clock().tick(64000)
       expect(@problem.poll.calls.count()).toEqual(6)
 
-      expect($('.capa_alert').text()).toEqual("The grading process is still running. Refresh the page to see updates.")
+      expect($('.notification-gentle-alert .notification-message').text()).toEqual("The grading process is still running. Refresh the page to see updates.")

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -28,7 +28,7 @@ class @Problem
     problem_prefix = @element_id.replace(/problem_/,'')
     @inputs = @$("[id^='input_#{problem_prefix}_']")
     @$('div.action button').click @refreshAnswers
-    @reviewButton = @$('.action .review-btn')
+    @reviewButton = @$('.notification-btn.review-btn')
     @reviewButton.click @scroll_to_problem_meta
     @submitButton = @$('.action .submit')
     @submitButtonLabel = @$('.action .submit .submit-label')
@@ -45,6 +45,7 @@ class @Problem
     @saveNotification = @$('.notification-save')
     @saveButtonLabel = @$('.action .save .save-label')
     @saveButton.click @save
+    @gentleAlertNotification = @$('.notification-gentle-alert')
 
     # Accessibility helper for sighted keyboard users to show <clarification> tooltips on focus:
     @$('.clarification').focus (ev) =>
@@ -373,6 +374,7 @@ class @Problem
           if @el.hasClass 'showed'
             @el.removeClass 'showed'
         else
+          @saveNotification.remove()
           @gentle_alert response.success
       Logger.log 'problem_graded', [@answers, response.contents], @id
 
@@ -443,12 +445,9 @@ class @Problem
         @scroll_to_problem_meta()
 
   gentle_alert: (msg) =>
-    if @el.find('.capa_alert').length
-      @el.find('.capa_alert').remove()
-    alert_elem = "<div class='capa_alert'>" + msg + "</div>"
-    @el.find('.action').after(alert_elem)
-    @el.find('.capa_alert').css(opacity: 0).animate(opacity: 1, 700)
-    window.SR.readElts @el.find('.capa_alert')
+    @el.find('.notification-gentle-alert .notification-message').html(msg)
+    @gentleAlertNotification.show()
+    @gentleAlertNotification.focus()
 
   save: =>
     if not @submit_save_waitfor(@save_internal)

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -3,6 +3,7 @@ Problem Page.
 """
 from bok_choy.page_object import PageObject
 from common.test.acceptance.pages.common.utils import click_css
+from selenium.webdriver.common.keys import Keys
 
 
 class ProblemPage(PageObject):
@@ -151,6 +152,21 @@ class ProblemPage(PageObject):
         self.wait_for(lambda: self.q(css='.notification.warning.notification-save').focused,
                       'Waiting for the focus to be on the save notification')
 
+    def wait_for_gentle_alert_notification(self):
+        """
+        Wait for the Gentle Alert Notification to be present
+        """
+        self.wait_for_element_visibility('.notification.warning.notification-gentle-alert',
+                                         'Waiting for Gentle Alert notification to be visible')
+        self.wait_for(lambda: self.q(css='.notification.warning.notification-gentle-alert').focused,
+                      'Waiting for the focus to be on the gentle alert notification')
+
+    def is_gentle_alert_notification_visible(self):
+        """
+        Is the Gentle Alert Notification visible?
+        """
+        return self.q(css='.notification.warning.notification-gentle-alert').visible
+
     def is_reset_button_present(self):
         """ Check for the presence of the reset button. """
         return self.q(css='.problem .reset').present
@@ -244,6 +260,21 @@ class ProblemPage(PageObject):
             lambda: self.q(css='.notification-hint').focused,
             'Waiting for the focus to be on the hint notification'
         )
+
+    def click_review_in_notification(self):
+        """
+        Click on the "Review" button within the visible notification.
+        """
+        # The review button cannot be clicked on until it is tabbed to, so first tab to it.
+        # Multiple tabs may be required depending on the content (for instance, hints with links).
+        def tab_until_review_focused():
+            """ Tab until the review button is focused """
+            self.browser.switch_to_active_element().send_keys(Keys.TAB)
+            return self.q(css='.notification .review-btn').focused
+
+        self.wait_for(tab_until_review_focused, 'Waiting for the Review button to become focused')
+
+        click_css(self, '.notification .review-btn', require_notification=False)
 
     def get_hint_button_disabled_attr(self):
         """ Return the disabled attribute of all hint buttons (once hints are visible, there will be two). """

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -144,6 +144,10 @@ class ProblemHintTest(ProblemsTest, EventsTestMixin):
         # Now both "hint" buttons should be disabled, as there are no more hints.
         self.assertEqual(['true', 'true'], problem_page.get_hint_button_disabled_attr())
 
+        # Now click on "Review" and make sure the focus goes to the correct place.
+        problem_page.click_review_in_notification()
+        self.assertTrue(problem_page.is_focus_on_problem_meta())
+
         # Check corresponding tracking events
         actual_events = self.wait_for_events(
             event_filter={'event_type': 'edx.problem.hint.demandhint_displayed'},

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -148,6 +148,8 @@ class ProblemTypeTestMixin(object):
         When I answer a "<ProblemType>" problem "correctly"
         Then my "<ProblemType>" answer is marked "correct"
         And The "<ProblemType>" problem displays a "correct" answer
+        And a success notification is shown
+        And clicking on "Review" moves focus to the problem meta area
         And a "problem_check" server event is emitted
         And a "problem_check" browser event is emitted
         """
@@ -162,6 +164,9 @@ class ProblemTypeTestMixin(object):
         self.problem_page.click_submit()
         self.wait_for_status('correct')
         self.problem_page.wait_success_notification()
+        # Check that clicking on "Review" goes to the problem meta location
+        self.problem_page.click_review_in_notification()
+        self.assertTrue(self.problem_page.is_focus_on_problem_meta())
 
         # Check for corresponding tracking event
         expected_events = [
@@ -262,8 +267,9 @@ class ProblemTypeTestMixin(object):
         When I select and answer and click the "Save" button
         Then I should see the Save notification
         And the Save button should not be disabled
+        And clicking on "Review" moves focus to the problem meta area
         And if I change the answer selected
-        And the Save notification should be removed
+        Then the Save notification should be removed
         """
         self.problem_page.wait_for(
             lambda: self.problem_page.problem_name == self.problem_name,
@@ -276,9 +282,13 @@ class ProblemTypeTestMixin(object):
         # Ensure "Save" button is enabled after save is complete.
         self.assertTrue(self.problem_page.is_save_button_enabled())
         self.problem_page.wait_for_save_notification()
-        self.answer_problem(correctness='incorrect')
+        # Check that clicking on "Review" goes to the problem meta location
+        self.problem_page.click_review_in_notification()
+        self.assertTrue(self.problem_page.is_focus_on_problem_meta())
+
+        # Not all problems will detect the change and remove the save notification
         if self.can_update_save_notification:
-            # Not all problems will detect the change and remove the save notification
+            self.answer_problem(correctness='incorrect')
             self.assertFalse(self.problem_page.is_save_notification_visible())
 
     @attr(shard=7)
@@ -647,8 +657,38 @@ class NumericalProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         """
         Answer numerical problem.
         """
-        textvalue = "pi + 1" if correctness == 'correct' else str(random.randint(-2, 2))
+        textvalue = ''
+        if correctness == 'correct':
+            textvalue = "pi + 1"
+        elif correctness == 'error':
+            textvalue = 'notNum'
+        else:
+            textvalue = str(random.randint(-2, 2))
         self.problem_page.fill_answer(textvalue)
+
+    def test_error_input_gentle_alert(self):
+        """
+        Scenario: I can answer a problem with erroneous input and will see a gentle alert
+        Given a Numerical Problem type
+        I can input a string answer
+        Then I will see a Gentle alert notification
+        And focus will shift to that notification
+        And clicking on "Review" moves focus to the problem meta area
+        """
+        # Make sure we're looking at the right problem
+        self.problem_page.wait_for(
+            lambda: self.problem_page.problem_name == self.problem_name,
+            "Make sure the correct problem is on the page"
+        )
+
+        # Answer the problem with an erroneous input to cause a gentle alert
+        self.assertFalse(self.problem_page.is_gentle_alert_notification_visible())
+        self.answer_problem(correctness='error')
+        self.problem_page.click_submit()
+        self.problem_page.wait_for_gentle_alert_notification()
+        # Check that clicking on "Review" goes to the problem meta location
+        self.problem_page.click_review_in_notification()
+        self.assertTrue(self.problem_page.is_focus_on_problem_meta())
 
 
 class FormulaProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -21,7 +21,7 @@ from openedx.core.djangolib.markup import HTML
             <%include file="problem_notifications.html" args="
              notification_name='hint',
              notification_type='hint',
-             notification_icon='question',
+             notification_icon='fa-question',
              notification_message=hint_notification_message,
              should_enable_next_hint=should_enable_next_hint"
            />
@@ -66,12 +66,12 @@ from openedx.core.djangolib.markup import HTML
         ${_("You have used {num_used} of {num_total} attempts").format(num_used=attempts_used, num_total=attempts_allowed)}
     % endif
     </div>
-
+  </div>
     % if answer_notification_type:
         % if 'correct' == answer_notification_type:
             <%include file="problem_notifications.html" args="
                 notification_type='success',
-                notification_icon='check',
+                notification_icon='fa-check',
                 notification_name='submit',
                 notification_message=answer_notification_message"
             />
@@ -79,7 +79,7 @@ from openedx.core.djangolib.markup import HTML
         % if 'incorrect' == answer_notification_type:
             <%include file="problem_notifications.html" args="
                 notification_type='error',
-                notification_icon='close',
+                notification_icon='fa-close',
                 notification_name='submit',
                 notification_message=answer_notification_message"
             />
@@ -87,7 +87,7 @@ from openedx.core.djangolib.markup import HTML
         % if 'partially-correct' == answer_notification_type:
             <%include file="problem_notifications.html" args="
                 notification_type='success',
-                notification_icon='asterisk',
+                notification_icon='fa-asterisk',
                 notification_name='submit',
                 notification_message=answer_notification_message"
             />
@@ -96,11 +96,15 @@ from openedx.core.djangolib.markup import HTML
     % if save_notification_message:
       <%include file="problem_notifications.html" args="
         notification_type='warning',
-        notification_icon='save',
+        notification_icon='fa-save',
         notification_name='save',
         notification_message=save_notification_message"
       />
     % endif
-
-  </div>
+    <%include file="problem_notifications.html" args="
+      notification_type='warning',
+      notification_icon='fa-exclamation-circle',
+      notification_name='gentle-alert',
+      notification_message=''"
+    />
 </div>

--- a/lms/templates/problem_notifications.html
+++ b/lms/templates/problem_notifications.html
@@ -2,14 +2,17 @@
                                    notification_message, should_enable_next_hint"/>
 <%! from django.utils.translation import ugettext as _ %>
 
-<div class="notification ${notification_type} ${'notification-'}${notification_name}"
+<div class="notification ${notification_type} ${'notification-'}${notification_name} ${'is-hidden' if notification_name == 'gentle-alert' else '' }"
      tabindex="-1">
-    <span class="icon fa fa-${notification_icon}" aria-hidden="true"></span>
+    <span class="icon fa ${notification_icon}" aria-hidden="true"></span>
     <span class="notification-message" aria-describedby="${ id }-problem-title">${notification_message}
     </span>
     <div class="notification-btn-wrapper">
         % if notification_name is 'hint':
-        <button class="btn btn-default btn-small notification-btn hint-button" ${'' if should_enable_next_hint else 'disabled'}>${_('Next Hint')}</button>
+        <button class="btn btn-default btn-small notification-btn hint-button"
+                ${'' if should_enable_next_hint else 'disabled'}>
+          ${_('Next Hint')}
+        </button>
         % endif
         <button class="btn btn-default btn-small notification-btn review-btn sr">${_('Review')}</button>
     </div>


### PR DESCRIPTION
TNL-5454
### Description

This PR updates the gentle alert to match the new capa notifications.

[TNL-5454](https://openedx.atlassian.net/browse/TNL-5454)

@chris-mike @sstack22, This is an initial PR for UX review of the new gentle_alert.

@cahrens, @alisan617  This is almost ready for review, I just wanted to do a little clean up and further testing.  I will let you know.
### Screenshot

<img width="867" alt="screen shot 2016-09-16 at 1 33 42 pm" src="https://cloud.githubusercontent.com/assets/2854941/18595548/36f67ef0-7c13-11e6-846b-2d1e70af0836.png">
### Methods of testing
- Use the problem:  Example Week 1: Getting Started > Homework - Question Styles > Mathematical Expressions
- Answer the question something like, asd, and you will receive a gentle-alert.
### Sandbox

https://staubina-icon.sandbox.edx.org/
- [x] Build a sandbox for your branch and add a link here
### Testing
- [x] i18n
- [x] RTL
- [x] safecommit shows 0 violations
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @alisan617 
- [x] Code review: @cahrens 
- [x] UX review: @chris-mike 
- [x] Product review: @sstack22 
### Squash commits
- [x] Squash commits
