### PR TITLE
WL-611: Fix "Access Denied" when downloading report

### DIFF
--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -194,10 +194,11 @@ class ReportStore(object):
         storage_type = config.get('STORAGE_TYPE', '').lower()
         if storage_type == 's3':
             return DjangoStorageReportStore(
-                storage_class='storages.backends.s3boto.S3BotoStorage',
+                storage_class='openedx.core.storage.S3ReportStorage',
                 storage_kwargs={
                     'bucket': config['BUCKET'],
                     'location': config['ROOT_PATH'],
+                    'custom_domain': config.get("CUSTOM_DOMAIN", None),
                     'querystring_expire': 300,
                     'gzip': True,
                 },

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2372,6 +2372,7 @@ GRADES_DOWNLOAD = {
 FINANCIAL_REPORTS = {
     'STORAGE_TYPE': 'localfs',
     'BUCKET': 'edx-financial-reports',
+    'CUSTOM_DOMAIN': 'edx-financial-reports.s3.amazonaws.com',
     'ROOT_PATH': '/tmp/edx-s3/financial_reports',
 }
 

--- a/openedx/core/storage.py
+++ b/openedx/core/storage.py
@@ -13,6 +13,7 @@ from openedx.core.djangoapps.theming.storage import (
     ThemeCachedFilesMixin,
     ThemePipelineMixin
 )
+from storages.backends.s3boto import S3BotoStorage
 
 
 class ProductionStorage(
@@ -42,6 +43,29 @@ class DevelopmentStorage(
     so that we can skip packaging and optimization.
     """
     pass
+
+
+class S3ReportStorage(S3BotoStorage):  # pylint: disable=abstract-method
+    """
+    Storage for reports.
+    """
+    def __init__(self, acl=None, bucket=None, custom_domain=None, **settings):
+        """
+        init method for S3ReportStorage, Note that we have added an extra key-word
+        argument named "custom_domain" and this argument should not be passed to the superclass's init.
+
+        Args:
+            acl: content policy for the uploads i.e. private, public etc.
+            bucket: Name of S3 bucket to use for storing and/or retrieving content
+            custom_domain: custom domain to use for generating file urls
+            **settings: additional settings to be passed in to S3BotoStorage,
+
+        Returns:
+
+        """
+        if custom_domain:
+            self.custom_domain = custom_domain
+        super(S3ReportStorage, self).__init__(acl=acl, bucket=bucket, **settings)
 
 
 @lru_cache()


### PR DESCRIPTION
Hi @mattdrayer , @asadiqbal08 

Kindly take a look at the PR it fixes the wrong bucket name problem for financial reports.

We would also have to make supporting secure configuration changes to add `CUSTOM_DOMAIN` with proper value in `EDXAPP_FINANCIAL_REPORTS`, I will create a ticket once these changes have been approved.

**Problem Description:** 
One of the first issues I noticed when investigating this broken report is that the download URL references the wrong AWS S3 bucket.
For example, here is the link displayed in the instructor dashboard:
https://edxuploads.s3.amazonaws.com/production/REDACTED.csv
instead it should be the following link:
https://edx-financial-reports.s3.amazonaws.com/production/REDACTED.csv
