### PR TITLE
Bump problem-builder to v2.6.5

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@v2.6.1#egg=xblock-problem-builder==2.6.1
+git+https://github.com/open-craft/problem-builder.git@v2.6.5#egg=xblock-problem-builder==2.6.5
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
This patch fixes the problem where Problem Builder Long Answer blocks throw an error when used inside courses with long course keys (> 50 characters), see [TNL-5932](https://openedx.atlassian.net/browse/TNL-5932).

It introduces a new 255-char `course_key` field to the `Answer` model. The old 50-char `course_id` field is still present and used for fallback, but is deprecated and will be removed in next release.

This release replaces the initial approach from https://github.com/edx/edx-platform/pull/14013, because it was found that simply extending the existing `course_id` column isn't going to work well in production because the table affected by the migration is quite large and extending column length requires locking the table for the duration of the migration.

For more information on the new approach proposed by @maxrothman in https://github.com/edx/edx-platform/pull/14013#issuecomment-261635454, see https://github.com/open-craft/problem-builder/pull/131.

Below is the output of `sqlmigrate` for the new migration:

```
BEGIN;
ALTER TABLE `problem_builder_answer` ADD COLUMN `course_key` varchar(255) NULL;
ALTER TABLE `problem_builder_answer` ADD CONSTRAINT `problem_builder_answer_student_id_2ce682a818c95cbc_uniq` UNIQUE (`student_id`, `course_key`, `name`);
CREATE INDEX `problem_builder_answer_c8235886` ON `problem_builder_answer` (`course_key`);

COMMIT;
```

Next release will add a data migration to copy contents of `course_id` to the new `course_key` column. EdX will fake this migration and copy data in batches instead.
Next release will also drop the deprecated `course_id` column.

See https://github.com/edx/edx-platform/pull/14013#issuecomment-261635454 for more information.

**Environments**:  edx.org and edge.edx.org

**Merge deadline**: ASAP - this is blocking a course on Edge

**JIRA tickets**: [TNL-5932](https://openedx.atlassian.net/browse/TNL-5932)

**Discussions**: https://github.com/edx/edx-platform/pull/14013, https://github.com/open-craft/problem-builder/pull/131 and [TNL-5932](https://openedx.atlassian.net/browse/TNL-5932)

**Sandbox URL**:

Sandboxes contain revision 86177cba7fca2177c9bc943df3c5f24ed1534402.

There is a course with course key longer than 50 characters that already contains some long answer blocks.

I also created a course that was prepared with an older version of problem builder using now deprecated `course_id` field.

- LMS: https://pr14044.sandbox.opencraft.hosting/
- Studio: https://studio-pr14044.sandbox.opencraft.hosting/

**Partner information**: hosted on edX Edge (Davidson College)

**Testing instructions**:

Check that you can successfully add a Problem Builder "Long Answer" component to a course with a course key that is longer than 50 character and that answers answered on an older version of problem-builder continue to work correctly with this patch.

1. Install problem-builder v2.6.1
1. Create a course with a combined course key less than 50 characters.
1. Add a Problem Builder component, then add the Long Answer component.
1. Answered several questions.
1. Create a course with a combined course key *more* than 50 characters.
1. Add Unit with Problem Builder and a Long Answer element - watched it fail.
1. Installed problem-builder from this PR.
1. Run migrations.
1. Verify that the answers are still present in the first course.
1. Verify that the Long Answer element in the course with the very long course ID is working now, and you can submit answers to it.

**Reviewers**
- [ ] @haikuginger 
- [ ] @adampalay
- [ ] @maxrothman / @edx/devops

**Settings**
```yaml
NGINX_SET_X_FORWARDED_HEADERS: false
INSIGHTS_VERSION: '58086e85d673e692cd498793905d8739cfc01515'
EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/open-craft/problem-builder.git@v2.6.5#egg=xblock-problem-builder==2.6.5
```