### PR TITLE
Upgrade django-oauth2-provider to 1.1.4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -41,7 +41,7 @@ djangorestframework-oauth==1.1.0
 edx-ccx-keys==0.2.1
 edx-drf-extensions==0.5.1
 edx-lint==0.4.3
-edx-django-oauth2-provider==1.1.1
+edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
 edx-oauth2-provider==1.1.3
 edx-opaque-keys==0.3.4


### PR DESCRIPTION
Upgrading django-oauth2-provider to 1.1.4 in order to add index to oauth2_grants table.

See: https://github.com/edx/django-oauth2-provider/compare/1.1.1...edx:1.1.4?expand=1

@clintonb @jibsheet @jmbowman 

Fixes [PLAT-1062](https://openedx.atlassian.net/browse/PLAT-1062)
