### PR TITLE
Cleanup a11y ignores/tickets

### DIFF
--- a/common/lib/capa/capa/tests/test_shuffle.py
+++ b/common/lib/capa/capa/tests/test_shuffle.py
@@ -194,7 +194,10 @@ class CapaShuffleTest(unittest.TestCase):
         """)
         problem = new_loncapa_problem(xml_str, seed=0)
         the_html = problem.get_html()
-        self.assertRegexpMatches(the_html, r"<div>.*\[.*'Alpha'.*'Beta'.*'B'.*'A'.*'C'.*'D'.*'Psi'.*'Omega'.*\].*</div>")
+        self.assertRegexpMatches(
+            the_html,
+            r"<div>.*\[.*'Alpha'.*'Beta'.*'B'.*'A'.*'C'.*'D'.*'Psi'.*'Omega'.*\].*</div>"
+        )
 
     def test_shuffle_fixed_both_ends_thin(self):
         xml_str = textwrap.dedent("""

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -180,7 +180,6 @@ class DiscussionResponsePaginationTestMixin(BaseDiscussionMixin):
         self.assertFalse(self.thread_page.has_add_response_button())
 
 
-@attr(shard=2)
 class DiscussionHomePageTest(UniqueCourseTest):
     """
     Tests for the discussion home page.
@@ -195,6 +194,7 @@ class DiscussionHomePageTest(UniqueCourseTest):
         self.page = DiscussionTabHomePage(self.browser, self.course_id)
         self.page.visit()
 
+    @attr(shard=2)
     def test_new_post_button(self):
         """
         Scenario: I can create new posts from the Discussion home page.
@@ -211,7 +211,7 @@ class DiscussionHomePageTest(UniqueCourseTest):
         self.page.a11y_audit.config.set_rules({
             "ignore": [
                 'section',  # TODO: AC-491
-                'aria-required-children',  # TNL-5169, AC-534
+                'aria-required-children',  # TODO: AC-534
             ]
         })
         self.page.a11y_audit.check_for_accessibility_errors()
@@ -397,7 +397,6 @@ class DiscussionTabSingleThreadTest(BaseDiscussionTestCase, DiscussionResponsePa
         self.assertFalse(self.thread_page.is_comment_deletable("comment1"))
 
 
-@attr(shard=2)
 class DiscussionTabMultipleThreadTest(BaseDiscussionTestCase):
     """
     Tests for the discussion page with multiple threads
@@ -423,6 +422,7 @@ class DiscussionTabMultipleThreadTest(BaseDiscussionTestCase):
         )
         self.thread_page_1.visit()
 
+    @attr(shard=2)
     def setup_multiple_threads(self, thread_count):
         threads = []
         for i in range(thread_count):
@@ -440,7 +440,7 @@ class DiscussionTabMultipleThreadTest(BaseDiscussionTestCase):
         self.thread_page_1.a11y_audit.config.set_rules({
             "ignore": [
                 'section',  # TODO: AC-491
-                'aria-required-children',  # TNL-5169, AC-534
+                'aria-required-children',  # TODO: AC-534
             ]
         })
 
@@ -449,14 +449,13 @@ class DiscussionTabMultipleThreadTest(BaseDiscussionTestCase):
         self.thread_page_2.a11y_audit.config.set_rules({
             "ignore": [
                 'section',  # TODO: AC-491
-                'aria-required-children',  # TNL-5169, AC-534
+                'aria-required-children',  # TODO: AC-534
             ]
         })
 
         self.thread_page_2.a11y_audit.check_for_accessibility_errors()
 
 
-@attr(shard=2)
 class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
     """
     Tests for checking the display of attributes on open and closed threads
@@ -490,6 +489,7 @@ class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
         page.close_open_thread()
         return page
 
+    @attr(shard=2)
     def test_originally_open_thread_vote_display(self):
         page = self.setup_openclosed_thread_page()
         self.assertFalse(page.is_element_visible('.thread-main-wrapper .action-vote'))
@@ -497,6 +497,7 @@ class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
         self.assertFalse(page.is_element_visible('.response_response1 .action-vote'))
         self.assertTrue(page.is_element_visible('.response_response1 .display-vote'))
 
+    @attr(shard=2)
     def test_originally_closed_thread_vote_display(self):
         page = self.setup_openclosed_thread_page(True)
         self.assertTrue(page.is_element_visible('.thread-main-wrapper .action-vote'))
@@ -510,7 +511,7 @@ class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
         page.a11y_audit.config.set_rules({
             'ignore': [
                 'section',  # TODO: AC-491
-                'color-contrast',  # Commented out for now because they reproducibly fail on Jenkis but not locally
+                'color-contrast',  # Commented out for now because they reproducibly fail on Jenkins but not locally
             ]
         })
         page.a11y_audit.check_for_accessibility_errors()
@@ -519,7 +520,7 @@ class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
         page.a11y_audit.config.set_rules({
             'ignore': [
                 'section',  # TODO: AC-491
-                'color-contrast',  # Commented out for now because they reproducibly fail on Jenkis but not locally
+                'color-contrast',  # Commented out for now because they reproducibly fail on Jenkins but not locally
             ]
         })
         page.a11y_audit.check_for_accessibility_errors()
@@ -565,7 +566,6 @@ class DiscussionCommentDeletionTest(BaseDiscussionTestCase):
         page.delete_comment("comment_other_author")
 
 
-@attr(shard=2)
 class DiscussionResponseEditTest(BaseDiscussionTestCase):
     """
     Tests for editing responses displayed beneath thread in the single thread view.
@@ -591,6 +591,7 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
         page.set_response_editor_value(response_id, new_response)
         page.submit_response_edit(response_id, new_response)
 
+    @attr(shard=2)
     def test_edit_response_add_link(self):
         """
         Scenario: User submits valid input to the 'add link' form
@@ -624,6 +625,7 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
         ).html[0]
         self.assertEqual(expected_response_html, actual_response_html)
 
+    @attr(shard=2)
     def test_edit_response_add_image(self):
         """
         Scenario: User submits valid input to the 'add image' form
@@ -657,6 +659,7 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
         ).html[0]
         self.assertEqual(expected_response_html, actual_response_html)
 
+    @attr(shard=2)
     def test_edit_response_add_image_error_msg(self):
         """
         Scenario: User submits invalid input to the 'add image' form
@@ -676,6 +679,7 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
             "image", "response_self_author", '', '')
         page.verify_link_editor_error_messages_shown()
 
+    @attr(shard=2)
     def test_edit_response_add_decorative_image(self):
         """
         Scenario: User submits invalid input to the 'add image' form
@@ -711,6 +715,7 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
         ).html[0]
         self.assertEqual(expected_response_html, actual_response_html)
 
+    @attr(shard=2)
     def test_edit_response_add_link_error_msg(self):
         """
         Scenario: User submits invalid input to the 'add link' form
@@ -730,6 +735,7 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
             "link", "response_self_author", '', '')
         page.verify_link_editor_error_messages_shown()
 
+    @attr(shard=2)
     def test_edit_response_as_student(self):
         """
         Scenario: Students should be able to edit the response they created not responses of other users
@@ -747,6 +753,7 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
         self.assertFalse(page.is_response_editable("response_other_author"))
         self.edit_response(page, "response_self_author")
 
+    @attr(shard=2)
     def test_edit_response_as_moderator(self):
         """
         Scenario: Moderator should be able to edit the response they created and responses of other users
@@ -763,6 +770,7 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
         self.edit_response(page, "response_self_author")
         self.edit_response(page, "response_other_author")
 
+    @attr(shard=2)
     @flaky  # TODO fix this, see TNL-5453
     def test_vote_report_endorse_after_edit(self):
         """
@@ -806,14 +814,13 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
         page.a11y_audit.config.set_rules({
             'ignore': [
                 'section',  # TODO: AC-491
-                'aria-required-children',  # TNL-5169, AC-534
+                'aria-required-children',  # TODO: AC-534
             ]
         })
         page.visit()
         page.a11y_audit.check_for_accessibility_errors()
 
 
-@attr(shard=2)
 class DiscussionCommentEditTest(BaseDiscussionTestCase):
     """
     Tests for editing comments displayed beneath responses in the single thread view.
@@ -835,6 +842,7 @@ class DiscussionCommentEditTest(BaseDiscussionTestCase):
         page.set_comment_editor_value(comment_id, new_comment)
         page.submit_comment_edit(comment_id, new_comment)
 
+    @attr(shard=2)
     def test_edit_comment_as_student(self):
         self.setup_user()
         self.setup_view()
@@ -845,6 +853,7 @@ class DiscussionCommentEditTest(BaseDiscussionTestCase):
         self.assertFalse(page.is_comment_editable("comment_other_author"))
         self.edit_comment(page, "comment_self_author")
 
+    @attr(shard=2)
     def test_edit_comment_as_moderator(self):
         self.setup_user(roles=["Moderator"])
         self.setup_view()
@@ -855,6 +864,7 @@ class DiscussionCommentEditTest(BaseDiscussionTestCase):
         self.edit_comment(page, "comment_self_author")
         self.edit_comment(page, "comment_other_author")
 
+    @attr(shard=2)
     def test_cancel_comment_edit(self):
         self.setup_user()
         self.setup_view()
@@ -866,6 +876,7 @@ class DiscussionCommentEditTest(BaseDiscussionTestCase):
         page.set_comment_editor_value("comment_self_author", "edited body")
         page.cancel_comment_edit("comment_self_author", original_body)
 
+    @attr(shard=2)
     def test_editor_visibility(self):
         """Only one editor should be visible at a time within a single response"""
         self.setup_user(roles=["Moderator"])
@@ -904,7 +915,7 @@ class DiscussionCommentEditTest(BaseDiscussionTestCase):
         page.a11y_audit.config.set_rules({
             'ignore': [
                 'section',  # TODO: AC-491
-                'aria-required-children',  # TNL-5169, AC-534
+                'aria-required-children',  # TODO: AC-534
             ]
         })
         page.a11y_audit.check_for_accessibility_errors()
@@ -1250,7 +1261,6 @@ class DiscussionUserProfileTest(UniqueCourseTest):
         self.assertTrue(learner_profile_page.field_is_visible('username'))
 
 
-@attr(shard=2)
 class DiscussionSearchAlertTest(UniqueCourseTest):
     """
     Tests for spawning and dismissing alerts related to user search actions and their results.
@@ -1279,11 +1289,13 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
         actual = self.page.get_search_alert_messages()
         self.assertTrue(all(map(lambda msg, sub: msg.lower().find(sub.lower()) >= 0, actual, expected)))
 
+    @attr(shard=2)
     def test_no_rewrite(self):
         self.setup_corrected_text(None)
         self.page.perform_search()
         self.check_search_alert_messages(["no threads"])
 
+    @attr(shard=2)
     def test_rewrite_dismiss(self):
         self.setup_corrected_text("foo")
         self.page.perform_search()
@@ -1291,6 +1303,7 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
         self.page.dismiss_alert_message("foo")
         self.check_search_alert_messages([])
 
+    @attr(shard=2)
     def test_new_search(self):
         self.setup_corrected_text("foo")
         self.page.perform_search()
@@ -1304,11 +1317,13 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
         self.page.perform_search()
         self.check_search_alert_messages(["no threads"])
 
+    @attr(shard=2)
     def test_rewrite_and_user(self):
         self.setup_corrected_text("foo")
         self.page.perform_search(self.SEARCHED_USERNAME)
         self.check_search_alert_messages(["foo", self.SEARCHED_USERNAME])
 
+    @attr(shard=2)
     def test_user_only(self):
         self.setup_corrected_text(None)
         self.page.perform_search(self.SEARCHED_USERNAME)
@@ -1328,7 +1343,7 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
         self.page.a11y_audit.config.set_rules({
             'ignore': [
                 'section',  # TODO: AC-491
-                'aria-required-children',  # TNL-5169, AC-534
+                'aria-required-children',  # TODO: AC-534
             ]
         })
         self.page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -775,13 +775,6 @@ class LearnerProfileA11yTest(LearnerProfileTestMixin, WebAppTest):
         """
         username, _ = self.log_in_as_unique_user()
         profile_page = self.visit_profile_page(username)
-
-        profile_page.a11y_audit.config.set_rules({
-            "ignore": [
-                'link-href',  # TODO: AC-231
-            ],
-        })
-
         profile_page.a11y_audit.check_for_accessibility_errors()
 
         profile_page.make_field_editable('language_proficiencies')
@@ -802,13 +795,6 @@ class LearnerProfileA11yTest(LearnerProfileTestMixin, WebAppTest):
         different_username, _ = self.initialize_different_user(privacy=self.PRIVACY_PUBLIC)
         self.log_in_as_unique_user()
         profile_page = self.visit_profile_page(different_username)
-
-        profile_page.a11y_audit.config.set_rules({
-            "ignore": [
-                'link-href',  # TODO: AC-231
-            ],
-        })
-
         profile_page.a11y_audit.check_for_accessibility_errors()
 
     def test_badges_accessibility(self):
@@ -818,13 +804,6 @@ class LearnerProfileA11yTest(LearnerProfileTestMixin, WebAppTest):
         username = 'testcert'
         AutoAuthPage(self.browser, username=username).visit()
         profile_page = self.visit_profile_page(username)
-
-        profile_page.a11y_audit.config.set_rules({
-            "ignore": [
-                'link-href',  # TODO: AC-231
-                'color-contrast',  # TODO: AC-231
-            ],
-        })
         profile_page.display_accomplishments()
         profile_page.a11y_audit.check_for_accessibility_errors()
         profile_page.badges[0].display_modal()

--- a/common/test/acceptance/tests/lms/test_lms_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard.py
@@ -318,10 +318,4 @@ class LmsDashboardA11yTest(BaseLmsDashboardTestMultiple):
         """
         course_listings = self.dashboard_page.get_courses()
         self.assertEqual(len(course_listings), 3)
-        self.dashboard_page.a11y_audit.config.set_rules({
-            'ignore': [
-                'link-href',  # AC-530
-                'aria-required-children',  # AC-534
-            ]
-        })
         self.dashboard_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -89,7 +89,7 @@ class BulkEmailTest(BaseInstructorDashboardTest):
         ])
         self.send_email_page.a11y_audit.config.set_rules({
             "ignore": [
-                'button-name',  # TODO: AC-491
+                'button-name',  # TODO: TNL-5830
             ]
         })
         self.send_email_page.a11y_audit.check_for_accessibility_errors()
@@ -991,13 +991,6 @@ class CertificatesTest(BaseInstructorDashboardTest):
         self.certificates_section.a11y_audit.config.set_scope([
             '.certificates-wrapper'
         ])
-        self.certificates_section.a11y_audit.config.set_rules({
-            "ignore": [
-                'checkboxgroup',  # TODO: AC-491
-                'duplicate-id',  # TODO: AC-491
-                'radiogroup',  # TODO: AC-491
-            ]
-        })
         self.certificates_section.a11y_audit.check_for_accessibility_errors()
 
 
@@ -1207,10 +1200,4 @@ class CertificateInvalidationTest(BaseInstructorDashboardTest):
         self.certificates_section.a11y_audit.config.set_scope([
             '.certificates-wrapper'
         ])
-        self.certificates_section.a11y_audit.config.set_rules({
-            "ignore": [
-                'duplicate-id',  # TODO: AC-491
-                'radiogroup',  # TODO: AC-491
-            ]
-        })
         self.certificates_section.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -652,12 +652,9 @@ class StudioLibraryA11yTest(StudioLibraryTest):
         lib_page.visit()
         lib_page.wait_until_ready()
 
-        # There are several existing color contrast errors on this page,
-        # we will ignore this error in the test until we fix them.
         lib_page.a11y_audit.config.set_rules({
             "ignore": [
-                'icon-aria-hidden',  # TODO: AC-229
-                'link-href',  # TODO: AC-564
+                'link-href',  # TODO: AC-590
             ],
         })
 

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -500,12 +500,9 @@ class StudioSettingsA11yTest(StudioCourseTest):
         self.settings_page.visit()
         self.settings_page.wait_for_page()
 
-        # There are several existing color contrast errors on this page,
-        # we will ignore this error in the test until we fix them.
         self.settings_page.a11y_audit.config.set_rules({
             "ignore": [
-                'link-href',  # TODO: AC-557
-                'icon-aria-hidden',  # TODO: AC-229
+                'link-href',  # TODO: AC-590
             ],
         })
 
@@ -515,7 +512,7 @@ class StudioSettingsA11yTest(StudioCourseTest):
         # on this page. CodeMirror generates markup that does
         # not pass our accessibility testing rules.
         self.settings_page.a11y_audit.config.set_scope(
-            exclude=['.CodeMirror textarea']
+            exclude=['.CodeMirror textarea']  # TODO: TNL-5831
         )
 
         self.settings_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/studio/test_studio_textbooks.py
+++ b/common/test/acceptance/tests/studio/test_studio_textbooks.py
@@ -61,7 +61,6 @@ class TextbooksTest(StudioCourseTest):
 
         self.textbook_view_page.a11y_audit.config.set_rules({
             'ignore': [
-                'skip-link',  # AC-501
                 'section'  # AC-503
             ],
         })
@@ -85,9 +84,6 @@ class TextbooksTest(StudioCourseTest):
         self.textbook_view_page.a11y_audit.config.set_rules({
             'ignore': [
                 'color-contrast',  # will always fail because pdf.js converts pdf to divs with transparent text
-                'html-lang',  # AC-504
-                'meta-viewport',  # AC-505
-                'skip-link',  # AC-506
             ],
         })
         self.textbook_view_page.a11y_audit.check_for_accessibility_errors()


### PR DESCRIPTION
Background: in my effort to find the complete list of vendor a11y issues, I went through all a11y ignores that still exist in our bok choy tests. Many of those had associated tickets that were already closed, so I basically just tried deleting them all initially. I then went back to the tests that failed and made sure associated JIRA tickets were correct (and open).

While I was at this, I fixed discussion a11y tests so they only run in the a11y test phase.

@staubina please review. Given that I'm only cleanup up tests, I think a single review suffices here.

We seem to be hitting all sorts of npm issues today, hence the frequent re-running of stages. However, a11y has now passed.

FYI @cptvitamin 
