### PR TITLE
Upgrade django-oauth2-provider to 1.1.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -41,7 +41,7 @@ djangorestframework-oauth==1.1.0
 edx-ccx-keys==0.2.1
 edx-drf-extensions==0.5.1
 edx-lint==0.4.3
-edx-django-oauth2-provider==1.1.1
+edx-django-oauth2-provider==1.1.2
 edx-django-sites-extensions==2.1.1
 edx-oauth2-provider==1.1.3
 edx-opaque-keys==0.3.4


### PR DESCRIPTION
Upgrade django-oauth2-provider to 1.1.2, which contains additional indexes to address [PLAT-1062](https://openedx.atlassian.net/browse/PLAT-1062)

Related PR: https://github.com/edx/django-oauth2-provider/pull/36/

@edx/devops 
@clintonb 
@jmbowman 
