### PR TITLE
Removing Scored/has_score from randomized content block

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -99,12 +99,6 @@ class LibraryContentFields(object):
         values=_get_capa_types(),
         scope=Scope.settings,
     )
-    has_score = Boolean(
-        display_name=_("Scored"),
-        help=_("Set this value to True if this module is either a graded assignment or a practice problem."),
-        default=False,
-        scope=Scope.settings,
-    )
     selected = List(
         # This is a list of (block_type, block_id) tuples used to record
         # which random/first set of matching blocks was selected per user

--- a/common/test/acceptance/pages/studio/library.py
+++ b/common/test/acceptance/pages/studio/library.py
@@ -140,7 +140,6 @@ class StudioLibraryContentEditor(ComponentEditorView):
     # Labels used to identify the fields on the edit modal:
     LIBRARY_LABEL = "Library"
     COUNT_LABEL = "Count"
-    SCORED_LABEL = "Scored"
     PROBLEM_TYPE_LABEL = "Problem Type"
 
     @property
@@ -173,26 +172,6 @@ class StudioLibraryContentEditor(ComponentEditorView):
         count_text.send_keys(Keys.BACK_SPACE)
         count_text.send_keys(count)
         EmptyPromise(lambda: self.count == count, "count is updated in modal.").fulfill()
-
-    @property
-    def scored(self):
-        """
-        Gets value of scored select
-        """
-        value = self.get_selected_option_text(self.SCORED_LABEL)
-        if value == 'True':
-            return True
-        elif value == 'False':
-            return False
-        raise ValueError("Unknown value {value} set for {label}".format(value=value, label=self.SCORED_LABEL))
-
-    @scored.setter
-    def scored(self, scored):
-        """
-        Sets value of scored select
-        """
-        self.set_select_value(self.SCORED_LABEL, str(scored))
-        EmptyPromise(lambda: self.scored == scored, "scored is updated in modal.").fulfill()
 
     @property
     def capa_type(self):

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -68,7 +68,6 @@ class LibraryContentTestBase(UniqueCourseTest):
             'source_library_id': unicode(self.library_key),
             'mode': 'random',
             'max_count': 1,
-            'has_score': False
         }
 
         self.lib_block = XBlockFixtureDesc('library_content', "Library Content", metadata=library_content_metadata)

--- a/common/test/acceptance/tests/studio/test_studio_library_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_library_container.py
@@ -65,7 +65,6 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest, TestWithSe
             'source_library_id': unicode(self.library_key),
             'mode': 'random',
             'max_count': 1,
-            'has_score': False
         }
 
         course_fixture.add_children(
@@ -84,13 +83,8 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest, TestWithSe
         """
         return StudioLibraryContainerXBlockWrapper.from_xblock_wrapper(xblock)
 
-    @ddt.data(
-        (1, True),
-        (2, False),
-        (3, True),
-    )
-    @ddt.unpack
-    def test_can_edit_metadata(self, max_count, scored):
+    @ddt.data(1, 2, 3)
+    def test_can_edit_metadata(self, max_count):
         """
         Scenario: Given I have a library, a course and library content xblock in a course
         When I go to studio unit page for library content block
@@ -103,7 +97,6 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest, TestWithSe
         edit_modal = StudioLibraryContentEditor(self.browser, library_container.locator)
         edit_modal.library_name = library_name
         edit_modal.count = max_count
-        edit_modal.scored = scored
 
         library_container.save_settings()  # saving settings
 
@@ -112,7 +105,6 @@ class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest, TestWithSe
         edit_modal = StudioLibraryContentEditor(self.browser, library_container.locator)
         self.assertEqual(edit_modal.library_name, library_name)
         self.assertEqual(edit_modal.count, max_count)
-        self.assertEqual(edit_modal.scored, scored)
 
     def test_no_library_shows_library_not_configured(self):
         """


### PR DESCRIPTION
## [TNL-4171](https://openedx.atlassian.net/browse/TNL-4171)
### Remove Scored field from randomized content blocks.

It was discovered that the "Scored" field presented to course teams for randomized content blocks had no effect; though this field originally was intended to update the block's `has_score` field, a [later refactoring](https://github.com/edx/edx-platform/commit/79de77cf9589885248d82fb8ad1f4c80de8dadc4) means that content libraries are always treated as scored if they have child blocks; the Scored field no longer had any effect. This both caused confusing behavior and rendered our documentation on the Scored field incorrect. As the field has no effect, it is being removed entirely.

Once this is merged, the "settings" modal (the bottom is shown here, as that's where the Scored field appeared) for a randomized content block in studio will change **from:**
<img width="1009" alt="screen shot 2016-09-30 at 9 58 22 am" src="https://cloud.githubusercontent.com/assets/12545624/18994141/64a467d6-86f4-11e6-8268-b41794e09041.png">

**to:**
<img width="1000" alt="screen shot 2016-09-30 at 9 57 25 am" src="https://cloud.githubusercontent.com/assets/12545624/18994109/3e88fc1a-86f4-11e6-9888-c45a0f383575.png">
### Sandbox
- [x] https://sanfordstudent.sandbox.edx.org/
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: one of @nasthagiri, @efischer19, @jcdyer, @yro 
- [x] Code review: another of the above.
- [ ] Doc Review: @catong 
- [x] Product FYI: @sstack22 
### Post-review
- [x] Rebase and squash commits
