### PR TITLE
Allow to store multiple anonymous ids per (user, course)

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -123,7 +123,6 @@ class AnonymousUserId(models.Model):
     user = models.ForeignKey(User, db_index=True)
     anonymous_user_id = models.CharField(unique=True, max_length=32)
     course_id = CourseKeyField(db_index=True, max_length=255, blank=True)
-    unique_together = (user, course_id)
 
 
 def anonymous_id_for_user(user, course_id, save=True):
@@ -161,22 +160,11 @@ def anonymous_id_for_user(user, course_id, save=True):
         return digest
 
     try:
-        anonymous_user_id, __ = AnonymousUserId.objects.get_or_create(
-            defaults={'anonymous_user_id': digest},
+        AnonymousUserId.objects.get_or_create(
             user=user,
-            course_id=course_id
+            course_id=course_id,
+            anonymous_user_id=digest,
         )
-        if anonymous_user_id.anonymous_user_id != digest:
-            log.error(
-                u"Stored anonymous user id %(anonymous_user_id)r for "
-                u"user %(user)r in course %(course_id)r doesn't match "
-                u"computed id %(digest)r", {
-                    "anonymous_user_id": anonymous_user_id.anonymous_user_id,
-                    "user": user,
-                    "course_id": course_id,
-                    "digest": digest,
-                }
-            )
     except IntegrityError:
         # Another thread has already created this entry, so
         # continue

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -12,7 +12,7 @@ import ddt
 from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import Client
 from edx_oauth2_provider.tests.factories import ClientFactory
 import httpretty
@@ -863,7 +863,7 @@ class AnonymousLookupTable(ModuleStoreTestCase):
     def setUp(self):
         super(AnonymousLookupTable, self).setUp()
         self.course = CourseFactory.create()
-        self.user = UserFactory()
+        self.user = UserFactory.create()
         CourseModeFactory.create(
             course_id=self.course.id,
             mode_slug='honor',
@@ -891,6 +891,18 @@ class AnonymousLookupTable(ModuleStoreTestCase):
         real_user = user_by_anonymous_id(anonymous_id)
         self.assertEqual(self.user, real_user)
         self.assertEqual(anonymous_id, anonymous_id_for_user(self.user, course2.id, save=False))
+
+    def test_secret_key_changes(self):
+        """Test that a new anonymous id is returned when the secret key changes."""
+        CourseEnrollment.enroll(self.user, self.course.id)
+        anonymous_id = anonymous_id_for_user(self.user, self.course.id)
+        with override_settings(SECRET_KEY='some_new_and_totally_secret_key'):
+            # Recreate user object to clear cached anonymous id.
+            self.user = User.objects.get(pk=self.user.id)
+            new_anonymous_id = anonymous_id_for_user(self.user, self.course.id)
+            self.assertNotEqual(anonymous_id, new_anonymous_id)
+            self.assertEqual(self.user, user_by_anonymous_id(anonymous_id))
+            self.assertEqual(self.user, user_by_anonymous_id(new_anonymous_id))
 
 
 @attr(shard=3)


### PR DESCRIPTION
The current version of `anonymous_id_for_user()` computes a new version of the anonynous ID for a user and course, but does not store it in the databse.  This can happen when the `SECRET_KEY` setting was changed, and results in inconsistent behaviour, since the id returned by `anonymous_id_for_user()` cannot be inverted by `user_by_anonymous_id()` anymore.

This change works around this problem by storing multiple anonymous ids per (user, course).  This way, the anonymous id will still change when the secret key gets changed, but both the old and the new version can be inverted to get the original user again.

**JIRA tickets**: [OSPR-1501](https://openedx.atlassian.net/browse/OSPR-1501)

**Discussions**: N/A

**Dependencies**: None

**Screenshots**: N/A

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**: I don't see how to manually test this change.

**Author notes and concerns**: N/A

**Reviewers**
- [x] OpenCraft internal reviewer: @pomegranited
- [ ] edX reviewer[s] TBD
