### PR TITLE
capa problem text and numerical input field display

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -179,10 +179,14 @@ div.problem {
 
   form > label, .problem-group-label {
     display: block;
-    margin-bottom: 0;
+    margin-bottom: $baseline;
     font: inherit;
     color: inherit;
     -webkit-font-smoothing: initial;
+  }
+
+  .problem-group-label + .question-description {
+    margin-top: -$baseline;
   }
 
 }
@@ -757,11 +761,6 @@ div.problem {
 // ====================
 .problem {
   .capa_inputtype.textline, .inputtype.formulaequationinput {
-
-    label {
-      margin-top: $baseline / 2;
-      display: inline-block;
-    }
 
     input {
       @include box-sizing(border-box);


### PR DESCRIPTION
[TNL-5564](https://openedx.atlassian.net/browse/TNL-5564)
## Description
- Fix the label display with or without description, it should display in a new line.
  (The inconsistency happened when the PR for "problem feedback and explanation specs" work took place while Lahore team was updating the problem markup.)

[Sandbox example](https://alisan617.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/1414ffd5143b4b508f739b563ab468b7/workflow/2?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40vertical_f04afeac0131)
## Testing Checklist
- [x] Manually test responsive behavior.
- [x] Manually test right-to-left behavior.
- [x] Manually test a11y support.
## Reviewers
- [ ] Code review: @cahrens
- [x] Code review: @staubina
