### PR TITLE
Fix sharing icons on certificate page at narrower resolutions

### DIFF
--- a/lms/static/certificates/sass/_layouts.scss
+++ b/lms/static/certificates/sass/_layouts.scss
@@ -80,36 +80,41 @@
             margin-bottom: spacing-vertical(small);
         }
 
-        .message-actions .action {
-            display: block;
-            width: 100%;
-            margin: 0 auto spacing-vertical(small) auto;
+        .message-actions {
+            @include span(12);
 
-            &:last-child {
-                margin-bottom: 0;
-            }
-
-            // CASE: icon display only
-            &.icon-only {
-
-                @media(min-width: $bp-screen-md) {
-                    padding: spacing-vertical(x-small) spacing-horizontal(base);
-
-                    .icon {
-                        @include margin-right(0);
-                    }
-                }
-            }
-
-            @media(min-width: $bp-screen-md) {
-                display: inline-block;
-                vertical-align: middle;
-                width: auto;
-                margin-bottom: 0;
-                margin-right: spacing-horizontal(mid-small);
+            .action {
+                display: block;
+                width: 100%;
+                margin: 0 auto spacing-vertical(small) auto;
 
                 &:last-child {
-                    margin-right: 0;
+                    margin-bottom: 0;
+                }
+
+                // CASE: icon display only
+                &.icon-only {
+
+                    @media(min-width: $bp-screen-md) {
+                        padding: spacing-vertical(x-small) spacing-horizontal(base);
+
+                        .icon {
+                            @include margin-right(0);
+                        }
+                    }
+                }
+
+                @media(min-width: $bp-screen-md) {
+                    display: inline-block;
+                    vertical-align: middle;
+                    min-width: 130px;
+                    width: auto;
+                    margin-bottom: 0;
+                    margin-right: spacing-horizontal(mid-small);
+
+                    &:last-child {
+                        margin-right: 0;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## [TNL-6085](https://openedx.atlassian.net/browse/TNL-6085)

### Description
Fix social sharing buttons at narrower widths on web certificates page. This was broken as part of the Susy replacement and I only noticed on Stage, but I judged it to be a small enough UI issue to not hold up the release.

**Previously**:
![](https://i.bjacobel.com/20161202-dbckd.png)

**With these changes**:
![](https://i.bjacobel.com/20161205-ebc2i.png)
(at medium width)

![](https://i.bjacobel.com/20161205-1j1vz.png)
(at small width)

### Sandbox
- [x] [View as staff@example.com](https://cert-sharing-icons.sandbox.edx.org/certificates/user/5/course/course-v1:edX+Test101+course?preview=verified)

### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit violation code review process
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @andy-armstrong 
- [x] @AlasdairSwan 

### Post-review
- [ ] Rebase and squash commits