### PR TITLE
update_course_in_cache should retry on exceptions

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/tasks.py
+++ b/openedx/core/djangoapps/content/block_structure/tasks.py
@@ -15,9 +15,17 @@ log = logging.getLogger('edx.celery.task')
     default_retry_delay=settings.BLOCK_STRUCTURES_SETTINGS['BLOCK_STRUCTURES_TASK_DEFAULT_RETRY_DELAY'],
     max_retries=settings.BLOCK_STRUCTURES_SETTINGS['BLOCK_STRUCTURES_TASK_MAX_RETRIES'],
 )
-def update_course_in_cache(course_key):
+def update_course_in_cache(course_id):
     """
     Updates the course blocks (in the database) for the specified course.
     """
-    course_key = CourseKey.from_string(course_key)
-    api.update_course_in_cache(course_key)
+    try:
+        course_key = CourseKey.from_string(course_id)
+        api.update_course_in_cache(course_key)
+    except Exception as exc:   # pylint: disable=broad-except
+        # TODO: TNL-5799, check splunk logs to narrow down the broad except above
+        log.info("update_course_in_cache. Retry #{} for this task, exception: {}".format(
+            update_course_in_cache.request.retries,
+            repr(exc)
+        ))
+        raise update_course_in_cache.retry(args=[course_id], exc=exc)

--- a/openedx/core/djangoapps/content/block_structure/tests/test_tasks.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_tasks.py
@@ -1,0 +1,24 @@
+"""
+Unit tests for the Course Blocks tasks
+"""
+
+from mock import patch
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+from ..tasks import update_course_in_cache
+
+
+class UpdateCourseInCacheTaskTest(ModuleStoreTestCase):
+    """
+    Ensures that the update_course_in_cache task runs as expected.
+    """
+    @patch('openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache.retry')
+    @patch('openedx.core.djangoapps.content.block_structure.api.update_course_in_cache')
+    def test_retry_on_error(self, mock_update, mock_retry):
+        """
+        Ensures that tasks will be retried if IntegrityErrors are encountered.
+        """
+        mock_update.side_effect = Exception("WHAMMY")
+        update_course_in_cache.apply(args=["invalid_course_key raises exception 12345 meow"])
+        self.assertTrue(mock_retry.called)


### PR DESCRIPTION
Previously, retry() was never called, so the task was never retried despite
defining several retry-related variables.

Found after [this comment](https://github.com/edx/edx-platform/pull/13765#discussion_r83570715) was made on my other task-related PR. I grepped through the edx-platform codebase; this was the only location where a `@task` was defined with retry variables that didn't have some sort of retry logic set up.
