### PR TITLE
edx-val version bump

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -217,7 +217,7 @@ Randy Ostler <rando305@gmail.com>
 Thomas Young <thomas@upcoder.com>
 Andrew Dekker <simultech@gmail.com>
 Christopher Lee <clee@edx.org>
-Mushtaq Ali <mushtaque.ali@arbisoft.com>
+Mushtaq Ali <mushtaak@gmail.com>
 Colin Fredericks <colin.fredericks@gmail.com>
 Xiaolu Xiong <beardeer@gmail.com>
 Tim Krones <t.krones@gmx.net>

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -80,7 +80,7 @@ git+https://github.com/edx/edx-ora2.git@1.1.11#egg=ora2==1.1.11
 -e git+https://github.com/edx/edx-submissions.git@1.1.1#egg=edx-submissions==1.1.1
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.3.2#egg=i18n-tools==v0.3.2
-git+https://github.com/edx/edx-val.git@0.0.10#egg=edxval==0.0.10
+git+https://github.com/edx/edx-val.git@0.0.10#egg=edxval==0.0.11
 git+https://github.com/pmitros/RecommenderXBlock.git@v1.1#egg=recommender-xblock==1.1
 git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock


### PR DESCRIPTION
This PR bumps edx-val version to 0.0.11.

Course video migration issue was fixed in [PR#66](https://github.com/edx/edx-val/pull/66)

[TNL-6094](https://openedx.atlassian.net/browse/TNL-6094)

@muzaffaryousaf review ?

@brittneyexline FYI as a release master.

