### PR TITLE
Remove course structure api except grading policy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -276,3 +276,4 @@ Kevin Kim <kkim@edx.org>
 Albert St. Aubin Jr. <astaubin@edx.org>
 Casey Litton <caseylitton@gmail.com>
 Jhony Avella <jhony.avella@edunext.co>
+Tyler Hallada <thallada@edx.org>

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -16,7 +16,7 @@ from contentstore.courseware_index import CoursewareSearchIndexer, SearchIndexin
 from contentstore.tests.utils import CourseTestCase
 from contentstore.utils import reverse_course_url, reverse_library_url, add_instructor, reverse_usage_url
 from contentstore.views.course import (
-    course_outline_initial_state, reindex_course_and_check_access, _deprecated_blocks_info
+    course_outline_initial_state, reindex_course_and_check_access
 )
 from contentstore.views.item import create_xblock_info, VisibilityState
 from course_action_state.managers import CourseRerunUIStateManager
@@ -442,119 +442,6 @@ class TestCourseOutline(CourseTestCase):
                 self.store.unpublish(self.vertical.location, self.user.id)
 
         course_module.advanced_modules.extend(block_types)
-
-    def _verify_deprecated_info(self, course_id, advanced_modules, info, deprecated_block_types):
-        """
-        Verify deprecated info.
-        """
-        expected_blocks = []
-        for block_type in deprecated_block_types:
-            expected_blocks.append(
-                [
-                    reverse_usage_url('container_handler', self.vertical.location),
-                    '{} Problem'.format(block_type)
-                ]
-            )
-
-        self.assertEqual(info['block_types'], deprecated_block_types)
-        self.assertEqual(
-            info['block_types_enabled'],
-            any(component in advanced_modules for component in deprecated_block_types)
-        )
-
-        self.assertItemsEqual(info['blocks'], expected_blocks)
-        self.assertEqual(
-            info['advance_settings_url'],
-            reverse_course_url('advanced_settings_handler', course_id)
-        )
-
-    @ddt.data(
-        [{'publish': True}, ['notes']],
-        [{'publish': False}, ['notes']],
-        [{'publish': True}, ['notes', 'lti']]
-    )
-    @ddt.unpack
-    def test_verify_deprecated_warning_message(self, publish, block_types):
-        """
-        Verify deprecated warning info.
-        """
-        course_module = modulestore().get_item(self.course.location)
-        self._create_test_data(course_module, create_blocks=True, block_types=block_types, publish=publish)
-        info = _deprecated_blocks_info(course_module, block_types)
-        self._verify_deprecated_info(
-            course_module.id,
-            course_module.advanced_modules,
-            info,
-            block_types
-        )
-
-    @ddt.data(
-        {'delete_vertical': True},
-        {'delete_vertical': False},
-    )
-    @ddt.unpack
-    def test_deprecated_blocks_list_updated_correctly(self, delete_vertical):
-        """
-        Verify that deprecated blocks list shown on banner is updated correctly.
-
-        Here is the scenario:
-            This list of deprecated blocks shown on banner contains published
-            and un-published blocks. That list should be updated when we delete
-            un-published block(s). This behavior should be same if we delete
-            unpublished vertical or problem.
-        """
-        block_types = ['notes']
-        course_module = modulestore().get_item(self.course.location)
-
-        vertical1 = ItemFactory.create(
-            parent_location=self.sequential.location, category='vertical', display_name='Vert1 Subsection1'
-        )
-        problem1 = ItemFactory.create(
-            parent_location=vertical1.location,
-            category='notes',
-            display_name='notes problem in vert1',
-            publish_item=False
-        )
-
-        info = _deprecated_blocks_info(course_module, block_types)
-        # info['blocks'] should be empty here because there is nothing
-        # published or un-published present
-        self.assertEqual(info['blocks'], [])
-
-        vertical2 = ItemFactory.create(
-            parent_location=self.sequential.location, category='vertical', display_name='Vert2 Subsection1'
-        )
-        ItemFactory.create(
-            parent_location=vertical2.location,
-            category='notes',
-            display_name='notes problem in vert2',
-            pubish_item=True
-        )
-        # At this point CourseStructure will contain both the above
-        # published and un-published verticals
-
-        info = _deprecated_blocks_info(course_module, block_types)
-        self.assertItemsEqual(
-            info['blocks'],
-            [
-                [reverse_usage_url('container_handler', vertical1.location), 'notes problem in vert1'],
-                [reverse_usage_url('container_handler', vertical2.location), 'notes problem in vert2']
-            ]
-        )
-
-        # Delete the un-published vertical or problem so that CourseStructure updates its data
-        if delete_vertical:
-            self.store.delete_item(vertical1.location, self.user.id)
-        else:
-            self.store.delete_item(problem1.location, self.user.id)
-
-        info = _deprecated_blocks_info(course_module, block_types)
-        # info['blocks'] should only contain the info about vertical2 which is published.
-        # There shouldn't be any info present about un-published vertical1
-        self.assertEqual(
-            info['blocks'],
-            [[reverse_usage_url('container_handler', vertical2.location), 'notes problem in vert2']]
-        )
 
 
 class TestCourseReIndex(CourseTestCase):

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -57,56 +57,6 @@ from openedx.core.djangolib.markup import HTML, Text
   </div>
   %endif
 
-    %if deprecated_blocks_info.get('blocks') or deprecated_blocks_info.get('block_types_enabled'):
-      <div class="wrapper wrapper-alert wrapper-alert-error is-shown">
-        <div class="alert announcement">
-          <span class="feedback-symbol fa fa-warning" aria-hidden="true"></span><span class="sr">${_("Warning")}</span>
-
-          <div class="copy">
-            <h2 class="title title-3 warning-heading-text">${_("This course uses features that are no longer supported.")}</h2>
-
-            %if deprecated_blocks_info.get('blocks'):
-              <div class="components-list">
-                <p class="components-list-heading-text">${_("You must delete or replace the following components.")}</p>
-                  <nav class="nav-related" aria-label="${_('Unsupported Components')}">
-                    <ul>
-                      % for component_parent_url, component_display_name in deprecated_blocks_info['blocks']:
-                          <li class="nav-item">
-                                % if component_display_name:
-                                    <a href="${component_parent_url}">${component_display_name}</a>
-                                % else:
-                                    <a href="${component_parent_url}">${_("Deprecated Component")}</a>
-                                % endif
-                          </li>
-                      % endfor
-                    </ul>
-                  </nav>
-              </div>
-            %endif
-
-            % if deprecated_blocks_info.get('block_types_enabled'):
-              <div class="advance-modules-list">
-                <p class="advance-modules-remove-text">
-                  ${Text(_("To avoid errors, {platform_name} strongly recommends that you remove unsupported features from the course advanced settings. To do this, go to the {link_start}Advanced Settings page{link_end}, locate the \"Advanced Module List\" setting, and then delete the following modules from the list.")).format(
-                    platform_name=static.get_platform_name(),
-                    link_start=HTML('<a href="{advance_settings_url}">').format(advance_settings_url=deprecated_blocks_info['advance_settings_url']),
-                    link_end=HTML("</a>")
-                  )}
-                </p>
-                <nav class="nav-related" aria-label="${_('Unsupported Advance Modules')}">
-                  <ul>
-                    % for block_type in deprecated_blocks_info['block_types']:
-                      <li class="nav-item">${block_type}</li>
-                    % endfor
-                  </ul>
-                </nav>
-              </div>
-            % endif
-          </div>
-        </div>
-      </div>
-    %endif
-
 </%block>
 
 <%block name="content">

--- a/lms/djangoapps/course_structure_api/v0/serializers.py
+++ b/lms/djangoapps/course_structure_api/v0/serializers.py
@@ -1,4 +1,7 @@
-""" Django REST Framework Serializers """
+""" Django REST Framework Serializers
+
+TODO: delete me once grading policy is implemented in course_api.
+"""
 
 from django.core.urlresolvers import reverse
 from rest_framework import serializers

--- a/lms/djangoapps/course_structure_api/v0/urls.py
+++ b/lms/djangoapps/course_structure_api/v0/urls.py
@@ -1,5 +1,7 @@
 """
 Courses Structure API v0 URI specification
+
+TODO: delete me once grading policy is implemented in course_api.
 """
 from django.conf import settings
 from django.conf.urls import patterns, url
@@ -11,9 +13,6 @@ COURSE_ID_PATTERN = settings.COURSE_ID_PATTERN
 
 urlpatterns = patterns(
     '',
-    url(r'^courses/$', views.CourseList.as_view(), name='list'),
-    url(r'^courses/{}/$'.format(COURSE_ID_PATTERN), views.CourseDetail.as_view(), name='detail'),
-    url(r'^course_structures/{}/$'.format(COURSE_ID_PATTERN), views.CourseStructure.as_view(), name='structure'),
     url(
         r'^grading_policies/{}/$'.format(COURSE_ID_PATTERN),
         views.CourseGradingPolicy.as_view(),

--- a/lms/djangoapps/course_structure_api/v0/views.py
+++ b/lms/djangoapps/course_structure_api/v0/views.py
@@ -1,4 +1,7 @@
-""" API implementation for course-oriented interactions. """
+""" API implementation for course-oriented interactions.
+
+TODO: delete me once grading policy is implemented in course_api.
+"""
 
 import logging
 
@@ -7,16 +10,14 @@ from django.http import Http404
 from rest_framework.authentication import SessionAuthentication
 from rest_framework_oauth.authentication import OAuth2Authentication
 from rest_framework.exceptions import AuthenticationFailed
-from rest_framework.generics import RetrieveAPIView, ListAPIView
+from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from xmodule.modulestore.django import modulestore
 from opaque_keys.edx.keys import CourseKey
 
-from course_structure_api.v0 import serializers
 from courseware import courses
 from courseware.access import has_access
-from openedx.core.djangoapps.content.course_structures.api.v0 import api, errors
+from openedx.core.djangoapps.content.course_structures.api.v0 import api
 from openedx.core.lib.exceptions import CourseNotFoundError
 from student.roles import CourseInstructorRole, CourseStaffRole
 
@@ -98,167 +99,6 @@ class CourseViewMixin(object):
         super(CourseViewMixin, self).perform_authentication(request)
         if request.user.is_anonymous() and not settings.DEBUG:
             raise AuthenticationFailed
-
-
-class CourseList(CourseViewMixin, ListAPIView):
-    """
-    **Use Case**
-
-        Get a paginated list of courses in the edX Platform.
-
-        The list can be filtered by course_id.
-
-        Each page in the list can contain up to 10 courses.
-
-    **Example Requests**
-
-          GET /api/course_structure/v0/courses/
-
-          GET /api/course_structure/v0/courses/?course_id={course_id1},{course_id2}
-
-    **Response Values**
-
-        * count: The number of courses in the edX platform.
-
-        * next: The URI to the next page of courses.
-
-        * previous: The URI to the previous page of courses.
-
-        * num_pages: The number of pages listing courses.
-
-        * results:  A list of courses returned. Each collection in the list
-          contains these fields.
-
-            * id: The unique identifier for the course.
-
-            * name: The name of the course.
-
-            * category: The type of content. In this case, the value is always
-              "course".
-
-            * org: The organization specified for the course.
-
-            * run: The run of the course.
-
-            * course: The course number.
-
-            * uri: The URI to use to get details of the course.
-
-            * image_url: The URI for the course's main image.
-
-            * start: The course start date.
-
-            * end: The course end date. If course end date is not specified, the
-              value is null.
-    """
-    serializer_class = serializers.CourseSerializer
-
-    def get_queryset(self):
-        course_ids = self.request.query_params.get('course_id', None)
-
-        results = []
-        if course_ids:
-            course_ids = course_ids.split(',')
-            for course_id in course_ids:
-                course_key = CourseKey.from_string(course_id)
-                course_descriptor = courses.get_course(course_key)
-                results.append(course_descriptor)
-        else:
-            results = modulestore().get_courses()
-
-        # Ensure only course descriptors are returned.
-        results = (course for course in results if course.scope_ids.block_type == 'course')
-
-        # Ensure only courses accessible by the user are returned.
-        results = (course for course in results if self.user_can_access_course(self.request.user, course))
-
-        # Sort the results in a predictable manner.
-        return sorted(results, key=lambda course: unicode(course.id))
-
-
-class CourseDetail(CourseViewMixin, RetrieveAPIView):
-    """
-    **Use Case**
-
-        Get details for a specific course.
-
-    **Example Request**:
-
-        GET /api/course_structure/v0/courses/{course_id}/
-
-    **Response Values**
-
-        * id: The unique identifier for the course.
-
-        * name: The name of the course.
-
-        * category: The type of content.
-
-        * org: The organization that is offering the course.
-
-        * run: The run of the course.
-
-        * course: The course number.
-
-        * uri: The URI to use to get details about the course.
-
-        * image_url: The URI for the course's main image.
-
-        * start: The course start date.
-
-        * end: The course end date. If course end date is not specified, the
-          value is null.
-    """
-    serializer_class = serializers.CourseSerializer
-
-    def get_object(self, queryset=None):
-        return self.get_course_or_404()
-
-
-class CourseStructure(CourseViewMixin, RetrieveAPIView):
-    """
-    **Use Case**
-
-        Get the course structure. This endpoint returns all blocks in the
-        course.
-
-    **Example requests**:
-
-        GET /api/course_structure/v0/course_structures/{course_id}/
-
-    **Response Values**
-
-        * root: The ID of the root node of the course structure.
-
-        * blocks: A dictionary that maps block IDs to a collection of
-          information about each block. Each block contains the following
-          fields.
-
-          * id: The ID of the block.
-
-          * type: The type of block. Possible values include sequential,
-            vertical, html, problem, video, and discussion. The type can also be
-            the name of a custom type of block used for the course.
-
-          * display_name: The display name configured for the block.
-
-          * graded: Whether or not the sequential or problem is graded. The
-            value is true or false.
-
-          * format: The assignment type.
-
-          * children: If the block has child blocks, a list of IDs of the child
-            blocks in the order they appear in the course.
-    """
-
-    @CourseViewMixin.course_check
-    def get(self, request, **kwargs):
-        try:
-            return Response(api.course_structure(self.course_key))
-        except errors.CourseStructureNotAvailableError:
-            # If we don't have data stored, we will try to regenerate it, so
-            # return a 503 and as them to retry in 2 minutes.
-            return Response(status=503, headers={'Retry-After': '120'})
 
 
 class CourseGradingPolicy(CourseViewMixin, ListAPIView):

--- a/openedx/core/djangoapps/content/course_structures/api/v0/api.py
+++ b/openedx/core/djangoapps/content/course_structures/api/v0/api.py
@@ -4,13 +4,11 @@ API implementation of the Course Structure API for Python code.
 Note: The course list and course detail functionality isn't currently supported here because
 of the tricky interactions between DRF and the code.
 Most of that information is available by accessing the course objects directly.
+
+TODO: delete me once grading policy is implemented in course_api.
 """
-from collections import OrderedDict
 from openedx.core.lib.exceptions import CourseNotFoundError
-from .serializers import GradingPolicySerializer, CourseStructureSerializer
-from .errors import CourseStructureNotAvailableError
-from openedx.core.djangoapps.content.course_structures import models, tasks
-from util.cache import cache
+from .serializers import GradingPolicySerializer
 from xmodule.modulestore.django import modulestore
 
 
@@ -30,79 +28,6 @@ def _retrieve_course(course_key):
         raise CourseNotFoundError
 
     return course
-
-
-def course_structure(course_key, block_types=None):
-    """
-    Retrieves the entire course structure, including information about all the blocks used in the
-    course if `block_types` is None else information about `block_types` will be returned only.
-    Final serialized information will be cached.
-
-    Args:
-        course_key: the CourseKey of the course we'd like to retrieve.
-        block_types: list of required block types. Possible values include sequential,
-                     vertical, html, problem, video, and discussion. The type can also be
-                     the name of a custom type of block used for the course.
-    Returns:
-        The serialized output of the course structure:
-            * root: The ID of the root node of the course structure.
-
-            * blocks: A dictionary that maps block IDs to a collection of
-            information about each block. Each block contains the following
-            fields.
-
-                * id: The ID of the block.
-
-                * type: The type of block. Possible values include sequential,
-                    vertical, html, problem, video, and discussion. The type can also be
-                    the name of a custom type of block used for the course.
-
-                * display_name: The display name configured for the block.
-
-                * graded: Whether or not the sequential or problem is graded. The
-                    value is true or false.
-
-                * format: The assignment type.
-
-                * children: If the block has child blocks, a list of IDs of the child
-                blocks.
-    Raises:
-        CourseStructureNotAvailableError, CourseNotFoundError
-
-    """
-    course = _retrieve_course(course_key)
-
-    modified_timestamp = models.CourseStructure.objects.filter(course_id=course_key).values('modified')
-    if modified_timestamp.exists():
-        cache_key = 'openedx.content.course_structures.api.v0.api.course_structure.{}.{}.{}'.format(
-            course_key, modified_timestamp[0]['modified'], '_'.join(block_types or [])
-        )
-        data = cache.get(cache_key)  # pylint: disable=maybe-no-member
-        if data is not None:
-            return data
-
-        try:
-            requested_course_structure = models.CourseStructure.objects.get(course_id=course.id)
-        except models.CourseStructure.DoesNotExist:
-            pass
-        else:
-            structure = requested_course_structure.structure
-            if block_types is not None:
-                blocks = requested_course_structure.ordered_blocks
-                required_blocks = OrderedDict()
-                for usage_id, block_data in blocks.iteritems():
-                    if block_data['block_type'] in block_types:
-                        required_blocks[usage_id] = block_data
-
-                structure['blocks'] = required_blocks
-
-            data = CourseStructureSerializer(structure).data
-            cache.set(cache_key, data, None)  # pylint: disable=maybe-no-member
-            return data
-
-    # If we don't have data stored, generate it and return an error.
-    tasks.update_course_structure.delay(unicode(course_key))
-    raise CourseStructureNotAvailableError
 
 
 def course_grading_policy(course_key):

--- a/openedx/core/djangoapps/content/course_structures/api/v0/serializers.py
+++ b/openedx/core/djangoapps/content/course_structures/api/v0/serializers.py
@@ -1,5 +1,7 @@
 """
 API Serializers
+
+TODO: delete me once grading policy is implemented in course_api.
 """
 from collections import defaultdict
 
@@ -25,52 +27,3 @@ class GradingPolicySerializer(serializers.Serializer):
                 defaultdict(lambda: None, obj)
             )
         )
-
-
-# pylint: disable=invalid-name
-class BlockSerializer(serializers.Serializer):
-    """ Serializer for course structure block. """
-    id = serializers.CharField(source='usage_key')
-    type = serializers.CharField(source='block_type')
-    parent = serializers.CharField(required=False)
-    display_name = serializers.CharField()
-    graded = serializers.BooleanField(default=False)
-    format = serializers.CharField()
-    children = serializers.CharField()
-
-    def to_representation(self, obj):
-        """
-        Return a representation of the block.
-
-        NOTE: this method maintains backwards compatibility with the behavior
-        of Django Rest Framework v2.
-        """
-        data = super(BlockSerializer, self).to_representation(obj)
-
-        # Backwards compatibility with the behavior of DRF v2
-        # Include a NULL value for "parent" in the representation
-        # (instead of excluding the key entirely)
-        if obj.get("parent") is None:
-            data["parent"] = None
-
-        # Backwards compatibility with the behavior of DRF v2
-        # Leave the children list as a list instead of serializing
-        # it to a string.
-        data["children"] = obj["children"]
-
-        return data
-
-
-class CourseStructureSerializer(serializers.Serializer):
-    """ Serializer for course structure. """
-    root = serializers.CharField()
-    blocks = serializers.SerializerMethodField()
-
-    def get_blocks(self, structure):
-        """ Serialize the individual blocks. """
-        serialized = {}
-
-        for key, block in structure['blocks'].iteritems():
-            serialized[key] = BlockSerializer(block).data
-
-        return serialized

--- a/openedx/core/djangoapps/content/course_structures/api/v0/tests_api.py
+++ b/openedx/core/djangoapps/content/course_structures/api/v0/tests_api.py
@@ -1,7 +1,6 @@
 """
 Course Structure api.py tests
 """
-from .api import course_structure
 from openedx.core.djangoapps.content.course_structures.signals import listen_for_course_publish
 from xmodule.modulestore.django import SignalHandler
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -96,56 +95,3 @@ class CourseStructureApiTests(ModuleStoreTestCase):
         add_block(course)
 
         return blocks
-
-    def test_course_structure_with_no_block_types(self):
-        """
-        Verify that course_structure returns info for entire course.
-        """
-        with mock.patch(self.MOCK_CACHE, cache.caches['default']):
-            with self.assertNumQueries(3):
-                structure = course_structure(self.course.id)
-
-        expected = {
-            u'root': unicode(self.course.location),
-            u'blocks': self._expected_blocks()
-        }
-
-        self.assertDictEqual(structure, expected)
-
-        with mock.patch(self.MOCK_CACHE, cache.caches['default']):
-            with self.assertNumQueries(2):
-                course_structure(self.course.id)
-
-    def test_course_structure_with_block_types(self):
-        """
-        Verify that course_structure returns info for required block_types only when specific block_types are requested.
-        """
-        block_types = ['html', 'video']
-
-        with mock.patch(self.MOCK_CACHE, cache.caches['default']):
-            with self.assertNumQueries(3):
-                structure = course_structure(self.course.id, block_types=block_types)
-
-        expected = {
-            u'root': unicode(self.course.location),
-            u'blocks': self._expected_blocks(block_types=block_types, get_parent=True)
-        }
-
-        self.assertDictEqual(structure, expected)
-
-        with mock.patch(self.MOCK_CACHE, cache.caches['default']):
-            with self.assertNumQueries(2):
-                course_structure(self.course.id, block_types=block_types)
-
-    def test_course_structure_with_non_existed_block_types(self):
-        """
-        Verify that course_structure returns empty info for non-existed block_types.
-        """
-        block_types = ['phantom']
-        structure = course_structure(self.course.id, block_types=block_types)
-        expected = {
-            u'root': unicode(self.course.location),
-            u'blocks': {}
-        }
-
-        self.assertDictEqual(structure, expected)


### PR DESCRIPTION
[AN-7827](https://openedx.atlassian.net/browse/AN-7827)

The course structure API is deprecated (to be replaced by the course API). Insights is the only application still using the old course structure API and we just [switched over to using the course API](https://github.com/edx/edx-analytics-dashboard/pull/550) except for the grading policy endpoint because that has not been ported to the course API yet.

This PR removes all of the course structure API except everything needed to keep the grading policy endpoint running.

@nasthagiri @dsjen 
