### PR TITLE
[SOL-2082] Add a value to SiteConfiguration to enable ecommerce Receipt Page usage

### DIFF
--- a/lms/djangoapps/commerce/models.py
+++ b/lms/djangoapps/commerce/models.py
@@ -15,6 +15,7 @@ class CommerceConfiguration(ConfigurationModel):
 
     API_NAME = 'commerce'
     CACHE_KEY = 'commerce.api.data'
+    DEFAULT_RECEIPT_PAGE_URL = '/commerce/checkout/receipt/?orderNum='
 
     checkout_on_ecommerce_service = models.BooleanField(
         default=False,
@@ -35,7 +36,7 @@ class CommerceConfiguration(ConfigurationModel):
     )
     receipt_page = models.CharField(
         max_length=255,
-        default='/commerce/checkout/receipt/?orderNum=',
+        default=DEFAULT_RECEIPT_PAGE_URL,
         help_text=_('Path to order receipt page.')
     )
 

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -12,6 +12,39 @@ class EcommerceService(object):
     def __init__(self):
         self.config = CommerceConfiguration.current()
 
+    @property
+    def ecommerce_url_root(self):
+        """ Retrieve Ecommerce service public url root. """
+        return configuration_helpers.get_value('ECOMMERCE_PUBLIC_URL_ROOT', settings.ECOMMERCE_PUBLIC_URL_ROOT)
+
+    def get_absolute_ecommerce_url(self, ecommerce_page_url):
+        """ Return the absolute URL to the ecommerce page.
+
+        Args:
+            ecommerce_page_url (str): Relative path to the ecommerce page.
+
+        Returns:
+            Absolute path to the ecommerce page.
+        """
+        return urljoin(self.ecommerce_url_root, ecommerce_page_url)
+
+    def get_receipt_page_url(self, order_number):
+        """
+        Gets the URL for the Order Receipt page hosted by the ecommerce service.
+
+        Args:
+            order_number (str): Order number.
+
+        Returns:
+            Receipt page for the specified Order.
+        """
+        ecommerce_receipt_page_url = configuration_helpers.get_value('ECOMMERCE_RECEIPT_PAGE_URL')
+        if ecommerce_receipt_page_url:
+            receipt_page_url = self.get_absolute_ecommerce_url(ecommerce_receipt_page_url)
+        else:
+            receipt_page_url = self.config.receipt_page
+        return receipt_page_url + order_number
+
     def is_enabled(self, user):
         """
         Determines the availability of the EcommerceService based on user activation and service configuration.
@@ -29,11 +62,7 @@ class EcommerceService(object):
         Example:
             http://localhost:8002/basket/single_item/
         """
-        ecommerce_url_root = configuration_helpers.get_value(
-            'ECOMMERCE_PUBLIC_URL_ROOT',
-            settings.ECOMMERCE_PUBLIC_URL_ROOT,
-        )
-        return urljoin(ecommerce_url_root, self.config.single_course_checkout_page)
+        return self.get_absolute_ecommerce_url(self.config.single_course_checkout_page)
 
     def checkout_page_url(self, sku):
         """ Construct the URL to the ecommerce checkout page and include a product.
@@ -41,4 +70,4 @@ class EcommerceService(object):
         Example:
             http://localhost:8002/basket/single_item/?sku=5H3HG5
         """
-        return "{}?sku={}".format(self.payment_page_url(), sku)
+        return "{}?sku={}".format(self.get_absolute_ecommerce_url(self.config.single_course_checkout_page), sku)

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -22,6 +22,7 @@ from edxmako.shortcuts import render_to_response
 import pytz
 
 from commerce.models import CommerceConfiguration
+from lms.djangoapps.commerce.utils import EcommerceService
 from openedx.core.djangoapps.external_auth.login_and_register import (
     login as external_auth_login,
     register as external_auth_register
@@ -316,7 +317,7 @@ def _external_auth_intercept(request, mode):
 def get_user_orders(user):
     """Given a user, get the detail of all the orders from the Ecommerce service.
 
-    Arguments:
+    Args:
         user (User): The user to authenticate as when requesting ecommerce.
 
     Returns:
@@ -351,7 +352,7 @@ def get_user_orders(user):
                                     'order_date': strftime_localized(
                                         date_placed.replace(tzinfo=pytz.UTC), 'SHORT_DATE'
                                     ),
-                                    'receipt_url': commerce_configuration.receipt_page + order['number']
+                                    'receipt_url': EcommerceService().get_receipt_page_url(order['number'])
                                 }
                                 user_orders.append(order_data)
                             except KeyError:


### PR DESCRIPTION
@mjfrey Here's the PR for Enabling Ecommerce Receipt Page.

Here's the list of things we have to do before merging this:
- [x] Tag anyone whose work will be affected by this change for a code review.
- [x] Write a document on `How to enable the usage of the Ecommerce Receipt Page`.
- [x] To test this on the staging server, we'll need an account with access to Django Admin.
- [x] Make sure this works for the WL sites.

Here are screenshots showing what I had to change in Django Admin to test this locally.

**CommerceConfiguration**
<img width="660" alt="screen shot 2016-10-06 at 09 16 03" src="https://cloud.githubusercontent.com/assets/6833568/19143728/0b0b31b2-8ba6-11e6-8c0b-b1fea36938d3.png">

**SiteConfiguration**
<img width="762" alt="screen shot 2016-10-06 at 09 37 43" src="https://cloud.githubusercontent.com/assets/6833568/19144223/9ecea576-8ba8-11e6-839d-17f5ddab3696.png">
