### PR TITLE
add cookie consent feature flag and popup banner

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -367,6 +367,10 @@ FEATURES = {
 
     # Allow public account creation
     'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
+
+    # Enable footer banner for cookie consent.
+    # See https://cookieconsent.insites.com/ for more.
+    'ENABLE_COOKIE_CONSENT': False,
 }
 
 # Ignore static asset files on import which match this pattern

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -83,3 +83,7 @@
     <link rel="stylesheet" type="text/css" href="${url}"></link>
   % endfor
 % endif
+
+% if settings.FEATURES.get('ENABLE_COOKIE_CONSENT', False):
+  <%include file="widgets/cookie-consent.html" />
+% endif

--- a/lms/templates/widgets/cookie-consent.html
+++ b/lms/templates/widgets/cookie-consent.html
@@ -1,0 +1,46 @@
+<!-- Cookie Consent -->
+<%page expression_filter="h"/>
+<%! from django.utils.translation import ugettext as _ %>
+<%namespace name='static' file='../static_content.html'/>
+ 
+<link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.1/cookieconsent.min.css" />
+<script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.1/cookieconsent.min.js"></script>
+
+<script>
+window.addEventListener("load", function(){
+  window.cookieconsent.initialise({
+
+    window: '<div dir="${static.dir_rtl()}" role="dialog" tabindex="-1" id="cookiepopup" aria-label="cookieconsent" class="cc-window {{classes}}"><!--googleoff: all-->{{children}}<!--googleon: all--></div>',
+
+    palette:{
+      popup: {background: "#323538", text: "#ffffff"},
+      button: {background: "#005379", text: "#ffffff"},
+    },
+    "content": {
+      "message": "${_('This website uses cookies to ensure you get the best experience on our website.')}",
+      "dismiss": "${_('Got it!')}",
+      "link": "${_('Learn more')}",
+    },
+    theme: "classic",
+    "elements": {
+        "dismiss": '<a aria-label="dismiss cookie message" id="dismiss" role=button tabindex="2" class="cc-btn cc-dismiss:focus">{{dismiss}}</a>',
+    },
+    "position": "bottom",
+    "static": "true"
+  },
+  function(popup){
+
+    $(".cc-window").on('keydown', function(event) {
+      if (event.keyCode == 27 ){
+        popup.close();
+      } 
+    });
+
+    $("#dismiss").on('keydown', function(event) {
+      if (event.keyCode == 13 || event.keyCode == 32 ) {
+        popup.onButtonClick(event);
+      }
+    });  
+  });
+});
+</script>


### PR DESCRIPTION
Added an ENABLE_COOKIE_CONSENT feature flag to provide for [The Cookie Law](https://www.cookielaw.org/the-cookie-law/) by showing a banner using [this](https://cookieconsent.insites.com/) service. Not so applicable in the US I think, but from the conference I remember a lot of UK/EU based organizations that might need this. 