### PR TITLE
Reset needs to display error messages.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1520,7 +1520,7 @@ class CapaMixin(CapaFields):
             return {
                 'success': False,
                 # Translators: 'closed' means the problem's due date has passed. You may no longer attempt to solve the problem.
-                'error': _("Problem is closed."),
+                'msg': _("You cannot select Reset for a problem that is closed."),
             }
 
         if not self.is_submitted():
@@ -1528,8 +1528,7 @@ class CapaMixin(CapaFields):
             self.track_function_unmask('reset_problem_fail', event_info)
             return {
                 'success': False,
-                # Translators: A student must "make an attempt" to solve the problem on the page before they can reset it.
-                'error': _("Refresh the page and make an attempt before resetting."),
+                'msg': _("You must submit an answer before you can select Reset."),
             }
 
         if self.is_submitted() and self.rerandomize in [RANDOMIZATION.ALWAYS, RANDOMIZATION.ONRESET]:

--- a/common/lib/xmodule/xmodule/js/fixtures/problem_content.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/problem_content.html
@@ -28,4 +28,13 @@
     <a href="/courseware/6.002_Spring_2012/${ explain }" class="new-page">Explanation</a>
     <div class="submission_feedback"></div>
   </div>
+
+  <div class="notification warning notification-gentle-alert is-hidden" tabindex="-1">
+    <span class="icon fa fa-exclamation-circle" aria-hidden="true"></span>
+    <span class="notification-message" aria-describedby="title">
+    </span>
+    <div class="notification-btn-wrapper">
+        <button class="btn btn-default btn-small notification-btn review-btn sr">Review</button>
+    </div>
+  </div>
 </div>

--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -90,7 +90,6 @@ describe 'Problem', ->
   describe 'renderProgressState', ->
     beforeEach ->
       @problem = new Problem($('.xblock-student_view'))
-      #@renderProgressState = @problem.renderProgressState
 
     testProgessData = (problem, status, detail, graded, expected_progress_after_render) ->
       problem.el.data('progress_status', status)
@@ -396,11 +395,27 @@ describe 'Problem', ->
 
     it 'render the returned content', ->
       spyOn($, 'postWithPrefix').and.callFake (url, answers, callback) ->
-        callback html: "Reset"
+        callback html: "Reset", success: true
         promise =
             always: (callable) -> callable()
       @problem.reset()
       expect(@problem.el.html()).toEqual 'Reset'
+
+    it 'sends a message to the window SR element', ->
+      spyOn($, 'postWithPrefix').and.callFake (url, answers, callback) ->
+        callback html: "Reset", success: true
+        promise =
+          always: (callable) -> callable()
+       @problem.reset()
+       expect(window.SR.readText).toHaveBeenCalledWith 'This problem has been reset.'
+
+    it 'shows a notification on error', ->
+      spyOn($, 'postWithPrefix').and.callFake (url, answers, callback) ->
+        callback msg: "Error on reset.", success: false
+        promise =
+          always: (callable) -> callable()
+      @problem.reset()
+      expect($('.notification-gentle-alert .notification-message').text()).toEqual("Error on reset.")
 
     it 'tests if all the buttons are disabled and the text of submit button remains same while resetting', (done) ->
       deferred = $.Deferred()

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -406,10 +406,13 @@ class @Problem
   reset_internal: =>
     Logger.log 'problem_reset', @answers
     $.postWithPrefix "#{@url}/problem_reset", id: @id, (response) =>
-      @el.trigger('contentChanged', [@id, response.html])
-      @render(response.html)
-      @updateProgress response
-      @scroll_to_problem_meta()
+      if response.success
+        @el.trigger('contentChanged', [@id, response.html])
+        @render(response.html, @scroll_to_problem_meta)
+        @updateProgress response
+        window.SR.readText(gettext('This problem has been reset.'))
+      else
+        @gentle_alert response.msg
 
   # TODO this needs modification to deal with javascript responses; perhaps we
   # need something where responsetypes can define their own behavior when show

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -108,7 +108,7 @@ class ProblemTypeTestBase(ProblemsTest, EventsTestMixin):
             'problem',
             self.problem_name,
             data=self.factory.build_xml(**self.factory_kwargs),
-            metadata={'rerandomize': 'always'}
+            metadata={'rerandomize': 'always', 'show_reset_button': True}
         )
 
     def wait_for_status(self, status):
@@ -315,6 +315,24 @@ class ProblemTypeTestMixin(object):
         self.assertTrue(self.problem_page.is_focus_on_problem_meta())
         # Answer should be reset
         self.wait_for_status('unanswered')
+
+    @attr(shard=7)
+    def test_reset_shows_errors(self):
+        """
+        Scenario: Reset will show server errors
+        If I reset a problem without first answering it
+        Then a "gentle notification" is shown
+        And the focus moves to the "gentle notification"
+        """
+        self.problem_page.wait_for(
+            lambda: self.problem_page.problem_name == self.problem_name,
+            "Make sure the correct problem is on the page"
+        )
+        self.wait_for_status('unanswered')
+        self.assertFalse(self.problem_page.is_gentle_alert_notification_visible())
+        # Click reset without first answering the problem (possible because show_reset_button is set to True)
+        self.problem_page.click_reset()
+        self.problem_page.wait_for_gentle_alert_notification()
 
     @attr(shard=7)
     def test_partially_complete_notifications(self):


### PR DESCRIPTION
### Description

[TNL-5672](https://openedx.atlassian.net/browse/TNL-5672)

@cptvitamin Created TNL-5672 because he did not see keyboard focus moving to the problem "meta" area on reset. The only way I could reproduce this is if I hit a condition where reset threw a server error (for instance, if you try to reset a problem before ever answering it). The server error message was not being handled, and an extra re-rendering was happening, blowing away focus.

Note that it is odd that the Reset button is enabled when the action is not possible, but this is the same behavior as on master today (were the server error from reset is also ignored).

I have changed the behavior so that we show any server error encountered in the "gentle warning", and focus moves there.
### Sandbox
- [x] reset.sandbox.edx.org
### Testing
- [x] i18n
- [x] RTL
- [x] safecommit shows 0 violations
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @staubina  
- [x] Code review: @alisan617 
- [x] a11y review: @cptvitamin 
- [x] doc review: @catong 

FYI @sstack22 @chris-mike 
### Post-review
- [ ] Squash commits
