### PR TITLE
Fix CAPA's max_score computation

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -154,7 +154,7 @@ class LoncapaResponse(object):
     # By default, we set this to False, allowing subclasses to override as appropriate.
     multi_device_support = False
 
-    def __init__(self, xml, inputfields, context, system, capa_module):
+    def __init__(self, xml, inputfields, context, system, capa_module, minimal_init):
         """
         Init is passed the following arguments:
 
@@ -213,28 +213,29 @@ class LoncapaResponse(object):
             maxpoints = inputfield.get('points', '1')
             self.maxpoints.update({inputfield.get('id'): int(maxpoints)})
 
-        # dict for default answer map (provided in input elements)
-        self.default_answer_map = {}
-        for entry in self.inputfields:
-            answer = entry.get('correct_answer')
-            if answer:
-                self.default_answer_map[entry.get(
-                    'id')] = contextualize_text(answer, self.context)
+        if not minimal_init:
+            # dict for default answer map (provided in input elements)
+            self.default_answer_map = {}
+            for entry in self.inputfields:
+                answer = entry.get('correct_answer')
+                if answer:
+                    self.default_answer_map[entry.get(
+                        'id')] = contextualize_text(answer, self.context)
 
-        # Does this problem have partial credit?
-        # If so, what kind? Get it as a list of strings.
-        partial_credit = xml.xpath('.')[0].get('partial_credit', default=False)
+            # Does this problem have partial credit?
+            # If so, what kind? Get it as a list of strings.
+            partial_credit = xml.xpath('.')[0].get('partial_credit', default=False)
 
-        if str(partial_credit).lower().strip() == 'false':
-            self.has_partial_credit = False
-            self.credit_type = []
-        else:
-            self.has_partial_credit = True
-            self.credit_type = partial_credit.split(',')
-            self.credit_type = [word.strip().lower() for word in self.credit_type]
+            if str(partial_credit).lower().strip() == 'false':
+                self.has_partial_credit = False
+                self.credit_type = []
+            else:
+                self.has_partial_credit = True
+                self.credit_type = partial_credit.split(',')
+                self.credit_type = [word.strip().lower() for word in self.credit_type]
 
-        if hasattr(self, 'setup_response'):
-            self.setup_response()
+            if hasattr(self, 'setup_response'):
+                self.setup_response()
 
     def get_max_score(self):
         """


### PR DESCRIPTION
This fixes an issue when computing `max_score` with the `JavascriptResponse` CAPA response type.

Essentially, the `minimal_init` path (set by `get_max_score`) needs to exclude additional CAPA computations.  Here's the original PR that made an initial attempt at this: https://github.com/edx/edx-platform/pull/14001

Please review @efischer19 @sanfordstudent 

FYI @tobz 