### PR TITLE
Add logging around problematically queued task

### DIFF
--- a/openedx/core/lib/celery/routers.py
+++ b/openedx/core/lib/celery/routers.py
@@ -5,6 +5,9 @@ For more, see http://celery.readthedocs.io/en/latest/userguide/routing.html#rout
 """
 from abc import ABCMeta, abstractproperty
 from django.conf import settings
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class AlternateEnvironmentRouter(object):
@@ -30,6 +33,13 @@ class AlternateEnvironmentRouter(object):
         If None is returned from this method, default routing logic is used.
         """
         alternate_env = self.alternate_env_tasks.get(task, None)
+        if 'update_course_in_cache' in task:
+            log.info("TNL-5408: task={task}, args={args}, alternate_env={alt_env}, queues={queues}".format(
+                task=task,
+                args=args,
+                alt_env=alternate_env,
+                queues=getattr(settings, 'CELERY_QUEUES', []).keys()
+            ))
         if alternate_env:
             return self.ensure_queue_env(alternate_env)
         return None


### PR DESCRIPTION
# [TNL-5408](https://openedx.atlassian.net/browse/TNL-5408)

Thus far, I've been completely unable to discern any rhyme or reason as to why this fails sometimes. It kind of correlates with production deployments if you squint a bit, but there exist problem cases nowhere near any deploys as well.

All I can say for sure is that this is a problem with the task being queued, not the execution of that task on picked up by a queue. A CMS worker will always fail to runs these tasks (And as a fun addition - there are 2 different ways it can fail, and I have no idea why that's not deterministic - see screenshot below). To that end, I've beefed up logging of this particular task being enqueued. Hopefully running this for a few days will provide some additional data/insight into why this is happening.

What do you think, @jibsheet and @nasthagiri? Does this look like something we could sneak onto the ongoing RC/push out a patch release immediately after? From splunk/new relic, it looks like there were some ~5000 instances of this task (0.55 rpm) over the past week, so I don't think the additional volume will be overwhelming.