### PR TITLE
Hotfix/2016 10 24

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -95,7 +95,7 @@
             // end of Annotation tool files
 
             // externally hosted files
-            mathjax: '//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',  // eslint-disable-line max-len
+            mathjax: '//cdn.mathjax.org/mathjax/2.7-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',  // eslint-disable-line max-len
             'youtube': [
                 // youtube URL does not end in '.js'. We add '?noext' to the path so
                 // that require.js adds the '.js' to the query component of the URL,

--- a/cms/static/cms/js/spec/main.js
+++ b/cms/static/cms/js/spec/main.js
@@ -56,7 +56,7 @@
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
             'URI': 'xmodule_js/common_static/js/vendor/URI.min',
             'mock-ajax': 'xmodule_js/common_static/js/vendor/mock-ajax',
-            mathjax: '//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',   // eslint-disable-line max-len
+            mathjax: '//cdn.mathjax.org/mathjax/2.7-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',   // eslint-disable-line max-len
             'youtube': '//www.youtube.com/player_api?noext',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',
             'js/spec/test_utils': 'js/spec/test_utils'

--- a/cms/static/cms/js/spec/main_squire.js
+++ b/cms/static/cms/js/spec/main_squire.js
@@ -48,7 +48,7 @@
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
             'URI': 'xmodule_js/common_static/js/vendor/URI.min',
-            mathjax: '//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',   // eslint-disable-line max-len
+            mathjax: '//cdn.mathjax.org/mathjax/2.7-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',   // eslint-disable-line max-len
             'youtube': '//www.youtube.com/player_api?noext',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix'
         },

--- a/common/static/common/js/discussion/mathjax_include.js
+++ b/common/static/common/js/discussion/mathjax_include.js
@@ -42,6 +42,6 @@ if (typeof MathJax === 'undefined') {
             });
         };
     };
-    vendorScript.src = 'https://cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG';
+    vendorScript.src = 'https://cdn.mathjax.org/mathjax/2.7-latest/MathJax.js?config=TeX-MML-AM_SVG';
     document.body.appendChild(vendorScript);
 }

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -76,4 +76,4 @@
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.7-latest/MathJax.js?config=TeX-MML-AM_SVG"></script>

--- a/common/test/acceptance/pages/lms/teams.py
+++ b/common/test/acceptance/pages/lms/teams.py
@@ -6,7 +6,7 @@ Teams pages.
 from common.test.acceptance.pages.lms.course_page import CoursePage
 from common.test.acceptance.pages.lms.discussion import InlineDiscussionPage
 from common.test.acceptance.pages.common.paging import PaginatedUIMixin
-from common.test.acceptance.pages.common.utils import confirm_prompt
+from common.test.acceptance.pages.common.utils import confirm_prompt, click_css
 
 from common.test.acceptance.pages.lms.fields import FieldsMixin
 
@@ -502,11 +502,7 @@ class TeamPage(CoursePage, PaginatedUIMixin, BreadcrumbsMixin):
 
     def click_leave_team_link(self, remaining_members=0, cancel=False):
         """ Click on Leave Team link"""
-        self.wait_for(
-            lambda: self.team_leave_link_present,
-            description="Leave Team button did not become present"
-        )
-        self.q(css='.leave-team-link').first.click()
+        click_css(self, '.leave-team-link', require_notification=False)
         confirm_prompt(self, cancel, require_notification=False)
 
         if cancel is False:

--- a/common/test/acceptance/pages/lms/teams.py
+++ b/common/test/acceptance/pages/lms/teams.py
@@ -502,6 +502,10 @@ class TeamPage(CoursePage, PaginatedUIMixin, BreadcrumbsMixin):
 
     def click_leave_team_link(self, remaining_members=0, cancel=False):
         """ Click on Leave Team link"""
+        self.wait_for(
+            lambda: self.team_leave_link_present,
+            description="Leave Team button did not become present"
+        )
         self.q(css='.leave-team-link').first.click()
         confirm_prompt(self, cancel, require_notification=False)
 

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -1042,8 +1042,21 @@ class CreateTeamTest(TeamFormActions):
         Then I should see the error message and highlighted fields.
         """
         self.verify_and_navigate_to_create_team_page()
-        self.team_management_page.submit_form()
 
+        # `submit_form` clicks on a button, but that button doesn't always
+        # have the click event handler registered on it in time. That's why
+        # this test is flaky. Unfortunately, I don't know of a straightforward
+        # way to write something that waits for that event handler to be bound
+        # to the button element. So I used time.sleep as well, even though
+        # the bok choy docs explicitly ask us not to:
+        # http://bok-choy.readthedocs.io/en/latest/guidelines.html
+        # Sorry! For the story to address this anti-pattern, see TNL-5820
+        time.sleep(0.5)
+        self.team_management_page.submit_form()
+        self.team_management_page.wait_for(
+            lambda: self.team_management_page.validation_message_text,
+            "Validation message text never loaded."
+        )
         self.assertEqual(
             self.team_management_page.validation_message_text,
             'Check the highlighted fields below and try again.'
@@ -1150,6 +1163,13 @@ class CreateTeamTest(TeamFormActions):
         self.assertTrue(self.browse_teams_page.get_pagination_header_text().startswith('Showing 0 out of 0 total'))
 
         self.verify_and_navigate_to_create_team_page()
+
+        # We add a sleep here to allow time for the click event handler to bind
+        # to the cancel button. Using time.sleep in bok-choy tests is,
+        # generally, an anti-pattern. So don't copy this :).
+        # For the story to address this anti-pattern, see TNL-5820
+        time.sleep(0.5)
+
         self.team_management_page.cancel_team()
 
         self.assertTrue(self.browse_teams_page.is_browser_on_page())
@@ -1941,6 +1961,13 @@ class TeamPageTest(TeamsTabBase):
             }
         ]
         with self.assert_events_match_during(event_filter=self.only_team_events, expected_events=expected_events):
+            # I think we're seeing the same problem that we're seeing in
+            # CreateTeamTest.test_user_can_see_error_message_for_missing_data.
+            # We click on the "leave team" link after it's loaded, but before
+            # its JavaScript event handler is added. Adding this sleep gives
+            # enough time for that event handler to bind to the link. Sorry!
+            # For the story to address this anti-pattern, see TNL-5820
+            time.sleep(0.5)
             self.team_page.click_leave_team_link()
         self.assert_team_details(num_members=0, is_member=False)
         self.assertTrue(self.team_page.join_team_button_present)

--- a/lms/static/lms/js/spec/main.js
+++ b/lms/static/lms/js/spec/main.js
@@ -51,7 +51,7 @@
             'squire': 'xmodule_js/common_static/js/vendor/Squire',
             'jasmine-imagediff': 'xmodule_js/common_static/js/vendor/jasmine-imagediff',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
-            mathjax: '//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',  // eslint-disable-line max-len
+            mathjax: '//cdn.mathjax.org/mathjax/2.7-latest/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',  // eslint-disable-line max-len
             'youtube': '//www.youtube.com/player_api?noext',
             'coffee/src/ajax_prefix': 'xmodule_js/common_static/coffee/src/ajax_prefix',
             'coffee/src/instructor_dashboard/student_admin': 'coffee/src/instructor_dashboard/student_admin',


### PR DESCRIPTION
Not just one, but TWO `time.sleep`s to fix flaky tests.

The problem is that we seem to have a race condition where backbone renders a button that we're able to click on before a click event handler is bound to it. Bok choy doesn't really have a way to deal with that scenario.

When I added the `time.sleep`s, both of the tests passed 20/20 times on jenkins:
https://build.testeng.edx.org/view/All/job/edx-platform-specific-tests/327/console
https://build.testeng.edx.org/view/All/job/edx-platform-specific-tests/331/console

I'll be filing a ticket to address this scenario, but for now I just left some lengthy comments explaining why we have to sleep.

@andy-armstrong and @robrap , please review?

Other people who might be interested:
@benpatterson 
@jzoldak 
@bjacobel 
@nasthagiri 
@Qubad786 
@attiyaIshaque 
