### PR TITLE
Clean up construction of program detail page links

### DIFF
--- a/lms/djangoapps/learner_dashboard/tests/test_programs.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_programs.py
@@ -200,8 +200,7 @@ class TestProgramListing(ProgramsApiConfigMixin, CredentialsApiConfigMixin, Shar
 
     def test_links_to_detail_pages(self):
         """
-        Verify that links to detail pages are present when enabled, instead of
-        links to the marketing site.
+        Verify that links to detail pages are present.
         """
         self.create_programs_config()
         self.mock_programs_api(self.data)
@@ -220,22 +219,6 @@ class TestProgramListing(ProgramsApiConfigMixin, CredentialsApiConfigMixin, Shar
             self.assertEqual(
                 actual_program['detail_url'],
                 '{}/{}'.format(base, slug)
-            )
-
-        # Verify that links to the marketing site are present when detail pages are disabled.
-        self.create_programs_config(program_details_enabled=False, marketing_path='bar')
-        marketing_root = urljoin(settings.MKTG_URLS.get('ROOT'), 'bar').rstrip('/')
-
-        response = self.client.get(self.url)
-        actual = self.load_serialized_data(response, 'programsData')
-        actual = sorted(actual, key=self.program_sort_key)
-
-        for index, actual_program in enumerate(actual):
-            expected_program = self.data[index]
-
-            self.assertEqual(
-                actual_program['detail_url'],
-                '{}/{}'.format(marketing_root, expected_program['marketing_slug'])
             )
 
     def test_certificates_listed(self):

--- a/openedx/core/djangoapps/programs/models.py
+++ b/openedx/core/djangoapps/programs/models.py
@@ -7,11 +7,11 @@ from django.db import models
 from config_models.models import ConfigurationModel
 
 
-# TODO: To be simplified as part of ECOM-5136.
 class ProgramsApiConfig(ConfigurationModel):
     """
-    Manages configuration for connecting to the Programs service and using its
-    API.
+    DEPRECATED. To be removed as part of ECOM-5136.
+
+    Manages configuration for connecting to the Programs service and using its API.
     """
     OAUTH2_CLIENT_NAME = 'programs'
     CACHE_KEY = 'programs.api.data'

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -149,13 +149,8 @@ def attach_program_detail_url(programs):
     marketing_url = get_program_marketing_url(programs_config)
 
     for program in programs:
-        if programs_config.show_program_details:
-            base = reverse('program_details_view', kwargs={'program_id': program['id']}).rstrip('/')
-            slug = slugify(program['name'])
-        else:
-            # TODO: Remove. Learners should always be sent to the LMS' program details page.
-            base = marketing_url
-            slug = program['marketing_slug']
+        base = reverse('program_details_view', kwargs={'program_id': program['id']}).rstrip('/')
+        slug = slugify(program['name'])
 
         program['detail_url'] = '{base}/{slug}'.format(base=base, slug=slug)
 


### PR DESCRIPTION
We used to link program cards on the LMS program listing page to the marketing site. Those cards now link to detail pages also hosted by the LMS, rendering that functionality obsolete.

ECOM-5063

@edx/ecommerce please review.