### PR TITLE
Remove invalid selector

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -239,11 +239,6 @@ div.problem {
   input[type="checkbox"] {
     @include margin(($baseline/4) ($baseline/2) ($baseline/4) ($baseline/4));
   }
-
-  text {
-    @include margin-left(25px);
-    display: inline;
-  }
 }
 
 // +Problem - Choice Group


### PR DESCRIPTION
Simple removing a selector that is not used by sass and not part of CSS. 
