### PR TITLE
Handle null weighted_possible values safely.

### DIFF
--- a/lms/djangoapps/grades/scores.py
+++ b/lms/djangoapps/grades/scores.py
@@ -108,8 +108,7 @@ def get_score(submissions_scores, csm_scores, persisted_block, block):
         _get_score_from_persisted_or_latest_block(persisted_block, block, weight)
     )
 
-    assert weighted_possible is not None
-    has_valid_denominator = weighted_possible > 0.0
+    has_valid_denominator = weighted_possible is not None and weighted_possible > 0.0
     graded = _get_graded_from_block(persisted_block, block) if has_valid_denominator else False
 
     return ProblemScore(


### PR DESCRIPTION
## [TNL-5689](https://openedx.atlassian.net/browse/TNL-5689): Server error when checking a problem.

Rather than failing, treat the block as unscored.  No new tests, because we haven't figured out how to trigger the condition yet, but we want to get this in so as not to break the release.  A further commit with be forthcoming with appropriate tests.
### Reviewers
- [x] @sanfordstudent 
- [x] @efischer19 

FYI: @nasthagiri @cahrens 
