### PR TITLE
Video download button does not appear in course (TNL-5769)

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -217,7 +217,9 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
         if self.edx_video_id and edxval_api:
             try:
                 val_profiles = ["youtube", "desktop_webm", "desktop_mp4"]
-                val_video_urls = edxval_api.get_urls_for_profiles(self.edx_video_id, val_profiles)
+
+                # strip edx_video_id to prevent ValVideoNotFoundError error if unwanted spaces are there. TNL-5769
+                val_video_urls = edxval_api.get_urls_for_profiles(self.edx_video_id.strip(), val_profiles)
 
                 # VAL will always give us the keys for the profiles we asked for, but
                 # if it doesn't have an encoded video entry for that Video + Profile, the


### PR DESCRIPTION
This PR is made in effort to resolve [TNL-5769](https://openedx.atlassian.net/browse/TNL-5769)

A brief summary and attempted solution is as follows:

- Despite having the Video Download Allowed set to True, the download button was not appearing for the video.
- Video ID was extended by '\t'(tab). This extra tab was causing a problem while fetching video by edxval api so download link was not rendering.
- The problem is resolved by stripping Video ID before sending it to edxval api method which fetches video from the database.
- A test is written to ensure any valid Video ID having unwanted space(s) before or after it should not cause any problem.

###  Sandbox
[Sandbox](https://studio-tnl-5769.sandbox.edx.org) is created to test this implementation.
### How to test?
Goto sandbox and edit any course and add a video component with the following properties
**Default Video URL**: _https://www.youtube.com/watch?v=-8d9jHTWhw0_
**Video Download Allowed**: _true_    
...