### PR TITLE
Pin `sqlparse` to 0.2.x

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -140,6 +140,7 @@ django-cors-headers==1.1.0
 
 # Debug toolbar
 django_debug_toolbar==1.5
+sqlparse>=0.2.0,<0.3.0
 
 # Used for testing
 before_after==0.1.3


### PR DESCRIPTION
Per @cpennington's [comment](https://github.com/edx/edx-platform/pull/13352#issuecomment-254928698), pin `sqlparse` to 0.2.x minor release to prevent a problem where django-debug-toolbar broke due to backward incompatibility when `sqlparse` went from 0.1 → 0.2.
