### PR TITLE
User Info Cookie Updates

### DIFF
--- a/common/djangoapps/student/cookies.py
+++ b/common/djangoapps/student/cookies.py
@@ -1,17 +1,42 @@
 """
 Utility functions for setting "logged in" cookies used by subdomains.
 """
+from __future__ import unicode_literals
 
-import time
 import json
+import time
 
-from django.dispatch import Signal
-
-from django.utils.http import cookie_date
+import six
 from django.conf import settings
 from django.core.urlresolvers import reverse, NoReverseMatch
+from django.dispatch import Signal
+from django.utils.http import cookie_date
 
-CREATE_LOGON_COOKIE = Signal(providing_args=["user", "response"])
+from student.models import CourseEnrollment
+
+CREATE_LOGON_COOKIE = Signal(providing_args=['user', 'response'])
+
+
+def _get_cookie_settings(request):
+    """ Returns the common cookie settings (e.g. expiration time). """
+
+    if request.session.get_expire_at_browser_close():
+        max_age = None
+        expires = None
+    else:
+        max_age = request.session.get_expiry_age()
+        expires_time = time.time() + max_age
+        expires = cookie_date(expires_time)
+
+    cookie_settings = {
+        'max_age': max_age,
+        'expires': expires,
+        'domain': settings.SESSION_COOKIE_DOMAIN,
+        'path': '/',
+        'httponly': None,
+    }
+
+    return cookie_settings
 
 
 def set_logged_in_cookies(request, response, user):
@@ -31,7 +56,6 @@ def set_logged_in_cookies(request, response, user):
     {
         "version": 1,
         "username": "test-user",
-        "email": "test-user@example.com",
         "header_urls": {
             "account_settings": "https://example.com/account/settings",
             "learner_profile": "https://example.com/u/test-user",
@@ -49,21 +73,7 @@ def set_logged_in_cookies(request, response, user):
         HttpResponse
 
     """
-    if request.session.get_expire_at_browser_close():
-        max_age = None
-        expires = None
-    else:
-        max_age = request.session.get_expiry_age()
-        expires_time = time.time() + max_age
-        expires = cookie_date(expires_time)
-
-    cookie_settings = {
-        'max_age': max_age,
-        'expires': expires,
-        'domain': settings.SESSION_COOKIE_DOMAIN,
-        'path': '/',
-        'httponly': None,
-    }
+    cookie_settings = _get_cookie_settings(request)
 
     # Backwards compatibility: set the cookie indicating that the user
     # is logged in.  This is just a boolean value, so it's not very useful.
@@ -75,6 +85,42 @@ def set_logged_in_cookies(request, response, user):
         secure=None,
         **cookie_settings
     )
+
+    set_user_info_cookie(response, request)
+
+    # give signal receivers a chance to add cookies
+    CREATE_LOGON_COOKIE.send(sender=None, user=user, response=response)
+
+    return response
+
+
+def set_user_info_cookie(response, request):
+    """ Sets the user info cookie on the response. """
+    cookie_settings = _get_cookie_settings(request)
+
+    # In production, TLS should be enabled so that this cookie is encrypted
+    # when we send it.  We also need to set "secure" to True so that the browser
+    # will transmit it only over secure connections.
+    #
+    # In non-production environments (acceptance tests, devstack, and sandboxes),
+    # we still want to set this cookie.  However, we do NOT want to set it to "secure"
+    # because the browser won't send it back to us.  This can cause an infinite redirect
+    # loop in the third-party auth flow, which calls `is_logged_in_cookie_set` to determine
+    # whether it needs to set the cookie or continue to the next pipeline stage.
+    user_info_cookie_is_secure = request.is_secure()
+    user_info = get_user_info_cookie_data(request)
+
+    response.set_cookie(
+        settings.EDXMKTG_USER_INFO_COOKIE_NAME.encode('utf-8'),
+        json.dumps(user_info),
+        secure=user_info_cookie_is_secure,
+        **cookie_settings
+    )
+
+
+def get_user_info_cookie_data(request):
+    """ Returns information that wil populate the user info cookie. """
+    user = request.user
 
     # Set a cookie with user info.  This can be used by external sites
     # to customize content based on user information.  Currently,
@@ -94,38 +140,17 @@ def set_logged_in_cookies(request, response, user):
         pass
 
     # Convert relative URL paths to absolute URIs
-    for url_name, url_path in header_urls.iteritems():
+    for url_name, url_path in six.iteritems(header_urls):
         header_urls[url_name] = request.build_absolute_uri(url_path)
 
     user_info = {
         'version': settings.EDXMKTG_USER_INFO_COOKIE_VERSION,
         'username': user.username,
-        'email': user.email,
         'header_urls': header_urls,
+        'enrollmentStatusHash': CourseEnrollment.generate_enrollment_status_hash(user)
     }
 
-    # In production, TLS should be enabled so that this cookie is encrypted
-    # when we send it.  We also need to set "secure" to True so that the browser
-    # will transmit it only over secure connections.
-    #
-    # In non-production environments (acceptance tests, devstack, and sandboxes),
-    # we still want to set this cookie.  However, we do NOT want to set it to "secure"
-    # because the browser won't send it back to us.  This can cause an infinite redirect
-    # loop in the third-party auth flow, which calls `is_logged_in_cookie_set` to determine
-    # whether it needs to set the cookie or continue to the next pipeline stage.
-    user_info_cookie_is_secure = request.is_secure()
-
-    response.set_cookie(
-        settings.EDXMKTG_USER_INFO_COOKIE_NAME.encode('utf-8'),
-        json.dumps(user_info),
-        secure=user_info_cookie_is_secure,
-        **cookie_settings
-    )
-
-    # give signal receivers a chance to add cookies
-    CREATE_LOGON_COOKIE.send(sender=None, user=user, response=response)
-
-    return response
+    return user_info
 
 
 def delete_logged_in_cookies(response):

--- a/common/djangoapps/student/tests/test_cookies.py
+++ b/common/djangoapps/student/tests/test_cookies.py
@@ -1,0 +1,57 @@
+# pylint: disable=missing-docstring
+from __future__ import unicode_literals
+
+import six
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.test import RequestFactory
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from student.cookies import get_user_info_cookie_data
+from student.models import CourseEnrollment
+from student.tests.factories import UserFactory
+
+
+class CookieTests(SharedModuleStoreTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(CookieTests, cls).setUpClass()
+        cls.course = CourseFactory()
+
+    def setUp(self):
+        super(CookieTests, self).setUp()
+        self.user = UserFactory.create()
+
+    def _get_expected_header_urls(self, request):
+        expected_header_urls = {
+            'logout': reverse('logout'),
+        }
+
+        # Studio (CMS) does not have the URLs below
+        if settings.ROOT_URLCONF == 'lms.urls':
+            expected_header_urls.update({
+                'account_settings': reverse('account_settings'),
+                'learner_profile': reverse('learner_profile', kwargs={'username': self.user.username}),
+            })
+
+        # Convert relative URL paths to absolute URIs
+        for url_name, url_path in six.iteritems(expected_header_urls):
+            expected_header_urls[url_name] = request.build_absolute_uri(url_path)
+
+        return expected_header_urls
+
+    def test_get_user_info_cookie_data(self):
+        request = RequestFactory().get('/')
+        request.user = self.user
+
+        actual = get_user_info_cookie_data(request)
+
+        expected = {
+            'version': settings.EDXMKTG_USER_INFO_COOKIE_VERSION,
+            'username': self.user.username,
+            'header_urls': self._get_expected_header_urls(request),
+            'enrollmentStatusHash': CourseEnrollment.generate_enrollment_status_hash(self.user)
+        }
+
+        self.assertDictEqual(actual, expected)

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -1,6 +1,6 @@
-'''
+"""
 Tests for student activation and login
-'''
+"""
 import json
 import unittest
 
@@ -30,9 +30,9 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 
 class LoginTest(CacheIsolationTestCase):
-    '''
+    """
     Test student.views.login_user() view
-    '''
+    """
 
     ENABLED_CACHES = ['default']
 
@@ -171,12 +171,8 @@ class LoginTest(CacheIsolationTestCase):
         cookie = self.client.cookies[settings.EDXMKTG_USER_INFO_COOKIE_NAME]
         user_info = json.loads(cookie.value)
 
-        # Check that the version is set
         self.assertEqual(user_info["version"], settings.EDXMKTG_USER_INFO_COOKIE_VERSION)
-
-        # Check that the username and email are set
         self.assertEqual(user_info["username"], self.user.username)
-        self.assertEqual(user_info["email"], self.user.email)
 
         # Check that the URLs are absolute
         for url in user_info["header_urls"].values():

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -1,0 +1,84 @@
+# pylint: disable=missing-docstring
+
+import hashlib
+
+from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
+from django.db.models.functions import Lower
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from student.models import CourseEnrollment
+from student.tests.factories import UserFactory, CourseEnrollmentFactory
+
+
+class CourseEnrollmentTests(SharedModuleStoreTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(CourseEnrollmentTests, cls).setUpClass()
+        cls.course = CourseFactory()
+
+    def setUp(self):
+        super(CourseEnrollmentTests, self).setUp()
+        self.user = UserFactory.create()
+
+    def test_enrollment_status_hash_cache_key(self):
+        username = 'test-user'
+        user = UserFactory(username=username)
+        expected = 'enrollment_status_hash_' + username
+        self.assertEqual(CourseEnrollment.enrollment_status_hash_cache_key(user), expected)
+
+    def assert_enrollment_status_hash_cached(self, user, expected_value):
+        self.assertEqual(cache.get(CourseEnrollment.enrollment_status_hash_cache_key(user)), expected_value)
+
+    def test_generate_enrollment_status_hash(self):
+        """ Verify the method returns a hash of a user's current enrollments. """
+        # Return None for anonymous users
+        self.assertIsNone(CourseEnrollment.generate_enrollment_status_hash(AnonymousUser()))
+
+        # No enrollments
+        expected = hashlib.md5(self.user.username).hexdigest()
+        self.assertEqual(CourseEnrollment.generate_enrollment_status_hash(self.user), expected)
+        self.assert_enrollment_status_hash_cached(self.user, expected)
+
+        # No active enrollments
+        enrollment_mode = 'verified'
+        course_id = self.course.id  # pylint: disable=no-member
+        enrollment = CourseEnrollmentFactory.create(user=self.user, course_id=course_id, mode=enrollment_mode,
+                                                    is_active=False)
+        self.assertEqual(CourseEnrollment.generate_enrollment_status_hash(self.user), expected)
+        self.assert_enrollment_status_hash_cached(self.user, expected)
+
+        # One active enrollment
+        enrollment.is_active = True
+        enrollment.save()
+        expected = '{username}&{course_id}={mode}'.format(
+            username=self.user.username, course_id=str(course_id).lower(), mode=enrollment_mode.lower()
+        )
+        expected = hashlib.md5(expected).hexdigest()
+        self.assertEqual(CourseEnrollment.generate_enrollment_status_hash(self.user), expected)
+        self.assert_enrollment_status_hash_cached(self.user, expected)
+
+        # Multiple enrollments
+        CourseEnrollmentFactory.create(user=self.user)
+        enrollments = CourseEnrollment.enrollments_for_user(self.user).order_by(Lower('course_id'))
+        hash_elements = [self.user.username]
+        hash_elements += [
+            '{course_id}={mode}'.format(course_id=str(enrollment.course_id).lower(), mode=enrollment.mode.lower()) for
+            enrollment in enrollments]
+        expected = hashlib.md5('&'.join(hash_elements)).hexdigest()
+        self.assertEqual(CourseEnrollment.generate_enrollment_status_hash(self.user), expected)
+        self.assert_enrollment_status_hash_cached(self.user, expected)
+
+    def test_save_deletes_cached_enrollment_status_hash(self):
+        """ Verify the method deletes the cached enrollment status hash for the user. """
+        # There should be no cached value for a new user with no enrollments.
+        self.assertIsNone(cache.get(CourseEnrollment.enrollment_status_hash_cache_key(self.user)))
+
+        # Generating a status hash should cache the generated value.
+        status_hash = CourseEnrollment.generate_enrollment_status_hash(self.user)
+        self.assert_enrollment_status_hash_cached(self.user, status_hash)
+
+        # Modifying enrollments should delete the cached value.
+        CourseEnrollmentFactory.create(user=self.user)
+        self.assertIsNone(cache.get(CourseEnrollment.enrollment_status_hash_cache_key(self.user)))

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -107,7 +107,7 @@ from student.helpers import (
     DISABLE_UNENROLL_CERT_STATES,
     destroy_oauth_tokens
 )
-from student.cookies import set_logged_in_cookies, delete_logged_in_cookies
+from student.cookies import set_logged_in_cookies, delete_logged_in_cookies, set_user_info_cookie
 from student.models import anonymous_id_for_user, UserAttribute, EnrollStatusChange
 from shoppingcart.models import DonationConfiguration, CourseRegistrationCode
 
@@ -785,7 +785,9 @@ def dashboard(request):
             'ecommerce_payment_page': ecommerce_service.payment_page_url(),
         })
 
-    return render_to_response('dashboard.html', context)
+    response = render_to_response('dashboard.html', context)
+    set_user_info_cookie(response, request)
+    return response
 
 
 def _create_recent_enrollment_message(course_enrollments, course_modes):  # pylint: disable=invalid-name

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -99,6 +99,7 @@ rules==1.1.1
 scipy==0.14.0
 Shapely==1.2.16
 singledispatch==3.4.0.2
+six>=1.10.0,<2.0.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
 stevedore==1.10.0


### PR DESCRIPTION
The cookie stored at login now stores a hash of the user's enrollments. This can be used to determine if enrollment data, cached client-side, needs to be refreshed. Additionally, the cookie is now updated when the users visit the student dashboard.

ECOM-4707