### PR TITLE
Add duplicate functionality for unit, sub-section and section

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -484,7 +484,8 @@ class DuplicateHelper(object):
             "Duplicated item differs from original"
         )
 
-    def _check_equality(self, source_usage_key, duplicate_usage_key, parent_usage_key=None, check_asides=False):
+    def _check_equality(self, source_usage_key, duplicate_usage_key, parent_usage_key=None, check_asides=False,
+                        is_child=False):
         """
         Gets source and duplicated items from the modulestore using supplied usage keys.
         Then verifies that they represent equivalent items (modulo parents and other
@@ -523,10 +524,9 @@ class DuplicateHelper(object):
                 "Parent duplicate should be different from source"
             )
 
-        # Set the location, display name, and parent to be the same so we can make sure the rest of the
+        # Set the location and parent to be the same so we can make sure the rest of the
         # duplicate is equal.
         duplicated_item.location = original_item.location
-        duplicated_item.display_name = original_item.display_name
         duplicated_item.parent = original_item.parent
 
         # Children will also be duplicated, so for the purposes of testing equality, we will set
@@ -538,11 +538,26 @@ class DuplicateHelper(object):
                 "Duplicated item differs in number of children"
             )
             for i in xrange(len(original_item.children)):
-                if not self._check_equality(original_item.children[i], duplicated_item.children[i]):
+                if not self._check_equality(original_item.children[i], duplicated_item.children[i], is_child=True):
                     return False
             duplicated_item.children = original_item.children
+        return self._verify_duplicate_display_name(original_item, duplicated_item, is_child)
 
-        return original_item == duplicated_item
+    def _verify_duplicate_display_name(self, original_item, duplicated_item, is_child=False):
+        """
+        Verifies display name of duplicated item.
+        """
+        if is_child:
+            if original_item.display_name is None:
+                return duplicated_item.display_name == original_item.category
+            return duplicated_item.display_name == original_item.display_name
+        if original_item.display_name is not None:
+            return duplicated_item.display_name == "Duplicate of '{display_name}'".format(
+                display_name=original_item.display_name
+            )
+        return duplicated_item.display_name == "Duplicate of {display_name}".format(
+            display_name=original_item.category
+        )
 
     def _duplicate_item(self, parent_usage_key, source_usage_key, display_name=None):
         """
@@ -571,16 +586,20 @@ class TestDuplicateItem(ItemTest, DuplicateHelper):
         resp = self.create_xblock(parent_usage_key=self.usage_key, category='chapter')
         self.chapter_usage_key = self.response_usage_key(resp)
 
-        # create a sequential containing a problem and an html component
+        # create a sequential
         resp = self.create_xblock(parent_usage_key=self.chapter_usage_key, category='sequential')
         self.seq_usage_key = self.response_usage_key(resp)
 
+        # create a vertical containing a problem and an html component
+        resp = self.create_xblock(parent_usage_key=self.seq_usage_key, category='vertical')
+        self.vert_usage_key = self.response_usage_key(resp)
+
         # create problem and an html component
-        resp = self.create_xblock(parent_usage_key=self.seq_usage_key, category='problem',
+        resp = self.create_xblock(parent_usage_key=self.vert_usage_key, category='problem',
                                   boilerplate='multiplechoice.yaml')
         self.problem_usage_key = self.response_usage_key(resp)
 
-        resp = self.create_xblock(parent_usage_key=self.seq_usage_key, category='html')
+        resp = self.create_xblock(parent_usage_key=self.vert_usage_key, category='html')
         self.html_usage_key = self.response_usage_key(resp)
 
         # Create a second sequential just (testing children of children)
@@ -591,8 +610,9 @@ class TestDuplicateItem(ItemTest, DuplicateHelper):
         Tests that a duplicated xblock is identical to the original,
         except for location and display name.
         """
-        self._duplicate_and_verify(self.problem_usage_key, self.seq_usage_key)
-        self._duplicate_and_verify(self.html_usage_key, self.seq_usage_key)
+        self._duplicate_and_verify(self.problem_usage_key, self.vert_usage_key)
+        self._duplicate_and_verify(self.html_usage_key, self.vert_usage_key)
+        self._duplicate_and_verify(self.vert_usage_key, self.seq_usage_key)
         self._duplicate_and_verify(self.seq_usage_key, self.chapter_usage_key)
         self._duplicate_and_verify(self.chapter_usage_key, self.usage_key)
 
@@ -625,9 +645,10 @@ class TestDuplicateItem(ItemTest, DuplicateHelper):
                     "duplicated item not ordered after source item"
                 )
 
-        verify_order(self.problem_usage_key, self.seq_usage_key, 0)
+        verify_order(self.problem_usage_key, self.vert_usage_key, 0)
         # 2 because duplicate of problem should be located before.
-        verify_order(self.html_usage_key, self.seq_usage_key, 2)
+        verify_order(self.html_usage_key, self.vert_usage_key, 2)
+        verify_order(self.vert_usage_key, self.seq_usage_key, 0)
         verify_order(self.seq_usage_key, self.chapter_usage_key, 0)
 
         # Test duplicating something into a location that is not the parent of the original item.
@@ -645,12 +666,12 @@ class TestDuplicateItem(ItemTest, DuplicateHelper):
             return usage_key
 
         # Display name comes from template.
-        dupe_usage_key = verify_name(self.problem_usage_key, self.seq_usage_key, "Duplicate of 'Multiple Choice'")
+        dupe_usage_key = verify_name(self.problem_usage_key, self.vert_usage_key, "Duplicate of 'Multiple Choice'")
         # Test dupe of dupe.
-        verify_name(dupe_usage_key, self.seq_usage_key, "Duplicate of 'Duplicate of 'Multiple Choice''")
+        verify_name(dupe_usage_key, self.vert_usage_key, "Duplicate of 'Duplicate of 'Multiple Choice''")
 
         # Uses default display_name of 'Text' from HTML component.
-        verify_name(self.html_usage_key, self.seq_usage_key, "Duplicate of 'Text'")
+        verify_name(self.html_usage_key, self.vert_usage_key, "Duplicate of 'Text'")
 
         # The sequence does not have a display_name set, so category is shown.
         verify_name(self.seq_usage_key, self.chapter_usage_key, "Duplicate of sequential")

--- a/cms/static/js/models/xblock_info.js
+++ b/cms/static/js/models/xblock_info.js
@@ -196,6 +196,10 @@ function(Backbone, _, str, ModuleUtils) {
             return this.isActionRequired('deletable');
         },
 
+        isDuplicable: function() {
+            return this.isActionRequired('duplicable');
+        },
+
         isDraggable: function() {
             return this.isActionRequired('draggable');
         },

--- a/cms/static/js/views/course_outline.js
+++ b/cms/static/js/views/course_outline.js
@@ -91,9 +91,28 @@ define(['jquery', 'underscore', 'js/views/xblock_outline', 'common/js/components
                 }
             },
 
-            onSectionAdded: function(locator) {
+            /**
+             * Perform specific actions for duplicated xblock.
+             * @param {String}  locator  The locator of the new duplicated xblock.
+             * @param {String}  xblockType The front-end terminology of the xblock category.
+             * @param {jquery Element}  xblockElement  The xblock element to be duplicated.
+             */
+            onChildDuplicated: function(locator, xblockType, xblockElement) {
+                var scrollOffset = ViewUtils.getScrollOffset(xblockElement);
+                if (xblockType === 'section') {
+                    this.onSectionAdded(locator, xblockElement, scrollOffset);
+                } else {
+                    // For all other block types, refresh the view and do the following:
+                    //  - show the new block expanded
+                    //  - ensure it is scrolled into view
+                    //  - make its name editable
+                    this.refresh(this.createNewItemViewState(locator, scrollOffset));
+                }
+            },
+
+            onSectionAdded: function(locator, xblockElement, scrollOffset) {
                 var self = this,
-                    initialState = self.createNewItemViewState(locator),
+                    initialState = self.createNewItemViewState(locator, scrollOffset),
                     sectionInfo, sectionView;
                 // For new chapters in a non-empty view, add a new child view and render it
                 // to avoid the expense of refreshing the entire page.
@@ -108,7 +127,7 @@ define(['jquery', 'underscore', 'js/views/xblock_outline', 'common/js/components
                         sectionView.initialState = initialState;
                         sectionView.expandedLocators = self.expandedLocators;
                         sectionView.render();
-                        self.addChildView(sectionView);
+                        self.addChildView(sectionView, xblockElement);
                         sectionView.setViewState(initialState);
                     });
                 } else {

--- a/cms/static/js/views/xblock_outline.js
+++ b/cms/static/js/views/xblock_outline.js
@@ -14,8 +14,10 @@
  *  - edit_display_name - true if the shown xblock's display name should be in inline edit mode
  */
 define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/components/utils/view_utils',
-        'js/views/utils/xblock_utils', 'js/views/xblock_string_field_editor'],
-    function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, XBlockStringFieldEditor) {
+        'js/views/utils/xblock_utils', 'js/views/xblock_string_field_editor',
+        'edx-ui-toolkit/js/utils/string-utils', 'edx-ui-toolkit/js/utils/html-utils'],
+    function($, _, gettext, BaseView, ViewUtils, XBlockViewUtils, XBlockStringFieldEditor, StringUtils, HtmlUtils) {
+        'use strict';
         var XBlockOutlineView = BaseView.extend({
             // takes XBlockInfo as a model
 
@@ -68,7 +70,10 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
                 if (this.parentInfo) {
                     this.setElement($(html));
                 } else {
-                    this.$el.html(html);
+                    HtmlUtils.setHtml(
+                        this.$el,
+                        HtmlUtils.HTML(html)
+                    );
                 }
             },
 
@@ -83,7 +88,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
                     defaultNewChildName = null,
                     isCollapsed = this.shouldRenderChildren() && !this.shouldExpandChildren();
                 if (childInfo) {
-                    addChildName = interpolate(gettext('New %(component_type)s'), {
+                    addChildName = StringUtils.interpolate(gettext('New {component_type}'), {
                         component_type: childInfo.display_name
                     }, true);
                     defaultNewChildName = childInfo.display_name;
@@ -126,8 +131,12 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
                 return this.$('> .outline-content > ol');
             },
 
-            addChildView: function(childView) {
-                this.getListElement().append(childView.$el);
+            addChildView: function(childView, xblockElement) {
+                if (xblockElement) {
+                    childView.$el.insertAfter(xblockElement);
+                } else {
+                    this.getListElement().append(childView.$el);
+                }
             },
 
             addNameEditor: function() {
@@ -186,6 +195,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
             addButtonActions: function(element) {
                 var self = this;
                 element.find('.delete-button').click(_.bind(this.handleDeleteEvent, this));
+                element.find('.duplicate-button').click(_.bind(this.handleDuplicateEvent, this));
                 element.find('.button-new').click(_.bind(this.handleAddEvent, this));
             },
 
@@ -281,9 +291,9 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
 
             handleDeleteEvent: function(event) {
                 var self = this,
-                    parentView = this.parentView;
+                    parentView = this.parentView,
+                    xblockType = XBlockViewUtils.getXBlockType(this.model.get('category'), parentView.model, true);
                 event.preventDefault();
-                var xblockType = XBlockViewUtils.getXBlockType(this.model.get('category'), parentView.model, true);
                 XBlockViewUtils.deleteXBlock(this.model, xblockType).done(function() {
                     if (parentView) {
                         parentView.onChildDeleted(self, event);
@@ -291,12 +301,50 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
                 });
             },
 
+            /**
+             * Finds appropriate parent element for an xblock element.
+             * @param {jquery Element}  xblockElement  The xblock element to be duplicated.
+             * @param {String}  xblockType The front-end terminology of the xblock category.
+             * @returns {jquery Element} Appropriate parent element of xblock element.
+             */
+            getParentElement: function(xblockElement, xblockType) {
+                var xblockMap = {
+                        unit: 'subsection',
+                        subsection: 'section',
+                        section: 'course'
+                    },
+                    parentXblockType = xblockMap[xblockType];
+                return xblockElement.closest('.outline-' + parentXblockType);
+            },
+
+            /**
+             * Duplicate event handler.
+             */
+            handleDuplicateEvent: function(event) {
+                var self = this,
+                    xblockType = XBlockViewUtils.getXBlockType(self.model.get('category'), self.parentView.model, true),
+                    xblockElement = $(event.currentTarget).closest('.outline-item'),
+                    parentElement = self.getParentElement(xblockElement, xblockType);
+
+                event.preventDefault();
+                XBlockViewUtils.duplicateXBlock(xblockElement, parentElement)
+                    .done(function(data) {
+                        if (self.parentView) {
+                            self.parentView.onChildDuplicated(
+                                data.locator,
+                                xblockType,
+                                xblockElement
+                            );
+                        }
+                    });
+            },
+
             handleAddEvent: function(event) {
                 var self = this,
-                    target = $(event.currentTarget),
-                    category = target.data('category');
+                    $target = $(event.currentTarget),
+                    category = $target.data('category');
                 event.preventDefault();
-                XBlockViewUtils.addXBlock(target).done(function(locator) {
+                XBlockViewUtils.addXBlock($target).done(function(locator) {
                     self.onChildAdded(locator, category, event);
                 });
             }

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -112,6 +112,14 @@ if (is_proctored_exam) {
                         </a>
                     </li>
                 <% } %>
+                <% if (xblockInfo.isDuplicable()) { %>
+                    <li class="action-item action-duplicate">
+                        <a href="#" data-tooltip="<%- gettext('Duplicate') %>" class="duplicate-button action-button">
+                            <span class="icon fa fa-copy" aria-hidden="true"></span>
+                            <span class="sr action-button-text"><%- gettext('Duplicate') %></span>
+                        </a>
+                    </li>
+                <% } %>
                 <% if (xblockInfo.isDeletable()) { %>
                     <li class="action-item action-delete">
                         <a href="#" data-tooltip="<%- gettext('Delete') %>" class="delete-button action-button">

--- a/cms/templates/js/mock/mock-course-outline-page.underscore
+++ b/cms/templates/js/mock/mock-course-outline-page.underscore
@@ -38,7 +38,7 @@
         <section class="content">
             <article class="content-primary" role="main">
                 <div class="wrapper-dnd">
-                    <article class="outline" data-locator="mock-course" data-course-key="slashes:MockCourse">
+                    <article class="outline outline-course" data-locator="mock-course" data-course-key="slashes:MockCourse">
                         <div class="no-content add-xblock-component">
                             <p>You haven't added any content to this course yet.
                                 <a href="#" class="button button-new" data-category="chapter" data-parent="mock-course" data-default-name="Section" title="Click to add a new section">


### PR DESCRIPTION
# Description

This change adds duplicate functionality to section, subsection and unit on studio course outline.

### [TNL-5797](https://openedx.atlassian.net/browse/TNL-5797), [TNL-5798](https://openedx.atlassian.net/browse/TNL-5798)

### Sandbox
- [x] [Sandbox link](https://studio-duplicatexblock.sandbox.edx.org/course/course-v1:edX+DemoX+Demo_Course)
### Testing
- [x] Unit
- [x] Jasmine
- [x] Manual
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @muzaffaryousaf 
- [x] Code review: @muhammad-ammar 
- [ ] A11y review: @cptvitamin  
- [ ] Doc: @catong  
- [x] Product: @sstack22 
### Post-review
- [x] Squash commits
