### PR TITLE
Fix bad closing tag in staff problem info template

### DIFF
--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -83,26 +83,26 @@ ${block_content}
         % endif
         ]
       </div>
-      <div id="result_${location.name | h}"/>
+      <div id="result_${location.name | h}"></div>
     </div>
 
     <div class="staff_info" style="display:block">
-is_released = ${is_released}
-location = ${location.to_deprecated_string() | h}
+      is_released = ${is_released}
+      location = ${location.to_deprecated_string() | h}
 
-<table summary="${_('Module Fields')}">
-  <tr><th>${_('Module Fields')}</th></tr>
-  %for name, field in fields:
-  <tr><td style="width:25%">${name}</td><td><pre style="display:inline-block; margin: 0;">${field | h}</pre></td></tr>
-  %endfor
-</table>
-<table>
-  <tr><th>${_('XML attributes')}</th></tr>
-  %for name, field in xml_attributes.items():
-  <tr><td style="width:25%">${name}</td><td><pre style="display:inline-block; margin: 0;">${field | h}</pre></td></tr>
-  %endfor
-</table>
-category = ${category | h}
+      <table summary="${_('Module Fields')}">
+        <tr><th>${_('Module Fields')}</th></tr>
+        %for name, field in fields:
+        <tr><td style="width:25%">${name}</td><td><pre style="display:inline-block; margin: 0;">${field | h}</pre></td></tr>
+        %endfor
+      </table>
+      <table>
+        <tr><th>${_('XML attributes')}</th></tr>
+        %for name, field in xml_attributes.items():
+        <tr><td style="width:25%">${name}</td><td><pre style="display:inline-block; margin: 0;">${field | h}</pre></td></tr>
+        %endfor
+      </table>
+      category = ${category | h}
     </div>
     %if render_histogram:
     <div id="histogram_${element_id}" class="histogram" data-histogram="${histogram}"></div>


### PR DESCRIPTION
Fixed badly closed div causing HTML siblings to be swallowed in student view (when logged in as staff). Specifically noticed the issue with Problem Builder forms not showing the submit button on mobile (made the components multi device). Also fixed indent to be more readable.  
