### PR TITLE
Break early if max_score is not defined

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -317,7 +317,11 @@ def _fire_score_changed_for_block(course_id, student, block, module_state_key):
             field_data_cache=cache,
             course_key=course_id
         )
-        points_earned, points_possible = weighted_score(0, module.max_score(), getattr(module, 'weight', None))
+        max_score = module.max_score()
+        if max_score is None:
+            return
+        else:
+            points_earned, points_possible = weighted_score(0, max_score, getattr(module, 'weight', None))
     else:
         points_earned, points_possible = 0, 0
     SCORE_CHANGED.send(


### PR DESCRIPTION
Some XModules are breaking their contracts and defining has_score but not
max_score.
# [TNL-5715](https://openedx.atlassian.net/browse/TNL-5715)

@sanfordstudent @jcdyer @nasthagiri @adampalay 
