### PR TITLE
Add lti consumer xblock modules to LTI REST endpoints

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1052,6 +1052,7 @@ def get_course_lti_endpoints(request, course_id):
     anonymous_user = AnonymousUser()
     anonymous_user.known = False  # make these "noauth" requests like module_render.handle_xblock_callback_noauth
     lti_descriptors = modulestore().get_items(course.id, qualifiers={'category': 'lti'})
+    lti_descriptors.extend(modulestore().get_items(course.id, qualifiers={'category': 'lti_consumer'}))
 
     lti_noauth_modules = [
         get_module_for_descriptor(


### PR DESCRIPTION
This allows LTI consumer xblock modules being hooked into get_course_lti_endpoints for
discovering LTI result/outcome endpoints.

**Background**: The old xmodule supports enumerates LTI endpoints so that they can be discovered and consumed by external tools. However, this functionality is missing when xmodule was refactored into xblock. Currently, only the old LTI xmodules can be discovered when /courses/COURSE_ID/lti_rest_endpoints/ is called. 

**Testing**:
- Create an LTI consumer component by following instructions here: http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html 
- Access htts://LMS_URL/courses/COURSE_ID/lti_rest_endpoints/

The endpoints for LTI component should be listed in JSON format.   

This PR depends on https://github.com/edx/xblock-lti-consumer/pull/22 to enable the endpoints to query both old xmodules and new xblocks.
