### PR TITLE
Add UTM tracking for registrations

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -11,7 +11,8 @@ from xmodule.modulestore.django import modulestore
 from config_models.admin import ConfigurationModelAdmin
 from student.models import (
     UserProfile, UserTestGroup, CourseEnrollmentAllowed, DashboardConfiguration, CourseEnrollment, Registration,
-    PendingNameChange, CourseAccessRole, LinkedInAddToProfileConfiguration, UserAttribute, LogoutViewConfiguration
+    PendingNameChange, CourseAccessRole, LinkedInAddToProfileConfiguration, UserAttribute, LogoutViewConfiguration,
+    RegistrationCookieConfiguration
 )
 from student.roles import REGISTERED_ACCESS_ROLES
 
@@ -184,6 +185,7 @@ admin.site.register(Registration)
 admin.site.register(PendingNameChange)
 admin.site.register(DashboardConfiguration, ConfigurationModelAdmin)
 admin.site.register(LogoutViewConfiguration, ConfigurationModelAdmin)
+admin.site.register(RegistrationCookieConfiguration, ConfigurationModelAdmin)
 
 
 # We must first un-register the User model since it may also be registered by the auth app.

--- a/common/djangoapps/student/migrations/0007_registrationcookieconfiguration.py
+++ b/common/djangoapps/student/migrations/0007_registrationcookieconfiguration.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('student', '0006_logoutviewconfiguration'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RegistrationCookieConfiguration',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
+                ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
+                ('utm_cookie_name', models.CharField(help_text='Name of the UTM cookie', max_length=255)),
+                ('affiliate_cookie_name', models.CharField(help_text='Name of the affiliate cookie', max_length=255)),
+                ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
+            ],
+            options={
+                'ordering': ('-change_date',),
+                'abstract': False,
+            },
+        ),
+    ]

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2253,6 +2253,28 @@ class EnrollmentRefundConfiguration(ConfigurationModel):
         self.refund_window_microseconds = int(refund_window.total_seconds() * 1000000)
 
 
+class RegistrationCookieConfiguration(ConfigurationModel):
+    """
+    Configuration for registration cookies.
+    """
+    utm_cookie_name = models.CharField(
+        max_length=255,
+        help_text=_("Name of the UTM cookie")
+    )
+
+    affiliate_cookie_name = models.CharField(
+        max_length=255,
+        help_text=_("Name of the affiliate cookie")
+    )
+
+    def __unicode__(self):
+        """Unicode representation of this config. """
+        return u"UTM: {utm_name}; AFFILIATE: {affiliate_name}".format(
+            utm_name=self.utm_cookie_name,
+            affiliate_name=self.affiliate_cookie_name
+        )
+
+
 class UserAttribute(TimeStampedModel):
     """
     Record additional metadata about a user, stored as key/value pairs of text.

--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -12,6 +12,7 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.utils.importlib import import_module
 import mock
+import pytz
 
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from lang_pref import LANGUAGE_KEY
@@ -19,7 +20,7 @@ from notification_prefs import NOTIFICATION_PREF_KEY
 from external_auth.models import ExternalAuthMap
 import student
 from student.models import UserAttribute
-from student.views import REGISTRATION_AFFILIATE_ID
+from student.views import REGISTRATION_AFFILIATE_ID, REGISTRATION_UTM_PARAMETERS, REGISTRATION_UTM_CREATED_AT
 
 TEST_CS_URL = 'https://comments.service.test:123/'
 
@@ -280,7 +281,7 @@ class TestCreateAccount(TestCase):
                 self.assertIsNone(preference)
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-    def test_referral_attribution(self):
+    def test_affiliate_referral_attribution(self):
         """
         Verify that a referral attribution is recorded if an affiliate
         cookie is present upon a new user's registration.
@@ -291,11 +292,73 @@ class TestCreateAccount(TestCase):
         self.assertEqual(UserAttribute.get_user_attribute(user, REGISTRATION_AFFILIATE_ID), affiliate_id)
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    def test_utm_referral_attribution(self):
+        """
+        Verify that a referral attribution is recorded if an affiliate
+        cookie is present upon a new user's registration.
+        """
+        utm_cookie_name = 'edx.test.utm'
+        with mock.patch('student.models.RegistrationCookieConfiguration.current') as config:
+            instance = config.return_value
+            instance.utm_cookie_name = utm_cookie_name
+
+            timestamp = 1475521816879
+            utm_cookie = {
+                'utm_source': 'test-source',
+                'utm_medium': 'test-medium',
+                'utm_campaign': 'test-campaign',
+                'utm_term': 'test-term',
+                'utm_content': 'test-content',
+                'created_at': timestamp
+            }
+
+            created_at = datetime.fromtimestamp(timestamp / float(1000), tz=pytz.UTC)
+
+            self.client.cookies[utm_cookie_name] = json.dumps(utm_cookie)
+            user = self.create_account_and_fetch_profile().user
+            self.assertEqual(
+                UserAttribute.get_user_attribute(user, REGISTRATION_UTM_PARAMETERS.get('utm_source')),
+                utm_cookie.get('utm_source')
+            )
+            self.assertEqual(
+                UserAttribute.get_user_attribute(user, REGISTRATION_UTM_PARAMETERS.get('utm_medium')),
+                utm_cookie.get('utm_medium')
+            )
+            self.assertEqual(
+                UserAttribute.get_user_attribute(user, REGISTRATION_UTM_PARAMETERS.get('utm_campaign')),
+                utm_cookie.get('utm_campaign')
+            )
+            self.assertEqual(
+                UserAttribute.get_user_attribute(user, REGISTRATION_UTM_PARAMETERS.get('utm_term')),
+                utm_cookie.get('utm_term')
+            )
+            self.assertEqual(
+                UserAttribute.get_user_attribute(user, REGISTRATION_UTM_PARAMETERS.get('utm_content')),
+                utm_cookie.get('utm_content')
+            )
+            self.assertEqual(
+                UserAttribute.get_user_attribute(user, REGISTRATION_UTM_CREATED_AT),
+                str(created_at)
+            )
+
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_no_referral(self):
         """Verify that no referral is recorded when a cookie is not present."""
-        self.assertIsNone(self.client.cookies.get(settings.AFFILIATE_COOKIE_NAME))  # pylint: disable=no-member
-        user = self.create_account_and_fetch_profile().user
-        self.assertIsNone(UserAttribute.get_user_attribute(user, REGISTRATION_AFFILIATE_ID))
+        utm_cookie_name = 'edx.test.utm'
+        with mock.patch('student.models.RegistrationCookieConfiguration.current') as config:
+            instance = config.return_value
+            instance.utm_cookie_name = utm_cookie_name
+
+            self.assertIsNone(self.client.cookies.get(settings.AFFILIATE_COOKIE_NAME))  # pylint: disable=no-member
+            self.assertIsNone(self.client.cookies.get(utm_cookie_name))  # pylint: disable=no-member
+            user = self.create_account_and_fetch_profile().user
+            self.assertIsNone(UserAttribute.get_user_attribute(user, REGISTRATION_AFFILIATE_ID))
+            self.assertIsNone(UserAttribute.get_user_attribute(user, REGISTRATION_UTM_PARAMETERS.get('utm_source')))
+            self.assertIsNone(UserAttribute.get_user_attribute(user, REGISTRATION_UTM_PARAMETERS.get('utm_medium')))
+            self.assertIsNone(UserAttribute.get_user_attribute(user, REGISTRATION_UTM_PARAMETERS.get('utm_campaign')))
+            self.assertIsNone(UserAttribute.get_user_attribute(user, REGISTRATION_UTM_PARAMETERS.get('utm_term')))
+            self.assertIsNone(UserAttribute.get_user_attribute(user, REGISTRATION_UTM_PARAMETERS.get('utm_content')))
+            self.assertIsNone(UserAttribute.get_user_attribute(user, REGISTRATION_UTM_CREATED_AT))
 
 
 @ddt.ddt


### PR DESCRIPTION
Add UTM cookie tracking for registrations.
Add config model for cookie names.

ECOM-5539

@edx/ecommerce please review
