### PR TITLE
Optimize max_score by moving from XModule to Descriptor

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -129,7 +129,7 @@ class LoncapaProblem(object):
     Main class for capa Problems.
     """
     def __init__(self, problem_text, id, capa_system, capa_module,  # pylint: disable=redefined-builtin
-                 state=None, seed=None):
+                 state=None, seed=None, minimal_init=False):
         """
         Initializes capa Problem.
 
@@ -186,7 +186,10 @@ class LoncapaProblem(object):
         self._process_includes()
 
         # construct script processor context (eg for customresponse problems)
-        self.context = self._extract_context(self.tree)
+        if minimal_init:
+            self.context = {'script_code': ""}
+        else:
+            self.context = self._extract_context(self.tree)
 
         # Pre-parse the XML tree: modifies it to add ID's and perform some in-place
         # transformations.  This also creates the dict (self.responders) of Response
@@ -209,7 +212,8 @@ class LoncapaProblem(object):
             if hasattr(response, 'late_transforms'):
                 response.late_transforms(self)
 
-        self.extracted_tree = self._extract_html(self.tree)
+        if not minimal_init:
+            self.extracted_tree = self._extract_html(self.tree)
 
     def make_xml_compatible(self, tree):
         """

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -357,12 +357,6 @@ class CapaMixin(CapaFields):
         """
         return self.lcp.get_score()
 
-    def max_score(self):
-        """
-        Access the problem's max score
-        """
-        return self.lcp.get_max_score()
-
     def get_progress(self):
         """
         For now, just return score / max_score

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -275,6 +275,38 @@ class CapaDescriptor(CapaFields, RawDescriptor):
             )
         return False
 
+    def max_score(self):
+        """
+        Return the problem's max score
+        """
+        from capa.capa_problem import LoncapaProblem, LoncapaSystem
+        capa_system = LoncapaSystem(
+            ajax_url=None,
+            anonymous_student_id=None,
+            cache=None,
+            can_execute_unsafe_code=None,
+            get_python_lib_zip=None,
+            DEBUG=None,
+            filestore=self.runtime.resources_fs,
+            i18n=self.runtime.service(self, "i18n"),
+            node_path=None,
+            render_template=None,
+            seed=None,
+            STATIC_URL=None,
+            xqueue=None,
+            matlab_api_key=None,
+        )
+        lcp = LoncapaProblem(
+            problem_text=self.data,
+            id=self.location.html_id(),
+            capa_system=capa_system,
+            capa_module=self,
+            state={},
+            seed=1,
+            minimal_init=True,
+        )
+        return lcp.get_max_score()
+
     # Proxy to CapaModule for access to any of its attributes
     answer_available = module_attr('answer_available')
     submit_button_name = module_attr('submit_button_name')

--- a/common/lib/xmodule/xmodule/js/src/capa/display.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.js
@@ -604,7 +604,7 @@
                 case 'incorrect':
                 case 'correct':
                     window.SR.readTexts(that.get_sr_status(response.contents));
-                    that.el.trigger('contentChanged', [that.id, response.contents]);
+                    that.el.trigger('contentChanged', [that.id, response.contents, response]);
                     that.render(response.contents, that.focus_on_submit_notification);
                     that.updateProgress(response);
                     break;
@@ -662,7 +662,7 @@
                 id: this.id
             }, function(response) {
                 if (response.success) {
-                    that.el.trigger('contentChanged', [that.id, response.html]);
+                    that.el.trigger('contentChanged', [that.id, response.html, response]);
                     that.render(response.html, that.scroll_to_problem_meta);
                     that.updateProgress(response);
                     return window.SR.readText(gettext('This problem has been reset.'));
@@ -773,7 +773,7 @@
                 var saveMessage;
                 saveMessage = response.msg;
                 if (response.success) {
-                    that.el.trigger('contentChanged', [that.id, response.html]);
+                    that.el.trigger('contentChanged', [that.id, response.html, response]);
                     edx.HtmlUtils.setHtml(
                         that.el.find('.notification-save .notification-message'),
                         edx.HtmlUtils.HTML(saveMessage)

--- a/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.coffee
@@ -45,23 +45,24 @@ class @Sequence
   hookUpContentStateChangeEvent: ->
     $('.problems-wrapper').bind(
       'contentChanged',
-      (event, problem_id, new_content_state) =>
-        @addToUpdatedProblems problem_id, new_content_state
+      (event, problem_id, new_content_state, new_state) =>
+        @addToUpdatedProblems problem_id, new_content_state, new_state
     )
 
-  addToUpdatedProblems: (problem_id, new_content_state) =>
+  addToUpdatedProblems: (problem_id, new_content_state, new_state) =>
     # Used to keep updated problem's state temporarily.
     # params:
     #   'problem_id' is problem id.
-    #   'new_content_state' is updated problem's state.
+    #   'new_content_state' is the updated content of the problem.
+    #   'new_state' is the updated state of the problem.
 
     # initialize for the current sequence if there isn't any updated problem
     # for this position.
     if not @anyUpdatedProblems @position
       @updatedProblems[@position] = {}
 
-    # Now, put problem content against problem id for current active sequence.
-    @updatedProblems[@position][problem_id] = new_content_state
+    # Now, put problem content and score against problem id for current active sequence.
+    @updatedProblems[@position][problem_id] = [new_content_state, new_state]
 
   anyUpdatedProblems:(position) ->
     # check for the updated problems for given sequence position.
@@ -161,10 +162,15 @@ class @Sequence
 
       # update the data-attributes with latest contents only for updated problems.
       if @anyUpdatedProblems new_position
-        $.each @updatedProblems[new_position], (problem_id, latest_content) =>
+        $.each @updatedProblems[new_position], (problem_id, latest_data) =>
+          latest_content = latest_data[0]
+          latest_response = latest_data[1]
           @content_container
           .find("[data-problem-id='#{ problem_id }']")
           .data('content', latest_content)
+          .data('problem-score', latest_response.current_score)
+          .data('problem-total-possible', latest_response.total_possible)
+          .data('attempts-used', latest_response.attempts_used)
 
       XBlock.initializeBlocks(@content_container, @requestToken)
 

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -649,9 +649,6 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
         params.update(body)
         return params
 
-    def max_score(self):
-        return self.weight if self.has_score else None
-
     @XBlock.handler
     def grade_handler(self, request, suffix):  # pylint: disable=unused-argument
         """
@@ -898,6 +895,10 @@ class LTIDescriptor(LTIFields, MetadataOnlyEditingDescriptor, EmptyDataRawDescri
     """
     Descriptor for LTI Xmodule.
     """
+
+    def max_score(self):
+        return self.weight if self.has_score else None
+
     module_class = LTIModule
     resources_dir = None
     grade_handler = module_attr('grade_handler')

--- a/common/lib/xmodule/xmodule/tests/test_lti_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti_unit.py
@@ -72,6 +72,7 @@ class LTIModuleTest(LogicTest):
 
         self.xmodule.due = None
         self.xmodule.graceperiod = None
+        self.xmodule.descriptor = self.system.construct_xblock_from_class(self.descriptor_class, self.xmodule.scope_ids)
 
     def get_request_body(self, params=None):
         """Fetches the body of a request specified by params"""

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -806,6 +806,7 @@ class XModule(HTMLSnippet, XModuleMixin):
     entry_point = "xmodule.v1"
 
     has_score = descriptor_attr('has_score')
+    max_score = descriptor_attr('max_score')
     show_in_read_only_mode = descriptor_attr('show_in_read_only_mode')
     _field_data_cache = descriptor_attr('_field_data_cache')
     _field_data = descriptor_attr('_field_data')
@@ -1201,7 +1202,6 @@ class XModuleDescriptor(HTMLSnippet, ResourceTemplates, XModuleMixin):
     get_progress = module_attr('get_progress')
     get_score = module_attr('get_score')
     handle_ajax = module_attr('handle_ajax')
-    max_score = module_attr('max_score')
     student_view = module_attr(STUDENT_VIEW)
     get_child_descriptors = module_attr('get_child_descriptors')
     xmodule_handler = module_attr('xmodule_handler')

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -124,13 +124,14 @@ def enqueue_subsection_update(sender, **kwargs):  # pylint: disable=unused-argum
     Handles the PROBLEM_SCORE_CHANGED signal by enqueueing a subsection update operation to occur asynchronously.
     """
     recalculate_subsection_grade.apply_async(
-        args=(
-            kwargs['user_id'],
-            kwargs['course_id'],
-            kwargs['usage_id'],
-            kwargs.get('only_if_higher'),
-            kwargs.get('points_earned'),
-            kwargs.get('points_possible'),
+        kwargs=dict(
+            user_id=kwargs['user_id'],
+            course_id=kwargs['course_id'],
+            usage_id=kwargs['usage_id'],
+            only_if_higher=kwargs.get('only_if_higher'),
+            raw_earned=kwargs.get('points_earned'),
+            raw_possible=kwargs.get('points_possible'),
+            score_deleted=kwargs.get('score_deleted', False),
         )
     )
 

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -23,50 +23,40 @@ log = getLogger(__name__)
 
 
 @task(default_retry_delay=30, routing_key=settings.RECALCULATE_GRADES_ROUTING_KEY)
-def recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible):
+def recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible, **kwargs):
     """
     Updates a saved subsection grade.
-    This method expects the following parameters:
-        - user_id: serialized id of applicable User object
-        - course_id: Unicode string identifying the course
-        - usage_id: Unicode string identifying the course block
-        - only_if_higher: boolean indicating whether grades should
-        be updated only if the new raw_earned is higher than the previous
-        value.
-        - raw_earned: the raw points the learner earned on the problem that
-        triggered the update
-        - raw_possible: the max raw points the leaner could have earned
-        on the problem
+
+    Arguments:
+        user_id (int): id of applicable User object
+        course_id (string): identifying the course
+        usage_id (string): identifying the course block
+        only_if_higher (boolean): indicating whether grades should
+            be updated only if the new raw_earned is higher than the
+            previous value.
+        raw_earned (float): the raw points the learner earned on the
+            problem that triggered the update.
+        raw_possible (float): the max raw points the leaner could have
+            earned on the problem.
+        score_deleted (boolean): indicating whether the grade change is
+            a result of the problem's score being deleted.
     """
     course_key = CourseLocator.from_string(course_id)
     if not PersistentGradesEnabledFlag.feature_enabled(course_key):
         return
 
+    score_deleted = kwargs['score_deleted']
     scored_block_usage_key = UsageKey.from_string(usage_id).replace(course_key=course_key)
-    score = get_score(user_id, scored_block_usage_key)
 
-    # If the score is None, it has not been saved at all yet
-    # and we need to retry until it has been saved.
-    if score is None:
+    # Verify the database has been updated with the scores when the task was
+    # created. This race condition occurs if the transaction in the task
+    # creator's process hasn't committed before the task initiates in the worker
+    # process.
+    if not _has_database_updated_with_new_score(
+            user_id, scored_block_usage_key, raw_earned, raw_possible, score_deleted,
+    ):
         raise _retry_recalculate_subsection_grade(
-            user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible,
-        )
-    else:
-        module_raw_earned, module_raw_possible = score  # pylint: disable=unpacking-non-sequence
-
-    # Validate that the retrieved scores match the scores when the task was created.
-    # This race condition occurs if the transaction in the task creator's process hasn't
-    # committed before the task initiates in the worker process.
-    grades_match = module_raw_earned == raw_earned and module_raw_possible == raw_possible
-
-    # We have to account for the situation where a student's state
-    # has been deleted- in this case, get_score returns (None, None), but
-    # the score change signal will contain 0 for raw_earned.
-    state_deleted = module_raw_earned is None and module_raw_possible is None and raw_earned == 0
-
-    if not (state_deleted or grades_match):
-        raise _retry_recalculate_subsection_grade(
-            user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible,
+            user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible, score_deleted,
         )
 
     _update_subsection_grades(
@@ -78,6 +68,28 @@ def recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher, r
         usage_id,
         raw_earned,
         raw_possible,
+        score_deleted,
+    )
+
+
+def _has_database_updated_with_new_score(
+        user_id, scored_block_usage_key, expected_raw_earned, expected_raw_possible, score_deleted,
+):
+    """
+    Returns whether the database has been updated with the
+    expected new score values for the given problem and user.
+    """
+    score = get_score(user_id, scored_block_usage_key)
+
+    if score is None:
+        # score should be None only if it was deleted.
+        # Otherwise, it hasn't yet been saved.
+        return score_deleted
+
+    found_raw_earned, found_raw_possible = score  # pylint: disable=unpacking-non-sequence
+    return (
+        found_raw_earned == expected_raw_earned and
+        found_raw_possible == expected_raw_possible
     )
 
 
@@ -90,6 +102,7 @@ def _update_subsection_grades(
         usage_id,
         raw_earned,
         raw_possible,
+        score_deleted,
 ):
     """
     A helper function to update subsection grades in the database
@@ -124,23 +137,26 @@ def _update_subsection_grades(
 
     except IntegrityError as exc:
         raise _retry_recalculate_subsection_grade(
-            user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible, exc,
+            user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible, score_deleted, exc,
         )
 
 
-def _retry_recalculate_subsection_grade(user_id, course_id, usage_id, only_if_higher, grade, max_grade, exc=None):
+def _retry_recalculate_subsection_grade(
+        user_id, course_id, usage_id, only_if_higher, raw_earned, raw_possible, score_deleted, exc=None,
+):
     """
     Calls retry for the recalculate_subsection_grade task with the
     given inputs.
     """
     recalculate_subsection_grade.retry(
-        args=[
-            user_id,
-            course_id,
-            usage_id,
-            only_if_higher,
-            grade,
-            max_grade,
-        ],
-        exc=exc
+        kwargs=dict(
+            user_id=user_id,
+            course_id=course_id,
+            usage_id=usage_id,
+            only_if_higher=only_if_higher,
+            raw_earned=raw_earned,
+            raw_possible=raw_possible,
+            score_deleted=score_deleted,
+        ),
+        exc=exc,
     )


### PR DESCRIPTION
## [TNL-5939](https://openedx.atlassian.net/browse/TNL-5939)

### Description

Prior to this PR, an XBlock's `max_score` method used to be on the XModule interface.  So even though `max_score` is not a user-specific value, accessing it required binding with the XModule.  This was causing a performance hit in the Grades Transformer - and resulted in 1/3 of the total cost of collecting _all_ Block Transformer data.

Thus, this PR moves the `max_score` method to the XModuleDescriptor interface instead, substantially improving the performance of the BT collect phase.

There were 2 additional bug fixes needed as they were surfaced as part of this PR and have been included as separate commits:

1. The Delete Student State implementation needed to be updated since it was relying on a side-effect of the XModule binding.  Prior to this, when the XModule was bound to get the `max_score`, the `StudentModule` object was re-created for the user right after it was deleted.  Hence, the code in `recalculate_subsection_grade` expected an entry to be there with values of `None` rather than the entry being non-existent.  This PR now changes the code to expect the entry to not be there when the student state is deleted.

2. The CAPA Progress state was exhibiting flaky behavior.  It was showing outdated progress state when navigating back and forth between tabs in the sequence.  ([Jira ticket](https://openedx.atlassian.net/browse/TNL-5988)) 

### Reviewers
2 of @efischer19 @jcdyer @sanfordstudent 

FYI @staubina 

### Post-review
- [ ] Rebase and squash commits
