### PR TITLE
[WIP] Prototyping user consent setting

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -187,6 +187,15 @@ class AccountCreationForm(forms.Form):
                                 "required": _("To enroll, you must follow the honor code.")
                             }
                         )
+                elif field_name == "data_sharing_consent":
+                    if field_value == "require":
+                        self.fields[field_name] = TrueField(
+                            error_messages={
+                                "required": _("Your ID provider requires you to consent to data sharing.")
+                            }
+                        )
+                    elif field_value == "optional":
+                        self.fields[field_name] = forms.BooleanField()
                 else:
                     required = field_value == "required"
                     min_length = 1 if field_name in ("gender", "level_of_education") else 2

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1532,10 +1532,9 @@ def _do_create_account(form, custom_form=None, request=None):
             raise
     # Add a pipeline flag to create a DataSharingConsentSettings object
     if request is not None and third_party_auth.is_enabled() and pipeline.running(request):
-        running_pipeline = third_party_auth.pipeline.get(request)
+        running_pipeline = pipeline.get(request)
         if running_pipeline:
             sharing_authorized = bool(form.cleaned_data.get('data_sharing_consent'))
-            log.warning(form.cleaned_data)
             running_pipeline['kwargs']['create_data_sharing_consent'] = sharing_authorized
 
     # add this account creation to password history
@@ -1611,9 +1610,9 @@ def create_account_with_params(request, params):
 
     if should_link_with_social_auth or (third_party_auth.is_enabled() and pipeline.running(request)):
         params["password"] = pipeline.make_random_password()
-        running_pipeline = third_party_auth.pipeline.get(request)
+        running_pipeline = pipeline.get(request)
         if running_pipeline:
-            current_provider = third_party_auth.provider.Registry.get_from_pipeline(running_pipeline)
+            current_provider = provider.Registry.get_from_pipeline(running_pipeline)
             consent_field = {
                 'data_sharing_consent': 'require' if current_provider.require_data_sharing_consent else 'optional'
             }

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1482,7 +1482,7 @@ def user_signup_handler(sender, **kwargs):  # pylint: disable=unused-argument
             log.info(u'user {} originated from a white labeled "Microsite"'.format(kwargs['instance'].id))
 
 
-def _do_create_account(form, custom_form=None):
+def _do_create_account(form, custom_form=None, request=None):
     """
     Given cleaned post variables, create the User and UserProfile objects, as well as the
     registration for this user.
@@ -1530,6 +1530,13 @@ def _do_create_account(form, custom_form=None):
             )
         else:
             raise
+    # Add a pipeline flag to create a DataSharingConsentSettings object
+    if request is not None and third_party_auth.is_enabled() and pipeline.running(request):
+        running_pipeline = third_party_auth.pipeline.get(request)
+        if running_pipeline:
+            sharing_authorized = bool(form.cleaned_data.get('data_sharing_consent'))
+            log.warning(form.cleaned_data)
+            running_pipeline['kwargs']['create_data_sharing_consent'] = sharing_authorized
 
     # add this account creation to password history
     # NOTE, this will be a NOP unless the feature has been turned on in configuration
@@ -1604,6 +1611,14 @@ def create_account_with_params(request, params):
 
     if should_link_with_social_auth or (third_party_auth.is_enabled() and pipeline.running(request)):
         params["password"] = pipeline.make_random_password()
+        running_pipeline = third_party_auth.pipeline.get(request)
+        if running_pipeline:
+            current_provider = third_party_auth.provider.Registry.get_from_pipeline(running_pipeline)
+            consent_field = {
+                'data_sharing_consent': 'require' if current_provider.require_data_sharing_consent else 'optional'
+            }
+            if current_provider and current_provider.show_data_sharing_consent_checkbox():
+                extra_fields.update(consent_field)
 
     # if doing signup for an external authorization, then get email, password, name from the eamap
     # don't use the ones from the form, since the user could have hacked those
@@ -1654,7 +1669,7 @@ def create_account_with_params(request, params):
     # Perform operations within a transaction that are critical to account creation
     with transaction.atomic():
         # first, create the account
-        (user, profile, registration) = _do_create_account(form, custom_form)
+        (user, profile, registration) = _do_create_account(form, custom_form, request)
 
         # next, link the account with social auth, if provided via the API.
         # (If the user is using the normal register page, the social auth pipeline does the linking, not this code)

--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -173,6 +173,9 @@ admin.site.register(ProviderApiPermissions, ApiPermissionsAdmin)
 
 
 class DataSharingConsentSettingAdmin(admin.ModelAdmin):
+    """
+    Django admin form for DataSharingConsentSetting
+    """
 
     readonly_fields = ('date_set',)
 

--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -15,7 +15,8 @@ from .models import (
     LTIProviderConfig,
     ProviderApiPermissions,
     _PSA_OAUTH2_BACKENDS,
-    _PSA_SAML_BACKENDS
+    _PSA_SAML_BACKENDS,
+    DataSharingConsentSetting
 )
 from .tasks import fetch_saml_metadata
 from third_party_auth.provider import Registry
@@ -169,3 +170,15 @@ class ApiPermissionsAdmin(admin.ModelAdmin):
     form = ApiPermissionsAdminForm
 
 admin.site.register(ProviderApiPermissions, ApiPermissionsAdmin)
+
+
+class DataSharingConsentSettingAdmin(admin.ModelAdmin):
+
+    readonly_fields = ('date_set',)
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:  # editing an existing object
+            return self.model._meta.get_all_field_names()  # pylint: disable=protected-access
+        return self.readonly_fields
+
+admin.site.register(DataSharingConsentSetting, DataSharingConsentSettingAdmin)

--- a/common/djangoapps/third_party_auth/migrations/0006_data_sharing_consent.py
+++ b/common/djangoapps/third_party_auth/migrations/0006_data_sharing_consent.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default', '0003_alter_email_max_length'),
+        ('third_party_auth', '0005_add_site_field'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DataSharingConsentSetting',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('enabled', models.BooleanField(default=False, help_text='If selected, this means that the user has chosen to share data with this SSO provider.')),
+                ('date_set', models.DateTimeField(help_text='This field indicates the timestamp at which the object was created.', auto_now=True)),
+                ('auth', models.OneToOneField(related_name='consent_setting', to='default.UserSocialAuth', help_text='The UserSocialAuth database row to which this consent is attached.')),
+            ],
+        ),
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='data_sharing_consent_error',
+            field=models.CharField(help_text='If the SSO requires data sharing consent, but the user does not provide it at registration, text from this field will be used to inform the user of the error.', max_length=200, blank=True),
+        ),
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='data_sharing_consent_prompt',
+            field=models.CharField(help_text='When data sharing consent is requested, this text will appear next to the relevant form element to help users make an informed decision about whether to grant consent.', max_length=200, blank=True),
+        ),
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='request_data_sharing_consent',
+            field=models.BooleanField(default=True, help_text='If this option is selected, users will be presented with an option to share course information with the SSO provider when registering.'),
+        ),
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='require_data_sharing_consent',
+            field=models.BooleanField(default=False, help_text='If this option is selected, users who sign in using this SSO provider will not be able to proceed unless they affirmatively select the option to grant data sharing consent.'),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='data_sharing_consent_error',
+            field=models.CharField(help_text='If the SSO requires data sharing consent, but the user does not provide it at registration, text from this field will be used to inform the user of the error.', max_length=200, blank=True),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='data_sharing_consent_prompt',
+            field=models.CharField(help_text='When data sharing consent is requested, this text will appear next to the relevant form element to help users make an informed decision about whether to grant consent.', max_length=200, blank=True),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='request_data_sharing_consent',
+            field=models.BooleanField(default=True, help_text='If this option is selected, users will be presented with an option to share course information with the SSO provider when registering.'),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='require_data_sharing_consent',
+            field=models.BooleanField(default=False, help_text='If this option is selected, users who sign in using this SSO provider will not be able to proceed unless they affirmatively select the option to grant data sharing consent.'),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='data_sharing_consent_error',
+            field=models.CharField(help_text='If the SSO requires data sharing consent, but the user does not provide it at registration, text from this field will be used to inform the user of the error.', max_length=200, blank=True),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='data_sharing_consent_prompt',
+            field=models.CharField(help_text='When data sharing consent is requested, this text will appear next to the relevant form element to help users make an informed decision about whether to grant consent.', max_length=200, blank=True),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='request_data_sharing_consent',
+            field=models.BooleanField(default=True, help_text='If this option is selected, users will be presented with an option to share course information with the SSO provider when registering.'),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='require_data_sharing_consent',
+            field=models.BooleanField(default=False, help_text='If this option is selected, users who sign in using this SSO provider will not be able to proceed unless they affirmatively select the option to grant data sharing consent.'),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -255,6 +255,9 @@ class ProviderConfig(ConfigurationModel):
         return remote_id
 
     def show_data_sharing_consent_checkbox(self):
+        """
+        Determine whether a data sharing consent checkbox should be shown at registration
+        """
         return self.require_data_sharing_consent or self.request_data_sharing_consent
 
     @classmethod

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -78,6 +78,10 @@ class AuthNotConfigured(SocialAuthBaseException):
 
 
 class DataSharingConsentSetting(models.Model):
+    """
+    Model is designed to store a particular user's preference in terms of whether
+    to share data with an SSO provider.
+    """
 
     auth = models.OneToOneField(
         UserSocialAuth,
@@ -99,6 +103,9 @@ class DataSharingConsentSetting(models.Model):
             "This field indicates the timestamp at which the object was created."
         ),
     )
+
+    def __unicode__(self):
+        return u'{} - {} - {}'.format(self.auth, self.enabled, self.date_set)
 
 
 class ProviderConfig(ConfigurationModel):

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -83,6 +83,7 @@ import student
 from logging import getLogger
 
 from . import provider
+from .models import DataSharingConsentSetting
 
 
 # These are the query string params you can pass
@@ -176,6 +177,7 @@ class ProviderUserState(object):
     def __init__(self, enabled_provider, user, association):
         # Boolean. Whether the user has an account associated with the provider
         self.has_account = association is not None
+        self.association = association or None
         if self.has_account:
             # UserSocialAuth row ID
             self.association_id = association.id
@@ -284,7 +286,7 @@ def get_complete_url(backend_name):
     return _get_url('social:complete', backend_name)
 
 
-def get_disconnect_url(provider_id, association_id):
+def get_disconnect_url(provider_id, association_id=None):
     """Gets URL for the endpoint that starts the disconnect pipeline.
 
     Args:
@@ -300,7 +302,7 @@ def get_disconnect_url(provider_id, association_id):
         ValueError: if no provider is enabled with the given ID.
     """
     backend_name = _get_enabled_provider(provider_id).backend_name
-    if association_id:
+    if association_id is not None:
         return _get_url('social:disconnect_individual', backend_name, url_params={'association_id': association_id})
     else:
         return _get_url('social:disconnect', backend_name)
@@ -572,6 +574,11 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
                 'User "%s" is using third_party_auth to login but has not yet activated their account. ',
                 user.username
             )
+
+
+def create_data_sharing_consent(social, **kwargs):
+    logger.warning(kwargs)
+    DataSharingConsentSetting.objects.create(auth=social, enabled=kwargs.pop('create_data_sharing_consent', False))
 
 
 @partial.partial

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -576,18 +576,19 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
             )
 
 
-def create_data_sharing_consent(social, create_data_sharing_consent=None, **kwargs):
+def create_data_sharing_consent(social, **kwargs):
     """
     If an earlier pipeline step adds the "create_data_sharing_consent" kwargs as a True value,
     create a DataSharingConsentSetting object and tie it to the pipeline's social object.
     """
-    if create_data_sharing_consent is not None:
+    consent = kwargs.pop('create_data_sharing_consent', None)
+    if consent is not None:
         try:
             existing_consent = social.consent_setting
             existing_consent.delete()
         except DataSharingConsentSetting.DoesNotExist:
             pass
-        DataSharingConsentSetting.objects.create(auth=social, enabled=create_data_sharing_consent)
+        DataSharingConsentSetting.objects.create(auth=social, enabled=consent)
 
 
 @partial.partial

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -576,9 +576,18 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
             )
 
 
-def create_data_sharing_consent(social, **kwargs):
-    logger.warning(kwargs)
-    DataSharingConsentSetting.objects.create(auth=social, enabled=kwargs.pop('create_data_sharing_consent', False))
+def create_data_sharing_consent(social, create_data_sharing_consent=None, **kwargs):
+    """
+    If an earlier pipeline step adds the "create_data_sharing_consent" kwargs as a True value,
+    create a DataSharingConsentSetting object and tie it to the pipeline's social object.
+    """
+    if create_data_sharing_consent is not None:
+        try:
+            existing_consent = social.consent_setting
+            existing_consent.delete()
+        except DataSharingConsentSetting.DoesNotExist:
+            pass
+        DataSharingConsentSetting.objects.create(auth=social, enabled=create_data_sharing_consent)
 
 
 @partial.partial

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -49,6 +49,7 @@ def apply_settings(django_settings):
         'third_party_auth.pipeline.ensure_user_information',
         'social.pipeline.user.create_user',
         'social.pipeline.social_auth.associate_user',
+        'third_party_auth.pipeline.create_data_sharing_consent',
         'social.pipeline.social_auth.load_extra_data',
         'social.pipeline.user.user_details',
         'third_party_auth.pipeline.set_logged_in_cookies',

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -84,6 +84,7 @@ class IntegrationTestMixin(object):
                 'name': 'My Customized Name',
                 'username': 'new_username',
                 'honor_code': True,
+                'data_sharing_consent': True,
             }
         )
         self.assertEqual(ajax_register_response.status_code, 200)

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -496,6 +496,7 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
             'password': 'password',
             'mailing_address': '',
             'email': 'user@email.com',
+            'data_sharing_consent': 'true',
         }
 
         if overrides:

--- a/common/djangoapps/third_party_auth/tests/specs/test_lti.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_lti.py
@@ -36,18 +36,21 @@ class IntegrationTestLTI(testutil.TestCase):
             lti_consumer_key='other1',
             lti_consumer_secret='secret1',
             lti_max_timestamp_age=10,
+            request_data_sharing_consent=False,
         )
         self.configure_lti_provider(
             name='LTI Test Tool Consumer', enabled=True,
             lti_consumer_key=LTI_CONSUMER_KEY,
             lti_consumer_secret=LTI_CONSUMER_SECRET,
             lti_max_timestamp_age=10,
+            request_data_sharing_consent=False,
         )
         self.configure_lti_provider(
             name='Tool Consumer with Secret in Settings', enabled=True,
             lti_consumer_key=OTHER_LTI_CONSUMER_KEY,
             lti_consumer_secret='',
             lti_max_timestamp_age=10,
+            request_data_sharing_consent=False,
         )
         self.lti = Client(
             client_key=LTI_CONSUMER_KEY,

--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -190,7 +190,7 @@ class CombinedLoginAndRegisterPage(PageObject):
 
     def register(
             self, email="", password="", username="", full_name="", country="", favorite_movie="",
-            terms_of_service=False
+            terms_of_service=False, data_sharing_consent=False
     ):
         """Fills in and submits the registration form.
 
@@ -224,6 +224,8 @@ class CombinedLoginAndRegisterPage(PageObject):
             self.q(css="#register-favorite_movie").fill(favorite_movie)
         if terms_of_service:
             self.q(css="#register-honor_code").click()
+        if data_sharing_consent and self.q(css="#register-data_sharing_consent"):
+            self.q(css="#register-data_sharing_consent").click()
 
         # Submit it
         self.q(css=".register-button").click()

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -377,7 +377,12 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
         self.assertIn("Galactica1", self.register_page.username_value)
 
         # Set country, accept the terms, and submit the form:
-        self.register_page.register(country="US", favorite_movie="Battlestar Galactica", terms_of_service=True)
+        self.register_page.register(
+            country="US",
+            favorite_movie="Battlestar Galactica",
+            terms_of_service=True,
+            data_sharing_consent=True,
+        )
 
         # Expect that we reach the dashboard and we're auto-enrolled in the course
         course_names = self.dashboard_page.wait_for_page().available_courses

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -245,6 +245,7 @@
                 color: $red;
             }
             
+            &[for="register-data_sharing_consent"],
             &[for="register-honor_code"],
             &[for="register-terms_of_service"] {
                 display: inline-block;

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -838,6 +838,9 @@ class RegistrationView(APIView):
         )
 
     def _add_request_data_sharing_consent_field(self, form_desc, provider):
+        """
+        Adds a field to the form that allows the user to enable data sharing
+        """
         default_label = _(u"I consent to share coursework data with {provider_name}").format(
             provider_name=provider.name
         )

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -837,6 +837,30 @@ class RegistrationView(APIView):
             supplementalText=terms_text
         )
 
+    def _add_request_data_sharing_consent_field(self, form_desc, provider):
+        default_label = _(u"I consent to share coursework data with {provider_name}").format(
+            provider_name=provider.name
+        )
+        label = provider.data_sharing_consent_prompt or default_label
+
+        default_error_msg = _(u"{provider_name} requires that you consent to sharing coursework data.").format(
+            provider_name=provider.name
+        )
+        error_msg = provider.data_sharing_consent_error or default_error_msg
+
+        required = provider.require_data_sharing_consent
+
+        form_desc.add_field(
+            "data_sharing_consent",
+            label=label,
+            field_type="checkbox",
+            default=False,
+            required=required,
+            error_messages={
+                "required": error_msg,
+            },
+        )
+
     def _apply_third_party_auth_overrides(self, request, form_desc):
         """Modify the registration form if the user has authenticated with a third-party provider.
 
@@ -873,6 +897,9 @@ class RegistrationView(APIView):
                             form_desc.override_field_properties(
                                 field_name, default=field_overrides[field_name]
                             )
+
+                    if current_provider.show_data_sharing_consent_checkbox():
+                        self._add_request_data_sharing_consent_field(form_desc, current_provider)
 
                     # Hide the password field
                     form_desc.override_field_properties(

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -269,6 +269,13 @@ class RegistrationView(APIView):
                     options=getattr(field, 'choices', None), error_messages=field.error_messages,
                     include_default_option=field_options.get('include_default_option'),
                 )
+        if third_party_auth.is_enabled():
+            running_pipeline = third_party_auth.pipeline.get(request)
+            if running_pipeline:
+                current_provider = third_party_auth.provider.Registry.get_from_pipeline(running_pipeline)
+                    if current_provider:
+                        if current_provider.show_data_sharing_consent_checkbox():
+                            self._add_request_data_sharing_consent_field(form_desc, current_provider)
 
         # Extra fields configured in Django settings
         # may be required, optional, or hidden
@@ -900,9 +907,6 @@ class RegistrationView(APIView):
                             form_desc.override_field_properties(
                                 field_name, default=field_overrides[field_name]
                             )
-
-                    if current_provider.show_data_sharing_consent_checkbox():
-                        self._add_request_data_sharing_consent_field(form_desc, current_provider)
 
                     # Hide the password field
                     form_desc.override_field_properties(

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -273,9 +273,8 @@ class RegistrationView(APIView):
             running_pipeline = third_party_auth.pipeline.get(request)
             if running_pipeline:
                 current_provider = third_party_auth.provider.Registry.get_from_pipeline(running_pipeline)
-                    if current_provider:
-                        if current_provider.show_data_sharing_consent_checkbox():
-                            self._add_request_data_sharing_consent_field(form_desc, current_provider)
+                if current_provider and current_provider.show_data_sharing_consent_checkbox():
+                    self._add_request_data_sharing_consent_field(form_desc, current_provider)
 
         # Extra fields configured in Django settings
         # may be required, optional, or hidden


### PR DESCRIPTION
**Sandbox:**
- LMS: http://pr13628.sandbox.opencraft.hosting/
- Admin (use `staff` account): http://pr13628.sandbox.opencraft.hosting/admin/third_party_auth

**Testing instructions**:
1. In sandbox, click the Register button, and register with the TestShib SSO provider; note that the process seems identical to the past.
2. In sandbox, go to the Admin panel, and update the TestShib SSO provider to require data sharing consent
3. In an incognito browser window, go to the sandbox again, and register a different account using a different TestShib username/password
4. Note that this time, you're prompted to share data with the provider, and you cannot submit the registration form until you do.
5. Once you've successfully registered, go back to the Admin panel and look for a newly-created "DataSharingConsentSetting" object that's tied to your new account with a datestamp indicating when it was created.

**Reviewers**
- [ ] @e-kolpakov 

**Settings**

``` yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
  ENABLE_THIRD_PARTY_AUTH: true
```
