### PR TITLE
Add display_organization as field indexed

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -567,6 +567,7 @@ class CourseAboutSearchIndexer(object):
         AboutInfo("enrollment_start", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("enrollment_end", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("org", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
+        AboutInfo("display_organization", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("modes", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_MODE),
         AboutInfo("language", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
     ]

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -444,7 +444,9 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
     def _test_course_about_property_index(self, store):
         """ Test that informational properties in the course object end up in the course_info index """
         display_name = "Help, I need somebody!"
+        display_organization = "HogwartsX"
         self.course.display_name = display_name
+        self.course.display_organization = display_organization
         self.update_item(store, self.course)
         self.reindex_course(store)
         response = self.searcher.search(
@@ -453,6 +455,7 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
         )
         self.assertEqual(response["total"], 1)
         self.assertEqual(response["results"][0]["data"]["content"]["display_name"], display_name)
+        self.assertEqual(response["results"][0]["data"]["content"]["display_organization"], display_organization)
 
     def _test_course_about_store_index(self, store):
         """ Test that informational properties in the about store end up in the course_info index """


### PR DESCRIPTION
This add display_organization as indexed course property and allow to set 
`COURSE_DISCOVERY_FILTERS = ["display_organization", "language", "modes"] ` instead of `COURSE_DISCOVERY_FILTERS = ["org", "language", "modes"]`
