### PR TITLE
Aj/tnl 5644 exposed icon

### DIFF
--- a/common/lib/capa/capa/templates/annotationinput.html
+++ b/common/lib/capa/capa/templates/annotationinput.html
@@ -22,12 +22,10 @@
     % for option in options:
         <li>
             % if has_options_value:
-                % if all([c == 'correct' for c in option['choice'], status]):
-                <span class="tag-status correct" id="status_${id}" aria-describedby="input_${id}_comment"><span class="sr">Status: Correct</span></span>
-                % elif all([c == 'partially-correct' for c in option['choice'], status]):
-                <span class="tag-status partially-correct" id="status_${id}" aria-describedby="input_${id}_comment"><span class="sr">Status: Partially Correct</span></span>
-                % elif all([c == 'incorrect' for c in option['choice'], status]):
-                <span class="tag-status incorrect" id="status_${id}" aria-describedby="input_${id}_comment"><span class="sr">Status: Incorrect</span></span>
+                % if all([c == status.classname for c in option['choice'], status]):
+                <span class="tag-status ${status.classname}" aria-describedby="input_${id}_comment">
+                    <%include file="status_span.html" args="status=status"/>
+                </span>
                 % endif
             % endif
 
@@ -53,7 +51,7 @@
         <input type="hidden" class="value" name="input_${id}" id="input_${id}" value="${value|h}" />
     % endif
 
-    <span class="status ${status.classname}" id="status_${id}" aria-describedby="label_${id}"><span class="sr">${status.display_name}</span></span>
+    <%include file="status_span.html" args="status=status, status_id=id"/>
 
     <p id="answer_${id}" class="answer answer-annotation"></p>
 </div>

--- a/common/lib/capa/capa/templates/chemicalequationinput.html
+++ b/common/lib/capa/capa/templates/chemicalequationinput.html
@@ -2,23 +2,21 @@
 <div id="chemicalequationinput_${id}" class="chemicalequationinput">
     <div class="script_placeholder" data-src="${previewer}"/>
 
-    <div class="${status.classname}" id="status_${id}">
+    <div class="${status.classname}">
 
-    <input type="text" name="input_${id}" id="input_${id}" aria-label="${remove_markup(response_data['label'])}" aria-describedby="answer_${id}" data-input-id="${id}" value="${value|h}"
-   % if size:
-   size="${size}"
-   % endif
-   />
+      <input type="text" name="input_${id}" id="input_${id}" aria-label="${remove_markup(response_data['label'])}"
+             aria-describedby="answer_${id}" data-input-id="${id}" value="${value|h}"
+             % if size:
+              size="${size}"
+             % endif
+      />
 
-      <p class="status" aria-describedby="input_${id}">
+      <p class="status">
         ${value|h}
-        <span class="sr">${status.display_name}</span>
+        <%include file="status_span.html" args="status=status, status_id=id"/>
       </p>
 
       <div id="input_${id}_preview" class="equation"></div>
-  <p id="answer_${id}" class="answer"></p>
-
-% if status in ['unsubmitted', 'correct', 'incorrect', 'partially-correct', 'incomplete']:
-</div>
-% endif
+      <p id="answer_${id}" class="answer"></p>
+  </div>
 </div>

--- a/common/lib/capa/capa/templates/choicegroup.html
+++ b/common/lib/capa/capa/templates/choicegroup.html
@@ -7,7 +7,7 @@
     ))
 %>
 <form class="choicegroup capa_inputtype" id="inputtype_${id}">
-    <fieldset ${HTML(describedby_html)}>
+    <fieldset ${describedby_html}>
       % if response_data['label']:
         <legend id="${id}-legend" class="response-fieldset-legend field-group-hd">${response_data['label']}</legend>
       % endif
@@ -37,7 +37,7 @@
                     % endif
                 % endif
                 class="${label_class}"
-                ${HTML(describedby_html)}
+                ${describedby_html}
                 >
                 <input type="${input_type}" name="input_${id}${name_array_suffix}" id="input_${id}_${choice_id}" class="field-input input-${input_type}" value="${choice_id}"
                 ## If the student selected this choice...
@@ -49,8 +49,8 @@
                 /> ${HTML(choice_label)}
 
                 % if is_radio_input(choice_id):
-                  % if status in ('correct', 'partially-correct', 'incorrect') and not show_correctness == 'never':
-                    <span class="sr status" id="${id}-${choice_id}-labeltext">${status.display_name}</span>
+                  % if not show_correctness == 'never' and status.classname != 'unanswered':
+                    <%include file="status_span.html" args="status=status, status_id=id"/>
                   % endif
                 % endif
             </label>
@@ -59,10 +59,12 @@
         <span id="answer_${id}"></span>
     </fieldset>
     <div class="indicator-container">
-        % if input_type == 'checkbox' or not value:
-            <span class="status ${status.classname if show_correctness != 'never' else 'unanswered'}" id="status_${id}" aria-describedby="${id}-legend" data-tooltip="${status.display_tooltip}">
-                <span class="sr">${status.display_tooltip}</span>
-            </span>
+        % if input_type == 'checkbox' or status.classname == 'unanswered':
+          % if show_correctness != 'never':
+            <%include file="status_span.html" args="status=status, status_id=id"/>
+          % else:
+            <%include file="status_span.html" args="status=status, status_id=id, hide_correctness=True"/>
+          % endif
         % endif
     </div>
     % if show_correctness == "never" and (value or status not in ['unsubmitted']):

--- a/common/lib/capa/capa/templates/choicetext.html
+++ b/common/lib/capa/capa/templates/choicetext.html
@@ -66,9 +66,7 @@ from openedx.core.djangolib.markup import HTML
 
     <div class="indicator-container">
     % if input_type == 'checkbox' or not element_checked:
-        <span class="status ${status.classname}" id="status_${id}">
-            <span class="sr">${status.display_name}</span>
-        </span>
+        <%include file="status_span.html" args="status=status, status_id=id"/>
     % endif
     </div>
 

--- a/common/lib/capa/capa/templates/codeinput.html
+++ b/common/lib/capa/capa/templates/codeinput.html
@@ -26,12 +26,9 @@ from openedx.core.djangolib.markup import HTML
   </span>
 
   <div class="grader-status" tabindex="-1">
-      <span id="status_${id}"
-            class="${status.classname}"
-            aria-describedby="input_${id}"
-      >
-          <span class="status sr">${status.display_name}</span>
-      </span>
+
+    <%include file="status_span.html" args="status=status, status_id=id"/>
+
     % if status == 'queued':
       <span style="display:none;" class="xqueue" id="${id}">${queue_len}</span>
     % endif

--- a/common/lib/capa/capa/templates/crystallography.html
+++ b/common/lib/capa/capa/templates/crystallography.html
@@ -16,9 +16,7 @@
 
     <input type="text" name="input_${id}" aria-describedby="answer_${id}" id="input_${id}" value="${value|h}" style="display:none;"/>
 
-    <p class="status" aria-describedby="input_${id}">
-        <span class="sr">${status.display_name}</span>
-    </p>
+    <%include file="status_span.html" args="status=status, status_id=id"/>
 
     <p id="answer_${id}" class="answer"></p>
 

--- a/common/lib/capa/capa/templates/designprotein2dinput.html
+++ b/common/lib/capa/capa/templates/designprotein2dinput.html
@@ -10,9 +10,7 @@
     <input type="hidden" name="target_shape" id="target_shape" value ="${target_shape}"></input>
     <input type="hidden" name="input_${id}" id="input_${id}" aria-describedby="answer_${id}" value="${value|h}"/>
 
-    <p class="status" aria-describedby="input_${id}">
-        <span class="sr">${status.display_name}</span>
-    </p>
+    <%include file="status_span.html" args="status=status, status_id=id"/>
 
     <p id="answer_${id}" class="answer"></p>
   % if status in ['unsubmitted', 'correct', 'incorrect', 'partially-correct', 'incomplete']:

--- a/common/lib/capa/capa/templates/drag_and_drop_input.html
+++ b/common/lib/capa/capa/templates/drag_and_drop_input.html
@@ -17,8 +17,9 @@
     <input type="text" name="input_${id}" id="input_${id}" aria-describedby="answer_${id}" value="${value|h}"
     style="display:none;"/>
 
+
     <p class="status drag-and-drop--status" aria-describedby="input_${id}">
-        <span class="sr">${status.display_name}</span>
+        <%include file="status_span.html" args="status=status, status_id=id"/>
     </p>
 
     <p id="answer_${id}" class="answer"></p>

--- a/common/lib/capa/capa/templates/editageneinput.html
+++ b/common/lib/capa/capa/templates/editageneinput.html
@@ -3,7 +3,7 @@
     <div class="script_placeholder" data-src="${applet_loader}"/>
 
     % if status in ['unsubmitted', 'correct', 'incorrect', 'partially-correct', 'incomplete']:
-    <div class="${status.classname}" id="status_${id}">
+    <div class="${status.classname}">
     % endif
 
     <div id="genex_container"></div>
@@ -12,7 +12,7 @@
     <input type="hidden" name="input_${id}" aria-describedby="answer_${id}" id="input_${id}" value="${value|h}"/>
 
     <p class="status" aria-describedby="input_${id}">
-        <span class="sr">${status.display_name}</span>
+        <%include file="status_span.html" args="status=status, status_id=id"/>
     </p>
 
     <p id="answer_${id}" class="answer"></p>

--- a/common/lib/capa/capa/templates/editamolecule.html
+++ b/common/lib/capa/capa/templates/editamolecule.html
@@ -2,7 +2,7 @@
   <div class="script_placeholder" data-src="${applet_loader}"/>
 
     % if status in ['unsubmitted', 'correct', 'incorrect', 'partially-correct', 'incomplete']:
-    <div class="${status.classname}" id="status_${id}">
+    <div class="${status.classname}">
     % endif
 
     <div id="applet_${id}" class="applet" data-molfile-src="${file}" style="display:block;width:500px;height:400px">
@@ -17,7 +17,7 @@
     <p id="answer_${id}" class="answer"></p>
 
     <p class="status" aria-describedby="input_${id}">
-      <span class="sr">${status.display_name}</span>
+      <%include file="status_span.html" args="status=status, status_id=id"/>
     </p>
 
     <div class="error_message" style="padding: 5px 5px 5px 5px; background-color:#FA6666; height:60px;width:400px; display: none"></div>

--- a/common/lib/capa/capa/templates/formulaequationinput.html
+++ b/common/lib/capa/capa/templates/formulaequationinput.html
@@ -2,7 +2,7 @@
 <%! from openedx.core.djangolib.markup import HTML %>
 <% doinline = 'style="display:inline-block;vertical-align:top"' if inline else "" %>
 <div id="formulaequationinput_${id}" class="inputtype formulaequationinput" ${doinline | n, decode.utf8}>
-    <div class="${status.classname}" id="status_${id}">
+    <div class="${status.classname}">
       % if response_data['label']:
           <label class="problem-group-label" for="input_${id}" id="label_${id}">${response_data['label']}</label>
       % endif
@@ -11,16 +11,14 @@
         % endfor
         <input type="text" name="input_${id}" id="input_${id}"
             data-input-id="${id}" value="${value}"
-            ${HTML(describedby_html)}
+            ${describedby_html}
             % if size:
             size="${size}"
             % endif
             />
         <span class="trailing_text">${trailing_text}</span>
 
-        <span class="status" id="${id}_status" aria-describedby="label_${id}" data-tooltip="${status.display_tooltip}">
-            <span class="sr">${status.display_tooltip}</span>
-        </span>
+        <%include file="status_span.html" args="status=status, status_id=id"/>
 
         <p id="answer_${id}" class="answer"></p>
 

--- a/common/lib/capa/capa/templates/imageinput.html
+++ b/common/lib/capa/capa/templates/imageinput.html
@@ -40,11 +40,5 @@
     (new ImageInput('${id}'));
   </script>
 
-      <span
-        class="status ${status.classname}"
-        id="status_${id}"
-        aria-describedby="input_${id}"
-      >
-        <span class="sr">${status.display_name}</span>
-      </span>
+  <%include file="status_span.html" args="status=status, status_id=id"/>
 </div>

--- a/common/lib/capa/capa/templates/javascriptinput.html
+++ b/common/lib/capa/capa/templates/javascriptinput.html
@@ -1,8 +1,9 @@
+<%page expression_filter="h"/>
 <form class="javascriptinput capa_inputtype" id="inputtype_${id}">
   <input type="hidden" name="input_${id}" id="input_${id}" class="javascriptinput_input"/>
     <div class="javascriptinput_data" data-display_class="${display_class}" 
         data-problem_state="${problem_state}" data-params="${params}" 
-        data-submission="${value|h}" data-evaluation="${msg|h}">
+        data-submission="${value}" data-evaluation="${msg}">
     </div>
     <div class="script_placeholder" data-src="/static/js/${display_file}"></div>
     <div class="javascriptinput_container"></div>

--- a/common/lib/capa/capa/templates/jsinput.html
+++ b/common/lib/capa/capa/templates/jsinput.html
@@ -22,7 +22,7 @@
   <div class="script_placeholder" data-src="${jschannel_loader}"/>
   <div class="script_placeholder" data-src="${jsinput_loader}"/>
   % if status in ['unsubmitted', 'correct', 'incorrect', 'partially-correct', 'incomplete']:
-  <div class="${status.classname}" id="status_${id}">
+  <div class="${status.classname}">
   % endif
 
   <iframe name="iframe_${id}"
@@ -42,7 +42,7 @@
     <p id="answer_${id}" class="answer"></p>
 
     <p class="status">
-        <span class="sr">${status.display_name}</span>
+      <%include file="status_span.html" args="status=status, status_id=id"/>
     </p>
 
     <div class="error_message" style="padding: 5px 5px 5px 5px; background-color:#FA6666; height:60px;width:400px; display: none"></div>

--- a/common/lib/capa/capa/templates/matlabinput.html
+++ b/common/lib/capa/capa/templates/matlabinput.html
@@ -17,12 +17,9 @@
   >${value|h}</textarea>
 
   <div class="grader-status" tabindex="-1">
-      <span id="status_${id}"
-            class="${status.classname}"
-            aria-describedby="input_${id}"
-      >
-          <span class="status sr">${status.display_name}</span>
-      </span>
+
+    <%include file="status_span.html" args="status=status, status_id=id"/>
+
     % if status == 'queued':
       <span style="display:none;" class="xqueue" id="${id}">${queue_len}</span>
     % endif

--- a/common/lib/capa/capa/templates/optioninput.html
+++ b/common/lib/capa/capa/templates/optioninput.html
@@ -11,7 +11,7 @@
     <p class="question-description" id="${description_id}">${description_text}</p>
   % endfor
 
-   <select name="input_${id}" id="input_${id}" ${HTML(describedby_html)}>
+   <select name="input_${id}" id="input_${id}" ${describedby_html}>
       <option value="option_${id}_dummy_default">${default_option_text}</option>
       % for option_id, option_description in options:
           <option value="${option_id}"
@@ -23,11 +23,7 @@
     </select>
 
   <div class="indicator-container">
-    <span class="status ${status.classname}"
-        id="status_${id}"
-        aria-describedby="label_${id}" data-tooltip="${status.display_tooltip}">
-        <span class="sr">${status.display_tooltip}</span>
-    </span>
+    <%include file="status_span.html" args="status=status, status_id=id"/>
   </div>
   <p class="answer" id="answer_${id}"></p>
   % if msg:

--- a/common/lib/capa/capa/templates/schematicinput.html
+++ b/common/lib/capa/capa/templates/schematicinput.html
@@ -18,7 +18,7 @@
 
   <span id="answer_${id}"></span>
   <div class="indicator-container">
-    <span class="status ${status.classname}" id="status_${id}" aria-describedby="input_${id}"></span>
-    <span class="sr">${status.display_tooltip}</span>
+    <%include file="status_span.html" args="status=status, status_id=id"/>
+
   </div>
 </div>

--- a/common/lib/capa/capa/templates/solutionspan.html
+++ b/common/lib/capa/capa/templates/solutionspan.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <div class="solution-span">
  <span id="solution_${id}"></span>
 </div>

--- a/common/lib/capa/capa/templates/status_span.html
+++ b/common/lib/capa/capa/templates/status_span.html
@@ -1,0 +1,13 @@
+<%page expression_filter="h" args="status, status_id='', hide_correctness=False"/>
+
+% if status_id == '':
+<span class="status ${'' if hide_correctness == True else status.classname}"
+      data-tooltip="${'' if hide_correctness == True else status.display_tooltip}">
+% else:
+<span class="status ${'' if hide_correctness == True else status.classname}" id="status_${status_id}"
+      data-tooltip="${'' if hide_correctness == True else status.display_tooltip}">
+% endif
+  % if hide_correctness == False:
+  <span class="sr">${status.display_name}</span><span class="status-icon" aria-hidden="true"></span>
+  % endif
+</span>

--- a/common/lib/capa/capa/templates/textline.html
+++ b/common/lib/capa/capa/templates/textline.html
@@ -9,7 +9,7 @@
 % endif
 
 % if status in ('unsubmitted', 'correct', 'incorrect', 'partially-correct', 'incomplete'):
-    <div class="${status.classname} ${doinline}" id="status_${id}">
+    <div class="${status.classname} ${doinline}">
 % endif
 
 % if hidden:
@@ -23,7 +23,7 @@
 % for description_id, description_text in response_data['descriptions'].items():
     <p class="question-description" id="${description_id}">${description_text}</p>
 % endfor
-<input type="text" name="input_${id}" id="input_${id}" ${HTML(describedby_html)} value="${value}"
+<input type="text" name="input_${id}" id="input_${id}" ${describedby_html} value="${value}"
     % if do_math:
         class="math"
     % endif
@@ -36,9 +36,7 @@
 />
 <span class="trailing_text">${trailing_text}</span>
 
-<span class="status" aria-describedby="label_${id}" data-tooltip="${status.display_tooltip}">
-    <span class="sr">${status.display_tooltip}</span>
-</span>
+<%include file="status_span.html" args="status=status, status_id=id"/>
 
 <p id="answer_${id}" class="answer"></p>
 

--- a/common/lib/capa/capa/tests/helpers.py
+++ b/common/lib/capa/capa/tests/helpers.py
@@ -22,7 +22,8 @@ def get_template(template_name):
     Return template for a capa inputtype.
     """
     return TemplateLookup(
-        directories=[path(__file__).dirname().dirname() / 'templates']
+        directories=[path(__file__).dirname().dirname() / 'templates'],
+        default_filters=['decode.utf8']
     ).get_template(template_name)
 
 

--- a/common/lib/capa/capa/tests/test_html_render.py
+++ b/common/lib/capa/capa/tests/test_html_render.py
@@ -1,16 +1,17 @@
 """
 CAPA HTML rendering tests.
 """
-import ddt
-import unittest
-from lxml import etree
-import os
 import textwrap
+import unittest
 
+import ddt
 import mock
+import os
+from capa.tests.helpers import test_capa_system, new_loncapa_problem
+from lxml import etree
+from openedx.core.djangolib.markup import HTML
 
 from .response_xml_factory import StringResponseXMLFactory, CustomResponseXMLFactory
-from capa.tests.helpers import test_capa_system, new_loncapa_problem
 
 
 @ddt.ddt
@@ -190,7 +191,7 @@ class CapaHtmlRenderTest(unittest.TestCase):
             'trailing_text': '',
             'size': None,
             'response_data': {'label': 'Test question', 'descriptions': {}},
-            'describedby_html': ''
+            'describedby_html': HTML('aria-describedby="status_1_2_1"')
         }
 
         expected_solution_context = {'id': '1_solution_1'}

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -16,27 +16,27 @@ TODO:
 - test funny xml chars -- should never get xml parse error if things are escaped properly.
 
 """
-from collections import OrderedDict
 import json
-from lxml import etree
-from lxml.html import fromstring
-import unittest
 import textwrap
+import unittest
 import xml.sax.saxutils as saxutils
+from collections import OrderedDict
 
-from capa.tests.helpers import test_capa_system
 from capa import inputtypes
 from capa.checker import DemoSystem
-from mock import ANY, patch
-from pyparsing import ParseException
-
+from capa.tests.helpers import test_capa_system
 from capa.xqueue_interface import XQUEUE_TIMEOUT
+from lxml import etree
+from lxml.html import fromstring
+from mock import ANY, patch
+from openedx.core.djangolib.markup import HTML
+from pyparsing import ParseException
 
 # just a handy shortcut
 lookup_tag = inputtypes.registry.get_class_for_tag
 
 
-DESCRIBEDBY = 'aria-describedby="desc-1 desc-2"'
+DESCRIBEDBY = HTML('aria-describedby="status_{status_id} desc-1 desc-2"')
 DESCRIPTIONS = OrderedDict([('desc-1', 'description text 1'), ('desc-2', 'description text 2')])
 RESPONSE_DATA = {
     'label': 'question text 101',
@@ -67,7 +67,7 @@ class OptionInputTest(unittest.TestCase):
         option_input = lookup_tag('optioninput')(test_capa_system(), element, state)
 
         context = option_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'sky_input'
         expected = {
             'STATIC_URL': '/dummy-static/',
             'value': 'Down',
@@ -75,10 +75,10 @@ class OptionInputTest(unittest.TestCase):
             'status': inputtypes.Status('answered'),
             'msg': '',
             'inline': False,
-            'id': 'sky_input',
+            'id': prob_id,
             'default_option_text': 'Select an option',
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id='sky_input')
         }
 
         self.assertEqual(context, expected)
@@ -147,7 +147,7 @@ class ChoiceGroupTest(unittest.TestCase):
             'submitted_message': 'Answer received.',
             'name_array_suffix': expected_suffix,   # what is this for??
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id='sky_input')
         }
 
         self.assertEqual(context, expected)
@@ -189,10 +189,10 @@ class JavascriptInputTest(unittest.TestCase):
         the_input = lookup_tag('javascriptinput')(test_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'status': inputtypes.Status('unanswered'),
             'msg': '',
             'value': '3',
@@ -201,7 +201,7 @@ class JavascriptInputTest(unittest.TestCase):
             'display_class': display_class,
             'problem_state': problem_state,
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         self.assertEqual(context, expected)
@@ -225,10 +225,10 @@ class TextLineTest(unittest.TestCase):
         the_input = lookup_tag('textline')(test_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': 'BumbleBee',
             'status': inputtypes.Status('unanswered'),
             'size': size,
@@ -239,7 +239,7 @@ class TextLineTest(unittest.TestCase):
             'trailing_text': '',
             'preprocessor': None,
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
         self.assertEqual(context, expected)
 
@@ -261,10 +261,10 @@ class TextLineTest(unittest.TestCase):
         the_input = lookup_tag('textline')(test_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': 'BumbleBee',
             'status': inputtypes.Status('unanswered'),
             'size': size,
@@ -278,7 +278,7 @@ class TextLineTest(unittest.TestCase):
                 'script_src': script,
             },
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
         self.assertEqual(context, expected)
 
@@ -309,10 +309,10 @@ class TextLineTest(unittest.TestCase):
             the_input = lookup_tag('textline')(test_capa_system(), element, state)
 
             context = the_input._get_render_context()  # pylint: disable=protected-access
-
+            prob_id = 'prob_1_2'
             expected = {
                 'STATIC_URL': '/dummy-static/',
-                'id': 'prob_1_2',
+                'id': prob_id,
                 'value': 'BumbleBee',
                 'status': inputtypes.Status('unanswered'),
                 'size': size,
@@ -323,7 +323,7 @@ class TextLineTest(unittest.TestCase):
                 'trailing_text': expected_text,
                 'preprocessor': None,
                 'response_data': RESPONSE_DATA,
-                'describedby_html': DESCRIBEDBY
+                'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
             }
             self.assertEqual(context, expected)
 
@@ -355,10 +355,10 @@ class FileSubmissionTest(unittest.TestCase):
         the_input = input_class(test_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'status': inputtypes.Status('queued'),
             'msg': the_input.submitted_msg,
             'value': 'BumbleBee.py',
@@ -366,7 +366,7 @@ class FileSubmissionTest(unittest.TestCase):
             'allowed_files': '["runme.py", "nooooo.rb", "ohai.java"]',
             'required_files': '["cookies.py"]',
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         self.assertEqual(context, expected)
@@ -407,10 +407,10 @@ class CodeInputTest(unittest.TestCase):
         the_input = input_class(test_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': 'print "good evening"',
             'status': inputtypes.Status('queued'),
             'msg': the_input.submitted_msg,
@@ -424,7 +424,7 @@ class CodeInputTest(unittest.TestCase):
             'aria_label': '{mode} editor'.format(mode=mode),
             'code_mirror_exit_message': 'Press ESC then TAB or click outside of the code editor to exit',
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         self.assertEqual(context, expected)
@@ -486,7 +486,7 @@ class MatlabTest(unittest.TestCase):
             'queue_len': '3',
             'matlab_editor_js': '/dummy-static/js/vendor/CodeMirror/octave.js',
             'response_data': {},
-            'describedby_html': ''
+            'describedby_html': HTML('aria-describedby="status_prob_1_2"')
         }
 
         self.assertEqual(context, expected)
@@ -503,10 +503,10 @@ class MatlabTest(unittest.TestCase):
 
         the_input = self.input_class(test_capa_system(), elt, state)
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': 'print "good evening"',
             'status': inputtypes.Status('queued'),
             'msg': the_input.submitted_msg,
@@ -521,7 +521,7 @@ class MatlabTest(unittest.TestCase):
             'queue_len': '3',
             'matlab_editor_js': '/dummy-static/js/vendor/CodeMirror/octave.js',
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         self.assertEqual(context, expected)
@@ -535,12 +535,12 @@ class MatlabTest(unittest.TestCase):
                 'response_data': RESPONSE_DATA
             }
             elt = etree.fromstring(self.xml)
-
+            prob_id = 'prob_1_2'
             the_input = self.input_class(test_capa_system(), elt, state)
             context = the_input._get_render_context()  # pylint: disable=protected-access
             expected = {
                 'STATIC_URL': '/dummy-static/',
-                'id': 'prob_1_2',
+                'id': prob_id,
                 'value': 'print "good evening"',
                 'status': inputtypes.Status(status),
                 'msg': '',
@@ -555,7 +555,7 @@ class MatlabTest(unittest.TestCase):
                 'queue_len': '0',
                 'matlab_editor_js': '/dummy-static/js/vendor/CodeMirror/octave.js',
                 'response_data': RESPONSE_DATA,
-                'describedby_html': DESCRIBEDBY
+                'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
             }
 
             self.assertEqual(context, expected)
@@ -569,12 +569,12 @@ class MatlabTest(unittest.TestCase):
             'response_data': RESPONSE_DATA
         }
         elt = etree.fromstring(self.xml)
-
+        prob_id = 'prob_1_2'
         the_input = self.input_class(test_capa_system(), elt, state)
         context = the_input._get_render_context()  # pylint: disable=protected-access
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': 'print "good evening"',
             'status': inputtypes.Status('queued'),
             'msg': the_input.submitted_msg,
@@ -589,7 +589,7 @@ class MatlabTest(unittest.TestCase):
             'queue_len': '1',
             'matlab_editor_js': '/dummy-static/js/vendor/CodeMirror/octave.js',
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         self.assertEqual(context, expected)
@@ -713,7 +713,8 @@ class MatlabTest(unittest.TestCase):
             \'msg\': u\'Submitted. As soon as a response is returned,
             this message will be replaced by that feedback.\',
             \'matlab_editor_js\': \'/dummy-static/js/vendor/CodeMirror/octave.js\',
-            \'hidden\': \'\', \'id\': \'prob_1_2\', \'describedby_html\': \'\',
+            \'hidden\': \'\', \'id\': \'prob_1_2\',
+            \'describedby_html\': Markup(u\'aria-describedby="status_prob_1_2"\'),
             \'response_data\': {}}</div>
             """).replace('\n', ' ').strip()
         )
@@ -804,9 +805,10 @@ class MatlabTest(unittest.TestCase):
         context = self.the_input._get_render_context()  # pylint: disable=protected-access
 
         self.maxDiff = None
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': 'print "good evening"',
             'status': inputtypes.Status('queued'),
             'msg': self.the_input.submitted_msg,
@@ -821,7 +823,7 @@ class MatlabTest(unittest.TestCase):
             'queue_len': '3',
             'matlab_editor_js': '/dummy-static/js/vendor/CodeMirror/octave.js',
             'response_data': {},
-            'describedby_html': ''
+            'describedby_html': 'aria-describedby="status_{id}"'.format(id=prob_id)
         }
 
         self.assertEqual(context, expected)
@@ -917,10 +919,10 @@ class SchematicTest(unittest.TestCase):
         the_input = lookup_tag('schematic')(test_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': value,
             'status': inputtypes.Status('unsubmitted'),
             'msg': '',
@@ -932,7 +934,7 @@ class SchematicTest(unittest.TestCase):
             'analyses': analyses,
             'submit_analyses': submit_analyses,
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         self.assertEqual(context, expected)
@@ -965,10 +967,10 @@ class ImageInputTest(unittest.TestCase):
         the_input = lookup_tag('imageinput')(test_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': value,
             'status': inputtypes.Status('unsubmitted'),
             'width': width,
@@ -978,7 +980,7 @@ class ImageInputTest(unittest.TestCase):
             'gy': egy,
             'msg': '',
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         self.assertEqual(context, expected)
@@ -1024,17 +1026,17 @@ class CrystallographyTest(unittest.TestCase):
         the_input = lookup_tag('crystallography')(test_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': value,
             'status': inputtypes.Status('unsubmitted'),
             'msg': '',
             'width': width,
             'height': height,
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         self.assertEqual(context, expected)
@@ -1070,10 +1072,10 @@ class VseprTest(unittest.TestCase):
         the_input = lookup_tag('vsepr_input')(test_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': value,
             'status': inputtypes.Status('unsubmitted'),
             'msg': '',
@@ -1082,7 +1084,7 @@ class VseprTest(unittest.TestCase):
             'molecules': molecules,
             'geometries': geometries,
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         self.assertEqual(context, expected)
@@ -1108,17 +1110,17 @@ class ChemicalEquationTest(unittest.TestCase):
     def test_rendering(self):
         ''' Verify that the render context matches the expected render context'''
         context = self.the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': 'H2OYeah',
             'status': inputtypes.Status('unanswered'),
             'msg': '',
             'size': self.size,
             'previewer': '/dummy-static/js/capa/chemical_equation_preview.js',
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
         self.assertEqual(context, expected)
 
@@ -1201,10 +1203,10 @@ class FormulaEquationTest(unittest.TestCase):
         Verify that the render context matches the expected render context
         """
         context = self.the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'prob_1_2'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': 'x^2+1/2',
             'status': inputtypes.Status('unanswered'),
             'msg': '',
@@ -1213,7 +1215,7 @@ class FormulaEquationTest(unittest.TestCase):
             'inline': False,
             'trailing_text': '',
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
         self.assertEqual(context, expected)
 
@@ -1247,10 +1249,10 @@ class FormulaEquationTest(unittest.TestCase):
             the_input = lookup_tag('formulaequationinput')(test_capa_system(), element, state)
 
             context = the_input._get_render_context()  # pylint: disable=protected-access
-
+            prob_id = 'prob_1_2'
             expected = {
                 'STATIC_URL': '/dummy-static/',
-                'id': 'prob_1_2',
+                'id': prob_id,
                 'value': 'x^2+1/2',
                 'status': inputtypes.Status('unanswered'),
                 'msg': '',
@@ -1259,7 +1261,7 @@ class FormulaEquationTest(unittest.TestCase):
                 'inline': False,
                 'trailing_text': expected_text,
                 'response_data': RESPONSE_DATA,
-                'describedby_html': DESCRIBEDBY
+                'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
             }
 
             self.assertEqual(context, expected)
@@ -1381,17 +1383,17 @@ class DragAndDropTest(unittest.TestCase):
         }
 
         the_input = lookup_tag('drag_and_drop_input')(test_capa_system(), element, state)
-
+        prob_id = 'prob_1_2'
         context = the_input._get_render_context()  # pylint: disable=protected-access
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'prob_1_2',
+            'id': prob_id,
             'value': value,
             'status': inputtypes.Status('unsubmitted'),
             'msg': '',
             'drag_and_drop_json': json.dumps(user_input),
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         # as we are dumping 'draggables' dicts while dumping user_input, string
@@ -1437,10 +1439,10 @@ class AnnotationInputTest(unittest.TestCase):
         the_input = lookup_tag(tag)(test_capa_system(), element, state)
 
         context = the_input._get_render_context()  # pylint: disable=protected-access
-
+        prob_id = 'annotation_input'
         expected = {
             'STATIC_URL': '/dummy-static/',
-            'id': 'annotation_input',
+            'id': prob_id,
             'status': inputtypes.Status('answered'),
             'msg': '',
             'title': 'foo',
@@ -1460,7 +1462,7 @@ class AnnotationInputTest(unittest.TestCase):
             'debug': False,
             'return_to_annotation': True,
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
 
         self.maxDiff = None
@@ -1499,9 +1501,10 @@ class TestChoiceText(unittest.TestCase):
   </{tag}>
         """.format(tag=tag, choice_tag=choice_tag)
         element = etree.fromstring(xml_str)
+        prob_id = 'choicetext_input'
         state = {
             'value': '{}',
-            'id': 'choicetext_input',
+            'id': prob_id,
             'status': inputtypes.Status('answered'),
             'response_data': RESPONSE_DATA
         }
@@ -1516,7 +1519,6 @@ class TestChoiceText(unittest.TestCase):
             ('choiceinput_0', [first_choice_content, first_input]),
             ('choiceinput_1', [second_choice_content, second_input, second_choice_text])
         ]
-
         expected = {
             'STATIC_URL': '/dummy-static/',
             'msg': '',
@@ -1525,7 +1527,7 @@ class TestChoiceText(unittest.TestCase):
             'show_correctness': 'always',
             'submitted_message': 'Answer received.',
             'response_data': RESPONSE_DATA,
-            'describedby_html': DESCRIBEDBY
+            'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
         }
         expected.update(state)
         the_input = lookup_tag(tag)(test_capa_system(), element, state)

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -23,9 +23,6 @@
 // ====================
 $annotation-yellow: rgba(255,255,10,0.3);
 $color-copy-tip: rgb(100,100,100);
-$correct: $green-d2;
-$partially-correct: $green-d2;
-$incorrect: $red;
 
 // FontAwesome Icon code
 // ====================
@@ -50,11 +47,13 @@ $asterisk-icon: '\f069'; // .fa-asterisk
 // ====================
 @mixin status-icon($color: $gray, $fontAwesomeIcon: "\f00d"){
 
-  &:after {
-    @extend %use-font-awesome;
-    color: $color;
-    font-size: 1.2em;
-    content: $fontAwesomeIcon;
+  .status-icon {
+    &:after {
+      @extend %use-font-awesome;
+      color: $color;
+      font-size: 1.2em;
+      content: $fontAwesomeIcon;
+    }
   }
 }
 
@@ -318,6 +317,12 @@ div.problem {
         @include status-icon($incorrect, $cross-icon);
       }
 
+      &.unsubmitted,
+      &.unanswered {
+        .status-icon {
+          content: '';
+        }
+      }
     }
   }
 }
@@ -818,12 +823,14 @@ div.problem {
       }
 
       .status {
-        &:after {
-          content: ''; // clear out correct or incorrect icon
+        .status-icon {
+          &:after {
+            content: '';
+          }
         }
       }
-
     }
+
   }
 
   .trailing_text {

--- a/common/lib/xmodule/xmodule/js/src/capa/display.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.js
@@ -962,7 +962,6 @@
                     $status = $('#status_' + id);
                     if ($status[0]) {
                         $status.removeClass().addClass('unanswered');
-                        $status.empty().css('display', 'inline-block');
                     } else {
                         $('<span>', {
                             class: 'unanswered',
@@ -979,8 +978,8 @@
                 id = ($select.attr('id').match(/^input_(.*)$/))[1];
                 return $select.on('change', function() {
                     return $('#status_' + id).removeClass().addClass('unanswered')
-                        .find('span')
-                        .text(gettext('Status: unsubmitted'));
+                        .find('.sr')
+                        .text(gettext('unsubmitted'));
                 });
             },
             textline: function(element) {

--- a/common/static/sass/edx-pattern-library-shims/base/_variables.scss
+++ b/common/static/sass/edx-pattern-library-shims/base/_variables.scss
@@ -144,6 +144,13 @@ $success-color: rgb(0, 155, 0) !default;
 $warning-color: rgb(255, 192, 31) !default;
 $warning-color-accent: rgb(255, 252, 221) !default;
 
+
+// CAPA correctness color to be consistent with Alert styles above
+$correct: $success-color;
+$partially-correct: $success-color;
+$incorrect: $error-color;
+
+
 // BUTTONS
 
 // disabled button

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -617,12 +617,12 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
             metadata={'graded': True},
             display_name='Problem Vertical'
         )
-        self.define_option_problem(u'Pröblem1', parent=vertical)
+        self.define_option_problem(u'Problem1', parent=vertical)
 
-        self.submit_student_answer(self.student_1.username, u'Pröblem1', ['Option 1'])
+        self.submit_student_answer(self.student_1.username, u'Problem1', ['Option 1'])
         result = upload_problem_grade_report(None, None, self.course.id, None, 'graded')
         self.assertDictContainsSubset({'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}, result)
-        problem_name = u'Homework 1: Problem - Pröblem1'
+        problem_name = u'Homework 1: Problem - Problem1'
         header_row = self.csv_header_row + [problem_name + ' (Earned)', problem_name + ' (Possible)']
         self.verify_rows_in_csv([
             dict(zip(
@@ -646,7 +646,7 @@ class TestProblemGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
 
     @patch('lms.djangoapps.instructor_task.tasks_helper._get_current_task')
     @patch('lms.djangoapps.instructor_task.tasks_helper.iterate_grades_for')
-    @ddt.data(u'Cannöt grade student', '')
+    @ddt.data(u'Cannot grade student', '')
     def test_grading_failure(self, error_message, mock_iterate_grades_for, _mock_current_task):
         """
         Test that any grading errors are properly reported in the progress
@@ -683,8 +683,8 @@ class TestProblemReportSplitTestContent(TestReportMixin, TestConditionalContent,
 
     def setUp(self):
         super(TestProblemReportSplitTestContent, self).setUp()
-        self.problem_a_url = u'pröblem_a_url'
-        self.problem_b_url = u'pröblem_b_url'
+        self.problem_a_url = u'problem_a_url'
+        self.problem_b_url = u'problem_b_url'
         self.define_option_problem(self.problem_a_url, parent=self.vertical_a)
         self.define_option_problem(self.problem_b_url, parent=self.vertical_b)
 
@@ -711,7 +711,7 @@ class TestProblemReportSplitTestContent(TestReportMixin, TestConditionalContent,
                 {'action_name': 'graded', 'attempted': 2, 'succeeded': 2, 'failed': 0}, result
             )
 
-        problem_names = [u'Homework 1: Problem - pröblem_a_url', u'Homework 1: Problem - pröblem_b_url']
+        problem_names = [u'Homework 1: Problem - problem_a_url', u'Homework 1: Problem - problem_b_url']
         header_row = [u'Student ID', u'Email', u'Username', u'Final Grade']
         for problem in problem_names:
             header_row += [problem + ' (Earned)', problem + ' (Possible)']
@@ -817,12 +817,12 @@ class TestProblemReportCohortedContent(TestReportMixin, ContentGroupTestCase, In
             display_name='Problem Vertical'
         )
         self.define_option_problem(
-            u"Pröblem0",
+            u"Problem0",
             parent=vertical,
             group_access={self.course.user_partitions[0].id: [self.course.user_partitions[0].groups[0].id]}
         )
         self.define_option_problem(
-            u"Pröblem1",
+            u"Problem1",
             parent=vertical,
             group_access={self.course.user_partitions[0].id: [self.course.user_partitions[0].groups[1].id]}
         )
@@ -845,20 +845,20 @@ class TestProblemReportCohortedContent(TestReportMixin, ContentGroupTestCase, In
         ))
 
     def test_cohort_content(self):
-        self.submit_student_answer(self.alpha_user.username, u'Pröblem0', ['Option 1', 'Option 1'])
-        resp = self.submit_student_answer(self.alpha_user.username, u'Pröblem1', ['Option 1', 'Option 1'])
+        self.submit_student_answer(self.alpha_user.username, u'Problem0', ['Option 1', 'Option 1'])
+        resp = self.submit_student_answer(self.alpha_user.username, u'Problem1', ['Option 1', 'Option 1'])
         self.assertEqual(resp.status_code, 404)
 
-        resp = self.submit_student_answer(self.beta_user.username, u'Pröblem0', ['Option 1', 'Option 2'])
+        resp = self.submit_student_answer(self.beta_user.username, u'Problem0', ['Option 1', 'Option 2'])
         self.assertEqual(resp.status_code, 404)
-        self.submit_student_answer(self.beta_user.username, u'Pröblem1', ['Option 1', 'Option 2'])
+        self.submit_student_answer(self.beta_user.username, u'Problem1', ['Option 1', 'Option 2'])
 
         with patch('lms.djangoapps.instructor_task.tasks_helper._get_current_task'):
             result = upload_problem_grade_report(None, None, self.course.id, None, 'graded')
             self.assertDictContainsSubset(
                 {'action_name': 'graded', 'attempted': 4, 'succeeded': 4, 'failed': 0}, result
             )
-        problem_names = [u'Homework 1: Problem - Pröblem0', u'Homework 1: Problem - Pröblem1']
+        problem_names = [u'Homework 1: Problem - Problem0', u'Homework 1: Problem - Problem1']
         header_row = [u'Student ID', u'Email', u'Username', u'Final Grade']
         for problem in problem_names:
             header_row += [problem + ' (Earned)', problem + ' (Possible)']


### PR DESCRIPTION
## [TNL-5644](https://openedx.atlassian.net/browse/TNL-5644)
### Description

Updated the Status icons to use the span component so that the Screen reader would function as expected. Also, moved the status components for the problems to a template.

In addition, addresses these issues:
1. Remove - aria-describedby on <span class="status incorrect/correct/unanswered"
2. Add - aria-describedby to all inputs/selects that references the <span class="status incorrect/correct/unanswered" <-- will need a unique ID. For radio buttons and checkbox problems, the aria-describedby should be on the fieldset. Basically, in conjunction with 1 this reverts the "aria-describedby" relationship.
3. Change - Status text "This answer is incorrect/correct TO "correct/incorrect (too verbose) It's OK for it to be verbose in the <span class="notification-message
### Sandbox

Sandbox:
https://staubina-icon.sandbox.edx.org
- [x] Build a sandbox for your branch and add a link here
### Testing
- [x] i18n
- [x] RTL
- [x] safecommit violation code review process
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @alisan617
- [x] Accessibility review: @cptvitamin 
- [x] Product review: @sstack22 
### Post-review
- [x] Rebase and squash commits
