### PR TITLE
ENT-39: Update Data sharing Consent logic to let people in

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -101,6 +101,7 @@ from util.milestones_helpers import (
 from util.password_policy_validators import validate_password_strength
 import third_party_auth
 from third_party_auth import pipeline, provider
+from third_party_auth.models import ProviderConfig
 from student.helpers import (
     check_verify_status_by_course,
     auth_pipeline_urls, get_next_url_for_login_page,
@@ -1635,7 +1636,7 @@ def create_account_with_params(request, params):
 
     if pipeline.active_provider_requests_data_sharing(request):
         extra_fields['data_sharing_consent'] = 'optional'
-    if pipeline.active_provider_requires_data_sharing(request):
+    if pipeline.active_provider_enforces_data_sharing(request, ProviderConfig.AT_LOGIN):
         extra_fields['data_sharing_consent'] = 'required'
 
     # if doing signup for an external authorization, then get email, password, name from the eamap

--- a/common/djangoapps/third_party_auth/middleware.py
+++ b/common/djangoapps/third_party_auth/middleware.py
@@ -4,7 +4,7 @@ from social.apps.django_app.middleware import SocialAuthExceptionMiddleware
 from social.apps.django_app.default.models import UserSocialAuth
 
 from . import pipeline
-from .models import UserDataSharingConsentAudit
+from .models import UserDataSharingConsentAudit, ProviderConfig
 
 
 class ExceptionMiddleware(SocialAuthExceptionMiddleware):
@@ -38,7 +38,7 @@ class ResetSessionIfPipelineBrokenMiddleware(object):
         """
         view_module = view_func.__module__
 
-        if not pipeline.active_provider_requires_data_sharing(request):
+        if not pipeline.active_provider_enforces_data_sharing(request, ProviderConfig.AT_LOGIN):
             return
 
         running_pipeline = pipeline.get(request)

--- a/common/djangoapps/third_party_auth/migrations/0007_auto_20161107_0541.py
+++ b/common/djangoapps/third_party_auth/migrations/0007_auto_20161107_0541.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0006_data_sharing_consent'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='ltiproviderconfig',
+            name='data_sharing_consent',
+        ),
+        migrations.RemoveField(
+            model_name='oauth2providerconfig',
+            name='data_sharing_consent',
+        ),
+        migrations.RemoveField(
+            model_name='samlproviderconfig',
+            name='data_sharing_consent',
+        ),
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='enable_data_sharing_consent',
+            field=models.BooleanField(default=False, help_text='This field is used to determine whether data sharing consent is enabled or disabled of users signing in using this SSO provider. If disabled, consent will not be requested, and course data will not be shared.'),
+        ),
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='enforce_data_sharing_consent',
+            field=models.CharField(default=b'optional', help_text='This field is used to determine the place from where user must consent to data sharing in order to proceed.', max_length=25, choices=[(b'optional', b'Optional'), (b'at_login', b'At Login'), (b'at_enrollment', b'At Enrollment')]),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='enable_data_sharing_consent',
+            field=models.BooleanField(default=False, help_text='This field is used to determine whether data sharing consent is enabled or disabled of users signing in using this SSO provider. If disabled, consent will not be requested, and course data will not be shared.'),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='enforce_data_sharing_consent',
+            field=models.CharField(default=b'optional', help_text='This field is used to determine the place from where user must consent to data sharing in order to proceed.', max_length=25, choices=[(b'optional', b'Optional'), (b'at_login', b'At Login'), (b'at_enrollment', b'At Enrollment')]),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='enable_data_sharing_consent',
+            field=models.BooleanField(default=False, help_text='This field is used to determine whether data sharing consent is enabled or disabled of users signing in using this SSO provider. If disabled, consent will not be requested, and course data will not be shared.'),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='enforce_data_sharing_consent',
+            field=models.CharField(default=b'optional', help_text='This field is used to determine the place from where user must consent to data sharing in order to proceed.', max_length=25, choices=[(b'optional', b'Optional'), (b'at_login', b'At Login'), (b'at_enrollment', b'At Enrollment')]),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -279,23 +279,32 @@ class ProviderConfig(ConfigurationModel):
             "authentication using the correct link is still possible."
         ),
     )
-    DATA_CONSENT_DISABLED = 'disabled'
+
     DATA_CONSENT_OPTIONAL = 'optional'
-    DATA_CONSENT_REQUIRED = 'required'
-    DATA_CONSENT_STATE_CHOICES = (
-        (DATA_CONSENT_DISABLED, 'Disabled'),
+    AT_LOGIN = 'at_login'
+    AT_ENROLLMENT = 'at_enrollment'
+    DATA_SHARING_CONSENT_CHOICES = (
         (DATA_CONSENT_OPTIONAL, 'Optional'),
-        (DATA_CONSENT_REQUIRED, 'Required')
+        (AT_LOGIN, 'At Login'),
+        (AT_ENROLLMENT, 'At Enrollment'),
     )
-    data_sharing_consent = models.CharField(
-        max_length=8,
-        blank=False,
-        choices=DATA_CONSENT_STATE_CHOICES,
-        default=DATA_CONSENT_DISABLED,
+
+    enable_data_sharing_consent = models.BooleanField(
+        default=False,
         help_text=_(
-            "This field is used to determine whether data sharing consent is requested "
-            "or required of users signing in using this SSO provider. If disabled, consent "
+            "This field is used to determine whether data sharing consent is enabled or "
+            "disabled of users signing in using this SSO provider. If disabled, consent "
             "will not be requested, and course data will not be shared."
+        )
+    )
+    enforce_data_sharing_consent = models.CharField(
+        max_length=25,
+        blank=False,
+        choices=DATA_SHARING_CONSENT_CHOICES,
+        default=DATA_CONSENT_OPTIONAL,
+        help_text=_(
+            "This field determines if data sharing consent is optional, if it's required at login, "
+            "or if it's required when registering for courses."
         )
     )
     prefix = None  # used for provider_id. Set to a string value in subclass
@@ -315,19 +324,22 @@ class ProviderConfig(ConfigurationModel):
             raise ValidationError('Either an icon class or an icon image must be given (but not both)')
 
     @property
-    def require_data_sharing_consent(self):
-        """
-        Does the provider require data sharing consent?
-        """
-        return self.data_sharing_consent == self.DATA_CONSENT_REQUIRED
-
-    @property
-    def request_data_sharing_consent(self):
+    def requests_data_sharing_consent(self):
         """
         Does the provider request data sharing consent, regardless of whether
         or not it's required?
         """
-        return self.data_sharing_consent != self.DATA_CONSENT_DISABLED
+        return self.enable_data_sharing_consent
+
+    def enforces_data_sharing_consent(self, enforcement_location):
+        """
+        Does the provider enforce data sharing consent at the given point ?
+
+        Args:
+            enforcement_location (str): the point where to see data sharing consent state.
+            argument can either be "optional", 'at_login' or 'at_enrollment'
+        """
+        return self.requests_data_sharing_consent and self.enforce_data_sharing_consent == enforcement_location
 
     @property
     def provider_id(self):

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -100,7 +100,10 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
         """
         Configure TestShib to require data sharing consent before running the registration test
         """
-        self._configure_testshib_provider(data_sharing_consent='required')
+        self._configure_testshib_provider(
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent='at_enrollment',
+        )
         super(TestShibIntegrationTest, self).test_register(data_sharing_consent=True)
 
     def test_login_redirects_to_consent_when_required(self):
@@ -117,7 +120,8 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
         self.client.logout()
         # Set up the provider to require data sharing consent
         self._configure_testshib_provider(
-            data_sharing_consent='required',
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent="at_enrollment",
             assert_metadata_updates=False,
         )
         provider_login_url = self._check_login_page()
@@ -138,7 +142,55 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
         Configure TestShib to request data sharing consent, and then check
         the form to make sure that the option to enable it is present.
         """
-        self._configure_testshib_provider(data_sharing_consent='optional')
+        self._configure_testshib_provider(
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent="optional",
+        )
+        # The user goes to the register page, and sees a button to register with the provider:
+        provider_register_url = self._check_register_page()
+        # The user clicks on the Dummy button:
+        try_login_response = self.client.get(provider_register_url)
+        # The user should be redirected to the provider's login page:
+        self.assertEqual(try_login_response.status_code, 302)
+        provider_response = self.do_provider_login(try_login_response['Location'])
+        # We should be redirected to the register screen since this account is not linked to an edX account:
+        self.assertEqual(provider_response.status_code, 302)
+        self.assertEqual(provider_response['Location'], self.url_prefix + self.register_page_url)
+        register_response = self.client.get(self.register_page_url)
+        tpa_context = register_response.context["data"]["third_party_auth"]  # pylint: disable=no-member
+        self.assertEqual(tpa_context["errorMessage"], None)
+        # Check that the "You've successfully signed into [PROVIDER_NAME]" message is shown.
+        self.assertEqual(tpa_context["currentProvider"], self.PROVIDER_NAME)
+        # Check that the data (e.g. email) from the provider is displayed in the form:
+        form_data = register_response.context['data']['registration_form_desc']  # pylint: disable=no-member
+        form_fields = {field['name']: field for field in form_data['fields']}
+        # Verify that the data sharing consent checkbox is present
+        self.assertIn('data_sharing_consent', form_fields)
+        # Verify that the data sharing consent checkbox is not required
+        self.assertFalse(form_fields['data_sharing_consent']['required'])
+        registration_values = {
+            'email': 'email-edited@tpa-test.none',
+            'name': 'My Customized Name',
+            'username': 'new_username',
+            'honor_code': True,
+            'data_sharing_consent': False
+        }
+        # Now complete the form:
+        ajax_register_response = self.client.post(
+            reverse('user_api_registration'),
+            registration_values
+        )
+        self.assertEqual(ajax_register_response.status_code, 200)
+
+    def test_registration_form_has_data_sharing_consent_when_required_but_not_must(self):
+        """
+        Configure TestShib to request data sharing consent, and then check
+        the form to make sure that the option to enable it is present.
+        """
+        self._configure_testshib_provider(
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent="at_enrollment",
+        )
         # The user goes to the register page, and sees a button to register with the provider:
         provider_register_url = self._check_register_page()
         # The user clicks on the Dummy button:
@@ -177,10 +229,13 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
 
     def test_registration_not_allowed_without_data_sharing_consent(self):
         """
-        Configure TestShib to require data sharing consent, but don't provide
+        Configure TestShib to enforce data sharing consent, but don't provide
         consent when registering
         """
-        self._configure_testshib_provider(data_sharing_consent='required')
+        self._configure_testshib_provider(
+            enable_data_sharing_consent=True,
+            enforce_data_sharing_consent="at_login",
+        )
         # The user goes to the register page, and sees a button to register with the provider:
         provider_register_url = self._check_register_page()
         # The user clicks on the Dummy button:

--- a/common/static/common/js/third_party_auth/grant_data_sharing_permissions.js
+++ b/common/static/common/js/third_party_auth/grant_data_sharing_permissions.js
@@ -1,0 +1,17 @@
+(function() {
+    'use strict';
+
+    $(document).ready(function() {
+        $('#data-sharing').submit(function(event) {
+            var $dataSharingConsentCheckbox = $('#register-data_sharing_consent');
+            var warningMessage = $dataSharingConsentCheckbox.data('warningMessage');
+
+            if (!$dataSharingConsentCheckbox.is(':checked') && warningMessage) {
+                // eslint-disable-next-line no-alert
+                if (!window.confirm(warningMessage)) {
+                    event.preventDefault();
+                }
+            }
+        });
+    });
+}).call(this);

--- a/common/templates/grant_data_sharing_permissions.html
+++ b/common/templates/grant_data_sharing_permissions.html
@@ -3,12 +3,13 @@
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
+from openedx.core.djangolib.js_utils import dump_js_escaped_json
 %>
-
-<!--<%namespace name='static' file='/static_content.html'/>-->
 
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
+
+<script type="text/javascript" src="${static.url('common/js/third_party_auth/grant_data_sharing_permissions.js')}"></script>
 
 <%block name="pagetitle">${_("Additional permissions required")}</%block>
 <main id="main" aria-label="Content" tabindex="-1">
@@ -38,6 +39,8 @@ from django.utils.translation import ugettext as _
                             type="checkbox"
                             name="data_sharing_consent"
                             class="input-block checkbox"
+                            data-consent="${data_sharing_consent}"
+                            data-warning-message="${messages['warning'].get(data_sharing_consent, messages['warning']['optional'])}"
                         />
                         <label for="register-data_sharing_consent">
                             ${_("I agree to allow {platform_name} to share data about my enrollment, completion and performance in all {platform_name} courses and programs where my enrollment is sponsored by {provider}.*").format(provider=sso_provider, platform_name=platform_name)}
@@ -45,7 +48,7 @@ from django.utils.translation import ugettext as _
                     </div>
                     <input type="hidden" name="csrfmiddlewaretoken" value="${ csrftoken }" />
                     <button type="submit" class="action-primary action">Submit</button>
-                    <p class="note">${_("*{provider} requires data sharing consent; if consent is not provided, you will be redirected to log in manually.").format(provider=sso_provider)}
+                    <p class="note">${messages['note'].get(data_sharing_consent, messages['note']['optional'])}
                 </form>
             </div>
         </section>

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -25,7 +25,8 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 import third_party_auth
 from third_party_auth import pipeline
 from third_party_auth.provider import Registry
-from third_party_auth.pipeline import active_provider_requires_data_sharing, active_provider_requests_data_sharing
+from third_party_auth.pipeline import active_provider_enforces_data_sharing, active_provider_requests_data_sharing
+from third_party_auth.models import ProviderConfig
 from django_comment_common.models import Role
 from edxmako.shortcuts import marketing_link
 from student.forms import get_registration_extension_form
@@ -284,9 +285,13 @@ class RegistrationView(APIView):
 
         # Add a data sharing consent dialog if it's requested
         if active_provider_requests_data_sharing(request):
-            required = active_provider_requires_data_sharing(request)
+            enforced = active_provider_enforces_data_sharing(request, ProviderConfig.AT_LOGIN)
             provider_name = Registry.get_from_pipeline(pipeline.get(request)).name
-            self._add_data_sharing_consent_field(form_desc, provider_name, required)
+
+            # data sharing consent checkbox is required only when provider enforces it and
+            # does not want the user account created otherwise. that is why we are setting
+            # "required" html attribute only when providers enforces data sharing consent.
+            self._add_data_sharing_consent_field(form_desc, provider_name, required=enforced)
 
         return HttpResponse(form_desc.to_json(), content_type="application/json")
 


### PR DESCRIPTION
Hi @mattdrayer , @asadiqbal08 

This is a preliminary implementation for ENT-39, I will adding more functionality and modifying existing one if needed, Kindly take a look on the overall approach and let me know your thoughts. 

**Description of changes:**
**Background**
Right now the Data sharing consent logic is set up so that if a user says "no" they are not able to sign in / finish creating account, and are sent back to the Logistration page origin. We would like to change this.
**Acceptance Criteria**
1. If user does not agree to Data Sharing consent display an "Are you Sure?" modal that allows user to continue or agree to share data.
   - If user agrees, follow normal pattern
2. If user does not agree, system continues with Create Account and Sign In process. User Identity is linked to the Enterprise organization, but the user is no longer eligible for Entitlements.
   - [Prof Ed] Go to Checkout page
   - [Verified] Go to Track Selection
   - [Audit] Go to Dashboard, user enrolled, course displayed on Dashboard
   - [Credit] Go to Checkout
