### PR TITLE
Provide a default configuration for forums if none already exists.

### DIFF
--- a/common/djangoapps/django_comment_common/migrations/0003_enable_forums.py
+++ b/common/djangoapps/django_comment_common/migrations/0003_enable_forums.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from django.db import migrations, models
+
+def add_default_enable(apps, schema_editor):
+    ForumsConfig = apps.get_model("django_comment_common", "ForumsConfig")
+    settings_count = ForumsConfig.objects.count()
+    if settings_count is 0:
+        # By default we want the comment client enabled, but this is *not* enabling
+        # discussions themselves by default, as in showing the Disucussions tab, or
+        # inline discussions, etc.  It just allows the underlying service client to work.
+        settings = ForumsConfig(enabled=True)
+        settings.save()
+
+
+def reverse_noop(apps, schema_editor):
+    return
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_comment_common', '0002_forumsconfig'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_default_enable, reverse_code=reverse_noop),
+    ]


### PR DESCRIPTION
Since forums being enabled now depends on the `enabled` field of the `ForumsConfig` model, and since that value defaults to `False` if there's no configuration, we need to provide a default entry lest users without previously-modified `ForumsConfig` entries go to use the new code/updated release and find their forums disabled.

/cc @ormsbee 