### PR TITLE
Fix alignment of "mark as answer button" by adding btn-link class

### DIFF
--- a/common/static/common/templates/discussion/forum-action-answer.underscore
+++ b/common/static/common/templates/discussion/forum-action-answer.underscore
@@ -1,5 +1,5 @@
 <li class="actions-item">
-    <button class="btn action-button action-answer" role="checkbox" aria-checked="false">
+    <button class="btn-link action-button action-answer" role="checkbox" aria-checked="false">
         <span class="sr"><%- gettext("Mark as Answer") %></span>
         <span class="action-label" aria-hidden="true">
             <span class="label-unchecked"><%- gettext("Mark as Answer") %></span>


### PR DESCRIPTION
[TNL-5586](https://openedx.atlassian.net/browse/TNL-5586)

We're hoping to get this into Wednesday's release.

https://bjacobel.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/cba3e4cd91d0466b9ac50926e495b76f/threads/57e169a118bed95391000000
- [x] @andy-armstrong 
- [x] @alisan617 

FYI @Qubad786 @awaisdar001 
