### PR TITLE
Upgrade django-user-tasks to resolve makemigrations issue

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -34,7 +34,7 @@ django-simple-history==1.6.3
 django-statici18n==1.1.5
 django-storages==1.4.1
 django-method-override==0.1.0
-django-user-tasks==0.1.1
+django-user-tasks==0.1.2
 # We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3


### PR DESCRIPTION
The new django-user-tasks version is already on PyPI, merging this should prevent `makemigrations` from attempting to create new migrations for this package.  The upgrade itself contains a new migration that makes no schema changes.