### PR TITLE
Decouple student's dependency on badges with django signals

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -47,7 +47,6 @@ from simple_history.models import HistoricalRecords
 from track import contexts
 from xmodule_django.models import CourseKeyField, NoneToEmptyManager
 
-from lms.djangoapps.badges.utils import badges_enabled
 from certificates.models import GeneratedCertificate
 from course_modes.models import CourseMode
 from enrollment.api import _default_course_mode
@@ -1297,9 +1296,7 @@ class CourseEnrollment(models.Model):
         # User is allowed to enroll if they've reached this point.
         enrollment = cls.get_or_create_enrollment(user, course_key)
         enrollment.update_enrollment(is_active=True, mode=mode)
-        if badges_enabled():
-            from lms.djangoapps.badges.events.course_meta import award_enrollment_badge
-            award_enrollment_badge(user)
+        enrollment.send_signal(EnrollStatusChange.enroll)
 
         return enrollment
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1077,8 +1077,7 @@ def change_enrollment(request, check_access=True):
             try:
                 enroll_mode = CourseMode.auto_enroll_mode(course_id, available_modes)
                 if enroll_mode:
-                    enrollment = CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
-                    enrollment.send_signal(EnrollStatusChange.enroll)
+                    CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
             except Exception:  # pylint: disable=broad-except
                 return HttpResponseBadRequest(_("Could not enroll"))
 

--- a/lms/djangoapps/badges/apps.py
+++ b/lms/djangoapps/badges/apps.py
@@ -1,0 +1,20 @@
+"""
+Badges Application Configuration
+
+Signal handlers are connected here.
+"""
+
+from django.apps import AppConfig
+
+
+class BadgesConfig(AppConfig):
+    """
+    Application Configuration for Badges.
+    """
+    name = u'badges'
+
+    def ready(self):
+        """
+        Connect signal handlers.
+        """
+        from . import handlers  # pylint: disable=unused-variable

--- a/lms/djangoapps/badges/handlers.py
+++ b/lms/djangoapps/badges/handlers.py
@@ -1,0 +1,17 @@
+"""
+Badges related signal handlers.
+"""
+from django.dispatch import receiver
+
+from lms.djangoapps.badges.events.course_meta import award_enrollment_badge
+from lms.djangoapps.badges.utils import badges_enabled
+from student.models import ENROLL_STATUS_CHANGE, EnrollStatusChange
+
+
+@receiver(ENROLL_STATUS_CHANGE)
+def award_badge_on_enrollment(sender, event=None, user=None, **kwargs):  # pylint: disable=unused-argument
+    """
+    Awards enrollment badge to the given user on new enrollments.
+    """
+    if badges_enabled and event == EnrollStatusChange.enroll:
+        award_enrollment_badge(user)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2095,7 +2095,7 @@ INSTALLED_APPS = (
     'learner_dashboard',
 
     # Needed whether or not enabled, due to migrations
-    'badges',
+    'badges.apps.BadgesConfig',
 
     # Enables default site and redirects
     'django_sites_extensions',


### PR DESCRIPTION
This PR removes a direct call to the badges app from the student app.  The direct call is replaced by an indirect notification using django signals.

Please review: @robrap @doctoryes @jcdyer @andy-armstrong 
