### PR TITLE
Add swift settings to CMS

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -265,6 +265,9 @@ if FEATURES.get('AUTH_USE_CAS'):
             CAS_ATTRIBUTE_CALLBACK['function']
         )
 
+# Specific setting for the File Upload Service to store media in a bucket.
+FILE_UPLOAD_STORAGE_BUCKET_NAME = ENV_TOKENS.get('FILE_UPLOAD_STORAGE_BUCKET_NAME', FILE_UPLOAD_STORAGE_BUCKET_NAME)
+FILE_UPLOAD_STORAGE_PREFIX = ENV_TOKENS.get('FILE_UPLOAD_STORAGE_PREFIX', FILE_UPLOAD_STORAGE_PREFIX)
 
 ################ SECURE AUTH ITEMS ###############################
 # Secret things: passwords, access keys, etc.

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -84,6 +84,10 @@ from lms.envs.common import (
     # django-debug-toolbar
     DEBUG_TOOLBAR_PATCH_SETTINGS,
     BLOCK_STRUCTURES_SETTINGS,
+
+    # File upload defaults
+    FILE_UPLOAD_STORAGE_BUCKET_NAME,
+    FILE_UPLOAD_STORAGE_PREFIX,
 )
 from path import Path as path
 from warnings import simplefilter

--- a/cms/envs/openstack.py
+++ b/cms/envs/openstack.py
@@ -2,4 +2,28 @@
 Settings for OpenStack deployments.
 """
 
+# We import the aws settings because that's currently where the base settings are stored for all deployments.
+# TODO - fix this when aws.py is split/renamed.
 from .aws import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+SWIFT_AUTH_URL = AUTH_TOKENS.get('SWIFT_AUTH_URL')
+SWIFT_AUTH_VERSION = AUTH_TOKENS.get('SWIFT_AUTH_VERSION', 1)
+SWIFT_USERNAME = AUTH_TOKENS.get('SWIFT_USERNAME')
+SWIFT_KEY = AUTH_TOKENS.get('SWIFT_KEY')
+SWIFT_TENANT_NAME = AUTH_TOKENS.get('SWIFT_TENANT_NAME')
+SWIFT_TENANT_ID = AUTH_TOKENS.get('SWIFT_TENANT_ID')
+SWIFT_CONTAINER_NAME = FILE_UPLOAD_STORAGE_BUCKET_NAME
+SWIFT_NAME_PREFIX = FILE_UPLOAD_STORAGE_PREFIX
+SWIFT_USE_TEMP_URLS = AUTH_TOKENS.get('SWIFT_USE_TEMP_URLS', False)
+SWIFT_TEMP_URL_KEY = AUTH_TOKENS.get('SWIFT_TEMP_URL_KEY')
+SWIFT_TEMP_URL_DURATION = AUTH_TOKENS.get('SWIFT_TEMP_URL_DURATION', 1800)  # seconds
+
+if AUTH_TOKENS.get('SWIFT_REGION_NAME'):
+    SWIFT_EXTRA_OPTIONS = {'region_name': AUTH_TOKENS['SWIFT_REGION_NAME']}
+
+if AUTH_TOKENS.get('DEFAULT_FILE_STORAGE'):
+    DEFAULT_FILE_STORAGE = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
+elif SWIFT_AUTH_URL and SWIFT_USERNAME and SWIFT_KEY:
+    DEFAULT_FILE_STORAGE = 'swift.storage.SwiftStorage'
+else:
+    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'

--- a/lms/envs/openstack.py
+++ b/lms/envs/openstack.py
@@ -2,6 +2,8 @@
 Settings for OpenStack deployments.
 """
 
+# We import the aws settings because that's currently where the base settings are stored for all deployments.
+# TODO - fix this when aws.py is split/renamed.
 from .aws import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 SWIFT_AUTH_URL = AUTH_TOKENS.get('SWIFT_AUTH_URL')


### PR DESCRIPTION
In #13930, we added django-user-tasks to the CMS. Setup for this package includes the use of local storage, and previously, Swift local storage settings were not being populated for the CMS. This PR adds the correct Swift variables to the CMS settings and allows successful provisioning.

**Dependencies**: https://github.com/edx/configuration/pull/3522 - required if using SWIFT storage.

**Sandbox URL**: [pr14015.sandbox.opencraft.hosting](http://pr14015.sandbox.opencraft.hosting/) (persistent databases)

This sandbox was also deployed using this change:

* LMS: http://ficus.sandbox.opencraft.hosting/
* Studio: http://studio.ficus.sandbox.opencraft.hosting/

It is running [open-craft:jill/ficus.rc1](https://github.com/edx/edx-platform/compare/master...open-craft:jill/ficus.rc1), based on [release-2017-01-06](https://github.com/edx/edx-platform/commit/80a7bfd58db57176f7caa2cbcc6a31024fdf097f), the tag which will be used for `ficus.RC1`.

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: ASAP - we'd like to include this in the ficus release. CC @nedbat 

**Testing instructions**:

1. Spawn an EdX instance using OpenStack settings, using the master branches of edx-platform and configuration, using the edx_sandbox playbook. Be sure that Swift storage is enabled.
2. Note that the provisioning process fails, giving an error indicating that Swift storage has missing variables.
3. Spawn another EdX instance, using this branch instead.
4. Note that provisioning succeeds.

**Reviewers**
- [x] @mtyaka  
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_USE_SWIFT_STORAGE: true
EDXAPP_SETTINGS: 'openstack'
EDXAPP_DEFAULT_FILE_STORAGE: 'swift.storage.SwiftStorage'
EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: 'xx'
EDXAPP_SWIFT_AUTH_VERSION: '2'
EDXAPP_SWIFT_USERNAME: 'xx'
EDXAPP_SWIFT_KEY: 'xx'
EDXAPP_SWIFT_TENANT_NAME: 'xx'
EDXAPP_SWIFT_AUTH_URL: 'xx
EDXAPP_SWIFT_REGION_NAME: 'xx'
```