### PR TITLE
Fix valid signature

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -885,8 +885,10 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
             "Content-Type": "application/json",
             "Date": formatdate(timeval=None, localtime=False, usegmt=True)
         }
+
+        body_for_signature = {"EdX-ID": str(self.receipt_id)}
         _message, _sig, authorization = generate_signed_message(
-            "POST", headers, body, access_key, secret_key
+            "POST", headers, body_for_signature, access_key, secret_key
         )
         headers['Authorization'] = authorization
 

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1109,13 +1109,15 @@ def results_callback(request):
 
     headers = {
         "Authorization": request.META.get("HTTP_AUTHORIZATION", ""),
+        "Content-Type": "application/json",
         "Date": request.META.get("HTTP_DATE", "")
     }
 
+    body_for_signature = {"EdX-ID": body_dict.get("EdX-ID")}
     has_valid_signature(
         "POST",
         headers,
-        body_dict,
+        body_for_signature,
         settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_ACCESS_KEY"],
         settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_SECRET_KEY"]
     )


### PR DESCRIPTION
### Description

[OSPR-1539](https://openedx.atlassian.net/browse/OSPR-1539)

The reason the signature doesn't match in the `verify_student` app its because the headers and body used for signing are different when send and coming back from Software Secure. My solution is to match the headers and body. For the headers is just adding the `Content-Type` header to the dict. For the body when you are creating the request the body is this

```
body = {
            "EdX-ID": str(self.receipt_id),
            "ExpectedName": self.name,
            "PhotoID": photo_id_url,
            "PhotoIDKey": photo_id_key,
            "SendResponseTo": callback_url,
            "UserPhoto": self.image_url("face"),
            "UserPhotoKey": self._encrypted_user_photo_key_str(),
        }
```

but what Software Secure returns is this

```
receipt_id = body_dict.get("EdX-ID")
    result = body_dict.get("Result")
    reason = body_dict.get("Reason", "")
    error_code = body_dict.get("MessageType", "")
```

As you can see the body will not match, hence the signature validation will fail. The only common thing between the two of them is the `EdX-ID` so using only this param will make the body the same. At the end the header and body are transformed to strings and then hashed

```
hashed = hmac.new(secret_key.encode('utf-8'), message, sha256)
    signature = binascii.b2a_base64(hashed.digest()).rstrip('\n')
```

so it really doesn't matter how big the body is.
### Notes

I'm assuming that the date header that is send to Software Secure and the date header send back from them is the same. If they are not then the only thing to do is to remove the this header from the request.
### How to test this PR

```
print has_valid_signature(
        "POST",
        headers,
        body_for_signature,
        settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_ACCESS_KEY"],
        settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_SECRET_KEY"]
    )
```
### Reviewers
- [ ] Code review: @douglashall
