### PR TITLE
Updates problem-builder to v2.6.1

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@v2.0.4#egg=xblock-problem-builder==2.0.4
+git+https://github.com/open-craft/problem-builder.git@v2.6.1#egg=xblock-problem-builder==2.6.1
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
Updates problem-builder to v2.6.1.
Ref https://github.com/open-craft/problem-builder/pull/128

**JIRA tickets**: Fixes the instructor_task import errors from [TNL-5903](https://openedx.atlassian.net/browse/TNL-5903).

**Dependencies**: https://github.com/edx/xblock-configuration/pull/9

**Sandbox URL**:
* LMS: http://pr13938-3.sandbox.opencraft.hosting
* Studio: http://studio-pr13938-3.sandbox.opencraft.hosting

**Partner information**: DavidsonX

**Testing instructions**:

1. Login as staff to sandbox: http://pr13938-3.sandbox.opencraft.hosting/
1. Navigate to `Features > Instructor Tool`
1. Ensure that you can filter and download results.
1. Smoke test the other Problem Builder features (should be unaffected).

**Reviewers**
- [x] @haikuginger 
- [x] @dianakhuang 

**Settings**
```yaml
EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/open-craft/problem-builder.git@v2.6.1#egg=xblock-problem-builder==2.6.1
```