### PR TITLE
Allow multiple values for a single tag

### DIFF
--- a/cms/lib/xblock/tagging/admin.py
+++ b/cms/lib/xblock/tagging/admin.py
@@ -1,0 +1,20 @@
+"""
+Admin registration for tags models
+"""
+from django.contrib import admin
+from .models import TagCategories, TagAvailableValues
+
+
+class TagCategoriesAdmin(admin.ModelAdmin):
+    """Admin for TagCategories"""
+    search_fields = ('name', 'title')
+    list_display = ('id', 'name', 'title')
+
+
+class TagAvailableValuesAdmin(admin.ModelAdmin):
+    """Admin for TagAvailableValues"""
+    list_display = ('id', 'category', 'value')
+
+
+admin.site.register(TagCategories, TagCategoriesAdmin)
+admin.site.register(TagAvailableValues, TagAvailableValuesAdmin)

--- a/cms/lib/xblock/tagging/migrations/0002_auto_20170116_1541.py
+++ b/cms/lib/xblock/tagging/migrations/0002_auto_20170116_1541.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tagging', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='tagavailablevalues',
+            options={'ordering': ('id',), 'verbose_name': 'available tag value'},
+        ),
+        migrations.AlterModelOptions(
+            name='tagcategories',
+            options={'ordering': ('title',), 'verbose_name': 'tag category', 'verbose_name_plural': 'tag categories'},
+        ),
+    ]

--- a/cms/lib/xblock/tagging/models.py
+++ b/cms/lib/xblock/tagging/models.py
@@ -14,6 +14,8 @@ class TagCategories(models.Model):
     class Meta(object):
         app_label = "tagging"
         ordering = ('title',)
+        verbose_name = "tag category"
+        verbose_name_plural = "tag categories"
 
     def __unicode__(self):
         return "[TagCategories] {}: {}".format(self.name, self.title)
@@ -35,6 +37,7 @@ class TagAvailableValues(models.Model):
     class Meta(object):
         app_label = "tagging"
         ordering = ('id',)
+        verbose_name = "available tag value"
 
     def __unicode__(self):
         return "[TagAvailableValues] {}: {}".format(self.category, self.value)

--- a/cms/lib/xblock/tagging/test.py
+++ b/cms/lib/xblock/tagging/test.py
@@ -3,6 +3,7 @@ Tests for the Studio Tagging XBlockAside
 """
 
 import ddt
+import json
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -38,6 +39,7 @@ class StructuredTagsAsideTestCase(ModuleStoreTestCase):
         self.aside_name = 'tagging_aside'
         self.aside_tag_dif = 'difficulty'
         self.aside_tag_dif_value = 'Hard'
+        self.aside_tag_dif_value2 = 'Easy'
         self.aside_tag_lo = 'learning_outcome'
 
         course = CourseFactory.create(default_store=ModuleStoreEnum.Type.split)
@@ -152,27 +154,27 @@ class StructuredTagsAsideTestCase(ModuleStoreTestCase):
         self.assertEquals(div_node.get('data-runtime-version'), '1')
         self.assertIn('xblock_asides-v1', div_node.get('class'))
 
-        select_nodes = div_node.xpath('div/select')
+        select_nodes = div_node.xpath("div//select[@multiple='multiple']")
         self.assertEquals(len(select_nodes), 2)
 
         select_node1 = select_nodes[0]
         self.assertEquals(select_node1.get('name'), self.aside_tag_dif)
 
         option_nodes1 = select_node1.xpath('option')
-        self.assertEquals(len(option_nodes1), 4)
+        self.assertEquals(len(option_nodes1), 3)
 
         option_values1 = [opt_elem.text for opt_elem in option_nodes1]
-        self.assertEquals(option_values1, ['Not selected', 'Easy', 'Medium', 'Hard'])
+        self.assertEquals(option_values1, ['Easy', 'Hard', 'Medium'])
 
         select_node2 = select_nodes[1]
         self.assertEquals(select_node2.get('name'), self.aside_tag_lo)
+        self.assertEquals(select_node2.get('multiple'), 'multiple')
 
         option_nodes2 = select_node2.xpath('option')
-        self.assertEquals(len(option_nodes2), 4)
+        self.assertEquals(len(option_nodes2), 3)
 
         option_values2 = [opt_elem.text for opt_elem in option_nodes2 if opt_elem.text]
-        self.assertEquals(option_values2, ['Not selected', 'Learned nothing',
-                                           'Learned a few things', 'Learned everything'])
+        self.assertEquals(option_values2, ['Learned a few things', 'Learned everything', 'Learned nothing'])
 
         # Now ensure the acid_aside is not in the result
         self.assertNotRegexpMatches(problem_html, r"data-block-type=[\"\']acid_aside[\"\']")
@@ -195,27 +197,44 @@ class StructuredTagsAsideTestCase(ModuleStoreTestCase):
         client = AjaxEnabledTestClient()
         client.login(username=self.user.username, password=self.user_password)
 
-        response = client.post(path=handler_url, data={})
+        response = client.post(handler_url, json.dumps({}), content_type="application/json")
         self.assertEqual(response.status_code, 400)
 
-        response = client.post(path=handler_url, data={'tag': 'undefined_tag:undefined'})
+        response = client.post(handler_url, json.dumps({'undefined_tag': ['undefined1', 'undefined2']}),
+                               content_type="application/json")
         self.assertEqual(response.status_code, 400)
 
-        val = '%s:undefined' % self.aside_tag_dif
-        response = client.post(path=handler_url, data={'tag': val})
+        response = client.post(handler_url, json.dumps({self.aside_tag_dif: ['undefined1', 'undefined2']}),
+                               content_type="application/json")
         self.assertEqual(response.status_code, 400)
 
-        val = '%s:%s' % (self.aside_tag_dif, self.aside_tag_dif_value)
-        response = client.post(path=handler_url, data={'tag': val})
+        def _test_helper_func(problem_location):
+            """
+            Helper function
+            """
+            problem = modulestore().get_item(problem_location)
+            asides = problem.runtime.get_asides(problem)
+            tag_aside = None
+            for aside in asides:
+                if isinstance(aside, StructuredTagsAside):
+                    tag_aside = aside
+                    break
+            return tag_aside
+
+        response = client.post(handler_url, json.dumps({self.aside_tag_dif: [self.aside_tag_dif_value]}),
+                               content_type="application/json")
         self.assertEqual(response.status_code, 200)
 
-        problem = modulestore().get_item(self.problem.location)
-        asides = problem.runtime.get_asides(problem)
-        tag_aside = None
-        for aside in asides:
-            if isinstance(aside, StructuredTagsAside):
-                tag_aside = aside
-                break
-
+        tag_aside = _test_helper_func(self.problem.location)
         self.assertIsNotNone(tag_aside, "Necessary StructuredTagsAside object isn't found")
-        self.assertEqual(tag_aside.saved_tags[self.aside_tag_dif], self.aside_tag_dif_value)
+        self.assertEqual(tag_aside.saved_tags[self.aside_tag_dif], [self.aside_tag_dif_value])
+
+        response = client.post(handler_url, json.dumps({self.aside_tag_dif: [self.aside_tag_dif_value,
+                                                                             self.aside_tag_dif_value2]}),
+                               content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+
+        tag_aside = _test_helper_func(self.problem.location)
+        self.assertIsNotNone(tag_aside, "Necessary StructuredTagsAside object isn't found")
+        self.assertEqual(tag_aside.saved_tags[self.aside_tag_dif], [self.aside_tag_dif_value,
+                                                                    self.aside_tag_dif_value2])

--- a/cms/static/js/xblock_asides/structured_tags.js
+++ b/cms/static/js/xblock_asides/structured_tags.js
@@ -3,29 +3,36 @@
 
     function StructuredTagsView(runtime, element) {
         var $element = $(element);
+        var saveTagsInProgress = false;
 
-        $element.find('select').each(function() {
-            var loader = this;
-            var sts = $(this).attr('structured-tags-select-init');
+        $($element).find('.save_tags').click(function(e) {
+            var dataToPost = {};
+            if (!saveTagsInProgress) {
+                saveTagsInProgress = true;
 
-            if (typeof sts === typeof undefined || sts === false) {
-                $(this).attr('structured-tags-select-init', 1);
-                $(this).change(function(e) {
-                    e.preventDefault();
-                    var selectedKey = $(loader).find('option:selected').val();
+                $element.find('select').each(function() {
+                    dataToPost[$(this).attr('name')] = $(this).val();
+                });
+
+                e.preventDefault();
+                runtime.notify('save', {
+                    state: 'start',
+                    element: element,
+                    message: gettext('Updating Tags')
+                });
+
+                $.ajax({
+                    type: 'POST',
+                    url: runtime.handlerUrl(element, 'save_tags'),
+                    data: JSON.stringify(dataToPost),
+                    dataType: 'json',
+                    contentType: 'application/json; charset=utf-8'
+                }).always(function() {
                     runtime.notify('save', {
-                        state: 'start',
-                        element: element,
-                        message: gettext('Updating Tags')
+                        state: 'end',
+                        element: element
                     });
-                    $.post(runtime.handlerUrl(element, 'save_tags'), {
-                        'tag': $(loader).attr('name') + ':' + selectedKey
-                    }).done(function() {
-                        runtime.notify('save', {
-                            state: 'end',
-                            element: element
-                        });
-                    });
+                    saveTagsInProgress = false;
                 });
             }
         });

--- a/cms/templates/structured_tags_block.html
+++ b/cms/templates/structured_tags_block.html
@@ -1,16 +1,33 @@
 <div class="xblock-render" class="studio-xblock-wrapper">
-    % for tag in tags:
-    <label for="tags_${tag['key']}_${block_location}">${tag['title']}</label>:
-    <select id="tags_${tag['key']}_${block_location}" name="${tag['key']}">
-        <option value="" ${'' if tag['current_value'] else 'selected=""'}>Not selected</option>
-        % for v in tag['values']:
-            <%
-                selected = ''
-                if v == tag['current_value']:
-                    selected = 'selected'
-            %>
-            <option value="${v}" ${selected}>${v}</option>
+    <div class="wrapper">
+        % for tag in tags:
+        <div class="wrapper-content left">
+            <div><label for="tags_${tag['key']}_${block_location}">${tag['title']}</label>:</div>
+            <div>
+            <select id="tags_${tag['key']}_${block_location}" name="${tag['key']}" multiple="multiple">
+                % for v in tag['values']:
+                    <%
+                        selected = ''
+                        if v in tag['current_values']:
+                            selected = 'selected'
+                    %>
+                    <option value="${v}" ${selected}>${v}</option>
+                % endfor
+            </select>
+            </div>
+        </div>
         % endfor
-    </select>
-    % endfor
+
+        % if tags_count > 0:
+        <div class="wrapper-content left">
+            <div class="outline-content">
+                <div class="add-item">
+                    <a href="javascript: void(0);" class="button button-new save_tags" title="Save tags">
+                        <span class="action-button-text">Save tags</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+        % endif
+    </div>
 </div>


### PR DESCRIPTION
This task is continuation my work on tagging xblock aside.
This new feature gives ability to mark some problem with multiple values for each tag:

![multi_tags](https://cloud.githubusercontent.com/assets/1876893/19951879/06053f46-a172-11e6-98b5-fd8ce2ee4161.jpeg)

@cpennington please take a look