### PR TITLE
removing extra instance of MILESTONES_APP

### DIFF
--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -136,7 +136,6 @@ FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
 FEATURES['ENABLE_SOFTWARE_SECURE_FAKE'] = True
 
 ########################### Entrance Exams #################################
-FEATURES['MILESTONES_APP'] = True
 FEATURES['ENTRANCE_EXAMS'] = True
 
 FEATURES['ENABLE_SPECIAL_EXAMS'] = True


### PR DESCRIPTION
Reviewers: two of @cahrens @nasthagiri @efischer19 @jcdyer 

While debugging some strange bok choy behavior I discovered that this setting is declared twice in the LMS bok choy settings file.
