### PR TITLE
TNL-5721 – Fix check source module access before appending it to required modules

### DIFF
--- a/common/lib/xmodule/xmodule/conditional_module.py
+++ b/common/lib/xmodule/xmodule/conditional_module.py
@@ -160,8 +160,11 @@ class ConditionalModule(ConditionalFields, XModule, StudioEditableModule):
                     # the descriptor of a required module to have a property but
                     # for the resulting module to be a (flavor of) ErrorModule.
                     # So just log and return false.
-                    log.warn('Error in conditional module: \
-                        required module {module} has no {module_attr}'.format(module=module, module_attr=attr_name))
+                    if module is not None:
+                        # We do not want to log when module is None, and it is when requester
+                        # does not have access to the requested required module.
+                        log.warn('Error in conditional module: \
+                            required module {module} has no {module_attr}'.format(module=module, module_attr=attr_name))
                     return False
 
                 attr = getattr(module, attr_name)

--- a/lms/templates/conditional_module.html
+++ b/lms/templates/conditional_module.html
@@ -1,7 +1,9 @@
-<%
-
+<%!
 from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext as _
+%>
 
+<%
 def _message(reqm, message):
     return message.format(link="<a href={url}>{url_name}</a>".format(
         url = reverse('jump_to', kwargs=dict(course_id=reqm.course_id.to_deprecated_string(),
@@ -9,7 +11,13 @@ def _message(reqm, message):
         url_name = reqm.display_name_with_default_escaped))
 %>
 % if message:
-	% for reqm in module.required_modules:
-		<p class="conditional-message">${_message(reqm, message)}</p>
-	% endfor
+    % for reqm in module.required_modules:
+        % if reqm:
+            <p class="conditional-message">${_message(reqm, message)}</p>
+        % else:
+            <p class="conditional-message">
+                ${_("You do not have access to this dependency module.")}
+            </p>
+        % endif
+    % endfor
 % endif


### PR DESCRIPTION
## [TNL-5721](https://openedx.atlassian.net/browse/TNL-5721)

### Description
Conditional modules with staff only required module(s), when accessed as student, caused uncatched exception while rendering it in mako template. Now, we are checking for the `required_module` before using the data from it in string interpolation.

### Sandbox
- [x] on ticket
### Testing
- [x] Unit tests have been added.

### Screenshot
Conditional with three required modules with one of them having staff access.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @adampalay 
- [x] Code review: @attiyaIshaque 

### Post-review
- [x] Rebase and squash commits
