### PR TITLE
Allows course team to directly activate / disable web certificates

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -322,9 +322,6 @@ def certificate_activation_handler(request, course_key_string):
     POST
         json: is_active. update the activation state of certificate
     """
-    # Only global staff (PMs) are able to activate/deactivate certificate configuration
-    if not GlobalStaff().has_user(request.user):
-        raise PermissionDenied()
     course_key = CourseKey.from_string(course_key_string)
     store = modulestore()
     try:

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -812,28 +812,6 @@ class CertificatesDetailHandlerTestCase(
         )
         self.assertEquals(response.status_code, 403)
 
-    @ddt.data(*itertools.product([True, False], [C4X_SIGNATORY_PATH, SIGNATORY_PATH]))
-    @ddt.unpack
-    def test_certificate_activation_without_global_staff_permissions(self, activate, signatory_path):
-        """
-        Tests certificate Activate and Deactivate should not be allowed if user
-        does not have global staff permissions on course.
-        """
-        test_url = reverse_course_url('certificates.certificate_activation_handler', self.course.id)
-        self._add_course_certificates(count=1, signatory_count=2, asset_path_format=signatory_path)
-        user = UserFactory()
-        for role in [CourseInstructorRole, CourseStaffRole]:
-            role(self.course.id).add_users(user)
-        self.client.login(username=user.username, password='test')
-        response = self.client.post(
-            test_url,
-            data=json.dumps({"is_active": activate}),
-            content_type="application/json",
-            HTTP_ACCEPT="application/json",
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest"
-        )
-        self.assertEquals(response.status_code, 403)
-
     @ddt.data(C4X_SIGNATORY_PATH, SIGNATORY_PATH)
     def test_certificate_activation_failure(self, signatory_path):
         """

--- a/cms/static/js/certificates/spec/views/certificate_preview_spec.js
+++ b/cms/static/js/certificates/spec/views/certificate_preview_spec.js
@@ -83,12 +83,6 @@ function(_, $, Course, CertificatePreview, TemplateHelpers, ViewHelpers, AjaxHel
                 expect(this.view.toggleCertificateActivation).toHaveBeenCalled();
             });
 
-            it('toggle certificate activation button should not be present if user is not global staff', function() {
-                window.CMS.User = {isGlobalStaff: false};
-                appendSetFixtures(this.view.render().el);
-                expect(this.view.$(SELECTORS.activate_certificate)).not.toExist();
-            });
-
             it('certificate deactivation works fine', function() {
                 var requests = AjaxHelpers.requests(this),
                     notificationSpy = ViewHelpers.createNotificationSpy();

--- a/cms/templates/js/certificate-web-preview.underscore
+++ b/cms/templates/js/certificate-web-preview.underscore
@@ -7,7 +7,6 @@
 <a href=<%= certificate_web_view_url %> class="button preview-certificate-link" target="_blank">
     <%= gettext("Preview Certificate") %>
 </a>
-<% if (CMS.User.isGlobalStaff) { %>
 <button class="button activate-cert">
     <span>
     <% if(!is_active) { %>
@@ -16,4 +15,3 @@
         <%= gettext("Deactivate") %></span>
     <% } %>
 </button>
-<% } %>


### PR DESCRIPTION
*JIRA* - https://openedx.atlassian.net/browse/TNL-6086
 #HackathonXV 

*Goal*
Allow course team instructors to directly activate / deactivate their web certificates from within Studio. This effort is in support of the line item proposed by Michele Floecker for Hackathon XV.

*Screenshot*
You can see here that a the "honor" username is a course instructor (non-admin course role) and can see the Activate action in Studio.  
![image](https://cloud.githubusercontent.com/assets/2023680/20756590/3c63d172-b6e1-11e6-93dc-3c4b56143f35.png)

*Sandbox Link*
https://studio-marcotuts.sandbox.edx.org/certificates/course-v1:edX+DemoX+Demo_Course 

*Reviewers*
- [ ] @mattdrayer is helping!
- [ ] @edx/doc 
- [ ] second reviewer

*Original Source / Reference*
https://openedx.atlassian.net/wiki/display/OPEN/Hackathon+XV

