### PR TITLE
mobile api filter enrollments by org

### DIFF
--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -72,13 +72,13 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
         self.login()
         self.enroll(course_id)
 
-    def api_response(self, reverse_args=None, expected_response_code=200, **kwargs):
+    def api_response(self, reverse_args=None, expected_response_code=200, data=None, **kwargs):
         """
         Helper method for calling endpoint, verifying and returning response.
         If expected_response_code is None, doesn't verify the response' status_code.
         """
         url = self.reverse_url(reverse_args, **kwargs)
-        response = self.url_method(url, **kwargs)
+        response = self.url_method(url, data=data, **kwargs)
         if expected_response_code is not None:
             self.assertEqual(response.status_code, expected_response_code)
         return response
@@ -92,9 +92,9 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
             reverse_args.update({'username': kwargs.get('username', self.user.username)})
         return reverse(self.REVERSE_INFO['name'], kwargs=reverse_args)
 
-    def url_method(self, url, **kwargs):  # pylint: disable=unused-argument
+    def url_method(self, url, data=None, **kwargs):  # pylint: disable=unused-argument
         """Base implementation that returns response from the GET method of the URL."""
-        return self.client.get(url)
+        return self.client.get(url, data=data)
 
 
 class MobileAuthTestMixin(object):

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -275,6 +275,31 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         self.assertIn('/api/discussion/v1/courses/{}'.format(self.course.id), response_discussion_url)
 
 
+    def test_org_query(self):
+        self.login()
+
+        # Create list of courses with various organizations
+        courses = [
+            CourseFactory.create(org='edX', mobile_available=True),
+            CourseFactory.create(org='edX', mobile_available=True),
+            CourseFactory.create(org='edX', mobile_available=True, visible_to_staff_only=True),
+            CourseFactory.create(org='Proversity.org', mobile_available=True),
+            CourseFactory.create(org='MITx', mobile_available=True),
+            CourseFactory.create(org='HarvardX', mobile_available=True),
+        ]
+
+        # Enroll in all the courses
+        self.assertEqual(len(response.data), 3)
+        for course in courses:
+            self.enroll(course.id)
+
+        response = self.api_response(data={'org':'edX'})
+
+        # Verify only edX courses are returned
+        for entry in response.data:
+            self.assertEqual(entry['course']['org'], 'edX')
+
+
 @attr(shard=2)
 class CourseStatusAPITestCase(MobileAPITestCase):
     """

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -274,7 +274,6 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         response_discussion_url = response.data[0]['course']['discussion_url']  # pylint: disable=E1101
         self.assertIn('/api/discussion/v1/courses/{}'.format(self.course.id), response_discussion_url)
 
-
     def test_org_query(self):
         self.login()
 
@@ -289,11 +288,13 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         ]
 
         # Enroll in all the courses
-        self.assertEqual(len(response.data), 3)
         for course in courses:
             self.enroll(course.id)
 
-        response = self.api_response(data={'org':'edX'})
+        response = self.api_response(data={'org': 'edX'})
+
+        # Test for 3 expected courses
+        self.assertEqual(len(response.data), 3)
 
         # Verify only edX courses are returned
         for entry in response.data:

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -271,6 +271,9 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
     pagination_class = None
 
     def is_org(self, check_org, course_org):
+        """
+        Check course org matches request org param or no param provided
+        """
         return check_org is None or (check_org.lower() == course_org.lower())
 
     def get_queryset(self):

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -270,14 +270,18 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
     # the default behavior by setting the pagination_class to None.
     pagination_class = None
 
+    def is_org(self, check_org, course_org):
+        return check_org is None or (check_org.lower() == course_org.lower())
+
     def get_queryset(self):
         enrollments = self.queryset.filter(
             user__username=self.kwargs['username'],
             is_active=True
         ).order_by('created').reverse()
+        org = self.request.query_params.get('org', None)
         return [
             enrollment for enrollment in enrollments
-            if enrollment.course_overview and
+            if enrollment.course_overview and self.is_org(org, enrollment.course_overview.org) and
             is_mobile_available_for_user(self.request.user, enrollment.course_overview)
         ]
 


### PR DESCRIPTION
Reopening PR for quality tests as per [request](https://github.com/edx/edx-platform/pull/13097#issuecomment-249976895) from @shaunagm 

Previous PR: https://github.com/edx/edx-platform/pull/13097 

Slight change to user enrollments endpoint in the mobile API. Allows for filtering by organization short code, already available on the courses endpoint. This is a prerequisite to an upcoming mobile app contribution to allow for filtering by organization directly from the yaml config. Use case is pretty self explanatory: Provides for course differentiation in organisation branded mobile apps. Useful when serving organization specific microsites from the same datastores.
