### PR TITLE
Removed unnecessary http:

### DIFF
--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -87,7 +87,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <h3 class="title">${_("Course Summary Page")} <span class="tip">${_("(for student enrollment and access)")}</span></h3>
             <div class="copy">
               <%
-                link_for_about_page = ("https:" if is_secure else "http:") + lms_link_for_about_page
+                link_for_about_page = lms_link_for_about_page
               %>
               <p><a class="link-courseURL" rel="external" href="${link_for_about_page}">${link_for_about_page}</a></p>
             </div>


### PR DESCRIPTION
This pull request is being created in response to https://openedx.atlassian.net/browse/TNL-5237
It appears that the value of lms_link_for_about_page now includes the value of https. So the value doesn't need to be added to the link_for_about_page. This pull request simply removes the redundant addition.
