### PR TITLE
Hide bookmarks link for the blocks in the LTI mode

### DIFF
--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -45,10 +45,14 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
         if context:
             child_context = copy(context)
         else:
-            child_context = {
-                'bookmarked': self.runtime.service(self, 'bookmarks').is_bookmarked(usage_key=self.location),  # pylint: disable=no-member
-                'username': self.runtime.service(self, 'user').get_current_user().opt_attrs['edx-platform.username']
-            }
+            child_context = {}
+
+        if 'bookmarked' not in child_context:
+            bookmarks_service = self.runtime.service(self, 'bookmarks')
+            child_context['bookmarked'] = bookmarks_service.is_bookmarked(usage_key=self.location),  # pylint: disable=no-member
+        if 'username' not in child_context:
+            user_service = self.runtime.service(self, 'user')
+            child_context['username'] = user_service.get_current_user().opt_attrs['edx-platform.username']
 
         child_context['child_of_vertical'] = True
 
@@ -68,7 +72,7 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
             'items': contents,
             'xblock_context': context,
             'unit_title': self.display_name_with_default if not is_child_of_vertical else None,
-            'show_bookmark_button': not is_child_of_vertical,
+            'show_bookmark_button': child_context.get('show_bookmark_button', not is_child_of_vertical),
             'bookmarked': child_context['bookmarked'],
             'bookmark_id': u"{},{}".format(child_context['username'], unicode(self.location))
         }))

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1996,13 +1996,17 @@ class TestRenderVerticalXBlock(ModuleStoreTestCase):
 
         self.course = CourseFactory.create()
         self.chapter = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
-                parent_location=self.course.location, category='chapter', display_name="Chapter")
+                parent_location=self.course.location, category='chapter', display_name="Chapter"
+        )
         self.section = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
-                parent_location=self.chapter.location, category='sequential', display_name="Sequence")
+                parent_location=self.chapter.location, category='sequential', display_name="Sequence"
+        )
         self.vertical = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
-                parent_location=self.section.location, category='vertical', display_name="Vertical")
+                parent_location=self.section.location, category='vertical', display_name="Vertical"
+        )
         self.html_block = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
-            parent_location=self.vertical.location, category='html', data="Test HTML Content")
+            parent_location=self.vertical.location, category='html', data="Test HTML Content"
+        )
 
         CourseEnrollmentFactory(user=self.user, course_id=self.course.id)
 

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1996,13 +1996,13 @@ class TestRenderVerticalXBlock(ModuleStoreTestCase):
 
         self.course = CourseFactory.create()
         self.chapter = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
-                parent_location=self.course.location, category='chapter', display_name="Chapter"
+            parent_location=self.course.location, category='chapter', display_name="Chapter"
         )
         self.section = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
-                parent_location=self.chapter.location, category='sequential', display_name="Sequence"
+            parent_location=self.chapter.location, category='sequential', display_name="Sequence"
         )
         self.vertical = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
-                parent_location=self.section.location, category='vertical', display_name="Vertical"
+            parent_location=self.section.location, category='vertical', display_name="Vertical"
         )
         self.html_block = ItemFactory.create(  # pylint: disable=attribute-defined-outside-init
             parent_location=self.vertical.location, category='html', data="Test HTML Content"

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2010,7 +2010,7 @@ class TestRenderVerticalXBlock(ModuleStoreTestCase):
 
         CourseEnrollmentFactory(user=self.user, course_id=self.course.id)
 
-    def get_response(self, url_encoded_params=None, usage_id=None):
+    def get_response(self):
         """ Returns the HTML for the page with vertical block"""
 
         self.assertTrue(self.client.login(username=self.user.username, password='test'))

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -40,6 +40,8 @@ class RenderXBlockTestMixin(object):
         '<div class="wrap-instructor-info"',
     ]
 
+    BOOKMARK_HTML_ELEMENT = '<div class="bookmark-button-wrapper"'
+
     @abstractmethod
     def get_response(self, url_encoded_params=None, usage_id=None):
         """

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -41,7 +41,7 @@ class RenderXBlockTestMixin(object):
     ]
 
     @abstractmethod
-    def get_response(self, url_encoded_params=None):
+    def get_response(self, url_encoded_params=None, usage_id=None):
         """
         Abstract method to get the response from the endpoint that is being tested.
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1246,8 +1246,11 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
             request, unicode(course_key), unicode(usage_key), disable_staff_debug_info=True, course=course
         )
 
+        student_view_context = request.GET.dict()
+        student_view_context['show_bookmark_button'] = False
+
         context = {
-            'fragment': block.render('student_view', context=request.GET),
+            'fragment': block.render('student_view', context=student_view_context),
             'course': course,
             'disable_accordion': True,
             'allow_iframing': True,

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -228,8 +228,6 @@ class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCa
                 data="<p>Test HTML Content %d<p>" % i
             )
 
-        bookmark_html = '<div class="bookmark-button-wrapper"'
-
         mock_user = UserFactory()
         mock_user.id = 100
 
@@ -247,8 +245,8 @@ class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCa
         )
 
         vertical_html = module.render(STUDENT_VIEW).content
-        self.assertIn(bookmark_html, vertical_html)
+        self.assertIn(self.BOOKMARK_HTML_ELEMENT, vertical_html)
 
         self.setup_user(admin=False, enroll=False, login=True)
         response = self.get_response(usage_id=unicode(self.vertical_block.location))
-        self.assertNotContains(response, bookmark_html)
+        self.assertNotContains(response, self.BOOKMARK_HTML_ELEMENT)


### PR DESCRIPTION
There is no need to show bookmarks link for the blocks that are displayed through the LTI.
Because there is no way for users accessing content to reach the bookmarks list.

![canvas1](https://cloud.githubusercontent.com/assets/1876893/19654176/fd73ca0e-9a1f-11e6-9701-bc86437cebe4.jpeg)

![canvas2](https://cloud.githubusercontent.com/assets/1876893/19654184/014cf8bc-9a20-11e6-9feb-393cabaaf06a.jpeg)
