### PR TITLE
Allow authors to remove option for unproctored exams

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -740,6 +740,17 @@ class CourseFields(object):
         scope=Scope.settings
     )
 
+    allow_proctoring_opt_out = Boolean(
+        display_name=_("Allow Opting Out of Proctored Exams"),
+        help=_(
+            "Enter true or false. If this value is true, learners can choose to take proctored exams "
+            "without proctoring. If this value is false, all learners must take the exam with proctoring. "
+            "This setting only applies if proctored exams are enabled for the course."
+        ),
+        default=True,
+        scope=Scope.settings
+    )
+
     create_zendesk_tickets = Boolean(
         display_name=_("Create Zendesk Tickets For Suspicious Proctored Exam Attempts"),
         help=_(
@@ -752,7 +763,8 @@ class CourseFields(object):
     enable_timed_exams = Boolean(
         display_name=_("Enable Timed Exams"),
         help=_(
-            "Enter true or false. If this value is true, timed exams are enabled in your course."
+            "Enter true or false. If this value is true, timed exams are enabled in your course. "
+            "Regardless of this setting, timed exams are enabled if Enable Proctored Exams is set to true."
         ),
         default=False,
         scope=Scope.settings

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -117,6 +117,12 @@ class ProctoringFields(object):
         scope=Scope.settings,
     )
 
+    def _get_course(self):
+        """
+        Return course by course id.
+        """
+        return self.descriptor.runtime.modulestore.get_course(self.course_id)  # pylint: disable=no-member
+
     @property
     def is_timed_exam(self):
         """
@@ -129,6 +135,14 @@ class ProctoringFields(object):
     def is_proctored_exam(self):
         """ Alias the is_proctored_enabled field to the more legible is_proctored_exam """
         return self.is_proctored_enabled
+
+    @property
+    def allow_proctoring_opt_out(self):
+        """
+        Returns true if the learner should be given the option to choose between
+        taking a proctored exam, or opting out to take the exam without proctoring.
+        """
+        return self._get_course().allow_proctoring_opt_out
 
     @is_proctored_exam.setter
     def is_proctored_exam(self, value):
@@ -453,6 +467,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
                     self.default_time_limit_minutes else 0
                 ),
                 'is_practice_exam': self.is_practice_exam,
+                'allow_proctoring_opt_out': self.allow_proctoring_opt_out,
                 'due_date': self.due
             }
 

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -220,6 +220,7 @@ class AdvancedSettingsPage(CoursePage):
             'video_bumper',
             'cert_html_view_enabled',
             'enable_proctored_exams',
+            'allow_proctoring_opt_out',
             'enable_timed_exams',
             'enable_subsection_gating',
             'learning_info',

--- a/lms/static/sass/_build-course.scss
+++ b/lms/static/sass/_build-course.scss
@@ -10,6 +10,10 @@
 @import 'shared/alerts_pattern_library_shim';
 @import 'shared/tooltips';
 
+// Pattern Library shims
+@import 'edx-pattern-library-shims/base/variables';
+@import 'edx-pattern-library-shims/buttons';
+
 // base - elements
 @import 'elements/typography';
 @import 'elements/controls';

--- a/lms/static/sass/_build-lms-v1.scss
+++ b/lms/static/sass/_build-lms-v1.scss
@@ -12,6 +12,10 @@
 // base - starter
 @import 'base/base';
 
+// Pattern Library shims
+@import 'edx-pattern-library-shims/base/variables';
+@import 'edx-pattern-library-shims/buttons';
+
 // base - elements
 @import 'elements/controls';
 @import 'elements/creative-commons';
@@ -74,6 +78,3 @@
 // overrides
 @import 'developer'; // used for any developer-created scss that needs further polish/refactoring
 @import 'shame';     // used for any bad-form/orphaned scss
-
-// CAPA Problem Feedback
-@import 'edx-pattern-library-shims/buttons';

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -252,7 +252,7 @@ html.video-fullscreen {
       @extend .timed-exam;
 
       .proctored-exam-message {
-        border-top: ($baseline/10) solid rgb(207, 216, 220);
+        border-top: ($baseline/10) solid $uxpl-gray-background;
         padding-top: 25px;
       }
 
@@ -266,56 +266,47 @@ html.video-fullscreen {
           padding: 0 ($baseline*5) 0 ($baseline*2.5);
         }
       }
+
       hr {
-        border-bottom: 1px solid rgb(207, 216, 220);
+        border-bottom: 1px solid $uxpl-gray-background;
       }
+
       .gated-sequence {
-        border-bottom: 2px solid rgb(207, 216, 220);
+        border-bottom: 2px solid $uxpl-gray-background;
         padding: 22px ($baseline*5) 15px 50px;
         position: relative;
-        span {
-          .fa {
-            position: absolute;
-            font-size: 22px;
-            left: 0;
-            top: $baseline;
-            color: rgb(206, 216, 220);
-          }
-        }
-        .start-timed-exam {
+
+        &.start-timed-exam {
           margin-bottom:($baseline/2);
           display: block;
+
+          &.action-primary {
+            .icon {
+              color: $uxpl-blue-base;
+            }
+          }
         }
+
         p {
-          color: #414141;
+          color: $uxpl-gray-base;
           strong {
             font-weight: 600;
           }
         }
-        > .fa {
+
+        .icon {
           @include right(35px);
           position: absolute;
-          top: 50%;
           font-size: 30px;
-          margin-top: -15px;
-          &.fa-arrow-circle-right {
-            top: 30%;
-          }
+          color: $uxpl-gray-base;
         }
+
         &:last-child {
-          > .fa {
-            color: rgb(206, 216, 220);
-          }
-          border-bottom: none;
-        }
-        &:last-child {
-          > .practice-exam {
-            color: $uxpl-blue-base;
-          }
           border-bottom: none;
         }
       }
     }
+
     .proctored-exam-skip-confirm-wrapper {
       border-left: ($baseline/4) solid $red;
       padding: $baseline ($baseline*1.5);;
@@ -343,7 +334,7 @@ html.video-fullscreen {
       padding: 30px 0px 20px 0px;
       border-bottom: ($baseline/10) solid #CFD9DD;
       hr {
-        border-bottom: 1px solid rgb(207, 216, 220);
+        border-bottom: 1px solid $uxpl-gray-background;
       }
       .clearfix {
         clear: both;
@@ -375,9 +366,9 @@ html.video-fullscreen {
         margin-bottom: ($baseline/20);
         color: #797676;
       }
-      .proctored-exam-instruction{
+      .proctored-exam-instruction {
         padding: ($baseline/2) 0;
-        border-bottom: 2px solid rgb(207, 216, 220);
+        border-bottom: 2px solid $uxpl-gray-background;
       }
     }
     .border-b-0 {
@@ -391,7 +382,7 @@ html.video-fullscreen {
       border-bottom : none;
       a.footer-link {
         display: block;
-        padding: 10px 0px 10px 0px;
+        padding: ($baseline/2) 0;
       }
     }
     p {

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -91,7 +91,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.3#egg=xblock-utils==1.0.3
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.0.9#egg=xblock-lti-consumer==1.0.9
-git+https://github.com/edx/edx-proctoring.git@0.15.0#egg=edx-proctoring==0.15.0
+git+https://github.com/edx/edx-proctoring.git@0.16.1#egg=edx-proctoring==0.16.1
 
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga


### PR DESCRIPTION
## [TNL-5084](https://openedx.atlassian.net/browse/TNL-5084)
### Description

This story adds the ability for authors to specify that their courses do not support unproctored exams. This is useful so that the course author doesn't have to be concerned about unverified users logging in and finding out the exam questions, and they don't have to implement a separate exam for those users.

See the library's implementation PR too: https://github.com/edx/edx-proctoring/pull/315
### Screenshots

Here's the advanced setting in Studio:

![image](https://cloud.githubusercontent.com/assets/5985072/19865707/b91b49a0-9f73-11e6-95b9-22a5e0b89e5d.png)

Here's the resulting proctored course without the option to choose an unproctored exam:

![image](https://cloud.githubusercontent.com/assets/5985072/19736288/a889d12e-9b7c-11e6-98c5-7581411b7067.png)
### Sandbox
- [x] https://andy-armstrong.sandbox.edx.org/courses/course-v1:AndyA+AAPT+1/courseware/9b7aeac146d54fc7a552f2feb2b00f51/be3702e5245a4d6f96194449303bdbf3/

Note: use the verified@example.com user who is pre-verified for the course. The feature does not work with staff users who cannot take proctored exams.
### Testing
- [x] i18n
- [x] RTL
- [x] safecommit violation code review process
- [x] Unit, integration, acceptance tests as appropriate
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @dianakhuang 
- [ ] Code review: @robrap 
- [ ] Doc Review: @catong 
- [ ] UX review: @chris-mike 
- [x] Product review: @marcotuts 
### Post-review
- [ ] Rebase and squash commits
