### PR TITLE
Fix user registration 

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -2,6 +2,7 @@
 This file contains celery tasks for sending email
 """
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.core import mail
 
 from celery.task import task  # pylint: disable=no-name-in-module, import-error
@@ -12,10 +13,11 @@ log = get_task_logger(__name__)
 
 
 @task(bind=True)
-def send_activation_email(self, user, subject, message, from_address):
+def send_activation_email(self, user_id, subject, message, from_address):
     """
     Sending an activation email to the users.
     """
+    user = User.objects.get(id=user_id)
     max_retries = settings.RETRY_ACTIVATION_EMAIL_MAX_ATTEMPTS
     retries = self.request.retries + 1
     dest_addr = user.email

--- a/common/djangoapps/student/tests/test_tasks.py
+++ b/common/djangoapps/student/tests/test_tasks.py
@@ -9,29 +9,36 @@ from django.conf import settings
 from student.tasks import send_activation_email
 from boto.exception import NoAuthHandlerFound
 
+from lms.djangoapps.courseware.tests.factories import UserFactory
+
 
 class SendActivationEmailTestCase(TestCase):
     """
     Test for send activation email to user
     """
+    def setUp(self):
+        """ Setup components used by each test."""
+        super(SendActivationEmailTestCase, self).setUp()
+        self.student = UserFactory()
+
     @mock.patch('time.sleep', mock.Mock(return_value=None))
     @mock.patch('student.tasks.log')
-    @mock.patch('django.contrib.auth.models.User')
-    def test_send_email(self, mock_user, mock_log):
+    @mock.patch('django.contrib.auth.models.User.email_user', mock.Mock(side_effect=NoAuthHandlerFound))
+    def test_send_email(self, mock_log):
         """
         Tests retries when the activation email doesn't send
         """
         from_address = 'task_testing@edX.com'
-        mock_user.email_user.side_effect = NoAuthHandlerFound
         email_max_attempts = settings.RETRY_ACTIVATION_EMAIL_MAX_ATTEMPTS + 1
 
-        send_activation_email.delay(mock_user, 'Task_test', 'Task_test_message', from_address)
+        # pylint: disable=no-member
+        send_activation_email.delay(self.student.id, 'Task_test', 'Task_test_message', from_address)
 
         # Asserts sending email retry logging.
         for attempt in xrange(1, email_max_attempts):
             mock_log.info.assert_any_call(
                 'Retrying sending email to user {dest_addr}, attempt # {attempt} of {max_attempts}'.format(
-                    dest_addr=mock_user.email,
+                    dest_addr=self.student.email,
                     attempt=attempt,
                     max_attempts=email_max_attempts
                 ))
@@ -41,7 +48,7 @@ class SendActivationEmailTestCase(TestCase):
         mock_log.error.assert_called_with(
             'Unable to send activation email to user from "%s" to "%s"',
             from_address,
-            mock_user.email,
+            self.student.email,
             exc_info=True
         )
         self.assertEquals(mock_log.error.call_count, 1)

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1790,7 +1790,7 @@ def create_account_with_params(request, params):
             'email_from_address',
             settings.DEFAULT_FROM_EMAIL
         )
-        send_activation_email.delay(user, subject, message, from_address)
+        send_activation_email.delay(user.id, subject, message, from_address)
     else:
         registration.activate()
         _enroll_user_in_pending_courses(user)  # Enroll student in any pending courses


### PR DESCRIPTION
[ECOM-5784](https://openedx.atlassian.net/browse/ECOM-5784)
Celery need to serialize the arguments for a task. Here, user is not serialize-able, replace it with ID.
