### PR TITLE
Fix issue with --theme-dirs arg to paver compile_sass

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -452,7 +452,7 @@ def compile_sass(options):
     force = options.get('force')
     systems = getattr(options, 'system', ALL_SYSTEMS)
     themes = getattr(options, 'themes', [])
-    theme_dirs = getattr(options, 'theme-dirs', [])
+    theme_dirs = getattr(options, 'theme_dirs', [])
 
     if not theme_dirs and themes:
         # We can not compile a theme sass without knowing the directory that contains the theme.


### PR DESCRIPTION
Getattr + paver does some sort of strange translation of `--kebab-cased` arguments into `snake_cased` ones. Because of this, it seems that the `--theme-dirs` argument to `paver compile_sass` has been broken for some time.

Before:
```
edxapp@precise64:~/edx-platform$ paver compile_sass --theme-dirs=/edx/app/edxapp/themes/edx-platform --themes=globalacademy.hms.harvard.edu --system=lms
Usage: paver pavelib.assets.compile_sass [options]

paver: error: no such option: --theme-dirs
```

After:
```
edxapp@precise64:~/edx-platform$ paver compile_sass --theme-dirs=/edx/app/edxapp/themes/edx-platform --themes=globalacademy.hms.harvard.edu --system=lms
---> pavelib.assets.compile_sass
		Started compiling Sass:
Finished compiling 'common' sass.
Started compiling 'lms' Sass for '/edx/app/edxapp/themes/edx-platform/globalacademy.hms.harvard.edu'.
mkdir_p path('/edx/app/edxapp/themes/edx-platform/globalacademy.hms.harvard.edu/lms/static/css')
Finished compiling 'lms' Sass for '/edx/app/edxapp/themes/edx-platform/globalacademy.hms.harvard.edu'.
Started compiling 'lms' Sass for 'system'.
Finished compiling 'lms' Sass for 'system'.
```

- [ ] @benpatterson
- [ ] @jzoldak 
