### PR TITLE
Fix command opts for paver command 

### DIFF
--- a/openedx/core/djangoapps/theming/management/commands/compile_sass.py
+++ b/openedx/core/djangoapps/theming/management/commands/compile_sass.py
@@ -135,5 +135,5 @@ class Command(BaseCommand):
 
         call_task(
             'pavelib.assets.compile_sass',
-            options={'system': system, 'theme-dirs': theme_dirs, 'themes': themes, 'force': force, 'debug': debug},
+            options={'system': system, 'theme_dirs': theme_dirs, 'themes': themes, 'force': force, 'debug': debug},
         )

--- a/pavelib/paver_tests/test_assets.py
+++ b/pavelib/paver_tests/test_assets.py
@@ -98,7 +98,7 @@ class TestPaverThemeAssetTasks(PaverTestCase):
         self.reset_task_messages()
         call_task(
             'pavelib.assets.compile_sass',
-            options={"system": system, "debug": debug, "force": force, "theme-dirs": [TEST_THEME.dirname()],
+            options={"system": system, "debug": debug, "force": force, "theme_dirs": [TEST_THEME.dirname()],
                      "themes": [TEST_THEME.basename()]},
         )
         expected_messages = []
@@ -194,7 +194,7 @@ class TestPaverWatchAssetTasks(TestCase):
             with patch('pavelib.assets.PollingObserver.start'):
                 call_task(
                     'pavelib.assets.watch_assets',
-                    options={"background": True, "theme-dirs": [TEST_THEME.dirname()],
+                    options={"background": True, "theme_dirs": [TEST_THEME.dirname()],
                              "themes": [TEST_THEME.basename()]},
                 )
                 self.assertEqual(mock_register.call_count, 2)


### PR DESCRIPTION
## [PLAT-1102](https://openedx.atlassian.net/browse/PLAT-1102)

### Description
A corner case scenario was missing from paver commands related to watch and compile theme assets. It is mentioned in doc string of method `cmpdopts`  [here in paver/paver/tasks.py](https://github.com/paver/paver/blob/master/paver/tasks.py#L590), `-`  is converted into `_` when options are parsed by this method. We were using `cmdopts` for options(passed via command line to paver commands) parsing ignoring this fact. Due to this option `--theme-dirs` was converted to `theme_dirs` after being worked on by `cmdopts`. In our code, we were expecting it `theme-dirs`.
The bug is fixed by changing `theme-dirs` to `theme_dirs` and then the converitng value of this option to python list. 
Some code duplication is removed by making a method `get_parsed_option`, which is responsible for populating variables after converting them into python list with options specified in paver command.
Tests are refactored accordingly.

### How to Test?
As this is management command, DevOps may run this in order to test if the command is working.

**Screenshot**
Not Applicable


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @Ayub-Khan 
- [x] Code review: @awaisdar001
- [x] Code review: @Qubad786 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [ ] Rebase and squash commits