### PR TITLE
Fix for spurious 'cb() never called' errors.

### DIFF
--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 source $HOME/jenkins_env
 
 # Clear the mongo database
@@ -27,4 +29,5 @@ PATH=$PATH:node_modules/.bin
 
 # Manage the npm cache on Jenkins.
 # (In this case, remove it. That ensures from run-to-run, it is a clean npm environment)
+echo "--> Cleaning npm cache"
 npm cache clean

--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -24,3 +24,7 @@ source $HOME/edx-venv/bin/activate
 
 # add the node_js packages dir to PATH
 PATH=$PATH:node_modules/.bin
+
+# Manage the npm cache on Jenkins.
+# (In this case, remove it. That ensures from run-to-run, it is a clean npm environment)
+npm cache clean


### PR DESCRIPTION
Some Jenkins builds are erroring when attempting to set up the
npm environment with the error:

`npm ERR! cb() never called!`

Although it could point to a couple of different things, it is more classically
a sign of a dirty npm environment cache. Cleaning the cache at the start
of any given Jenkins job (which are sourced through this file) should
alleviate the problem.
