### PR TITLE
Fixes DOC-3360 to make help context-sensitive

### DIFF
--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -1,5 +1,6 @@
 <%page expression_filter="h"/>
 <%inherit file="main.html" />
+<%def name="online_help_token()"><% return "learnerdashboard" %></%def>
 <%namespace name='static' file='static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -1,5 +1,5 @@
 ## mako
-<%page expression_filter="h"/>
+<%page expression_filter="h" args="online_help_token"/>
 <%namespace name='static' file='static_content.html'/>
 <%namespace file='main.html' import="login_query"/>
 <%!
@@ -104,7 +104,7 @@ site_status_msg = get_site_status_msg(course_id)
 
       <%include file="user_dropdown.html"/>
 
-      <a href="${get_online_help_info(online_help_token)['doc_url']}" 
+      <a href="${get_online_help_info(online_help_token)['doc_url']}"
          target="_blank"
          class="doc-link">${_("Help")}</a>
 


### PR DESCRIPTION
[DOC-3360](https://openedx.atlassian.net/browse/DOC-3360) outlines how to change the edx.org theme to make the help links context sensitive, as they are for the Edge site. 
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @nasthagiri 
- [x] Subject matter expert: @douglashall 
- [ ] Doc team review (sanity check): @catong @srpearce  
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Sandbox (optional)
- [ ] There's a [sandbox](https://lamagnifica.sandbox.edx.org)!
### Post-review
- [ ] Add description to release notes task as a comment
- [ ] Squash commits
