### PR TITLE
Yro fix montevideo tz

### DIFF
--- a/docs/shared/requirements.txt
+++ b/docs/shared/requirements.txt
@@ -45,7 +45,7 @@ pygments==1.5
 pymongo==2.4.1
 python-memcached==1.48
 python-openid==2.2.5
-pytz==2015.2
+pytz==2016.7
 PyYAML==3.10
 requests==2.3.0
 Shapely==1.2.16

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -2002,8 +2002,8 @@ class CountryTimeZoneListViewTest(UserApiTestCase):
         self.assertIn(time_zone_name, common_timezones_set)
         self.assertEqual(time_zone_info['description'], get_display_time_zone(time_zone_name))
 
-    @ddt.data((ALL_TIME_ZONES_URI, 432),
-              (COUNTRY_TIME_ZONES_URI, 27))
+    @ddt.data((ALL_TIME_ZONES_URI, 436),
+              (COUNTRY_TIME_ZONES_URI, 28))
     @ddt.unpack
     def test_get_basic(self, country_uri, expected_count):
         """ Verify that correct time zone info is returned """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -90,7 +90,7 @@ python-dateutil==2.1
 # We can also remove the fix to auth_url in third_party_auth/saml.py when that fix is included upstream.
 python-social-auth==0.2.12
 
-pytz==2015.2
+pytz==2016.7
 pysrt==0.4.7
 PyYAML==3.10
 requests==2.9.1

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -76,7 +76,7 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.12#egg=XBlock==0.4.12
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@1.1.10#egg=ora2==1.1.10
+git+https://github.com/edx/edx-ora2.git@1.1.11#egg=ora2==1.1.11
 -e git+https://github.com/edx/edx-submissions.git@1.1.1#egg=edx-submissions==1.1.1
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.3.2#egg=i18n-tools==v0.3.2


### PR DESCRIPTION
## [TNL-5813](https://openedx.atlassian.net/browse/TNL-5813)

### Description

Updates display UTC offset for timezone America/Montevideo (this tz no longer uses DST). 
Update pytz library to latest IANA database. Tick up version of edx-ora2 to latest, to resolve pytz versioning conflicts.

### Testing
- [x] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @jcdyer 
- [x] Code review: @nasthagiri 

FYI: @efischer19 

### Post-review
- [x] Rebase and squash commits

TNL-5813
