### PR TITLE
Fix textbook tests so a11y tests only run in a11y test phase

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_textbooks.py
+++ b/common/test/acceptance/tests/studio/test_studio_textbooks.py
@@ -8,7 +8,6 @@ from common.test.acceptance.tests.helpers import disable_animations
 from nose.plugins.attrib import attr
 
 
-@attr(shard=2)
 class TextbooksTest(StudioCourseTest):
     """
     Test that textbook functionality is working properly on studio side
@@ -29,6 +28,7 @@ class TextbooksTest(StudioCourseTest):
 
         self.textbook_view_page = TextbookViewPage(self.browser, self.course_id)
 
+    @attr(shard=2)
     def test_create_first_book_message(self):
         """
         Scenario: A message is displayed on the textbooks page when there are no uploaded textbooks
@@ -39,6 +39,7 @@ class TextbooksTest(StudioCourseTest):
         message = self.textbook_upload_page.get_element_text('.wrapper-content .no-textbook-content')
         self.assertIn("You haven't added any textbooks", message)
 
+    @attr(shard=2)
     def test_new_textbook_upload(self):
         """
         Scenario: View Live link for textbook is correctly populated


### PR DESCRIPTION
[TNL-5513](https://openedx.atlassian.net/browse/TNL-5513)

Moves the shard decorator to the non-a11y test points because this test class is a mix of bok choy and a11y test points. Previously, the a11y tests were run in both the a11y and bok choy test phases.

The test point mentioned in TNL-5513 passed 90 times (running mostly in bok choy test phase, as I don't know how to run a11y tests in the "specific test" Jenkins job).

The flakiness may have been fixed by the recently merged #13756.

@jzoldak @staubina please review
