### PR TITLE
handle refund notification message formatting when translated with un…

### DIFF
--- a/lms/djangoapps/commerce/signals.py
+++ b/lms/djangoapps/commerce/signals.py
@@ -1,19 +1,21 @@
 """
 Signal handling functions for use with external commerce service.
 """
+from __future__ import unicode_literals
+
 import json
 import logging
 from urlparse import urljoin
 
+import requests
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.dispatch import receiver
 from django.utils.translation import ugettext as _
 from edx_rest_api_client.exceptions import HttpClientError
-import requests
-
 from request_cache.middleware import RequestCache
 from student.models import UNENROLL_DONE
+
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client, is_commerce_service_configured
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming import helpers as theming_helpers
@@ -182,7 +184,7 @@ def create_zendesk_ticket(requester_name, requester_email, subject, body, tags=N
 
         # Check for HTTP codes other than 201 (Created)
         if response.status_code != 201:
-            log.error(u'Failed to create ticket. Status: [%d], Body: [%s]', response.status_code, response.content)
+            log.error('Failed to create ticket. Status: [%d], Body: [%s]', response.status_code, response.content)
         else:
             log.debug('Successfully created ticket.')
     except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
…icode characters (ECOM-5858)

I just changed the file that handles refund notification message formatting to use unicode literals. That should address [ECOM-5858](https://openedx.atlassian.net/browse/ECOM-5858).

I wasn't sure how to test this scenario, where ugettext introduced the unicode that was formatted to a bytestring. So I didn't add tests. Also it's 2016; every string should be a unicode string :).

reviewers: 
- [x] @clintonb 
- [x] @awaisdar001 