### PR TITLE
Masquerade should not apply to user dropdown

### DIFF
--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -149,16 +149,16 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertIn(self.problem_display_name, problem_html)
         self.assertEqual(show_answer_expected, "Show Answer" in problem_html)
 
-    def verify_original_user_profile_link(self):
+    def verify_real_user_profile_link(self):
         """
         Verifies that the 'Profile' link in the navigation dropdown is pointing
-        to the original user.
+        to the real user.
         """
         content = self.get_courseware_page().content
         self.assertIn(
             '<a href="/u/{}" class="action dropdown-menuitem">Profile</a>'.format(self.test_user.username),
             content,
-            "Profile link should point to original user",
+            "Profile link should point to real user",
         )
 
 
@@ -339,7 +339,7 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         self.assertEqual(self.get_progress_detail(), u'2/2')
 
         # Verify that the user dropdown links have not changed
-        self.verify_original_user_profile_link()
+        self.verify_real_user_profile_link()
 
         # Temporarily override the student state.
         self.submit_answer('Correct', 'Incorrect')

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -149,6 +149,18 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertIn(self.problem_display_name, problem_html)
         self.assertEqual(show_answer_expected, "Show Answer" in problem_html)
 
+    def verify_original_user_profile_link(self):
+        """
+        Verifies that the 'Profile' link in the navigation dropdown is pointing
+        to the original user.
+        """
+        content = self.get_courseware_page().content
+        self.assertIn(
+            '<a href="/u/{}" class="action dropdown-menuitem">Profile</a>'.format(self.test_user.username),
+            content,
+            "Profile link should point to original user",
+        )
+
 
 @attr(shard=1)
 class NormalStudentVisibilityTest(MasqueradeTestCase):
@@ -325,6 +337,9 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         # Masquerade as the student, and check we can see the student state.
         self.update_masquerade(role='student', user_name=self.student_user.username)
         self.assertEqual(self.get_progress_detail(), u'2/2')
+
+        # Verify that the user dropdown links have not changed
+        self.verify_original_user_profile_link()
 
         # Temporarily override the student state.
         self.submit_answer('Correct', 'Incorrect')

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -384,6 +384,7 @@ class CoursewareIndex(View):
             'staff_access': self.is_staff,
             'studio_url': get_studio_url(self.course, 'course'),
             'masquerade': self.masquerade,
+            'real_user': self.real_user,
             'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
             'bookmarks_api_url': reverse('bookmarks'),
             'language_preference': self._get_language_preference(),
@@ -406,7 +407,6 @@ class CoursewareIndex(View):
                 courseware_context['entrance_exam_passed'] = user_has_passed_entrance_exam(self.request, self.course)
 
         # staff masquerading data
-        courseware_context['real_user'] = self.real_user
         now = datetime.now(UTC())
         effective_start = _adjust_start_date_for_beta_testers(self.effective_user, self.course, self.course_key)
         if not in_preview_mode() and self.is_staff and now < effective_start:

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -406,6 +406,7 @@ class CoursewareIndex(View):
                 courseware_context['entrance_exam_passed'] = user_has_passed_entrance_exam(self.request, self.course)
 
         # staff masquerading data
+        courseware_context['real_user'] = self.real_user
         now = datetime.now(UTC())
         effective_start = _adjust_start_date_for_beta_testers(self.effective_user, self.course, self.course_key)
         if not in_preview_mode() and self.is_staff and now < effective_start:

--- a/lms/templates/user_dropdown.html
+++ b/lms/templates/user_dropdown.html
@@ -2,6 +2,11 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='static_content.html'/>
 
+## This template should not use the target student's details when masquerading, see TNL-4895
+<%
+original_user = real_user or user
+%>
+
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
@@ -14,8 +19,8 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
         <a href="${reverse('dashboard')}" class="menu-title">
             <span class="sr-only">${_("Dashboard for:")}</span>
             <%
-            username = user.username
-            profile_image_url = get_profile_image_urls_for_user(user)['medium']
+            username = original_user.username
+            profile_image_url = get_profile_image_urls_for_user(original_user)['medium']
             %>
             <img class="menu-image" src="${profile_image_url}" alt="">
             ${username}
@@ -28,7 +33,7 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
             <ul class="dropdown-menu list-divided is-hidden" id="${_("Usermenu")}" tabindex="-1">
                 <%block name="navigation_dropdown_menu_links" >
                     <li class="dropdown-item item has-block-link"><a href="${reverse('dashboard')}" class="action dropdown-menuitem">${_("Dashboard")}</a></li>
-                    <li class="dropdown-item item has-block-link"><a href="${reverse('learner_profile', kwargs={'username': user.username})}" class="action dropdown-menuitem">${_("Profile")}</a></li>
+                    <li class="dropdown-item item has-block-link"><a href="${reverse('learner_profile', kwargs={'username': original_user.username})}" class="action dropdown-menuitem">${_("Profile")}</a></li>
                     <li class="dropdown-item item has-block-link"><a href="${reverse('account_settings')}" class="action dropdown-menuitem">${_("Account")}</a></li>
                 </%block>
                 <li class="dropdown-item item has-block-link"><a href="${reverse('logout')}" role="menuitem" class="action dropdown-menuitem">${_("Sign Out")}</a></li>
@@ -41,8 +46,8 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
             <a href="${reverse('dashboard')}" class="user-link">
                 <span class="sr">${_("Dashboard for:")}</span>
                 <%
-                username = user.username
-                profile_image_url = get_profile_image_urls_for_user(user)['medium']
+                username = original_user.username
+                profile_image_url = get_profile_image_urls_for_user(original_user)['medium']
                 %>
                 <img class="user-image-frame" src="${profile_image_url}" alt="${_('Profile image for {username}').format(username=username)}">
                 <div class="label-username">${username}</div>

--- a/lms/templates/user_dropdown.html
+++ b/lms/templates/user_dropdown.html
@@ -4,7 +4,7 @@
 
 ## This template should not use the target student's details when masquerading, see TNL-4895
 <%
-original_user = real_user or user
+self.real_user = real_user if real_user != UNDEFINED else user
 %>
 
 <%!
@@ -19,8 +19,8 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
         <a href="${reverse('dashboard')}" class="menu-title">
             <span class="sr-only">${_("Dashboard for:")}</span>
             <%
-            username = original_user.username
-            profile_image_url = get_profile_image_urls_for_user(original_user)['medium']
+            username = self.real_user.username
+            profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
             %>
             <img class="menu-image" src="${profile_image_url}" alt="">
             ${username}
@@ -33,7 +33,7 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
             <ul class="dropdown-menu list-divided is-hidden" id="${_("Usermenu")}" tabindex="-1">
                 <%block name="navigation_dropdown_menu_links" >
                     <li class="dropdown-item item has-block-link"><a href="${reverse('dashboard')}" class="action dropdown-menuitem">${_("Dashboard")}</a></li>
-                    <li class="dropdown-item item has-block-link"><a href="${reverse('learner_profile', kwargs={'username': original_user.username})}" class="action dropdown-menuitem">${_("Profile")}</a></li>
+                    <li class="dropdown-item item has-block-link"><a href="${reverse('learner_profile', kwargs={'username': self.real_user.username})}" class="action dropdown-menuitem">${_("Profile")}</a></li>
                     <li class="dropdown-item item has-block-link"><a href="${reverse('account_settings')}" class="action dropdown-menuitem">${_("Account")}</a></li>
                 </%block>
                 <li class="dropdown-item item has-block-link"><a href="${reverse('logout')}" role="menuitem" class="action dropdown-menuitem">${_("Sign Out")}</a></li>
@@ -46,8 +46,8 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
             <a href="${reverse('dashboard')}" class="user-link">
                 <span class="sr">${_("Dashboard for:")}</span>
                 <%
-                username = original_user.username
-                profile_image_url = get_profile_image_urls_for_user(original_user)['medium']
+                username = self.real_user.username
+                profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
                 %>
                 <img class="user-image-frame" src="${profile_image_url}" alt="${_('Profile image for {username}').format(username=username)}">
                 <div class="label-username">${username}</div>


### PR DESCRIPTION
## [TNL-4895](https://openedx.atlassian.net/browse/TNL-4895)
### Description

Exposes real_user to the user_dropdown template, allowing for the requested
feature change of keeping the profile links pointed at the real user's profile.
### Reviewers
- [ ] @sanfordstudent 
- [x] @jcdyer 
