### PR TITLE
Additional acceptance test to check the problem meta is not altered b…

### DIFF
--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -48,6 +48,13 @@ class ProblemPage(PageObject):
         return self.q(css="div.problems-wrapper").text[0]
 
     @property
+    def problem_meta(self):
+        """
+        Return the problem meta text
+        """
+        return self.q(css=".problems-wrapper .problem-progress").text[0]
+
+    @property
     def message_text(self):
         """
         Return the "message" text of the question of the problem.

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -714,36 +714,6 @@ class ProblemStateOnNavigationTest(UniqueCourseTest):
         )
         self.assertEqual(self.problem_page.problem_name, problem_name)
 
-    def test_problem_meta_after_submit_and_navigate(self):
-        """
-        Scenario:
-        I go to sequential position 1
-        Facing problem1, I select 'choice_1'
-        Then I click submit button
-        Then I go to sequential position 2
-        Then I came back to sequential position 1 again
-        Facing problem1, I observe the problem1 meta and score data is not
-        altered before and after sequence navigation
-        """
-        # Go to sequential position 1 and assert that we are on problem 1.
-        self.go_to_tab_and_assert_problem(1, self.problem1_name)
-
-        # Update problem 1's content state by clicking check button.
-        self.problem_page.click_choice('choice_choice_1')
-        self.problem_page.click_submit()
-        self.problem_page.wait_for_expected_status('label.choicegroup_incorrect', 'incorrect')
-
-        before_meta = self.problem_page.problem_meta
-
-        # Go to sequential position 2 and assert that we are on problem 2.
-        self.go_to_tab_and_assert_problem(2, self.problem2_name)
-
-        # Come back to our original unit in the sequence and assert that the content hasn't changed.
-        self.go_to_tab_and_assert_problem(1, self.problem1_name)
-
-        after_meta = self.problem_page.problem_meta
-        self.assertEqual(before_meta, after_meta)
-
     def test_perform_problem_submit_and_navigate(self):
         """
         Scenario:
@@ -765,6 +735,7 @@ class ProblemStateOnNavigationTest(UniqueCourseTest):
 
         # Save problem 1's content state as we're about to switch units in the sequence.
         problem1_content_before_switch = self.problem_page.problem_content
+        before_meta = self.problem_page.problem_meta
 
         # Go to sequential position 2 and assert that we are on problem 2.
         self.go_to_tab_and_assert_problem(2, self.problem2_name)
@@ -772,7 +743,10 @@ class ProblemStateOnNavigationTest(UniqueCourseTest):
         # Come back to our original unit in the sequence and assert that the content hasn't changed.
         self.go_to_tab_and_assert_problem(1, self.problem1_name)
         problem1_content_after_coming_back = self.problem_page.problem_content
+        after_meta = self.problem_page.problem_meta
+
         self.assertEqual(problem1_content_before_switch, problem1_content_after_coming_back)
+        self.assertEqual(before_meta, after_meta)
 
     def test_perform_problem_save_and_navigate(self):
         """
@@ -795,6 +769,7 @@ class ProblemStateOnNavigationTest(UniqueCourseTest):
 
         # Save problem 1's content state as we're about to switch units in the sequence.
         problem1_content_before_switch = self.problem_page.problem_input_content
+        before_meta = self.problem_page.problem_meta
 
         # Go to sequential position 2 and assert that we are on problem 2.
         self.go_to_tab_and_assert_problem(2, self.problem2_name)
@@ -804,7 +779,10 @@ class ProblemStateOnNavigationTest(UniqueCourseTest):
         # Come back to our original unit in the sequence and assert that the content hasn't changed.
         self.go_to_tab_and_assert_problem(1, self.problem1_name)
         problem1_content_after_coming_back = self.problem_page.problem_input_content
+        after_meta = self.problem_page.problem_meta
+
         self.assertIn(problem1_content_after_coming_back, problem1_content_before_switch)
+        self.assertEqual(before_meta, after_meta)
 
     def test_perform_problem_reset_and_navigate(self):
         """
@@ -829,6 +807,7 @@ class ProblemStateOnNavigationTest(UniqueCourseTest):
 
         # Save problem 1's content state as we're about to switch units in the sequence.
         problem1_content_before_switch = self.problem_page.problem_content
+        before_meta = self.problem_page.problem_meta
 
         # Go to sequential position 2 and assert that we are on problem 2.
         self.go_to_tab_and_assert_problem(2, self.problem2_name)
@@ -836,7 +815,10 @@ class ProblemStateOnNavigationTest(UniqueCourseTest):
         # Come back to our original unit in the sequence and assert that the content hasn't changed.
         self.go_to_tab_and_assert_problem(1, self.problem1_name)
         problem1_content_after_coming_back = self.problem_page.problem_content
+        after_meta = self.problem_page.problem_meta
+
         self.assertEqual(problem1_content_before_switch, problem1_content_after_coming_back)
+        self.assertEqual(before_meta, after_meta)
 
 
 class SubsectionHiddenAfterDueDateTest(UniqueCourseTest):

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -663,7 +663,7 @@ class CoursewareMultipleVerticalsTest(UniqueCourseTest, EventsTestMixin):
 
 class ProblemStateOnNavigationTest(UniqueCourseTest):
     """
-    Test courseware with problems in multiple verticals
+    Test courseware with problems in multiple verticals.
     """
     USERNAME = "STUDENT_TESTER"
     EMAIL = "student101@example.com"
@@ -713,6 +713,36 @@ class ProblemStateOnNavigationTest(UniqueCourseTest):
             'wait for problem header'
         )
         self.assertEqual(self.problem_page.problem_name, problem_name)
+
+    def test_problem_meta_after_submit_and_navigate(self):
+        """
+        Scenario:
+        I go to sequential position 1
+        Facing problem1, I select 'choice_1'
+        Then I click submit button
+        Then I go to sequential position 2
+        Then I came back to sequential position 1 again
+        Facing problem1, I observe the problem1 meta and score data is not
+        altered before and after sequence navigation
+        """
+        # Go to sequential position 1 and assert that we are on problem 1.
+        self.go_to_tab_and_assert_problem(1, self.problem1_name)
+
+        # Update problem 1's content state by clicking check button.
+        self.problem_page.click_choice('choice_choice_1')
+        self.problem_page.click_submit()
+        self.problem_page.wait_for_expected_status('label.choicegroup_incorrect', 'incorrect')
+
+        before_meta = self.problem_page.problem_meta
+
+        # Go to sequential position 2 and assert that we are on problem 2.
+        self.go_to_tab_and_assert_problem(2, self.problem2_name)
+
+        # Come back to our original unit in the sequence and assert that the content hasn't changed.
+        self.go_to_tab_and_assert_problem(1, self.problem1_name)
+
+        after_meta = self.problem_page.problem_meta
+        self.assertEqual(before_meta, after_meta)
 
     def test_perform_problem_submit_and_navigate(self):
         """


### PR DESCRIPTION
…y sequence navigation.

This is a new test to check for changes in the problem meta when navigating sequential problem sets.

It will fail until this PR: https://github.com/edx/edx-platform/pull/14001 is merged

@cahrens @nasthagiri Please review this when you have a moment.  I will rebase on master when 14001 is merged.