### PR TITLE
Increase polling rate to wait for mini-notification

### DIFF
--- a/common/test/acceptance/pages/common/utils.py
+++ b/common/test/acceptance/pages/common/utils.py
@@ -17,8 +17,18 @@ def wait_for_notification(page):
         """Whether or not the notification is finished showing."""
         return page.q(css='.wrapper-notification-mini.is-hiding').present
 
-    EmptyPromise(_is_saving, 'Notification should have been shown.', timeout=60).fulfill()
-    EmptyPromise(_is_saving_done, 'Notification should have been hidden.', timeout=60).fulfill()
+    EmptyPromise(
+        _is_saving,
+        'Notification should have been shown.',
+        try_interval=0.1,
+        timeout=60,
+    ).fulfill()
+    EmptyPromise(
+        _is_saving_done,
+        'Notification should have been hidden.',
+        try_interval=0.1,
+        timeout=60,
+    ).fulfill()
 
 
 def click_css(page, css, source_index=0, require_notification=True):

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -129,7 +129,6 @@ class LibraryEditPageTest(StudioLibraryTest):
         """
         self.assertFalse(self.browser.find_elements_by_css_selector('span.large-discussion-icon'))
 
-    @flaky  # TODO fix this, see TNL-2322
     def test_library_pagination(self):
         """
         Scenario: Ensure that adding several XBlocks to a library results in pagination.


### PR DESCRIPTION
The `test_library_pagination` test is known to be flaky. I believe that this is due to a timing issue - specifically, bok-choy's `EmptyPromise` polls the promised method every 0.5 seconds. However, the mini notification can appear and disappear pretty quickly - if it does so in less than 0.5 seconds, and its visibility doesn't intersect with one of bok-choy's polls, then bok-choy will time out having never seen the mini-notification become visible. I'm not sure why only this test would be flaky, though - I'd expect it to be affecting more than this.

This change sets the EmptyPromise to poll every 0.1 seconds. While this will not, and cannot, guarantee that the test will never fail unnecessarily again, it should substantially reduce the frequency of incidence - if a < 0.5s appearance with just the wrong alignment is rare, a < 0.1s appearance with just the wrong alignment should be even more rare.

**JIRA tickets**: Fixes SOL-2071

**Dependencies**: None

**Merge deadline**: November 7 2016

**Testing instructions**:

1. Observe green integration tests.
2. Read the code; decide whether you agree with the logic resulting in the change.

**Reviewers**
- [ ] @itsjeyd 
- [x] edX reviewer[s] TBD

**Notes**
I've tagged the test to run 40 times, and I've run the integration tests 3 times, for a total of 120 non-flaky passes on this specific test.

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```