### PR TITLE
Upgrade Django to 1.8.15

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -35,7 +35,7 @@ django-method-override==0.1.0
 # We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
-django==1.8.14
+django==1.8.15
 djangorestframework-jwt==1.8.0
 djangorestframework-oauth==1.1.0
 edx-ccx-keys==0.2.1


### PR DESCRIPTION
Replaces this PR: 
https://github.com/edx/edx-platform/pull/13595
due to needing a different branch name - using the pipeline to deploy this hotfix.

@jibsheet @macdiesel @edx/platform-team FYI & please review.
