### PR TITLE
removes redundant alt attribute value

### DIFF
--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -156,6 +156,10 @@ class DashboardPage(PageObject):
         """ Retrieves the specified social sharing widget by its classification """
         return self.q(css='a.action-{}'.format(widget_name))
 
+    def get_profile_img(self):
+        """ Retrieves the user's profile image """
+        return self.q(css='img.user-image-frame')
+
     def get_courses(self):
         """
         Get all courses shown in the dashboard

--- a/common/test/acceptance/tests/lms/test_lms_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard.py
@@ -305,6 +305,13 @@ class LmsDashboardPageTest(BaseLmsDashboardTest):
         # and course starts within 5 days
         self.assertEqual(course_date, expected_course_date)
 
+    def test_profile_img_alt_empty(self):
+        """
+        Validate value of profile image alt attribue is null
+        """
+        profile_img = self.dashboard_page.get_profile_img()
+        self.assertEqual(profile_img.attrs('alt')[0], '')
+
 
 @attr('a11y')
 class LmsDashboardA11yTest(BaseLmsDashboardTestMultiple):

--- a/lms/templates/user_dropdown.html
+++ b/lms/templates/user_dropdown.html
@@ -49,7 +49,7 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
                 username = self.real_user.username
                 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
                 %>
-                <img class="user-image-frame" src="${profile_image_url}" alt="${_('Profile image for {username}').format(username=username)}">
+                <img class="user-image-frame" src="${profile_image_url}" alt="">
                 <div class="label-username">${username}</div>
             </a>
         </li>


### PR DESCRIPTION
This is a regression of https://openedx.atlassian.net/browse/AC-332 which removes the alt attribute value from the avatar image that appears in the user account dropdown menu.  There is screen reader text here, that when combined with the username, sufficiently describes the menu.  Including an alt attribute value results in redundant information in the label.

Reviewers:

@cahrens 
@arizzitano 