### PR TITLE
HULL-103 Add the course root to the bulk email template context so that templa…

### DIFF
--- a/lms/djangoapps/bulk_email/admin.py
+++ b/lms/djangoapps/bulk_email/admin.py
@@ -36,6 +36,7 @@ two curly braces on each side), to indicate where the email text is to be insert
 Other tags that may be used (surrounded by one curly brace on each side):
 {platform_name}        : the name of the platform
 {course_title}         : the name of the course
+{course_root}          : the URL path to the root of the course
 {course_url}           : the course's full URL
 {email}                : the user's email address
 {account_settings_url} : URL at which users can change account preferences

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -100,13 +100,15 @@ def _get_course_email_context(course):
     course_id = course.id.to_deprecated_string()
     course_title = course.display_name
     course_end_date = get_default_time_display(course.end)
+    course_root = reverse('course_root', kwargs={'course_id': course_id})
     course_url = '{}{}'.format(
         settings.LMS_ROOT_URL,
-        reverse('course_root', kwargs={'course_id': course_id})
+        course_root
     )
     image_url = u'{}{}'.format(settings.LMS_ROOT_URL, course_image_url(course))
     email_context = {
         'course_title': course_title,
+        'course_root': course_root,
         'course_url': course_url,
         'course_image_url': image_url,
         'course_end_date': course_end_date,

--- a/lms/djangoapps/bulk_email/tests/test_tasks.py
+++ b/lms/djangoapps/bulk_email/tests/test_tasks.py
@@ -33,6 +33,7 @@ from django.core.management import call_command
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from bulk_email.models import CourseEmail, Optout, SEND_TO_MYSELF, SEND_TO_STAFF, SEND_TO_LEARNERS
+from bulk_email.tasks import _get_course_email_context
 
 from instructor_task.tasks import send_bulk_course_email
 from instructor_task.subtasks import update_subtask_status, SubtaskStatus
@@ -434,3 +435,14 @@ class TestBulkEmailInstructorTask(InstructorTaskCourseTestCase):
         with patch('bulk_email.tasks.get_connection', autospec=True) as get_conn:
             get_conn.return_value.send_messages.side_effect = cycle([None])
             self._test_run_with_task(send_bulk_course_email, 'emailed', num_emails, num_emails)
+
+    def test_get_course_email_context_has_correct_keys(self):
+        result = _get_course_email_context(self.course)
+        self.assertIn('course_title', result)
+        self.assertIn('course_root', result)
+        self.assertIn('course_url', result)
+        self.assertIn('course_image_url', result)
+        self.assertIn('course_end_date', result)
+        self.assertIn('account_settings_url', result)
+        self.assertIn('email_settings_url', result)
+        self.assertIn('platform_name', result)


### PR DESCRIPTION
…tes can customize the full course URL with a custom hostname.
