### PR TITLE
Remove "show_closed_captions" in cookie

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -34,13 +34,12 @@
                 'handleKeypress', 'handleKeypressLink', 'openLanguageMenu', 'closeLanguageMenu',
                 'previousLanguageMenuItem', 'nextLanguageMenuItem', 'handleCaptionToggle',
                 'showClosedCaptions', 'hideClosedCaptions', 'toggleClosedCaptions',
-                'updateCaptioningCookie', 'handleCaptioningCookie', 'handleTranscriptToggle',
+                'handleTranscriptToggle',
                 'listenForDragDrop'
             );
             this.state = state;
             this.state.videoCaption = this;
             this.renderElements();
-            this.handleCaptioningCookie();
             this.listenForDragDrop();
 
             return $.Deferred().resolve().promise();
@@ -1146,31 +1145,14 @@
                 }
             },
 
-            handleCaptioningCookie: function() {
-                if ($.cookie('show_closed_captions') === 'true') {
-                    this.state.showClosedCaptions = true;
-                    this.showClosedCaptions();
-
-                    // keep it going until turned off
-                    $.cookie('show_closed_captions', 'true', {
-                        expires: 3650,
-                        path: '/'
-                    });
-                } else {
-                    this.hideClosedCaptions();
-                }
-            },
-
             toggleClosedCaptions: function(event) {
                 event.preventDefault();
 
                 if (this.state.el.hasClass('has-captions')) {
                     this.state.showClosedCaptions = false;
-                    this.updateCaptioningCookie(false);
                     this.hideClosedCaptions();
                 } else {
                     this.state.showClosedCaptions = true;
-                    this.updateCaptioningCookie(true);
                     this.showClosedCaptions();
                 }
             },
@@ -1210,19 +1192,6 @@
                     .attr('title', gettext('Turn on closed captioning'));
 
                 this.state.el.trigger('captions:hide');
-            },
-
-            updateCaptioningCookie: function(method) {
-                if (method) {
-                    $.cookie('show_closed_captions', 'true', {
-                        expires: 3650,
-                        path: '/'
-                    });
-                } else {
-                    $.cookie('show_closed_captions', null, {
-                        path: '/'
-                    });
-                }
             },
 
             listenForDragDrop: function() {

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -40,6 +40,7 @@
             this.state = state;
             this.state.videoCaption = this;
             this.renderElements();
+            this.hideClosedCaptions();
             this.listenForDragDrop();
 
             return $.Deferred().resolve().promise();

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -246,17 +246,23 @@ class YouTubeVideoTest(VideoBaseTest):
         self.assets.append('chinese_transcripts.srt')
         self.navigate_to_video()
 
-        # Show captions and make sure they're visible and cookie is set
+        # Captions should not be visible by default
+        self.assertFalse(self.video.is_closed_captions_visible())
+
+        # Show captions and make sure they're visible and reset after page reload
         self.video.show_closed_captions()
         self.video.wait_for_closed_captions()
-        self.assertTrue(self.video.is_closed_captions_visible)
+        self.assertTrue(self.video.is_closed_captions_visible())
         self.video.reload_page()
-        self.assertTrue(self.video.is_closed_captions_visible)
+        self.assertFalse(self.video.is_closed_captions_visible())
 
-        # Hide captions and make sure they're hidden and cookie is unset
+        # Now show captions again
+        self.video.show_closed_captions()
+        self.video.wait_for_closed_captions()
+        self.assertTrue(self.video.is_closed_captions_visible())
+
+        # Hide captions and make sure they're hidden
         self.video.hide_closed_captions()
-        self.video.wait_for_closed_captions_to_be_hidden()
-        self.video.reload_page()
         self.video.wait_for_closed_captions_to_be_hidden()
 
     def test_transcript_button_transcripts_and_sub_fields_empty(self):


### PR DESCRIPTION
Storing caption status in global cookie is wired. Below are my reasons:
1. This cookie is only useful when you watch the same video once and refresh/close the page and then come back to watch again, which does not make much sense.
2. Current implementation of this cookie is global, and will override/interfere with other videos in the same domain (not only same course).
3. Because of **2**, if the other video does not have transcripts(captions), the toggle button of captions will not show up, so there is no way of closing the captions even during video playing. See below.

![Image of #3](https://myleshk.github.io/img/3.png)

Please check this problem. Thx.
