### PR TITLE
Fix Malformed Staticbook url

### DIFF
--- a/lms/djangoapps/staticbook/views.py
+++ b/lms/djangoapps/staticbook/views.py
@@ -108,7 +108,7 @@ def pdf_index(request, course_id, book_index, chapter=None, page=None):
 
     viewer_params += '#zoom=page-fit&disableRange=true'
     if page is not None:
-        viewer_params += '&amp;page={}'.format(page)
+        viewer_params += '&page={}'.format(page)
 
     if request.GET.get('viewer', '') == 'true':
         template = 'pdf_viewer.html'


### PR DESCRIPTION
PDF textbooks should have the ability to link to a chapter and a page from the url. This was a capability until recently. It actually seems to still be a possibility, but the links aren't working because of a slightly malformed url. Take for example the following static texbook in 8.01x. 

https://courses.edx.org/courses/course-v1:MITx+8.01.1x+3T2016/pdfbook/0/chapter/4/3

This should link to the textbook at chapter 4 page 3. Instead it just jumps to the beginning of Chapter 4. I noticed that the pdf.js is getting called with the following url. 

https://courses.edx.org/courses/course-v1:MITx+8.01.1x+3T2016/pdfbook/0/chapter/4/3?viewer=true&file=https://srayyan.github.io/TEALMIT/textbook_801/chapter04_onedimensionalkinematics_v07.pdf#zoom=page-fit&disableRange=true&amp;page=3

When I looked at the MITx residential stack the same example was working properly. The only difference is that the end of the url isn't &amp;page=3 it is just &page=3
I tested locally and remotely, and this solves the issue. See the following

https://courses.edx.org/courses/course-v1:MITx+8.01.1x+3T2016/pdfbook/0/chapter/4/3?viewer=true&file=https://srayyan.github.io/TEALMIT/textbook_801/chapter04_onedimensionalkinematics_v07.pdf#zoom=page-fit&disableRange=true&page=3

The 8.01.1x course is running currently and has many references to the textbook that include page references. This issue is also affecting any other course that is using a static textbook.

**Sandbox**: https://staticbook.sandbox.edx.org/
