### PR TITLE
Updated learner profile to only use the tab panel view when there is …

### DIFF
--- a/lms/static/js/spec/student_profile/helpers.js
+++ b/lms/static/js/spec/student_profile/helpers.js
@@ -100,10 +100,10 @@ define(['underscore', 'URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
         expect(learnerProfileView.$('.wrapper-profile-section-two').length).toBe(0);
     };
 
-    var expectTabbedViewToBeHidden = function(requests, tabbedViewView) {
+    var expectTabbedViewToBeUndefined = function(requests, tabbedViewView) {
         // Unrelated initial request, no badge request
         expect(requests.length).toBe(1);
-        expect(tabbedViewView.$el.find('.page-content-nav').is(':visible')).toBe(false);
+        expect(tabbedViewView).toBe(undefined);
     };
 
     var expectTabbedViewToBeShown = function(tabbedViewView) {
@@ -228,10 +228,17 @@ define(['underscore', 'URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
         expectLimitedProfileSectionsAndFieldsToBeRendered: expectLimitedProfileSectionsAndFieldsToBeRendered,
         expectProfileSectionsAndFieldsToBeRendered: expectProfileSectionsAndFieldsToBeRendered,
         expectProfileSectionsNotToBeRendered: expectProfileSectionsNotToBeRendered,
-        expectTabbedViewToBeHidden: expectTabbedViewToBeHidden, expectTabbedViewToBeShown: expectTabbedViewToBeShown,
-        expectBadgesDisplayed: expectBadgesDisplayed, expectBadgesHidden: expectBadgesHidden,
-        expectBadgeLoadingErrorIsRendered: expectBadgeLoadingErrorIsRendered, breakBadgeLoading: breakBadgeLoading,
-        firstPageBadges: firstPageBadges, secondPageBadges: secondPageBadges, thirdPageBadges: thirdPageBadges,
-        emptyBadges: emptyBadges, expectPage: expectPage, makeBadge: makeBadge
+        expectTabbedViewToBeUndefined: expectTabbedViewToBeUndefined,
+        expectTabbedViewToBeShown: expectTabbedViewToBeShown,
+        expectBadgesDisplayed: expectBadgesDisplayed,
+        expectBadgesHidden: expectBadgesHidden,
+        expectBadgeLoadingErrorIsRendered: expectBadgeLoadingErrorIsRendered,
+        breakBadgeLoading: breakBadgeLoading,
+        firstPageBadges: firstPageBadges,
+        secondPageBadges: secondPageBadges,
+        thirdPageBadges: thirdPageBadges,
+        emptyBadges: emptyBadges,
+        expectPage: expectPage,
+        makeBadge: makeBadge
     };
 });

--- a/lms/static/js/spec/student_profile/learner_profile_factory_spec.js
+++ b/lms/static/js/spec/student_profile/learner_profile_factory_spec.js
@@ -72,7 +72,7 @@ define(['backbone', 'jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helper
                     tabbedView = context.learnerProfileView.tabbedView,
                     learnerProfileView = context.learnerProfileView;
 
-                LearnerProfileHelpers.expectTabbedViewToBeHidden(requests, tabbedView);
+                LearnerProfileHelpers.expectTabbedViewToBeUndefined(requests, tabbedView);
                 LearnerProfileHelpers.expectBadgesHidden(learnerProfileView);
             });
 
@@ -83,7 +83,7 @@ define(['backbone', 'jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helper
                     tabbedView = context.learnerProfileView.tabbedView,
                     learnerProfileView = context.learnerProfileView;
 
-                LearnerProfileHelpers.expectTabbedViewToBeHidden(requests, tabbedView);
+                LearnerProfileHelpers.expectTabbedViewToBeUndefined(requests, tabbedView);
                 LearnerProfileHelpers.expectBadgesHidden(learnerProfileView);
             });
 

--- a/lms/static/js/student_profile/views/learner_profile_view.js
+++ b/lms/static/js/student_profile/views/learner_profile_view.js
@@ -39,17 +39,14 @@
                 },
 
                 render: function() {
-                    var self = this;
+                    var tabs,
+                        self = this;
 
                     this.sectionTwoView = new SectionTwoTab({
                         viewList: this.options.sectionTwoFieldViews,
                         showFullProfile: this.showFullProfile,
                         ownProfile: this.options.ownProfile
                     });
-
-                    var tabs = [
-                    {view: this.sectionTwoView, title: gettext('About Me'), url: 'about_me'}
-                    ];
 
                     HtmlUtils.setHtml(this.$el, HtmlUtils.template(learnerProfileTemplate)({
                         username: self.options.accountSettingsModel.get('username'),
@@ -59,45 +56,45 @@
                     this.renderFields();
 
                     if (this.showFullProfile() && (this.options.accountSettingsModel.get('accomplishments_shared'))) {
-                        tabs.push({
-                            view: this.options.badgeListContainer,
-                            title: gettext('Accomplishments'),
-                            url: 'accomplishments'
-                        });
+                        tabs = [
+                            {view: this.sectionTwoView, title: gettext('About Me'), url: 'about_me'},
+                            {
+                                view: this.options.badgeListContainer,
+                                title: gettext('Accomplishments'),
+                                url: 'accomplishments'
+                            }
+                        ];
+
+                        // Build the accomplishments Tab and fill with data
                         this.options.badgeListContainer.collection.fetch().done(function() {
                             self.options.badgeListContainer.render();
                         }).error(function() {
                             self.options.badgeListContainer.renderError();
                         });
-                    }
-                    this.tabbedView = new TabbedView({
-                        tabs: tabs,
-                        router: this.router,
-                        viewLabel: gettext('Profile')
-                    });
 
-                    this.tabbedView.render();
+                        this.tabbedView = new TabbedView({
+                            tabs: tabs,
+                            router: this.router,
+                            viewLabel: gettext('Profile')
+                        });
 
-                    if (tabs.length === 1) {
-                    // If the tab is unambiguous, don't display the tab interface.
-                        this.tabbedView.$el.find('.page-content-nav').hide();
-                    }
+                        this.tabbedView.render();
+                        this.$el.find('.account-settings-container').append(this.tabbedView.el);
 
-                    this.$el.find('.account-settings-container').append(this.tabbedView.el);
-
-                    if (this.firstRender) {
-                        this.router.on('route:loadTab', _.bind(this.setActiveTab, this));
-                        Backbone.history.start();
-                        this.firstRender = false;
-                    // Load from history.
-                        this.router.navigate((Backbone.history.getFragment() || 'about_me'), {trigger: true});
+                        if (this.firstRender) {
+                            this.router.on('route:loadTab', _.bind(this.setActiveTab, this));
+                            Backbone.history.start();
+                            this.firstRender = false;
+                            // Load from history.
+                            this.router.navigate((Backbone.history.getFragment() || 'about_me'), {trigger: true});
+                        } else {
+                            // Restart the router so the tab will be brought up anew.
+                            Backbone.history.stop();
+                            Backbone.history.start();
+                        }
                     } else {
-                    // Restart the router so the tab will be brought up anew.
-                        Backbone.history.stop();
-                        Backbone.history.start();
+                        this.$el.find('.account-settings-container').append(this.sectionTwoView.render().el);
                     }
-
-
                     return this;
                 },
 


### PR DESCRIPTION
…accomplishments.

TNL-5283
## [TNL-5283](https://openedx.atlassian.net/browse/TNL-5283)
### Description

Changed the learner profile to only use a TabPanelView when accomplishments are enabled.
### Sandbox
- [x] Build a sandbox for your branch and add a link here

https://staubina-tabs.sandbox.edx.org/u/verified#about_me
### Testing
- [x] safecommit violation code review process
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @alisan617 
- [x] Accessibility review: @cptvitamin 
- [x] Product review: @sstack22 
### Post-review
- [x] Rebase and squash commits
