### PR TITLE
TNL-6004 Fixing 500 in video transcripts.

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -1073,3 +1073,13 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
         descriptor = instantiate_descriptor(data=xml_data_transcripts)
         validation = descriptor.validate()
         self.assert_validation_message(validation, expected_validation_msg)
+
+    def test_video_transcript_none(self):
+        """
+        Test video when transcripts is None.
+        """
+        descriptor = instantiate_descriptor(data=None)
+        descriptor.transcripts = None
+        response = descriptor.get_transcripts_info()
+        expected = {'transcripts': {}, 'sub': ''}
+        self.assertEquals(expected, response)

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -673,7 +673,7 @@ class VideoTranscriptsMixin(object):
             transcripts = copy.deepcopy(get_bumper_settings(self).get('transcripts', {}))
             sub = transcripts.pop("en", "")
         else:
-            transcripts = self.transcripts
+            transcripts = self.transcripts if self.transcripts else {}
             sub = self.sub
 
         # Only attach transcripts that are not empty.


### PR DESCRIPTION
## [TNL-6004](https://openedx.atlassian.net/browse/TNL-6004)

### Description
A course team member or edX staff should be able to input a learner username or email to check their progress page either `None` is passed to video transcripts.

### How to Test?
 It wasn’t reproducible, so just grabbed the traceback and written a failing test resulting into similar traceback.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @noraiz-anwar 
- [x] Code review: @Qubad786 

FYI: @awaisdar001 

### Post-review
- [x] Rebase and squash commits