### PR TITLE
Add enable-migrations parameter for python unit tests

### DIFF
--- a/docs/en_us/internal/testing.rst
+++ b/docs/en_us/internal/testing.rst
@@ -179,6 +179,16 @@ To run cms python tests without ``collectstatic`` use this command.
 
     paver test_system -s cms --fasttest
 
+For the sake of speed, by default the python unit test database tables
+are created directly from apps' models. If you want to run the tests
+against a database created by applying the migrations instead, use the
+``--enable-migrations`` option.
+
+
+::
+
+    paver test_system -s lms --enable-migrations
+
 To run a single django test class use this command.
 
 ::

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -46,6 +46,12 @@ __test__ = False  # do not collect
         dest='disable_migrations',
         help="Create tables directly from apps' models. Can also be used by exporting DISABLE_MIGRATIONS=1."
     ),
+    make_option(
+        '--enable-migrations',
+        action='store_false',
+        dest='disable_migrations',
+        help="Create tables by applying migrations."
+    ),
     ("fail_fast", None, "deprecated in favor of fail-fast"),
     ("test_id=", None, "deprecated in favor of test-id"),
     ('cov_args=', None, 'deprecated in favor of cov-args'),


### PR DESCRIPTION
Followup to #13732 in which the default migration behavior was changed to disable migrations without a way to enable them via a paver command.

@cpennington 
@edx/testeng 
