### PR TITLE
Updated to the problem meta to show a 0/total when student scores 0 p…

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -397,6 +397,7 @@ class CapaMixin(CapaFields):
             'progress_detail': Progress.to_js_detail_str(progress),
             'content': self.get_problem_html(encapsulate=False),
             'graded': self.graded,
+            'attempts_used': self.attempts,
         })
 
     def submit_button_name(self):

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -92,6 +92,7 @@ class CapaModule(CapaMixin, XModule):
             return 'Error: {} is not a known capa action'.format(dispatch)
 
         before = self.get_progress()
+        before_attempts = self.attempts
 
         try:
             result = handlers[dispatch](data)
@@ -117,11 +118,13 @@ class CapaModule(CapaMixin, XModule):
             raise ProcessingError(generic_error_message), None, traceback_obj
 
         after = self.get_progress()
-
+        after_attempts = self.attempts
+        progress_changed = (after != before) or (before_attempts != after_attempts)
         result.update({
-            'progress_changed': after != before,
+            'progress_changed': progress_changed,
             'progress_status': Progress.to_js_status_str(after),
             'progress_detail': Progress.to_js_detail_str(after),
+            'attempts_used': self.attempts,
         })
 
         return json.dumps(result, cls=ComplexEncoder)

--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -91,9 +91,10 @@ describe 'Problem', ->
     beforeEach ->
       @problem = new Problem($('.xblock-student_view'))
 
-    testProgessData = (problem, status, detail, graded, expected_progress_after_render) ->
+    testProgessData = (problem, status, detail, graded, attempts_used, expected_progress_after_render) ->
       problem.el.data('progress_status', status)
       problem.el.data('progress_detail', detail)
+      problem.el.data('attempts_used', attempts_used)
       problem.el.data('graded', graded)
       expect(problem.$('.problem-progress').html()).toEqual ""
       problem.renderProgressState()
@@ -101,35 +102,41 @@ describe 'Problem', ->
 
     describe 'with a status of "none"', ->
       it 'reports the number of points possible and graded', ->
-        testProgessData(@problem, 'none', '0/1', "True", "1 point possible (graded)")
+        testProgessData(@problem, 'none', '0/1', "True", '0', "1 point possible (graded)")
 
       it 'displays the number of points possible when rendering happens with the content', ->
-        testProgessData(@problem, 'none', '0/2', "True", "2 points possible (graded)")
+        testProgessData(@problem, 'none', '0/2', "True", '0', "2 points possible (graded)")
 
       it 'reports the number of points possible and ungraded', ->
-        testProgessData(@problem, 'none', '0/1', "False", "1 point possible (ungraded)")
+        testProgessData(@problem, 'none', '0/1', "False", '0', "1 point possible (ungraded)")
 
       it 'displays ungraded if number of points possible is 0', ->
-        testProgessData(@problem, 'none', '0', "False", "0 points possible (ungraded)")
+        testProgessData(@problem, 'none', '0', "False", '0', "0 points possible (ungraded)")
 
       it 'displays ungraded if number of points possible is 0, even if graded value is True', ->
-        testProgessData(@problem, 'none', '0', "True", "0 points possible (ungraded)")
+        testProgessData(@problem, 'none', '0', "True", '0', "0 points possible (ungraded)")
+
+      it 'reports the correct score with status none and >0 attempts', ->
+        testProgessData(@problem, 'none', '0/1', "True", '1', "0/1 point (graded)")
+
+      it 'reports the correct score with >1 weight, status none, and >0 attempts', ->
+        testProgessData(@problem, 'none', '0/2', "True", '2', "0/2 points (graded)")
 
     describe 'with any other valid status', ->
 
       it 'reports the current score', ->
-        testProgessData(@problem, 'foo', '1/1', "True", "1/1 point (graded)")
+        testProgessData(@problem, 'foo', '1/1', "True", '1', "1/1 point (graded)")
 
       it 'shows current score when rendering happens with the content', ->
-        testProgessData(@problem, 'test status', '2/2', "True", "2/2 points (graded)")
+        testProgessData(@problem, 'test status', '2/2', "True", '1', "2/2 points (graded)")
 
       it 'reports the current score even if problem is ungraded', ->
-        testProgessData(@problem, 'test status', '1/1', "False", "1/1 point (ungraded)")
+        testProgessData(@problem, 'test status', '1/1', "False", '1', "1/1 point (ungraded)")
 
     describe 'with valid status and string containing an integer like "0" for detail', ->
       # These tests are to address a failure specific to Chrome 51 and 52 +
       it 'shows 0 points possible for the detail', ->
-        testProgessData(@problem, 'foo', '0', "False", "")
+        testProgessData(@problem, 'foo', '0', "False", '1', "")
 
   describe 'render', ->
     beforeEach ->

--- a/common/lib/xmodule/xmodule/js/src/capa/display.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.js
@@ -206,14 +206,15 @@
         };
 
         Problem.prototype.renderProgressState = function() {
-            var a, detail, earned, graded, possible, progress, progressTemplate, status;
+            var a, detail, earned, graded, possible, progress, progressTemplate, status, attempts;
             detail = this.el.data('progress_detail');
             status = this.el.data('progress_status');
             graded = this.el.data('graded');
-
+            attempts = this.el.data('attempts_used');
             // Render 'x/y point(s)' if student has attempted question
-            if (status !== 'none' && (detail !== null && detail !== undefined) && (jQuery.type(detail) === 'string') &&
-                detail.indexOf('/') > 0) {
+            if ((status !== 'none' || (status === 'none' && attempts > 0)) &&
+                    (detail !== null && detail !== undefined) &&
+                    (jQuery.type(detail) === 'string') && detail.indexOf('/') > 0) {
                 a = detail.split('/');
                 earned = parseFloat(a[0]);
                 possible = parseFloat(a[1]);
@@ -236,11 +237,9 @@
                     earned: earned,
                     possible: possible
                 }, true);
-            }
-
-            // Render 'x point(s) possible' if student has not yet attempted question
-            // Status is set to none when a user has a score of 0, and 0 when the problem has a weight of 0.
-            if (status === 'none' || status === 0) {
+            } else if (status === 'none' || status === 0 || status === '0') {
+                // Render 'x point(s) possible' if student has not yet attempted question
+                // Status is set to none when a user has a score of 0, and 0 when the problem has a weight of 0.
                 if ((detail !== null && detail !== undefined) && (jQuery.type(detail) === 'string') &&
                     detail.indexOf('/') > 0) {
                     a = detail.split('/');
@@ -270,6 +269,7 @@
             if (response.progress_changed) {
                 this.el.data('progress_status', response.progress_status);
                 this.el.data('progress_detail', response.progress_detail);
+                this.el.data('attempts_used', response.attempts_used);
                 this.el.trigger('progressChanged');
             }
             return this.renderProgressState();
@@ -278,6 +278,7 @@
         Problem.prototype.forceUpdate = function(response) {
             this.el.data('progress_status', response.progress_status);
             this.el.data('progress_detail', response.progress_detail);
+            this.el.data('attempts_used', response.attempts_used);
             this.el.trigger('progressChanged');
             return this.renderProgressState();
         };

--- a/lms/djangoapps/courseware/features/problems.feature
+++ b/lms/djangoapps/courseware/features/problems.feature
@@ -121,23 +121,23 @@ Feature: LMS.Answer problems
         Then I should see a score of "<Points Possible>"
 
         Examples:
-        | ProblemType       | Correctness   | Score                        | Points Possible               |
-        | drop down         | correct       | 1/1 point (ungraded)  | 1 point possible (ungraded)   |
-        | drop down         | incorrect     | 1 point possible (ungraded)  | 1 point possible (ungraded)   |
-        | multiple choice   | correct       | 1/1 point (ungraded)  | 1 point possible (ungraded)   |
-        | multiple choice   | incorrect     | 1 point possible (ungraded)  | 1 point possible (ungraded)   |
-        | checkbox          | correct       | 1/1 point (ungraded)  | 1 point possible (ungraded)   |
-        | checkbox          | incorrect     | 1 point possible (ungraded)  | 1 point possible (ungraded)   |
-        | radio             | correct       | 1/1 point (ungraded)  | 1 point possible (ungraded)   |
-        | radio             | incorrect     | 1 point possible (ungraded)  | 1 point possible (ungraded)   |
-        | numerical         | correct       | 1/1 point (ungraded)  | 1 point possible (ungraded)   |
-        | numerical         | incorrect     | 1 point possible (ungraded)  | 1 point possible (ungraded)   |
-        | formula           | correct       | 1/1 point (ungraded)  | 1 point possible (ungraded)   |
-        | formula           | incorrect     | 1 point possible (ungraded)  | 1 point possible (ungraded)   |
-        | script            | correct       | 2/2 points (ungraded) | 2 points possible (ungraded)  |
-        | script            | incorrect     | 2 points possible (ungraded) | 2 points possible (ungraded)  |
-        | image             | correct       | 1/1 point (ungraded)  | 1 point possible (ungraded)   |
-        | image             | incorrect     | 1 point possible (ungraded)  | 1 point possible (ungraded)   |
+        | ProblemType       | Correctness   | Score                 | Points Possible        |
+        | drop down         | correct       | 1/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | drop down         | incorrect     | 0/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | multiple choice   | correct       | 1/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | multiple choice   | incorrect     | 0/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | checkbox          | correct       | 1/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | checkbox          | incorrect     | 0/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | radio             | correct       | 1/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | radio             | incorrect     | 0/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | numerical         | correct       | 1/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | numerical         | incorrect     | 0/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | formula           | correct       | 1/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | formula           | incorrect     | 0/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | script            | correct       | 2/2 points (ungraded) | 0/2 points (ungraded)  |
+        | script            | incorrect     | 0/2 points (ungraded) | 0/2 points (ungraded)  |
+        | image             | correct       | 1/1 point (ungraded)  | 0/1 point (ungraded)   |
+        | image             | incorrect     | 0/1 point (ungraded)  | 0/1 point (ungraded)   |
 
     Scenario: I can see my score on a problem when I answer it and after I reset it
         Given I am viewing a "<ProblemType>" problem with randomization "<Randomization>" with reset button on
@@ -147,23 +147,23 @@ Feature: LMS.Answer problems
         Then I should see a score of "<Points Possible>"
 
         Examples:
-        | ProblemType       | Correctness   | Score                         | Points Possible               | Randomization |
-        | drop down         | correct       | 1/1 point (ungraded)   | 1 point possible (ungraded)   | never         |
-        | drop down         | incorrect     | 1 point possible (ungraded)   | 1 point possible (ungraded)   | never         |
-        | multiple choice   | correct       | 1/1 point (ungraded)   | 1 point possible (ungraded)   | never         |
-        | multiple choice   | incorrect     | 1 point possible (ungraded)   | 1 point possible (ungraded)   | never         |
-        | checkbox          | correct       | 1/1 point (ungraded)   | 1 point possible (ungraded)   | never         |
-        | checkbox          | incorrect     | 1 point possible (ungraded)   | 1 point possible (ungraded)   | never         |
-        | radio             | correct       | 1/1 point (ungraded)   | 1 point possible (ungraded)   | never         |
-        | radio             | incorrect     | 1 point possible (ungraded)   | 1 point possible (ungraded)   | never         |
-        | numerical         | correct       | 1/1 point (ungraded)   | 1 point possible (ungraded)   | never         |
-        | numerical         | incorrect     | 1 point possible (ungraded)   | 1 point possible (ungraded)   | never         |
-        | formula           | correct       | 1/1 point (ungraded)   | 1 point possible (ungraded)   | never         |
-        | formula           | incorrect     | 1 point possible (ungraded)   | 1 point possible (ungraded)   | never         |
-        | script            | correct       | 2/2 points (ungraded)  | 2 points possible (ungraded)  | never         |
-        | script            | incorrect     | 2 points possible (ungraded)  | 2 points possible (ungraded)  | never         |
-        | image             | correct       | 1/1 point (ungraded)   | 1 point possible (ungraded)   | never         |
-        | image             | incorrect     | 1 point possible (ungraded)   | 1 point possible (ungraded)   | never         |
+        | ProblemType       | Correctness   | Score                  | Points Possible        | Randomization |
+        | drop down         | correct       | 1/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | drop down         | incorrect     | 0/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | multiple choice   | correct       | 1/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | multiple choice   | incorrect     | 0/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | checkbox          | correct       | 1/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | checkbox          | incorrect     | 0/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | radio             | correct       | 1/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | radio             | incorrect     | 0/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | numerical         | correct       | 1/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | numerical         | incorrect     | 0/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | formula           | correct       | 1/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | formula           | incorrect     | 0/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | script            | correct       | 2/2 points (ungraded)  | 0/2 points (ungraded)  | never         |
+        | script            | incorrect     | 0/2 points (ungraded)  | 0/2 points (ungraded)  | never         |
+        | image             | correct       | 1/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
+        | image             | incorrect     | 0/1 point (ungraded)   | 0/1 point (ungraded)   | never         |
 
     Scenario: I can see my score on a problem to which I submit a blank answer
         Given I am viewing a "<ProblemType>" problem
@@ -172,7 +172,7 @@ Feature: LMS.Answer problems
 
         Examples:
         | ProblemType       | Points Possible               |
-        | image             | 1 point possible (ungraded)   |
+        | image             | 0/1 point (ungraded)   |
 
     Scenario: I can reset the correctness of a problem after changing my answer
         Given I am viewing a "<ProblemType>" problem

--- a/lms/templates/problem_ajax.html
+++ b/lms/templates/problem_ajax.html
@@ -1,1 +1,7 @@
-<div id="problem_${element_id}" class="problems-wrapper" role="group" aria-labelledby="${element_id}-problem-title" data-problem-id="${id}" data-url="${ajax_url}" data-progress_status="${progress_status}" data-progress_detail="${progress_detail}" data-content="${content | h}" data-graded="${graded}"></div>
+<div id="problem_${element_id}"
+     class="problems-wrapper"
+     role="group" aria-labelledby="${element_id}-problem-title"
+     data-problem-id="${id}" data-url="${ajax_url}"
+     data-progress_status="${progress_status}" data-progress_detail="${progress_detail}"
+     data-content="${content | h}" data-graded="${graded}" data-attempts_used="${attempts_used}">
+</div>

--- a/lms/templates/problem_ajax.html
+++ b/lms/templates/problem_ajax.html
@@ -2,6 +2,6 @@
      class="problems-wrapper"
      role="group" aria-labelledby="${element_id}-problem-title"
      data-problem-id="${id}" data-url="${ajax_url}"
-     data-progress_status="${progress_status}" data-progress_detail="${progress_detail}"
-     data-content="${content | h}" data-graded="${graded}" data-attempts_used="${attempts_used}">
+     data-progress-status="${progress_status}" data-progress-detail="${progress_detail}"
+     data-content="${content | h}" data-graded="${graded}" data-attempts-used="${attempts_used}">
 </div>


### PR DESCRIPTION
Based on this PR: https://github.com/edx/edx-platform/pull/13704, once it is merged I will change the base to Master
## [TNL-5549](https://openedx.atlassian.net/browse/TNL-5549)
### Description

Updates the Problem Meta to show 0/<total> when an attempt has been made, but the user has scored no points.
### Sandbox

**New Sandbox needed**
- [ ] Build a sandbox for your branch and add a link here
### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit violation code review process
- [ ] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @cahrens 
- [ ] Code review: @alisan617 
- [ ] Product review: @sstack22 
### Post-review
- [ ] Rebase and squash commits
