### PR TITLE
Fix flaky bokchoy test: test_automatic_cohort_help, test_manual_cohort_help

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -409,6 +409,9 @@ class CohortManagementSection(PageObject):
         if content_group:
             self._select_associated_content_group(content_group)
         self.save_cohort_settings()
+        EmptyPromise(
+            lambda: cohort_name == self.get_selected_cohort(), "Waiting for new cohort"
+        ).fulfill()
 
     def get_cohort_group_setup(self):
         """

--- a/common/test/acceptance/tests/discussion/test_cohort_management.py
+++ b/common/test/acceptance/tests/discussion/test_cohort_management.py
@@ -250,10 +250,6 @@ class CohortConfigurationTest(EventsTestMixin, UniqueCourseTest, CohortTestMixin
         start_time = datetime.now(UTC)
         self.assertNotIn(cohort_name, self.cohort_management_page.get_cohorts())
         self.cohort_management_page.add_cohort(cohort_name, assignment_type=assignment_type)
-        # After adding the cohort, it should automatically be selected
-        EmptyPromise(
-            lambda: cohort_name == self.cohort_management_page.get_selected_cohort(), "Waiting for new cohort to appear"
-        ).fulfill()
         self.assertEqual(0, self.cohort_management_page.get_selected_cohort_count())
         # After adding the cohort, it should automatically be selected and its
         # assignment_type should be "manual" as this is the default assignment type
@@ -1154,11 +1150,6 @@ class CohortContentGroupAssociationTest(UniqueCourseTest, CohortTestMixin):
         Creates a new cohort linked to a content group.
         """
         self.cohort_management_page.add_cohort(new_cohort, content_group=cohort_group)
-        # After adding the cohort, it should automatically be selected
-        EmptyPromise(
-            lambda: new_cohort == self.cohort_management_page.get_selected_cohort(),
-            "Waiting for new cohort to appear"
-        ).fulfill()
         self.assertEqual(cohort_group, self.cohort_management_page.get_cohort_associated_content_group())
 
     def _link_cohort_to_content_group(self, cohort_name, content_group):

--- a/common/test/acceptance/tests/lms/test_lms_cohorted_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_cohorted_courseware_search.py
@@ -207,10 +207,6 @@ class CoursewareSearchCohortTest(ContainerBase):
             Create cohort and assign student to it.
             """
             cohort_management_page.add_cohort(cohort_name, content_group=content_group)
-            # After adding the cohort, it should automatically be selected
-            EmptyPromise(
-                lambda: cohort_name == cohort_management_page.get_selected_cohort(), "Waiting for new cohort"
-            ).fulfill()
             cohort_management_page.add_students_to_selected_cohort([student])
         add_cohort_with_student("Cohort A", self.content_group_a, self.cohort_a_student_username)
         add_cohort_with_student("Cohort B", self.content_group_b, self.cohort_b_student_username)

--- a/common/test/acceptance/tests/lms/test_lms_help.py
+++ b/common/test/acceptance/tests/lms/test_lms_help.py
@@ -70,7 +70,6 @@ class TestCohortHelp(ContainerBase):
 
         self.verify_help_link(href)
 
-    @flaky  # TODO fix this, see TNL-5709
     def test_automatic_cohort_help(self):
         """
         Scenario: Help in 'What does it mean?' is correct when we create cohort automatically.

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -360,10 +360,6 @@ class CourseWithContentGroupsTest(StaffViewTest):
         def add_cohort_with_student(cohort_name, content_group, student):
             """ Create cohort and assign student to it. """
             cohort_management_page.add_cohort(cohort_name, content_group=content_group)
-            # After adding the cohort, it should automatically be selected
-            EmptyPromise(
-                lambda: cohort_name == cohort_management_page.get_selected_cohort(), "Waiting for new cohort"
-            ).fulfill()
             cohort_management_page.add_students_to_selected_cohort([student])
         add_cohort_with_student("Cohort Alpha", "alpha", student_a_username)
         add_cohort_with_student("Cohort Beta", "beta", student_b_username)

--- a/common/test/acceptance/tests/test_cohorted_courseware.py
+++ b/common/test/acceptance/tests/test_cohorted_courseware.py
@@ -147,10 +147,6 @@ class EndToEndCohortedCoursewareTest(ContainerBase):
 
         def add_cohort_with_student(cohort_name, content_group, student):
             cohort_management_page.add_cohort(cohort_name, content_group=content_group)
-            # After adding the cohort, it should automatically be selected
-            EmptyPromise(
-                lambda: cohort_name == cohort_management_page.get_selected_cohort(), "Waiting for new cohort"
-            ).fulfill()
             cohort_management_page.add_students_to_selected_cohort([student])
 
         add_cohort_with_student("Cohort A", self.content_group_a, self.cohort_a_student_username)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-5709

FYI @Muddasser 

This PR moves the "waiting for new cohort promise" into the `add_cohort` method so it's centralized and automatically applied to other callers of that method (including the 2 current flaky ones: `test_automatic_cohort` and `test_manual_cohort`.
