### PR TITLE
allow selection of seat type during manual enrollment on instructor d…

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -164,6 +164,15 @@ class CourseEnrollmentAdmin(admin.ModelAdmin):
         model = CourseEnrollment
 
 
+class CourseEnrollmentAllowedAdmin(admin.ModelAdmin):
+    """ Admin interface for the CourseEnrollmentAllowed model. """
+    list_display = ('email', 'course_id', 'mode', 'auto_enroll',)
+    search_fields = ('email', 'course_id', 'mode',)
+
+    class Meta(object):
+        model = CourseEnrollmentAllowed
+
+
 class UserProfileInline(admin.StackedInline):
     """ Inline admin interface for UserProfile model. """
     model = UserProfile
@@ -198,7 +207,7 @@ class UserAttributeAdmin(admin.ModelAdmin):
 
 
 admin.site.register(UserTestGroup)
-admin.site.register(CourseEnrollmentAllowed)
+admin.site.register(CourseEnrollmentAllowed, CourseEnrollmentAllowedAdmin)
 admin.site.register(Registration)
 admin.site.register(PendingNameChange)
 admin.site.register(DashboardConfiguration, ConfigurationModelAdmin)

--- a/common/djangoapps/student/migrations/0011_courseenrollmentallowed_mode.py
+++ b/common/djangoapps/student/migrations/0011_courseenrollmentallowed_mode.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('student', '0010_auto_20170207_0458'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseenrollmentallowed',
+            name='mode',
+            field=models.CharField(default=b'audit', max_length=100),
+        ),
+    ]

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1267,7 +1267,7 @@ class CourseEnrollment(models.Model):
 
         Also emits relevant events for analytics purposes.
         """
-        if mode is None:
+        if not mode:
             mode = _default_course_mode(unicode(course_key))
         # All the server-side checks for whether a user is allowed to enroll.
         try:
@@ -1905,6 +1905,8 @@ class CourseEnrollmentAllowed(models.Model):
     email = models.CharField(max_length=255, db_index=True)
     course_id = CourseKeyField(max_length=255, db_index=True)
     auto_enroll = models.BooleanField(default=0)
+    # Represents the course mode in which user is allowed to enroll
+    mode = models.CharField(default=CourseMode.DEFAULT_MODE_SLUG, max_length=100)
 
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)
 
@@ -1912,7 +1914,7 @@ class CourseEnrollmentAllowed(models.Model):
         unique_together = (('email', 'course_id'),)
 
     def __unicode__(self):
-        return "[CourseEnrollmentAllowed] %s: %s (%s)" % (self.email, self.course_id, self.created)
+        return '%s: %s [%s] (%s)' % (self.email, self.course_id, self.mode, self.created)
 
     @classmethod
     def may_enroll_and_unenrolled(cls, course_id):

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -162,6 +162,7 @@ class CourseEnrollmentAllowedFactory(DjangoModelFactory):
 
     email = 'test@edx.org'
     course_id = CourseKey.from_string('edX/toy/2012_Fall')
+    mode = 'audit'
 
 
 class PendingEmailChangeFactory(DjangoModelFactory):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -2091,10 +2091,14 @@ def _enroll_user_in_pending_courses(student):
     """
     Enroll student in any pending courses he/she may have.
     """
-    ceas = CourseEnrollmentAllowed.objects.filter(email=student.email)
-    for cea in ceas:
-        if cea.auto_enroll:
-            enrollment = CourseEnrollment.enroll(student, cea.course_id)
+    course_enrollment_allowed_list = CourseEnrollmentAllowed.objects.filter(email=student.email)
+    for course_enrollment_allowed in course_enrollment_allowed_list:
+        if course_enrollment_allowed.auto_enroll:
+            enrollment = CourseEnrollment.enroll(
+                user=student,
+                course_key=course_enrollment_allowed.course_id,
+                mode=course_enrollment_allowed.mode,
+            )
             manual_enrollment_audit = ManualEnrollmentAudit.get_manual_enrollment_by_email(student.email)
             if manual_enrollment_audit is not None:
                 # get the enrolled by user and reason from the ManualEnrollmentAudit table.

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -100,7 +100,8 @@ def get_user_email_language(user):
     return UserPreference.get_value(user, LANGUAGE_KEY)
 
 
-def enroll_email(course_id, student_email, auto_enroll=False, email_students=False, email_params=None, language=None):
+def enroll_email(course_id, student_email, auto_enroll=False, email_students=False, email_params=None,
+                 language=None, course_mode=None):
     """
     Enroll a student by email.
 
@@ -111,6 +112,7 @@ def enroll_email(course_id, student_email, auto_enroll=False, email_students=Fal
     `email_students` determines if student should be notified of action by email.
     `email_params` parameters used while parsing email templates (a `dict`).
     `language` is the language used to render the email.
+    `course_mode` is the course mode in which user will be enrolled.
 
     returns two EmailEnrollmentState's
         representing state before and after the action.
@@ -120,16 +122,6 @@ def enroll_email(course_id, student_email, auto_enroll=False, email_students=Fal
     if previous_state.user:
         # if the student is currently unenrolled, don't enroll them in their
         # previous mode
-
-        # for now, White Labels use 'shoppingcart' which is based on the
-        # "honor" course_mode. Given the change to use "audit" as the default
-        # course_mode in Open edX, we need to be backwards compatible with
-        # how White Labels approach enrollment modes.
-        if CourseMode.is_white_label(course_id):
-            course_mode = CourseMode.DEFAULT_SHOPPINGCART_MODE_SLUG
-        else:
-            course_mode = None
-
         if previous_state.enrollment:
             course_mode = previous_state.mode
 
@@ -140,9 +132,15 @@ def enroll_email(course_id, student_email, auto_enroll=False, email_students=Fal
             email_params['full_name'] = previous_state.full_name
             send_mail_to_student(student_email, email_params, language=language)
     else:
-        cea, _ = CourseEnrollmentAllowed.objects.get_or_create(course_id=course_id, email=student_email)
-        cea.auto_enroll = auto_enroll
-        cea.save()
+        course_enrollment_allowed, __ = CourseEnrollmentAllowed.objects.get_or_create(
+            course_id=course_id,
+            email=student_email,
+        )
+        course_enrollment_allowed.auto_enroll = auto_enroll
+        if course_mode is not None:
+            course_enrollment_allowed.mode = course_mode
+
+        course_enrollment_allowed.save()
         if email_students:
             email_params['message'] = 'allowed_enroll'
             email_params['email_address'] = student_email

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -1121,11 +1121,66 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         res_json = json.loads(response.content)
         self.assertEqual(res_json, expected)
 
+    def test_enroll_in_specific_course_mode_with_username(self):
+        # add two course modes 'honor' and 'verified' for the provided course
+        CourseModeFactory.create(course_id=unicode(self.course.id), mode_slug=CourseMode.HONOR)
+        CourseModeFactory.create(course_id=unicode(self.course.id), mode_slug=CourseMode.VERIFIED)
+
+        # verify that there are now two course modes 'honor' and 'verified'
+        self.assertEqual(len(CourseMode.modes_for_course_dict(self.course.id)), 2)
+
+        # now use enrollment api to enroll a student in 'verified' mode directly
+        url = reverse('students_update_enrollment', kwargs={'course_id': unicode(self.course.id)})
+        response = self.client.post(
+            url,
+            {
+                'identifiers': self.notenrolled_student.username,
+                'action': 'enroll',
+                'email_students': False,
+                'course_mode': CourseMode.VERIFIED,
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # expected response data for students update enrollment api
+        expected = {
+            'action': 'enroll',
+            'auto_enroll': False,
+            'results': [
+                {
+                    'identifier': self.notenrolled_student.username,
+                    'before': {
+                        'enrollment': False,
+                        'auto_enroll': False,
+                        'user': True,
+                        'allowed': False,
+                    },
+                    'after': {
+                        'enrollment': True,
+                        'auto_enroll': False,
+                        'user': True,
+                        'allowed': False,
+                    }
+                }
+            ]
+        }
+
+        # verify the enrollment api response data and check that the student
+        # is now enrolled in the 'verified' mode
+        course_enrollment = CourseEnrollment.objects.get(
+            user=self.notenrolled_student, course_id=self.course.id
+        )
+        manual_enrollments = ManualEnrollmentAudit.objects.all()
+        self.assertEqual(manual_enrollments.count(), 1)
+        self.assertEqual(manual_enrollments[0].state_transition, UNENROLLED_TO_ENROLLED)
+        res_json = json.loads(response.content)
+        self.assertEqual(res_json, expected)
+        self.assertEqual(course_enrollment.mode, 'verified')
+
     def test_enroll_without_email(self):
         url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
         response = self.client.post(url, {'identifiers': self.notenrolled_student.email, 'action': 'enroll',
                                           'email_students': False})
-        print "type(self.notenrolled_student.email): {}".format(type(self.notenrolled_student.email))
         self.assertEqual(response.status_code, 200)
 
         # test that the user is now enrolled
@@ -1171,7 +1226,6 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         environ = {'wsgi.url_scheme': protocol}
         response = self.client.post(url, params, **environ)
 
-        print "type(self.notenrolled_student.email): {}".format(type(self.notenrolled_student.email))
         self.assertEqual(response.status_code, 200)
 
         # test that the user is now enrolled
@@ -1283,7 +1337,6 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
                   'auto_enroll': True}
         environ = {'wsgi.url_scheme': protocol}
         response = self.client.post(url, params, **environ)
-        print "type(self.notregistered_email): {}".format(type(self.notregistered_email))
         self.assertEqual(response.status_code, 200)
 
         # Check the outbox
@@ -1308,11 +1361,102 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
             )
         )
 
+    @ddt.data('http', 'https')
+    def test_enroll_in_specific_course_mode_with_email_not_registered_autoenroll(self, protocol):
+        # add two course modes 'honor' and 'verified' for the provided course
+        CourseModeFactory.create(course_id=unicode(self.course.id), mode_slug=CourseMode.HONOR)
+        CourseModeFactory.create(course_id=unicode(self.course.id), mode_slug=CourseMode.VERIFIED)
+
+        # verify that there are now two course modes 'honor' and 'verified'
+        self.assertEqual(len(CourseMode.modes_for_course_dict(self.course.id)), 2)
+
+        # now use enrollment api to enroll a student in 'verified' mode directly
+        url = reverse('students_update_enrollment', kwargs={'course_id': unicode(self.course.id)})
+        environ = {'wsgi.url_scheme': protocol}
+        response = self.client.post(
+            url,
+            {
+                'identifiers': self.notregistered_email,
+                'action': 'enroll',
+                'auto_enroll': True,
+                'email_students': True,
+                'course_mode': CourseMode.VERIFIED,
+            },
+            **environ
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # expected response data for students update enrollment api
+        expected = {
+            'action': 'enroll',
+            'auto_enroll': True,
+            'results': [
+                {
+                    'identifier': self.notregistered_email,
+                    'before': {
+                        'enrollment': False,
+                        'auto_enroll': False,
+                        'user': False,
+                        'allowed': False,
+                    },
+                    'after': {
+                        'enrollment': False,
+                        'auto_enroll': True,
+                        'user': False,
+                        'allowed': True,
+                    }
+                }
+            ]
+        }
+
+        # check that the student is not yet enrolled in the 'verified' mode
+        # instead of enrollment there in new record in the model
+        # 'CourseEnrollmentAllowed' with desired course mode
+        self.assertEqual(
+            CourseEnrollment.objects.filter(user=self.notenrolled_student, course_id=self.course.id).count(), 0
+        )
+        self.assertTrue(
+            CourseEnrollmentAllowed.objects.filter(email=self.notregistered_email, course_id=self.course.id).exists()
+        )
+        self.assertEqual(
+            CourseEnrollmentAllowed.objects.get(email=self.notregistered_email, course_id=self.course.id).mode,
+            CourseMode.VERIFIED
+        )
+
+        # check that the student is not yet enrolled in the 'verified' mode
+        # verify the enrollment api response data
+        manual_enrollments = ManualEnrollmentAudit.objects.all()
+        self.assertEqual(manual_enrollments.count(), 1)
+        self.assertEqual(manual_enrollments[0].state_transition, UNENROLLED_TO_ALLOWEDTOENROLL)
+        res_json = json.loads(response.content)
+        self.assertEqual(res_json, expected)
+
+        # Check the outbox and verify the content of generated email
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(
+            mail.outbox[0].subject,
+            u'You have been invited to register for {}'.format(self.course.display_name)
+        )
+        self.assertEqual(
+            mail.outbox[0].body,
+            "Dear student,\n\nYou have been invited to join {display_name} at edx.org by a member of the "
+            "course staff.\n\n"
+            "To finish your registration, please visit {protocol}://{site}/register and fill out the "
+            "registration form making sure to use {user_email} in the E-mail field.\n"
+            "Once you have registered and activated your account, "
+            "you will see {display_name} listed on your dashboard.\n\n----\n"
+            "This email was automatically sent from edx.org to {user_email}".format(
+                display_name=self.course.display_name,
+                protocol=protocol,
+                site=self.site_name,
+                user_email=self.notregistered_email,
+            )
+        )
+
     def test_unenroll_without_email(self):
         url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
         response = self.client.post(url, {'identifiers': self.enrolled_student.email, 'action': 'unenroll',
                                           'email_students': False})
-        print "type(self.enrolled_student.email): {}".format(type(self.enrolled_student.email))
         self.assertEqual(response.status_code, 200)
 
         # test that the user is now unenrolled
@@ -1355,7 +1499,6 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
         response = self.client.post(url, {'identifiers': self.enrolled_student.email, 'action': 'unenroll',
                                           'email_students': True})
-        print "type(self.enrolled_student.email): {}".format(type(self.enrolled_student.email))
         self.assertEqual(response.status_code, 200)
 
         # test that the user is now unenrolled
@@ -1412,7 +1555,6 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
         response = self.client.post(url,
                                     {'identifiers': self.allowed_email, 'action': 'unenroll', 'email_students': True})
-        print "type(self.allowed_email): {}".format(type(self.allowed_email))
         self.assertEqual(response.status_code, 200)
 
         # test the response data
@@ -1518,7 +1660,6 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
                   'auto_enroll': True}
         environ = {'wsgi.url_scheme': protocol}
         response = self.client.post(url, params, **environ)
-        print "type(self.notregistered_email): {}".format(type(self.notregistered_email))
         self.assertEqual(response.status_code, 200)
 
         # Check the outbox

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -596,6 +596,7 @@ def students_update_enrollment(request, course_id):
     - email_students is a boolean (defaults to false)
         If email_students is true, students will be sent email notification
         If email_students is false, students will not be sent email notification
+    - course_mode is a string identifier for the selected course mode, e.g. 'honor', 'verified' etc
 
     Returns an analog to this JSON structure: {
         "action": "enroll",
@@ -620,6 +621,7 @@ def students_update_enrollment(request, course_id):
     }
     """
     course_id = CourseKey.from_string(course_id)
+    course_mode = request.POST.get('course_mode')
     action = request.POST.get('action')
     identifiers_raw = request.POST.get('identifiers')
     identifiers = _split_input_list(identifiers_raw)
@@ -664,7 +666,13 @@ def students_update_enrollment(request, course_id):
             validate_email(email)  # Raises ValidationError if invalid
             if action == 'enroll':
                 before, after, enrollment_obj = enroll_email(
-                    course_id, email, auto_enroll, email_students, email_params, language=language
+                    course_id,
+                    email,
+                    auto_enroll,
+                    email_students,
+                    email_params,
+                    language=language,
+                    course_mode=course_mode
                 )
                 before_enrollment = before.to_dict()['enrollment']
                 before_user_registered = before.to_dict()['user']

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -479,6 +479,7 @@ def _section_course_info(course, access):
 def _section_membership(course, access, is_white_label):
     """ Provide data for the corresponding dashboard section """
     course_key = course.id
+    course_modes = CourseMode.modes_for_course_dict(course_key)
     ccx_enabled = settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx
     section_data = {
         'section_key': 'membership',
@@ -494,6 +495,7 @@ def _section_membership(course, access, is_white_label):
         'modify_access_url': reverse('modify_access', kwargs={'course_id': unicode(course_key)}),
         'list_forum_members_url': reverse('list_forum_members', kwargs={'course_id': unicode(course_key)}),
         'update_forum_role_membership_url': reverse('update_forum_role_membership', kwargs={'course_id': unicode(course_key)}),
+        'course_modes': course_modes,
     }
     return section_data
 

--- a/lms/static/js/fixtures/instructor_dashboard/batchenrollment.html
+++ b/lms/static/js/fixtures/instructor_dashboard/batchenrollment.html
@@ -1,0 +1,76 @@
+<section id="membership" class="idash-section active-section" aria-labelledby="header-membership">
+    <h2 class="hd hd-2" id="header-membership">Membership</h2>
+
+    <fieldset class="batch-enrollment membership-section">
+        <legend id="heading-batch-enrollment" class="hd hd-3">Batch Enrollment</legend>
+        <label>
+            Enter email addresses and/or usernames separated by new lines or commas.
+            You will not receive notifications for messages that cannot be delivered, so be sure to double-check
+            spelling.
+            <textarea rows="6" name="student-ids" placeholder="Email Addresses/Usernames" spellcheck="false"></textarea>
+        </label>
+        <input id="is_course_white_label" value="False" type="hidden">
+        <div class="enroll-option">
+            <label for="course-modes-list-selector" class="has-hint">Select a course mode:
+                <select id="course-modes-list-selector" name="course_mode" class="course-modes-list-selector">
+                <option value="honor">Honor code certificate</option>
+                <option value="verified">Verified certificate</option>
+                </select>
+
+                <div class="hint dropdown-hint auto-enroll-hint">
+                    <span class="hint-caret"></span>
+                    <p id="auto-enroll-tip">
+                        Learners will be automatically enrolled in the course mode that you select.
+                        <br><br>
+                        If you select <b>Unenroll</b> below, you do not need to select a course mode.
+                    </p>
+                </div>
+            </label>
+        </div>
+        <div class="enroll-option">
+            <label class="has-hint">
+                <input name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes"
+                       aria-describedby="heading-batch-enrollment" type="checkbox">
+                <span class="label-text">Enroll learners automatically</span>
+                <div class="hint auto-enroll-hint">
+                    <span class="hint-caret"></span>
+                    <p id="auto-enroll-tip">
+                        If you select this option, learners will be automatically enrolled in the course. If a learner
+                        does not yet have an account on Devstack, the learner will be automatically enrolled in the
+                        course when the learner registers and activates an account.
+                        If you do not select this option, learners will not be automatically enrolled in the course. If
+                        a learner does not yet have an account on Devstack, the learner can enroll in the course after
+                        the learner registers and activates an account.
+                        <br><br>
+                        If you select <b>Unenroll</b> below, you do not need to select this option.
+                    </p>
+                </div>
+            </label>
+        </div>
+        <div class="enroll-option">
+            <label class="has-hint">
+                <input name="email-students" id="email-students" value="Notify-students-by-email" checked="yes"
+                       aria-describedby="heading-batch-enrollment" type="checkbox">
+                <span class="label-text">Notify learners by email</span>
+                <div class="hint email-students-hint">
+                    <span class="hint-caret"></span>
+                    <p id="email-students-tip">
+                        If you select this option, learners receive an email message when they are successfully enrolled
+                        in your course.
+                    </p>
+                </div>
+            </label>
+        </div>
+        <div>
+            <input name="enrollment-button" class="enrollment-button" value="Enroll"
+                   data-endpoint="/courses/course-v1:edX+TEST_01+2016_R1/instructor/api/students_update_enrollment"
+                   data-action="enroll" type="button">
+            <input name="enrollment-button" class="enrollment-button" value="Unenroll"
+                   data-endpoint="/courses/course-v1:edX+TEST_01+2016_R1/instructor/api/students_update_enrollment"
+                   data-action="unenroll" type="button">
+        </div>
+        <div class="request-response"></div>
+        <div class="request-response-error"></div>
+    </fieldset>
+
+</section>

--- a/lms/static/js/instructor_dashboard/membership.js
+++ b/lms/static/js/instructor_dashboard/membership.js
@@ -596,6 +596,7 @@ such that the value can be defined later than this assignment (file load order).
             this.$enrollment_button = this.$container.find('.enrollment-button');
             this.$is_course_white_label = this.$container.find('#is_course_white_label').val();
             this.$reason_field = this.$container.find("textarea[name='reason-field']");
+            this.$course_mode = this.$container.find('select#course-modes-list-selector');
             this.$checkbox_autoenroll = this.$container.find("input[name='auto-enroll']");
             this.$checkbox_emailstudents = this.$container.find("input[name='email-students']");
             this.checkbox_emailstudents_initialstate = this.$checkbox_emailstudents.is(':checked');
@@ -614,6 +615,7 @@ such that the value can be defined later than this assignment (file load order).
                     action: $(event.target).data('action'),
                     identifiers: batchEnroll.$identifier_input.val(),
                     auto_enroll: batchEnroll.$checkbox_autoenroll.is(':checked'),
+                    course_mode: batchEnroll.$course_mode.val(),
                     email_students: emailStudents,
                     reason: batchEnroll.$reason_field.val()
                 };
@@ -636,6 +638,7 @@ such that the value can be defined later than this assignment (file load order).
             this.$identifier_input.val('');
             this.$reason_field.val('');
             this.$checkbox_emailstudents.attr('checked', this.checkbox_emailstudents_initialstate);
+            this.$course_mode.find('option:eq(0)').prop('selected', true);
             return this.$checkbox_autoenroll.attr('checked', true);
         };
 

--- a/lms/static/js/spec/instructor_dashboard/batch_enrollment_spec.js
+++ b/lms/static/js/spec/instructor_dashboard/batch_enrollment_spec.js
@@ -1,0 +1,50 @@
+define([
+    'jquery',
+    'js/instructor_dashboard/membership'
+],
+    function($) {
+        'use strict';
+        describe('BatchEnrollment', function() {
+            beforeEach(function(done) {
+                loadFixtures('js/fixtures/instructor_dashboard/batchenrollment.html');
+
+                this.membershipSection = $('section#membership');
+                window.InstructorDashboard.sections.Membership(this.membershipSection);
+
+                jasmine.waitUntil(function() {
+                    return $('section#membership').find('.enrollment-button').is(':visible');
+                }).always(done);
+            });
+
+            it('sends an enrollment ajax call with provided data and selected course mode', function() {
+                var courseMode = 'verified',
+                    userForEnrollment = 'test_user',
+                    studentIdsInput = this.membershipSection.find('textarea[name="student-ids"]'),
+                    courseModeSelector = this.membershipSection.find('select#course-modes-list-selector'),
+                    enrollButton = this.membershipSection.find('.enrollment-button[value="Enroll"]');
+
+                spyOn($, 'ajax');
+                // add the test user in batch enrollment list
+                studentIdsInput.val(userForEnrollment);
+                // select the course mode 'verified' from course modes dropdown
+                courseModeSelector.val(courseMode);
+                // click on the button 'Enroll'
+                enrollButton.click();
+
+                // now verify that the last ajax POST request has desired parameters
+                expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
+                expect($.ajax.calls.mostRecent().args[0].data).toEqual({
+                    action: 'enroll',
+                    identifiers: userForEnrollment,
+                    auto_enroll: true,
+                    course_mode: courseMode,
+                    email_students: true,
+                    reason: void 0  // set to 'undefined' by default
+                });
+                expect($.ajax.calls.mostRecent().args[0].url).toEqual(
+                    enrollButton.data('endpoint')
+                );
+            });
+        });
+    }
+);

--- a/lms/static/lms/js/spec/main.js
+++ b/lms/static/lms/js/spec/main.js
@@ -746,6 +746,7 @@
         'js/spec/financial-assistance/financial_assistance_form_view_spec.js',
         'js/spec/groups/views/cohorts_spec.js',
         'js/spec/groups/views/discussions_spec.js',
+        'js/spec/instructor_dashboard/batch_enrollment_spec.js',
         'js/spec/instructor_dashboard/certificates_bulk_exception_spec.js',
         'js/spec/instructor_dashboard/certificates_exception_spec.js',
         'js/spec/instructor_dashboard/certificates_invalidation_spec.js',

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -621,7 +621,7 @@
       top: ($baseline/2);
       left: -9999em;
       padding: ($baseline/2);
-      width: 50%;
+      width: 40%;
       background-color: $light-gray3;
       box-shadow: 2px 2px 3px $shadow;
 
@@ -641,11 +641,20 @@
      * Ideally we want to handle functionality with JS.
      * This functionality should eventually be moved into CS/JS, and out of here. */ 
     .has-hint:hover > .hint {    
-        @include left($baseline*10);
+        @include left($baseline*15);
     }
     
     .has-hint input:focus ~ .hint {
-        @include left($baseline*10);
+        @include left($baseline*15);
+    }
+    .has-hint:hover > .dropdown-hint {
+        width: 30%;
+        @include left($baseline*20);
+    }
+
+    .has-hint input:focus ~ .dropdown-hint {
+        width: 30%;
+        @include left($baseline*20);
     }
     /* *** */
   }

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -8,7 +8,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <legend id="heading-batch-enrollment" class="hd hd-3">${_("Batch Enrollment")}</legend>
     <label>
         ${_("Enter email addresses and/or usernames separated by new lines or commas.")}
-        ${_("You will not get notification for emails that bounce, so please double-check spelling.")}
+        ${_("You will not receive notifications for messages that cannot be delivered, so be sure to double-check spelling.")}
         <textarea rows="6" name="student-ids" placeholder="${_("Email Addresses/Usernames")}" spellcheck="false"></textarea>
     </label>
     <input type="hidden" id="is_course_white_label" value="${section_data['is_white_label']}">
@@ -21,16 +21,34 @@ from openedx.core.djangolib.markup import HTML, Text
         </label>
     %endif
     <div class="enroll-option">
+        <label for="course-modes-list-selector" class="has-hint">${_("Select a course mode: ")}
+            <select id="course-modes-list-selector" name="course_mode" class="course-modes-list-selector">
+                %for mode_name, mode_data in section_data['course_modes'].items():
+                    <option value="${mode_name}">${mode_data.name}</option>
+                %endfor
+            </select>
+
+            <div class="hint dropdown-hint auto-enroll-hint">
+                <span class="hint-caret"></span>
+                <p id="auto-enroll-tip">
+                    ${_("Learners will be automatically enrolled in the course mode that you select.")}
+                    <br /><br />
+                    ${_("If you select {b_start}Unenroll{b_end} below, you do not need to select a course mode.").format(b_start="<b>", b_end="</b>")}
+                </p>
+            </div>
+        </label>
+    </div>
+    <div class="enroll-option">
         <label class="has-hint">
             <input type="checkbox" name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes" aria-describedby="heading-batch-enrollment">
-            <span class="label-text">${_("Auto Enroll")}</span>
+            <span class="label-text">${_("Enroll learners automatically")}</span>
             <div class="hint auto-enroll-hint">
                 <span class="hint-caret"></span>
                 <p id="auto-enroll-tip">
-                    ${Text(_("If this option is {em_start}checked{em_end}, users who have not yet registered for {platform_name} will be automatically enrolled.")).format(em_start=HTML('<em>'), em_end=HTML('</em>'), platform_name=settings.PLATFORM_NAME)}
-                    ${Text(_("If this option is left {em_start}unchecked{em_end}, users who have not yet registered for {platform_name} will not be enrolled, but will be allowed to enroll once they make an account.")).format(em_start=HTML('<em>'), em_end=HTML('</em>'), platform_name=settings.PLATFORM_NAME)}
+                    ${_("If you select this option, learners will be automatically enrolled in the course. If a learner does not yet have an account on {platform_name}, the learner will be automatically enrolled in the course when the learner registers and activates an account.").format(platform_name=settings.PLATFORM_NAME)}
+                    ${_("If you do not select this option, learners will not be automatically enrolled in the course. If a learner does not yet have an account on {platform_name}, the learner can enroll in the course after the learner registers and activates an account.").format(platform_name=settings.PLATFORM_NAME)}
                     <br /><br />
-                    ${_("Checking this box has no effect if 'Unenroll' is selected.")}
+                    ${_("If you select {b_start}Unenroll{b_end} below, you do not need to select this option.").format(b_start="<b>", b_end="</b>")}
                 </p>
             </div>
         </label>
@@ -39,11 +57,11 @@ from openedx.core.djangolib.markup import HTML, Text
         <label class="has-hint">
           <input type="checkbox" name="email-students" id="email-students" value="Notify-students-by-email" aria-describedby="heading-batch-enrollment"
                  ${'checked="yes"' if settings.FEATURES.get('BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT') else ''}>
-            <span class="label-text">${_("Notify users by email")}</span>
+            <span class="label-text">${_("Notify learners by email")}</span>
             <div class="hint email-students-hint">
                 <span class="hint-caret"></span>
                 <p id="email-students-tip">
-                    ${Text(_("If this option is {em_start}checked{em_end}, users will receive an email notification.")).format(em_start=HTML('<em>'), em_end=HTML('</em>'))}
+                    ${_("If you select this option, learners receive an email message when they are successfully enrolled in your course.")}
                 </p>
             </div>
         </label>


### PR DESCRIPTION
…ashboard

SOL-2107
@hasnain-naveed @ibrahimahmed443 @malikshahzad228 @douglashall 
- Add drop down field for selection of available course modes on page `Membership (Batch Enrollment)`
- Update the method `instructor.views.api.students_update_enrollment` to use the value for selected course mode for enrollment
- Add tests for students enrollment from instructor dashboard
- Add jasmine tests for `Batch Enrollment` 

**Sandbox:** https://zubair-arbi.sandbox.edx.org/courses/course-v1:Test+TEST_01+2016/instructor#view-membership

<img width="1119" alt="screen shot 2016-11-03 at 2 14 27 pm" src="https://cloud.githubusercontent.com/assets/5072991/19961298/b5611fee-a1d3-11e6-9342-77659206aed5.png">


