### PR TITLE
MA-2871: return response_count on thread patch

### DIFF
--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -903,7 +903,7 @@ def update_thread(request, thread_id, update_data):
         The updated thread; see discussion_api.views.ThreadViewSet for more
         detail.
     """
-    cc_thread, context = _get_thread_and_context(request, thread_id)
+    cc_thread, context = _get_thread_and_context(request, thread_id, retrieve_kwargs={"with_responses": True})
     _check_editable_fields(cc_thread, update_data, context)
     serializer = ThreadSerializer(cc_thread, data=update_data, partial=True, context=context)
     actions_form = ThreadActionsForm(update_data)

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -834,7 +834,12 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
 
     def test_basic(self):
         self.register_get_user_response(self.user)
-        self.register_thread({"created_at": "Test Created Date", "updated_at": "Test Updated Date", "read": True})
+        self.register_thread({
+            "created_at": "Test Created Date",
+            "updated_at": "Test Updated Date",
+            "read": True,
+            "resp_total": 2,
+        })
         request_data = {"raw_body": "Edited body"}
         response = self.request_patch(request_data)
         self.assertEqual(response.status_code, 200)
@@ -851,6 +856,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
                 "updated_at": "Test Updated Date",
                 "comment_count": 1,
                 "read": True,
+                "response_count": 2,
             })
         )
         self.assertEqual(
@@ -923,7 +929,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
 
     def test_patch_read_owner_user(self):
         self.register_get_user_response(self.user)
-        self.register_thread()
+        self.register_thread({"resp_total": 2})
         self.register_read_response(self.user, "thread", "test_thread")
         request_data = {"read": True}
 
@@ -938,6 +944,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
                 "editable_fields": [
                     "abuse_flagged", "following", "raw_body", "read", "title", "topic_id", "type", "voted"
                 ],
+                "response_count": 2,
             })
         )
 
@@ -946,7 +953,11 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
         thread_owner_user = UserFactory.create(password=self.password)
         CourseEnrollmentFactory.create(user=thread_owner_user, course_id=self.course.id)
         self.register_get_user_response(thread_owner_user)
-        self.register_thread({"username": thread_owner_user.username, "user_id": str(thread_owner_user.id)})
+        self.register_thread({
+            "username": thread_owner_user.username,
+            "user_id": str(thread_owner_user.id),
+            "resp_total": 2,
+        })
         self.register_read_response(self.user, "thread", "test_thread")
 
         request_data = {"read": True}
@@ -962,6 +973,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
                 "editable_fields": [
                     "abuse_flagged", "following", "read", "voted"
                 ],
+                "response_count": 2,
             })
         )
 


### PR DESCRIPTION
## [MA-2871](https://openedx.atlassian.net/browse/MA-2871)

Return 'response_count' in thread PATCH response.

### Testing
- [x] Unit

### Sandbox
- [x] [http://wjia-dapi.sandbox.edx.org/](http://wjia-dapi.sandbox.edx.org/)

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review:  @jcdyer 
- [x] Code review: @robrap  
 
### Post-review
- [x] Squash commits