### PR TITLE
Remove access for inactive users

### DIFF
--- a/cms/djangoapps/contentstore/views/user.py
+++ b/cms/djangoapps/contentstore/views/user.py
@@ -147,13 +147,6 @@ def _course_team_user(request, course_key, email):
     if not ((requester_perms & STUDIO_EDIT_ROLES) or (user.id == request.user.id)):
         return permissions_error_response
 
-    # can't modify an inactive user
-    if not user.is_active:
-        msg = {
-            "error": _('User {email} has registered but has not yet activated his/her account.').format(email=email),
-        }
-        return JsonResponse(msg, 400)
-
     if request.method == "DELETE":
         new_role = None
     else:
@@ -164,6 +157,13 @@ def _course_team_user(request, course_key, email):
             new_role = request.json.get("role", request.POST.get("role"))
         else:
             return JsonResponse({"error": _("No `role` specified.")}, 400)
+
+    # can't modify an inactive user but can remove it
+    if not (user.is_active or new_role is None):
+        msg = {
+            "error": _('User {email} has registered but has not yet activated his/her account.').format(email=email),
+        }
+        return JsonResponse(msg, 400)
 
     old_roles = set()
     role_added = False
@@ -177,7 +177,7 @@ def _course_team_user(request, course_key, email):
                 role_added = True
             else:
                 return permissions_error_response
-        elif role.has_user(user):
+        elif role.has_user(user, check_user_activation=False):
             # Remove the user from this old role:
             old_roles.add(role)
 

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -130,11 +130,19 @@ class RoleBase(AccessRole):
         self.course_key = course_key
         self._role_name = role_name
 
-    def has_user(self, user):
+    # pylint: disable=arguments-differ
+    def has_user(self, user, check_user_activation=True):
         """
-        Return whether the supplied django user has access to this role.
+        Check if the supplied django user has access to this role.
+
+        Arguments:
+            user: user to check against access to role
+            check_user_activation: Indicating whether or not we need to check
+                user activation while checking user roles
+        Return:
+            bool identifying if user has that particular role or not
         """
-        if not (user.is_authenticated() and user.is_active):
+        if check_user_activation and not (user.is_authenticated() and user.is_active):
             return False
 
         # pylint: disable=protected-access

--- a/common/test/acceptance/pages/studio/auto_auth.py
+++ b/common/test/acceptance/pages/studio/auto_auth.py
@@ -12,19 +12,24 @@ class AutoAuthPage(PageObject):
     """
     The automatic authorization page.
     When allowed via the django settings file, visiting
-    this url will create a user and log them in.
+    this url will create/update a user and log them in.
     """
 
     def __init__(self, browser, username=None, email=None, password=None,
-                 staff=None, course_id=None, roles=None, no_login=None):
+                 staff=None, course_id=None, roles=None, no_login=None, is_active=None):
         """
         Auto-auth is an end-point for HTTP GET requests.
         By default, it will create accounts with random user credentials,
         but you can also specify credentials using querystring parameters.
 
+        Can be used to update an account, call to this end-point with already
+        made account's credentials along with values to update will result into
+        an account update.
+
         `username`, `email`, and `password` are the user's credentials (strings)
         `staff` is a boolean indicating whether the user is global staff.
         `course_id` is the ID of the course to enroll the student in.
+        `is_active` activation status of user
         Currently, this has the form "org/number/run"
 
         Note that "global staff" is NOT the same as course staff.
@@ -54,6 +59,9 @@ class AutoAuthPage(PageObject):
 
         if no_login:
             self._params['no_login'] = True
+
+        if is_active is not None:
+            self._params['is_active'] = 'true' if is_active else 'false'
 
     @property
     def url(self):


### PR DESCRIPTION
## [TNL-6015](https://openedx.atlassian.net/browse/TNL-6015)

### Description
If you attempt to remove a user's access to a content library, and their account is not active, you get a client-side validation error and the change cannot be made.
User's access is modified by a generic method written [here](https://github.com/edx/edx-platform/blob/master/cms/djangoapps/contentstore/views/user.py#L102), for any CRUD operation user's activation is checked and an error is thrown if user under operation is inactive.
I have implemeted solution in a way so when request to delete a user will be made, user's active/inactive status will not be checked.
Acceptance tests are added for this implementation.

### How to Test?

**Stage** 

- Go to https://studio.stage.edx.org/home/ and select libraries tab.
- Select any library, go to settings and select User Access.
- Add any user after clicking +New Team Memebr
- Uncheck Active checkbox of the user just added, from admin.
- Try removing this user now. Error will be prompt here.

**Sandbox**
Try repeating steps above, but in this case user should be removed without any error.
- [studio-tnl-6015.sandbox.edx.org](https://studio-tnl-6015.sandbox.edx.org/home/)

**Screenshots**
Error can be seen in given screenshot.
![image-2016-11-28-12-24-10-624](https://cloud.githubusercontent.com/assets/22347092/20754264/f1f4e3f6-b72b-11e6-89be-37bee6a4b909.png)



### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Style and readability review: @attiyaIshaque 
- [ ] Code review: @awaisdar001 
- [x] Code review: @Qubad786  

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [ ] Rebase and squash commits