### PR TITLE
[TNL-5947] Fix: Don't show visibility settings on library pages.

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -268,7 +268,9 @@ def xblock_view_handler(request, usage_key_string, view_name):
     if 'application/json' in accept_header:
         store = modulestore()
         xblock = store.get_item(usage_key)
-        container_views = ['container_preview', 'reorderable_container_child_preview', 'container_child_preview']
+        container_views = [
+            'container_preview', 'reorderable_container_child_preview', 'library_container_child_preview'
+        ]
 
         # wrap the generated fragment in the xmodule_editor div so that the javascript
         # can bind to it correctly
@@ -295,7 +297,7 @@ def xblock_view_handler(request, usage_key_string, view_name):
         elif view_name in PREVIEW_VIEWS + container_views:
             is_pages_view = view_name == STUDENT_VIEW   # Only the "Pages" view uses student view in Studio
             can_edit = has_studio_write_access(request.user, usage_key.course_key)
-            can_edit_visibility = not view_name == 'container_child_preview'
+            can_edit_visibility = not view_name == 'library_container_child_preview'
 
             # Determine the items to be shown as reorderable. Note that the view
             # 'reorderable_container_child_preview' is only rendered for xblocks that

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -294,6 +294,7 @@ def xblock_view_handler(request, usage_key_string, view_name):
 
         elif view_name in PREVIEW_VIEWS + container_views:
             is_pages_view = view_name == STUDENT_VIEW   # Only the "Pages" view uses student view in Studio
+            is_library_view = view_name == 'container_child_preview'
             can_edit = has_studio_write_access(request.user, usage_key.course_key)
 
             # Determine the items to be shown as reorderable. Note that the view
@@ -330,6 +331,7 @@ def xblock_view_handler(request, usage_key_string, view_name):
                 'is_pages_view': is_pages_view,     # This setting disables the recursive wrapping of xblocks
                 'is_unit_page': is_unit(xblock),
                 'can_edit': can_edit,
+                'can_edit_visibility': not is_library_view,
                 'root_xblock': xblock if (view_name == 'container_preview') else None,
                 'reorderable_items': reorderable_items,
                 'paging': paging,

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import hashlib
+import json
 import logging
 from collections import OrderedDict
 from datetime import datetime
@@ -297,7 +298,6 @@ def xblock_view_handler(request, usage_key_string, view_name):
         elif view_name in PREVIEW_VIEWS + container_views:
             is_pages_view = view_name == STUDENT_VIEW   # Only the "Pages" view uses student view in Studio
             can_edit = has_studio_write_access(request.user, usage_key.course_key)
-            can_edit_visibility = not view_name == 'library_container_child_preview'
 
             # Determine the items to be shown as reorderable. Note that the view
             # 'reorderable_container_child_preview' is only rendered for xblocks that
@@ -327,18 +327,21 @@ def xblock_view_handler(request, usage_key_string, view_name):
                 )
 
             force_render = request.GET.get('force_render', None)
+            can_edit_visibility = request.GET.get('can_edit_visibility', None)
 
             # Set up the context to be passed to each XBlock's render method.
             context = {
                 'is_pages_view': is_pages_view,     # This setting disables the recursive wrapping of xblocks
                 'is_unit_page': is_unit(xblock),
                 'can_edit': can_edit,
-                'can_edit_visibility': can_edit_visibility,
                 'root_xblock': xblock if (view_name == 'container_preview') else None,
                 'reorderable_items': reorderable_items,
                 'paging': paging,
                 'force_render': force_render,
             }
+
+            if can_edit_visibility is not None:
+                context['can_edit_visibility'] = json.loads(can_edit_visibility)
 
             fragment = get_preview_fragment(request, xblock, context)
 

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -294,8 +294,8 @@ def xblock_view_handler(request, usage_key_string, view_name):
 
         elif view_name in PREVIEW_VIEWS + container_views:
             is_pages_view = view_name == STUDENT_VIEW   # Only the "Pages" view uses student view in Studio
-            is_library_view = view_name == 'container_child_preview'
             can_edit = has_studio_write_access(request.user, usage_key.course_key)
+            can_edit_visibility = not view_name == 'container_child_preview'
 
             # Determine the items to be shown as reorderable. Note that the view
             # 'reorderable_container_child_preview' is only rendered for xblocks that
@@ -331,7 +331,7 @@ def xblock_view_handler(request, usage_key_string, view_name):
                 'is_pages_view': is_pages_view,     # This setting disables the recursive wrapping of xblocks
                 'is_unit_page': is_unit(xblock),
                 'can_edit': can_edit,
-                'can_edit_visibility': not is_library_view,
+                'can_edit_visibility': can_edit_visibility,
                 'root_xblock': xblock if (view_name == 'container_preview') else None,
                 'reorderable_items': reorderable_items,
                 'paging': paging,

--- a/cms/static/js/views/paged_container.js
+++ b/cms/static/js/views/paged_container.js
@@ -73,7 +73,7 @@ define(['jquery', 'underscore', 'common/js/components/utils/view_utils', 'js/vie
                 };
             },
 
-            new_child_view: 'container_child_preview',
+            new_child_view: 'library_container_child_preview',
 
             render: function(options) {
                 options = options || {};

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -302,7 +302,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'common/j
              * refreshing.
              * @returns {jQuery promise} A promise representing the complete operation.
              */
-            refreshChildXBlock: function(xblockElement, block_added, is_duplicate) {
+            refreshChildXBlock: function(xblockElement, block_added, is_duplicate, renderParameters) {
                 var self = this,
                     xblockInfo,
                     TemporaryXBlockView,
@@ -327,6 +327,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'common/j
                     el: xblockElement
                 });
                 return temporaryView.render({
+                    data: renderParameters || {},
                     success: function() {
                         self.onXBlockRefresh(temporaryView, block_added, is_duplicate);
                         temporaryView.unbind();  // Remove the temporary view

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -298,11 +298,11 @@ define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'common/j
              * Refresh an xblock element inline on the page, using the specified xblockInfo.
              * Note that the element is removed and replaced with the newly rendered xblock.
              * @param xblockElement The xblock element to be refreshed.
-             * @param block_added Specifies if a block has been added, rather than just needs
+             * @param blockAdded Specifies if a block has been added, rather than just needs
              * refreshing.
              * @returns {jQuery promise} A promise representing the complete operation.
              */
-            refreshChildXBlock: function(xblockElement, block_added, is_duplicate, renderParameters) {
+            refreshChildXBlock: function(xblockElement, blockAdded, isDuplicate, renderParameters) {
                 var self = this,
                     xblockInfo,
                     TemporaryXBlockView,
@@ -329,7 +329,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'common/j
                 return temporaryView.render({
                     data: renderParameters || {},
                     success: function() {
-                        self.onXBlockRefresh(temporaryView, block_added, is_duplicate);
+                        self.onXBlockRefresh(temporaryView, blockAdded, isDuplicate);
                         temporaryView.unbind();  // Remove the temporary view
                     },
                     initRuntimeData: this

--- a/cms/static/js/views/pages/paged_container.js
+++ b/cms/static/js/views/pages/paged_container.js
@@ -28,11 +28,13 @@ define(['jquery', 'underscore', 'gettext', 'js/views/pages/container', 'js/views
 
             refreshXBlock: function(element, block_added, is_duplicate) {
                 var xblockElement = this.findXBlockElement(element),
-                    rootLocator = this.xblockView.model.id;
+                    rootLocator = this.xblockView.model.id,
+                    renderParameters;
                 if (xblockElement.length === 0 || xblockElement.data('locator') === rootLocator) {
                     this.render({refresh: true, block_added: block_added});
                 } else {
-                    this.refreshChildXBlock(xblockElement, block_added, is_duplicate);
+                    renderParameters = {can_edit_visibility: false};
+                    this.refreshChildXBlock(xblockElement, block_added, is_duplicate, renderParameters);
                 }
             },
 

--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -23,6 +23,7 @@ define(['jquery', 'underscore', 'common/js/components/utils/view_utils', 'js/vie
                     url: decodeURIComponent(xblockUrl) + '/' + view,
                     type: 'GET',
                     cache: false,
+                    data: options.data || {},
                     headers: {Accept: 'application/json'},
                     success: function(fragment) {
                         self.handleXBlockFragment(fragment, options);

--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -19,6 +19,7 @@ define(['jquery', 'underscore', 'common/js/components/utils/view_utils', 'js/vie
                     view = this.view,
                     xblockInfo = this.model,
                     xblockUrl = xblockInfo.url();
+                options = options || {};
                 return $.ajax({
                     url: decodeURIComponent(xblockUrl) + '/' + view,
                     type: 'GET',

--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -18,13 +18,13 @@ define(['jquery', 'underscore', 'common/js/components/utils/view_utils', 'js/vie
                 var self = this,
                     view = this.view,
                     xblockInfo = this.model,
-                    xblockUrl = xblockInfo.url();
-                options = options || {};
+                    xblockUrl = xblockInfo.url(),
+                    data = options === 'undefined' ? {} : options.data;
                 return $.ajax({
                     url: decodeURIComponent(xblockUrl) + '/' + view,
                     type: 'GET',
                     cache: false,
-                    data: options.data || {},
+                    data: data,
                     headers: {Accept: 'application/json'},
                     success: function(fragment) {
                         self.handleXBlockFragment(fragment, options);


### PR DESCRIPTION
This PR fixes a bug where components added to a content library would incorrectly display a button for editing visibility settings (that button should be hidden on library pages).

**JIRA tickets**:

- [OC-2110](https://tasks.opencraft.com/browse/OC-2110)
- [TNL-5947](https://openedx.atlassian.net/browse/TNL-5947)

**Discussions**:

See [TNL-5947](https://openedx.atlassian.net/browse/TNL-5947).

**Dependencies**:

None

**Screenshots**:

Content library after adding HTML block (before):

![content-library-before](https://cloud.githubusercontent.com/assets/961441/20754210/30403088-b70a-11e6-8855-284b1197aedd.png)

Content library after adding HTMl block (after):

![content-library-after](https://cloud.githubusercontent.com/assets/961441/20754213/37c601e8-b70a-11e6-9e93-cebc91241961.png)

**Sandbox URLs**:

- Studio: http://studio-pr14073.sandbox.opencraft.hosting/
- LMS: http://pr14073.sandbox.opencraft.hosting/

**Deployment targets**: 

- edx.org
- edge.edx.org

**Merge deadline**:

ASAP

**Testing instructions**:

1. Log in to Studio and navigate to the "Libraries" tab.
2. Create a new library by clicking "New Library" or click on an existing one.
3. Add an HTML component to the library. Observe that the header does not show a visibility button.
4. Refresh the page and make sure the visibility button is still hidden.

**Reviewers**
- [ ] OpenCraft: @smarnach 
- [ ] edX: @awaisdar001, CC @cahrens 
