### PR TITLE
ENT-36: Fix NameError issue for saml management command

### DIFF
--- a/common/djangoapps/third_party_auth/management/commands/saml.py
+++ b/common/djangoapps/third_party_auth/management/commands/saml.py
@@ -15,17 +15,19 @@ class Command(BaseCommand):
         parser.add_argument('--pull', action='store_true', help="Pull updated metadata from external IDPs")
 
     def handle(self, *args, **options):
-        if options['pull']:
-            log_handler = logging.StreamHandler(self.stdout)
-            log_handler.setLevel(logging.DEBUG)
-            log = logging.getLogger('third_party_auth.tasks')
-            log.propagate = False
-            log.addHandler(log_handler)
-            num_changed, num_failed, num_total = fetch_saml_metadata()
-            self.stdout.write(
-                "\nDone. Fetched {num_total} total. {num_changed} were updated and {num_failed} failed.\n".format(
-                    num_changed=num_changed, num_failed=num_failed, num_total=num_total
-                )
+        should_pull_saml_metadata = options.get('pull', False)
+
+        if not should_pull_saml_metadata:
+            raise CommandError("Command can only be used with '--pull' option.")
+
+        log_handler = logging.StreamHandler(self.stdout)
+        log_handler.setLevel(logging.DEBUG)
+        log = logging.getLogger('third_party_auth.tasks')
+        log.propagate = False
+        log.addHandler(log_handler)
+        num_changed, num_failed, num_total = fetch_saml_metadata()
+        self.stdout.write(
+            "\nDone. Fetched {num_total} total. {num_changed} were updated and {num_failed} failed.\n".format(
+                num_changed=num_changed, num_failed=num_failed, num_total=num_total
             )
-        else:
-            raise CommandError("Unknown argment: {}".format(subcommand))
+        )

--- a/common/djangoapps/third_party_auth/management/commands/tests/__init__.py
+++ b/common/djangoapps/third_party_auth/management/commands/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+This directory contains tests for third_party_auth app.
+"""

--- a/common/djangoapps/third_party_auth/management/commands/tests/test_saml.py
+++ b/common/djangoapps/third_party_auth/management/commands/tests/test_saml.py
@@ -1,0 +1,31 @@
+"""
+Tests for `saml` management command, this command fetches saml metadata from providers and updates
+existing data accordingly.
+"""
+import unittest
+
+from django.test import TestCase
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.conf import settings
+
+
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class TestSAMLCommand(TestCase):
+    """
+    Test django management command for fetching saml metadata.
+    """
+    def test_raises_command_error_for_invalid_arguments(self):
+        """
+        Test that management command raises `CommandError` with a proper message in case of
+        invalid command arguments.
+
+        This test would fail with an error if ValueError is raised.
+        """
+        # Call `saml` command without any argument so that it raises a CommandError
+        with self.assertRaisesMessage(CommandError, "Command can only be used with '--pull' option."):
+            call_command("saml")
+
+        # Call `saml` command without any argument so that it raises a CommandError
+        with self.assertRaisesMessage(CommandError, "Command can only be used with '--pull' option."):
+            call_command("saml", pull=False)


### PR DESCRIPTION
Hi @mattdrayer , @jibsheet , @asadiqbal08 

This PR fixes the issue with `saml --pull` management command.

**Problem Description:**
mangement command for fetching saml metadata fails with the following error when used with an argument other than `--pull`

```
Traceback (most recent call last):
  File "manage.py", line 116, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/third_party_auth/management/commands/saml.py", line 31, in handle
    raise CommandError("Unknown argment: {}".format(subcommand))
NameError: global name 'subcommand' is not defined
```

Command should instead instead fail with `CommandError` with appropriate msg if an argument other than `--pull` is given.
