### PR TITLE
Fix flaky test: test_youtube_id_w_different_local_server_sub

### DIFF
--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -124,6 +124,12 @@ class VideoComponentPage(VideoPage):
                            'Video Buffering Completed')
             self._wait_for(self.is_controls_visible, 'Player Controls are Visible')
 
+    def wait_for_message(self, message_type, expected_message):
+        """
+        Wait until the message of the requested type is as expected.
+        """
+        self._wait_for(lambda: self.message(message_type) == expected_message, "Waiting for message update.")
+
     @wait_for_js
     def is_controls_visible(self):
         """

--- a/common/test/acceptance/tests/video/test_studio_video_transcript.py
+++ b/common/test/acceptance/tests/video/test_studio_video_transcript.py
@@ -178,7 +178,7 @@ class VideoTranscriptTest(CMSVideoBaseTest):
         self.assertEqual(self.video.message('status'), 'Timed Transcript Conflict')
         self.assertTrue(self.video.is_transcript_button_visible('replace'))
         self.video.click_button_subtitles()
-        self.assertEqual(self.video.message('status'), 'Timed Transcript Found')
+        self.video.wait_for_message('status', 'Timed Transcript Found')
         self.open_advanced_tab()
         self.assertTrue(self.video.verify_field_value('Default Timed Transcript', 't_neq_exist'))
 


### PR DESCRIPTION
TNL-5759

This fix was verified on jenkins with the `@flaky(max_runs=15, min_passes=15)` decorator:
https://build.testeng.edx.org/job/edx-platform-test-subset/624749/console

Reviewers: @yro @sanfordstudent or @efischer19 
