### PR TITLE
Revert "Bug fix: collect test results when running in multiprocess mode."

### DIFF
--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -168,7 +168,7 @@ case "$TEST_SUITE" in
         cp -R $HOME/firefox/ firefox/
         export SELENIUM_FIREFOX_PATH=firefox/firefox
 
-        PAVER_ARGS="-n $NUMBER_OF_BOKCHOY_THREADS --with-flaky --with-xunitmp"
+        PAVER_ARGS="-n $NUMBER_OF_BOKCHOY_THREADS --with-flaky --with-xunit"
 
         case "$SHARD" in
 


### PR DESCRIPTION
@benpatterson @cpennington 

Reverting because the way that the test results are consolidated on Jenkins they are overwriting each other. See the Test Result Trend Graph, which fell from >1000 tests to <200.