### PR TITLE
Persistent Grades Flag multiple entries per course

### DIFF
--- a/lms/djangoapps/grades/config/models.py
+++ b/lms/djangoapps/grades/config/models.py
@@ -35,10 +35,8 @@ class PersistentGradesEnabledFlag(ConfigurationModel):
         if not PersistentGradesEnabledFlag.is_enabled():
             return False
         elif not PersistentGradesEnabledFlag.current().enabled_for_all_courses and course_id:
-            try:
-                return CoursePersistentGradesFlag.objects.get(course_id=course_id).enabled
-            except CoursePersistentGradesFlag.DoesNotExist:
-                return False
+            effective = CoursePersistentGradesFlag.objects.filter(course_id=course_id).order_by('-change_date').first()
+            return effective.enabled if effective is not None else False
         return True
 
     class Meta(object):
@@ -63,7 +61,7 @@ class CoursePersistentGradesFlag(ConfigurationModel):
         app_label = "grades"
 
     # The course that these features are attached to.
-    course_id = CourseKeyField(max_length=255, db_index=True, unique=True)
+    course_id = CourseKeyField(max_length=255, db_index=True)
 
     def __unicode__(self):
         not_en = "Not "

--- a/lms/djangoapps/grades/config/tests/test_models.py
+++ b/lms/djangoapps/grades/config/tests/test_models.py
@@ -47,3 +47,45 @@ class PersistentGradesFeatureFlagTests(TestCase):
                 PersistentGradesEnabledFlag.feature_enabled(self.course_id_2),
                 global_flag and enabled_for_all_courses
             )
+
+    def test_enable_disable_course_flag(self):
+        """
+        Ensures that the flag, once enabled for a course, can also be disabled.
+        """
+        with persistent_grades_feature_flags(
+            global_flag=True,
+            enabled_for_all_courses=False,
+            course_id=self.course_id_1,
+            enabled_for_course=True
+        ):
+            self.assertTrue(PersistentGradesEnabledFlag.feature_enabled(self.course_id_1))
+            # Prior to TNL-5698, creating a second object would fail due to db constraints
+            with persistent_grades_feature_flags(
+                global_flag=True,
+                enabled_for_all_courses=False,
+                course_id=self.course_id_1,
+                enabled_for_course=False
+            ):
+                self.assertFalse(PersistentGradesEnabledFlag.feature_enabled(self.course_id_1))
+
+    def test_enable_disable_globally(self):
+        """
+        Ensures that the flag, once enabled globally, can also be disabled.
+        """
+        with persistent_grades_feature_flags(
+            global_flag=True,
+            enabled_for_all_courses=True,
+        ):
+            self.assertTrue(PersistentGradesEnabledFlag.feature_enabled())
+            self.assertTrue(PersistentGradesEnabledFlag.feature_enabled(self.course_id_1))
+            with persistent_grades_feature_flags(
+                global_flag=True,
+                enabled_for_all_courses=False,
+            ):
+                self.assertTrue(PersistentGradesEnabledFlag.feature_enabled())
+                self.assertFalse(PersistentGradesEnabledFlag.feature_enabled(self.course_id_1))
+                with persistent_grades_feature_flags(
+                    global_flag=False,
+                ):
+                    self.assertFalse(PersistentGradesEnabledFlag.feature_enabled())
+                    self.assertFalse(PersistentGradesEnabledFlag.feature_enabled(self.course_id_1))

--- a/lms/djangoapps/grades/migrations/0005_multiple_course_flags.py
+++ b/lms/djangoapps/grades/migrations/0005_multiple_course_flags.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import xmodule_django.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('grades', '0004_visibleblocks_course_id'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='coursepersistentgradesflag',
+            name='course_id',
+            field=xmodule_django.models.CourseKeyField(max_length=255, db_index=True),
+        ),
+    ]


### PR DESCRIPTION
With this change, it is now possible to enable and disable the feature for a
particular course as many times as desired. Fix confirmed locally.

TNL-5698
