### PR TITLE
Disable migrations by default in python unit tests

### DIFF
--- a/docs/en_us/internal/testing.rst
+++ b/docs/en_us/internal/testing.rst
@@ -173,12 +173,6 @@ To run these tests without ``collectstatic``, which is faster, append the follow
 
     paver test_system -s lms --fasttest
 
-For even more speed, use the ``--disable-migrations`` option to run tests without applying migrations and instead create tables directly from apps' models.
-
-::
-
-    paver test_system -s lms --disable-migrations
-
 To run cms python tests without ``collectstatic`` use this command.
 
 ::

--- a/pavelib/utils/test/suites/python_suite.py
+++ b/pavelib/utils/test/suites/python_suite.py
@@ -18,7 +18,7 @@ class PythonTestSuite(TestSuite):
     def __init__(self, *args, **kwargs):
         super(PythonTestSuite, self).__init__(*args, **kwargs)
         self.opts = kwargs
-        self.disable_migrations = kwargs.get('disable_migrations', False)
+        self.disable_migrations = kwargs.get('disable_migrations', True)
         self.fasttest = kwargs.get('fasttest', False)
         self.subsuites = kwargs.get('subsuites', self._default_subsuites)
 


### PR DESCRIPTION
@cpennington 
