### PR TITLE
Standardize logged errors

### DIFF
--- a/lms/djangoapps/grades/new/subsection_grade.py
+++ b/lms/djangoapps/grades/new/subsection_grade.py
@@ -33,7 +33,7 @@ def persistence_safe_fallback():
     except DatabaseError:
         # Error deliberately logged, then swallowed. It's assumed that the wrapped code is not guaranteed to succeed.
         # TODO: enqueue a celery task to finish the task asynchronously, see TNL-5471
-        log.warning("Persistent Grades: Persistence Error, falling back.\n{}".format(format_exc()))
+        log.warning("Persistent Grades: database_error.safe_fallback.\n{}".format(format_exc()))
 
 
 class SubsectionGrade(object):
@@ -80,7 +80,7 @@ class SubsectionGrade(object):
                 student, descendant_key, course_structure, scores_client, submissions_scores, persisted_values={},
             )
         self.all_total, self.graded_total = graders.aggregate_scores(self.scores, self.display_name, self.location)
-        self._log_event(log.warning, u"init_from_structure", student)
+        self._log_event(log.info, u"init_from_structure", student)
 
     def init_from_model(self, student, model, course_structure, scores_client, submissions_scores):
         """
@@ -112,7 +112,7 @@ class SubsectionGrade(object):
             section=self.display_name,
             module_id=self.location,
         )
-        self._log_event(log.warning, u"init_from_model", student)
+        self._log_event(log.info, u"init_from_model", student)
 
     @classmethod
     def bulk_create_models(cls, student, subsection_grades, course_key):
@@ -275,7 +275,7 @@ class SubsectionGradeFactory(object):
         If read_only is True, doesn't save any updates to the grades.
         """
         self._log_event(
-            log.warning, u"create, read_only: {0}, subsection: {1}".format(read_only, subsection.location)
+            log.info, u"create, read_only: {0}, subsection: {1}".format(read_only, subsection.location)
         )
 
         block_structure = self._get_block_structure(block_structure)
@@ -298,7 +298,7 @@ class SubsectionGradeFactory(object):
         """
         Bulk creates all the unsaved subsection_grades to this point.
         """
-        self._log_event(log.warning, u"bulk_create_unsaved")
+        self._log_event(log.info, u"bulk_create_unsaved")
 
         with persistence_safe_fallback():
             SubsectionGrade.bulk_create_models(self.student, self._unsaved_subsection_grades, self.course.id)

--- a/lms/djangoapps/grades/scores.py
+++ b/lms/djangoapps/grades/scores.py
@@ -89,7 +89,12 @@ def get_score(user, block, scores_client, submissions_scores_cache, weight, poss
         if possible is None:
             possible = score.total
         elif possible != score.total:
-            log.error(u"Persisted Grades: possible value {} != score.total value {}".format(possible, score.total))
+            log.error(
+                u"Persistent Grades: scores.get_score, possible value {} != score.total value {}".format(
+                    possible,
+                    score.total
+                )
+            )
     else:
         # This means we don't have a valid score entry and we don't have a
         # cached_max_score on hand. We know they've earned 0.0 points on this.


### PR DESCRIPTION
For easier consumption by splunk, match the pattern used by other grades-
related log statements.

Report showing grading events: https://splunk.edx.org/en-US/app/search/report?sid=1474392727.423062&s=%2FservicesNS%2Fefischer%2540edx.org%2Fsearch%2Fsaved%2Fsearches%2FRobust%2520Grading%2520Events
Alert for errors: https://splunk.edx.org/en-US/app/search/alert?s=%2FservicesNS%2Fnobody%2Fsearch%2Fsaved%2Fsearches%2FRobust%2520Grades%2520Errors

FYI @nasthagiri @jcdyer @sanfordstudent 
