### PR TITLE
Fix checking empty array

### DIFF
--- a/common/static/common/js/discussion/views/discussion_topic_menu_view.js
+++ b/common/static/common/js/discussion/views/discussion_topic_menu_view.js
@@ -28,13 +28,13 @@
                 context.topics_html = this.renderCategoryMap(this.course_settings.get('category_map'));
                 edx.HtmlUtils.setHtml(this.$el, edx.HtmlUtils.template($('#topic-template').html())(context));
 
-                $general = this.$('.post-topic option:contains(General)');
+                $general = this.$('.post-topic option:contains(General)');  // always return array.
 
                 if (this.getCurrentTopicId()) {
                     this.setTopic(this.$('.post-topic option').filter(
                         '[data-discussion-id="' + this.getCurrentTopicId() + '"]'
                     ));
-                } else if ($general) {
+                } else if ($general.length > 0) {
                     this.setTopic($general);
                 } else {
                     this.setTopic(this.$('.post-topic option').first());

--- a/common/static/common/js/spec/discussion/view/discussion_topic_menu_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/discussion_topic_menu_view_spec.js
@@ -2,6 +2,7 @@
 (function() {
     'use strict';
     describe('DiscussionTopicMenuView', function() {
+        var ExpectedDiscussionId;
         beforeEach(function() {
             this.createTopicView = function(options) {
                 options = _.extend({
@@ -87,12 +88,18 @@
             expect(this.view.$el.find('option.topic-title:selected').text()).toContain('<em>');
         });
 
-        it('appropriate topic is selected if `topicId` is passed', function() {
+        it('appropriate topic is selected if topicId is passed', function() {
             this.createTopicView({
                 topicId: 'c49f0dfb8fc94c9c8d9999cc95190c56'
             });
             this.view.render();
             expect(this.view.$el.find('option.topic-title:selected').text()).toEqual('Numerical Input');
+        });
+        it('if general topic is not present then topiId is set to first discussion topicId', function() {
+            this.createTopicView({});
+            this.view.render();
+            ExpectedDiscussionId = this.view.$('.post-topic option').first().data('discussion-id');
+            expect(this.view.getCurrentTopicId()).toEqual(ExpectedDiscussionId);
         });
     });
 }).call(this);


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-5750

**Sanbox:**
https://shr.sandbox.edx.org/courses/course-v1:edX+cs101+2016/discussion/forum/

**Detail:**
The discussion `topicId` is set using the logic that if we have `general` text in select options then it `data-discussion-id` is set to `topicId` and if its not then the default value will be first's select option `data-discussion-id`.Problem rises when we are checking the general topic is present or not using simple if like `if ($general)` which is true for null or undefined but not for array as we are getting the `$general` topic using jquery `this.$('.post-topic option:contains(General)')` which always return array (filled or empty).

**Solution:** 
We check the array is empty or not using `length` property.
