### PR TITLE
WL-833 Allow for LinkedIn add to profile cert name override

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2065,11 +2065,25 @@ class LinkedInAddToProfileConfiguration(ConfigurationModel):
         )
 
     def _cert_name(self, course_name, cert_mode):
-        """Name of the certification, for display on LinkedIn. """
-        return self.MODE_TO_CERT_NAME.get(
+        """
+        Name of the certification, for display on LinkedIn.
+
+        Arguments:
+            course_name (unicode): The display name of the course.
+            cert_mode (str): The course mode of the user's certificate (e.g. "verified", "honor", "professional")
+
+        Returns:
+            str: The formatted string to display for the name field on the LinkedIn Add to Profile dialog.
+        """
+        default_cert_name = self.MODE_TO_CERT_NAME.get(
             cert_mode,
             _(u"{platform_name} Certificate for {course_name}")
-        ).format(
+        )
+        # Look for an override of the certificate name in the SOCIAL_SHARING_SETTINGS setting
+        share_settings = configuration_helpers.get_value('SOCIAL_SHARING_SETTINGS', settings.SOCIAL_SHARING_SETTINGS)
+        cert_name = share_settings.get('CERTIFICATE_LINKEDIN_MODE_TO_CERT_NAME', {}).get(cert_mode, default_cert_name)
+
+        return cert_name.format(
             platform_name=configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
             course_name=course_name
         )

--- a/common/djangoapps/student/tests/test_linkedin.py
+++ b/common/djangoapps/student/tests/test_linkedin.py
@@ -7,6 +7,7 @@ from urllib import urlencode, quote
 from django.conf import settings
 from django.test import TestCase
 from opaque_keys.edx.locator import CourseLocator
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
 from student.models import LinkedInAddToProfileConfiguration
 
 
@@ -17,6 +18,16 @@ class LinkedInAddToProfileUrlTests(TestCase):
     COURSE_KEY = CourseLocator(org="edx", course="DemoX", run="Demo_Course")
     COURSE_NAME = u"Test Course ☃"
     CERT_URL = u"http://s3.edx/cert"
+    SITE_CONFIGURATION = {
+        'SOCIAL_SHARING_SETTINGS': {
+            'CERTIFICATE_LINKEDIN_MODE_TO_CERT_NAME': {
+                'honor': u'{platform_name} Honor Code Credential for {course_name}',
+                'verified': u'{platform_name} Verified Credential for {course_name}',
+                'professional': u'{platform_name} Professional Credential for {course_name}',
+                'no-id-professional': u'{platform_name} Professional Credential for {course_name}',
+            }
+        }
+    }
 
     @ddt.data(
         ('honor', u'Honor+Code+Certificate+for+Test+Course+%E2%98%83'),
@@ -50,6 +61,41 @@ class LinkedInAddToProfileUrlTests(TestCase):
         )
 
         self.assertEqual(actual_url, expected_url)
+
+    @ddt.data(
+        ('honor', u'Honor+Code+Credential+for+Test+Course+%E2%98%83'),
+        ('verified', u'Verified+Credential+for+Test+Course+%E2%98%83'),
+        ('professional', u'Professional+Credential+for+Test+Course+%E2%98%83'),
+        ('no-id-professional', u'Professional+Credential+for+Test+Course+%E2%98%83'),
+        ('default_mode', u'Certificate+for+Test+Course+%E2%98%83')
+    )
+    @ddt.unpack
+    def test_linked_in_url_with_cert_name_override(self, cert_mode, expected_cert_name):
+        config = LinkedInAddToProfileConfiguration(
+            company_identifier='0_mC_o2MizqdtZEmkVXjH4eYwMj4DnkCWrZP_D9',
+            enabled=True
+        )
+
+        expected_url = (
+            'http://www.linkedin.com/profile/add'
+            '?_ed=0_mC_o2MizqdtZEmkVXjH4eYwMj4DnkCWrZP_D9&'
+            'pfCertificationName={platform_name}+{expected_cert_name}&'
+            'pfCertificationUrl=http%3A%2F%2Fs3.edx%2Fcert&'
+            'source=o'
+        ).format(
+            expected_cert_name=expected_cert_name,
+            platform_name=quote(settings.PLATFORM_NAME.encode('utf-8'))
+        )
+
+        with with_site_configuration_context(configuration=self.SITE_CONFIGURATION):
+            actual_url = config.add_to_profile_url(
+                self.COURSE_KEY,
+                self.COURSE_NAME,
+                cert_mode,
+                self.CERT_URL
+            )
+
+            self.assertEqual(actual_url, expected_url)
 
     def test_linked_in_url_tracking_code(self):
         config = LinkedInAddToProfileConfiguration(


### PR DESCRIPTION
This change is needed to allow us to customize the certificate name that is displayed when a user attempts to share their certificate on LinkedIn via our add to profile button.