### PR TITLE
New option 'ENROLL_ACTIVE_USERS_ONLY' that allows to enroll only active users

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1100,7 +1100,11 @@ def change_enrollment(request, check_access=True):
             try:
                 enroll_mode = CourseMode.auto_enroll_mode(course_id, available_modes)
                 if enroll_mode:
-                    CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
+                    if settings.FEATURES.get('ENROLL_ACTIVE_USERS_ONLY', False) and not user.is_active:
+                        CourseEnrollmentAllowed.objects.get_or_create(course_id=course_id, email=user.email,
+                                                                      auto_enroll=True)
+                    else:
+                        CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
             except Exception:  # pylint: disable=broad-except
                 return HttpResponseBadRequest(_("Could not enroll"))
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -99,6 +99,7 @@ FEATURES = {
     'ENABLE_MASQUERADE': True,  # allow course staff to change to student view of courseware
 
     'ENABLE_SYSADMIN_DASHBOARD': False,  # sysadmin dashboard, to see what courses are loaded, to delete & load courses
+    'ENROLL_ACTIVE_USERS_ONLY': False,
 
     'DISABLE_LOGIN_BUTTON': False,  # used in systems where login is automatic, eg MIT SSL
 


### PR DESCRIPTION
The current PR try to solve such problem:
Users can ignore the activation email and answer problems in the course. If they log out, they are then locked out of the course.
The new `FEATURES` option `ENROLL_ACTIVE_USERS_ONLY` allows to enroll users only after they confirm email address