### PR TITLE
DOC-3315: Add support for custom documentation base URLs

### DIFF
--- a/common/djangoapps/util/help_context_processor.py
+++ b/common/djangoapps/util/help_context_processor.py
@@ -25,12 +25,16 @@ def common_doc_url(request, config_file_object):  # pylint: disable=unused-argum
         config_file_object: Configuration file object.
     """
 
-    def get_online_help_info(page_token=None):
+    def get_online_help_info(page_token=None, base_url=None):
         """
         Args:
             page_token: A string that identifies the page for which the help information is requested.
                 It should correspond to an option in the docs/config_file_object.ini file.  If it doesn't, the "default"
                 option is used instead.
+
+            base_url: A string that identifies the base URL for the documentation link.  If not
+                provided, defaults to the value in settings.DOC_LINK_BASE_URL or otherwise to the
+                value of "url_base" in the config_file_object.
 
         Returns:
             A dict mapping the following items
@@ -67,7 +71,9 @@ def common_doc_url(request, config_file_object):  # pylint: disable=unused-argum
             # as the base of documentation link URLs. If it is not set, the
             # function reads the base of the documentation link URLs from
             # the .ini configuration file, lms_config.ini or cms_config.ini.
-            if settings.DOC_LINK_BASE_URL:
+            if base_url:
+                doc_base_url = base_url
+            elif settings.DOC_LINK_BASE_URL:
                 doc_base_url = settings.DOC_LINK_BASE_URL
             else:
                 doc_base_url = config_file_object.get("help_settings", "url_base")
@@ -90,11 +96,13 @@ def common_doc_url(request, config_file_object):  # pylint: disable=unused-argum
             # Read an optional configuration property that sets the base
             # URL of pdf links. By default, DOC_LINK_BASE_URL
             # is null, this test determines whether it is set to a non-null
-            # value. If it is set, this funtion will use its string value
+            # value. If it is set, this function will use its string value
             # as the base of documentation link URLs. If it is not set, the
             # function reads the base of the documentation link URLs from
             # the .ini configuration file, lms_config.ini or cms_config.ini.
-            if settings.DOC_LINK_BASE_URL:
+            if base_url:
+                pdf_base_url = base_url
+            elif settings.DOC_LINK_BASE_URL:
                 pdf_base_url = settings.DOC_LINK_BASE_URL
             else:
                 pdf_base_url = config_file_object.get("pdf_settings", "pdf_base")

--- a/common/djangoapps/util/help_context_processor.py
+++ b/common/djangoapps/util/help_context_processor.py
@@ -67,7 +67,7 @@ def common_doc_url(request, config_file_object):  # pylint: disable=unused-argum
             # Read an optional configuration property that sets the base
             # URL of documentation links. By default, DOC_LINK_BASE_URL
             # is null, this test determines whether it is set to a non-null
-            # value. If it is set, this funtion will use its string value
+            # value. If it is set, this function will use its string value
             # as the base of documentation link URLs. If it is not set, the
             # function reads the base of the documentation link URLs from
             # the .ini configuration file, lms_config.ini or cms_config.ini.

--- a/common/djangoapps/util/help_context_processor.py
+++ b/common/djangoapps/util/help_context_processor.py
@@ -71,12 +71,7 @@ def common_doc_url(request, config_file_object):  # pylint: disable=unused-argum
             # as the base of documentation link URLs. If it is not set, the
             # function reads the base of the documentation link URLs from
             # the .ini configuration file, lms_config.ini or cms_config.ini.
-            if base_url:
-                doc_base_url = base_url
-            elif settings.DOC_LINK_BASE_URL:
-                doc_base_url = settings.DOC_LINK_BASE_URL
-            else:
-                doc_base_url = config_file_object.get("help_settings", "url_base")
+            doc_base_url = _get_base_url("help_settings", "url_base")
 
             # Construct and return the URL for the documentation link.
             return "{url_base}/{language}/{version}/{page_path}".format(
@@ -100,12 +95,7 @@ def common_doc_url(request, config_file_object):  # pylint: disable=unused-argum
             # as the base of documentation link URLs. If it is not set, the
             # function reads the base of the documentation link URLs from
             # the .ini configuration file, lms_config.ini or cms_config.ini.
-            if base_url:
-                pdf_base_url = base_url
-            elif settings.DOC_LINK_BASE_URL:
-                pdf_base_url = settings.DOC_LINK_BASE_URL
-            else:
-                pdf_base_url = config_file_object.get("pdf_settings", "pdf_base")
+            pdf_base_url = _get_base_url("pdf_settings", "pdf_base")
 
             # Construct and return the URL for the PDF link.
             return "{pdf_base}/{version}/{pdf_file}".format(
@@ -113,6 +103,25 @@ def common_doc_url(request, config_file_object):  # pylint: disable=unused-argum
                 version=config_file_object.get("help_settings", "version"),
                 pdf_file=config_file_object.get("pdf_settings", "pdf_file"),
             )
+
+        def _get_base_url(section_name, option):
+            """
+            Returns a base url value, taking into account base_url, settings.DOC_LINK_BASE_URL,
+            and base configuration.
+
+            Args:
+                section_name: name of the section in the configuration from which the option should be found
+                  (if no value supplied in either base_url or settings.DOC_LINK_BASE_URL)
+                option: name of the configuration option
+            """
+            if base_url:
+                conditional_base_url = base_url
+            elif settings.DOC_LINK_BASE_URL:
+                conditional_base_url = settings.DOC_LINK_BASE_URL
+            else:
+                conditional_base_url = config_file_object.get(section_name, option)
+
+            return conditional_base_url
 
         return {
             "doc_url": get_doc_url(),

--- a/common/djangoapps/util/tests/test_help_context_processor.py
+++ b/common/djangoapps/util/tests/test_help_context_processor.py
@@ -1,0 +1,76 @@
+"""
+Tests for help_context_processor.py
+"""
+
+import ConfigParser
+from mock import patch
+
+from django.conf import settings
+from django.test import TestCase
+
+from util.help_context_processor import common_doc_url
+
+
+CONFIG_FILE = open(settings.REPO_ROOT / "docs" / "lms_config.ini")
+CONFIG = ConfigParser.ConfigParser()
+CONFIG.readfp(CONFIG_FILE)
+
+
+class HelpContextProcessorTest(TestCase):
+
+    def setUp(self):
+        super(HelpContextProcessorTest, self).setUp()
+
+    @staticmethod
+    def _get_doc_url(page_token=None, base_url=None):
+        return common_doc_url(None, CONFIG)['get_online_help_info'](page_token, base_url)['doc_url']
+
+    @staticmethod
+    def _get_pdf_url(base_url=None):
+        return common_doc_url(None, CONFIG)['get_online_help_info'](base_url=base_url)['pdf_url']
+
+    def test_get_doc_url(self):
+        # Test default values.
+        self.assertEqual(
+            "http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/index.html",
+            HelpContextProcessorTest._get_doc_url()
+        )
+
+        # Provide a known page_token.
+        self.assertEqual(
+            "http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/sfd_dashboard_profile/index.html",
+            HelpContextProcessorTest._get_doc_url('profile')
+        )
+
+        # Provide both a page_token and a base_url.
+        self.assertEqual(
+            "custom_base_url/en/latest/manage_live_course/course_data.html",
+            HelpContextProcessorTest._get_doc_url('instructor', 'custom_base_url')
+        )
+
+        # Use settings.DOC_LINK_BASE_URL to override default base_url.
+        with patch('django.conf.settings.DOC_LINK_BASE_URL', 'settings_base_url'):
+            self.assertEqual(
+                "settings_base_url/en/latest/manage_live_course/course_data.html",
+                HelpContextProcessorTest._get_doc_url('instructor')
+            )
+
+    def test_get_pdf_url(self):
+        # Test default values.
+        self.assertEqual(
+            "https://media.readthedocs.org/pdf/open-edx-learner-guide/latest/open-edx-learner-guide.pdf",
+            HelpContextProcessorTest._get_pdf_url()
+        )
+
+        # Provide a base_url.
+        self.assertEqual(
+            "custom_base_url/latest/open-edx-learner-guide.pdf",
+            HelpContextProcessorTest._get_pdf_url('custom_base_url')
+        )
+
+        # Use settings.DOC_LINK_BASE_URL to override default base_url.
+        with patch('django.conf.settings.DOC_LINK_BASE_URL', 'settings_base_url'):
+            self.assertEqual(
+                "settings_base_url/latest/open-edx-learner-guide.pdf",
+                HelpContextProcessorTest._get_pdf_url()
+            )

--- a/common/djangoapps/util/tests/test_help_context_processor.py
+++ b/common/djangoapps/util/tests/test_help_context_processor.py
@@ -17,16 +17,21 @@ CONFIG.readfp(CONFIG_FILE)
 
 
 class HelpContextProcessorTest(TestCase):
+    """
+    Tests for help_context_processor.py
+    """
 
     def setUp(self):
         super(HelpContextProcessorTest, self).setUp()
 
     @staticmethod
     def _get_doc_url(page_token=None, base_url=None):
+        """ Helper method for getting the doc url. """
         return common_doc_url(None, CONFIG)['get_online_help_info'](page_token, base_url)['doc_url']
 
     @staticmethod
     def _get_pdf_url(base_url=None):
+        """ Helper method for getting the pdf url. """
         return common_doc_url(None, CONFIG)['get_online_help_info'](base_url=base_url)['pdf_url']
 
     def test_get_doc_url(self):

--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -19,6 +19,12 @@ class InstructorDashboardPage(CoursePage):
     def is_browser_on_page(self):
         return self.q(css='div.instructor-dashboard-wrapper-2').present
 
+    def click_help(self):
+        """
+        Clicks the general Help button in the header.
+        """
+        self.q(css='.doc-link').first.click()
+
     def select_membership(self):
         """
         Selects the membership tab and returns the MembershipSection

--- a/common/test/acceptance/tests/lms/test_lms_help.py
+++ b/common/test/acceptance/tests/lms/test_lms_help.py
@@ -3,11 +3,12 @@ Test Help links in LMS
 """
 import json
 
-from flaky import flaky
 
-from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
+from common.test.acceptance.tests.lms.test_lms_instructor_dashboard import BaseInstructorDashboardTest
 from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage
+from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
 from common.test.acceptance.fixtures import LMS_BASE_URL
+from common.test.acceptance.fixtures.course import CourseFixture
 
 from common.test.acceptance.tests.helpers import (
     assert_link,
@@ -98,3 +99,27 @@ class TestCohortHelp(ContainerBase):
         data = json.dumps({'is_cohorted': True})
         response = course_fixture.session.patch(url, data=data, headers=course_fixture.headers)
         self.assertTrue(response.ok, "Failed to enable cohorts")
+
+
+class InstructorDashboardHelp(BaseInstructorDashboardTest):
+    """
+    Tests opening help from the general Help button in the instructor dashboard.
+    """
+
+    def setUp(self):
+        super(InstructorDashboardHelp, self).setUp()
+        self.course_fixture = CourseFixture(**self.course_info).install()
+        self.log_in_as_instructor()
+        self.instructor_dashboard_page = self.visit_instructor_dashboard()
+
+    def test_instructor_dashboard_help(self):
+        """
+        Scenario: Help button opens staff help
+        Given that I am viewing the Instructor Dashboard
+        When I click "Help"
+        Then I see the course staff help in a new tab
+        """
+        href = 'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/' \
+               'manage_live_course/course_data.html'
+        self.instructor_dashboard_page.click_help()
+        assert_opened_help_link_is_correct(self, href)

--- a/docs/lms_config.ini
+++ b/docs/lms_config.ini
@@ -17,7 +17,7 @@ pdf_file = open-edx-learner-guide.pdf
 [pages]
 default = index.html
 
-instructor = SFD_instructor_dash_help.html
+instructor = manage_live_course/course_data.html
 
 course = index.html
 

--- a/docs/lms_config.ini
+++ b/docs/lms_config.ini
@@ -7,7 +7,7 @@ version = latest
 
 # below are the pdf settings for the pdf file
 [pdf_settings]
-pdf_base = https://media.readthedocs.io/pdf/open-edx-learner-guide
+pdf_base = https://media.readthedocs.org/pdf/open-edx-learner-guide
 pdf_file = open-edx-learner-guide.pdf
 
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -889,6 +889,7 @@ AFFILIATE_COOKIE_NAME = ENV_TOKENS.get('AFFILIATE_COOKIE_NAME', AFFILIATE_COOKIE
 ############## Settings for LMS Context Sensitive Help ##############
 
 DOC_LINK_BASE_URL = ENV_TOKENS.get('DOC_LINK_BASE_URL', DOC_LINK_BASE_URL)
+INSTRUCTOR_DOC_LINK_BASE_URL = ENV_TOKENS.get('INSTRUCTOR_DOC_LINK_BASE_URL', INSTRUCTOR_DOC_LINK_BASE_URL)
 
 ############## Settings for the Enterprise App ######################
 

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -210,6 +210,7 @@ ECOMMERCE_API_URL = 'http://localhost:8043/api/v2/'
 ECOMMERCE_API_SIGNING_KEY = 'ecommerce-key'
 
 LMS_ROOT_URL = "http://localhost:8000"
+INSTRUCTOR_DOC_LINK_BASE_URL = 'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3027,6 +3027,7 @@ REDIRECT_CACHE_KEY_PREFIX = 'redirects'
 ############## Settings for LMS Context Sensitive Help ##############
 
 DOC_LINK_BASE_URL = None
+INSTRUCTOR_DOC_LINK_BASE_URL = 'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
 
 ############## Settings for the Enterprise App ######################
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3027,7 +3027,7 @@ REDIRECT_CACHE_KEY_PREFIX = 'redirects'
 ############## Settings for LMS Context Sensitive Help ##############
 
 DOC_LINK_BASE_URL = None
-INSTRUCTOR_DOC_LINK_BASE_URL = 'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
+INSTRUCTOR_DOC_LINK_BASE_URL = None
 
 ############## Settings for the Enterprise App ######################
 

--- a/lms/templates/header.html
+++ b/lms/templates/header.html
@@ -1,4 +1,7 @@
 ## mako
-<%page expression_filter="h" args="online_help_token"/>
+<%page expression_filter="h" args="online_help_token,doc_base_url"/>
 <%namespace name='static' file='static_content.html'/>
-<%include file="${static.get_template_path(relative_path='navigation.html')}"  args="online_help_token=online_help_token"  />
+<%include
+    file="${static.get_template_path(relative_path='navigation.html')}"
+    args="online_help_token=online_help_token,doc_base_url=doc_base_url"
+/>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -1,11 +1,13 @@
 <%page expression_filter="h"/>
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
-<%def name="online_help_token()"><% return "instructor" %></%def>
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from django.conf import settings
 %>
+<%def name="online_help_token()"><% return "instructor" %></%def>
+<%def name="doc_base_url()"><% return settings.INSTRUCTOR_DOC_LINK_BASE_URL %></%def>
 <%block name="bodyclass">view-in-course view-instructordash</%block>
 
 ## ----- Tips on adding something to the new instructor dashboard -----

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -12,6 +12,7 @@
 
 <%namespace name='static' file='static_content.html'/>
 <% online_help_token = self.online_help_token() if hasattr(self, 'online_help_token') else None %>
+<% doc_base_url = self.doc_base_url() if hasattr(self, 'doc_base_url') else None %>
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.http import urlquote_plus
@@ -132,7 +133,10 @@ from pipeline_mako import render_require_js_path_overrides
     <a class="nav-skip" href="#main">${_("Skip to main content")}</a>
 
     % if not disable_header:
-        <%include file="${static.get_template_path('header.html')}" args="online_help_token=online_help_token" />
+        <%include
+            file="${static.get_template_path('header.html')}"
+            args="online_help_token=online_help_token,doc_base_url=doc_base_url"
+        />
     % endif
 
     <div class="content-wrapper" id="content">

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -1,5 +1,5 @@
 ## mako
-<%page expression_filter="h" args="online_help_token"/>
+<%page expression_filter="h" args="online_help_token,doc_base_url"/>
 <%namespace name='static' file='static_content.html'/>
 <%namespace file='main.html' import="login_query"/>
 <%!
@@ -100,7 +100,7 @@ site_status_msg = get_site_status_msg(course_id)
 
       <%include file="user_dropdown.html"/>
 
-      <a href="${get_online_help_info(online_help_token)['doc_url']}" 
+      <a href="${get_online_help_info(online_help_token, doc_base_url)['doc_url']}"
          target="_blank"
          class="doc-link">${_("Help")}</a>
 

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -1,5 +1,5 @@
 ## mako
-<%page expression_filter="h" args="online_help_token"/>
+<%page expression_filter="h" args="online_help_token,doc_base_url"/>
 <%namespace name='static' file='static_content.html'/>
 <%namespace file='main.html' import="login_query"/>
 <%!
@@ -104,7 +104,7 @@ site_status_msg = get_site_status_msg(course_id)
 
       <%include file="user_dropdown.html"/>
 
-      <a href="${get_online_help_info(online_help_token)['doc_url']}"
+      <a href="${get_online_help_info(online_help_token, doc_base_url)['doc_url']}"
          target="_blank"
          class="doc-link">${_("Help")}</a>
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DOC-3315

Tests have been added, though this can't merge until Devops defines the new variable in configuration repos (I haven't created the ticket yet).

Confession: after working on this PR today, I'm actually thinking that this wasn't the best approach to take. CMS sets DOC_LINK_BASE_URL to partner doc, and LMS sets it to learner doc. This PR introduces INSTRUCTOR_DOC_LINK_BASE_URL to use for partner doc within the context of LMS. If CMS ever wanted to link to learner doc (which doesn't seem far-fetched), it would have to introduce something else-- LEARNER_DOC_LINK_BASE_URL? It seems like really the help function just needs to be able to create a link for either learner or instructor doc, and both environments should have consistent variable/value mappings. But eh, this works.

Please review:
- [ ] @nasthagiri 
- [ ] @sanfordstudent
- [ ] @catong   

Sandbox: https://lmsinstructorhelp.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-course_info (new setting value has been set in lms.env.json)

Note that without the new setting specified, Help in the Instructor Dashboard went to https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/manage_live_course/course_data.html (which of course doesn't exist). When openedx installations upgrade to the next named release, they will have a broken link until they add the new settings variable.

- [ ] squash commits