### PR TITLE
Introduce a new AcceptanceTest base class

### DIFF
--- a/common/test/acceptance/performance/test_studio_performance.py
+++ b/common/test/acceptance/performance/test_studio_performance.py
@@ -1,14 +1,17 @@
 """
 Single page performance tests for Studio.
 """
-from bok_choy.web_app_test import WebAppTest, with_cache
+from bok_choy.web_app_test import with_cache
+from nose.plugins.attrib import attr
+
+from ..tests.helpers import AcceptanceTest
+
 from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
 from common.test.acceptance.pages.studio.overview import CourseOutlinePage
-from nose.plugins.attrib import attr
 
 
 @attr(har_mode='explicit')
-class StudioPagePerformanceTest(WebAppTest):
+class StudioPagePerformanceTest(AcceptanceTest):
     """
     Base class to capture studio performance with HTTP Archives.
 

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -408,7 +408,7 @@ def assert_opened_help_link_is_correct(test, url):
     """
     Asserts that url of browser when help link is clicked is correct.
     Arguments:
-        test (WebAppTest): test calling this method.
+        test (AcceptanceTest): test calling this method.
         url (str): url to verify.
     """
     test.browser.switch_to_window(test.browser.window_handles[-1])
@@ -690,7 +690,19 @@ class CollectedEventsDescription(object):
         return '\n\n'.join(message_lines)
 
 
-class UniqueCourseTest(WebAppTest):
+class AcceptanceTest(WebAppTest):
+    """
+    The base class of all acceptance tests.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(AcceptanceTest, self).__init__(*args, **kwargs)
+
+        # Use long messages so that failures show actual and expected values
+        self.longMessage = True  # pylint: disable=invalid-name
+
+
+class UniqueCourseTest(AcceptanceTest):
     """
     Test that provides a unique course ID.
     """
@@ -818,7 +830,7 @@ def assert_nav_help_link(test, page, href, signed_in=True):
     then clicks to ensure that help opens correctly.
 
     Arguments:
-    test (WebAppTest): Test object
+    test (AcceptanceTest): Test object
     page (PageObject): Page object to perform tests on.
     href (str): The help link which we expect to see when it is opened.
     signed_in (bool): Specifies whether user is logged in or not. (It effects the css)
@@ -843,7 +855,7 @@ def assert_side_bar_help_link(test, page, href, help_text, as_list_item=False, i
     then clicks to ensure that help opens correctly.
 
     Arguments:
-    test (WebAppTest): Test object
+    test (AcceptanceTest): Test object
     page (PageObject): Page object to perform tests on.
     href (str): The help link which we expect to see when it is opened.
     as_list_item (bool): Specifies whether help element is in one of the

--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -5,19 +5,17 @@ End-to-end tests for the Account Settings page.
 from datetime import datetime
 from unittest import skip
 
-from bok_choy.web_app_test import WebAppTest
 from bok_choy.page_object import XSS_INJECTION
-from flaky import flaky
 from nose.plugins.attrib import attr
 from pytz import timezone, utc
 
 from common.test.acceptance.pages.lms.account_settings import AccountSettingsPage
 from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
 from common.test.acceptance.pages.lms.dashboard import DashboardPage
-from common.test.acceptance.tests.helpers import EventsTestMixin
+from common.test.acceptance.tests.helpers import AcceptanceTest, EventsTestMixin
 
 
-class AccountSettingsTestMixin(EventsTestMixin, WebAppTest):
+class AccountSettingsTestMixin(EventsTestMixin, AcceptanceTest):
     """
     Mixin with helper methods to test the account settings page.
     """
@@ -91,7 +89,7 @@ class AccountSettingsTestMixin(EventsTestMixin, WebAppTest):
 
 
 @attr(shard=8)
-class DashboardMenuTest(AccountSettingsTestMixin, WebAppTest):
+class DashboardMenuTest(AccountSettingsTestMixin, AcceptanceTest):
     """
     Tests that the dashboard menu works correctly with the account settings page.
     """
@@ -114,7 +112,7 @@ class DashboardMenuTest(AccountSettingsTestMixin, WebAppTest):
 
 
 @attr(shard=8)
-class AccountSettingsPageTest(AccountSettingsTestMixin, WebAppTest):
+class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
     """
     Tests that verify behaviour of the Account Settings page.
     """
@@ -503,7 +501,7 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, WebAppTest):
 
 
 @attr('a11y')
-class AccountSettingsA11yTest(AccountSettingsTestMixin, WebAppTest):
+class AccountSettingsA11yTest(AccountSettingsTestMixin, AcceptanceTest):
     """
     Class to test account settings accessibility.
     """

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -4,7 +4,6 @@ End-to-end tests for Student's Profile Page.
 """
 from contextlib import contextmanager
 
-from bok_choy.web_app_test import WebAppTest
 from datetime import datetime
 from nose.plugins.attrib import attr
 
@@ -14,7 +13,7 @@ from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
 from common.test.acceptance.pages.lms.learner_profile import LearnerProfilePage
 from common.test.acceptance.pages.lms.dashboard import DashboardPage
 
-from common.test.acceptance.tests.helpers import EventsTestMixin
+from common.test.acceptance.tests.helpers import AcceptanceTest, EventsTestMixin
 
 
 class LearnerProfileTestMixin(EventsTestMixin):
@@ -181,7 +180,7 @@ class LearnerProfileTestMixin(EventsTestMixin):
 
 
 @attr(shard=4)
-class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
+class OwnLearnerProfilePageTest(LearnerProfileTestMixin, AcceptanceTest):
     """
     Tests that verify a student's own profile page.
     """
@@ -696,7 +695,7 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
 
 
 @attr(shard=4)
-class DifferentUserLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
+class DifferentUserLearnerProfilePageTest(LearnerProfileTestMixin, AcceptanceTest):
     """
     Tests that verify viewing the profile page of a different user.
     """
@@ -763,7 +762,7 @@ class DifferentUserLearnerProfilePageTest(LearnerProfileTestMixin, WebAppTest):
 
 
 @attr('a11y')
-class LearnerProfileA11yTest(LearnerProfileTestMixin, WebAppTest):
+class LearnerProfileA11yTest(LearnerProfileTestMixin, AcceptanceTest):
     """
     Class to test learner profile accessibility.
     """

--- a/common/test/acceptance/tests/lms/test_lms_course_discovery.py
+++ b/common/test/acceptance/tests/lms/test_lms_course_discovery.py
@@ -5,15 +5,14 @@ import datetime
 import json
 import uuid
 
-from bok_choy.web_app_test import WebAppTest
-from common.test.acceptance.tests.helpers import remove_file
+from common.test.acceptance.tests.helpers import AcceptanceTest, remove_file
 from common.test.acceptance.pages.common.logout import LogoutPage
 from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
 from common.test.acceptance.pages.lms.discovery import CourseDiscoveryPage
 from common.test.acceptance.fixtures.course import CourseFixture
 
 
-class CourseDiscoveryTest(WebAppTest):
+class CourseDiscoveryTest(AcceptanceTest):
     """
     Test searching for courses.
     """

--- a/common/test/acceptance/tests/lms/test_lms_dashboard_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard_search.py
@@ -4,8 +4,7 @@ Test dashboard search
 import os
 import json
 
-from bok_choy.web_app_test import WebAppTest
-from common.test.acceptance.tests.helpers import generate_course_key
+from common.test.acceptance.tests.helpers import AcceptanceTest, generate_course_key
 from common.test.acceptance.pages.common.logout import LogoutPage
 from common.test.acceptance.pages.common.utils import click_css
 from common.test.acceptance.pages.studio.utils import add_html_component, type_in_codemirror
@@ -16,7 +15,7 @@ from common.test.acceptance.pages.lms.dashboard_search import DashboardSearchPag
 from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 
 
-class DashboardSearchTest(WebAppTest):
+class DashboardSearchTest(AcceptanceTest):
     """
     Test dashboard search.
     """

--- a/common/test/acceptance/tests/lms/test_lms_index.py
+++ b/common/test/acceptance/tests/lms/test_lms_index.py
@@ -5,11 +5,11 @@ what students see @ edx.org because we redirect requests to a separate web appli
 """
 import datetime
 
-from bok_choy.web_app_test import WebAppTest
 from common.test.acceptance.pages.lms.index import IndexPage
+from common.test.acceptance.tests.helpers import AcceptanceTest
 
 
-class BaseLmsIndexTest(WebAppTest):
+class BaseLmsIndexTest(AcceptanceTest):
     """ Base test suite for the LMS Index (Home) page """
 
     def setUp(self):

--- a/common/test/acceptance/tests/lms/test_oauth2.py
+++ b/common/test/acceptance/tests/lms/test_oauth2.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 """Tests for OAuth2 permission delegation."""
-from common.test.acceptance.pages.lms.oauth2_confirmation import OAuth2Confirmation
-from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
-from bok_choy.web_app_test import WebAppTest
 
 from urlparse import urlparse, parse_qsl
 
+from common.test.acceptance.pages.lms.oauth2_confirmation import OAuth2Confirmation
+from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.tests.helpers import AcceptanceTest
 
-class OAuth2PermissionDelegationTests(WebAppTest):
+
+class OAuth2PermissionDelegationTests(AcceptanceTest):
     """
     Tests for acceptance/denial of permission delegation requests.
     """

--- a/common/test/acceptance/tests/studio/base_studio_test.py
+++ b/common/test/acceptance/tests/studio/base_studio_test.py
@@ -1,12 +1,11 @@
 """
 Base classes used by studio tests.
 """
-from bok_choy.web_app_test import WebAppTest
 from bok_choy.page_object import XSS_INJECTION
 from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
 from common.test.acceptance.fixtures.course import CourseFixture
 from common.test.acceptance.fixtures.library import LibraryFixture
-from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.tests.helpers import AcceptanceTest, UniqueCourseTest
 from common.test.acceptance.pages.studio.overview import CourseOutlinePage
 from common.test.acceptance.pages.studio.utils import verify_ordering
 
@@ -130,7 +129,7 @@ class ContainerBase(StudioCourseTest):
         verify_ordering(self, container, expected_ordering)
 
 
-class StudioLibraryTest(WebAppTest):
+class StudioLibraryTest(AcceptanceTest):
     """
     Base class for all Studio library tests.
     """

--- a/common/test/acceptance/tests/studio/test_studio_acid_xblock.py
+++ b/common/test/acceptance/tests/studio/test_studio_acid_xblock.py
@@ -1,15 +1,14 @@
 """
 Acceptance tests for Studio related to the acid xblock.
 """
-from bok_choy.web_app_test import WebAppTest
-
 from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
 from common.test.acceptance.pages.studio.overview import CourseOutlinePage
 from common.test.acceptance.pages.xblock.acid import AcidView
 from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.tests.helpers import AcceptanceTest
 
 
-class XBlockAcidBase(WebAppTest):
+class XBlockAcidBase(AcceptanceTest):
     """
     Base class for tests that verify that XBlock integration is working correctly
     """

--- a/common/test/acceptance/tests/studio/test_studio_course_create.py
+++ b/common/test/acceptance/tests/studio/test_studio_course_create.py
@@ -2,8 +2,9 @@
 Acceptance tests for course creation.
 """
 import uuid
-from bok_choy.web_app_test import WebAppTest
 from nose.plugins.attrib import attr
+
+from common.test.acceptance.tests.helpers import AcceptanceTest
 
 from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
 from common.test.acceptance.pages.studio.index import DashboardPage
@@ -11,7 +12,7 @@ from common.test.acceptance.pages.studio.overview import CourseOutlinePage
 
 
 @attr(shard=8)
-class CreateCourseTest(WebAppTest):
+class CreateCourseTest(AcceptanceTest):
     """
     Test that we can create a new course the studio home page.
     """

--- a/common/test/acceptance/tests/studio/test_studio_general.py
+++ b/common/test/acceptance/tests/studio/test_studio_general.py
@@ -3,8 +3,6 @@ Acceptance tests for Studio.
 """
 import uuid
 
-from bok_choy.web_app_test import WebAppTest
-
 from base_studio_test import StudioCourseTest
 from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
@@ -21,10 +19,10 @@ from common.test.acceptance.pages.studio.settings_graders import GradingPage
 from common.test.acceptance.pages.studio.signup import SignupPage
 from common.test.acceptance.pages.studio.textbook_upload import TextbookUploadPage
 from common.test.acceptance.pages.studio.users import CourseTeamPage
-from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.tests.helpers import AcceptanceTest, UniqueCourseTest
 
 
-class LoggedOutTest(WebAppTest):
+class LoggedOutTest(AcceptanceTest):
     """
     Smoke test for pages in Studio that are visible when logged out.
     """
@@ -42,7 +40,7 @@ class LoggedOutTest(WebAppTest):
             page.visit()
 
 
-class LoggedInPagesTest(WebAppTest):
+class LoggedInPagesTest(AcceptanceTest):
     """
     Verify the pages in Studio that you can get to when logged in and do not have a course yet.
     """

--- a/common/test/acceptance/tests/studio/test_studio_help.py
+++ b/common/test/acceptance/tests/studio/test_studio_help.py
@@ -3,7 +3,6 @@ Test the Studio help links.
 """
 
 from flaky import flaky
-from bok_choy.web_app_test import WebAppTest
 from unittest import skip
 
 from common.test.acceptance.fixtures.course import XBlockFixtureDesc
@@ -29,6 +28,7 @@ from common.test.acceptance.pages.studio.import_export import ExportCoursePage, 
 from common.test.acceptance.pages.studio.users import CourseTeamPage
 from common.test.acceptance.fixtures.programs import ProgramsConfigMixin
 from common.test.acceptance.tests.helpers import (
+    AcceptanceTest,
     assert_nav_help_link,
     assert_side_bar_help_link
 )
@@ -75,7 +75,7 @@ class StudioHelpTest(StudioCourseTest):
             )
 
 
-class SignInHelpTest(WebAppTest):
+class SignInHelpTest(AcceptanceTest):
     """
     Tests help links on 'Sign In' page
     """
@@ -107,7 +107,7 @@ class SignInHelpTest(WebAppTest):
         )
 
 
-class SignUpHelpTest(WebAppTest):
+class SignUpHelpTest(AcceptanceTest):
     """
     Tests help links on 'Sign Up' page.
     """
@@ -191,7 +191,7 @@ class HomeHelpTest(StudioCourseTest):
         )
 
 
-class NewCourseHelpTest(WebAppTest):
+class NewCourseHelpTest(AcceptanceTest):
     """
     Test help links while creating a new course.
     """
@@ -247,7 +247,7 @@ class NewCourseHelpTest(WebAppTest):
         )
 
 
-class NewLibraryHelpTest(WebAppTest):
+class NewLibraryHelpTest(AcceptanceTest):
     """
     Test help links while creating a new library
     """
@@ -303,7 +303,7 @@ class NewLibraryHelpTest(WebAppTest):
         )
 
 
-class LibraryTabHelpTest(WebAppTest):
+class LibraryTabHelpTest(AcceptanceTest):
     """
     Test help links on the library tab present at dashboard.
     """
@@ -517,7 +517,7 @@ class LibraryExportHelpTest(StudioLibraryTest):
         )
 
 
-class NewProgramHelpTest(ProgramsConfigMixin, WebAppTest):
+class NewProgramHelpTest(ProgramsConfigMixin, AcceptanceTest):
     """
     Test help links on a 'New Program' page
     """
@@ -1251,7 +1251,7 @@ class ToolsExportHelpTest(StudioCourseTest):
         )
 
 
-class StudioWelcomeHelpTest(WebAppTest):
+class StudioWelcomeHelpTest(AcceptanceTest):
     """
     Tests help link on 'Welcome' page ( User not logged in)
     """

--- a/common/test/acceptance/tests/studio/test_studio_home.py
+++ b/common/test/acceptance/tests/studio/test_studio_home.py
@@ -1,7 +1,6 @@
 """
 Acceptance tests for Home Page (My Courses / My Libraries).
 """
-from bok_choy.web_app_test import WebAppTest
 from flaky import flaky
 from opaque_keys.edx.locator import LibraryLocator
 from uuid import uuid4
@@ -13,13 +12,14 @@ from common.test.acceptance.pages.studio.library import LibraryEditPage
 from common.test.acceptance.pages.studio.index import DashboardPage, DashboardPageWithPrograms
 from common.test.acceptance.pages.lms.account_settings import AccountSettingsPage
 from common.test.acceptance.tests.helpers import (
+    AcceptanceTest,
     select_option_by_text,
     get_selected_option_text
 )
 from openedx.core.djangoapps.programs.tests import factories
 
 
-class CreateLibraryTest(WebAppTest):
+class CreateLibraryTest(AcceptanceTest):
     """
     Test that we can create a new content library on the studio home page.
     """
@@ -69,7 +69,7 @@ class CreateLibraryTest(WebAppTest):
         self.assertTrue(self.dashboard_page.has_library(name=name, org=org, number=number))
 
 
-class DashboardProgramsTabTest(ProgramsConfigMixin, CatalogConfigMixin, WebAppTest):
+class DashboardProgramsTabTest(ProgramsConfigMixin, CatalogConfigMixin, AcceptanceTest):
     """
     Test the programs tab on the studio home page.
     """
@@ -161,7 +161,7 @@ class DashboardProgramsTabTest(ProgramsConfigMixin, CatalogConfigMixin, WebAppTe
         self.assertFalse(self.dashboard_page.is_new_program_button_present())
 
 
-class StudioLanguageTest(WebAppTest):
+class StudioLanguageTest(AcceptanceTest):
     """ Test suite for the Studio Language """
     def setUp(self):
         super(StudioLanguageTest, self).setUp()


### PR DESCRIPTION
This PR refactors all acceptance tests to subclass a new class ``AcceptanceTest``. The intention is that this class can contain shared initialization for all edX acceptance tests. 

The only initialization for now is to set ``longMessage`` to true, so that all test failures will show actual and expected values. This is based upon the advice in the following Stack Overflow post:

http://stackoverflow.com/questions/4634625/python-can-unittest-display-expected-and-actual-values

@jzoldak @cpennington please review.

FYI @benpatterson 