### PR TITLE
Add 404 and 500 handlers back in.

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -199,6 +199,7 @@ if 'debug_toolbar' in settings.INSTALLED_APPS:
     )
 
 # Custom error pages
+# These are used by Django to render these error codes. Do not remove.
 # pylint: disable=invalid-name
 handler404 = 'contentstore.views.render_404'
 handler500 = 'contentstore.views.render_500'

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -925,6 +925,13 @@ if 'debug_toolbar' in settings.INSTALLED_APPS:
         url(r'^__debug__/', include(debug_toolbar.urls)),
     )
 
+
+# Custom error pages
+# These are used by Django to render these error codes. Do not remove.
+# pylint: disable=invalid-name
+handler404 = 'static_template_view.views.render_404'
+handler500 = 'static_template_view.views.render_500'
+
 # include into our URL patterns the HTTP REST API that comes with edx-proctoring.
 urlpatterns += (
     url(r'^api/', include('edx_proctoring.urls')),


### PR DESCRIPTION
Sandbox: https://dianakhuang.sandbox.edx.org/

Note: There aren't any tests added for this because Django shows a different 404 / 500 page for dev and test environments.

Reviewers: @andy-armstrong @adampalay 