### PR TITLE
ENT-11 Adding link to enterprise page in the footer

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -164,6 +164,7 @@ def _footer_social_links():
 
 def _footer_navigation_links():
     """Return the navigation links to display in the footer. """
+    platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
     return [
         {
             "name": link_name,
@@ -172,13 +173,14 @@ def _footer_navigation_links():
         }
         for link_name, link_url, link_title in [
             ("about", marketing_link("ABOUT"), _("About")),
+            ("enterprise", marketing_link("ENTERPRISE"),
+             _("{platform_name} for Business").format(platform_name=platform_name)),
             ("blog", marketing_link("BLOG"), _("Blog")),
             ("news", marketing_link("NEWS"), _("News")),
             ("help-center", settings.SUPPORT_SITE_LINK, _("Help Center")),
             ("contact", marketing_link("CONTACT"), _("Contact")),
             ("careers", marketing_link("CAREERS"), _("Careers")),
             ("donate", marketing_link("DONATE"), _("Donate")),
-            ("media_kit", marketing_link("MEDIA_KIT"), _("Media Kit"))
         ]
         if link_url and link_url != "#"
     ]
@@ -192,6 +194,7 @@ def _footer_legal_links():
         ("privacy_policy", marketing_link("PRIVACY"), _("Privacy Policy")),
         ("accessibility_policy", marketing_link("ACCESSIBILITY"), _("Accessibility Policy")),
         ("sitemap", marketing_link("SITE_MAP"), _("Sitemap")),
+        ("media_kit", marketing_link("MEDIA_KIT"), _("Media Kit")),
     ]
 
     # Backwards compatibility: If a combined "terms of service and honor code"

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 import mock
 from branding.api import get_logo_url, get_footer
+from django.test.utils import override_settings
 
 
 class TestHeader(TestCase):
@@ -40,8 +41,10 @@ class TestFooter(TestCase):
         "TOS_AND_HONOR": "/edx-terms-service",
         "PRIVACY": "/edx-privacy-policy",
         "ACCESSIBILITY": "/accessibility",
-        "MEDIA_KIT": "/media-kit"
+        "MEDIA_KIT": "/media-kit",
+        "ENTERPRISE": "/enterprise"
     })
+    @override_settings(PLATFORM_NAME='\xe9dX')
     def test_get_footer(self):
         actual_footer = get_footer(is_secure=True)
         expected_footer = {
@@ -49,12 +52,12 @@ class TestFooter(TestCase):
                          ' EdX logos are registered trademarks or trademarks of edX Inc.',
             'navigation_links': [
                 {'url': 'https://edx.org/about-us', 'name': 'about', 'title': 'About'},
+                {'url': 'https://edx.org/enterprise', 'name': 'enterprise', 'title': '\xe9dX for Business'},
                 {'url': 'https://edx.org/edx-blog', 'name': 'blog', 'title': 'Blog'},
                 {'url': 'https://edx.org/news-announcements', 'name': 'news', 'title': 'News'},
                 {'url': 'https://support.example.com', 'name': 'help-center', 'title': 'Help Center'},
                 {'url': 'https://edx.org/contact', 'name': 'contact', 'title': 'Contact'},
-                {'url': 'https://edx.org/donate', 'name': 'donate', 'title': 'Donate'},
-                {'url': 'https://edx.org/media-kit', 'name': 'media_kit', 'title': 'Media Kit'}
+                {'url': 'https://edx.org/donate', 'name': 'donate', 'title': 'Donate'}
             ],
             'legal_links': [
                 {'url': 'https://edx.org/edx-terms-service',
@@ -64,7 +67,8 @@ class TestFooter(TestCase):
                 {'url': 'https://edx.org/accessibility',
                  'name': 'accessibility_policy',
                  'title': 'Accessibility Policy'},
-                {'url': 'https://edx.org/sitemap', 'name': 'sitemap', 'title': 'Sitemap'}
+                {'url': 'https://edx.org/sitemap', 'name': 'sitemap', 'title': 'Sitemap'},
+                {'url': 'https://edx.org/media-kit', 'name': 'media_kit', 'title': 'Media Kit'}
             ],
             'social_links': [
                 {'url': '#', 'action': 'Like \xe9dX on Facebook', 'name': 'facebook',

--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -172,11 +172,11 @@ footer#footer-edx-v3 {
     padding: 20px 10px;
 
     .site-details {
-      @include span-columns(7);
+      @include span-columns(8);
     }
 
     .external-links {
-      @include span-columns(5);
+      @include span-columns(4);
     }
 
     .social-media-links,
@@ -195,11 +195,11 @@ footer#footer-edx-v3 {
     }
 
     .site-details {
-      @include span-columns(6);
+      @include span-columns(7);
     }
 
     .external-links {
-      @include span-columns(4);
+      @include span-columns(3);
     }
 
     .social-media-links {


### PR DESCRIPTION
With the launch of the new enterprise marketing page, we want to add a link to it in the footer to be available across edx.org.