### PR TITLE
Corrected issue with the Show Hint button not enabling with just 1 hint.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -565,12 +565,12 @@ class CapaMixin(CapaFields):
 
         return html
 
-    def _should_enable_demand_hint(self, hint_index, demand_hints):
+    def _should_enable_demand_hint(self, demand_hints, hint_index=None):
         """
         Should the demand hint option be enabled?
 
         Arguments:
-            hint_index (int): The current hint index.
+            hint_index (int): The current hint index, or None (default value) if no hint is currently being shown.
             demand_hints (list): List of hints.
         Returns:
             bool: True is the demand hint is possible.
@@ -578,7 +578,11 @@ class CapaMixin(CapaFields):
         """
         # hint_index is the index of the last hint that will be displayed in this rendering,
         # so add 1 to check if others exist.
-        return len(demand_hints) > 0, len(demand_hints) > 0 and hint_index + 1 < len(demand_hints)
+        if hint_index is None:
+            should_enable = len(demand_hints) > 0
+        else:
+            should_enable = len(demand_hints) > 0 and hint_index + 1 < len(demand_hints)
+        return len(demand_hints) > 0, should_enable
 
     def get_demand_hint(self, hint_index):
         """
@@ -621,7 +625,7 @@ class CapaMixin(CapaFields):
         event_info['hint_text'] = get_inner_html_from_xpath(demand_hints[hint_index])
         self.runtime.publish(self, 'edx.problem.hint.demandhint_displayed', event_info)
 
-        _, should_enable_next_hint = self._should_enable_demand_hint(hint_index, demand_hints)
+        _, should_enable_next_hint = self._should_enable_demand_hint(demand_hints=demand_hints, hint_index=hint_index)
 
         # We report the index of this hint, the client works out what index to use to get the next hint
         return {
@@ -663,9 +667,8 @@ class CapaMixin(CapaFields):
         }
 
         # If demand hints are available, emit hint button and div.
-        hint_index = 0
         demand_hints = self.lcp.tree.xpath("//problem/demandhint/hint")
-        demand_hint_possible, should_enable_next_hint = self._should_enable_demand_hint(hint_index, demand_hints)
+        demand_hint_possible, should_enable_next_hint = self._should_enable_demand_hint(demand_hints=demand_hints)
 
         answer_notification_type, answer_notification_message = self._get_answer_notification(
             render_notifications=submit_notification)

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1238,7 +1238,8 @@ class CapaModuleTest(unittest.TestCase):
         module = CapaFactory.create(xml=self.demand_xml)
         module.get_problem_html()  # ignoring html result
         context = module.system.render_template.call_args[0][1]
-        self.assertEqual(context['demand_hint_possible'], True)
+        self.assertTrue(context['demand_hint_possible'])
+        self.assertTrue(context['should_enable_next_hint'])
 
         # Check the AJAX call that gets the hint by index
         result = module.get_demand_hint(0)
@@ -1252,6 +1253,35 @@ class CapaModuleTest(unittest.TestCase):
         result = module.get_demand_hint(2)  # here the server wraps around to index 0
         self.assertEqual(result['hint_index'], 0)
         self.assertTrue(result['should_enable_next_hint'])
+
+    def test_single_demand_hint(self):
+        """
+        Test the hint button enabled state when there is just a single hint.
+        """
+        test_xml = """
+            <problem>
+            <p>That is the question</p>
+            <multiplechoiceresponse>
+              <choicegroup type="MultipleChoice">
+                <choice correct="false">Alpha <choicehint>A hint</choicehint>
+                </choice>
+                <choice correct="true">Beta</choice>
+              </choicegroup>
+            </multiplechoiceresponse>
+            <demandhint>
+              <hint>Only demand hint</hint>
+            </demandhint>
+            </problem>"""
+        module = CapaFactory.create(xml=test_xml)
+        module.get_problem_html()  # ignoring html result
+        context = module.system.render_template.call_args[0][1]
+        self.assertTrue(context['demand_hint_possible'])
+        self.assertTrue(context['should_enable_next_hint'])
+
+        # Check the AJAX call that gets the hint by index
+        result = module.get_demand_hint(0)
+        self.assertEqual(result['hint_index'], 0)
+        self.assertFalse(result['should_enable_next_hint'])
 
     def test_demand_hint_logging(self):
         module = CapaFactory.create(xml=self.demand_xml)


### PR DESCRIPTION
## [TNL-5737](https://openedx.atlassian.net/browse/TNL-5737)
### Description

Correct issue with the Hint button not being enabled with one hint.
### Sandbox

*\* Currently bieng built*\* 
staubina-hint.sandbox.edx.org
- [ ] Build a sandbox for your branch and add a link here
### Testing
- [ ] safecommit violation code review process
- [ ] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @cahrens 
- [ ] Code review: @alisan617 
- [ ] Product review: @sstack22 
### Post-review
- [ ] Rebase and squash commits
