### PR TITLE
Remove thread 'inline' rendering mode, make tab mode the One True Mode

### DIFF
--- a/common/static/common/js/discussion/views/discussion_inline_view.js
+++ b/common/static/common/js/discussion/views/discussion_inline_view.js
@@ -141,7 +141,7 @@
             this.threadView = new DiscussionThreadView({
                 el: this.$('.forum-content'),
                 model: thread,
-                mode: 'tab',
+                mode: 'inline',
                 course_settings: this.course_settings
             });
             this.threadView.render();

--- a/common/static/common/js/discussion/views/discussion_thread_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_view.js
@@ -152,14 +152,7 @@
                         });
                     });
                 }
-                if (this.mode === 'tab') {
-                    setTimeout(function() {
-                        return self.loadInitialResponses();
-                    }, 100);
-                    return this.$('.post-tools').hide();
-                } else {
-                    return this.collapse();
-                }
+                this.loadInitialResponses();
             };
 
             DiscussionThreadView.prototype.attrRenderer = $.extend({}, DiscussionContentView.prototype.attrRenderer, {
@@ -221,9 +214,7 @@
             };
 
             DiscussionThreadView.prototype.loadResponses = function(responseLimit, $elem, firstLoad) {
-                var takeFocus,
-                    self = this;
-                takeFocus = this.mode === 'tab' ? false : true;
+                var self = this;
                 this.responsesRequest = DiscussionUtil.safeAjax({
                     url: DiscussionUtil.urlFor(
                         'retrieve_single_thread', this.model.get('commentable_id'), this.model.id
@@ -234,7 +225,7 @@
                     },
                     $elem: $elem,
                     $loading: $elem,
-                    takeFocus: takeFocus,
+                    takeFocus: false,
                     complete: function() {
                         self.responsesRequest = null;
                     },
@@ -253,7 +244,6 @@
                         );
                         self.trigger('thread:responses:rendered');
                         self.loadedResponses = true;
-                        return self.$el.find('.discussion-article[data-id="' + self.model.id + '"]').focus();
                     },
                     error: function(xhr, textStatus) {
                         if (textStatus === 'abort') {

--- a/common/static/common/js/spec/discussion/view/discussion_inline_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/discussion_inline_view_spec.js
@@ -52,7 +52,12 @@
                     title: TEST_THREAD_TITLE
                 }),
                 page: 1,
-                num_pages: 1
+                num_pages: 1,
+                content: {
+                    endorsed_responses: [],
+                    non_endorsed_responses: [],
+                    children: []
+                }
             });
             testView.$('.discussion-show').click();
         };

--- a/common/static/common/templates/discussion/thread-show.underscore
+++ b/common/static/common/templates/discussion/thread-show.underscore
@@ -52,7 +52,7 @@
 
     <div class="post-body"><%- body %></div>
     <div class="post-context">
-        <% if (mode == "tab" && obj.courseware_url) { %>
+        <% if (mode === "tab" && obj.courseware_url) { %>
             <%
             var courseware_title_linked = interpolate(
                 '<a href="%(courseware_url)s">%(courseware_title)s</a>',

--- a/common/static/common/templates/discussion/thread.underscore
+++ b/common/static/common/templates/discussion/thread.underscore
@@ -32,8 +32,4 @@
             <% } %>
         </div>
     </div>
-    <div class="post-tools">
-        <button class="btn-link forum-thread-expand"><span class="icon fa fa-plus" aria-hidden="true"/><%- gettext("Expand discussion") %></button>
-        <button class="btn-link forum-thread-collapse"><span class="icon fa fa-minus" aria-hidden="true"/><%- gettext("Collapse discussion") %></button>
-    </div>
 </article>

--- a/lms/djangoapps/discussion/static/discussion/js/views/discussion_user_profile_view.js
+++ b/lms/djangoapps/discussion/static/discussion/js/views/discussion_user_profile_view.js
@@ -51,7 +51,7 @@
                     this.threadView = new DiscussionThreadView({
                         el: this.$('.forum-content'),
                         model: thread,
-                        mode: 'tab',
+                        mode: 'inline',
                         course_settings: this.courseSettings
                     });
                     this.threadView.render();


### PR DESCRIPTION
PR into https://github.com/edx/edx-platform/pull/14026

Note that it was necessary to keep passing `inline` and `tab` to the DiscussionThreadView, though custom UI for it has been eliminated, because of two small differences between the inline and tab modes:
- Inline mode doesn't show a "Related to: [topic]" box like the tab mode view does
- Tab mode doesn't show UI to change the thread topic when you edit the thread (which is a view instantiated inside of DiscussionThreadView) like tab mode view does.

---

- [x] @alisan617 
- [x] @andy-armstrong 