### PR TITLE
add location to attributes exported to neo4j

### DIFF
--- a/openedx/core/djangoapps/coursegraph/management/commands/dump_to_neo4j.py
+++ b/openedx/core/djangoapps/coursegraph/management/commands/dump_to_neo4j.py
@@ -82,6 +82,7 @@ class ModuleStoreSerializer(object):
         fields['course'] = course_key.course
         fields['run'] = course_key.run
         fields['course_key'] = six.text_type(course_key)
+        fields['location'] = six.text_type(item.location)
 
         label = item.scope_ids.block_type
 

--- a/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
+++ b/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
@@ -118,6 +118,7 @@ class TestModuleStoreSerializer(TestDumpToNeo4jCommandBase):
         self.assertIn("course", fields.keys())
         self.assertIn("run", fields.keys())
         self.assertIn("course_key", fields.keys())
+        self.assertIn("location", fields.keys())
         self.assertNotIn("checklist", fields.keys())
 
     def test_serialize_course(self):


### PR DESCRIPTION
I want to add items' locations to the attributes we export to neo4j. This is a very small change.

Reviewers (looking for 2 of 3! :))
- [ ] @benpatterson 
- [ ] @attiyaIshaque 
- [ ] @fredsmith 
