### PR TITLE
Ability to hide register button

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -107,6 +107,9 @@ def login_and_registration_form(request, initial_mode="login"):
     if ext_auth_response is not None:
         return ext_auth_response
 
+    disable_registration_button = configuration_helpers.get_value('DISABLE_REGISTER_BUTTON',
+                                                                  settings.FEATURES['DISABLE_REGISTER_BUTTON'])
+
     # Otherwise, render the combined login/registration page
     context = {
         'data': {
@@ -124,6 +127,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'login_form_desc': json.loads(form_descriptions['login']),
             'registration_form_desc': json.loads(form_descriptions['registration']),
             'password_reset_form_desc': json.loads(form_descriptions['password_reset']),
+            'disable_registration_button': disable_registration_button,
         },
         'login_redirect_url': redirect_to,  # This gets added to the query string of the "Sign In" button in header
         'responsive': True,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -101,6 +101,7 @@ FEATURES = {
     'ENABLE_SYSADMIN_DASHBOARD': False,  # sysadmin dashboard, to see what courses are loaded, to delete & load courses
 
     'DISABLE_LOGIN_BUTTON': False,  # used in systems where login is automatic, eg MIT SSL
+    'DISABLE_REGISTER_BUTTON': False,  # used for cases if you want to register users only after push "enroll" button
 
     # extrernal access methods
     'AUTH_USE_OPENID': False,

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -52,6 +52,8 @@
 
                     this.thirdPartyAuthHint = options.third_party_auth_hint || null;
 
+                    this.disableRegistrationButton = options.disable_registration_button || false;
+
                     if (options.login_redirect_url) {
                     // Ensure that the next URL is internal for security reasons
                         if (! window.isExternal(options.login_redirect_url)) {
@@ -119,7 +121,8 @@
                             resetModel: this.resetModel,
                             thirdPartyAuth: this.thirdPartyAuth,
                             platformName: this.platformName,
-                            supportURL: this.supportURL
+                            supportURL: this.supportURL,
+                            disableRegistrationButton: this.disableRegistrationButton
                         });
 
                     // Listen for 'password-help' event to toggle sub-views

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -36,6 +36,7 @@
                     this.errorMessage = data.thirdPartyAuth.errorMessage || '';
                     this.platformName = data.platformName;
                     this.resetModel = data.resetModel;
+                    this.disableRegistrationButton = data.disableRegistrationButton || false;
                     this.supportURL = data.supportURL;
 
                     this.listenTo(this.model, 'sync', this.saveSuccess);
@@ -53,7 +54,8 @@
                             currentProvider: this.currentProvider,
                             providers: this.providers,
                             hasSecondaryProviders: this.hasSecondaryProviders,
-                            platformName: this.platformName
+                            platformName: this.platformName,
+                            disableRegistrationButton: this.disableRegistrationButton
                         }
                     }));
 

--- a/lms/templates/login-sidebar.html
+++ b/lms/templates/login-sidebar.html
@@ -1,6 +1,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 
 <header>
@@ -16,8 +17,10 @@ from django.core.urlresolvers import reverse
 % endif
 
 <div class="cta cta-help">
-  <h3>${_("Not Enrolled?")}</h3>
-  <p><a href="${reverse('register_user')}">${_("Sign up for {platform_name} today!").format(platform_name=platform_name)}</a></p>
+  % if not configuration_helpers.get_value('DISABLE_REGISTER_BUTTON', settings.FEATURES['DISABLE_REGISTER_BUTTON']):
+    <h3>${_("Not Enrolled?")}</h3>
+    <p><a href="${reverse('register_user')}">${_("Sign up for {platform_name} today!").format(platform_name=platform_name)}</a></p>
+  % endif
 
   ## Disable help unless the FAQ marketing link is enabled
   % if settings.MKTG_URL_LINK_MAP.get('FAQ'):

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext as _
 from context_processors import doc_url
 from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangolib.markup import HTML, Text
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # App that handles subdomain specific branding
 from branding import api as branding_api
@@ -151,9 +152,11 @@ site_status_msg = get_site_status_msg(course_id)
                 <a class="btn-neutral" href="${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}">${_("Register")}</a>
               </li>
             % else:
+              % if not configuration_helpers.get_value('DISABLE_REGISTER_BUTTON', settings.FEATURES['DISABLE_REGISTER_BUTTON']):
               <li class="item nav-global-04">
                 <a class="btn-neutral" href="/register${login_query()}">${_("Register")}</a>
               </li>
+              % endif
             % endif
           % endif
         </%block>

--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -53,6 +53,7 @@
     <% } %>
 </form>
 
+<% if ( !context.disableRegistrationButton ) { %>
 <div class="toggle-form">
     <div class="section-title">
         <h2>
@@ -61,3 +62,4 @@
     </div>
     <button class="nav-btn form-toggle" data-type="register"><%- gettext("Create an account") %></button>
 </div>
+<% } %>


### PR DESCRIPTION
Reason of this PR:
This will ensure that a student has to click "Enroll In" to register on the platform and automatically be enrolled in the course. Students coming to this page and clicking "Register" instead of "Enroll In" are not enrolled in the course they have been assigned and respond by panicking. 
The new `FEATURES` option `DISABLE_REGISTER_BUTTON` used for cases if you want to register users only after push "enroll" button