### PR TITLE
put display previously removed in capa space pr

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -256,6 +256,7 @@ div.problem {
   .indicator-container {
     min-height: 1px;
     width: 25px;
+    display: inline-block;
   }
 
   fieldset {


### PR DESCRIPTION
Put back the display for indicator container, which causes the button bar pixel shift in MC/CATA option click.

This will bring back the tad space above the multi part problem in capa spacing PR.
## Reviewers
- [x] code review: @cahrens 
- [x] code review: @bjacobel 
