### PR TITLE
Update grade when CAPA problem state is reset

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1476,6 +1476,9 @@ class CapaMixin(CapaFields):
         # Pull in the new problem seed
         self.set_state_from_lcp()
 
+        # Grade may have changed, so publish new value
+        self.publish_grade()
+
         event_info['new_state'] = self.lcp.get_state()
         self.track_function_unmask('reset_problem', event_info)
 


### PR DESCRIPTION
## [TNL-5686](https://openedx.atlassian.net/browse/TNL-5686)
### Description

This PR updates capa's reset_problem method to re-publish its grade since the score is reset to 0.  This change is also needed so that the persisted subsection grade is updated.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [ ] Code review: @jcdyer or @sanfordstudent 

FYI: @cahrens 
### Sandbox

https://nasthagiri.sandbox.edx.org
### Post-review
- [ ] Rebase and squash commits
