### PR TITLE
Initial set of changes for ui correctness state when saving a problem

### DIFF
--- a/common/lib/capa/capa/templates/choicegroup.html
+++ b/common/lib/capa/capa/templates/choicegroup.html
@@ -19,21 +19,13 @@
             <%
               label_class = 'response-label field-label label-inline'
             %>
+
             <label id="${id}-${choice_id}-label"
                 ## If the student has selected this choice...
                 % if is_radio_input(choice_id):
-                <%
-                    if status == 'correct':
-                        correctness = 'correct'
-                    elif status == 'partially-correct':
-                        correctness = 'partially-correct'
-                    elif status == 'incorrect':
-                        correctness = 'incorrect'
-                    else:
-                        correctness = None
-                %>
-                    % if correctness and not show_correctness == 'never':
-                        <% label_class += ' choicegroup_' + correctness %>
+
+                    % if status.classname and not show_correctness == 'never':
+                        <% label_class += ' choicegroup_' + status.classname %>
                     % endif
                 % endif
                 class="${label_class}"
@@ -47,7 +39,6 @@
                 checked="true"
                 % endif
                 /> ${HTML(choice_label)}
-
                 % if is_radio_input(choice_id):
                   % if not show_correctness == 'never' and status.classname != 'unanswered':
                     <%include file="status_span.html" args="status=status, status_id=id"/>

--- a/common/lib/capa/capa/templates/choicetext.html
+++ b/common/lib/capa/capa/templates/choicetext.html
@@ -19,19 +19,9 @@ from openedx.core.djangolib.markup import HTML
         <% choice_id = choice_id %>
         <section id="forinput${choice_id}"
             % if input_type == 'radio' and choice_id in value :
-            <%
-                if status == 'correct':
-                    correctness = 'correct'
-                elif status == 'incorrect':
-                    correctness = 'incorrect'
-                elif status == 'partially-correct':
-                    correctness = 'partially-correct'
-                else:
-                    correctness = None
-            %>
-            % if correctness:
-                class="choicetextgroup_${correctness}"
-            % endif
+                % if status.classname:
+                    class="choicetextgroup_${status.classname}"
+                % endif
             % endif
             >
             <input class="ctinput" type="${input_type}" name="choiceinput_${id}" id="${choice_id}" value="${choice_id}"

--- a/common/lib/capa/capa/tests/test_input_templates.py
+++ b/common/lib/capa/capa/tests/test_input_templates.py
@@ -1084,7 +1084,7 @@ class ChoiceTextGroupTemplateTest(TemplateTestCase):
         conditions = [
             {'input_type': 'radio', 'value': self.VALUE_DICT}]
 
-        self.context['status'] = 'correct'
+        self.context['status'] = Status('correct')
 
         for test_conditions in conditions:
             self.context.update(test_conditions)
@@ -1104,7 +1104,7 @@ class ChoiceTextGroupTemplateTest(TemplateTestCase):
         conditions = [
             {'input_type': 'radio', 'value': self.VALUE_DICT}]
 
-        self.context['status'] = 'incorrect'
+        self.context['status'] = Status('incorrect')
 
         for test_conditions in conditions:
             self.context.update(test_conditions)

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -705,17 +705,13 @@ class MatlabTest(unittest.TestCase):
         self.assertEqual(
             etree.tostring(output),
             textwrap.dedent("""
-            <div>{\'status\': Status(\'queued\'), \'button_enabled\': True,
-            \'rows\': \'10\', \'queue_len\': \'3\', \'mode\': \'\',
-            \'tabsize\': 4, \'cols\': \'80\',
-            \'STATIC_URL\': \'/dummy-static/\', \'linenumbers\': \'true\', \'queue_msg\': \'\',
-            \'value\': \'print "good evening"\',
-            \'msg\': u\'Submitted. As soon as a response is returned,
-            this message will be replaced by that feedback.\',
+            <div>{\'status\': Status(\'queued\'), \'button_enabled\': True, \'rows\': \'10\', \'queue_len\': \'3\',
+            \'mode\': \'\', \'tabsize\': 4, \'cols\': \'80\', \'STATIC_URL\': \'/dummy-static/\', \'linenumbers\':
+            \'true\', \'queue_msg\': \'\', \'value\': \'print "good evening"\',
+            \'msg\': u\'Submitted. As soon as a response is returned, this message will be replaced by that feedback.\',
             \'matlab_editor_js\': \'/dummy-static/js/vendor/CodeMirror/octave.js\',
             \'hidden\': \'\', \'id\': \'prob_1_2\',
-            \'describedby_html\': Markup(u\'aria-describedby="status_prob_1_2"\'),
-            \'response_data\': {}}</div>
+            \'describedby_html\': Markup(u\'aria-describedby="status_prob_1_2"\'), \'response_data\': {}}</div>
             """).replace('\n', ' ').strip()
         )
 

--- a/common/lib/xmodule/xmodule/js/src/capa/display.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.js
@@ -779,6 +779,7 @@
                         edx.HtmlUtils.HTML(saveMessage)
                     );
                     that.clear_all_notifications();
+                    that.el.find('.wrapper-problem-response .message').hide();
                     that.saveNotification.show();
                     that.focus_on_save_notification();
                 } else {
@@ -938,7 +939,7 @@
                 return $(element).find('input').on('input', function() {
                     var $p;
                     $p = $(element).find('span.status');
-                    return $p.parent().removeClass().addClass('unsubmitted');
+                    return $p.parent().removeAttr('class').addClass('unsubmitted');
                 });
             },
             choicegroup: function(element) {
@@ -949,7 +950,7 @@
                     var $status;
                     $status = $('#status_' + id);
                     if ($status[0]) {
-                        $status.removeClass().addClass('unanswered');
+                        $status.removeAttr('class').addClass('unanswered');
                     } else {
                         $('<span>', {
                             class: 'unanswered',
@@ -957,7 +958,7 @@
                             id: 'status_' + id
                         });
                     }
-                    return $element.find('label').removeClass();
+                    return $element.find('label').removeAttr('class');
                 });
             },
             'option-input': function(element) {
@@ -965,7 +966,7 @@
                 $select = $(element).find('select');
                 id = ($select.attr('id').match(/^input_(.*)$/))[1];
                 return $select.on('change', function() {
-                    return $('#status_' + id).removeClass().addClass('unanswered')
+                    return $('#status_' + id).removeAttr('class').addClass('unanswered')
                         .find('.sr')
                         .text(gettext('unsubmitted'));
                 });

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -34,6 +34,13 @@ class ProblemPage(PageObject):
         return self.q(css="div.problem p").text
 
     @property
+    def problem_input_content(self):
+        """
+        Return the text of the question of the problem.
+        """
+        return self.q(css="div.wrapper-problem-response").text[0]
+
+    @property
     def problem_content(self):
         """
         Return the content of the problem
@@ -144,6 +151,12 @@ class ProblemPage(PageObject):
         """
         return self.q(css='.notification.notification-hint').visible
 
+    def is_feedback_message_notification_visible(self):
+        """
+        Is the Feedback Messaged notification visible
+        """
+        return self.q(css='.wrapper-problem-response .message').visible
+
     def is_save_notification_visible(self):
         """
         Is the Save Notification Visible?
@@ -155,6 +168,13 @@ class ProblemPage(PageObject):
         Is the Submit Notification Visible?
         """
         return self.q(css='.notification.success.notification-submit').visible
+
+    def wait_for_feedback_message_visibility(self):
+        """
+        Wait for the Feedback Message notification to be visible.
+        """
+        self.wait_for_element_visibility('.wrapper-problem-response .message',
+                                         'Waiting for the Feedback message to be visible')
 
     def wait_for_save_notification(self):
         """
@@ -236,6 +256,15 @@ class ProblemPage(PageObject):
         """
         msg = "Wait for status to be {}".format(message)
         self.wait_for_element_visibility(status_selector, msg)
+
+    def is_expected_status_visible(self, status_selector):
+        """
+        check for the expected status indicator to be visible.
+
+        Args:
+            status_selector(str): status selector string.
+        """
+        return self.q(css=status_selector).visible
 
     def wait_success_notification(self):
         """

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -764,14 +764,16 @@ class ProblemStateOnNavigationTest(UniqueCourseTest):
         self.problem_page.wait_for_save_notification()
 
         # Save problem 1's content state as we're about to switch units in the sequence.
-        problem1_content_before_switch = self.problem_page.problem_content
+        problem1_content_before_switch = self.problem_page.problem_input_content
 
         # Go to sequential position 2 and assert that we are on problem 2.
         self.go_to_tab_and_assert_problem(2, self.problem2_name)
 
+        self.problem_page.wait_for_expected_status('span.unanswered', 'unanswered')
+
         # Come back to our original unit in the sequence and assert that the content hasn't changed.
         self.go_to_tab_and_assert_problem(1, self.problem1_name)
-        problem1_content_after_coming_back = self.problem_page.problem_content
+        problem1_content_after_coming_back = self.problem_page.problem_input_content
         self.assertIn(problem1_content_after_coming_back, problem1_content_before_switch)
 
     def test_perform_problem_reset_and_navigate(self):

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -74,6 +74,7 @@ from openedx.core.djangolib.markup import HTML
                 notification_type='success',
                 notification_icon='fa-check',
                 notification_name='submit',
+                is_hidden=False,
                 notification_message=answer_notification_message"
             />
         % endif
@@ -82,6 +83,7 @@ from openedx.core.djangolib.markup import HTML
                 notification_type='error',
                 notification_icon='fa-close',
                 notification_name='submit',
+                is_hidden=False,
                 notification_message=answer_notification_message"
             />
         % endif
@@ -90,6 +92,7 @@ from openedx.core.djangolib.markup import HTML
                 notification_type='success',
                 notification_icon='fa-asterisk',
                 notification_name='submit',
+                is_hidden=False,
                 notification_message=answer_notification_message"
             />
         % endif
@@ -98,6 +101,7 @@ from openedx.core.djangolib.markup import HTML
       notification_type='warning',
       notification_icon='fa-save',
       notification_name='save',
-      notification_message=''"
+      notification_message=save_message,
+      is_hidden=not has_saved_answers"
     />
 </div>

--- a/lms/templates/problem_notifications.html
+++ b/lms/templates/problem_notifications.html
@@ -1,9 +1,9 @@
 <%page expression_filter="h" args="notification_name, notification_type, notification_icon,
-                                   notification_message, should_enable_next_hint"/>
+                                   notification_message, should_enable_next_hint, is_hidden=True"/>
 <%! from django.utils.translation import ugettext as _ %>
 
 <div class="notification ${notification_type} ${'notification-'}${notification_name}
-      ${'' if notification_name == 'submit' else 'is-hidden' }"
+      ${'' if not is_hidden else 'is-hidden' }"
      tabindex="-1">
     <span class="icon fa ${notification_icon}" aria-hidden="true"></span>
     <span class="notification-message" aria-describedby="${ short_id }-problem-title">${notification_message}


### PR DESCRIPTION
TNL-1955
## [TNL-1955](https://openedx.atlassian.net/browse/TNL-1955)

### Description

Updates so that when an answer is submitted, changed, and then saved the ui is cleared.

### Sandbox
- [x] Build a sandbox for your branch and add a link here

https://staubina-save.sandbox.edx.org

### Testing
- [x] i18n
- [x] RTL
- [x] safecommit violation code review process
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @muhammad-ammar 
- [x] Doc Review: @catong , FYI I am not sure if this requires doc updates.
- [x] Product review: @sstack22 

### Post-review
- [x] Rebase and squash commits
