### PR TITLE
Expose the user email to the api-admin view

### DIFF
--- a/openedx/core/djangoapps/api_admin/admin.py
+++ b/openedx/core/djangoapps/api_admin/admin.py
@@ -14,14 +14,18 @@ class ApiAccessRequestAdmin(admin.ModelAdmin):
     list_filter = ('status',)
     search_fields = ('user__email',)
     raw_id_fields = ('user',)
-    readonly_fields = ('user', 'website', 'reason', 'company_name', 'company_address', 'contacted', )
+    readonly_fields = ('user', 'email_address', 'website', 'reason', 'company_name', 'company_address', 'contacted',)
     exclude = ('site',)
+
+    def email_address(self, obj):
+        """User email requesting for API Access."""
+        return obj.user.email
 
     def get_fieldsets(self, request, obj=None):
         return (
             (None, {
                 'fields': (
-                    'user', 'website', 'reason', 'company_name', 'company_address',
+                    'user', 'email_address', 'website', 'reason', 'company_name', 'company_address',
                 )
             },),
             ('Status', {


### PR DESCRIPTION
This PR consists of the work required for exposing the user email requesting for api access in API Access admin panel. The attached image will depict how the change will look like.
<img width="740" alt="screen shot 2016-10-27 at 1 57 07 pm" src="https://cloud.githubusercontent.com/assets/7567613/19761037/b6b54ae0-9c4d-11e6-994e-6c0244c0acaa.png">

ECOM-5365
@schenedx @tasawernawaz please review.
