### PR TITLE
[ENT-18] Data sharing consent frontend

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -187,6 +187,19 @@ class AccountCreationForm(forms.Form):
                                 "required": _("To enroll, you must follow the honor code.")
                             }
                         )
+                elif field_name == 'data_sharing_consent':
+                    if field_value == "required":
+                        self.fields[field_name] = TrueField(
+                            error_messages={
+                                "required": _(
+                                    "Your SSO identity provider requires you to consent to course data sharing."
+                                )
+                            }
+                        )
+                    else:
+                        self.fields[field_name] = forms.BooleanField(
+                            required=False
+                        )
                 else:
                     required = field_value == "required"
                     min_length = 1 if field_name in ("gender", "level_of_education") else 2

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1606,6 +1606,11 @@ def create_account_with_params(request, params):
     if should_link_with_social_auth or (third_party_auth.is_enabled() and pipeline.running(request)):
         params["password"] = pipeline.make_random_password()
 
+    if pipeline.active_provider_requests_data_sharing(request):
+        extra_fields['data_sharing_consent'] = 'optional'
+    if pipeline.active_provider_requires_data_sharing(request):
+        extra_fields['data_sharing_consent'] = 'required'
+
     # if doing signup for an external authorization, then get email, password, name from the eamap
     # don't use the ones from the form, since the user could have hacked those
     # unless originally we didn't get a valid email or name from the external auth
@@ -1704,6 +1709,7 @@ def create_account_with_params(request, params):
     if third_party_auth.is_enabled() and pipeline.running(request):
         running_pipeline = pipeline.get(request)
         third_party_provider = provider.Registry.get_from_pipeline(running_pipeline)
+        running_pipeline['kwargs']['data_sharing_consent'] = form.cleaned_data.get('data_sharing_consent', None)
 
     # Track the user's registration
     if hasattr(settings, 'LMS_SEGMENT_KEY') and settings.LMS_SEGMENT_KEY:

--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -15,7 +15,8 @@ from .models import (
     LTIProviderConfig,
     ProviderApiPermissions,
     _PSA_OAUTH2_BACKENDS,
-    _PSA_SAML_BACKENDS
+    _PSA_SAML_BACKENDS,
+    UserDataSharingConsentAudit,
 )
 from .tasks import fetch_saml_metadata
 from third_party_auth.provider import Registry
@@ -169,3 +170,12 @@ class ApiPermissionsAdmin(admin.ModelAdmin):
     form = ApiPermissionsAdminForm
 
 admin.site.register(ProviderApiPermissions, ApiPermissionsAdmin)
+
+
+class UserDataSharingConsentAuditAdmin(admin.ModelAdmin):
+    """
+    Django Admin class for UserDataSharingConsentAudit
+    """
+    list_display = ('user_social_auth', 'state')
+
+admin.site.register(UserDataSharingConsentAudit, UserDataSharingConsentAuditAdmin)

--- a/common/djangoapps/third_party_auth/middleware.py
+++ b/common/djangoapps/third_party_auth/middleware.py
@@ -1,8 +1,10 @@
 """Middleware classes for third_party_auth."""
 
 from social.apps.django_app.middleware import SocialAuthExceptionMiddleware
+from social.apps.django_app.default.models import UserSocialAuth
 
 from . import pipeline
+from .models import UserDataSharingConsentAudit
 
 
 class ExceptionMiddleware(SocialAuthExceptionMiddleware):
@@ -23,3 +25,39 @@ class ExceptionMiddleware(SocialAuthExceptionMiddleware):
             redirect_uri = pipeline.AUTH_DISPATCH_URLS[auth_entry]
 
         return redirect_uri
+
+
+class ResetSessionIfPipelineBrokenMiddleware(object):
+    """
+    Middleware signs the user out if they need to provide data sharing consent,
+    haven't, and left the TPA pipeline prematurely
+    """
+    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=unused-argument
+        """
+        Conditionally sign out users who don't provide data sharing consent
+        """
+        view_module = view_func.__module__
+
+        if not pipeline.active_provider_requires_data_sharing(request):
+            return
+
+        running_pipeline = pipeline.get(request)
+        if running_pipeline:
+            social = running_pipeline['kwargs'].get('social')
+            quarantined_module = request.session.get('quarantined_module')
+            if social and quarantined_module and not view_module.startswith(quarantined_module):
+                try:
+                    consent_provided = social.data_sharing_consent_audit.enabled
+                except UserDataSharingConsentAudit.DoesNotExist:
+                    consent_provided = False
+                except AttributeError:
+                    try:
+                        consent_provided = UserSocialAuth.objects.get(
+                            uid=social.get('uid', '')
+                        ).data_sharing_consent_audit.enabled
+                    except UserSocialAuth.DoesNotExist:
+                        consent_provided = False
+                    except UserDataSharingConsentAudit.DoesNotExist:
+                        consent_provided = False
+                if not consent_provided:
+                    request.session.flush()

--- a/common/djangoapps/third_party_auth/migrations/0006_data_sharing_consent.py
+++ b/common/djangoapps/third_party_auth/migrations/0006_data_sharing_consent.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+import model_utils.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default', '0003_alter_email_max_length'),
+        ('third_party_auth', '0005_add_site_field'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserDataSharingConsentAudit',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
+                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
+                ('state', models.CharField(default=b'not_set', help_text='Stores whether the user linked to the attached UserSocialAuth object has consented to have their information shared with the SSO provider linked to the attached UserSocialAuth object.', max_length=8, choices=[(b'not_set', b'Not set'), (b'enabled', b'Enabled'), (b'disabled', b'Disabled')])),
+                ('user_social_auth', models.OneToOneField(related_name='data_sharing_consent_audit', to='default.UserSocialAuth', help_text='Links to a particular item in the UserSocialAuth table; each UserSocialAuth object uniquely links a particular user with a particular SSO provider.')),
+            ],
+            options={
+                'verbose_name': 'Data Sharing Consent Audit State',
+                'verbose_name_plural': 'Data Sharing Consent Audit States',
+            },
+        ),
+        migrations.CreateModel(
+            name='UserDataSharingConsentAuditHistory',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
+                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
+                ('previous_state', models.CharField(default=b'not_set', help_text='The state of the linked UserDataSharingConsentAudit prior to the state transition indicated by this record.', max_length=8, choices=[(b'not_set', b'Not set'), (b'enabled', b'Enabled'), (b'disabled', b'Disabled')])),
+                ('new_state', models.CharField(default=b'disabled', help_text='The state of the linked UserDataSharingConsentAudit after the state transition indicated by this record.', max_length=8, choices=[(b'not_set', b'Not set'), (b'enabled', b'Enabled'), (b'disabled', b'Disabled')])),
+                ('current_state', models.ForeignKey(related_name='historical_changes', to='third_party_auth.UserDataSharingConsentAudit', help_text='The UserDataSharingConsentAudit object that encodes the state at present of whether this user has given consent for data sharing to take place.')),
+            ],
+            options={
+                'verbose_name': 'Data Sharing Consent Historical Entry',
+                'verbose_name_plural': 'Data Sharing Consent Historical Entries',
+            },
+        ),
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='data_sharing_consent',
+            field=models.CharField(default=b'disabled', help_text='This field is used to determine whether data sharing consent is requested or required of users signing in using this SSO provider. If disabled, consent will not be requested, and course data will not be shared.', max_length=8, choices=[(b'disabled', b'Disabled'), (b'optional', b'Optional'), (b'required', b'Required')]),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='data_sharing_consent',
+            field=models.CharField(default=b'disabled', help_text='This field is used to determine whether data sharing consent is requested or required of users signing in using this SSO provider. If disabled, consent will not be requested, and course data will not be shared.', max_length=8, choices=[(b'disabled', b'Disabled'), (b'optional', b'Optional'), (b'required', b'Required')]),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='data_sharing_consent',
+            field=models.CharField(default=b'disabled', help_text='This field is used to determine whether data sharing consent is requested or required of users signing in using this SSO provider. If disabled, consent will not be requested, and course data will not be shared.', max_length=8, choices=[(b'disabled', b'Disabled'), (b'optional', b'Optional'), (b'required', b'Required')]),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -74,6 +74,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseBadRequest
 from django.shortcuts import redirect
 from social.apps.django_app.default import models
+from social.apps.django_app.default.models import UserSocialAuth
 from social.exceptions import AuthException
 from social.pipeline import partial
 from social.pipeline.social_auth import associate_by_email
@@ -83,6 +84,7 @@ import student
 from logging import getLogger
 
 from . import provider
+from .models import UserDataSharingConsentAudit
 
 
 # These are the query string params you can pass
@@ -198,6 +200,46 @@ class ProviderUserState(object):
 def get(request):
     """Gets the running pipeline from the passed request."""
     return request.session.get('partial_pipeline')
+
+
+def active_provider_requires_data_sharing(request):
+    """
+    Determine two things - first, whether there's an active third-party
+    identity provider currently running, and second, if that active provider
+    requires data sharing consent in order to proceed.
+    """
+    running_pipeline = get(request)
+    if running_pipeline:
+        current_provider = provider.Registry.get_from_pipeline(running_pipeline)
+        return current_provider and current_provider.require_data_sharing_consent
+    return False
+
+
+def active_provider_requests_data_sharing(request):
+    """
+    Determines two things - first, whether there's an active third-party
+    identity provider currently running, and second, if that active provider
+    requests data sharing consent in order to proceed.
+    """
+    running_pipeline = get(request)
+    if running_pipeline:
+        current_provider = provider.Registry.get_from_pipeline(running_pipeline)
+        return current_provider and current_provider.request_data_sharing_consent
+    return False
+
+
+def get_real_social_auth_object(request):
+    """
+    At times, the pipeline will have a "social" kwarg that contains a dictionary
+    rather than an actual DB-backed UserSocialAuth object. We need the real thing,
+    so this method allows us to get that by passing in the relevant request.
+    """
+    running_pipeline = get(request)
+    if running_pipeline and 'social' in running_pipeline['kwargs']:
+        social = running_pipeline['kwargs']['social']
+        if isinstance(social, dict):
+            social = UserSocialAuth.objects.get(uid=social.get('uid', ''))
+        return social
 
 
 def get_authenticated_user(auth_provider, username, uid):
@@ -648,6 +690,49 @@ def login_analytics(strategy, auth_entry, *args, **kwargs):
                 }
             }
         )
+
+
+@partial.partial
+def verify_data_sharing_consent(social, backend, **kwargs):
+    """
+    Checks to ensure that the user has provided data sharing consent
+    if the active SSO provider requires it; if not, then the user will
+    be redirected to a page from which they can provide consent.
+    """
+
+    def redirect_to_consent():
+        """
+        Method redirects the user to a page from which they can provide
+        required data sharing consent before proceeding in the pipeline
+        """
+        return redirect(reverse('grant_data_sharing_permissions'))
+
+    current_provider = provider.Registry.get_from_pipeline({'backend': backend.name, 'kwargs': kwargs})
+    if not current_provider.require_data_sharing_consent:
+        return
+    try:
+        consent = social.data_sharing_consent_audit
+    except UserDataSharingConsentAudit.DoesNotExist:
+        return redirect_to_consent()
+    if not consent.enabled:
+        return redirect_to_consent()
+
+
+def set_data_sharing_consent_record(social, data_sharing_consent=None, **kwargs):
+    """
+    If the pipeline produced a command to explicitly set the data sharing consent
+    record a particular way, set it that way.
+    """
+    if data_sharing_consent is None:
+        return
+
+    consent, _ = UserDataSharingConsentAudit.objects.get_or_create(user_social_auth=social)
+
+    if data_sharing_consent:
+        consent.enable()
+    else:
+        consent.disable()
+    consent.save()
 
 
 @partial.partial

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -49,6 +49,8 @@ def apply_settings(django_settings):
         'third_party_auth.pipeline.ensure_user_information',
         'social.pipeline.user.create_user',
         'social.pipeline.social_auth.associate_user',
+        'third_party_auth.pipeline.set_data_sharing_consent_record',
+        'third_party_auth.pipeline.verify_data_sharing_consent',
         'social.pipeline.social_auth.load_extra_data',
         'social.pipeline.user.user_details',
         'third_party_auth.pipeline.set_logged_in_cookies',

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -49,12 +49,13 @@ class IntegrationTestMixin(object):
         super(IntegrationTestMixin, self).setUp()
         self.login_page_url = reverse('signin_user')
         self.register_page_url = reverse('register_user')
+        self.provide_additional_consent_url = reverse('grant_data_sharing_permissions')
         patcher = testutil.patch_mako_templates()
         patcher.start()
         self.addCleanup(patcher.stop)
         # Override this method in a subclass and enable at least one provider.
 
-    def test_register(self):
+    def test_register(self, data_sharing_consent=False):
         # The user goes to the register page, and sees a button to register with the provider:
         provider_register_url = self._check_register_page()
         # The user clicks on the Dummy button:
@@ -76,15 +77,18 @@ class IntegrationTestMixin(object):
         self.assertEqual(form_fields['email']['defaultValue'], self.USER_EMAIL)
         self.assertEqual(form_fields['name']['defaultValue'], self.USER_NAME)
         self.assertEqual(form_fields['username']['defaultValue'], self.USER_USERNAME)
+        registration_values = {
+            'email': 'email-edited@tpa-test.none',
+            'name': 'My Customized Name',
+            'username': 'new_username',
+            'honor_code': True,
+        }
+        if data_sharing_consent:
+            registration_values.update({'data_sharing_consent': True})
         # Now complete the form:
         ajax_register_response = self.client.post(
             reverse('user_api_registration'),
-            {
-                'email': 'email-edited@tpa-test.none',
-                'name': 'My Customized Name',
-                'username': 'new_username',
-                'honor_code': True,
-            }
+            registration_values
         )
         self.assertEqual(ajax_register_response.status_code, 200)
         # Then the AJAX will finish the third party auth:

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -5,6 +5,7 @@ import ddt
 import unittest
 import httpretty
 from mock import patch
+from django.core.urlresolvers import reverse
 from social.apps.django_app.default.models import UserSocialAuth
 
 from third_party_auth.saml import log as saml_log
@@ -95,6 +96,126 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
         self._configure_testshib_provider()
         super(TestShibIntegrationTest, self).test_register()
 
+    def test_register_with_data_sharing_consent(self):
+        """
+        Configure TestShib to require data sharing consent before running the registration test
+        """
+        self._configure_testshib_provider(data_sharing_consent='required')
+        super(TestShibIntegrationTest, self).test_register(data_sharing_consent=True)
+
+    def test_login_redirects_to_consent_when_required(self):
+        """
+        Register a user without data sharing consent required, logout, set data sharing
+        consent to be required, and then check we're directed to a prompt to provide
+        consent when logging in.
+        """
+        # Set up the provider with standard settings
+        self._configure_testshib_provider()
+        # Register a user with the provider
+        super(TestShibIntegrationTest, self).test_register()
+        # Log out and clear the browser session
+        self.client.logout()
+        # Set up the provider to require data sharing consent
+        self._configure_testshib_provider(
+            data_sharing_consent='required',
+            assert_metadata_updates=False,
+        )
+        provider_login_url = self._check_login_page()
+        # The user clicks on the provider's button:
+        try_login_response = self.client.get(provider_login_url)
+        # The user should be redirected to the provider's login page:
+        self.assertEqual(try_login_response.status_code, 302)
+        complete_response = self.do_provider_login(try_login_response['Location'])
+        # We should be redirected to a screen to provide data sharing consent.
+        self.assertEqual(complete_response.status_code, 302)
+        self.assertEqual(
+            complete_response['Location'],
+            self.url_prefix + self.provide_additional_consent_url
+        )
+
+    def test_registration_form_has_data_sharing_consent_when_optional(self):
+        """
+        Configure TestShib to request data sharing consent, and then check
+        the form to make sure that the option to enable it is present.
+        """
+        self._configure_testshib_provider(data_sharing_consent='optional')
+        # The user goes to the register page, and sees a button to register with the provider:
+        provider_register_url = self._check_register_page()
+        # The user clicks on the Dummy button:
+        try_login_response = self.client.get(provider_register_url)
+        # The user should be redirected to the provider's login page:
+        self.assertEqual(try_login_response.status_code, 302)
+        provider_response = self.do_provider_login(try_login_response['Location'])
+        # We should be redirected to the register screen since this account is not linked to an edX account:
+        self.assertEqual(provider_response.status_code, 302)
+        self.assertEqual(provider_response['Location'], self.url_prefix + self.register_page_url)
+        register_response = self.client.get(self.register_page_url)
+        tpa_context = register_response.context["data"]["third_party_auth"]  # pylint: disable=no-member
+        self.assertEqual(tpa_context["errorMessage"], None)
+        # Check that the "You've successfully signed into [PROVIDER_NAME]" message is shown.
+        self.assertEqual(tpa_context["currentProvider"], self.PROVIDER_NAME)
+        # Check that the data (e.g. email) from the provider is displayed in the form:
+        form_data = register_response.context['data']['registration_form_desc']  # pylint: disable=no-member
+        form_fields = {field['name']: field for field in form_data['fields']}
+        # Verify that the data sharing consent checkbox is present
+        self.assertIn('data_sharing_consent', form_fields)
+        # Verify that the data sharing consent checkbox is not required
+        self.assertFalse(form_fields['data_sharing_consent']['required'])
+        registration_values = {
+            'email': 'email-edited@tpa-test.none',
+            'name': 'My Customized Name',
+            'username': 'new_username',
+            'honor_code': True,
+            'data_sharing_consent': False
+        }
+        # Now complete the form:
+        ajax_register_response = self.client.post(
+            reverse('user_api_registration'),
+            registration_values
+        )
+        self.assertEqual(ajax_register_response.status_code, 200)
+
+    def test_registration_not_allowed_without_data_sharing_consent(self):
+        """
+        Configure TestShib to require data sharing consent, but don't provide
+        consent when registering
+        """
+        self._configure_testshib_provider(data_sharing_consent='required')
+        # The user goes to the register page, and sees a button to register with the provider:
+        provider_register_url = self._check_register_page()
+        # The user clicks on the Dummy button:
+        try_login_response = self.client.get(provider_register_url)
+        # The user should be redirected to the provider's login page:
+        self.assertEqual(try_login_response.status_code, 302)
+        provider_response = self.do_provider_login(try_login_response['Location'])
+        # We should be redirected to the register screen since this account is not linked to an edX account:
+        self.assertEqual(provider_response.status_code, 302)
+        self.assertEqual(provider_response['Location'], self.url_prefix + self.register_page_url)
+        register_response = self.client.get(self.register_page_url)
+        tpa_context = register_response.context["data"]["third_party_auth"]  # pylint: disable=no-member
+        self.assertEqual(tpa_context["errorMessage"], None)
+        # Check that the "You've successfully signed into [PROVIDER_NAME]" message is shown.
+        self.assertEqual(tpa_context["currentProvider"], self.PROVIDER_NAME)
+        # Check that the data (e.g. email) from the provider is displayed in the form:
+        form_data = register_response.context['data']['registration_form_desc']  # pylint: disable=no-member
+        form_fields = {field['name']: field for field in form_data['fields']}
+        self.assertEqual(form_fields['email']['defaultValue'], self.USER_EMAIL)
+        self.assertEqual(form_fields['name']['defaultValue'], self.USER_NAME)
+        self.assertEqual(form_fields['username']['defaultValue'], self.USER_USERNAME)
+        registration_values = {
+            'email': 'email-edited@tpa-test.none',
+            'name': 'My Customized Name',
+            'username': 'new_username',
+            'honor_code': True,
+            'data_sharing_consent': False
+        }
+        # Now complete the form:
+        ajax_register_response = self.client.post(
+            reverse('user_api_registration'),
+            registration_values
+        )
+        self.assertEqual(ajax_register_response.status_code, 400)
+
     def test_login_records_attributes(self):
         """
         Test that attributes sent by a SAML provider are stored in the UserSocialAuth table.
@@ -163,6 +284,7 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
     def _configure_testshib_provider(self, **kwargs):
         """ Enable and configure the TestShib SAML IdP as a third_party_auth provider """
         fetch_metadata = kwargs.pop('fetch_metadata', True)
+        assert_metadata_updates = kwargs.pop('assert_metadata_updates', True)
         kwargs.setdefault('name', self.PROVIDER_NAME)
         kwargs.setdefault('enabled', True)
         kwargs.setdefault('visible', True)
@@ -176,9 +298,10 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
         if fetch_metadata:
             self.assertTrue(httpretty.is_enabled())
             num_changed, num_failed, num_total = fetch_saml_metadata()
-            self.assertEqual(num_failed, 0)
-            self.assertEqual(num_changed, 1)
-            self.assertEqual(num_total, 1)
+            if assert_metadata_updates:
+                self.assertEqual(num_failed, 0)
+                self.assertEqual(num_changed, 1)
+                self.assertEqual(num_total, 1)
 
     def do_provider_login(self, provider_redirect_url):
         """ Mocked: the user logs in to TestShib and then gets redirected back """

--- a/common/djangoapps/third_party_auth/urls.py
+++ b/common/djangoapps/third_party_auth/urls.py
@@ -2,7 +2,13 @@
 
 from django.conf.urls import include, patterns, url
 
-from .views import inactive_user_view, saml_metadata_view, lti_login_and_complete_view, post_to_custom_auth_form
+from .views import (
+    inactive_user_view,
+    saml_metadata_view,
+    lti_login_and_complete_view,
+    post_to_custom_auth_form,
+    GrantDataSharingPermissions
+)
 
 urlpatterns = patterns(
     '',
@@ -10,5 +16,10 @@ urlpatterns = patterns(
     url(r'^auth/custom_auth_entry', post_to_custom_auth_form, name='tpa_post_to_custom_auth_form'),
     url(r'^auth/saml/metadata.xml', saml_metadata_view),
     url(r'^auth/login/(?P<backend>lti)/$', lti_login_and_complete_view),
+    url(
+        r'^auth/grant_data_sharing_permissions',
+        GrantDataSharingPermissions.as_view(),
+        name='grant_data_sharing_permissions'
+    ),
     url(r'^auth/', include('social.apps.django_app.urls', namespace='social')),
 )

--- a/common/templates/grant_data_sharing_permissions.html
+++ b/common/templates/grant_data_sharing_permissions.html
@@ -1,0 +1,53 @@
+<%page expression_filter="h"/>
+
+<%!
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext as _
+%>
+
+<!--<%namespace name='static' file='/static_content.html'/>-->
+
+<%inherit file="/main.html" />
+<%namespace name='static' file='/static_content.html'/>
+
+<%block name="pagetitle">${_("Additional permissions required")}</%block>
+<main id="main" aria-label="Content" tabindex="-1">
+    <div id="data-sharing-consent-form" class="login-register">
+        <section class="form-type">
+            <div class="form-wrapper">
+                <form
+                    id="data-sharing"
+                    class="register-form"
+                    autocomplete="off"
+                    action="${reverse('grant_data_sharing_permissions')}",
+                    method="POST"
+                >
+                    <div class="section-title lines">
+                        <h2>
+                            <span class="text">
+                                ${_("Data Sharing Consent")}
+                            </span>
+                        </h2>
+                    </div>
+                    <span class="text">
+                        ${_("In order to link your account, we need consent to share your course data with {provider}.").format(provider=sso_provider)}
+                    </span>
+                    <div class="form-field data-sharing-consent">
+                        <input
+                            id="register-data_sharing_consent"
+                            type="checkbox"
+                            name="data_sharing_consent"
+                            class="input-block checkbox"
+                        />
+                        <label for="register-data_sharing_consent">
+                            ${_("I agree to allow {platform_name} to share data about my enrollment, completion and performance in all {platform_name} courses and programs where my enrollment is sponsored by {provider}.*").format(provider=sso_provider, platform_name=platform_name)}
+                        </label>
+                    </div>
+                    <input type="hidden" name="csrfmiddlewaretoken" value="${ csrftoken }" />
+                    <button type="submit" class="action-primary action">Submit</button>
+                    <p class="note">${_("*{provider} requires data sharing consent; if consent is not provided, you will be redirected to log in manually.").format(provider=sso_provider)}
+                </form>
+            </div>
+        </section>
+    </div>
+</main>

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1158,6 +1158,9 @@ MIDDLEWARE_CLASSES = (
 
     'openedx.core.djangoapps.theming.middleware.CurrentSiteThemeMiddleware',
 
+    # sign out TPA users who don't meet provider auth requirements
+    'third_party_auth.middleware.ResetSessionIfPipelineBrokenMiddleware',
+
     # This must be last
     'microsite_configuration.middleware.MicrositeSessionCookieDomainMiddleware',
 )

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -245,6 +245,7 @@
                 color: $red;
             }
             
+            &[for="register-data_sharing_consent"],
             &[for="register-honor_code"],
             &[for="register-terms_of_service"] {
                 display: inline-block;


### PR DESCRIPTION
This pull request adds some frontend features to the data sharing consent feature. It provides a step in the pipeline where users who have not consented to data sharing can either provide consent or decline to do so. Declining to do so will result in the user being logged out.

**JIRA tickets**: Implements ENT-18

**Discussions**: Discussed in ENT-24

**Dependencies**: Depends on #13687 (commits duplicated in this branch)

**Sandbox URL**:
- **LMS:** http://pr13737.sandbox.opencraft.hosting
- **Admin:** http://pr13737.sandbox.opencraft.hosting/admin/third_party_auth (use staff account)

**Merge deadline**: EOD 20 October 2016

**Testing instructions**:
1. In the sandbox admin, verify that the TestShib SAML IdP is set to neither require nor request data sharing consent.
2. Register a new user, using the TestShib SAML IdP. Verify that the process is identical to the one that exists now.
3. Disconnect that user from the IdP and sign out.
4. Modify the TestShib SAML IdP setting to request data sharing consent.
5. Register a new user, using the TestShib SAML IdP, noting that a checkbox for consent is present, checking it.
6. In the admin panel, note that DataSharingConsentAudit object for this user notes that data sharing is permitted.
7. Disconnect this user from the IdP and sign out.
8. Register a new user, using the TestShib SAML IdP, noting that a checkbox for consent is present, but leaving it blank.
9. Sign out of this user, but do not disconnect it from the IdP.
10. In the admin panel, note that the DataSharingConsentAudit for this user notes that data sharing is not permitted.
11. In the admin panel, set the TestShib SAML IdP to require data sharing consent.
12. Attempt to sign in, using the TestShib SAML user account you registered previously. Note that it redirects you to a page stating that additional permissions are required. Do not grant permission, but click Submit, noting that you are logged out.
13. Again attempt to sign in, using the TestShib SAML user account you registered previously. Again note that you are redirected to a page stating that additional permissions are required. Check the box granting permissions and click Submit, noting that you are logged in successfully.
14. Disconnect the user from the IdP and sign out.
15. Attempt to register a new user using the TestShib SAML IdP. Note that the checkbox for data sharing consent is present; note that if you attempt to register a user without checking it, you encounter an error message.
16. Note that once registered, the OpenEdX platform behaves normally.

**Author notes and concerns**:
1. UI requires some additional scheming/styling; feedback on this process is welcome.

**Reviewers**
- [ ] @bdero  
- [ ] @douglashall 
- [ ] @mattdrayer 
- [ ] @edx/devops 

**Settings**

``` yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
  ENABLE_THIRD_PARTY_AUTH: true
```
