### PR TITLE
Bumps problem-builder to v2.6.2

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@v2.6.1#egg=xblock-problem-builder==2.6.1
+git+https://github.com/open-craft/problem-builder.git@v2.6.2#egg=xblock-problem-builder==2.6.2
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
Updates problem-builder to v2.6.2 to address performance concerns raised by [problem-builder #119](https://github.com/open-craft/problem-builder/pull/119#discussion_r85763360).

cf. https://github.com/open-craft/problem-builder/pull/129

**Sandbox URL**: 

* LMS: http://pr13953.sandbox.opencraft.hosting (persistent databases)
* Studio: http://studio-pr13953.sandbox.opencraft.hosting

**Partner information**: DavidsonX

**Testing Instructions**: 

To test this change, compare the [v2.6.2 sandbox](http://pr13953.sandbox.opencraft.hosting) from this PR with the [v2.6.1 sandbox](http://pr13953.sandbox.opencraft.hosting) from https://github.com/edx/edx-platform/pull/13938.

1. Navigate to the Problem Builder Demo course, section `Features > Instructor Tools`.
1. Note that the list of course block options is the same for both sandboxes.

**Reviewers**
- [x] @itsjeyd 
- [ ] edX reviewer[s] TBD

CC @ormsbee 

**Settings**
```yaml
EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/open-craft/problem-builder.git@v2.6.2#egg=xblock-problem-builder==2.6.2
```