### PR TITLE
TNL-6017 Receive Updates checkbox saved in discussion forums.

### DIFF
--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -688,6 +688,26 @@ class DiscussionTabHomePage(CoursePage, DiscussionPageMixin):
             "waiting for server to return result"
         ).fulfill()
 
+    def is_element_visible(self, selector):
+        """
+        Returns true if the element matching the specified selector is visible.
+        """
+        query = self.q(css=selector)
+        return query.present and query.visible
+
+    def is_checkbox_selected(self, selector):
+        """
+        Returns true or false depending upon the matching checkbox is checked.
+        """
+        return self.q(css=selector).selected
+
+    def refresh_and_wait_for_load(self):
+        """
+        Refresh the page and wait for all resources to load.
+        """
+        self.browser.refresh()
+        self.wait_for_page()
+
     def get_search_alert_messages(self):
         return self.q(css=self.ALERT_SELECTOR + " .message").text
 
@@ -719,6 +739,13 @@ class DiscussionTabHomePage(CoursePage, DiscussionPageMixin):
             ),
             "New post action succeeded"
         ).fulfill()
+
+    def click_element(self, selector):
+        """
+         Clicks the element specified by selector
+        """
+        element = self.q(css=selector)
+        return element.click()
 
     @property
     def new_post_button(self):

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -206,6 +206,25 @@ class DiscussionHomePageTest(BaseDiscussionTestCase):
         self.page.click_new_post_button()
         self.assertIsNotNone(self.page.new_post_form)
 
+    def test_receive_update_checkbox(self):
+        """
+        Scenario: I can save the receive update email notification checkbox
+                on Discussion home page.
+            Given that I am on the Discussion home page
+            When I click on the 'Receive update' checkbox
+            Then it should always shown selected.
+        """
+        receive_updates_selector = '.email-setting'
+        receive_updates_checkbox = self.page.is_element_visible(receive_updates_selector)
+        self.assertTrue(receive_updates_checkbox)
+
+        self.assertFalse(self.page.is_checkbox_selected(receive_updates_selector))
+        self.page.click_element(receive_updates_selector)
+
+        self.assertTrue(self.page.is_checkbox_selected(receive_updates_selector))
+        self.page.refresh_and_wait_for_load()
+        self.assertTrue(self.page.is_checkbox_selected(receive_updates_selector))
+
     @attr('a11y')
     def test_page_accessibility(self):
         self.page.a11y_audit.config.set_rules({

--- a/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
+++ b/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
@@ -171,7 +171,7 @@
                 HtmlUtils.append(this.$('.forum-content').empty(), HtmlUtils.template(discussionHomeTemplate)({}));
                 this.$('.forum-nav-thread-list a').removeClass('is-active').find('.sr')
                     .remove();
-                this.$('input.email-setting').bind('click', this.updateEmailNotifications);
+                this.$('input.email-setting').bind('click', this.discussionThreadListView.updateEmailNotifications);
                 DiscussionUtil.safeAjax({
                     url: url,
                     type: 'GET',

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -168,6 +168,9 @@ FEATURES['ENABLE_COURSEWARE_SEARCH'] = True
 # Enable dashboard search for tests
 FEATURES['ENABLE_DASHBOARD_SEARCH'] = True
 
+# discussion home panel, which includes a subscription on/off setting for discussion digest emails.
+FEATURES['ENABLE_DISCUSSION_HOME_PANEL'] = True
+
 # Enable support for OpenBadges accomplishments
 FEATURES['ENABLE_OPENBADGES'] = True
 


### PR DESCRIPTION
## [TNL-6017](https://openedx.atlassian.net/browse/TNL-6017)

### Description

When a user checked the `Receive Updates` Checkbox on discussion homepage, and then click the home tab to navigate away from the forums. I have done `When go back to the forums, the checkbox remains checked` in this PR.

### How to Test?

**Stage**: 
- Go to the [Discussion Home Page](https://courses.stage.edx.org/courses/course-v1:edx+mit201+2016/discussion/forum/)
- Click the checkbox for Receive Updates 
- Click the Home tab to navigate away from the Discussion 
- Go back to the Discussion Home page and the checkbox will be unchecked 

**Sandbox**
- [tnl-6017.sandbox.edx.org](tnl-6017.sandbox.edx.org)
- Go to the [Discussion Home Page](https://tnl-6017.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/)
- Click the checkbox for Receive Updates 
- Click the Home tab to navigate away from the Discussion 
- Go back to the Discussion Home page and the checkbox will be checked 

### Testing
- [x] Acceptance tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @awaisdar001 
- [x] @noraiz-anwar 

### Post-review
- [x] Rebase and squash commits