### PR TITLE
Fix the wrong target.src for annotations

### DIFF
--- a/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
+++ b/common/static/js/vendor/ova/OpenSeaDragonAnnotation.js
@@ -805,7 +805,7 @@ Annotator.Plugin.OpenSeaDragon = (function(_super) {
                 // Save source url
                 var source = osda.viewer.source;
                 var tilesUrl = typeof source.tilesUrl!='undefined'?source.tilesUrl:'';
-                var functionUrl = typeof source.getTileUrl!='undefined'?source.getTileUrl:'';
+                var functionUrl = typeof source.getTileUrl!='undefined'?source.getTileUrl():'';
                 annotation.target.src = tilesUrl!=''?tilesUrl:('' + functionUrl).replace(/\s+/g, ' '); // - target.src (media source)
                 annotation.target.ext = source.fileFormat || ""; // - target.ext (extension)
                 


### PR DESCRIPTION
**Background**: OpenSeaDragonAnnotation.js is used by image/text/video annotation tool in edX. When creating an annotation using those tools, the `annotation.target.src` was assigned to a function instead of a string because the missing brackets. The `annotation` object is then serialized and send to the backend to store. However, target.src field is too long for the db field and backend will refuse to save. So the annotation is failed to create.
<img width="574" alt="screen shot 2016-10-02 at 00 12 39" src="https://cloud.githubusercontent.com/assets/465548/19019341/a5f31b88-8839-11e6-9388-9005c0f1d618.png">

**Studio Updates**: Annotations should be able to save now.

**LMS Updates**: Annotations should be able to save now.

Testing: 
- Enable image/text/vidoe annotation tool from course advanced setting: http://annotation.chs.harvard.edu/setup.php.
- Create an annotation component: http://annotation.chs.harvard.edu/image.php
- Click on the last button (the one with "A") and add an annotation by doing a drag and drop on the screen. Fill in some text.
- Enable debug console and monitor the ajax call to the backend
- Click on Submit to send the request to backend
- The request payload should have correct target.src value, which should be the media URL instead of a function
