### PR TITLE
Allows ChoiceResponse problems to set correctness with python variables

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -851,31 +851,30 @@ class ChoiceResponse(LoncapaResponse):
     def setup_response(self):
         self.assign_choice_names()
 
-        correct_xml = self.xml.xpath(
-            '//*[@id=$id]//choice[@correct="true"]',
-            id=self.xml.get('id')
-        )
+        self.correct_choices = set()
+        self.incorrect_choices = set()
+        for choice in self.get_choices():
 
-        self.correct_choices = set([
-            choice.get('name') for choice in correct_xml
-        ])
+            # contextualize the name and correct attributes
+            name = contextualize_text(choice.get('name'), self.context)
+            correct = contextualize_text(choice.get('correct'), self.context).upper()
 
-        incorrect_xml = self.xml.xpath(
-            '//*[@id=$id]//choice[@correct="false"]',
-            id=self.xml.get('id')
-        )
+            # divide choices into correct and incorrect
+            if correct == 'TRUE':
+                self.correct_choices.add(name)
+            elif correct == 'FALSE':
+                self.incorrect_choices.add(name)
 
-        self.incorrect_choices = set([
-            choice.get('name') for choice in incorrect_xml
-        ])
+    def get_choices(self):
+        """Returns this response's XML choice elements."""
+        return self.xml.xpath('//*[@id=$id]//choice', id=self.xml.get('id'))
 
     def assign_choice_names(self):
         """
         Initialize name attributes in <choice> tags for this response.
         """
 
-        for index, choice in enumerate(self.xml.xpath('//*[@id=$id]//choice',
-                                                      id=self.xml.get('id'))):
+        for index, choice in enumerate(self.get_choices()):
             choice.set("name", "choice_" + str(index))
             # If a choice does not have an id, assign 'A' 'B', .. used by CompoundHint
             if not choice.get('id'):

--- a/common/lib/capa/capa/tests/response_xml_factory.py
+++ b/common/lib/capa/capa/tests/response_xml_factory.py
@@ -172,6 +172,8 @@ class ResponseXMLFactory(object):
                 correctness = 'false'
             elif 'partial' in correct_val:
                 correctness = 'partial'
+            else:
+                correctness = correct_val
 
             choice_element.set('correct', correctness)
 


### PR DESCRIPTION
**Desired Deployment Date: 2016-10-31**

Allows ChoiceResponse CAPA problems to use script-computed variables to determine a choice's correctness, as MultipleChoiceResponse problems already do.

Adds a unit test for this change, and for the existing MultipleChoiceResponse computed correctness capability.

See related [edx-documentation/PR #1282](https://github.com/edx/edx-documentation/pull/1282).

**Sandbox URL**:
- LMS: http://pr13534.sandbox.opencraft.hosting/
- Studio: http://studio-pr13534.sandbox.opencraft.hosting/

See [ChoiceResponse Correctness Test Course](http://pr13534.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+CR101x+2016/courseware/5566acad60cf4d9a84dbcd92ffcda2d0/87e8a1dad9c34c45b480a8d9fd1befd2/).

**Testing instructions**:
1. In Studio, add a Checkbox Problem with the following Advanced XML:
   
   ```
   <problem>
   <script type="text/python">
   <![CDATA[
   random.seed(anonymous_student_id)  # Use different random numbers for each student.
   a = random.randint(1,10)
   b = random.randint(1,10)
   c = a + b
   
   ok0 = c % 2 == 0 # check remainder modulo 2
   text0 = "$a + $b is divisible by 2"
   
   ok1 = c % 3 == 0 # check remainder modulo 3
   text1 = "$a + $b is divisible by 3"
   
   ok2 = c % 5 == 0 # check remainder modulo 5
   text2 = "$a + $b is divisible by 5"
   
   ok3 = not any([ok0, ok1, ok2])
   text3 = "None of the above statements is true."
   ]]>
   </script>
   <p>Which statements about the number $a+$b are true? Select all that apply.</p>
   <choiceresponse>
     <checkboxgroup label="Mark the true statements" direction="vertical">
       <choice correct="$ok0">$text0 ... (should be $ok0)</choice>
       <choice correct="$ok1">$text1 ... (should be $ok1)</choice>
       <choice correct="$ok2">$text2 ... (should be $ok2)</choice>
       <choice correct="$ok3">$text3 ... (should be $ok3)</choice>
     </checkboxgroup>
   </choiceresponse>
   
   <p><strong>Comment:</strong> In the <code>choice</code> tags for this problem, both the <code>correct</code> attribute and tag content are set set using Python.</p>
   </problem>
   ```
2. Ensure that the choice content and "correctness" for each choice has been correctly set for the dynamically generated number values.

**Reviewers**
- [x] @itsjeyd 
- [x] @staubina 
