### PR TITLE
Use nodeenv to manage node version in Jenkins builds

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -15,7 +15,7 @@ from .utils.timer import timed
 
 
 PREREQS_STATE_DIR = os.getenv('PREREQ_CACHE_DIR', Env.REPO_ROOT / '.prereqs_cache')
-NPM_REGISTRY = "http://registry.npmjs.org/"
+NPM_REGISTRY = "https://registry.npmjs.org/"
 NO_PREREQ_MESSAGE = "NO_PREREQ_INSTALL is set, not installing prereqs"
 COVERAGE_REQ_FILE = 'requirements/edx/coverage.txt'
 

--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -4,6 +4,11 @@ set -e
 
 source $HOME/jenkins_env
 
+NODE_ENV_DIR=$HOME/nenv
+NODE_VERSION=0.10.37
+
+NODE_INSTALL_COMMAND="nodeenv --node=$NODE_VERSION --prebuilt $NODE_ENV_DIR --force"
+
 # Clear the mongo database
 # Note that this prevents us from running jobs in parallel on a single worker.
 mongo --quiet --eval 'db.getMongo().getDBNames().forEach(function(i){db.getSiblingDB(i).dropDatabase()})'
@@ -24,8 +29,35 @@ fi
 # Activate the Python virtualenv
 source $HOME/edx-venv/bin/activate
 
-# add the node_js packages dir to PATH
+# add the node packages dir to PATH
 PATH=$PATH:node_modules/.bin
+
+echo "setting up nodeenv"
+pip install nodeenv
+# Ensure we are starting with a clean node env directory
+rm -rf $NODE_ENV_DIR
+
+# Occasionally, the command to install node hangs. We need to catch that and retry.
+# Note that this will retry even if the command itself fails.
+WAIT_COUNT=0
+until timeout 30s $NODE_INSTALL_COMMAND || [ $WAIT_COUNT -eq 2 ]; do
+    echo "re-trying to install node version..."
+    sleep 2
+    WAIT_COUNT=$((WAIT_COUNT+1))
+done
+
+# If we tried the max number of times, we need to quit.
+if [ $WAIT_COUNT -eq 2 ]; then
+    echo "Node environment installation command was not successful. Exiting."
+    exit 1
+fi
+
+source $NODE_ENV_DIR/bin/activate
+echo "done setting up nodeenv"
+echo "node version is `node --version`"
+echo "npm version is `npm --version`"
+
+# TODO: Provide a cached node_modules/ directory for faster/smaller installs
 
 # Manage the npm cache on Jenkins.
 # (In this case, remove it. That ensures from run-to-run, it is a clean npm environment)


### PR DESCRIPTION
This pull request
* gives us the flexibility of managing node from pull-request to pull-request. It'll be a huge lift to folks that want to test out node upgrades like @bjacobel or @andy-armstrong 
* Sets us up for a port to Xenial, which will be accomplished in part by using nodeenv for managing the node environment. See a companion PR on the configuration repo for edxapp: https://github.com/edx/configuration/pull/3444

This pull request does not:
* Attempt to solve any stability issues in builds related to node.
* Make node installs any faster
* Create any caching infrastructure to speed up node installs. They will be approximately as fast as they were before. Downloading the node bits build-to-build adds about 3 seconds, which is worth it for the added flexibility.


