### PR TITLE
Bug fix: collect test results when running in multiprocess mode.

### DIFF
--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -168,6 +168,9 @@ case "$TEST_SUITE" in
         cp -R $HOME/firefox/ firefox/
         export SELENIUM_FIREFOX_PATH=firefox/firefox
 
+        # If we are using more than one thread at once (represented by the
+        # NUMBER_OF_BOKCHOY_THREADS variable), then we must use xunitmp
+        # in order to be able to represent the test results from multiple threads.
         case "$NUMBER_OF_BOKCHOY_THREADS" in
 
             "1"|1)

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -168,7 +168,18 @@ case "$TEST_SUITE" in
         cp -R $HOME/firefox/ firefox/
         export SELENIUM_FIREFOX_PATH=firefox/firefox
 
-        PAVER_ARGS="-n $NUMBER_OF_BOKCHOY_THREADS --with-flaky --with-xunit"
+        case "$NUMBER_OF_BOKCHOY_THREADS" in
+
+            "1"|1)
+                XUNIT_ARG=" --with-xunit"
+                ;;
+
+            *)
+                XUNIT_ARG=" --with-xunitmp"
+                ;;
+        esac
+
+        PAVER_ARGS="-n $NUMBER_OF_BOKCHOY_THREADS --with-flaky $XUNIT_ARG"
 
         case "$SHARD" in
 


### PR DESCRIPTION
This PR will allow us to run bok-choy in multiprocess mode on Jenkins, with reporting test results.

Currently, if we run in multiprocess mode, `paver` will interpret the environment variable and run nosetests in multiprocess mode for bok-choy, but no test results will be reported because --with-xunit does not work when run in multiprocess mode. Likewise last week we discovered that we cannot use --with-xunitmp when running in a single process.

So, we need to use xunitmp when running in multiprocessing mode, and xunit when running with a single process. That's handled by the environment variable and therefore the logic hinges on that setting.