### PR TITLE
Fix mathjax rendering

### DIFF
--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -384,10 +384,9 @@
                 } else if (RE_DISPLAYMATH.test(htmlString)) {
                     htmlString = htmlString.replace(RE_DISPLAYMATH, function($0, $1, $2, $3) {
                         /*
-                         bug fix, ordering is off
+                         corrected mathjax rendering in preview
                          */
-                        processedHtmlString = processor('$$' + $2 + '$$', 'display') + processedHtmlString;
-                        processedHtmlString = $1 + processedHtmlString;
+                        processedHtmlString += $1 + processor('$$' + $2 + '$$', 'display');
                         return $3;
                     });
                 } else {

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -758,3 +758,11 @@ class DiscussionTabHomePage(CoursePage, DiscussionPageMixin):
         """
         self.wait_for_element_visibility(".wmd-preview > *", "WMD preview pane has contents", timeout=10)
         return self.q(css=".wmd-preview").html[0]
+
+    def get_new_post_preview_text(self):
+        """
+        Get the rendered preview of the contents of the Discussions new post editor
+        Waits for content to appear, as the preview is triggered on debounced/delayed onchange
+        """
+        self.wait_for_element_visibility(".wmd-preview > div", "WMD preview pane has contents", timeout=10)
+        return self.q(css=".wmd-preview").text[0]

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -959,6 +959,22 @@ class DiscussionEditorPreviewTest(UniqueCourseTest):
             "</ul>"
         ))
 
+    def test_mathjax_rendering_in_order(self):
+        """
+        Tests that mathjax is rendered in proper order.
+
+        When user types mathjax expressions into discussion editor, it should render in the proper
+        order.
+        """
+        self.page.set_new_post_editor_value(
+            'Text line 1 \n'
+            '$$e[n]=d_1$$ \n'
+            'Text line 2 \n'
+            '$$e[n]=d_2$$'
+        )
+
+        self.assertEqual(self.page.get_new_post_preview_text(), 'Text line 1\nText line 2')
+
 
 @attr(shard=2)
 class InlineDiscussionTest(UniqueCourseTest, DiscussionResponsePaginationTestMixin):


### PR DESCRIPTION
[TNL-5451](https://openedx.atlassian.net/browse/TNL-5451)
Background:
The preview area in discussion post was showing the segments out of order in case when mathjax with multiple lines is typed.
![screenshot from 2016-09-26 14 15 03](https://cloud.githubusercontent.com/assets/22347092/18829349/44ac4298-83f5-11e6-818c-593bab54bc6f.png)

Fix:
After fix all mathjax segments are rendered in preview box, in the order as typed in input editor.
![screenshot from 2016-09-26 14 28 54](https://cloud.githubusercontent.com/assets/22347092/18829488/e4280848-83f5-11e6-8c06-fed572600fb6.png)

Reviewers:
@awaisdar001 
## Sandbox

https://mathjax.sandbox.edx.org/
