### PR TITLE
Fix discussion user roles

### DIFF
--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -665,6 +665,10 @@ class DiscussionUserProfilePage(CoursePage):
         self.wait_for_page()
         self.q(css='.learner-profile-link').first.click()
 
+    def get_user_roles(self):
+        """Get user roles"""
+        return self.q(css='.sidebar-user-roles').text[0]
+
 
 class DiscussionTabHomePage(CoursePage, DiscussionPageMixin):
 

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -1145,21 +1145,29 @@ class DiscussionUserProfileTest(UniqueCourseTest):
 
     def setUp(self):
         super(DiscussionUserProfileTest, self).setUp()
-        CourseFixture(**self.course_info).install()
+        self.setup_course()
         # The following line creates a user enrolled in our course, whose
         # threads will be viewed, but not the one who will view the page.
         # It isn't necessary to log them in, but using the AutoAuthPage
         # saves a lot of code.
-        self.profiled_user_id = AutoAuthPage(
-            self.browser,
-            username=self.PROFILED_USERNAME,
-            course_id=self.course_id
-        ).visit().get_user_id()
+        self.profiled_user_id = self.setup_user(username=self.PROFILED_USERNAME)
         # now create a second user who will view the profile.
-        self.user_id = AutoAuthPage(
-            self.browser,
-            course_id=self.course_id
-        ).visit().get_user_id()
+        self.user_id = self.setup_user()
+
+    def setup_course(self):
+        """
+        Set up the for the course discussion user-profile tests.
+        """
+        return CourseFixture(**self.course_info).install()
+
+    def setup_user(self, roles=None, **user_info):
+        """
+        Helper method to create and authenticate a user.
+        """
+        roles_str = ''
+        if roles:
+            roles_str = ','.join(roles)
+        return AutoAuthPage(self.browser, course_id=self.course_id, roles=roles_str, **user_info).visit().get_user_id()
 
     def check_pages(self, num_threads):
         # set up the stub server to return the desired amount of thread results
@@ -1261,6 +1269,41 @@ class DiscussionUserProfileTest(UniqueCourseTest):
 
         learner_profile_page.wait_for_page()
         self.assertTrue(learner_profile_page.field_is_visible('username'))
+
+    def test_learner_profile_roles(self):
+        """
+        Test that on the learner profile page user roles are correctly listed according to the course.
+        """
+        # Setup a learner with roles in a Course-A.
+        expected_student_roles = ['Administrator', 'Community TA', 'Moderator', 'Student']
+        self.profiled_user_id = self.setup_user(
+            roles=expected_student_roles,
+            username=self.PROFILED_USERNAME
+        )
+
+        # Visit the page and verify the roles are listed correctly.
+        page = self.check_pages(1)
+        student_roles = page.get_user_roles()
+        self.assertEqual(student_roles, ', '.join(expected_student_roles))
+
+        # Save the course_id of Course-A before setting up a new course.
+        old_course_id = self.course_id
+
+        # Setup Course-B and set user do not have additional roles and test roles are displayed correctly.
+        self.course_info['number'] = self.unique_id
+        self.setup_course()
+        new_course_id = self.course_id
+
+        # Set the user to have no extra role in the Course-B and verify the existing
+        # user is updated.
+        profiled_student_user_id = self.setup_user(roles=None, username=self.PROFILED_USERNAME)
+        self.assertEqual(self.profiled_user_id, profiled_student_user_id)
+        self.assertNotEqual(old_course_id, new_course_id)
+
+        # Visit the user profile in course discussion page of Course-B. Make sure the
+        # roles are listed correctly.
+        page = self.check_pages(1)
+        self.assertEqual(page.get_user_roles(), u'Student')
 
 
 class DiscussionSearchAlertTest(UniqueCourseTest):

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -1118,6 +1118,7 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
         self.student = UserFactory.create()
         self.profiled_user = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
+        CourseEnrollmentFactory.create(user=self.profiled_user, course_id=self.course.id)
 
     def get_response(self, mock_request, params, **headers):
         mock_request.side_effect = make_mock_request_impl(
@@ -1188,6 +1189,21 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
 
     def test_ajax_p2(self, mock_request):
         self.check_ajax(mock_request, page="2")
+
+    def test_404_non_enrolled_user(self, __):
+        """
+        Test that when student try to visit un-enrolled students' discussion profile,
+        the system raises Http404.
+        """
+        unenrolled_user = UserFactory.create()
+        request = RequestFactory().get("dummy_url")
+        request.user = self.student
+        with self.assertRaises(Http404):
+            views.user_profile(
+                request,
+                self.course.id.to_deprecated_string(),
+                unenrolled_user.id
+            )
 
     def test_404_profiled_user(self, mock_request):
         request = RequestFactory().get("dummy_url")

--- a/lms/templates/discussion/_user_profile.html
+++ b/lms/templates/discussion/_user_profile.html
@@ -3,8 +3,7 @@
 <div class="user-profile">
   <div class="sidebar-username"><a class="learner-profile-link" href="${learner_profile_page_url}">${django_user.username | h}</a></div>
   <div class="sidebar-user-roles">
-    <% role_names = django_user.roles.order_by("name").values_list("name", flat=True).distinct() %>
-    ${", ".join(_(role_name) for role_name in role_names)}
+    ${", ".join(_(role_name) for role_name in django_user_roles)}
   </div>
   <div class="sidebar-threads-count">${ungettext('%s discussion started', '%s discussions started', profiled_user['threads_count']) % span(profiled_user['threads_count']) | h}</div>
   <div class="sidebar-comments-count">${ungettext('%s comment', '%s comments', profiled_user['comments_count']) % span(profiled_user['comments_count']) | h}</div>


### PR DESCRIPTION
## [TNL-5816](https://openedx.atlassian.net/browse/TNL-5816)

### Description

When a student visits any users' discussion profile, his roles are displayed on the page. I have done the following changes in this PR.

- I have moved the logic of getting users' roles in the views.
- I have fixed the logic of getting users' roles is now with respect to the course 
- I am now raising `Http404` if the user is not enrolled in the course.

https://github.com/edx/edx-platform/pull/13939/files



### How to Test?

**Stage**: 
- In the discussion forum, visit a learner profile page. [Aishaq discussion profile](https://courses.stage.edx.org/courses/course-v1:HarvardX+CS101+2016_T4/discussion/forum/users/5183691). Note down the learner roles listed under the username as `Community TA, Moderator, Student`
- Verify the learner roles from the [Instructor Dashboard - Course-A](https://courses.stage.edx.org/courses/course-v1:HarvardX+CS101+2016_T4/instructor#view-membership). Verify the learner has only `Moderator` role in the course. 

- Go to the [Instructor Dashboard - Course-B](https://courses.stage.edx.org/courses/course-v1:HarvardX+CS102+2016_T4/instructor#view-membership) and verify the learner has `Community TA` role 


**Sandbox**
- [https://awais.sandbox.edx.org/](https://awais.sandbox.edx.org/)
- Create two courses (Course-A) and (Course-B) in the studio.
- Enroll a learner (audit) in both courses.
- Goto instructor dashboard of Course-A and add a role `Moderator` for the learner.
- Goto instructor dashboard of Course-B and add a role `Community TA` for the learner.
- Go to the discuss tab of Course-A and open learner profile and verify the learner has only `Moderator` role listed. 
- Go to the discuss tab of Course-B and open learner profile and verify the learner has only `Community TA` role listed. E.g.(`www.courses.edx.org/course-id-here/discussion/forum/users/learner-id/)

### Testing
- [x] Acceptance tests
- [x] Unit tests


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] F.I.R: @noraiz-anwar
- [x] Code review: @attiyaIshaque 
- [x] Code review: @Qubad786 

FYI: @adampalay 

### Post-review
- [x] Rebase and squash commits