### PR TITLE
ENT-32 Show enterprise customer branding on Logistration.

### DIFF
--- a/common/djangoapps/util/tests/test_enterprise_helpers.py
+++ b/common/djangoapps/util/tests/test_enterprise_helpers.py
@@ -12,7 +12,10 @@ from util.enterprise_helpers import (
     data_sharing_consent_required_at_login,
     data_sharing_consent_requirement_at_login,
     insert_enterprise_fields,
-    insert_enterprise_pipeline_elements
+    insert_enterprise_pipeline_elements,
+    set_enterprise_branding_filter_param,
+    get_enterprise_branding_filter_param,
+    get_enterprise_customer_logo_url
 )
 
 
@@ -144,3 +147,68 @@ class TestEnterpriseHelpers(unittest.TestCase):
         mock_ec.requests_data_sharing_consent = False
         insert_enterprise_fields(request, form_desc)
         form_desc.add_field.assert_not_called()
+
+    def test_set_enterprise_branding_filter_param(self):
+        """
+        Test that the enterprise customer branding parameters are setting correctly.
+        """
+        ec_uuid = '97b4a894-cea9-4103-8f9f-2c5c95a58ba3'
+        provider_id = 'test-provider-idp'
+
+        request = mock.MagicMock(session={}, GET={'ec_src': ec_uuid})
+        set_enterprise_branding_filter_param(request, provider_id=None)
+        self.assertEqual(get_enterprise_branding_filter_param(request), {'ec_uuid': ec_uuid})
+
+        set_enterprise_branding_filter_param(request, provider_id=provider_id)
+        self.assertEqual(get_enterprise_branding_filter_param(request), {'provider_id': provider_id})
+
+    @mock.patch('util.enterprise_helpers.enterprise_enabled', mock.Mock(return_value=True))
+    def test_get_enterprise_customer_logo_url(self):
+        """
+        Test test_get_enterprise_customer_logo_url return the logo url as desired.
+        """
+        ec_uuid = '97b4a894-cea9-4103-8f9f-2c5c95a58ba3'
+        provider_id = 'test-provider-idp'
+        request = mock.MagicMock(session={}, GET={'ec_src': ec_uuid})
+        branding_info = mock.Mock(
+            logo=mock.Mock(
+                url='/test/image.png'
+            )
+        )
+
+        set_enterprise_branding_filter_param(request, provider_id=None)
+        with mock.patch('enterprise.api.get_enterprise_branding_info_by_ec_uuid', return_value=branding_info):
+            logo_url = get_enterprise_customer_logo_url(request)
+            self.assertEqual(logo_url, '/test/image.png')
+
+        set_enterprise_branding_filter_param(request, provider_id)
+        with mock.patch('enterprise.api.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
+            logo_url = get_enterprise_customer_logo_url(request)
+            self.assertEqual(logo_url, '/test/image.png')
+
+    @mock.patch('util.enterprise_helpers.enterprise_enabled', mock.Mock(return_value=False))
+    def test_get_enterprise_customer_logo_url_return_none(self):
+        """
+        Test get_enterprise_customer_logo_url return 'None' when enterprise application is not installed.
+        """
+        request = mock.MagicMock(session={})
+        branding_info = mock.Mock()
+
+        set_enterprise_branding_filter_param(request, 'test-idp')
+        with mock.patch('enterprise.api.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
+            logo_url = get_enterprise_customer_logo_url(request)
+            self.assertEqual(logo_url, None)
+
+    @mock.patch('util.enterprise_helpers.enterprise_enabled', mock.Mock(return_value=True))
+    @mock.patch('util.enterprise_helpers.get_enterprise_branding_filter_param', mock.Mock(return_value=None))
+    def test_get_enterprise_customer_logo_url_return_none_when_param_missing(self):
+        """
+        Test get_enterprise_customer_logo_url return 'None' when filter parameters are missing.
+        """
+        request = mock.MagicMock(session={})
+        branding_info = mock.Mock()
+
+        set_enterprise_branding_filter_param(request, provider_id=None)
+        with mock.patch('enterprise.api.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
+            logo_url = get_enterprise_customer_logo_url(request)
+            self.assertEqual(logo_url, None)

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -60,6 +60,7 @@ class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseT
         self.request_factory = RequestFactory()
         self.student = UserFactory.create()
         self.request = self.request_factory.get("foo")
+        self.request.session = {}
         self.request.user = self.student
 
         patcher = mock.patch('edxmako.request_context.get_current_request', return_value=self.request)

--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -145,6 +145,7 @@
 
     img {
       height: 30px;
+      width: auto;
     }
   }
 

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -26,6 +26,11 @@
     a {
       display: block;
     }
+
+    img.ec-logo-size {
+      width: 84px;
+      height: 56px;
+    }
   }
 
   nav {

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -14,6 +14,7 @@ from openedx.core.djangolib.markup import HTML, Text
 from branding import api as branding_api
 # app that handles site status messages
 from status.status import get_site_status_msg
+from util.enterprise_helpers import get_enterprise_customer_logo_url
 %>
 
 ## Provide a hook for themes to inject branding on top.
@@ -51,7 +52,14 @@ site_status_msg = get_site_status_msg(course_id)
     <h1 class="logo">
       <a href="${marketing_link('ROOT')}">
         <%block name="navigation_logo">
-            <img src="${branding_api.get_logo_url(is_secure)}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
+        <%
+        logo_url = get_enterprise_customer_logo_url(request)
+        logo_size = 'ec-logo-size'
+        if logo_url is None:
+            logo_url = branding_api.get_logo_url(is_secure)
+            logo_size = ''
+        %>
+            <img class="${logo_size}" src="${logo_url}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
         </%block>
       </a>
     </h1>

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -46,7 +46,7 @@ edx-drf-extensions==1.2.1
 edx-lint==0.4.3
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.6.0
+edx-enterprise==0.8.0
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.1


### PR DESCRIPTION
@mattdrayer @zubair-arbi @e-kolpakov your initial thoughts at this point ? 


<img width="1278" alt="screen shot 2016-11-29 at 4 34 14 pm" src="https://cloud.githubusercontent.com/assets/7334669/20710297/7a1ab002-b65b-11e6-89b9-2ddc6fe2cc30.png">



##### There are two parts, The scenario, for No SSO based EC, is still under discussion on JIRA  [ENT-32](https://openedx.atlassian.net/browse/ENT-32) 
##### For SSO based ECs, there 's a feature in LMS SSO implementation that allows "hinted" login/registration - a query parameter is passed instructing LMS to use particular IdP for login. 

#### NOTE: This PR has partially dependency on [PR#14003](https://github.com/edx/edx-platform/pull/14003/files)

