### PR TITLE
Remove outdated comment

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/delete_course.py
+++ b/cms/djangoapps/contentstore/management/commands/delete_course.py
@@ -3,7 +3,6 @@
 
     Arguments:
         arg1 (str): Course key of the course to delete
-        arg2 (str): 'commit'
 
     Returns:
         none


### PR DESCRIPTION
The `commit` argument had already been removed from code [1][2][3],
prompted by the django18 upgrade.

[1] https://github.com/edx/edx-platform/pull/10927
[2] 07f015bb570ef5d0cad5cafc15353f3843bf4523
[3] a4006c86043ded7582f4902ae6377112ed7338a5
