### PR TITLE
Fix sporadic "'RequestFactory' object has no attribute 'build_absolute_uri'" python test error.

### DIFF
--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -14,21 +14,6 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from student.models import Registration
 
 
-def get_request_for_user(user):
-    """Create a request object for user."""
-    request = RequestFactory()
-    request.user = user
-    request.COOKIES = {}
-    request.META = {}
-    request.is_secure = lambda: True
-    request.get_host = lambda: "edx.org"
-    request.method = 'GET'
-    request.GET = {}
-    request.POST = {}
-    crum.set_current_request(request)
-    return request
-
-
 class LoginEnrollmentTestCase(TestCase):
     """
     Provides support for user creation,

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -23,9 +23,9 @@ from courseware.courses import (
     get_course_with_access,
 )
 from courseware.module_render import get_module_for_descriptor
-from courseware.tests.helpers import get_request_for_user
 from courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
+from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.courses import course_image_url
 from student.tests.factories import UserFactory
 from xmodule.modulestore.django import _get_modulestore_branch_setting, modulestore
@@ -276,7 +276,7 @@ class CoursesRenderTest(ModuleStoreTestCase):
         course_items = import_course_from_xml(store, self.user.id, TEST_DATA_DIR, ['toy'])
         course_key = course_items[0].id
         self.course = get_course_by_id(course_key)
-        self.request = get_request_for_user(UserFactory.create())
+        self.request = get_mock_request(UserFactory.create())
 
     def test_get_course_info_section_render(self):
         # Test render works okay

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -13,7 +13,6 @@ from courseware.module_render import toc_for_course, get_module, handle_xblock_c
 from courseware.tests.factories import UserFactory, InstructorFactory, StaffFactory
 from courseware.tests.helpers import (
     LoginEnrollmentTestCase,
-    get_request_for_user
 )
 from courseware.entrance_exams import (
     course_has_entrance_exam,
@@ -22,6 +21,7 @@ from courseware.entrance_exams import (
     user_can_skip_entrance_exam,
     user_has_passed_entrance_exam,
 )
+from openedx.core.djangolib.testing.utils import get_mock_request
 from student.models import CourseEnrollment
 from student.tests.factories import CourseEnrollmentFactory, AnonymousUserFactory
 from util.milestones_helpers import (
@@ -141,7 +141,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         self.course.entrance_exam_id = unicode(self.entrance_exam.scope_ids.usage_id)
 
         self.anonymous_user = AnonymousUserFactory()
-        self.request = get_request_for_user(UserFactory())
+        self.request = get_mock_request(UserFactory())
         modulestore().update_item(self.course, self.request.user.id)  # pylint: disable=no-member
 
         self.client.login(username=self.request.user.username, password="test")

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -12,9 +12,10 @@ from courseware.tabs import (
     get_course_tab_list, CoursewareTab, CourseInfoTab, ProgressTab,
     ExternalDiscussionCourseTab, ExternalLinkCourseTab
 )
-from courseware.tests.helpers import get_request_for_user, LoginEnrollmentTestCase
+from courseware.tests.helpers import LoginEnrollmentTestCase
 from courseware.tests.factories import InstructorFactory, StaffFactory
 from courseware.views.views import get_static_tab_contents, static_tab
+from openedx.core.djangolib.testing.utils import get_mock_request
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from util.milestones_helpers import (
@@ -255,14 +256,14 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
 
     def test_invalid_course_key(self):
         self.setup_user()
-        request = get_request_for_user(self.user)
+        request = get_mock_request(self.user)
         with self.assertRaises(Http404):
             static_tab(request, course_id='edX/toy', tab_slug='new_tab')
 
     def test_get_static_tab_contents(self):
         self.setup_user()
         course = get_course_by_id(self.course.id)
-        request = get_request_for_user(self.user)
+        request = get_mock_request(self.user)
         tab = xmodule_tabs.CourseTabList.get_tab_by_slug(course.tabs, 'new_tab')
 
         # Test render works okay
@@ -379,7 +380,7 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
             'description': 'Testing Courseware Tabs'
         }
         self.user.is_staff = False
-        request = get_request_for_user(self.user)
+        request = get_mock_request(self.user)
         self.course.entrance_exam_enabled = True
         self.course.entrance_exam_id = unicode(entrance_exam.location)
         milestone = add_milestone(milestone)
@@ -419,7 +420,7 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
         # log in again as student
         self.client.logout()
         self.login(self.email, self.password)
-        request = get_request_for_user(self.user)
+        request = get_mock_request(self.user)
         course_tab_list = get_course_tab_list(request, self.course)
         self.assertEqual(len(course_tab_list), 5)
 
@@ -432,7 +433,7 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
         self.client.logout()
         staff_user = StaffFactory(course_key=self.course.id)
         self.client.login(username=staff_user.username, password='test')
-        request = get_request_for_user(staff_user)
+        request = get_mock_request(staff_user)
         course_tab_list = get_course_tab_list(request, self.course)
         self.assertEqual(len(course_tab_list), 5)
 
@@ -474,7 +475,7 @@ class TextBookCourseViewsTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         Test that all textbooks tab links generating correctly.
         """
         type_to_reverse_name = {'textbook': 'book', 'pdftextbook': 'pdf_book', 'htmltextbook': 'html_book'}
-        request = get_request_for_user(self.user)
+        request = get_mock_request(self.user)
         course_tab_list = get_course_tab_list(request, self.course)
         num_of_textbooks_found = 0
         for tab in course_tab_list:
@@ -699,7 +700,7 @@ class CourseTabListTestCase(TabListTestCase):
         self.course.save()
 
         user = self.create_mock_user(is_authenticated=True, is_staff=False, is_enrolled=True)
-        request = get_request_for_user(user)
+        request = get_mock_request(user)
         course_tab_list = get_course_tab_list(request, self.course)
         name_list = [x.name for x in course_tab_list]
         self.assertIn('Static Tab Free', name_list)
@@ -709,7 +710,7 @@ class CourseTabListTestCase(TabListTestCase):
         self.client.logout()
         staff_user = StaffFactory(course_key=self.course.id)
         self.client.login(username=staff_user.username, password='test')
-        request = get_request_for_user(staff_user)
+        request = get_mock_request(staff_user)
         course_tab_list_staff = get_course_tab_list(request, self.course)
         name_list_staff = [x.name for x in course_tab_list_staff]
         self.assertIn('Static Tab Free', name_list_staff)

--- a/lms/djangoapps/gating/tests/test_api.py
+++ b/lms/djangoapps/gating/tests/test_api.py
@@ -91,7 +91,6 @@ class TestGetXBlockParent(GatingTestCase):
 
     def test_get_parent_with_category(self):
         """ Test test_get_parent_of_category """
-
         result = _get_xblock_parent(self.vert1, 'sequential')
         self.assertEqual(result.location, self.seq1.location)
         result = _get_xblock_parent(self.vert1, 'chapter')

--- a/lms/djangoapps/grades/tests/test_grades.py
+++ b/lms/djangoapps/grades/tests/test_grades.py
@@ -11,11 +11,10 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from courseware.model_data import set_score
-from courseware.tests.helpers import (
-    LoginEnrollmentTestCase,
-    get_request_for_user
-)
+from courseware.tests.helpers import LoginEnrollmentTestCase
+
 from lms.djangoapps.course_blocks.api import get_course_blocks
+from openedx.core.djangolib.testing.utils import get_mock_request
 from student.tests.factories import UserFactory
 from student.models import CourseEnrollment
 from xmodule.block_metadata_utils import display_name_with_default_escaped
@@ -185,7 +184,7 @@ class TestWeightedProblems(SharedModuleStoreTestCase):
     def setUp(self):
         super(TestWeightedProblems, self).setUp()
         self.user = UserFactory()
-        self.request = get_request_for_user(self.user)
+        self.request = get_mock_request(self.user)
 
     def _verify_grades(self, raw_earned, raw_possible, weight, expected_score):
         """
@@ -287,7 +286,7 @@ class TestScoreForModule(SharedModuleStoreTestCase):
         cls.m = ItemFactory.create(parent=cls.f, category="html", display_name="m")
         cls.n = ItemFactory.create(parent=cls.g, category="problem", display_name="n")
 
-        cls.request = get_request_for_user(UserFactory())
+        cls.request = get_mock_request(UserFactory())
         CourseEnrollment.enroll(cls.request.user, cls.course.id)
 
         answer_problem(cls.course, cls.request, cls.h, score=2, max_value=5)
@@ -449,7 +448,7 @@ class TestGetModuleScore(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
         """
         super(TestGetModuleScore, self).setUp()
 
-        self.request = get_request_for_user(UserFactory())
+        self.request = get_mock_request(UserFactory())
         self.client.login(username=self.request.user.username, password="test")
         CourseEnrollment.enroll(self.request.user, self.course.id)
 

--- a/lms/djangoapps/grades/tests/test_new.py
+++ b/lms/djangoapps/grades/tests/test_new.py
@@ -14,10 +14,10 @@ from mock import patch
 import pytz
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
-from courseware.tests.helpers import get_request_for_user
 from courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.grades.config.tests.utils import persistent_grades_feature_flags
+from openedx.core.djangolib.testing.utils import get_mock_request
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
@@ -70,7 +70,7 @@ class GradeTestBase(SharedModuleStoreTestCase):
 
     def setUp(self):
         super(GradeTestBase, self).setUp()
-        self.request = get_request_for_user(UserFactory())
+        self.request = get_mock_request(UserFactory())
         self.client.login(username=self.request.user.username, password="test")
         self.course_structure = get_course_blocks(self.request.user, self.course.location)
         self.subsection_grade_factory = SubsectionGradeFactory(self.request.user, self.course, self.course_structure)
@@ -321,7 +321,7 @@ class TestMultipleProblemTypesSubsectionScores(SharedModuleStoreTestCase):
         password = u'test'
         self.student = UserFactory.create(is_staff=False, username=u'test_student', password=password)
         self.client.login(username=self.student.username, password=password)
-        self.request = get_request_for_user(self.student)
+        self.request = get_mock_request(self.student)
         self.course_structure = get_course_blocks(self.student, self.course.location)
 
     @classmethod
@@ -411,7 +411,7 @@ class TestVariedMetadata(ProblemSubmissionTestMixin, ModuleStoreTestCase):
               </optionresponse>
             </problem>
         '''
-        self.request = get_request_for_user(UserFactory())
+        self.request = get_mock_request(UserFactory())
         self.client.login(username=self.request.user.username, password="test")
         CourseEnrollment.enroll(self.request.user, self.course.id)
         course_structure = get_course_blocks(self.request.user, self.course.location)
@@ -549,7 +549,7 @@ class TestCourseGradeLogging(ProblemSubmissionTestMixin, SharedModuleStoreTestCa
             display_name="test_problem_3",
             data=problem_xml
         )
-        self.request = get_request_for_user(UserFactory())
+        self.request = get_mock_request(UserFactory())
         self.client.login(username=self.request.user.username, password="test")
         self.course_structure = get_course_blocks(self.request.user, self.course.location)
         self.subsection_grade_factory = SubsectionGradeFactory(self.request.user, self.course, self.course_structure)

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -3,31 +3,24 @@
 Unit tests for instructor.enrollment methods.
 """
 
-import json
-import mock
-from mock import patch
 from abc import ABCMeta
-from courseware.models import StudentModule
-from courseware.tests.helpers import get_request_for_user
+import json
+
 from django.conf import settings
 from django.utils.translation import get_language
 from django.utils.translation import override as override_language
+import mock
+from mock import patch
 from nose.plugins.attrib import attr
-from ccx_keys.locator import CCXLocator
-from student.tests.factories import UserFactory
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from ccx_keys.locator import CCXLocator
+from courseware.models import StudentModule
 from grades.new.subsection_grade import SubsectionGradeFactory
 from grades.tests.utils import answer_problem
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 from lms.djangoapps.course_blocks.api import get_course_blocks
-from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
-from student.models import CourseEnrollment, CourseEnrollmentAllowed
-from student.roles import CourseCcxCoachRole
-from student.tests.factories import (
-    AdminFactory
-)
 from lms.djangoapps.instructor.enrollment import (
     EmailEnrollmentState,
     enroll_email,
@@ -37,11 +30,14 @@ from lms.djangoapps.instructor.enrollment import (
     unenroll_email,
     render_message_to_string,
 )
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
-
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, get_mock_request
+from student.models import CourseEnrollment, CourseEnrollmentAllowed
+from student.roles import CourseCcxCoachRole
+from student.tests.factories import AdminFactory, UserFactory
 from submissions import api as sub_api
 from student.models import anonymous_id_for_user
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase, TEST_DATA_SPLIT_MODULESTORE
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
 @attr(shard=1)
@@ -536,7 +532,7 @@ class TestStudentModuleGrading(SharedModuleStoreTestCase):
             display_name="Test Problem",
             data=problem_xml
         )
-        cls.request = get_request_for_user(UserFactory())
+        cls.request = get_mock_request(UserFactory())
         cls.user = cls.request.user
 
     def _get_subsection_grade_and_verify(self, all_earned, all_possible, graded_earned, graded_possible):

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -19,6 +19,7 @@ from capa.tests.response_xml_factory import OptionResponseXMLFactory
 from courseware.model_data import StudentModule
 from courseware.tests.tests import LoginEnrollmentTestCase
 from opaque_keys.edx.locations import Location, SlashSeparatedCourseKey
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.core.lib.url_utils import quote_slashes
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum
@@ -45,7 +46,7 @@ OPTION_1 = 'Option 1'
 OPTION_2 = 'Option 2'
 
 
-class InstructorTaskTestCase(TestCase):
+class InstructorTaskTestCase(CacheIsolationTestCase):
     """
     Tests API and view methods that involve the reporting of status for background tasks.
     """

--- a/lms/djangoapps/mobile_api/tests/test_milestones.py
+++ b/lms/djangoapps/mobile_api/tests/test_milestones.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from mock import patch
 
 from courseware.access_response import MilestoneError
-from courseware.tests.helpers import get_request_for_user
 from courseware.tests.test_entrance_exam import answer_entrance_exam_problem, add_entrance_exam_milestone
+from openedx.core.djangolib.testing.utils import get_mock_request
 from util.milestones_helpers import (
     add_prerequisite_course,
     fulfill_course_milestone,
@@ -115,7 +115,7 @@ class MobileAPIMilestonesMixin(object):
 
     def _pass_entrance_exam(self):
         """ Helper function to pass the entrance exam """
-        request = get_request_for_user(self.user)
+        request = get_mock_request(self.user)
         answer_entrance_exam_problem(self.course, request, self.problem_1)
 
     def _verify_unfulfilled_milestone_response(self):

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -359,13 +359,15 @@ class TestMasqueradedGroup(StaffMasqueradeTestCase):
         }
         request = self._create_mock_json_request(
             self.test_user,
-            body=json.dumps(request_json),
+            data=request_json,
             session=self.session
         )
-        handle_ajax(request, unicode(self.course.id))
+        response = handle_ajax(request, unicode(self.course.id))
+        # pylint has issues analyzing this class (maybe due to circular imports?)
+        self.assertEquals(response.status_code, 200)  # pylint: disable=no-member
 
         # Now setup the masquerade for the test user
-        setup_masquerade(request, self.test_user, True)
+        setup_masquerade(request, self.course.id, True)
         scheme = self.user_partition.scheme
         self.assertEqual(
             scheme.get_group_for_user(self.course.id, self.test_user, self.user_partition),

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -14,21 +14,12 @@ from django.test.utils import override_settings
 from mock import patch
 from nose.plugins.attrib import attr
 
+from openedx.core.djangolib.testing.utils import get_mock_request
+
 from student.tests.factories import UserFactory
 
 from ..middleware import SafeSessionMiddleware, SafeCookieData
 from .test_utils import TestSafeSessionsLogMixin
-
-
-def create_mock_request():
-    """
-    Creates and returns a mock request object for testing.
-    """
-    request = RequestFactory()
-    request.COOKIES = {}
-    request.META = {}
-    request.path = '/'
-    return request
 
 
 @attr(shard=2)
@@ -39,7 +30,7 @@ class TestSafeSessionProcessRequest(TestSafeSessionsLogMixin, TestCase):
     def setUp(self):
         super(TestSafeSessionProcessRequest, self).setUp()
         self.user = UserFactory.create()
-        self.request = create_mock_request()
+        self.request = get_mock_request()
 
     def assert_response(self, safe_cookie_data=None, success=True):
         """
@@ -141,7 +132,7 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, TestCase):
     def setUp(self):
         super(TestSafeSessionProcessResponse, self).setUp()
         self.user = UserFactory.create()
-        self.request = create_mock_request()
+        self.request = get_mock_request()
         self.request.session = {}
         self.client.response = HttpResponse()
         self.client.response.cookies = SimpleCookie()
@@ -245,7 +236,7 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, TestCase):
     def setUp(self):
         super(TestSafeSessionMiddleware, self).setUp()
         self.user = UserFactory.create()
-        self.request = create_mock_request()
+        self.request = get_mock_request()
         self.client.response = HttpResponse()
         self.client.response.cookies = SimpleCookie()
 

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
@@ -11,10 +11,10 @@ from pytz import common_timezones, utc
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import TestCase
 from django.test.utils import override_settings
 from dateutil.parser import parse as parse_datetime
 
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.core.lib.time_zone_utils import get_display_time_zone
 from student.tests.factories import UserFactory
 
@@ -43,7 +43,7 @@ from ...preferences.api import (
 
 @attr(shard=2)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
-class TestPreferenceAPI(TestCase):
+class TestPreferenceAPI(CacheIsolationTestCase):
     """
     These tests specifically cover the parts of the API methods that are not covered by test_views.py.
     This includes the specific types of error raised, and default behavior when optional arguments
@@ -441,7 +441,7 @@ class UpdateEmailOptInTests(ModuleStoreTestCase):
 
 
 @ddt.ddt
-class CountryTimeZoneTest(TestCase):
+class CountryTimeZoneTest(CacheIsolationTestCase):
     """
     Test cases to validate country code api functionality
     """

--- a/openedx/core/djangolib/testing/tests/test_utils.py
+++ b/openedx/core/djangolib/testing/tests/test_utils.py
@@ -1,0 +1,29 @@
+"""
+Test that testing utils do what they say.
+"""
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.http.request import HttpRequest
+from django.test import TestCase
+
+from ..utils import get_mock_request
+
+USER_MODEL = get_user_model()
+
+
+class TestGetMockRequest(TestCase):
+    """
+    Validate the behavior of get_mock_request
+    """
+    def test_mock_request_is_request(self):
+        request = get_mock_request(USER_MODEL())
+        self.assertIsInstance(request, HttpRequest)
+
+    def test_user_is_attached_to_mock_request(self):
+        user = USER_MODEL()
+        request = get_mock_request(user)
+        self.assertIs(request.user, user)
+
+    def test_mock_request_without_user(self):
+        request = get_mock_request()
+        self.assertIsInstance(request.user, AnonymousUser)

--- a/openedx/core/djangolib/testing/utils.py
+++ b/openedx/core/djangolib/testing/utils.py
@@ -10,9 +10,11 @@ Utility classes for testing django applications.
 
 import copy
 
+import crum
 from django import db
+from django.contrib.auth.models import AnonymousUser
 from django.core.cache import caches
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.conf import settings
 from django.contrib import sites
 
@@ -158,3 +160,18 @@ class NoseDatabaseIsolation(Plugin):
         """
         for db_ in db.connections.all():
             db_.close()
+
+
+def get_mock_request(user=None):
+    """
+    Create a request object for the user, if specified.
+    """
+    request = RequestFactory().get('/')
+    if user is not None:
+        request.user = user
+    else:
+        request.user = AnonymousUser()
+    request.is_secure = lambda: True
+    request.get_host = lambda: "edx.org"
+    crum.set_current_request(request)
+    return request


### PR DESCRIPTION
## [TNL-5811: Flaky python test: TestPreferenceAPI.test_get_user_preferences](https://openedx.atlassian.net/browse/TNL-5811)

I was able to trace this back to a couple functions that tried to wrap mock Request creation into a simple interface, but returned RequestFactory objects, rather than HttpRequest objects.  One looked like a slightly modified copypasta of the other.  I centralized them into one common, sensible location (in the first commit), and refactored all usages of the old functions (in the second commit).

This overlaps with Cale's #13835
### Reviewers:

- [x] @cpennington 
- [x] @tobz 