### PR TITLE
Update lms STATIC_URL and STATIC_ROOT to match cms

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -133,7 +133,7 @@ with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
 # collected
 STATIC_ROOT_BASE = ENV_TOKENS.get('STATIC_ROOT_BASE', None)
 if STATIC_ROOT_BASE:
-    STATIC_ROOT = path(STATIC_ROOT_BASE)
+    STATIC_ROOT = path(STATIC_ROOT_BASE) / EDX_PLATFORM_REVISION
 
 
 # STATIC_URL_BASE specifies the base url to use for static files
@@ -143,6 +143,7 @@ if STATIC_URL_BASE:
     STATIC_URL = STATIC_URL_BASE.encode('ascii')
     if not STATIC_URL.endswith("/"):
         STATIC_URL += "/"
+    STATIC_URL += EDX_PLATFORM_REVISION + "/"
 
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = ENV_TOKENS.get('DEFAULT_COURSE_ABOUT_IMAGE_URL', DEFAULT_COURSE_ABOUT_IMAGE_URL)


### PR DESCRIPTION
This was causing courses with the default course image url to break in lms because of the mismatching static file path

I'm not sure why the initial change to the cms STATIC_URL https://github.com/edx/edx-platform/pull/6218 did not also update the lms

<img width="1315" alt="screen shot 2016-09-30 at 12 18 15 pm" src="https://cloud.githubusercontent.com/assets/868615/19003964/1b6c1d3e-8708-11e6-897b-f9b8c44cbf3a.png">