### PR TITLE
Allow passing through title to iFrame.

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -592,8 +592,12 @@ class JSInput(InputTypeBase):
                                              #   set state
             Attribute('width', "400"),       # iframe width
             Attribute('height', "300"),      # iframe height
-            Attribute('sop', None)           # SOP will be relaxed only if this
-                                             # attribute is set to false.
+            # Title for the iframe, which should be supplied by the author of the problem. Not translated
+            # because we are in a class method and therefore do not have access to capa_system.i18n.
+            # Note that the default "display name" for the problem is also not translated.
+            Attribute('title', "Problem Remote Content"),
+            # SOP will be relaxed only if this attribute is set to false.
+            Attribute('sop', None)
         ]
 
     def _extra_context(self):

--- a/common/lib/capa/capa/templates/jsinput.html
+++ b/common/lib/capa/capa/templates/jsinput.html
@@ -1,11 +1,12 @@
+<%page expression_filter="h"/>
 <%! from openedx.core.djangolib.markup import HTML %>
-<section id="inputtype_${id}" class="jsinput"
+<div id="inputtype_${id}" class="jsinput"
     data="${gradefn}"
     % if saved_state:
-    data-stored="${saved_state|x}"
+    data-stored="${saved_state}"
     % endif
     % if initial_state:
-    data-initial-state="${initial_state|x}"
+    data-initial-state="${initial_state}"
     % endif
     % if get_statefn:
     data-getstate="${get_statefn}"
@@ -33,10 +34,11 @@
       src="${html_file}"
       height="${height}"
       width="${width}"
+      title="${title}"
       />
   <input type="hidden" name="input_${id}" id="input_${id}"
     waitfor=""
-    value="${value|h}"/>
+    value="${value}"/>
 
   <br/>
     <p id="answer_${id}" class="answer"></p>
@@ -54,4 +56,4 @@
   % if msg:
       <span class="message" tabindex="-1">${HTML(msg)}</span>
   % endif
-</section>
+</div>

--- a/common/lib/capa/capa/tests/response_xml_factory.py
+++ b/common/lib/capa/capa/tests/response_xml_factory.py
@@ -608,6 +608,18 @@ class ImageResponseXMLFactory(ResponseXMLFactory):
         return input_element
 
 
+class JSInputXMLFactory(CustomResponseXMLFactory):
+    """
+    Factory for producing <jsinput> XML.
+    Note that this factory currently does not create a functioning problem.
+    It will only create an empty iframe.
+    """
+
+    def create_input_element(self, **kwargs):
+        """ Create the <jsinput> element """
+        return etree.Element("jsinput")
+
+
 class MultipleChoiceResponseXMLFactory(ResponseXMLFactory):
     """ Factory for producing <multiplechoiceresponse> XML """
 

--- a/common/lib/xmodule/xmodule/templates/problem/jsinput_response.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/jsinput_response.yaml
@@ -66,6 +66,7 @@ data: |
               width="400"
               height="400"
               html_file="https://studio.edx.org/c4x/edX/DemoX/asset/webGLDemo.html"
+              title="Spinning Cone and Cube"
               sop="false"/>
           </customresponse>
       </problem>

--- a/common/static/js/capa/spec/jsinput_spec.js
+++ b/common/static/js/capa/spec/jsinput_spec.js
@@ -1,29 +1,29 @@
 describe('JSInput', function() {
-    var sections;
-    var inputFields;
+    var $jsinputContainers;
+    var $inputFields;
 
     beforeEach(function() {
         loadFixtures('js/capa/fixtures/jsinput.html');
-        sections = $('section[id^="inputtype_"]');
-        inputFields = $('input[id^="input_"]');
+        $jsinputContainers = $('.jsinput');
+        $inputFields = $('input[id^="input_"]');
         JSInput.walkDOM();
     });
 
     it('sets all data-processed attributes to true on first load', function() {
-        sections.each(function(index, item) {
+        $jsinputContainers.each(function(index, item) {
             expect(item).toHaveData('processed', true);
         });
     });
 
     it('sets the waitfor attribute to its update function', function() {
-        inputFields.each(function(index, item) {
+        $inputFields.each(function(index, item) {
             expect(item).toHaveAttr('waitfor');
         });
     });
 
-    it('tests the correct number of sections', function() {
-        expect(sections.length).toEqual(2);
-        expect(sections.length).toEqual(inputFields.length);
+    it('tests the correct number of jsinput instances', function() {
+        expect($jsinputContainers.length).toEqual(2);
+        expect($jsinputContainers.length).toEqual($inputFields.length);
     });
 });
 

--- a/common/static/js/capa/src/jsinput.js
+++ b/common/static/js/capa/src/jsinput.js
@@ -39,26 +39,26 @@ var JSInput = (function($, undefined) {
 
         /*                      Private methods                          */
 
-        var section = $(elem).parent().find('section[class="jsinput"]'),
-            sectionAttr = function(e) { return $(section).attr(e); },
+        var jsinputContainer = $(elem).parent().find('.jsinput'),
+            jsinputAttr = function(e) { return $(jsinputContainer).attr(e); },
             iframe = $(elem).find('iframe[name^="iframe_"]').get(0),
             cWindow = iframe.contentWindow,
             path = iframe.src.substring(0, iframe.src.lastIndexOf('/') + 1),
             // Get the hidden input field to pass to customresponse
             inputField = $(elem).parent().find('input[id^="input_"]'),
             // Get the grade function name
-            gradeFn = sectionAttr('data'),
+            gradeFn = jsinputAttr('data'),
             // Get state getter
-            stateGetter = sectionAttr('data-getstate'),
+            stateGetter = jsinputAttr('data-getstate'),
             // Get state setter
-            stateSetter = sectionAttr('data-setstate'),
+            stateSetter = jsinputAttr('data-setstate'),
             // Get stored state
-            storedState = sectionAttr('data-stored'),
+            storedState = jsinputAttr('data-stored'),
             // Get initial state
-            initialState = sectionAttr('data-initial-state'),
+            initialState = jsinputAttr('data-initial-state'),
             // Bypass single-origin policy only if this attribute is "false"
             // In that case, use JSChannel to do so.
-            sop = sectionAttr('data-sop'),
+            sop = jsinputAttr('data-sop'),
             channel;
 
         sop = (sop !== 'false');
@@ -189,14 +189,14 @@ var JSInput = (function($, undefined) {
     }
 
     function walkDOM() {
-        var allSections = $('section.jsinput');
+        var $jsinputContainers = $('.jsinput');
         // When a JSInput problem loads, its data-processed attribute is false,
         // so the jsconstructor will be called for it.
         // The constructor will not be called again on subsequent reruns of
         // this file by other JSInput. Only if it is reloaded, either with the
         // rest of the page or when it is submitted, will this constructor be
         // called again.
-        allSections.each(function(index, value) {
+        $jsinputContainers.each(function(index, value) {
             var dataProcessed = ($(value).attr('data-processed') === 'true');
             if (!dataProcessed) {
                 jsinputConstructor(value);

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -19,6 +19,7 @@ from capa.tests.response_xml_factory import (
     CustomResponseXMLFactory,
     FormulaResponseXMLFactory,
     ImageResponseXMLFactory,
+    JSInputXMLFactory,
     MultipleChoiceResponseXMLFactory,
     NumericalResponseXMLFactory,
     OptionResponseXMLFactory,
@@ -132,7 +133,29 @@ class ProblemTypeTestBase(ProblemsTest, EventsTestMixin):
         raise NotImplementedError()
 
 
-class ProblemTypeTestMixin(object):
+class ProblemTypeA11yTestMixin(object):
+    """
+    Shared a11y tests for all problem types.
+    """
+    @attr('a11y')
+    def test_problem_type_a11y(self):
+        """
+        Run accessibility audit for the problem type.
+        """
+        self.problem_page.wait_for(
+            lambda: self.problem_page.problem_name == self.problem_name,
+            "Make sure the correct problem is on the page"
+        )
+
+        # Set the scope to the problem container
+        self.problem_page.a11y_audit.config.set_scope(
+            include=['div#seq_content'])
+
+        # Run the accessibility audit.
+        self.problem_page.a11y_audit.check_for_accessibility_errors()
+
+
+class ProblemTypeTestMixin(ProblemTypeA11yTestMixin):
     """
     Test cases shared amongst problem types.
     """
@@ -356,23 +379,6 @@ class ProblemTypeTestMixin(object):
         self.answer_problem(correctness='partially-correct')
         self.problem_page.click_submit()
         self.problem_page.wait_partial_notification()
-
-    @attr('a11y')
-    def test_problem_type_a11y(self):
-        """
-        Run accessibility audit for the problem type.
-        """
-        self.problem_page.wait_for(
-            lambda: self.problem_page.problem_name == self.problem_name,
-            "Make sure the correct problem is on the page"
-        )
-
-        # Set the scope to the problem container
-        self.problem_page.a11y_audit.config.set_scope(
-            include=['div#seq_content'])
-
-        # Run the accessibility audit.
-        self.problem_page.a11y_audit.check_for_accessibility_errors()
 
 
 class AnnotationProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
@@ -799,6 +805,29 @@ class ScriptProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):
 
         self.problem_page.fill_answer(first_addend, input_num=0)
         self.problem_page.fill_answer(second_addend, input_num=1)
+
+
+class JSInputTypeTest(ProblemTypeTestBase, ProblemTypeA11yTestMixin):
+    """
+    TestCase Class for jsinput (custom JavaScript) problem type.
+    Right now the only test point that is executed is the a11y test.
+    This is because the factory simply creates an empty iframe.
+    """
+    problem_name = 'JSINPUT PROBLEM'
+    problem_type = 'customresponse'
+
+    factory = JSInputXMLFactory()
+
+    factory_kwargs = {
+        'question_text': 'IFrame shows below (but has no content)'
+    }
+
+    def answer_problem(self, correctness):
+        """
+        Problem is not set up to work (displays an empty iframe), but this method must
+        be extended because the parent class has marked it as abstract.
+        """
+        raise NotImplementedError()
 
 
 class CodeProblemTypeTest(ProblemTypeTestBase, ProblemTypeTestMixin):


### PR DESCRIPTION
## [TNL-6044](https://openedx.atlassian.net/browse/TNL-6044)

In the jsinput (custom JavaScript) problem type, adds "title" as a parameter that can be set on the resulting iframe. A new example problem will be created in a future story, but I went ahead and modified the current template to pass a title (note that a default title will be used if no title is explicitly provided).

Also changes a section to div as the section was not appropriate (and caused an a11y failure since it had no heading).

### Sandbox
- [x] https://studio-cahrens.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@491ff2be7e624d76ba6c066edf278828?action=new

### Testing
- [x] i18n (purposefully not translating default title string)
- [x] RTL
- [x] safecommit violation code review process (there are 2 violations in edited files, but they are well beyond the scope of this story). I did reduce violations quite a bit.
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @staubina 
- [x] Code review: @dianakhuang 
- [x] Doc Review: @catong 
- [ ] UX review: @chris-mike (FYI)
- [x] Accessibility review: @cptvitamin 
- [ ] Product review: @sstack22 

### Post-review
- [x] Rebase and squash commits