### PR TITLE
JER-161 Fix marketing link key typo

### DIFF
--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -807,7 +807,7 @@ class RegistrationView(APIView):
         # Translators: This is a legal document users must agree to
         # in order to register a new account.
         terms_label = _(u"Terms of Service")
-        terms_link = marketing_link("TIS")
+        terms_link = marketing_link("TOS")
         terms_text = _(u"Review the Terms of Service")
 
         # Translators: "Terms of service" is a legal document users must agree to


### PR DESCRIPTION
This typo breaks the registration page TOS links on the MITPE and HXPLUS WL sites.

https://mitprofessionalx.mit.edu/register
https://courses.harvardxplus.harvard.edu/register

@clrux Please review.

Related to https://github.com/edx/edx-platform/pull/13386.
