### PR TITLE
Fix screen-reader capa status prefixing

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -206,8 +206,8 @@ describe 'Problem', ->
 
     describe 'when the response is correct', ->
       it 'call render with returned content', ->
-        contents = '<section aria-label="Question 1"><p>Correct<span class="status">excellent</span></p></section>' +
-                   '<section aria-label="Question 2"><p>Yep<span class="status">correct</span></p></section>'
+        contents = '<div class="wrapper-problem-response" aria-label="Question 1"><p>Correct<span class="status">excellent</span></p></div>' +
+                   '<div class="wrapper-problem-response" aria-label="Question 2"><p>Yep<span class="status">correct</span></p></div>'
         spyOn($, 'postWithPrefix').and.callFake (url, answers, callback) ->
           callback(success: 'correct', contents: contents)
           promise =

--- a/common/lib/xmodule/xmodule/js/src/capa/display.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.js
@@ -640,7 +640,7 @@
             labeledStatus = [];
             for (i = 0, len = statusElement.length; i < len; i++) {
                 element = statusElement[i];
-                parentSection = $(element).closest('section');
+                parentSection = $(element).closest('.wrapper-problem-response');
                 addedStatus = false;
                 if (parentSection) {
                     ariaLabel = parentSection.attr('aria-label');

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -383,3 +383,10 @@ class ProblemPage(PageObject):
         """
         self.wait_for_element_visibility('.problem-progress', "Problem progress is visible")
         return self.q(css='.problem-progress').text[0]
+
+    @property
+    def status_sr_text(self):
+        """
+        Returns the text in the special "sr" region used for display status.
+        """
+        return self.q(css='#reader-feedback').text[0]

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -205,17 +205,23 @@ class ProblemNotificationTests(ProblemsTest):
         self.assertFalse(problem_page.is_success_notification_visible())
         problem_page.click_submit()
         problem_page.wait_success_notification()
+        self.assertEqual('Question 1: correct', problem_page.status_sr_text)
+
         # Clicking Save should clear the submit notification
         problem_page.click_save()
         self.assertFalse(problem_page.is_success_notification_visible())
         problem_page.wait_for_save_notification()
+
         # Changing the answer should clear the save notification
         problem_page.click_choice("choice_1")
         self.assertFalse(problem_page.is_save_notification_visible())
         problem_page.click_save()
+        problem_page.wait_for_save_notification()
+
         # Submitting the problem again should clear the save notification
         problem_page.click_submit()
         problem_page.wait_incorrect_notification()
+        self.assertEqual('Question 1: incorrect', problem_page.status_sr_text)
         self.assertFalse(problem_page.is_save_notification_visible())
 
 


### PR DESCRIPTION
## [TNL-5735](https://openedx.atlassian.net/browse/TNL-5735)
### Description

Fixes recent regression for "Question X" prefix on page-level status screen-reader text. Adds bok choy coverage, as the unit test didn't catch the recent change in HTML structure.
### Sandbox
- [x] Sandbox (still building): ​tnl5735.sandbox.edx.org
### Testing
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @staubina  
- [x] Code review: @alisan617

FYI @cptvitamin 
### Post-review
- [x] Rebase and squash commits
