### PR TITLE
Library creation test is not flaky anymore

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_home.py
+++ b/common/test/acceptance/tests/studio/test_studio_home.py
@@ -33,7 +33,6 @@ class CreateLibraryTest(WebAppTest):
         self.auth_page = AutoAuthPage(self.browser, staff=True)
         self.dashboard_page = DashboardPage(self.browser)
 
-    @flaky  # TODO: SOL-430
     def test_create_library(self):
         """
         From the home page:


### PR DESCRIPTION
**Description:** This PR removes `flaky` mark from test_create_library test, as it's not seem to be flaky anymore.

**JIRA:** [SOL-2070](https://openedx.atlassian.net/browse/SOL-2070)

**Testing instructions:** Run bok choy test suite a couple of times.

**Sandbox** won't be useful anyway.

**Merge deadline:** Nov 7th.

**Reviewers:**
- [x] @bdero 
- [x] @cahrens 