### PR TITLE
WIP: restrict enroll no atsign usernames

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -317,6 +317,10 @@ def _can_enroll_courselike(user, courselike):
     # which actually points to a CourseKey. Sigh.
     course_key = courselike.id
 
+    if settings.FEATURES.get('RESTRICT_ENROLL_NO_ATSIGN_USERNAMES') and '@' in user.username:
+        log.warning("ENROLLMENT DENIED in %s because @ in username %s" % (course_key, user.username))
+        return ACCESS_DENIED
+
     # If using a registration method to restrict enrollment (e.g., Shibboleth)
     if settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and enrollment_domain:
         if user is not None and user.is_authenticated() and \

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -318,7 +318,7 @@ def _can_enroll_courselike(user, courselike):
     course_key = courselike.id
 
     if settings.FEATURES.get('RESTRICT_ENROLL_NO_ATSIGN_USERNAMES') and '@' in user.username:
-        log.warning("ENROLLMENT DENIED in %s because @ in username %s" % (course_key, user.username))
+        log.warning("ENROLLMENT DENIED in %s because @ in username %s", course_key, user.username)
         return ACCESS_DENIED
 
     # If using a registration method to restrict enrollment (e.g., Shibboleth)

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -7,6 +7,7 @@ import ddt
 import itertools
 import pytz
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from ccx_keys.locator import CCXLocator
 from django.test.client import RequestFactory
@@ -473,6 +474,15 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
             invitation_only=False
         )
         self.assertFalse(access._has_access_course(user, 'enroll', course))
+
+        user = UserFactory.create(username="test@a.com")
+        course = Mock(
+            enrollment_start=yesterday, enrollment_end=tomorrow,
+            id=SlashSeparatedCourseKey('edX', 'test', '2012_Fall'), enrollment_domain='',
+            invitation_only=False
+        )
+        with patch.dict(settings.FEATURES, {'RESTRICT_ENROLL_NO_ATSIGN_USERNAMES': True}):
+            self.assertFalse(access._has_access_course(user, 'enroll', course))
 
     def test__user_passed_as_none(self):
         """Ensure has_access handles a user being passed as null"""


### PR DESCRIPTION
Introduces new feature flag, "RESTRICT_ENROLL_NO_ATSIGN_USERNAMES", which, if set, will deny course self-enrollment to a user with an "@" sign in the username.  Logs the denial.

Tested manually, confirmed works in a VM.  Needs unit tests.
