### PR TITLE
Flaky test annotations 2016-09-30

### DIFF
--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -2,18 +2,18 @@
 """
 End-to-end tests for the Account Settings page.
 """
+from datetime import datetime
 from unittest import skip
-from nose.plugins.attrib import attr
 
 from bok_choy.web_app_test import WebAppTest
 from bok_choy.page_object import XSS_INJECTION
-from datetime import datetime
+from flaky import flaky
+from nose.plugins.attrib import attr
 from pytz import timezone, utc
 
 from common.test.acceptance.pages.lms.account_settings import AccountSettingsPage
 from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
 from common.test.acceptance.pages.lms.dashboard import DashboardPage
-
 from common.test.acceptance.tests.helpers import EventsTestMixin
 
 
@@ -216,7 +216,13 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, WebAppTest):
                 self.assertEqual(self.account_settings_page.value_for_text_field(field_id), new_value)
 
     def _test_dropdown_field(
-            self, field_id, title, initial_value, new_values, success_message=SUCCESS_MESSAGE, reloads_on_save=False
+            self,
+            field_id,
+            title,
+            initial_value,
+            new_values,
+            success_message=SUCCESS_MESSAGE,  # pylint: disable=unused-argument
+            reloads_on_save=False
     ):
         """
         Test behaviour of a dropdown field.
@@ -250,6 +256,7 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, WebAppTest):
         """
         self._test_readonly_field('username', 'Username', self.username)
 
+    @flaky  # TNL-5691
     def test_full_name_field(self):
         """
         Test behaviour of "Full Name" field.

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -7,6 +7,7 @@ import json
 from datetime import datetime, timedelta
 
 import ddt
+from flaky import flaky
 from nose.plugins.attrib import attr
 
 from ..helpers import UniqueCourseTest, EventsTestMixin, auto_auth, create_multiple_choice_problem
@@ -262,6 +263,7 @@ class ProctoredExamTest(UniqueCourseTest):
 
         LogoutPage(self.browser).visit()
 
+    @flaky  # TNL-5643
     @ddt.data(True, False)
     def test_timed_exam_flow(self, hide_after_due):
         """

--- a/common/test/acceptance/tests/lms/test_lms_matlab_problem.py
+++ b/common/test/acceptance/tests/lms/test_lms_matlab_problem.py
@@ -2,13 +2,15 @@
 """
 Test for matlab problems
 """
+from textwrap import dedent
 import time
+
+from flaky import flaky
 
 from common.test.acceptance.pages.lms.matlab_problem import MatlabProblemPage
 from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 from common.test.acceptance.fixtures.xqueue import XQueueResponseFixture
 from common.test.acceptance.tests.lms.test_lms_problems import ProblemsTest
-from textwrap import dedent
 
 
 class MatlabProblemTest(ProblemsTest):
@@ -59,13 +61,14 @@ class MatlabProblemTest(ProblemsTest):
         self.assertEqual(matlab_problem_page.problem_name, 'Test Matlab Problem')
         return matlab_problem_page
 
+    @flaky  # TNL-4132
     def test_run_code(self):
         """
         Test "Run Code" button functionality.
         """
 
         # Enter a submission, which will trigger a pre-defined response from the XQueue stub.
-        self.submission = "a=1" + self.unique_id[0:5]
+        self.submission = "a=1" + self.unique_id[0:5]  # pylint: disable=attribute-defined-outside-init
 
         self.xqueue_grade_response = {'msg': self.submission}
 

--- a/common/test/acceptance/tests/studio/test_studio_course_info.py
+++ b/common/test/acceptance/tests/studio/test_studio_course_info.py
@@ -1,6 +1,8 @@
 """
 Acceptance Tests for Course Information
 """
+from flaky import flaky
+
 from common.test.acceptance.pages.studio.course_info import CourseUpdatesPage
 from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
 
@@ -77,6 +79,7 @@ class UsersCanAddUpdatesTest(StudioCourseTest):
         self.assertFalse(self.course_updates_page.is_first_update_message('Hello'))
         self.assertTrue(self.course_updates_page.is_first_update_message('Goodbye'))
 
+    @flaky  # TNL-5582
     def test_delete_course_update(self):
         """
         Scenario: Users can delete updates


### PR DESCRIPTION
## Adding decorators annotated with ticket numbers for flaky tests.

First weekly batch of flaky tests decorated, with links to tickets.
- [TNL-5643](https://openedx.atlassian.net/browse/TNL-5643): test_lms_courseware:ProctoredExamTest.test_timed_exam_flow
- [TNL-4132](https://openedx.atlassian.net/browse/TNL-4132): test_lms_matlab_problem:MatlabProblemTest.test_run_code
- [TNL-5582](https://openedx.atlassian.net/browse/TNL-5582): test_studio_course_info.UsersCanAddUpdatesTest.test_delete_course_update
- [TNL-5691](https://openedx.atlassian.net/browse/TNL-5691): test_account_settings.AccountSettingsPageTest.test_full_name_field
### Reviewers:
- [x] @staubina 
- [x] @sanfordstudent 

FYI: @edx/teaching-and-learning  @benpatterson 
