### PR TITLE
ENT-78: Update saml --pull command to raise error when it fails.

### DIFF
--- a/common/djangoapps/third_party_auth/management/commands/saml.py
+++ b/common/djangoapps/third_party_auth/management/commands/saml.py
@@ -25,9 +25,16 @@ class Command(BaseCommand):
         log = logging.getLogger('third_party_auth.tasks')
         log.propagate = False
         log.addHandler(log_handler)
-        num_changed, num_failed, num_total = fetch_saml_metadata()
+        num_changed, num_failed, num_total, failure_messages = fetch_saml_metadata()
         self.stdout.write(
             "\nDone. Fetched {num_total} total. {num_changed} were updated and {num_failed} failed.\n".format(
                 num_changed=num_changed, num_failed=num_failed, num_total=num_total
             )
         )
+
+        if num_failed > 0:
+            raise CommandError(
+                "Command finished with the following exceptions:\n\n{failures}".format(
+                    failures="\n\n".join(failure_messages)
+                )
+            )

--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -10,6 +10,7 @@ import pytz
 import logging
 from lxml import etree
 import requests
+from requests import exceptions
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from third_party_auth.models import SAMLConfiguration, SAMLProviderConfig, SAMLProviderData
 
@@ -32,12 +33,14 @@ def fetch_saml_metadata():
     It's OK to run this whether or not SAML is enabled.
 
     Return value:
-        tuple(num_changed, num_failed, num_total)
+        tuple(num_changed, num_failed, num_total, failure_messages)
         num_changed: Number of providers that are either new or whose metadata has changed
         num_failed: Number of providers that could not be updated
         num_total: Total number of providers whose metadata was fetched
+        failure_messages: List of error messages for the providers that could not be updated
     """
-    num_changed, num_failed = 0, 0
+    num_changed = 0
+    failure_messages = []
 
     # First make a list of all the metadata XML URLs:
     url_map = {}
@@ -75,10 +78,38 @@ def fetch_saml_metadata():
                     num_changed += 1
                 else:
                     log.info(u"→ Updated existing SAMLProviderData. Nothing has changed.")
-        except Exception as err:  # pylint: disable=broad-except
-            log.exception(err.message)
-            num_failed += 1
-    return (num_changed, num_failed, len(url_map))
+        except (exceptions.SSLError, exceptions.HTTPError, exceptions.RequestException, MetadataParseError) as error:
+            # Catch and process exception in case of errors during fetching and processing saml metadata.
+            # Here is a description of each exception.
+            # SSLError is raised in case of errors caused by SSL (e.g. SSL cer verification failure etc.)
+            # HTTPError is raised in case of unexpected status code (e.g. 500 error etc.)
+            # RequestException is the base exception for any request related error that "requests" lib raises.
+            # MetadataParseError is raised if there is error in the fetched meta data (e.g. missing @entityID etc.)
+
+            log.exception(error.message)
+            failure_messages.append(
+                "{error_type}: {error_message}\nMetadata Source: {url}\nEntity IDs: \n{entity_ids}.".format(
+                    error_type=type(error).__name__,
+                    error_message=error.message,
+                    url=url,
+                    entity_ids="\n".join(
+                        ["\t{}: {}".format(count, item) for count, item in enumerate(entity_ids, start=1)],
+                    )
+                )
+            )
+        except etree.XMLSyntaxError as error:
+            log.exception(error.message)
+            failure_messages.append(
+                "XMLSyntaxError: {error_message}\nMetadata Source: {url}\nEntity IDs: \n{entity_ids}.".format(
+                    error_message=str(error.error_log),
+                    url=url,
+                    entity_ids="\n".join(
+                        ["\t{}: {}".format(count, item) for count, item in enumerate(entity_ids, start=1)],
+                    )
+                )
+            )
+
+    return num_changed, len(failure_messages), len(url_map), failure_messages
 
 
 def _parse_metadata_xml(xml, entity_id):

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -149,8 +149,9 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
         kwargs.setdefault('attr_email', 'urn:oid:1.3.6.1.4.1.5923.1.1.1.6')  # eduPersonPrincipalName
         self.configure_saml_provider(**kwargs)
         self.assertTrue(httpretty.is_enabled())
-        num_changed, num_failed, num_total = fetch_saml_metadata()
+        num_changed, num_failed, num_total, failure_messages = fetch_saml_metadata()
         self.assertEqual(num_failed, 0)
+        self.assertEqual(len(failure_messages), 0)
         self.assertEqual(num_changed, 1)
         self.assertEqual(num_total, 1)
 
@@ -176,9 +177,10 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
 
         if fetch_metadata:
             self.assertTrue(httpretty.is_enabled())
-            num_changed, num_failed, num_total = fetch_saml_metadata()
+            num_changed, num_failed, num_total, failure_messages = fetch_saml_metadata()
             if assert_metadata_updates:
                 self.assertEqual(num_failed, 0)
+                self.assertEqual(len(failure_messages), 0)
                 self.assertEqual(num_changed, 1)
                 self.assertEqual(num_total, 1)
 


### PR DESCRIPTION
Hi @mattdrayer , @jibsheet , @asadiqbal08 , @bradenmacdonald 

Kindly take a look at this PR, it fixes the problem where command was returning 0 error code even for failures.

__Description of ENT-78:__
When running saml --pull it does not exit with an error code if an update fails
```Fetching https://idp.princeton.edu/idp/profile/Metadata/SAML
2016-11-29 11:40:13,898 INFO 16082 [requests.packages.urllib3.connectionpool] connectionpool.py:758 - Starting new HTTPS connection (1): idp.princeton.edu
404 Client Error: Not Found for url: https://idp.princeton.edu/idp/profile/Metadata/SAML
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/common/djangoapps/third_party_auth/tasks.py", line 60, in fetch_saml_metadata
    response.raise_for_status()  # May raise an HTTPError
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/requests/models.py", line 840, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
HTTPError: 404 Client Error: Not Found for url: https://idp.princeton.edu/idp/profile/Metadata/SAML

Done. Fetched 7 total. 0 were updated and 1 failed.
www-data@ip-10-4-71-90:/edx/app/edxapp$ echo $?
0
```
It's standard for command line tools to return a non-zero exit code when an error condition is encountered. This prevents the updating automation which runs twice a day from detecting error conditions.
