### PR TITLE
Bok choy test coverage for "Review" button

### DIFF
--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -3,6 +3,7 @@ Problem Page.
 """
 from bok_choy.page_object import PageObject
 from common.test.acceptance.pages.common.utils import click_css
+from selenium.webdriver.common.keys import Keys
 
 
 class ProblemPage(PageObject):
@@ -253,6 +254,21 @@ class ProblemPage(PageObject):
             lambda: self.q(css='.notification-hint').focused,
             'Waiting for the focus to be on the hint notification'
         )
+
+    def click_review_in_notification(self):
+        """
+        Click on the "Review" button within the visible notification.
+        """
+        # The review button cannot be clicked on until it is tabbed to, so first tab to it.
+        # Multiple tabs may be required depending on the content (for instance, hints with links).
+        def tab_until_review_focused():
+            """ Tab until the review button is focused """
+            self.browser.switch_to_active_element().send_keys(Keys.TAB)
+            return self.q(css='.notification .review-btn').focused
+
+        self.wait_for(tab_until_review_focused, 'Waiting for the Review button to become focused')
+
+        click_css(self, '.notification .review-btn', require_notification=False)
 
     def get_hint_button_disabled_attr(self):
         """ Return the disabled attribute of all hint buttons (once hints are visible, there will be two). """

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -144,6 +144,10 @@ class ProblemHintTest(ProblemsTest, EventsTestMixin):
         # Now both "hint" buttons should be disabled, as there are no more hints.
         self.assertEqual(['true', 'true'], problem_page.get_hint_button_disabled_attr())
 
+        # Now click on "Review" and make sure the focus goes to the correct place.
+        problem_page.click_review_in_notification()
+        self.assertTrue(problem_page.is_focus_on_problem_meta())
+
         # Check corresponding tracking events
         actual_events = self.wait_for_events(
             event_filter={'event_type': 'edx.problem.hint.demandhint_displayed'},

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -148,6 +148,8 @@ class ProblemTypeTestMixin(object):
         When I answer a "<ProblemType>" problem "correctly"
         Then my "<ProblemType>" answer is marked "correct"
         And The "<ProblemType>" problem displays a "correct" answer
+        And a success notification is shown
+        And clicking on "Review" moves focus to the problem meta area
         And a "problem_check" server event is emitted
         And a "problem_check" browser event is emitted
         """
@@ -162,6 +164,9 @@ class ProblemTypeTestMixin(object):
         self.problem_page.click_submit()
         self.wait_for_status('correct')
         self.problem_page.wait_success_notification()
+        # Check that clicking on "Review" goes to the problem meta location
+        self.problem_page.click_review_in_notification()
+        self.assertTrue(self.problem_page.is_focus_on_problem_meta())
 
         # Check for corresponding tracking event
         expected_events = [
@@ -262,8 +267,9 @@ class ProblemTypeTestMixin(object):
         When I select and answer and click the "Save" button
         Then I should see the Save notification
         And the Save button should not be disabled
+        And clicking on "Review" moves focus to the problem meta area
         And if I change the answer selected
-        And the Save notification should be removed
+        Then the Save notification should be removed
         """
         self.problem_page.wait_for(
             lambda: self.problem_page.problem_name == self.problem_name,
@@ -276,9 +282,13 @@ class ProblemTypeTestMixin(object):
         # Ensure "Save" button is enabled after save is complete.
         self.assertTrue(self.problem_page.is_save_button_enabled())
         self.problem_page.wait_for_save_notification()
-        self.answer_problem(correctness='incorrect')
+        # Check that clicking on "Review" goes to the problem meta location
+        self.problem_page.click_review_in_notification()
+        self.assertTrue(self.problem_page.is_focus_on_problem_meta())
+
+        # Not all problems will detect the change and remove the save notification
         if self.can_update_save_notification:
-            # Not all problems will detect the change and remove the save notification
+            self.answer_problem(correctness='incorrect')
             self.assertFalse(self.problem_page.is_save_notification_visible())
 
     @attr(shard=7)
@@ -663,6 +673,7 @@ class NumericalProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         I can input a string answer
         Then I will see a Gentle alert notification
         And focus will shift to that notification
+        And clicking on "Review" moves focus to the problem meta area
         """
         # Make sure we're looking at the right problem
         self.problem_page.wait_for(
@@ -674,6 +685,9 @@ class NumericalProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         self.answer_problem(correctness='error')
         self.problem_page.click_submit()
         self.problem_page.wait_for_gentle_alert_notification()
+        # Check that clicking on "Review" goes to the problem meta location
+        self.problem_page.click_review_in_notification()
+        self.assertTrue(self.problem_page.is_focus_on_problem_meta())
 
 
 class FormulaProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):


### PR DESCRIPTION
## [TNL-5567](https://openedx.atlassian.net/browse/TNL-5567)
### Description

Add coverage for the "Review" button on notifications. I didn't cover every variation of notifications, but did get most of them.

I think we only need a single code reviewer on this.
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @staubina 

FYI: @alisan617 
### Post-review
- [x] Rebase and squash commits
