### PR TITLE
Dashboard Final Grade Updates

### DIFF
--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -19,7 +19,7 @@ import httpretty
 from markupsafe import escape
 from mock import Mock, patch
 from nose.plugins.attrib import attr
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locations import SlashSeparatedCourseKey, CourseLocator
 from provider.constants import CONFIDENTIAL
 from pyquery import PyQuery as pq
 import pytz
@@ -58,6 +58,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls
 log = logging.getLogger(__name__)
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @ddt.ddt
 class CourseEndingTest(TestCase):
     """Test things related to course endings: certificates, surveys, etc"""
@@ -75,9 +76,13 @@ class CourseEndingTest(TestCase):
 
     @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': False})
     def test_cert_info(self):
-        user = Mock(username="fred")
+        user = Mock(username="fred", id="1")
         survey_url = "http://a_survey.com"
-        course = Mock(end_of_course_survey_url=survey_url, certificates_display_behavior='end')
+        course = Mock(
+            end_of_course_survey_url=survey_url,
+            certificates_display_behavior='end',
+            id=CourseLocator(org="x", course="y", run="z"),
+        )
         course_mode = 'honor'
 
         self.assertEqual(
@@ -104,6 +109,24 @@ class CourseEndingTest(TestCase):
                 'can_unenroll': True,
             }
         )
+
+        cert_status = {'status': 'generating', 'grade': '67', 'mode': 'honor'}
+        with patch('lms.djangoapps.grades.new.course_grade.CourseGradeFactory.get_persisted') as patch_persisted_grade:
+            patch_persisted_grade.return_value = Mock(percent=100)
+            self.assertEqual(
+                _cert_info(user, course, cert_status, course_mode),
+                {
+                    'status': 'generating',
+                    'show_disabled_download_button': True,
+                    'show_download_url': False,
+                    'show_survey_button': True,
+                    'survey_url': survey_url,
+                    'grade': '100',
+                    'mode': 'honor',
+                    'linked_in_url': None,
+                    'can_unenroll': False,
+                }
+            )
 
         cert_status = {'status': 'generating', 'grade': '67', 'mode': 'honor'}
         self.assertEqual(
@@ -165,7 +188,7 @@ class CourseEndingTest(TestCase):
         )
 
         # Test a course that doesn't have a survey specified
-        course2 = Mock(end_of_course_survey_url=None)
+        course2 = Mock(end_of_course_survey_url=None, id=CourseLocator(org="a", course="b", run="c"))
         cert_status = {
             'status': 'notpassing', 'grade': '67',
             'download_url': download_url, 'mode': 'honor'

--- a/lms/djangoapps/grades/new/course_grade.py
+++ b/lms/djangoapps/grades/new/course_grade.py
@@ -240,6 +240,25 @@ class CourseGrade(object):
 
         return course_grade
 
+    @classmethod
+    def get_persisted_grade(cls, user, course):
+        """
+        Gets the persisted grade in the database, without checking
+        whether it is up-to-date with the course's grading policy.
+        For read use only.
+        """
+        try:
+            persistent_grade = PersistentCourseGrade.read_course_grade(user.id, course.id)
+        except PersistentCourseGrade.DoesNotExist:
+            return None
+        else:
+            course_grade = CourseGrade(user, course, None)  # no course structure needed
+            course_grade._percent = persistent_grade.percent_grade  # pylint: disable=protected-access
+            course_grade._letter_grade = persistent_grade.letter_grade  # pylint: disable=protected-access
+            course_grade.course_version = persistent_grade.course_version
+            course_grade.course_edited_timestamp = persistent_grade.course_edited_timestamp
+            return course_grade
+
     @staticmethod
     def _calc_percent(grade_value):
         """
@@ -328,17 +347,17 @@ class CourseGradeFactory(object):
         course_structure = get_course_blocks(self.student, course.location)
         self._compute_and_update_grade(course, course_structure)
 
-    def _compute_and_update_grade(self, course, course_structure, read_only=False):
+    def get_persisted(self, course):
         """
-        Freshly computes and updates the grade for the student and course.
-
-        If read_only is True, doesn't save any updates to the grades.
+        Returns the saved grade for the given course and student,
+        irrespective of whether the saved grade is up-to-date.
         """
-        course_grade = CourseGrade(self.student, course, course_structure)
-        course_grade.compute_and_update(read_only)
-        return course_grade
+        if not PersistentGradesEnabledFlag.feature_enabled(course.id):
+            return None
 
-    def _get_saved_grade(self, course, course_structure):  # pylint: disable=unused-argument
+        return CourseGrade.get_persisted_grade(self.student, course)
+
+    def _get_saved_grade(self, course, course_structure):
         """
         Returns the saved grade for the given course and student.
         """
@@ -350,6 +369,16 @@ class CourseGradeFactory(object):
             course,
             course_structure
         )
+
+    def _compute_and_update_grade(self, course, course_structure, read_only=False):
+        """
+        Freshly computes and updates the grade for the student and course.
+
+        If read_only is True, doesn't save any updates to the grades.
+        """
+        course_grade = CourseGrade(self.student, course, course_structure)
+        course_grade.compute_and_update(read_only)
+        return course_grade
 
     def _user_has_access_to_course(self, course_structure):
         """


### PR DESCRIPTION
# [TNL-5314](https://openedx.atlassian.net/browse/TNL-5314)

As discussed, the displayed grade now reads first from the `PersistedCourseGrade` table if able, then falls back to the previous behavior of using the value stored on the certificates table.

Reviewers:
- [ ] @sanfordstudent 
- [ ] One of @nasthagiri or @jcdyer 