### PR TITLE
Revert "mobile api user course enrollments allow filter by org"

### DIFF
--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -72,13 +72,13 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
         self.login()
         self.enroll(course_id)
 
-    def api_response(self, reverse_args=None, expected_response_code=200, data=None, **kwargs):
+    def api_response(self, reverse_args=None, expected_response_code=200, **kwargs):
         """
         Helper method for calling endpoint, verifying and returning response.
         If expected_response_code is None, doesn't verify the response' status_code.
         """
         url = self.reverse_url(reverse_args, **kwargs)
-        response = self.url_method(url, data=data, **kwargs)
+        response = self.url_method(url, **kwargs)
         if expected_response_code is not None:
             self.assertEqual(response.status_code, expected_response_code)
         return response
@@ -92,9 +92,9 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
             reverse_args.update({'username': kwargs.get('username', self.user.username)})
         return reverse(self.REVERSE_INFO['name'], kwargs=reverse_args)
 
-    def url_method(self, url, data=None, **kwargs):  # pylint: disable=unused-argument
+    def url_method(self, url, **kwargs):  # pylint: disable=unused-argument
         """Base implementation that returns response from the GET method of the URL."""
-        return self.client.get(url, data=data)
+        return self.client.get(url)
 
 
 class MobileAuthTestMixin(object):

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -275,31 +275,6 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         self.assertIn('/api/discussion/v1/courses/{}'.format(self.course.id), response_discussion_url)
 
 
-    def test_org_query(self):
-        self.login()
-
-        # Create list of courses with various organizations
-        courses = [
-            CourseFactory.create(org='edX', mobile_available=True),
-            CourseFactory.create(org='edX', mobile_available=True),
-            CourseFactory.create(org='edX', mobile_available=True, visible_to_staff_only=True),
-            CourseFactory.create(org='Proversity.org', mobile_available=True),
-            CourseFactory.create(org='MITx', mobile_available=True),
-            CourseFactory.create(org='HarvardX', mobile_available=True),
-        ]
-
-        # Enroll in all the courses
-        self.assertEqual(len(response.data), 3)
-        for course in courses:
-            self.enroll(course.id)
-
-        response = self.api_response(data={'org':'edX'})
-
-        # Verify only edX courses are returned
-        for entry in response.data:
-            self.assertEqual(entry['course']['org'], 'edX')
-
-
 @attr(shard=2)
 class CourseStatusAPITestCase(MobileAPITestCase):
     """

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -270,18 +270,14 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
     # the default behavior by setting the pagination_class to None.
     pagination_class = None
 
-    def is_org(self, check_org, course_org):
-        return check_org is None or (check_org.lower() == course_org.lower())
-
     def get_queryset(self):
         enrollments = self.queryset.filter(
             user__username=self.kwargs['username'],
             is_active=True
         ).order_by('created').reverse()
-        org = self.request.query_params.get('org', None)
         return [
             enrollment for enrollment in enrollments
-            if enrollment.course_overview and self.is_org(org, enrollment.course_overview.org) and
+            if enrollment.course_overview and
             is_mobile_available_for_user(self.request.user, enrollment.course_overview)
         ]
 


### PR DESCRIPTION
Reverts edx/edx-platform#13097

Reverting because it broke the quality (pep8) on master.
