### PR TITLE
Bump problem-builder to v2.6.3

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@v2.6.1#egg=xblock-problem-builder==2.6.1
+git+https://github.com/open-craft/problem-builder.git@v2.6.3#egg=xblock-problem-builder==2.6.3
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
The new version extends the `course_id` field to support courses with course keys longer than 50 characters: https://github.com/open-craft/problem-builder/pull/130

Note that this includes changes from https://github.com/edx/edx-platform/pull/13953, which hasn't been merged yet.

Below is the output of sqlmigrate for the new migration:

```
BEGIN;
ALTER TABLE `problem_builder_answer` MODIFY `course_id` varchar(255) NOT NULL;

COMMIT;
```

**Environments**:  edx.org and edge.edx.org

**Merge deadline**: ASAP - this is blocking a course on Edge

**JIRA tickets**: [TNL-5932](https://openedx.atlassian.net/browse/TNL-5932)

**Discussions**: See JIRA ticket.

**Dependencies**: https://github.com/edx/edx-platform/pull/13953

**Sandbox URL**:

- LMS: http://pr14013.sandbox.opencraft.hosting/
- Studio: http://studio-pr14013.sandbox.opencraft.hosting/

**Partner information**: hosted on edX Edge (Davidson College)

**Testing instructions**:

Check that you can successfully add a Problem Builder "Long Answer" component to a course with a course key that is longer than 50 character. See working example on the sandbox: https://studio-pr14013.sandbox.opencraft.hosting/container/block-v1:VeryLongOrganizationName+VeryLongCourseName+VeryLongCourseRun2016+type@vertical+block@44e0d2e57f3840faa7278164960338ff

Compare this to the broken problem on the old (v2.6.2) sandbox where I created a course with the same course key length and tried to add a "Long Answer" component to it: https://studio-pr13953.sandbox.opencraft.hosting/container/block-v1:VeryLongOrganizationName+VeryLongCourseName+VeryLongCourseRun2016+type@vertical+block@0ce09c73c6874411907ff24cbd325394

**Author notes and concerns**:

1. problem-builder v2.6.3 includes changes from https://github.com/edx/edx-platform/pull/13953, which has not been merged into edx-platform yet.
2. This PR contains a migration of a potentially large MySQL table, we would like someone from @edx/devops to review it.

**Reviewers**
- [ ] @pomegranited
- [ ] @adampalay 
- [ ] @edx/devops 

**Settings**
```yaml
NGINX_SET_X_FORWARDED_HEADERS: false
EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/open-craft/problem-builder.git@v2.6.3#egg=xblock-problem-builder==2.6.3
```