### PR TITLE
ENT-50: Link EnterpriseCustomer to IDP

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0008_auto_20161114_0206.py
+++ b/common/djangoapps/third_party_auth/migrations/0008_auto_20161114_0206.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0007_auto_20161107_0541'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ltiproviderconfig',
+            name='enforce_data_sharing_consent',
+            field=models.CharField(default=b'optional', help_text="This field determines if data sharing consent is optional, if it's required at login, or if it's required when registering for courses.", max_length=25, choices=[(b'optional', b'Optional'), (b'at_login', b'At Login'), (b'at_enrollment', b'At Enrollment')]),
+        ),
+        migrations.AlterField(
+            model_name='oauth2providerconfig',
+            name='enforce_data_sharing_consent',
+            field=models.CharField(default=b'optional', help_text="This field determines if data sharing consent is optional, if it's required at login, or if it's required when registering for courses.", max_length=25, choices=[(b'optional', b'Optional'), (b'at_login', b'At Login'), (b'at_enrollment', b'At Enrollment')]),
+        ),
+        migrations.AlterField(
+            model_name='samlproviderconfig',
+            name='enforce_data_sharing_consent',
+            field=models.CharField(default=b'optional', help_text="This field determines if data sharing consent is optional, if it's required at login, or if it's required when registering for courses.", max_length=25, choices=[(b'optional', b'Optional'), (b'at_login', b'At Login'), (b'at_enrollment', b'At Enrollment')]),
+        ),
+    ]


### PR DESCRIPTION
Hi @mattdrayer , @asadiqbal08 , @haikuginger 

This PR updates "edx-enterprise" version for edx-platform and should be merged after https://github.com/edx/edx-enterprise/pull/9.

There is also a migrations file, this migrations just contain an update to help text for `enforce_data_sharing_consent` field. This field was added in a previous PR (https://github.com/edx/edx-platform/pull/13854), help text was updated during feedback changes but I forgot to update migrations accordingly.