### PR TITLE
Prevent url.min.js from being loaded outside a bundle

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1688,7 +1688,6 @@ REQUIRE_JS_PATH_OVERRIDES = {
     'js/bookmarks/views/bookmark_button': 'js/bookmarks/views/bookmark_button.js',
     'js/views/message_banner': 'js/views/message_banner.js',
     'moment': 'js/vendor/moment-with-locales.min.js',
-    'jquery.url': 'js/vendor/url.min.js',
     'js/courseware/course_home_events': 'js/courseware/course_home_events.js',
     'js/courseware/accordion_events': 'js/courseware/accordion_events.js',
     'js/courseware/link_clicked_events': 'js/courseware/link_clicked_events.js',

--- a/lms/static/lms/js/require-config.js
+++ b/lms/static/lms/js/require-config.js
@@ -40,6 +40,7 @@
         defineDependency('gettext', 'gettext');
         defineDependency('Logger', 'logger');
         defineDependency('URI', 'URI');
+        defineDependency('jQuery.url', 'jquery.url');
         defineDependency('Backbone', 'backbone');
 
         // Add the UI Toolkit helper classes that have been installed in the 'edx' namespace


### PR DESCRIPTION
## [TNL-4888](https://openedx.atlassian.net/browse/TNL-4888)
### Description

url.min.js was being loaded twice on some pages (login being one), which was creating performance issues. It is now loaded only inside the bundle, using RequireJS.
### Sandbox
- [x] https://url-min.sandbox.edx.org/login (verify url.min.js is not loaded standalone and that the string `window.url=function(){` occurs only in `lms-base-vendor.[hash].js`)
### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit violation code review process
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @andy-armstrong 
- [ ] @ormsbee 
### Post-review
- [ ] Rebase and squash commits
