### PR TITLE
AC-586 adding min-height and bg color for contrast

### DIFF
--- a/lms/static/sass/views/_homepage.scss
+++ b/lms/static/sass/views/_homepage.scss
@@ -55,18 +55,20 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
         .learn-more {
           @include left($learn-more-horizontal-position);
           @include box-sizing(border-box);
-          @include line-height(28);
           @extend %ui-depth2;
           position: absolute;
           top: ($baseline*2.75);
-          opacity: 0;
-          border: 3px solid $white;
-          border-radius: 3px;
           padding: 0 $baseline;
           width: ($baseline*10);
           height: ($baseline*2.5);
-          text-align: center;
+          border-color: $uxpl-blue-base;
+          border-radius: 3px;
+          background: $uxpl-blue-base;
           color: $white;
+          line-height: ($baseline*2.5);
+          text-align: center;
+          opacity: 0;
+          text-transform: none;
         }
       }
 
@@ -171,4 +173,3 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
     @include omega(4n);
   }
 }
-


### PR DESCRIPTION
# [AC-586](https://openedx.atlassian.net/browse/AC-586)

This adds a background color to course cards to satisfy automated color contrast checkers. I had to set a `min-height` on the actual image so the background color doesn't show beneath, but this seems to only affect our demo course image, which isn't live. In almost every case, the way the course cards look don't change.

<img width="308" alt="screen shot 2016-09-22 at 1 17 18 pm" src="https://cloud.githubusercontent.com/assets/2112024/18758661/ec6aa01a-80c6-11e6-8c4e-f04a47a8294e.png">
## Sandbox

https://clrux-ac-586.sandbox.edx.org
## Reviewers
- [x] @cptvitamin 
- [x] @marcotuts or @sstack22 
