### PR TITLE
move course version repopulation to runtime layer

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -955,7 +955,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
 
         item = system.load_item(location, for_parent=for_parent)
 
-        # TODO Once PLAT-1055 is implemented, we can remove the following line
+        # TODO Once TNL-5092 is implemented, we can remove the following line
         # of code. Until then, set the course_version field on the block to be
         # consistent with the Split modulestore. Since Mongo modulestore doesn't
         # maintain course versions set it to None.

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -131,6 +131,13 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
 
         class_ = self.load_block_type(block_data.block_type)
         block = self.xblock_from_json(class_, course_key, block_key, block_data, course_entry_override, **kwargs)
+
+        # TODO Once TNL-5092 is implemented, we can expose the course version
+        # information within the key identifier of the block.  Until then, set
+        # the course_version as a field on the returned block so higher layers
+        # can use it when needed.
+        block.course_version = version_guid
+
         self.modulestore.cache_block(course_key, version_guid, block_key, block)
         return block
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -779,15 +779,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             self._add_cache(course_entry.structure['_id'], runtime)
             self.cache_items(runtime, block_keys, course_entry.course_key, depth, lazy)
 
-        blocks = [runtime.load_item(block_key, course_entry, **kwargs) for block_key in block_keys]
-
-        # TODO Once PLAT-1055 is implemented, we can expose the course version
-        # information within the key identifier of the block.  Until then, set
-        # the course_version as a field on each returned block so higher layers
-        # can use it when needed.
-        for block in blocks:
-            block.course_version = course_entry.course_key.version_guid
-        return blocks
+        return [runtime.load_item(block_key, course_entry, **kwargs) for block_key in block_keys]
 
     def _get_cache(self, course_version_guid):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -454,6 +454,10 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
         self.assertEquals(len(blocks), 7)
         for block in blocks:
             self.assertEquals(block.course_version, course_version)
+            # ensure that when the block is retrieved from the runtime cache,
+            # the course version is still present
+            cached_block = course.runtime.load_item(block.location)
+            self.assertEqual(cached_block.course_version, block.course_version)
 
     @ddt.data((ModuleStoreEnum.Type.split, 2, False), (ModuleStoreEnum.Type.mongo, 3, True))
     @ddt.unpack

--- a/lms/djangoapps/grades/tests/test_transformer.py
+++ b/lms/djangoapps/grades/tests/test_transformer.py
@@ -352,6 +352,10 @@ class GradesTransformerTestCase(CourseStructureTestCase):
             blocks = self.build_course_with_problems()
         block_structure = get_course_blocks(self.student, blocks[u'course'].location, self.transformers)
         self.assertIsNotNone(block_structure.get_xblock_field(blocks[u'course'].location, u'course_version'))
+        self.assertEqual(
+            block_structure.get_xblock_field(blocks[u'problem'].location, u'course_version'),
+            block_structure.get_xblock_field(blocks[u'course'].location, u'course_version')
+        )
 
     def test_grading_policy_collected(self):
         # the calculated hash of the original and updated grading policies of the test course


### PR DESCRIPTION
## [TNL-6065](https://openedx.atlassian.net/browse/TNL-6065)

### Description

Moves repopulation of the `course_version` field on xblocks to the runtime layer. Previously, the `course_version` field was not populated when a block was retrieved from the cache.

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @nasthagiri 
- [x] Code review: @jcdyer 

### Post-review
- [x] Rebase and squash commits