### PR TITLE
Workaround for TE-1767 aka cb() never called

### DIFF
--- a/pavelib/paver_tests/test_paver_quality.py
+++ b/pavelib/paver_tests/test_paver_quality.py
@@ -14,7 +14,7 @@ from path import Path as path
 from paver.easy import BuildFailure
 
 import pavelib.quality
-from pavelib.paver_tests.utils import CustomShMock
+from pavelib.paver_tests.utils import fail_on_pylint, fail_on_eslint
 
 
 @ddt
@@ -298,7 +298,7 @@ class TestPaverRunQuality(unittest.TestCase):
         """
 
         # Underlying sh call must fail when it is running the pylint diff-quality task
-        self._mock_paver_sh.side_effect = CustomShMock().fail_on_pylint
+        self._mock_paver_sh.side_effect = fail_on_pylint
         _mock_pep8_violations = MagicMock(return_value=(0, []))
         with patch('pavelib.quality._get_pep8_violations', _mock_pep8_violations):
             with self.assertRaises(SystemExit):
@@ -318,7 +318,7 @@ class TestPaverRunQuality(unittest.TestCase):
         """
 
         # Underlying sh call must fail when it is running the eslint diff-quality task
-        self._mock_paver_sh.side_effect = CustomShMock().fail_on_eslint
+        self._mock_paver_sh.side_effect = fail_on_eslint
         _mock_pep8_violations = MagicMock(return_value=(0, []))
         with patch('pavelib.quality._get_pep8_violations', _mock_pep8_violations):
             with self.assertRaises(SystemExit):

--- a/pavelib/paver_tests/test_paver_quality.py
+++ b/pavelib/paver_tests/test_paver_quality.py
@@ -1,18 +1,20 @@
 """
 Tests for paver quality tasks
 """
-import os
-from path import Path as path
 import tempfile
 import textwrap
 import unittest
-from mock import patch, MagicMock, mock_open
-from ddt import ddt, file_data
 
-import pavelib.quality
+import os
 import paver.easy
 import paver.tasks
+from ddt import ddt, file_data
+from mock import patch, MagicMock, mock_open
+from path import Path as path
 from paver.easy import BuildFailure
+
+import pavelib.quality
+from pavelib.paver_tests.utils import CustomShMock
 
 
 @ddt
@@ -351,32 +353,3 @@ class TestPaverRunQuality(unittest.TestCase):
         self.assertEqual(_mock_pep8_violations.call_count, 1)
         # And assert that sh was called twice (for the call to "pylint" & "eslint")
         self.assertEqual(self._mock_paver_sh.call_count, 2)
-
-
-class CustomShMock(object):
-    """
-    Diff-quality makes a number of sh calls. None of those calls should be made during tests; however, some
-    of them need to have certain responses.
-    """
-
-    def fail_on_pylint(self, arg):
-        """
-        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
-        is going to fail when we pass in a percentage ("p") requirement.
-        """
-        if "pylint" in arg:
-            # Essentially mock diff-quality exiting with 1
-            paver.easy.sh("exit 1")
-        else:
-            return
-
-    def fail_on_eslint(self, arg):
-        """
-        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
-        is going to fail when we pass in a percentage ("p") requirement.
-        """
-        if "eslint" in arg:
-            # Essentially mock diff-quality exiting with 1
-            paver.easy.sh("exit 1")
-        else:
-            return

--- a/pavelib/paver_tests/utils.py
+++ b/pavelib/paver_tests/utils.py
@@ -63,50 +63,47 @@ class MockEnvironment(tasks.Environment):
             self.messages.append(unicode(output))
 
 
-class CustomShMock(object):
+def fail_on_eslint(arg):
     """
-    Diff-quality makes a number of sh calls. None of those calls should be made during tests; however, some
-    of them need to have certain responses.
+    For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
+    is going to fail when we pass in a percentage ("p") requirement.
     """
+    if "eslint" in arg:
+        # Essentially mock diff-quality exiting with 1
+        paver.easy.sh("exit 1")
+    else:
+        return
 
-    def fail_on_pylint(self, arg):
-        """
-        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
-        is going to fail when we pass in a percentage ("p") requirement.
-        """
-        if "pylint" in arg:
-            # Essentially mock diff-quality exiting with 1
-            paver.easy.sh("exit 1")
-        else:
-            return
 
-    def fail_on_eslint(self, arg):
-        """
-        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
-        is going to fail when we pass in a percentage ("p") requirement.
-        """
-        if "eslint" in arg:
-            # Essentially mock diff-quality exiting with 1
-            paver.easy.sh("exit 1")
-        else:
-            return
+def fail_on_pylint(arg):
+    """
+    For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
+    is going to fail when we pass in a percentage ("p") requirement.
+    """
+    if "pylint" in arg:
+        # Essentially mock diff-quality exiting with 1
+        paver.easy.sh("exit 1")
+    else:
+        return
 
-    def fail_on_npm_install(self, arg):
-        """
-        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
-        is going to fail when we pass in a percentage ("p") requirement.
-        """
-        if "npm install" in arg:
-            raise BuildFailure('Subprocess return code: 1')
-        else:
-            return
 
-    def unexpected_fail_on_npm_install(self, arg):
-        """
-        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
-        is going to fail when we pass in a percentage ("p") requirement.
-        """
-        if "npm install" in arg:
-            raise BuildFailure('Subprocess return code: 50')
-        else:
-            return
+def fail_on_npm_install(arg):
+    """
+    For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
+    is going to fail when we pass in a percentage ("p") requirement.
+    """
+    if "npm install" in arg:
+        raise BuildFailure('Subprocess return code: 1')
+    else:
+        return
+
+
+def unexpected_fail_on_npm_install(arg):
+    """
+    For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
+    is going to fail when we pass in a percentage ("p") requirement.
+    """
+    if "npm install" in arg:
+        raise BuildFailure('Subprocess return code: 50')
+    else:
+        return

--- a/pavelib/paver_tests/utils.py
+++ b/pavelib/paver_tests/utils.py
@@ -1,8 +1,11 @@
 """Unit tests for the Paver server tasks."""
 
 import os
+import paver.easy
 from paver import tasks
 from unittest import TestCase
+
+from paver.easy import BuildFailure
 
 
 class PaverTestCase(TestCase):
@@ -58,3 +61,52 @@ class MockEnvironment(tasks.Environment):
             output = message
         if not output.startswith("--->"):
             self.messages.append(unicode(output))
+
+
+class CustomShMock(object):
+    """
+    Diff-quality makes a number of sh calls. None of those calls should be made during tests; however, some
+    of them need to have certain responses.
+    """
+
+    def fail_on_pylint(self, arg):
+        """
+        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
+        is going to fail when we pass in a percentage ("p") requirement.
+        """
+        if "pylint" in arg:
+            # Essentially mock diff-quality exiting with 1
+            paver.easy.sh("exit 1")
+        else:
+            return
+
+    def fail_on_eslint(self, arg):
+        """
+        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
+        is going to fail when we pass in a percentage ("p") requirement.
+        """
+        if "eslint" in arg:
+            # Essentially mock diff-quality exiting with 1
+            paver.easy.sh("exit 1")
+        else:
+            return
+
+    def fail_on_npm_install(self, arg):
+        """
+        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
+        is going to fail when we pass in a percentage ("p") requirement.
+        """
+        if "npm install" in arg:
+            raise BuildFailure('Subprocess return code: 1')
+        else:
+            return
+
+    def unexpected_fail_on_npm_install(self, arg):
+        """
+        For our tests, we need the call for diff-quality running pep8 reports to fail, since that is what
+        is going to fail when we pass in a percentage ("p") requirement.
+        """
+        if "npm install" in arg:
+            raise BuildFailure('Subprocess return code: 50')
+        else:
+            return

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -138,13 +138,16 @@ def node_prereqs_installation():
        " {reg})".format(reg=NPM_REGISTRY))
 
     # Error handling around a race condition that produces "cb() never called" error. This
-    # ought to disappear when we upgrade npm to 3 or higher. TODO: clean this up when we do that.
+    # evinces itself as `cb_error_text` and it ought to disappear when we upgrade
+    # npm to 3 or higher. TODO: clean this up when we do that.
     try:
         sh('npm install')
     except BuildFailure, error_text:
         if cb_error_text in error_text:
             print "npm install error detected. Retrying..."
             sh('npm install')
+        else:
+            raise BuildFailure(error_text)
 
 
 def python_prereqs_installation():

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -8,7 +8,7 @@ import os
 import re
 import sys
 
-from paver.easy import sh, task
+from paver.easy import sh, task, BuildFailure
 
 from .utils.envs import Env
 from .utils.timer import timed
@@ -132,10 +132,19 @@ def node_prereqs_installation():
     """
     Configures npm and installs Node prerequisites
     """
+    cb_error_text = "Subprocess return code: 1"
     sh("test `npm config get registry` = \"{reg}\" || "
        "(echo setting registry; npm config set registry"
        " {reg})".format(reg=NPM_REGISTRY))
-    sh('npm install')
+
+    # Error handling around a race condition that produces "cb() never called" error. This
+    # ought to disappear when we upgrade npm to 3 or higher. TODO: clean this up when we do that.
+    try:
+        sh('npm install')
+    except BuildFailure, error_text:
+        if cb_error_text in error_text:
+            print "npm install error detected. Retrying..."
+            sh('npm install')
 
 
 def python_prereqs_installation():


### PR DESCRIPTION
Problem:
* Intermittent "cb() never called!" errors on npm installs for platform.
* This is likely due to a race condition on installing OS-specific bits that are built during time of install. When more than one compilation takes place at one time, this error can occur.

Workaround:
* Detect the error and re-run the install. (When retrying, one or all of the bits have been compiled. So running it again just finishes the install.)

Considerations:
* We won't be able to rely on Jenkins GUI to understand how long it takes to complete an npm install. We'll want to build in a timer to paver. (I have that as a TODO if folks are on-board with this workaround.)

Out of scope:
* Actually fixing npm to handle a race condition. This may have been fixed in npm3 but would take additional testing, and cannot be done until we upgrade node to a more recent version. So, I'm thinking we can put in a cheap workaround until that time.
* Using/creating a node_modules cache (which is another workaround).
