### PR TITLE
Add timestamps to Grade Report

### DIFF
--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -937,7 +937,7 @@ class ScoresClient(object):
     Eventually, this should read and write scores, but at the moment it only
     handles the read side of things.
     """
-    Score = namedtuple('Score', 'correct total')
+    Score = namedtuple('Score', 'correct total modified')
 
     def __init__(self, course_key, user_id):
         self.course_key = course_key
@@ -960,9 +960,9 @@ class ScoresClient(object):
         # attached to them (since old mongo identifiers don't include runs).
         # So we have to add that info back in before we put it into our lookup.
         self._locations_to_scores.update({
-            UsageKey.from_string(location).map_into_course(self.course_key): self.Score(correct, total)
-            for location, correct, total
-            in scores_qset.values_list('module_state_key', 'grade', 'max_grade')
+            UsageKey.from_string(location).map_into_course(self.course_key): self.Score(correct, total, modified)
+            for location, correct, total, modified
+            in scores_qset.values_list('module_state_key', 'grade', 'max_grade', 'modified')
         })
         self._has_fetched = True
 

--- a/lms/djangoapps/grades/scores.py
+++ b/lms/djangoapps/grades/scores.py
@@ -100,13 +100,20 @@ def get_score(submissions_scores, csm_scores, persisted_block, block):
     """
     weight = _get_weight_from_block(persisted_block, block)
 
+    last_answer_timestamp = None
+
     # Priority order for retrieving the scores:
     # submissions API -> CSM -> grades persisted block -> latest block content
-    raw_earned, raw_possible, weighted_earned, weighted_possible = (
-        _get_score_from_submissions(submissions_scores, block) or
-        _get_score_from_csm(csm_scores, block, weight) or
-        _get_score_from_persisted_or_latest_block(persisted_block, block, weight)
-    )
+    data = _get_score_from_submissions(submissions_scores, block)
+    if data:
+        raw_earned, raw_possible, weighted_earned, weighted_possible = data
+    else:
+        data = _get_score_from_csm(csm_scores, block, weight)
+        if data:
+            raw_earned, raw_possible, weighted_earned, weighted_possible, last_answer_timestamp = data
+        else:
+            data = _get_score_from_persisted_or_latest_block(persisted_block, block, weight)
+            raw_earned, raw_possible, weighted_earned, weighted_possible = data
 
     if weighted_possible is None or weighted_earned is None:
         return None
@@ -124,6 +131,7 @@ def get_score(submissions_scores, csm_scores, persisted_block, block):
             graded,
             display_name=display_name_with_default_escaped(block),
             module_id=block.location,
+            last_answer_timestamp=last_answer_timestamp
         )
 
 
@@ -177,7 +185,8 @@ def _get_score_from_csm(csm_scores, block, weight):
     if has_valid_score:
         raw_earned = score.correct if score.correct is not None else 0.0
         raw_possible = score.total
-        return (raw_earned, raw_possible) + weighted_score(raw_earned, raw_possible, weight)
+        last_timestamp = score.modified
+        return (raw_earned, raw_possible) + weighted_score(raw_earned, raw_possible, weight) + (last_timestamp,)
 
 
 def _get_score_from_persisted_or_latest_block(persisted_block, block, weight):


### PR DESCRIPTION
The Grade Report includes timestamp for column for each grade column in the report.
Timestamp in this context is the `datetime `of the last answer for any question in the graded block (taken as the max possible value from the `courseware_studentmodule.modified` field)

Reason for this PR
So that instructors can differentiate between students in different course module runs