### PR TITLE
Bump pylint threshold back up

### DIFF
--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -11,7 +11,7 @@ set -e
 ###############################################################################
 
 # Violations thresholds for failing the build
-export PYLINT_THRESHOLD=3550
+export PYLINT_THRESHOLD=3600
 export ESLINT_THRESHOLD=9850
 
 SAFELINT_THRESHOLDS=`cat scripts/safelint_thresholds.json`


### PR DESCRIPTION
@jzoldak @tobz This limit had been 3750 before https://github.com/edx/edx-platform/pull/13792, and was dropped to 3550 due a report showing 3547 current issues. This 3600 limit gives a little more breathing room to unblock development.

Thoughts?
