### PR TITLE
[SOL-2077] Update DnDv2 version to 2.0.10

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -97,4 +97,4 @@ git+https://github.com/edx/edx-proctoring.git@0.13.0#egg=edx-proctoring==0.13.0
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 -e git+https://github.com/open-craft/xblock-poll@v1.2#egg=xblock-poll==1.2
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.9#egg=xblock-drag-and-drop-v2==2.0.9
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.10#egg=xblock-drag-and-drop-v2==2.0.10


### PR DESCRIPTION
This pull request updates the Drag and Drop V2 XBlock to version 2.0.10 to fix an issue where the background image cannot be changed.

**JIRA tickets**: Fixes SOL-2077

**Dependencies**: None

**Merge deadline**: 9/23 for inclusion in this release

**Testing instructions**:
1. After creating a Drag and Drop XBlock, verify that the background image can be changed (see edx-solutions/xblock-drag-and-drop-v2#105)

**Reviewers**
- [ ] @pomegranited 
- [ ] @staubina 
- [ ] @cahrens  
- [x] @sstack22 
