### PR TITLE
specify if an item is detached

### DIFF
--- a/openedx/core/djangoapps/coursegraph/management/commands/dump_to_neo4j.py
+++ b/openedx/core/djangoapps/coursegraph/management/commands/dump_to_neo4j.py
@@ -13,6 +13,7 @@ from py2neo import Graph, Node, Relationship, authenticate, NodeSelector
 from py2neo.compat import integer, string, unicode as neo4j_unicode
 from request_cache.middleware import RequestCache
 from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.store_utilities import DETACHED_XBLOCK_TYPES
 
 from openedx.core.djangoapps.content.course_structures.models import CourseStructure
 
@@ -73,6 +74,7 @@ class ModuleStoreSerializer(object):
         )
 
         course_key = item.scope_ids.usage_id.course_key
+        block_type = item.scope_ids.block_type
 
         # set or reset some defaults
         fields['edited_on'] = six.text_type(getattr(item, 'edited_on', ''))
@@ -82,8 +84,8 @@ class ModuleStoreSerializer(object):
         fields['run'] = course_key.run
         fields['course_key'] = six.text_type(course_key)
         fields['location'] = six.text_type(item.location)
-
-        block_type = item.scope_ids.block_type
+        fields['block_type'] = block_type
+        fields['detached'] = block_type in DETACHED_XBLOCK_TYPES
 
         if block_type == 'course':
             # prune the checklists field

--- a/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
+++ b/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
@@ -218,6 +218,8 @@ class TestModuleStoreSerializer(TestDumpToNeo4jCommandBase):
         self.assertIn("run", fields.keys())
         self.assertIn("course_key", fields.keys())
         self.assertIn("location", fields.keys())
+        self.assertIn("block_type", fields.keys())
+        self.assertIn("detached", fields.keys())
         self.assertNotIn("checklist", fields.keys())
 
     def test_serialize_course(self):


### PR DESCRIPTION
### Description

This is a small PR that adds a couple fields to coursegraph xblock nodes. One is the type of the block. The second is whether or not the block is a "detached" one. This will help us distinguish detached blocks from true orphans.

### How to Test?
There's not really a straightforward way to test this besides running the automated test file

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @noraiz-anwar
- [x] @ayub-khan

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [x] Rebase and squash commits
