### PR TITLE
Move sync_user_info management command from common to LMS

### DIFF
--- a/lms/djangoapps/django_comment_client/management/commands/sync_user_info.py
+++ b/lms/djangoapps/django_comment_client/management/commands/sync_user_info.py
@@ -1,6 +1,7 @@
-##
-## One-off script to sync all user information to the discussion service (later info will be synced automatically)
-
+"""
+One-off script to sync all user information to the
+discussion service (later info will be synced automatically)
+"""
 
 from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User
@@ -8,6 +9,9 @@ import lms.lib.comment_client as cc
 
 
 class Command(BaseCommand):
+    """
+    Management command for adding all users to the discussion service.
+    """
     help = 'Sync all user ids, usernames, and emails to the discussion service'
 
     def handle(self, *args, **options):


### PR DESCRIPTION
Per goals described in [edX Platform Code Structure](https://openedx.atlassian.net/wiki/display/TNL/edx-platform+Code+Structure):
- Moving sync_user_info management command from `common` to `lms`.
