### PR TITLE
Fix accidentally exposed Supply Chain course run

### DIFF
--- a/openedx/core/djangoapps/catalog/tests/test_utils.py
+++ b/openedx/core/djangoapps/catalog/tests/test_utils.py
@@ -51,6 +51,7 @@ class TestGetPrograms(mixins.CatalogIntegrationMixin, TestCase):
         querystring = {
             'marketable': 1,
             'exclude_utm': 1,
+            'published_course_runs_only': 1,
         }
         if type:
             querystring['type'] = type

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -43,6 +43,7 @@ def get_programs(user, uuid=None, type=None):  # pylint: disable=redefined-built
         querystring = {
             'marketable': 1,
             'exclude_utm': 1,
+            'published_course_runs_only': 1,
         }
         if type:
             querystring['type'] = type

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -145,9 +145,6 @@ def attach_program_detail_url(programs):
     Returns:
         list, containing extended program dicts
     """
-    programs_config = ProgramsApiConfig.current()
-    marketing_url = get_program_marketing_url(programs_config)
-
     for program in programs:
         base = reverse('program_details_view', kwargs={'program_id': program['id']}).rstrip('/')
         slug = slugify(program['name'])


### PR DESCRIPTION
## [ECOM-6452 - Fix accidentally exposed Supply Chain course run](https://openedx.atlassian.net/browse/ECOM-6452)
### Description
There was an issue where learners are able to enroll in a run of a course of a **[MicroMaster Program](https://courses.edx.org/dashboard/programs/2fc3236d-78a9-45a1-8c0c-fc290e74259e/supply-chain-management)** that was unpublished in discovery (i.e. catalog).


![screen shot 2016-11-22 at 3 28 02 pm](https://cloud.githubusercontent.com/assets/4252738/21048528/91e12030-be31-11e6-86ab-0d09ff311ea7.png)

We needed to get rid of this behavior and only expose published course runs.

**FIX**
Fix the bug in the LMS (on course and program dashboards) so that if a course run is in the "unpublished" state, it is not presented as an enrollable run to learners

### How to Test?
**Stage** 
Please see the [ECOM-6452](https://openedx.atlassian.net/browse/ECOM-6452) description for Steps to reproduce


**Sandbox**
- _in discussion with @schenedx _

**Screenshots**
_Added above.._

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @adampalay 
- [x] Code review: @rlucioni   
- [x] Code review: @schenedx 

### Post-review
- [ ] Rebase and squash commits
