### PR TITLE
[SOL-1612] Add DnDv2 to advanced problems; relabel DnDv1 as deprecated

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1089,6 +1089,10 @@ ADVANCED_PROBLEM_TYPES = [
         'component': 'openassessment',
         'boilerplate_name': None,
     },
+    {
+        'component': 'drag-and-drop-v2',
+        'boilerplate_name': None
+    }
 ]
 
 

--- a/common/lib/xmodule/xmodule/templates/problem/drag_and_drop.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/drag_and_drop.yaml
@@ -1,6 +1,6 @@
 ---
 metadata:
-    display_name: Drag and Drop
+    display_name: Drag and Drop (Deprecated Version)
     markdown: !!null
     showanswer: never
 data: |


### PR DESCRIPTION
This pull request moves the Drag and Drop V2 module into position as a first-class advanced problem type, and relabels the existing Drag and Drop module to note its deprecation.

**JIRA tickets**: Implements SOL-1612

**Discussions**: See discussion on SOL-1612; DnDv1 deprecation has been in process for some time; this finalizes that change.

**Dependencies**: None

**Screenshots**:

**Sandbox URL**:
- **LMS:** http://pr13602.sandbox.opencraft.hosting
- **Studio:** http://studio-pr13602.sandbox.opencraft.hosting

**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client

**Testing instructions**:
1. Pull this branch of edx-platform into a working devstack
2. Run `paver devstack studio`
3. Create a new course without modifying any advanced settings, and a section, subsection, and unit in that course
4. In the new unit, under Add New Component, click the Problem button
5. Click the Advanced tab
6. Observe that there is one "Drag and Drop" item, and one "Drag and Drop (Deprecated Version)" item.
7. Click "Drag and Drop"; observe that it creates a DnDv2 block.
8. Repeat steps 4 through 6, but click "Drag and Drop (Deprecated Version)".
9. Observe that it creates a block containing a DnDv1 module.

**Author notes and concerns**:
1. It seems like there should be a better way to mark DnDv1 as a deprecated version than to change its Display Name variable. I know that on edx.org, it'll be flagged as unsupported and hidden, but it still feels like a bit of a kludge.

**Reviewers**
- [ ] @pomegranited 
- [ ] @cahrens 
- [ ] @sstack22 
