### PR TITLE
Hotfix: Remove is_enabled check for SAMLConfiguration in SAML management command

### DIFF
--- a/common/djangoapps/third_party_auth/management/commands/saml.py
+++ b/common/djangoapps/third_party_auth/management/commands/saml.py
@@ -4,7 +4,6 @@ Management commands for third_party_auth
 """
 from django.core.management.base import BaseCommand, CommandError
 import logging
-from third_party_auth.models import SAMLConfiguration
 from third_party_auth.tasks import fetch_saml_metadata
 
 
@@ -16,9 +15,6 @@ class Command(BaseCommand):
         parser.add_argument('--pull', action='store_true', help="Pull updated metadata from external IDPs")
 
     def handle(self, *args, **options):
-        if not SAMLConfiguration.is_enabled():
-            raise CommandError("SAML support is disabled via SAMLConfiguration.")
-
         if options['pull']:
             log_handler = logging.StreamHandler(self.stdout)
             log_handler.setLevel(logging.DEBUG)


### PR DESCRIPTION
This is a fix necessary for the `saml --pull` management command to continue working properly. `saml_fetch_metadata` already has the changes necessary for managing multiple Sites.

@adampalay @e0d 
