### PR TITLE
Quick fixes for users with unicode usernames.

### DIFF
--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -70,7 +70,7 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
             'unit_title': self.display_name_with_default if not is_child_of_vertical else None,
             'show_bookmark_button': not is_child_of_vertical,
             'bookmarked': child_context['bookmarked'],
-            'bookmark_id': "{},{}".format(child_context['username'], unicode(self.location))
+            'bookmark_id': u"{},{}".format(child_context['username'], unicode(self.location))
         }))
 
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/vertical_student_view.js'))

--- a/openedx/core/djangoapps/bookmarks/models.py
+++ b/openedx/core/djangoapps/bookmarks/models.py
@@ -98,7 +98,7 @@ class Bookmark(TimeStampedModel):
         """
         Return the resource id: {username,usage_id}.
         """
-        return "{0},{1}".format(self.user.username, self.usage_key)  # pylint: disable=no-member
+        return u"{0},{1}".format(self.user.username, self.usage_key)  # pylint: disable=no-member
 
     @property
     def display_name(self):

--- a/openedx/core/djangoapps/bookmarks/serializers.py
+++ b/openedx/core/djangoapps/bookmarks/serializers.py
@@ -51,7 +51,7 @@ class BookmarkSerializer(serializers.ModelSerializer):
         """
         Return the REST resource id: {username,usage_id}.
         """
-        return "{0},{1}".format(bookmark.user.username, bookmark.usage_key)
+        return u"{0},{1}".format(bookmark.user.username, bookmark.usage_key)
 
     def get_path(self, bookmark):
         """

--- a/openedx/core/djangoapps/user_api/accounts/image_helpers.py
+++ b/openedx/core/djangoapps/user_api/accounts/image_helpers.py
@@ -38,7 +38,8 @@ def _make_profile_image_name(username):
     Returns the user-specific part of the image filename, based on a hash of
     the username.
     """
-    return hashlib.md5(settings.PROFILE_IMAGE_SECRET_KEY + username).hexdigest()
+    hash_input = settings.PROFILE_IMAGE_SECRET_KEY + username
+    return hashlib.md5(hash_input.encode('utf-8')).hexdigest()
 
 
 def _get_profile_image_filename(name, size, file_extension=PROFILE_IMAGE_FILE_EXTENSION):


### PR DESCRIPTION
This PR fixes some issues arising at the bookmarks feature and image upload when the username has a unicode username. E.g, spanish names, arabic names, french names ...
## Background

Some forks of the plataform allow their users to have unicode usernames, when this happens, many places that assume an ascii username break. With this, we try to keep the amount of extra modifications to a minimum.
## Reviewers

We had a bit of a talk on the #general channel on slack, so I'm tagging all the participants

Not everyone can edit this message, but If you approve the changes in a comment, I will tick this boxes
- [x] @shaunagm 
- [x] @OmarIthawi 
- [x] @sambapete
