### PR TITLE
Update ORA version

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -76,7 +76,7 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@1.1.9#egg=ora2==1.1.9
+git+https://github.com/edx/edx-ora2.git@1.1.10#egg=ora2==1.1.10
 -e git+https://github.com/edx/edx-submissions.git@1.1.1#egg=edx-submissions==1.1.1
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.3.2#egg=i18n-tools==v0.3.2


### PR DESCRIPTION
This upgrade of ORA addresses the following 2 bugs--

1. Update colors to meet a11y color contrast, [TNL-5104](https://openedx.atlassian.net/browse/TNL-5104)
2. File upload input missing label [TNL-5786](https://openedx.atlassian.net/browse/TNL-5786)

- [x] have Eric Fischer update translations (especially if many display strings have changed, otherwise you may be able to skip this step)
- [x] create a PR on edx-ora2 containing the version bump and translation updates. https://github.com/edx/edx-ora2/pull/942
- [x] get a green Travis build on said PR
- [x] merge to master
- [x] green build on master
- [x] create a release tag on GitHub https://github.com/edx/edx-ora2/releases
- [x] manually inspect diff at https://github.com/edx/edx-ora2/compare/0.x.n-1...0.x.n, email contributors
- [x] create PR to update `requirements/edx/github.txt` in `edx-platform`. If manual testing of the changes against edx-platform is desired, create a sandbox. https://cahrens.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/graded_interactions/175e76c4951144a29d46211361266e0e/
- [x] make sure that the ORA acceptance tests have run and passed against the version bump commit (http://jenkins.edx.org:8080/view/ora2/job/ora2-acceptance-tests/). Every merged PR on ora2 master should cause the sandbox deployment and acceptance test sequence to trigger. If for some reason this is not working, get edx-platform PR branch version installed on sandbox, and manually run a11y and acceptance tests for ora.
- [x] get green build on the edx-platform PR, merge
- [ ] manually test changes in RC once weekly edx-platform release is on stage

@staubina Can I get a thumbs-up on this? Here is the sandbox built off of this branch: https://cahrens.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/graded_interactions/175e76c4951144a29d46211361266e0e/

FYI @efischer19 