### PR TITLE
use a QueryDict to encode a url param that potentially has unicode (E…

### DIFF
--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -1,14 +1,15 @@
+# coding=utf-8
 """
 Test the course_info xblock
 """
 import mock
 from nose.plugins.attrib import attr
 from pyquery import PyQuery as pq
-from urllib import urlencode
 
 from ccx_keys.locator import CCXLocator
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.http import QueryDict
 from django.test.utils import override_settings
 
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
@@ -89,7 +90,34 @@ class CourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
         url = reverse('info', args=[unicode(self.course.id)])
         response = self.client.get(url)
         start_date = strftime_localized(self.course.start, 'SHORT_DATE')
-        self.assertRedirects(response, '{0}?{1}'.format(reverse('dashboard'), urlencode({'notlive': start_date})))
+        expected_params = QueryDict(mutable=True)
+        expected_params['notlive'] = start_date
+        expected_url = '{url}?{params}'.format(
+            url=reverse('dashboard'),
+            params=expected_params.urlencode()
+        )
+        self.assertRedirects(response, expected_url)
+
+    @mock.patch.dict(settings.FEATURES, {'DISABLE_START_DATES': False})
+    @mock.patch("courseware.views.views.strftime_localized")
+    def test_non_live_course_other_language(self, mock_strftime_localized):
+        """Ensure that a user accessing a non-live course sees a redirect to
+        the student dashboard, not a 404, even if the localized date is unicode
+        """
+        self.setup_user()
+        self.enroll(self.course)
+        fake_unicode_start_time = u"üñîçø∂é_ßtå®t_tîµé"
+        mock_strftime_localized.return_value = fake_unicode_start_time
+
+        url = reverse('info', args=[unicode(self.course.id)])
+        response = self.client.get(url)
+        expected_params = QueryDict(mutable=True)
+        expected_params['notlive'] = fake_unicode_start_time
+        expected_url = u'{url}?{params}'.format(
+            url=reverse('dashboard'),
+            params=expected_params.urlencode()
+        )
+        self.assertRedirects(response, expected_url)
 
     def test_nonexistent_course(self):
         self.setup_user()


### PR DESCRIPTION
…COM-6390)

## [ECOM-6390](https://openedx.atlassian.net/browse/ECOM-6390)

### Description

replaces `urllib.urlencode` with django's [`QueryDict`](https://docs.djangoproject.com/en/1.10/ref/request-response/#django.http.QueryDict.urlencode) object to handle encoding unicode strings

### How to Test?

1. create a course and make sure start date is in the future (should be by default)
2. go to /update_lang/ and type in "eo" to get fake "esperanto" strings
3. access the course info page with a *student* account: /courses/<course_key>/

**Sandbox**
I'm having trouble making a sandbox :/. Luckily it's relatively straightforward to reproduce locally

**Screenshot**
After fix: 
![unspecified-21](https://cloud.githubusercontent.com/assets/2748698/20360258/09aefc2e-ac01-11e6-96a7-c3def5c81aa5.png)
Before fix: just 500 error

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code Review: @Qubad786
- [x] Code Review: @noraiz-anwar

FYI: Tag anyone who might be interested in this PR here.
@bderusha adding you as an optional reviewer

### Post-review
- [x] Rebase and squash commits