### PR TITLE
ECOM-6154 – remove transaction.atomic decorator

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -29,7 +29,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
-from django.db import models, IntegrityError, transaction
+from django.db import models, IntegrityError
 from django.db.models import Count
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver, Signal
@@ -1024,7 +1024,6 @@ class CourseEnrollment(models.Model):
         cache.delete(self.enrollment_status_hash_cache_key(self.user))
 
     @classmethod
-    @transaction.atomic
     def get_or_create_enrollment(cls, user, course_key):
         """
         Create an enrollment for a user in a class. By default *this enrollment


### PR DESCRIPTION
## [ECOM-6154](https://openedx.atlassian.net/browse/ECOM-6154)

### Description

In order to reduce the probabiltiy of `IntegrityError`s, I've removed atomic decorator from `get_or_create_enrollment`,  and `create` transaction is already atomic in `get_or_create` (i.e. database won't be left in dirty state). Moreover, longer transactions are more prone to integrity errors because there might be the chance that two almost concurrent requests start `get` taransaction which results in raising `DoesNotExist` then they both start `create` transaction and one of them comit it just before the other.

### How to Test?
Splunk is the only source I could think of right now.

**Stage**
This is not applicable.

**Sandbox**
This is not applicable.

**Screenshots**
This is not applicable.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @noraiz-anwar 
- [x] Code review: @rlucioni 
- [x] Code review: @awaisdar001 

FYI: @adampalay 

### Post-review
- [x] Rebase and squash commits