### PR TITLE
fix unformatted html in studio error response

### DIFF
--- a/cms/static/cms/js/main.js
+++ b/cms/static/cms/js/main.js
@@ -25,22 +25,23 @@
                 dataType: 'json'
             });
             $(document).ajaxError(function(event, jqXHR, ajaxSettings) {
-                var message, msg;
+                var msg, contentType,
+                    message = gettext('This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.');  // eslint-disable-line max-len
                 if (ajaxSettings.notifyOnError === false) {
                     return;
                 }
-                if (jqXHR.responseText) {
-                    try {
-                        message = JSON.parse(jqXHR.responseText).error;
-                    } catch (error) {
-                        message = str.truncate(jqXHR.responseText, 300);
-                    }
-                } else {
-                    message = gettext('This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.');  // eslint-disable-line max-len
+                contentType = jqXHR.getResponseHeader('content-type');
+                if (contentType && contentType.indexOf('json') > -1 && jqXHR.responseText) {
+                    message = JSON.parse(jqXHR.responseText).error;
                 }
                 msg = new NotificationView.Error({
                     'title': gettext("Studio's having trouble saving your work"),
                     'message': message
+                });
+                console.log('Studio AJAX Error', { // eslint-disable-line no-console
+                    url: event.currentTarget.URL,
+                    response: jqXHR.responseText,
+                    status: jqXHR.status
                 });
                 return msg.show();
             });


### PR DESCRIPTION
### Description
This PR fixes a [bug](https://openedx.atlassian.net/browse/TNL-5818) where the middleware sends back its own generic, unhelpful HTML error message in the case of a 403. Now, the error widget only displays the response error text if it's in JSON format and otherwise uses the existing default error message.

### Sandbox
https://studio-fix-unformatted-403.sandbox.edx.org

### Review
- [x] @bjacobel 
- [x] @andy-armstrong 

### Post-review
- [x] Rebase/squash