### PR TITLE
Fix 'makemigrations' and 'migrate' commands

### DIFF
--- a/common/djangoapps/course_modes/migrations/0001_initial.py
+++ b/common/djangoapps/course_modes/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
                 ('mode_display_name', models.CharField(max_length=255, verbose_name='Display Name')),
                 ('min_price', models.IntegerField(default=0, verbose_name='Price')),
                 ('currency', models.CharField(default=b'usd', max_length=8)),
-                ('expiration_datetime', models.DateTimeField(default=None, help_text='OPTIONAL: After this date/time, users will no longer be able to enroll in this mode. Leave this blank if users can enroll in this mode until enrollment closes for the course.', null=True, verbose_name='Upgrade Deadline', blank=True)),
+                ('_expiration_datetime', models.DateTimeField(db_column=b'expiration_datetime', default=None, help_text='OPTIONAL: After this date/time, users will no longer be able to enroll in this mode. Leave this blank if users can enroll in this mode until enrollment closes for the course.', null=True, verbose_name='Upgrade Deadline', blank=True)),
                 ('expiration_date', models.DateField(default=None, null=True, blank=True)),
                 ('suggested_prices', models.CommaSeparatedIntegerField(default=b'', max_length=255, blank=True)),
                 ('description', models.TextField(null=True, blank=True)),

--- a/lms/djangoapps/shoppingcart/migrations/0002_auto_20151208_1034.py
+++ b/lms/djangoapps/shoppingcart/migrations/0002_auto_20151208_1034.py
@@ -14,11 +14,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='courseregcodeitem',
             name='mode',
-            field=models.SlugField(default=b'audit'),
+            field=models.SlugField(default=b'honor'),
         ),
         migrations.AlterField(
             model_name='paidcourseregistration',
             name='mode',
-            field=models.SlugField(default=b'audit'),
+            field=models.SlugField(default=b'honor'),
         ),
     ]


### PR DESCRIPTION
The 'migrate' command complains about "model changes that are not yet
reflected in a migration" and suggests to run "makemigrations". On the
other hand the 'makemigrations' command (mistakenly) generates 2
new migrations that should not really exist.

Two model changes caused this issue:

1) The expiration_datetime field of the CourseMode model from the
course_modes app has been renamed to _expiration_datetime, but kept
inside the "expiration_datetime" column. Thus, this change affects the
model class, but not the SQL structure. It confuses django which
proposes to create a migration that drops the expiration_datetime
column and recreates it. We resolve this issue by making sure the
initial migration and the model agree.

2) The default value of the "mode" field from the CourseRegCodeItem
model has been changed from 'audit' to 'honor'. Again, this change only
affect the model class, but not the SQL structure. Since the "mode"
field was created in the 0002 migration, we only need to patch this
migration to make sure the migration files and the model agree.

Note that this patch does not require users to re-run migrations.
