### PR TITLE
TNL-5743: Disable tests causing OutOfMemory

### DIFF
--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -110,6 +110,7 @@ class SysadminBaseTestCase(SharedModuleStoreTestCase):
 
 
 @attr(shard=1)
+@unittest.skip("These tests are causing OutOfMemory on Jenkins.")
 @override_settings(
     MONGODB_LOG=TEST_MONGODB_LOG,
     GIT_REPO_DIR=settings.TEST_ROOT / "course_repos_{}".format(uuid4().hex)


### PR DESCRIPTION
## [TNL-5743](https://openedx.atlassian.net/browse/TNL-5743)
### Description

This PR disables TestSysAdminMongoCourseImport tests which have been leading to many OutOfMemory errors on Jenkins.

This is related to TNL-5743, which is about the subsequent real fix for these tests.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @nasthagiri 
- [ ] Code review: @doctoryes 
- [ ] Test eng Review: @edx/testeng 
### Post-review
- [ ] Rebase and squash commits
