### PR TITLE
[SOL-2077] Re-updating DnDv2 to 2.0.10

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -97,4 +97,4 @@ git+https://github.com/edx/edx-proctoring.git@0.13.0#egg=edx-proctoring==0.13.0
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 -e git+https://github.com/open-craft/xblock-poll@v1.2#egg=xblock-poll==1.2
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.9#egg=xblock-drag-and-drop-v2==2.0.9
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.10#egg=xblock-drag-and-drop-v2==2.0.10


### PR DESCRIPTION
This PR updates the included Drag and Drop XBlock to 2.0.10 (which now works).

This supersedes #13560 in an attempt to get this change into the current release.

**JIRA tickets**: Fixes SOL-2077

**Discussions**: Merged early (#13555) and reverted previously (#13556) 

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**: See edx-solutions/xblock-drag-and-drop-v2#105

**Reviewers**
- [x] @pomegranited 
- [ ] @staubina 
- [x] @cahrens 
- [ ] @sstack22 
