### PR TITLE
Added missing local_resource_url method to StudioEditModuleRuntime

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -37,7 +37,7 @@ from contentstore.utils import is_self_paced
 from openedx.core.lib.gating import api as gating_api
 from edxmako.shortcuts import render_to_string
 from models.settings.course_grading import CourseGradingModel
-from openedx.core.lib.xblock_utils import wrap_xblock, request_token
+from openedx.core.lib.xblock_utils import wrap_xblock, request_token, xblock_local_resource_url
 from static_replace import replace_static_urls
 from student.auth import has_studio_write_access, has_studio_read_access
 from util.date_utils import get_default_time_display
@@ -245,6 +245,12 @@ class StudioEditModuleRuntime(object):
             if service_name == "studio_user_permissions":
                 return StudioPermissionsService(self._user)
         return None
+
+    def local_resource_url(self, *args, **kwargs):
+        """
+        Return URL of XBlock local resource.
+        """
+        return xblock_local_resource_url(*args, **kwargs)
 
 
 @require_http_methods(("GET"))


### PR DESCRIPTION
**Description:** This PR adds missing `local_resource_url` to `StudioEditModuleRuntime`. Outcome of [YONK-435](https://openedx.atlassian.net/browse/YONK-435). Primary goal is to reduce code drift between edx and edx-solutions forks.

**JIRA:** [YONK-435](https://openedx.atlassian.net/browse/YONK-435)

**Sandbox:** TBD - currently being provisioned
* LMS: http://pr13876.sandbox.opencraft.hosting/
* Studio: http://studio-pr13876.sandbox.opencraft.hosting/

**Related PR:** https://github.com/edx-solutions/edx-platform/pull/749

**Testing instructions:** See https://github.com/edx-solutions/edx-platform/pull/749 (section YONK-435)

**Reviewers:**
- [ ] @itsjeyd 
- [ ] edX TBD

**Author concerns:** The bug itself brings the following concern: looks like XBlock runtime's API might change unexpectedly, potentially breaking unsuspecting XBlocks. It might be good to document XBlock runtime API's and clearly mark methods/services always available in any runtime, optionally available (similar to `XBlock.wants` services) and those only occasionally being available (i.e. private runtime methods).

In this particular case `StudioEditModuleRuntime` relied on second part of `CombinedSystem` to provide `local_resorce_url` method, but for some reason it was not available.