### PR TITLE
Install pa11ycrawler v1.5.4 from PyPi

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -160,6 +160,7 @@ nose-exclude
 nose-ignore-docstring
 nose-randomly==1.2.0
 nosexcover==1.0.7
+pa11ycrawler==1.5.4
 pep8==1.5.7
 PyContracts==1.7.1
 python-subunit==0.0.16

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -69,7 +69,6 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 
 # Used for testing
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
-git+https://github.com/edx/pa11ycrawler.git@1.5.2#egg=pa11ycrawler==1.5.2
 
 # Our libraries:
 git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12

--- a/scripts/accessibility-tests.sh
+++ b/scripts/accessibility-tests.sh
@@ -23,6 +23,9 @@ paver a11y_coverage
 
 if [ "$RUN_PA11YCRAWLER" = "1" ]
 then
+    # The settings that we use are installed with the pa11ycrawler module
+    export SCRAPY_SETTINGS_MODULE='pa11ycrawler.settings'
+
     echo "Running pa11ycrawler against test course..."
     paver pa11ycrawler --fasttest --skip-clean --fetch-course --with-html
 


### PR DESCRIPTION
Fixes TE-1711
- install from PyPi
- bump to [version 1.5.4](https://github.com/edx/pa11ycrawler/releases/tag/1.5.4)

@edx/testeng 
