### PR TITLE
Moving CAPA a11y ignore rules to relevant problem types.

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -46,6 +46,7 @@ ACCESSIBLE_CAPA_INPUT_TYPES = [
     'optioninput',
     'textline',
     'formulaequationinput',
+    'textbox',
 ]
 
 # these get captured as student responses

--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -818,8 +818,17 @@ class CodeInput(InputTypeBase):
         self.setup_code_response_rendering()
 
     def _extra_context(self):
-        """Defined queue_len, add it """
-        return {'queue_len': self.queue_len, }
+        """
+        Define queue_len, arial_label and code mirror exit message context variables
+        """
+        _ = self.capa_system.i18n.ugettext
+        return {
+            'queue_len': self.queue_len,
+            'aria_label': _('{programming_language} editor').format(
+                programming_language=self.loaded_attributes.get('mode')
+            ),
+            'code_mirror_exit_message': _('Press ESC then TAB or click outside of the code editor to exit')
+        }
 
 
 #-----------------------------------------------------------------------------

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -262,7 +262,12 @@ class LoncapaResponse(object):
         tree = etree.Element('section')
         tree.set('class', 'wrapper-problem-response')
         tree.set('tabindex', '-1')
-        tree.set('aria-label', response_label)
+        # tree.set('aria-labelledby', '{id}-problem-title question-title'.format(id=self.xml.get('id')))
+
+        section_heading = etree.SubElement(tree, 'h4')
+        section_heading.set('id', 'question-title')
+        section_heading.set('class', 'sr')
+        section_heading.set('value', response_label)
 
         if self.xml.get('multiple_inputtypes'):
             # add <div> to wrap all inputtypes

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -264,11 +264,11 @@ class LoncapaResponse(object):
         tree.set('tabindex', '-1')
         # tree.set('aria-labelledby', '{id}-problem-title question-title'.format(id=self.xml.get('id')))
 
-        # question title for screen readers
+        # question index for screen readers
         section_heading = etree.SubElement(tree, 'h4')
-        section_heading.set('id', '{id}-question-title'.format(id=self.xml.get('id')))
+        section_heading.set('id', u'{id}-question-title'.format(id=self.xml.get('id')))
         section_heading.set('class', 'sr')
-        section_heading.set('value', response_label)
+        section_heading.text = response_label
 
         if self.xml.get('multiple_inputtypes'):
             # add <div> to wrap all inputtypes

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -255,7 +255,8 @@ class LoncapaResponse(object):
 
         # response_id = problem_id + response index
         response_id = self.xml.attrib['id']
-        problem_id, response_index = response_id.rsplit('_', 1)
+
+        response_index = response_id.split('_')[-1]
         # Translators: index here could be 1,2,3 and so on
         response_label = _(u'Question {index}').format(index=response_index)
 
@@ -263,17 +264,8 @@ class LoncapaResponse(object):
         tree = etree.Element('div')
         tree.set('class', 'wrapper-problem-response')
         tree.set('tabindex', '-1')
+        tree.set('aria-label', response_label)
         tree.set('role', 'group')
-        tree.set('aria-labelledby', u'{problem_id}-problem-title {response_id}-question-index'.format(
-            problem_id=problem_id,
-            response_id=response_id
-        ))
-
-        # question index for screen readers
-        section_heading = etree.SubElement(tree, 'h4')
-        section_heading.set('id', u'{response_id}-question-index'.format(response_id=response_id))
-        section_heading.set('class', 'sr')
-        section_heading.text = response_label
 
         if self.xml.get('multiple_inputtypes'):
             # add <div> to wrap all inputtypes

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -260,9 +260,10 @@ class LoncapaResponse(object):
         response_label = _(u'Question {index}').format(index=response_index)
 
         # wrap the content inside a section
-        tree = etree.Element('section')
+        tree = etree.Element('div')
         tree.set('class', 'wrapper-problem-response')
         tree.set('tabindex', '-1')
+        tree.set('role', 'group')
         tree.set('aria-labelledby', u'{problem_id}-problem-title {response_id}-question-index'.format(
             problem_id=problem_id,
             response_id=response_id

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -253,8 +253,10 @@ class LoncapaResponse(object):
         """
         _ = self.capa_system.i18n.ugettext
 
-        # get responsetype index to make responsetype label
-        response_index = self.xml.attrib['id'].split('_')[-1]
+        # response_id = problem_id + response index
+        response_id = self.xml.attrib['id']
+        problem_id = response_id.split('_')[0]
+        response_index = response_id.split('_')[-1]
         # Translators: index here could be 1,2,3 and so on
         response_label = _(u'Question {index}').format(index=response_index)
 
@@ -262,11 +264,14 @@ class LoncapaResponse(object):
         tree = etree.Element('section')
         tree.set('class', 'wrapper-problem-response')
         tree.set('tabindex', '-1')
-        # tree.set('aria-labelledby', '{id}-problem-title question-title'.format(id=self.xml.get('id')))
+        tree.set('aria-labelledby', u'{problem_id}-problem-title {response_id}-question-index'.format(
+            problem_id=problem_id,
+            response_id=response_id
+        ))
 
         # question index for screen readers
         section_heading = etree.SubElement(tree, 'h4')
-        section_heading.set('id', u'{id}-question-title'.format(id=self.xml.get('id')))
+        section_heading.set('id', u'{response_id}-question-index'.format(response_id=response_id))
         section_heading.set('class', 'sr')
         section_heading.text = response_label
 
@@ -275,7 +280,7 @@ class LoncapaResponse(object):
             content = etree.SubElement(tree, 'div')
             content.set('class', 'multi-inputs-group')
             content.set('role', 'group')
-            content.set('aria-labelledby', self.xml.get('id'))
+            content.set('aria-labelledby', response_id)
         else:
             content = tree
 

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -264,8 +264,9 @@ class LoncapaResponse(object):
         tree.set('tabindex', '-1')
         # tree.set('aria-labelledby', '{id}-problem-title question-title'.format(id=self.xml.get('id')))
 
+        # question title for screen readers
         section_heading = etree.SubElement(tree, 'h4')
-        section_heading.set('id', 'question-title')
+        section_heading.set('id', '{id}-question-title'.format(id=self.xml.get('id')))
         section_heading.set('class', 'sr')
         section_heading.set('value', response_label)
 

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -255,8 +255,7 @@ class LoncapaResponse(object):
 
         # response_id = problem_id + response index
         response_id = self.xml.attrib['id']
-        problem_id = response_id.split('_')[0]
-        response_index = response_id.split('_')[-1]
+        problem_id, response_index = response_id.rsplit('_', 1)
         # Translators: index here could be 1,2,3 and so on
         response_label = _(u'Question {index}').format(index=response_index)
 

--- a/common/lib/capa/capa/templates/codeinput.html
+++ b/common/lib/capa/capa/templates/codeinput.html
@@ -1,12 +1,16 @@
+<%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML
 %>
-<section id="textbox_${id}" class="capa_inputtype textbox cminput">
-  <textarea rows="${rows}" cols="${cols}" name="input_${id}" 
-            aria-label="${_("{programming_language} editor").format(programming_language=mode)}" 
-            aria-describedby="answer_${id}" 
-            id="input_${id}" 
+<div id="textbox_${id}" class="capa_inputtype textbox cminput">
+  % if response_data['label']:
+      <label class="problem-group-label" for="cm-textarea-${id}">${response_data['label']}</label>
+  % endif
+  <textarea rows="${rows}" cols="${cols}" name="input_${id}"
+            aria-label="${aria_label}"
+            aria-describedby="answer_${id}"
+            id="input_${id}"
             tabindex="0"
             data-mode="${mode}"
             data-tabsize="${tabsize}"
@@ -16,7 +20,10 @@ from openedx.core.djangolib.markup import HTML
             % if hidden:
       	    style="display:none;"
             % endif
-  >${value|h}</textarea>
+  >${value}</textarea>
+  <span class="cm-editor-exit-message capa-message" id="cm-editor-exit-message-${id}">
+    ${code_mirror_exit_message}
+  </span>
 
   <div class="grader-status" tabindex="-1">
       <span id="status_${id}"
@@ -41,4 +48,4 @@ from openedx.core.djangolib.markup import HTML
   <div class="external-grader-message">
     ${HTML(msg)}
   </div>
-</section>
+</div>

--- a/common/lib/capa/capa/tests/helpers.py
+++ b/common/lib/capa/capa/tests/helpers.py
@@ -90,10 +90,10 @@ def mock_capa_module():
     return capa_module
 
 
-def new_loncapa_problem(xml, capa_system=None, seed=723, use_capa_render_template=False):
+def new_loncapa_problem(xml, problem_id='1', capa_system=None, seed=723, use_capa_render_template=False):
     """Construct a `LoncapaProblem` suitable for unit tests."""
     render_template = capa_render_template if use_capa_render_template else None
-    return LoncapaProblem(xml, id='1', seed=seed, capa_system=capa_system or test_capa_system(render_template),
+    return LoncapaProblem(xml, id=problem_id, seed=seed, capa_system=capa_system or test_capa_system(render_template),
                           capa_module=mock_capa_module())
 
 

--- a/common/lib/capa/capa/tests/test_capa_problem.py
+++ b/common/lib/capa/capa/tests/test_capa_problem.py
@@ -473,7 +473,7 @@ class CAPAMultiInputProblemTest(unittest.TestCase):
 
         # verify that only one multi input group div is present at correct path
         multi_inputs_group = html.xpath(
-            '//section[@class="wrapper-problem-response"]/div[@class="multi-inputs-group"]'
+            '//div[@class="wrapper-problem-response"]/div[@class="multi-inputs-group"]'
         )
         self.assertEqual(len(multi_inputs_group), 1)
 

--- a/common/lib/capa/capa/tests/test_html_render.py
+++ b/common/lib/capa/capa/tests/test_html_render.py
@@ -157,6 +157,12 @@ class CapaHtmlRenderTest(unittest.TestCase):
         # question index for screen readers
         self.assertEqual(response_element.find('h4').text, 'Question 1')
 
+        # verifies ids of problem title & question title
+        self.assertEqual(
+            response_element.attrib['aria-labelledby'],
+            '{problem_id}-problem-title {problem_id}_1-question-index'.format(problem_id=problem.problem_id)
+        )
+
         # Expect that the response <section>
         # that contains a <div> for the textline
         textline_element = response_element.find("div")

--- a/common/lib/capa/capa/tests/test_html_render.py
+++ b/common/lib/capa/capa/tests/test_html_render.py
@@ -161,14 +161,8 @@ class CapaHtmlRenderTest(unittest.TestCase):
         # Expect that the response has been turned into a <div> with correct attributes
         response_element = rendered_html.find('div')
 
-        # question index for screen readers
-        self.assertEqual(response_element.find('h4').text, 'Question 1')
-
-        # verifies ids of problem title & question title
-        self.assertEqual(
-            response_element.attrib['aria-labelledby'],
-            '{problem_id}-problem-title {problem_id}_1-question-index'.format(problem_id=problem.problem_id)
-        )
+        self.assertEqual(response_element.tag, "div")
+        self.assertEqual(response_element.attrib["aria-label"], "Question 1")
 
         # Expect that the response div.wrapper-problem-response
         # that contains a <div> for the textline
@@ -213,34 +207,7 @@ class CapaHtmlRenderTest(unittest.TestCase):
             expected_calls
         )
 
-    @ddt.unpack
-    @ddt.data(
-        {'problem_id': '94e85aba088b44b89fdc79cd59a02290'},
-        {'problem_id': 'python_grader'},
-    )
-    def test_problem_id_extracted_correctly(self, problem_id):
-        """
-        Verify that `problem_id` is extracted correctly.
-        """
-        kwargs = {
-            'question_text': "Test question",
-            'explanation_text': "Test explanation",
-            'answer': 'Test answer',
-            'hints': [('test prompt', 'test_hint', 'test hint text')]
-        }
-        xml_str = StringResponseXMLFactory().build_xml(**kwargs)
-
-        # Create the problem and render the HTML
-        problem = new_loncapa_problem(xml_str, problem_id=problem_id, use_capa_render_template=True)
-        rendered_html = etree.XML(problem.get_html())
-        div_element = rendered_html.xpath('//div[@class="wrapper-problem-response"]')[0]
-        self.assertEqual(
-            '{problem_id}-problem-title'.format(problem_id=problem_id) in div_element.attrib.get('aria-labelledby'),
-            True
-        )
-
-    def test_correct_question_index_for_sr(self):
-        """Verify that question index for screen readers is being set correctly"""
+    def test_correct_aria_label(self):
         xml = """
                  <problem>
                      <choiceresponse>
@@ -260,8 +227,8 @@ class CapaHtmlRenderTest(unittest.TestCase):
         problem = new_loncapa_problem(xml)
         rendered_html = etree.XML(problem.get_html())
         response_elements = rendered_html.findall('div')
-        self.assertEqual(response_elements[0].find('h4').text, 'Question 1')
-        self.assertEqual(response_elements[1].find('h4').text, 'Question 2')
+        self.assertEqual(response_elements[0].attrib['aria-label'], 'Question 1')
+        self.assertEqual(response_elements[1].attrib['aria-label'], 'Question 2')
 
     def test_render_response_with_overall_msg(self):
         # CustomResponse script that sets an overall_message

--- a/common/lib/capa/capa/tests/test_html_render.py
+++ b/common/lib/capa/capa/tests/test_html_render.py
@@ -153,8 +153,9 @@ class CapaHtmlRenderTest(unittest.TestCase):
 
         # Expect that the response has been turned into a <section> with correct attributes
         response_element = rendered_html.find("section")
-        self.assertEqual(response_element.tag, "section")
-        self.assertEqual(response_element.attrib["aria-label"], "Question 1")
+
+        # question index for screen readers
+        self.assertEqual(response_element.find('h4').text, 'Question 1')
 
         # Expect that the response <section>
         # that contains a <div> for the textline
@@ -199,7 +200,8 @@ class CapaHtmlRenderTest(unittest.TestCase):
             expected_calls
         )
 
-    def test_correct_aria_label(self):
+    def test_correct_question_index_for_sr(self):
+        """Verify that question index for screen readers is being set correctly"""
         xml = """
                  <problem>
                      <choiceresponse>
@@ -219,8 +221,8 @@ class CapaHtmlRenderTest(unittest.TestCase):
         problem = new_loncapa_problem(xml)
         rendered_html = etree.XML(problem.get_html())
         sections = rendered_html.findall('section')
-        self.assertEqual(sections[0].attrib['aria-label'], 'Question 1')
-        self.assertEqual(sections[1].attrib['aria-label'], 'Question 2')
+        self.assertEqual(sections[0].find('h4').text, 'Question 1')
+        self.assertEqual(sections[1].find('h4').text, 'Question 2')
 
     def test_render_response_with_overall_msg(self):
         # CustomResponse script that sets an overall_message

--- a/common/lib/capa/capa/tests/test_html_render.py
+++ b/common/lib/capa/capa/tests/test_html_render.py
@@ -150,17 +150,16 @@ class CapaHtmlRenderTest(unittest.TestCase):
         # Mock out the template renderer
         the_system = test_capa_system()
         the_system.render_template = mock.Mock()
-        the_system.render_template.return_value = "<div>Input Template Render</div>"
+        the_system.render_template.return_value = "<div class='input-template-render'>Input Template Render</div>"
 
         # Create the problem and render the HTML
         problem = new_loncapa_problem(xml_str, capa_system=the_system)
         rendered_html = etree.XML(problem.get_html())
-
         # Expect problem has been turned into a <div>
         self.assertEqual(rendered_html.tag, "div")
 
-        # Expect that the response has been turned into a <section> with correct attributes
-        response_element = rendered_html.find("section")
+        # Expect that the response has been turned into a <div> with correct attributes
+        response_element = rendered_html.find('div')
 
         # question index for screen readers
         self.assertEqual(response_element.find('h4').text, 'Question 1')
@@ -171,14 +170,14 @@ class CapaHtmlRenderTest(unittest.TestCase):
             '{problem_id}-problem-title {problem_id}_1-question-index'.format(problem_id=problem.problem_id)
         )
 
-        # Expect that the response <section>
+        # Expect that the response div.wrapper-problem-response
         # that contains a <div> for the textline
-        textline_element = response_element.find("div")
+        textline_element = response_element.find('div')
         self.assertEqual(textline_element.text, 'Input Template Render')
 
         # Expect a child <div> for the solution
         # with the rendered template
-        solution_element = rendered_html.find("div")
+        solution_element = rendered_html.xpath('//div[@class="input-template-render"]')[0]
         self.assertEqual(solution_element.text, 'Input Template Render')
 
         # Expect that the template renderer was called with the correct
@@ -234,9 +233,9 @@ class CapaHtmlRenderTest(unittest.TestCase):
         # Create the problem and render the HTML
         problem = new_loncapa_problem(xml_str, problem_id=problem_id, use_capa_render_template=True)
         rendered_html = etree.XML(problem.get_html())
-        section = rendered_html.xpath('//section[@class="wrapper-problem-response"]')[0]
+        div_element = rendered_html.xpath('//div[@class="wrapper-problem-response"]')[0]
         self.assertEqual(
-            '{problem_id}-problem-title'.format(problem_id=problem_id) in section.attrib.get('aria-labelledby'),
+            '{problem_id}-problem-title'.format(problem_id=problem_id) in div_element.attrib.get('aria-labelledby'),
             True
         )
 
@@ -260,9 +259,9 @@ class CapaHtmlRenderTest(unittest.TestCase):
                  """
         problem = new_loncapa_problem(xml)
         rendered_html = etree.XML(problem.get_html())
-        sections = rendered_html.findall('section')
-        self.assertEqual(sections[0].find('h4').text, 'Question 1')
-        self.assertEqual(sections[1].find('h4').text, 'Question 2')
+        response_elements = rendered_html.findall('div')
+        self.assertEqual(response_elements[0].find('h4').text, 'Question 1')
+        self.assertEqual(response_elements[1].find('h4').text, 'Question 2')
 
     def test_render_response_with_overall_msg(self):
         # CustomResponse script that sets an overall_message

--- a/common/lib/capa/capa/tests/test_input_templates.py
+++ b/common/lib/capa/capa/tests/test_input_templates.py
@@ -1181,3 +1181,43 @@ class SchematicInputTemplateTest(TemplateTestCase):
         Verify aria-label attribute rendering.
         """
         self.assert_label(aria_label=True)
+
+
+class CodeinputTemplateTest(TemplateTestCase):
+    """
+    Test mako template for `<textbox>` input
+    """
+
+    TEMPLATE_NAME = 'codeinput.html'
+
+    def setUp(self):
+        super(CodeinputTemplateTest, self).setUp()
+        self.context = {
+            'id': '1',
+            'status': Status('correct'),
+            'mode': 'parrot',
+            'linenumbers': 'false',
+            'rows': '37',
+            'cols': '11',
+            'tabsize': '7',
+            'hidden': '',
+            'msg': '',
+            'value': 'print "good evening"',
+            'aria_label': 'python editor',
+            'code_mirror_exit_message': 'Press ESC then TAB or click outside of the code editor to exit',
+            'response_data': self.RESPONSE_DATA,
+            'describedby': self.DESCRIBEDBY,
+        }
+
+    def test_label(self):
+        """
+        Verify question label is rendered correctly.
+        """
+        self.assert_label(xpath="//label[@class='problem-group-label']")
+
+    def test_editor_exit_message(self):
+        """
+        Verify that editor exit message is rendered.
+        """
+        xml = self.render_to_xml(self.context)
+        self.assert_has_text(xml, '//span[@id="cm-editor-exit-message-1"]', self.context['code_mirror_exit_message'])

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -421,6 +421,8 @@ class CodeInputTest(unittest.TestCase):
             'hidden': '',
             'tabsize': int(tabsize),
             'queue_len': '3',
+            'aria_label': '{mode} editor'.format(mode=mode),
+            'code_mirror_exit_message': 'Press ESC then TAB or click outside of the code editor to exit',
             'response_data': RESPONSE_DATA,
             'describedby_html': DESCRIBEDBY
         }

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -902,6 +902,12 @@ div.problem {
   }
 }
 
+.capa-message {
+  display: inline-block;
+  color: $gray-d1;
+  -webkit-font-smoothing: antialiased;
+}
+
 // +Problem - Actions
 // ====================
 div.problem .action {

--- a/common/lib/xmodule/xmodule/js/fixtures/codeinput_problem.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/codeinput_problem.html
@@ -1,0 +1,21 @@
+<div id="textbox_101" class="capa_inputtype textbox cminput">
+  <label class="problem-group-label" for="cm-textarea-101">question label here</label>
+  <textarea rows="40" cols="80" name="input_101"
+            aria-label="python editor"
+            aria-describedby="answer_101"
+            id="input_101"
+            tabindex="0"
+            data-mode="python"
+            data-tabsize="4"
+            data-linenums="true"
+  >write some awesome code</textarea>
+  <span class="cm-editor-exit-message capa-message" id="cm-editor-exit-message-101">
+    Press ESC then TAB or click outside of the code editor to exit
+  </span>
+
+  <div class="grader-status" tabindex="-1">
+      <span id="status_101" class="correct" aria-describedby="input_101">
+          <span class="status sr">correct</span>
+      </span>
+  </div>
+</div>

--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -848,3 +848,25 @@ describe 'Problem', ->
       expect(@problem.poll.calls.count()).toEqual(6)
 
       expect($('.notification-gentle-alert .notification-message').text()).toEqual("The grading process is still running. Refresh the page to see updates.")
+
+  describe 'codeinput problem', ->
+    codeinputProblemHtml = readFixtures('codeinput_problem.html')
+
+    beforeEach ->
+      spyOn($, 'postWithPrefix').and.callFake (url, callback) ->
+        callback html: codeinputProblemHtml
+      @problem = new Problem($('.xblock-student_view'))
+      @problem.render(codeinputProblemHtml)
+
+    it 'has rendered with correct a11y info', ->
+      CodeMirrorTextArea = $('textarea')[1]
+      CodeMirrorTextAreaId = 'cm-textarea-101'
+
+      # verify that question label has correct `for` attribute value
+      expect($('.problem-group-label').attr('for')).toEqual(CodeMirrorTextAreaId)
+
+      # verify that codemirror textarea has correct `id` attribute value
+      expect($(CodeMirrorTextArea).attr('id')).toEqual(CodeMirrorTextAreaId)
+
+      # verify that codemirror textarea has correct `aria-describedby` attribute value
+      expect($(CodeMirrorTextArea).attr('aria-describedby')).toEqual('cm-editor-exit-message-101 status_101')

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -399,7 +399,7 @@ class @Problem
         labeled_status.push($(element).text())
 
     return labeled_status
-  
+
   reset: =>
     @disableAllButtonsWhileRunning @reset_internal, false
 
@@ -675,7 +675,7 @@ class @Problem
       mode = element.data("mode")
       linenumbers = element.data("linenums")
       spaces = Array(parseInt(tabsize) + 1).join(" ")
-      CodeMirror.fromTextArea element[0], {
+      CodeMirrorEditor = CodeMirror.fromTextArea element[0], {
           lineNumbers: linenumbers
           indentUnit: tabsize
           tabSize: tabsize
@@ -692,7 +692,12 @@ class @Problem
               cm.replaceSelection(spaces, "end")
               return false
           }
-        }
+      }
+      id = element.attr("id").replace(/^input_/, "")
+      CodeMirrorTextArea = CodeMirrorEditor.getInputField()
+      CodeMirrorTextArea.setAttribute("id", "cm-textarea-#{id}")
+      CodeMirrorTextArea.setAttribute("aria-describedby", "cm-editor-exit-message-#{id} status_#{id}")
+      return CodeMirrorEditor
 
   inputtypeShowAnswerMethods:
     choicegroup: (element, display, answers) =>

--- a/common/test/acceptance/pages/lms/staff_view.py
+++ b/common/test/acceptance/pages/lms/staff_view.py
@@ -79,7 +79,7 @@ class StaffDebugPage(PageObject):
     url = None
 
     def is_browser_on_page(self):
-        return self.q(css='section.staff-modal').present
+        return self.q(css='.staff-modal').present
 
     def reset_attempts(self, user=None):
         """

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -561,7 +561,7 @@ class CAPAProblemA11yBaseTestMixin(object):
 
         # Set the scope to the problem question
         problem_page.a11y_audit.config.set_scope(
-            include=['section.wrapper-problem-response']
+            include=['.wrapper-problem-response']
         )
 
         # Run the accessibility audit.

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -826,6 +826,18 @@ class CodeProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         'unanswered': ['.grader-status .unanswered ~ .debug'],
     }
 
+    def setUp(self, *args, **kwargs):
+        """
+        Additional setup for CodeProblemTypeTest
+        """
+        super(CodeProblemTypeTest, self).setUp(*args, **kwargs)
+        self.problem_page.a11y_audit.config.set_rules({
+            'ignore': [
+                'section',  # TODO: AC-491
+                'label',  # TODO: AC-286
+            ]
+        })
+
     def answer_problem(self, correctness):
         """
         Answer code problem.
@@ -1020,6 +1032,18 @@ class SymbolicProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         'incorrect': ['div.capa_inputtype div.incorrect'],
         'unanswered': ['div.capa_inputtype div.unanswered'],
     }
+
+    def setUp(self, *args, **kwargs):
+        """
+        Additional setup for SymbolicProblemTypeTest
+        """
+        super(SymbolicProblemTypeTest, self).setUp(*args, **kwargs)
+        self.problem_page.a11y_audit.config.set_rules({
+            'ignore': [
+                'section',  # TODO: AC-491
+                'label',  # TODO: AC-294
+            ]
+        })
 
     def answer_problem(self, correctness):
         """

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -823,18 +823,6 @@ class CodeProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         'unanswered': ['.grader-status .unanswered ~ .debug'],
     }
 
-    def setUp(self, *args, **kwargs):
-        """
-        Additional setup for CodeProblemTypeTest
-        """
-        super(CodeProblemTypeTest, self).setUp(*args, **kwargs)
-        self.problem_page.a11y_audit.config.set_rules({
-            'ignore': [
-                'section',  # TODO: AC-491
-                'label',  # TODO: AC-286
-            ]
-        })
-
     def answer_problem(self, correctness):
         """
         Answer code problem.

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -371,13 +371,6 @@ class ProblemTypeTestMixin(object):
         self.problem_page.a11y_audit.config.set_scope(
             include=['div#seq_content'])
 
-        self.problem_page.a11y_audit.config.set_rules({
-            "ignore": [
-                'section',  # TODO: AC-491
-                'label',  # TODO: AC-491
-            ]
-        })
-
         # Run the accessibility audit.
         self.problem_page.a11y_audit.check_for_accessibility_errors()
 
@@ -413,6 +406,19 @@ class AnnotationProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         'partially-correct': ['span.partially-correct'],
         'unanswered': ['span.unanswered'],
     }
+
+    def setUp(self, *args, **kwargs):
+        """
+        Additional setup for AnnotationProblemTypeTest
+        """
+        super(AnnotationProblemTypeTest, self).setUp(*args, **kwargs)
+
+        self.problem_page.a11y_audit.config.set_rules({
+            "ignore": [
+                'label',  # TODO: AC-491
+                'section',  # TODO: AC-491
+            ]
+        })
 
     def answer_problem(self, correctness):
         """
@@ -946,6 +952,8 @@ class RadioTextProblemTypeTest(ChoiceTextProbelmTypeTestBase, ProblemTypeTestMix
         self.problem_page.a11y_audit.config.set_rules({
             "ignore": [
                 'radiogroup',  # TODO: AC-491
+                'label',  # TODO: AC-491
+                'section',  # TODO: AC-491
             ]
         })
 
@@ -979,6 +987,8 @@ class CheckboxTextProblemTypeTest(ChoiceTextProbelmTypeTestBase, ProblemTypeTest
         self.problem_page.a11y_audit.config.set_rules({
             "ignore": [
                 'checkboxgroup',  # TODO: AC-491
+                'label',  # TODO: AC-491
+                'section',  # TODO: AC-491
             ]
         })
 

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -373,8 +373,6 @@ class ProblemTypeTestMixin(object):
 
         self.problem_page.a11y_audit.config.set_rules({
             "ignore": [
-                'checkboxgroup',  # TODO: AC-491
-                'radiogroup',  # TODO: AC-491
                 'section',  # TODO: AC-491
                 'label',  # TODO: AC-491
             ]
@@ -415,12 +413,6 @@ class AnnotationProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         'partially-correct': ['span.partially-correct'],
         'unanswered': ['span.unanswered'],
     }
-
-    def setUp(self, *args, **kwargs):
-        """
-        Additional setup for AnnotationProblemTypeTest
-        """
-        super(AnnotationProblemTypeTest, self).setUp(*args, **kwargs)
 
     def answer_problem(self, correctness):
         """
@@ -951,6 +943,12 @@ class RadioTextProblemTypeTest(ChoiceTextProbelmTypeTestBase, ProblemTypeTestMix
         """
         super(RadioTextProblemTypeTest, self).setUp(*args, **kwargs)
 
+        self.problem_page.a11y_audit.config.set_rules({
+            "ignore": [
+                'radiogroup',  # TODO: AC-491
+            ]
+        })
+
 
 class CheckboxTextProblemTypeTest(ChoiceTextProbelmTypeTestBase, ProblemTypeTestMixin):
     """
@@ -977,6 +975,12 @@ class CheckboxTextProblemTypeTest(ChoiceTextProbelmTypeTestBase, ProblemTypeTest
         Additional setup for CheckboxTextProblemTypeTest
         """
         super(CheckboxTextProblemTypeTest, self).setUp(*args, **kwargs)
+
+        self.problem_page.a11y_audit.config.set_rules({
+            "ignore": [
+                'checkboxgroup',  # TODO: AC-491
+            ]
+        })
 
 
 class ImageProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -416,7 +416,6 @@ class AnnotationProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         self.problem_page.a11y_audit.config.set_rules({
             "ignore": [
                 'label',  # TODO: AC-491
-                'section',  # TODO: AC-491
             ]
         })
 
@@ -1046,18 +1045,6 @@ class SymbolicProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
         'incorrect': ['div.capa_inputtype div.incorrect'],
         'unanswered': ['div.capa_inputtype div.unanswered'],
     }
-
-    def setUp(self, *args, **kwargs):
-        """
-        Additional setup for SymbolicProblemTypeTest
-        """
-        super(SymbolicProblemTypeTest, self).setUp(*args, **kwargs)
-        self.problem_page.a11y_audit.config.set_rules({
-            'ignore': [
-                'section',  # TODO: AC-491
-                'label',  # TODO: AC-294
-            ]
-        })
 
     def answer_problem(self, correctness):
         """

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -561,7 +561,7 @@ html.video-fullscreen {
       }
     }
 
-    section.xqa-modal, section.staff-modal, section.history-modal {
+    .xqa-modal, .staff-modal, .history-modal {
         width: 80%;
         height: 80%;
         left: left(20%);

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -5,13 +5,13 @@ from openedx.core.djangolib.markup import HTML
 %>
 
 <%namespace name='static' file='static_content.html'/>
-<h3 class="hd hd-2 problem-header" id="${ id }-problem-title" aria-describedby="${ id }-problem-progress" tabindex="-1">
+<h3 class="hd hd-2 problem-header" id="${ short_id }-problem-title" aria-describedby="${ id }-problem-progress" tabindex="-1">
   ${ problem['name'] }
 </h3>
 
 <div class="problem-progress" id="${ id }-problem-progress"></div>
 
-<div class="problem" aria-labelledby="${ id }-problem-title">
+<div class="problem" aria-labelledby="${ short_id }-problem-title">
   ${ HTML(problem['html']) }
   <div class="action">
     <input type="hidden" name="problem_id" value="${ problem['name'] }" />
@@ -47,7 +47,7 @@ from openedx.core.djangolib.markup import HTML
     % endif
     % if answer_available:
     <span class="problem-action-button-wrapper">
-        <button class="show problem-action-btn btn-default btn-small" aria-describedby="${ id }-problem-title"><span class="icon fa fa-info-circle" aria-hidden="true"></span><span class="show-label">${_('Show Answer')}</span></button>
+        <button class="show problem-action-btn btn-default btn-small" aria-describedby="${ short_id }-problem-title"><span class="icon fa fa-info-circle" aria-hidden="true"></span><span class="show-label">${_('Show Answer')}</span></button>
     </span>
     % endif
     </div>

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -11,7 +11,7 @@ from openedx.core.djangolib.markup import HTML
 
 <div class="problem-progress" id="${ id }-problem-progress"></div>
 
-<div class="problem" aria-labelledby="${ short_id }-problem-title">
+<div class="problem">
   ${ HTML(problem['html']) }
   <div class="action">
     <input type="hidden" name="problem_id" value="${ problem['name'] }" />

--- a/lms/templates/problem_ajax.html
+++ b/lms/templates/problem_ajax.html
@@ -1,1 +1,1 @@
-<div id="problem_${element_id}" class="problems-wrapper" data-problem-id="${id}" data-url="${ajax_url}" data-progress_status="${progress_status}" data-progress_detail="${progress_detail}" data-content="${content | h}" data-graded="${graded}"></div>
+<div id="problem_${element_id}" class="problems-wrapper" role="group" aria-labelledby="${element_id}-problem-title" data-problem-id="${id}" data-url="${ajax_url}" data-progress_status="${progress_status}" data-progress_detail="${progress_detail}" data-content="${content | h}" data-graded="${graded}"></div>

--- a/lms/templates/problem_notifications.html
+++ b/lms/templates/problem_notifications.html
@@ -6,7 +6,7 @@
       ${'' if notification_name == 'submit' else 'is-hidden' }"
      tabindex="-1">
     <span class="icon fa ${notification_icon}" aria-hidden="true"></span>
-    <span class="notification-message" aria-describedby="${ id }-problem-title">${notification_message}
+    <span class="notification-message" aria-describedby="${ short_id }-problem-title">${notification_message}
     </span>
     <div class="notification-btn-wrapper">
         % if notification_name is 'hint':

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -31,7 +31,7 @@ ${block_content}
 </div>
 %  endif
 
-<section aria-hidden="true" role="dialog" tabindex="-1" id="${element_id}_xqa-modal" class="modal xqa-modal">
+<div aria-hidden="true" role="dialog" tabindex="-1" id="${element_id}_xqa-modal" class="modal xqa-modal">
   <div class="inner-wrapper">
     <header>
       <h2>${_("{platform_name} Content Quality Assessment").format(platform_name=settings.PLATFORM_NAME)}</h2>
@@ -51,9 +51,9 @@ ${block_content}
     </form>
 
   </div>
-</section>
+</div>
 
-<section aria-hidden="true" role="dialog" tabindex="-1" class="modal staff-modal" id="${element_id}_debug" >
+<div aria-hidden="true" role="dialog" tabindex="-1" class="modal staff-modal" id="${element_id}_debug" >
   <div class="inner-wrapper">
     <header>
       <h2>${_('Staff Debug')}</h2>
@@ -106,9 +106,9 @@ category = ${category | h}
     <div id="histogram_${element_id}" class="histogram" data-histogram="${histogram}"></div>
     %endif
   </div>
-</section>
+</div>
 
-<section aria-hidden="true" role="dialog" tabindex="-1" class="modal history-modal" id="${element_id}_history">
+<div aria-hidden="true" role="dialog" tabindex="-1" class="modal history-modal" id="${element_id}_history">
   <div class="inner-wrapper">
     <header>
       <h2>${_("Submission History Viewer")}</h2>
@@ -125,7 +125,7 @@ category = ${category | h}
     <div id="${element_id}_history_text" class="staff_info" style="display:block">
     </div>
   </div>
-</section>
+</div>
 
 <div id="${element_id}_setup"></div>
 


### PR DESCRIPTION
## [TNL-5574](https://openedx.atlassian.net/browse/TNL-5574)
## [TNL-5575](https://openedx.atlassian.net/browse/TNL-5575)
## [TNL-5576](https://openedx.atlassian.net/browse/TNL-5576)
## [TNL-5671](https://openedx.atlassian.net/browse/TNL-5671)
### Description

Purpose of this PR is:
- Remove a11y ignore rules from parent class and move them to particular children test classes.
- Replace section element with div since we can't add heading for that to avoid the section a11y error (staff_debug_info.html) 
- Add heading h4 to each response container i.e. section and refer problem-title & question index through that section. 
### Sandbox
- [Sandbox](https://capa-problem-section.sandbox.edx.org/)
### Testing
- [x] safecommit violation code review process
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @muhammad-ammar 
- [x] Code review: @mushtaqak 
- [x] Accessibility review: @cptvitamin @edx/edx-accessibility 
### Post-review
- [ ] Rebase and squash commits
