### PR TITLE
Prepare sub-dependencies for NPM 3 transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "backbone": "~1.3.2",
+    "backbone.paginator": "~2.0.3",
     "backbone-validation": "~0.11.5",
     "coffee-script": "1.6.1",
     "edx-pattern-library": "0.17.1",
@@ -10,6 +11,8 @@
     "jquery": "~2.2.0",
     "jquery-migrate": "^1.4.1",
     "jquery.scrollto": "~2.1.2",
+    "moment": "^2.15.1",
+    "moment-timezone": "~0.5.5",
     "picturefill": "~3.0.2",
     "requirejs": "~2.3.2",
     "uglify-js": "2.7.0",
@@ -22,7 +25,6 @@
     "eslint-config-edx": "^1.2.1",
     "jasmine-core": "^2.4.1",
     "jasmine-jquery": "^2.1.1",
-    "jquery": "^2.1.4",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.3",
     "karma-coverage": "^0.5.5",
@@ -35,6 +37,7 @@
     "pa11y": "4.0.1",
     "pa11y-reporter-json-oldnode": "1.0.0",
     "plato": "1.2.2",
+    "sinon": "1.17.3 || >1.17.4",
     "squirejs": "^0.1.0"
   }
 }

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -49,9 +49,9 @@ COMMON_LOOKUP_PATHS = [
 NPM_INSTALLED_LIBRARIES = [
     'backbone-validation/dist/backbone-validation-min.js',
     'backbone/backbone.js',
-    'edx-ui-toolkit/node_modules/backbone.paginator/lib/backbone.paginator.js',
-    'edx-ui-toolkit/node_modules/moment-timezone/builds/moment-timezone-with-data.js',
-    'edx-ui-toolkit/node_modules/moment/min/moment-with-locales.js',
+    'backbone.paginator/lib/backbone.paginator.js',
+    'moment-timezone/builds/moment-timezone-with-data.js',
+    'moment/min/moment-with-locales.js',
     'jquery-migrate/dist/jquery-migrate.js',
     'jquery.scrollto/jquery.scrollTo.js',
     'jquery/dist/jquery.js',
@@ -64,7 +64,7 @@ NPM_INSTALLED_LIBRARIES = [
 # A list of NPM installed developer libraries that should be copied into the common
 # static directory only in development mode.
 NPM_INSTALLED_DEVELOPER_LIBRARIES = [
-    'edx-ui-toolkit/node_modules/sinon/pkg/sinon.js',
+    'sinon/pkg/sinon.js',
     'squirejs/src/Squire.js',
 ]
 


### PR DESCRIPTION
### Description
See https://github.com/edx/edx-ui-toolkit/pull/87.

Platform expects these dependencies to be installed into `node_modules/edx-ui-toolkit/node_modules/lib`. When we upgrade to Node 6 / NPM 3, this will break.

Making these sub-dependencies of the UI Toolkit normal top-level dependencies ensures they will continued to be found by our existing copy-to-vendor-dir strategy, regardless of NPM version.

### Sandboxes
- Using this PR and configuration master: [peerdeps-npm1.sandbox.edx.org](peerdeps-npm1.sandbox.edx.org)
- Using this PR and my branch of configuration which upgrades to NPM 3/Node 6: [peerdeps-npm3.sandbox.edx.org](peerdeps-npm3.sandbox.edx.org)

### Review:
- [x] @andy-armstrong 
- [x] @alisan617 
- [x] Somebody from Tools, possibly @estute or @arizzitano or @benpatterson 

FYI devops, @jibsheet / @maxrothman 