### PR TITLE
fix None value for orientation update

### DIFF
--- a/openedx/core/djangoapps/profile_images/images.py
+++ b/openedx/core/djangoapps/profile_images/images.py
@@ -205,7 +205,8 @@ def _update_exif_orientation(exif, orientation):
     the exif orientation, return a new exif with the orientation set.
     """
     exif_dict = piexif.load(exif)
-    exif_dict['0th'][piexif.ImageIFD.Orientation] = orientation
+    if orientation:
+        exif_dict['0th'][piexif.ImageIFD.Orientation] = orientation
     return piexif.dump(exif_dict)
 
 

--- a/openedx/core/djangoapps/profile_images/tests/test_images.py
+++ b/openedx/core/djangoapps/profile_images/tests/test_images.py
@@ -24,6 +24,7 @@ from ..images import (
     validate_uploaded_image,
     _get_exif_orientation,
     _get_valid_file_types,
+    _update_exif_orientation
 )
 from .helpers import make_image_file, make_uploaded_file
 
@@ -185,6 +186,20 @@ class TestGenerateProfileImages(TestCase):
         with make_image_file(extension='.jpg') as imfile:
             for _, image in self._create_mocked_profile_images(imfile, requested_images):
                 self.check_exif_orientation(image, None)
+
+    def test_update_exif_orientation_without_orientation(self):
+        """
+        Test the update_exif_orientation without orientation will not throw exception.
+        """
+        requested_images = {10: "ten.jpg"}
+        with make_image_file(extension='.jpg') as imfile:
+            for _, image in self._create_mocked_profile_images(imfile, requested_images):
+                self.check_exif_orientation(image, None)
+                exif = image.info.get('exif', piexif.dump({}))
+                self.assertEqual(
+                    _update_exif_orientation(exif, None),
+                    image.info.get('exif', piexif.dump({}))
+                )
 
     def _create_mocked_profile_images(self, image_file, requested_images):
         """


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-5591

**Problem:**
We are using piexif library for image manipulation such as orientation (```ROTATE_90_DEGREE``` etc) and when orientation is ```None``` the pixef library didn't recognise orientation and throws error.

**Solution:**
I simple check cant prevent it that if orientation is present we will set it otherwise not.
