### PR TITLE
Logging improved for case when exception is raised during submission to SoftwareSecure

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -721,8 +721,11 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
                 self.status = "must_retry"
                 self.error_msg = response.text
                 self.save()
-        except Exception as error:
-            log.exception(error)
+        except Exception:       # pylint: disable=broad-except
+            log.exception(
+                'Software Secure submission failed for user %s, setting status to must_retry',
+                self.user.username
+            )
             self.status = "must_retry"
             self.save()
 


### PR DESCRIPTION
An [issue](https://openedx.atlassian.net/browse/ECOM-6114) was raised claiming frequent failing of photo verification. After thorough examination it came to know that SoftwareSecure (vendor responsible to do photo verifications) was down due to some unfortunate reasons.
At that time it was much difficult to track down actual problem as no information was logged about `ConnectionError` to third party server.
This PR is about logging, if any exception is raised during whole process of submission to SoftwareSecure.
Unit tests are written to ensure expected exceptions are logged. 
