### PR TITLE
comparison should be case-insensitive

### DIFF
--- a/common/djangoapps/student/management/commands/manage_user.py
+++ b/common/djangoapps/student/management/commands/manage_user.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
         certain issues, for example if the expected username has already been
         taken by someone else.
         """
-        if user.email != email:
+        if user.email.lower() != email.lower():
             # The passed email address doesn't match this username's email address.
             # Assume a problem and fail.
             raise CommandError(

--- a/common/djangoapps/student/management/tests/test_manage_user.py
+++ b/common/djangoapps/student/management/tests/test_manage_user.py
@@ -117,6 +117,16 @@ class TestManageUserCommand(TestCase):
         self.assertIn('email addresses do not match', str(exc_context.exception).lower())
         self.assertEqual([(TEST_USERNAME, TEST_EMAIL)], [(u.username, u.email) for u in User.objects.all()])
 
+    def test_same_email_varied_case(self):
+        """
+        Ensure that the operation is continues if the username matches an
+        existing user account and the supplied email differs only in cases.
+        """
+        User.objects.create(username=TEST_USERNAME, email=TEST_EMAIL.upper())
+        call_command('manage_user', TEST_USERNAME, TEST_EMAIL.lower())
+        user = User.objects.get(username=TEST_USERNAME)
+        self.assertEqual(user.email, TEST_EMAIL.upper())
+
     @ddt.data(*itertools.product([(True, True), (True, False), (False, True), (False, False)], repeat=2))
     @ddt.unpack
     def test_bits(self, initial_bits, expected_bits):

--- a/common/djangoapps/student/management/tests/test_manage_user.py
+++ b/common/djangoapps/student/management/tests/test_manage_user.py
@@ -119,7 +119,7 @@ class TestManageUserCommand(TestCase):
 
     def test_same_email_varied_case(self):
         """
-        Ensure that the operation is continues if the username matches an
+        Ensure that the operation continues if the username matches an
         existing user account and the supplied email differs only in cases.
         """
         User.objects.create(username=TEST_USERNAME, email=TEST_EMAIL.upper())


### PR DESCRIPTION
Emails should be compared case insensitively.  This issue causes real support roundtrips.
