### PR TITLE
Move monitoring from common to openedx/core

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -868,7 +868,7 @@ INSTALLED_APPS = (
     'embargo',
 
     # Monitoring signals
-    'monitoring',
+    'openedx.core.djangoapps.monitoring',
 
     # Course action state
     'course_action_state',

--- a/common/djangoapps/monitoring/startup.py
+++ b/common/djangoapps/monitoring/startup.py
@@ -1,4 +1,0 @@
-# Register signal handlers
-# pylint: disable=unused-import
-import signals
-import exceptions

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2010,7 +2010,7 @@ INSTALLED_APPS = (
     'embargo',
 
     # Monitoring functionality
-    'monitoring',
+    'openedx.core.djangoapps.monitoring',
 
     # Course action state
     'course_action_state',

--- a/openedx/core/djangoapps/monitoring/exceptions.py
+++ b/openedx/core/djangoapps/monitoring/exceptions.py
@@ -1,10 +1,17 @@
+"""
+Signal handler for exceptions.
+"""
 from django.core.signals import got_request_exception
 from django.dispatch import receiver
 import logging
 
 
 @receiver(got_request_exception)
-def record_request_exception(sender, **kwargs):
+def record_request_exception(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    Logs the stack trace whenever an exception
+    occurs in processing a request.
+    """
     logging.exception("Uncaught exception from {sender}".format(
         sender=sender
     ))

--- a/openedx/core/djangoapps/monitoring/signals.py
+++ b/openedx/core/djangoapps/monitoring/signals.py
@@ -13,7 +13,7 @@ from django.dispatch import receiver
 import dogstats_wrapper as dog_stats_api
 
 
-def _database_tags(action, sender, kwargs):
+def _database_tags(action, sender, kwargs):  # pylint: disable=unused-argument
     """
     Return a tags for the sender and database used in django.db.models signals.
 

--- a/openedx/core/djangoapps/monitoring/startup.py
+++ b/openedx/core/djangoapps/monitoring/startup.py
@@ -1,0 +1,6 @@
+"""
+Registers signal handlers at startup.
+"""
+# pylint: disable=unused-import
+import openedx.core.djangoapps.monitoring.signals
+import openedx.core.djangoapps.monitoring.exceptions


### PR DESCRIPTION
Per goals described in edX Platform Code Structure, the following changes were made as separate commits:
- Move monitoring from common to openedx/core
