### PR TITLE
Handle when no video transcript uploaded for a language

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -21,6 +21,7 @@ from mock import ANY, Mock, patch
 import ddt
 
 from django.conf import settings
+from django.test.utils import override_settings
 
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from opaque_keys.edx.keys import CourseKey
@@ -28,6 +29,7 @@ from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 
 from xmodule.tests import get_test_descriptor_system
+from xmodule.validation import StudioValidationMessage
 from xmodule.video_module import VideoDescriptor, create_youtube_string
 from xmodule.video_module.transcripts_utils import download_youtube_subs, save_to_store
 from . import LogicTest
@@ -75,6 +77,12 @@ YOUTUBE_SUBTITLES = (
     " navigate directly to any video or exercise by clicking on the appropriate tab. You can also"
     " progress to the next element by pressing the Arrow button, or by clicking on the next tab. Try"
     " that now. The tutorial will continue in the next video."
+)
+
+ALL_LANGUAGES = (
+    [u"en", u"English"],
+    [u"eo", u"Esperanto"],
+    [u"ur", u"Urdu"]
 )
 
 
@@ -780,6 +788,7 @@ class VideoExportTestCase(VideoDescriptorTestBase):
         self.assertEqual(xml.get('display_name'), u'\u8fd9\u662f\u6587')
 
 
+@ddt.ddt
 class VideoDescriptorIndexingTestCase(unittest.TestCase):
     """
     Make sure that VideoDescriptor can format data for indexing as expected.
@@ -993,3 +1002,74 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
         descriptor = instantiate_descriptor(data=None)
         translations = descriptor.available_translations(descriptor.get_transcripts_info(), verify_assets=False)
         self.assertEqual(translations, ['en'])
+
+    @override_settings(ALL_LANGUAGES=ALL_LANGUAGES)
+    def test_video_with_language_do_not_have_transcripts_translation(self):
+        """
+        Test translation retrieval of a video module with
+        a language having no transcripts uploaded by a user.
+        """
+        xml_data_transcripts = '''
+            <video display_name="Test Video"
+                   youtube="1.0:p2Q6BrNhdh8,0.75:izygArpw-Qo,1.25:1EeWXzPdhSA,1.5:rABDYkeK0x8"
+                   show_captions="false"
+                   download_track="false"
+                   start_time="00:00:01"
+                   download_video="false"
+                   end_time="00:01:00">
+              <source src="http://www.example.com/source.mp4"/>
+              <track src="http://www.example.com/track"/>
+              <handout src="http://www.example.com/handout"/>
+              <transcript language="ur" src="" />
+            </video>
+        '''
+        descriptor = instantiate_descriptor(data=xml_data_transcripts)
+        translations = descriptor.available_translations(descriptor.get_transcripts_info(), verify_assets=False)
+        self.assertNotEqual(translations, ['ur'])
+
+    def assert_validation_message(self, validation, expected_msg):
+        """
+        Asserts that the validation message has all expected content.
+
+        Args:
+            validation (StudioValidation): A validation object.
+            expected_msg (string): An expected validation message.
+        """
+        self.assertFalse(validation.empty)  # Validation contains some warning/message
+        self.assertTrue(validation.summary)
+        self.assertEqual(StudioValidationMessage.WARNING, validation.summary.type)
+        self.assertIn(expected_msg, validation.summary.text)
+
+    @ddt.data(
+        (
+            '<transcript language="ur" src="" />',
+            'There is no transcript file associated with the Urdu language.'
+        ),
+        (
+            '<transcript language="eo" src="" /><transcript language="ur" src="" />',
+            'There are no transcript files associated with the Esperanto, Urdu languages.'
+        ),
+    )
+    @ddt.unpack
+    @override_settings(ALL_LANGUAGES=ALL_LANGUAGES)
+    def test_no_transcript_validation_message(self, xml_transcripts, expected_validation_msg):
+        """
+        Test the validation message when no associated transcript file uploaded.
+        """
+        xml_data_transcripts = '''
+            <video display_name="Test Video"
+                   youtube="1.0:p2Q6BrNhdh8,0.75:izygArpw-Qo,1.25:1EeWXzPdhSA,1.5:rABDYkeK0x8"
+                   show_captions="false"
+                   download_track="false"
+                   start_time="00:00:01"
+                   download_video="false"
+                   end_time="00:01:00">
+              <source src="http://www.example.com/source.mp4"/>
+              <track src="http://www.example.com/track"/>
+              <handout src="http://www.example.com/handout"/>
+              {xml_transcripts}
+            </video>
+        '''.format(xml_transcripts=xml_transcripts)
+        descriptor = instantiate_descriptor(data=xml_data_transcripts)
+        validation = descriptor.validate()
+        self.assert_validation_message(validation, expected_validation_msg)

--- a/common/test/acceptance/tests/video/test_studio_video_editor.py
+++ b/common/test/acceptance/tests/video/test_studio_video_editor.py
@@ -126,6 +126,27 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.assertIn(unicode_text, self.video.captions_text)
         self.assertEqual(self.video.caption_languages.keys(), ['zh', 'uk'])
 
+    def test_save_language_upload_no_transcript(self):
+        """
+        Scenario: Transcript language is not shown in language menu if no transcript file is uploaded
+        Given I have created a Video component
+        And I edit the component
+        And I open tab "Advanced"
+        And I add a language "uk" but do not upload an .srt file
+        And I save changes
+        When I view the video language menu
+        Then I am not able to see the language "uk" translation language
+        """
+        self._create_video_component()
+        self.edit_component()
+        self.open_advanced_tab()
+        language_code = 'uk'
+        self.video.click_button('translation_add')
+        translations_count = self.video.translations_count()
+        self.video.select_translation_language(language_code, translations_count - 1)
+        self.save_unit_settings()
+        self.assertNotIn(language_code, self.video.caption_languages.keys())
+
     def test_upload_large_transcript(self):
         """
         Scenario: User can upload transcript file with > 1mb size


### PR DESCRIPTION
### Description

This change handles the case when no transcript file is uploaded for a language then raise an exception that transcript file is not uploaded yet. This wouldn't let user save transcript language if no transcript file is uploaded for it.

Also, this change handles the videos that have language already added in the database but no transcript file was uploaded. This prevents showing of such languages as transcript on the video.
### [TNL-5200](https://openedx.atlassian.net/browse/TNL-5200)
### [Sandbox](https://videotranscript.sandbox.edx.org/)
### Testing
- [x] Unit
- [x] Acceptance
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @muzaffaryousaf
- [x] Code review: @muhammad-ammar 
- [x] Doc: @catong 
- [x] Product: @sstack22 
### Post-review
- [x] Squash commits
