### PR TITLE
Use first_attempted value from database and attempted values from individual problems.

### DIFF
--- a/lms/djangoapps/grades/new/subsection_grade.py
+++ b/lms/djangoapps/grades/new/subsection_grade.py
@@ -51,6 +51,11 @@ class SubsectionGrade(object):
         Returns whether any problem in this subsection
         was attempted by the student.
         """
+
+        assert self.all_total is not None, (
+            "SubsectionGrade not fully populated yet.  Call init_from_structure or init_from_model "
+            "before use."
+        )
         return self.all_total.attempted
 
     def init_from_structure(self, student, course_structure, submissions_scores, csm_scores):
@@ -80,7 +85,7 @@ class SubsectionGrade(object):
             graded=True,
             display_name=self.display_name,
             module_id=self.location,
-            attempted=True,  # TODO TNL-5930
+            attempted=model.first_attempted is not None,
         )
         self.all_total = AggregatedScore(
             tw_earned=model.earned_all,
@@ -88,7 +93,7 @@ class SubsectionGrade(object):
             graded=False,
             display_name=self.display_name,
             module_id=self.location,
-            attempted=True,  # TODO TNL-5930
+            attempted=model.first_attempted is not None,
         )
         self._log_event(log.debug, u"init_from_model", student)
         return self
@@ -156,6 +161,7 @@ class SubsectionGrade(object):
             earned_graded=self.graded_total.earned,
             possible_graded=self.graded_total.possible,
             visible_blocks=self._get_visible_blocks,
+            attempted=self.attempted
         )
 
     @property

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -210,7 +210,7 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
             "earned_graded": 6.0,
             "possible_graded": 8.0,
             "visible_blocks": self.block_records,
-            "first_attempted": "2016-08-01 18:53:24.354741",
+            "attempted": True,
         }
 
     def test_create(self):
@@ -228,17 +228,8 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
         with self.assertRaises(IntegrityError):
             PersistentSubsectionGrade.create_grade(**self.params)
 
-    def test_create_bad_params(self):
-        """
-        Confirms create will fail if params are missing.
-        """
-        del self.params["earned_graded"]
-        with self.assertRaises(IntegrityError):
-            PersistentSubsectionGrade.create_grade(**self.params)
-
-    @ddt.data("course_version", "first_attempted")
-    def test_optional_fields(self, field):
-        del self.params[field]
+    def test_optional_fields(self):
+        del self.params["course_version"]
         PersistentSubsectionGrade.create_grade(**self.params)
 
     @ddt.data(
@@ -250,6 +241,7 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
         ("earned_graded", IntegrityError),
         ("possible_graded", IntegrityError),
         ("visible_blocks", KeyError),
+        ("attempted", KeyError),
     )
     @ddt.unpack
     def test_non_optional_fields(self, field, error):
@@ -267,6 +259,42 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
         if already_created:
             self.assertEqual(created_grade.id, updated_grade.id)
             self.assertEqual(created_grade.earned_all, 6)
+
+    def test_update_or_create_with_implicit_attempted(self):
+        grade = PersistentSubsectionGrade.update_or_create_grade(**self.params)
+        self.assertIsInstance(grade.first_attempted, datetime)
+
+    def test_create_inconsistent_unattempted(self):
+        self.params['attempted'] = False
+        grade = PersistentSubsectionGrade.create_grade(**self.params)
+        self.assertEqual(grade.earned_all, 0.0)
+
+    def test_update_inconsistent_unattempted(self):
+        self.params['attempted'] = False
+        PersistentSubsectionGrade.create_grade(**self.params)
+        grade = PersistentSubsectionGrade.update_or_create_grade(**self.params)
+        self.assertEqual(grade.earned_all, 0.0)
+
+    def test_first_attempted_not_changed_on_update(self):
+        PersistentSubsectionGrade.create_grade(**self.params)
+        moment = now()
+        grade = PersistentSubsectionGrade.update_or_create_grade(**self.params)
+        self.assertLess(grade.first_attempted, moment)
+
+    def test_unattempted_save_does_not_remove_attempt(self):
+        PersistentSubsectionGrade.create_grade(**self.params)
+        self.params['unattempted'] = False
+        grade = PersistentSubsectionGrade.update_or_create_grade(**self.params)
+        self.assertIsInstance(grade.first_attempted, datetime)
+        self.assertEqual(grade.earned_all, 6.0)
+
+    def test_explicitly_remove_attempts(self):
+        grade = PersistentSubsectionGrade.create_grade(**self.params)
+        self.assertIsInstance(grade.first_attempted, datetime)
+        self.assertEqual(grade.earned_all, 6.0)
+        grade.remove_attempts()
+        self.assertIsNone(grade.first_attempted)
+        self.assertEqual(grade.earned_all, 0.0)
 
 
 @ddt.ddt

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -8,6 +8,7 @@ import ddt
 from hashlib import sha1
 import json
 
+from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from django.test import TestCase
 from django.utils.timezone import now
@@ -225,7 +226,7 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
             )
             self.assertEqual(created_grade, read_grade)
             self.assertEqual(read_grade.visible_blocks.blocks, self.block_records)
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValidationError):
             PersistentSubsectionGrade.create_grade(**self.params)
 
     def test_optional_fields(self):
@@ -233,13 +234,13 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
         PersistentSubsectionGrade.create_grade(**self.params)
 
     @ddt.data(
-        ("user_id", IntegrityError),
+        ("user_id", ValidationError),
         ("usage_key", KeyError),
-        ("subtree_edited_timestamp", IntegrityError),
-        ("earned_all", IntegrityError),
-        ("possible_all", IntegrityError),
-        ("earned_graded", IntegrityError),
-        ("possible_graded", IntegrityError),
+        ("subtree_edited_timestamp", ValidationError),
+        ("earned_all", ValidationError),
+        ("possible_all", ValidationError),
+        ("earned_graded", ValidationError),
+        ("possible_graded", ValidationError),
         ("visible_blocks", KeyError),
         ("attempted", KeyError),
     )
@@ -260,20 +261,30 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
             self.assertEqual(created_grade.id, updated_grade.id)
             self.assertEqual(created_grade.earned_all, 6)
 
-    def test_update_or_create_with_implicit_attempted(self):
+    def test_update_or_create_attempted(self):
         grade = PersistentSubsectionGrade.update_or_create_grade(**self.params)
         self.assertIsInstance(grade.first_attempted, datetime)
 
+    def test_unattempted(self):
+        self.params['attempted'] = False
+        self.params['earned_all'] = 0.0
+        self.params['earned_graded'] = 0.0
+        grade = PersistentSubsectionGrade.create_grade(**self.params)
+        self.assertIsNone(grade.first_attempted)
+        self.assertEqual(grade.earned_all, 0.0)
+        self.assertEqual(grade.earned_graded, 0.0)
+
     def test_create_inconsistent_unattempted(self):
         self.params['attempted'] = False
-        grade = PersistentSubsectionGrade.create_grade(**self.params)
-        self.assertEqual(grade.earned_all, 0.0)
+        with self.assertRaises(ValidationError):
+            PersistentSubsectionGrade.create_grade(**self.params)
 
-    def test_update_inconsistent_unattempted(self):
+    def test_update_or_create_inconsistent_unattempted(self):
         self.params['attempted'] = False
-        PersistentSubsectionGrade.create_grade(**self.params)
-        grade = PersistentSubsectionGrade.update_or_create_grade(**self.params)
-        self.assertEqual(grade.earned_all, 0.0)
+        self.params['earned_all'] = 1.0
+        self.params['earned_graded'] = 1.0
+        with self.assertRaises(ValidationError):
+            PersistentSubsectionGrade.update_or_create_grade(**self.params)
 
     def test_first_attempted_not_changed_on_update(self):
         PersistentSubsectionGrade.create_grade(**self.params)
@@ -283,18 +294,10 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
 
     def test_unattempted_save_does_not_remove_attempt(self):
         PersistentSubsectionGrade.create_grade(**self.params)
-        self.params['unattempted'] = False
+        self.params['attempted'] = False
         grade = PersistentSubsectionGrade.update_or_create_grade(**self.params)
         self.assertIsInstance(grade.first_attempted, datetime)
         self.assertEqual(grade.earned_all, 6.0)
-
-    def test_explicitly_remove_attempts(self):
-        grade = PersistentSubsectionGrade.create_grade(**self.params)
-        self.assertIsInstance(grade.first_attempted, datetime)
-        self.assertEqual(grade.earned_all, 6.0)
-        grade.remove_attempts()
-        self.assertIsNone(grade.first_attempted)
-        self.assertEqual(grade.earned_all, 0.0)
 
 
 @ddt.ddt

--- a/lms/djangoapps/grades/tests/test_new.py
+++ b/lms/djangoapps/grades/tests/test_new.py
@@ -214,7 +214,7 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
                 'lms.djangoapps.grades.new.subsection_grade.SubsectionGradeFactory._get_bulk_cached_grade',
                 wraps=self.subsection_grade_factory._get_bulk_cached_grade
             ) as mock_get_bulk_cached_grade:
-                with self.assertNumQueries(12):
+                with self.assertNumQueries(14):
                     grade_a = self.subsection_grade_factory.create(self.sequence)
                 self.assertTrue(mock_get_bulk_cached_grade.called)
                 self.assertTrue(mock_create_grade.called)

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -113,7 +113,7 @@ class RecalculateSubsectionGradeTest(ModuleStoreTestCase):
         with self.store.default_store(default_store):
             self.set_up_course()
             self.assertTrue(PersistentGradesEnabledFlag.feature_enabled(self.course.id))
-            with check_mongo_calls(2) and self.assertNumQueries(24 + added_queries):
+            with check_mongo_calls(2) and self.assertNumQueries(22 + added_queries):
                 self._apply_recalculate_subsection_grade()
 
     @patch('lms.djangoapps.grades.signals.signals.SUBSECTION_SCORE_CHANGED.send')
@@ -161,7 +161,7 @@ class RecalculateSubsectionGradeTest(ModuleStoreTestCase):
             self.assertTrue(PersistentGradesEnabledFlag.feature_enabled(self.course.id))
             ItemFactory.create(parent=self.sequential, category='problem', display_name='problem2')
             ItemFactory.create(parent=self.sequential, category='problem', display_name='problem3')
-            with check_mongo_calls(2) and self.assertNumQueries(24 + added_queries):
+            with check_mongo_calls(2) and self.assertNumQueries(22 + added_queries):
                 self._apply_recalculate_subsection_grade()
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -113,7 +113,7 @@ class RecalculateSubsectionGradeTest(ModuleStoreTestCase):
         with self.store.default_store(default_store):
             self.set_up_course()
             self.assertTrue(PersistentGradesEnabledFlag.feature_enabled(self.course.id))
-            with check_mongo_calls(2) and self.assertNumQueries(23 + added_queries):
+            with check_mongo_calls(2) and self.assertNumQueries(24 + added_queries):
                 self._apply_recalculate_subsection_grade()
 
     @patch('lms.djangoapps.grades.signals.signals.SUBSECTION_SCORE_CHANGED.send')
@@ -161,7 +161,7 @@ class RecalculateSubsectionGradeTest(ModuleStoreTestCase):
             self.assertTrue(PersistentGradesEnabledFlag.feature_enabled(self.course.id))
             ItemFactory.create(parent=self.sequential, category='problem', display_name='problem2')
             ItemFactory.create(parent=self.sequential, category='problem', display_name='problem3')
-            with check_mongo_calls(2) and self.assertNumQueries(23 + added_queries):
+            with check_mongo_calls(2) and self.assertNumQueries(24 + added_queries):
                 self._apply_recalculate_subsection_grade()
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
@@ -172,7 +172,7 @@ class RecalculateSubsectionGradeTest(ModuleStoreTestCase):
             with check_mongo_calls(2) and self.assertNumQueries(0):
                 self._apply_recalculate_subsection_grade()
 
-    #@skip("Pending completion of TNL-5089")
+    @skip("Pending completion of TNL-5089")
     @ddt.data(
         (ModuleStoreEnum.Type.mongo, True),
         (ModuleStoreEnum.Type.split, True),

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -113,7 +113,7 @@ class RecalculateSubsectionGradeTest(ModuleStoreTestCase):
         with self.store.default_store(default_store):
             self.set_up_course()
             self.assertTrue(PersistentGradesEnabledFlag.feature_enabled(self.course.id))
-            with check_mongo_calls(2) and self.assertNumQueries(20 + added_queries):
+            with check_mongo_calls(2) and self.assertNumQueries(23 + added_queries):
                 self._apply_recalculate_subsection_grade()
 
     @patch('lms.djangoapps.grades.signals.signals.SUBSECTION_SCORE_CHANGED.send')
@@ -161,7 +161,7 @@ class RecalculateSubsectionGradeTest(ModuleStoreTestCase):
             self.assertTrue(PersistentGradesEnabledFlag.feature_enabled(self.course.id))
             ItemFactory.create(parent=self.sequential, category='problem', display_name='problem2')
             ItemFactory.create(parent=self.sequential, category='problem', display_name='problem3')
-            with check_mongo_calls(2) and self.assertNumQueries(20 + added_queries):
+            with check_mongo_calls(2) and self.assertNumQueries(23 + added_queries):
                 self._apply_recalculate_subsection_grade()
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
@@ -172,7 +172,7 @@ class RecalculateSubsectionGradeTest(ModuleStoreTestCase):
             with check_mongo_calls(2) and self.assertNumQueries(0):
                 self._apply_recalculate_subsection_grade()
 
-    @skip("Pending completion of TNL-5089")
+    #@skip("Pending completion of TNL-5089")
     @ddt.data(
         (ModuleStoreEnum.Type.mongo, True),
         (ModuleStoreEnum.Type.split, True),


### PR DESCRIPTION
## [TNL-5930](https://openedx.atlassian.net/browse/TNL-5930)

I looked into implementing object validation, but there doesn't seem to be a way to hook it into the middle of the update_or_create call, so I tried a different approach with a similar result.

### Reviewers

- [ ] @yro 
- [ ] @nasthagiri 

FYI: @sanfordstudent 

### TODO (Post review)

- [ ] Squash commits