### PR TITLE
Update course grade query parameters and check scores when updating subsection grade

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -423,18 +423,17 @@ class PersistentCourseGrade(TimeStampedModel):
         return cls.objects.get(user_id=user_id, course_id=course_id)
 
     @classmethod
-    def update_or_create_course_grade(cls, user_id, course_id, course_version=None, **kwargs):
+    def update_or_create_course_grade(cls, user_id, course_id, **kwargs):
         """
         Creates a course grade in the database.
         Returns a PersistedCourseGrade object.
         """
-        if course_version is None:
-            course_version = ""
+        if kwargs.get('course_version', None) is None:
+            kwargs['course_version'] = ""
 
         grade, _ = cls.objects.update_or_create(
             user_id=user_id,
             course_id=course_id,
-            course_version=course_version,
             defaults=kwargs
         )
         return grade

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -106,7 +106,6 @@ def score_published_handler(sender, block, user, raw_earned, raw_possible, only_
 
     if update_score:
         set_score(user.id, block.location, raw_earned, raw_possible)
-
         PROBLEM_SCORE_CHANGED.send(
             sender=None,
             points_earned=raw_earned,
@@ -130,6 +129,8 @@ def enqueue_subsection_update(sender, **kwargs):  # pylint: disable=unused-argum
             kwargs['course_id'],
             kwargs['usage_id'],
             kwargs.get('only_if_higher'),
+            kwargs.get('points_earned'),
+            kwargs.get('points_possible'),
         )
     )
 

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -6,7 +6,9 @@ from celery import task
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.utils import IntegrityError
+from logging import getLogger
 
+from courseware.model_data import get_score
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locator import CourseLocator
@@ -19,28 +21,120 @@ from .new.subsection_grade import SubsectionGradeFactory
 from .signals.signals import SUBSECTION_SCORE_CHANGED
 from .transformer import GradesTransformer
 
+log = getLogger(__name__)
+
 
 @task(default_retry_delay=30, routing_key=settings.RECALCULATE_GRADES_ROUTING_KEY)
-def recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher):
+def recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible):
     """
     Updates a saved subsection grade.
     This method expects the following parameters:
-       - user_id: serialized id of applicable User object
-       - course_id: Unicode string representing the course
-       - usage_id: Unicode string indicating the courseware instance
-       - only_if_higher: boolean indicating whether grades should
-        be updated only if the new grade is higher than the previous
+        - user_id: serialized id of applicable User object
+        - course_id: Unicode string identifying the course
+        - usage_id: Unicode string identifying the course block
+        - only_if_higher: boolean indicating whether grades should
+        be updated only if the new raw_earned is higher than the previous
         value.
+        - raw_earned: the raw points the learner earned on the problem that
+        triggered the update
+        - raw_possible: the max raw points the leaner could have earned
+        on the problem
     """
     if not PersistentGradesEnabledFlag.feature_enabled(course_id):
         return
 
     course_key = CourseLocator.from_string(course_id)
-    student = User.objects.get(id=user_id)
     scored_block_usage_key = UsageKey.from_string(usage_id).replace(course_key=course_key)
+    score = get_score(user_id, scored_block_usage_key)
 
+    # If the score is None, it has not been saved at all yet
+    # and we need to retry until it has been saved.
+    if score is None:
+        _retry_recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible)
+    else:
+        module_raw_earned, module_raw_possible = score  # pylint: disable=unpacking-non-sequence
+
+    # Validate that the retrieved scores match the scores when the task was created.
+    # This race condition occurs if the transaction in the task creator's process hasn't
+    # committed before the task initiates in the worker process.
+    grades_match = module_raw_earned == raw_earned and module_raw_possible == raw_possible
+
+    # We have to account for the situation where a student's state
+    # has been deleted- in this case, get_score returns (None, None), but
+    # the score change signal will contain 0 for raw_earned.
+    state_deleted = module_raw_earned is None and module_raw_possible is None and raw_earned == 0
+
+    if not (state_deleted or grades_match):
+        _retry_recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible)
+
+    _update_subsection_grades(
+        course_key,
+        scored_block_usage_key,
+        only_if_higher,
+        course_id,
+        user_id,
+        usage_id,
+        raw_earned,
+        raw_possible,
+    )
+
+
+@task(default_retry_delay=30, routing_key=settings.RECALCULATE_GRADES_ROUTING_KEY)
+def recalculate_course_grade(user_id, course_id):
+    """
+    Updates a saved course grade.
+    This method expects the following parameters:
+       - user_id: serialized id of applicable User object
+       - course_id: Unicode string representing the course
+    """
+    if not PersistentGradesEnabledFlag.feature_enabled(course_id):
+        return
+    student = User.objects.get(id=user_id)
+    course_key = CourseLocator.from_string(course_id)
+    course = modulestore().get_course(course_key, depth=0)
+
+    try:
+        CourseGradeFactory(student).update(course)
+    except IntegrityError as exc:
+        raise recalculate_course_grade.retry(args=[user_id, course_id], exc=exc)
+
+
+def _retry_recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher, grade, max_grade, exc=None):
+    """
+    Calls retry for the recalculate_subsection_grade task with the
+    given inputs.
+    """
+    raise recalculate_subsection_grade.retry(
+        args=[
+            user_id,
+            course_id,
+            usage_id,
+            only_if_higher,
+            grade,
+            max_grade,
+        ],
+        exc=exc
+    )
+
+
+def _update_subsection_grades(
+        course_key,
+        scored_block_usage_key,
+        only_if_higher,
+        course_id,
+        user_id,
+        usage_id,
+        raw_earned,
+        raw_possible,
+):
+    """
+    A helper function to update subsection grades in the database
+    for each subsection containing the given block, and to signal
+    that those subsection grades were updated.
+    """
     collected_block_structure = get_course_in_cache(course_key)
     course = modulestore().get_course(course_key, depth=0)
+    student = User.objects.get(id=user_id)
     subsection_grade_factory = SubsectionGradeFactory(student, course, collected_block_structure)
     subsections_to_update = collected_block_structure.get_transformer_block_field(
         scored_block_usage_key,
@@ -69,24 +163,4 @@ def recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher):
             )
 
     except IntegrityError as exc:
-        raise recalculate_subsection_grade.retry(args=[user_id, course_id, usage_id], exc=exc)
-
-
-@task(default_retry_delay=30, routing_key=settings.RECALCULATE_GRADES_ROUTING_KEY)
-def recalculate_course_grade(user_id, course_id):
-    """
-    Updates a saved course grade.
-    This method expects the following parameters:
-       - user_id: serialized id of applicable User object
-       - course_id: Unicode string representing the course
-    """
-    if not PersistentGradesEnabledFlag.feature_enabled(course_id):
-        return
-    student = User.objects.get(id=user_id)
-    course_key = CourseLocator.from_string(course_id)
-    course = modulestore().get_course(course_key, depth=0)
-
-    try:
-        CourseGradeFactory(student).update(course)
-    except IntegrityError as exc:
-        raise recalculate_course_grade.retry(args=[user_id, course_id], exc=exc)
+        _retry_recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible, exc)


### PR DESCRIPTION
Fixes two issues discovered during our bug bash:

1. Course grades were being queried via course id, user id, *and* course version. There is a uniqueness constraint on the table for the combination of user and course id, though. So, as soon as a course version was updated, all users' course grades would be frozen at their last value before the update to the course. This was resolved by removing the erroneous use of course version in the query.
2. There was a race condition between saving problem grades and kicking off the chain of updates to subsection and course grades that was supposed to follow. Sometimes the subsection grade update would start before the problem grade was done being saved to the database, meaning that when a learner submitted a problem, the subsection grade (and the course grade) would be calculated with their previous score for the problem. This was resolved by checking the `modified` timestamp on the student module for the course (which represents the last update to a student's problem scores in the database) when updating subsection grades based on a signal that a problem was updated.

TNL-5861