### PR TITLE
Track grading task latency

### DIFF
--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -123,7 +123,7 @@ def enqueue_subsection_update(sender, **kwargs):  # pylint: disable=unused-argum
     """
     Handles the PROBLEM_SCORE_CHANGED signal by enqueueing a subsection update operation to occur asynchronously.
     """
-    recalculate_subsection_grade.apply_async(
+    result = recalculate_subsection_grade.apply_async(
         kwargs=dict(
             user_id=kwargs['user_id'],
             course_id=kwargs['course_id'],
@@ -132,6 +132,12 @@ def enqueue_subsection_update(sender, **kwargs):  # pylint: disable=unused-argum
             raw_earned=kwargs.get('points_earned'),
             raw_possible=kwargs.get('points_possible'),
             score_deleted=kwargs.get('score_deleted', False),
+        )
+    )
+    log.info(
+        u'Grades: Request async calculation of subsection grades with args: {}. Task [{}]'.format(
+            ', '.join('{}:{}'.format(arg, kwargs[arg]) for arg in sorted(kwargs)),
+            getattr(result, 'id', 'N/A'),
         )
     )
 


### PR DESCRIPTION
## [TNL-5817: Track grading task latency](https://openedx.atlassian.net/browse/TNL-5817)

Currently adding a log statement when the task is first sent to rabbit/assigned a celery ID, to help track how long that task stays alive.  Format of the log statement should be discussed.

Example output is posted on the JIRA ticket above.

### Sandbox

- [ ] https://jcdyer.sandbox.edx.org/ (Log in to see example logs under /edx/app)
### Reviewers

- [ ] @sanfordstudent 
- [ ] @nasthagiri 

### Post-review

- [ ] Squash commits.