### PR TITLE
Fixes successfully build on circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,9 @@ general:
     - "test_root/log"
 
 dependencies:
+  pre:
+    - DEBIAN_FRONTEND=noninteractive sudo apt-get install -q -y $(cat requirements/system/ubuntu/apt-packages.txt)
+
   override:
     - npm install
 

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -300,6 +300,10 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
 
         mongoengine.connect(TEST_MONGODB_LOG['db'])
 
+        # Clean import logs to ensure courses fall within 2 page limit
+        import_logs = CourseImportLog.objects.all()
+        import_logs.delete()
+
         for _ in xrange(15):
             CourseImportLog(
                 course_id=SlashSeparatedCourseKey("test", "test", "test"),

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -79,7 +79,7 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12
 git+https://github.com/edx/edx-ora2.git@1.1.9#egg=ora2==1.1.9
 -e git+https://github.com/edx/edx-submissions.git@1.1.1#egg=edx-submissions==1.1.1
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
-git+https://github.com/edx/i18n-tools.git@v0.3.2#egg=i18n-tools==v0.3.2
+git+https://github.com/edx/i18n-tools.git@v0.3.4#egg=i18n-tools==v0.3.4
 git+https://github.com/edx/edx-val.git@0.0.9#egg=edxval==0.0.9
 git+https://github.com/pmitros/RecommenderXBlock.git@v1.1#egg=recommender-xblock==1.1
 git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1


### PR DESCRIPTION
Added apt-get install to CircleCI build. Updated test_sysadmin.py to clean courses before testing pagination (was resulting in 3 pages but expecting 2). Had to upgrade django-babel-underscore and i18n-tools dependencies to prevent i18n strings in underscore templates from compiling to dict with callback arg. Also running tests --with-xunit, instead of --with-xunitmp, helps avoid segmentation faults. 
