### PR TITLE
Use sever logic for when Submit should be enabled.

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -1141,13 +1141,6 @@ div.problem {
       &:hover {
         background-color: $btn-brand-focus-background;
       }
-
-      &.check {
-        &.is-disabled {
-          background: $btn-brand-disabled-background;
-          color: $btn-brand-disabled-color;
-        }
-      }
     }
   }
 

--- a/common/lib/xmodule/xmodule/js/fixtures/problem_content.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/problem_content.html
@@ -23,7 +23,7 @@
         <button class="show btn-default btn-small"><span class="show-label">Show Answer(s)</span> <span class="sr">(for question(s) above - adjacent to each field)</span></button>
       </span>
     </div>
-    <button class="submit btn-brand" data-submitting="Submitting" data-value="Submit"><span class="submit-label">Submit</span><span class="sr"> your answer</span></button>
+    <button class="submit btn-brand" data-submitting="Submitting" data-value="Submit" data-should-enable-submit-button="True"><span class="submit-label">Submit</span><span class="sr"> your answer</span></button>
 
     <a href="/courseware/6.002_Spring_2012/${ explain }" class="new-page">Explanation</a>
     <div class="submission_feedback"></div>

--- a/common/lib/xmodule/xmodule/js/src/capa/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.coffee
@@ -846,20 +846,14 @@ class @Problem
     #   'enable' is a boolean to determine enabling/disabling of submit button.
     #   'changeText' is a boolean to determine if there is need to change the
     #    text of submit button as well.
-    attempts_remaining = @submitButton.data('attempts-remaining')
     if enable
-      if attempts_remaining != 0
+      submitCanBeEnabled = @submitButton.data('should-enable-submit-button') == 'True'
+      if submitCanBeEnabled
         @submitButton.removeAttr 'disabled'
-        # the is-disabled is needed for Lettuce test below
-        # lms/djangoapps/courseware/features/problems.py submit_problem(step)
-        @submitButton.removeClass 'is-disabled'
       if changeText
         @submitButtonLabel.text(@submitButtonSubmitText)
     else
       @submitButton.attr({'disabled': 'disabled'})
-      # the is-disabled is needed for Lettuce test below
-      # lms/djangoapps/courseware/features/problems.py submit_problem(step)
-      @submitButton.addClass 'is-disabled'
       if changeText
         @submitButtonLabel.text(@submitButtonSubmittingText)
 

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -197,8 +197,14 @@ class ProblemPage(PageObject):
         """
         Checks if the submit button is disabled
         """
-        return (self.q(css='.problem .submit').attrs('disabled') and
-                'is-disabled' in self.q(css='.problem .submit').attrs('class')[0])
+        disabled_attr = self.q(css='.problem .submit').attrs('disabled')[0]
+        return disabled_attr == 'true'
+
+    def wait_for_submit_disabled(self):
+        """
+        Waits until the Submit button becomes disabled.
+        """
+        self.wait_for(self.is_submit_disabled, 'Waiting for submit to be enabled')
 
     def wait_for_focus_on_submit_notification(self):
         """

--- a/lms/djangoapps/courseware/features/problems.feature
+++ b/lms/djangoapps/courseware/features/problems.feature
@@ -174,21 +174,6 @@ Feature: LMS.Answer problems
         | ProblemType       | Points Possible               |
         | image             | 1 point possible (ungraded)   |
 
-    Scenario: I can't submit a blank answer
-        Given I am viewing a "<ProblemType>" problem
-        Then I can't submit a problem
-
-        Examples:
-        | ProblemType       |
-        | drop down         |
-        | multiple choice   |
-        | checkbox          |
-        | radio             |
-        | string            |
-        | numerical         |
-        | formula           |
-        | script            |
-
     Scenario: I can reset the correctness of a problem after changing my answer
         Given I am viewing a "<ProblemType>" problem
         Then my "<ProblemType>" answer is marked "unanswered"

--- a/lms/djangoapps/courseware/features/problems.py
+++ b/lms/djangoapps/courseware/features/problems.py
@@ -93,19 +93,10 @@ def submit_problem(step):
     # first scroll down so the loading mathjax button does not
     # cover up the Submit button
     world.browser.execute_script("window.scrollTo(0,1024)")
-    assert world.is_css_not_present("button.submit.is-disabled")
     world.css_click("button.submit")
 
     # Wait for the problem to finish re-rendering
     world.wait_for_ajax_complete()
-
-
-@step(u"I can't submit a problem")
-def assert_cant_submit_problem(step):   # pylint: disable=unused-argument
-    # first scroll down so the loading mathjax button does not
-    # cover up the Check button
-    world.browser.execute_script("window.scrollTo(0,1024)")
-    assert world.is_css_present("button.submit.is-disabled")
 
 
 @step(u'The "([^"]*)" problem displays a "([^"]*)" answer')

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -51,11 +51,7 @@ from openedx.core.djangolib.markup import HTML
     </span>
     % endif
     </div>
-    <button type="button" class="submit btn-brand" data-submitting="${ submit_button_submitting }" data-value="${ submit_button }" aria-describedby="submission_feedback_${short_id}" ${'' if should_enable_submit_button else 'disabled'}
-        % if attempts_allowed:
-            data-attempts-remaining="${attempts_allowed - attempts_used}"
-        % endif
-    >
+    <button type="button" class="submit btn-brand" data-submitting="${ submit_button_submitting }" data-value="${ submit_button }" data-should-enable-submit-button="${ should_enable_submit_button }" aria-describedby="submission_feedback_${short_id}" ${'' if should_enable_submit_button else 'disabled'}>
         <span class="submit-label" aria-hidden="true">${ submit_button }</span><span class="sr">${_("Submit your answer")}</span>
     </button>
     <div class="submission_feedback" id="submission_feedback_${short_id}">


### PR DESCRIPTION
@alisan617 and @staubina Please review this PR so I can proceed with merging our feature branch.

Sandbox (this subsection currently has a due date in the past):
https://disablesubmit.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/

Note: have not been able to figure out the sporadic issue. Right now I'm not seeing it again.... When it happens though, it's definitely a server problem where the number of attempts is wrong, and I can't see how it would have been effected by our code (meaning that the issue is probably lurking in master already). I'll create a bug to investigate it more if I continue to see it.

My thought is that should_enable_submit_button (capa_base method) uses _closed_ as part of it logic, and that checks the number of available attempts (as well as due date). So if the number of available attempts coming from the server is valid for the JS to use, why not use should_enable_submit_button itself, which will also have the due date logic?

```
def closed(self):
        """
        Is the student still allowed to submit answers?
        """
        if self.max_attempts is not None and self.attempts >= self.max_attempts:
            return True
        if self.is_past_due():
            return True

        return False
```
