### PR TITLE
[proof of concept] progressive profile

### DIFF
--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -66,7 +66,6 @@
     @include float(right);
     @include margin-left(flex-gutter());
     width: flex-grid(3);
-    margin-top: ($baseline*2);
 
     .user-info {
       @include clearfix();

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -210,6 +210,14 @@
       }
     }
   }
+
+  #progressive-profile {
+    @include float(right);
+    @include margin-left(flex-gutter());
+    margin-bottom: $baseline;
+    padding: 0;
+    width: flex-grid(3);
+  }
 }
 
 // CASE: empty dashboard

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -134,6 +134,12 @@ from openedx.core.djangolib.markup import HTML, Text
         % endif
     </div>
 
+    <div id="progressive-profile"></div>
+
+    <%static:require_module_async module_name="common/js/vendor/progressive-profiles" class_name="a">
+      new ProgressiveProfile.default('progressive-profile', '${user}');
+    </%static:require_module_async>
+
       % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
         <div id="dashboard-search-bar" class="search-bar dashboard-search-bar" role="search" aria-label="Dashboard">
           <form>
@@ -154,12 +160,6 @@ from openedx.core.djangolib.markup import HTML, Text
       % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
         <div id="dashboard-search-results" class="search-results dashboard-search-results"></div>
       % endif
-
-      <div id="progressive-profile"></div>
-
-      <%static:require_module_async module_name="common/js/vendor/progressive-profiles" class_name="a">
-        new ProgressiveProfile.default('progressive-profile', '${user}');
-      </%static:require_module_async>
 
       <div class="profile-sidebar" id="profile-sidebar" role="region" aria-label="Account Status Info">
         <header class="profile">

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -155,6 +155,10 @@ from openedx.core.djangolib.markup import HTML, Text
         <div id="dashboard-search-results" class="search-results dashboard-search-results"></div>
       % endif
 
+      <div id="progressive-profile">
+        progressive profile goes here
+      </div>
+
       <div class="profile-sidebar" id="profile-sidebar" role="region" aria-label="Account Status Info">
         <header class="profile">
           <h2 class="account-status-title sr">${_("Account Status Info")}: </h2>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -158,7 +158,7 @@ from openedx.core.djangolib.markup import HTML, Text
       <div id="progressive-profile"></div>
 
       <%static:require_module_async module_name="common/js/vendor/progressive-profiles" class_name="a">
-        new ProgressiveProfile.default('progressive-profile');
+        new ProgressiveProfile.default('progressive-profile', '${user}');
       </%static:require_module_async>
 
       <div class="profile-sidebar" id="profile-sidebar" role="region" aria-label="Account Status Info">

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -155,13 +155,11 @@ from openedx.core.djangolib.markup import HTML, Text
         <div id="dashboard-search-results" class="search-results dashboard-search-results"></div>
       % endif
 
-      <div id="progressive-profile">
-        progressive profile goes here
-      </div>
+      <div id="progressive-profile"></div>
 
-      <%static:require_module module_name="common/js/vendor/progressive-profiles" class_name="asdf">
-        DashboardSearchFactory();
-      </%static:require_module>
+      <%static:require_module_async module_name="common/js/vendor/progressive-profiles" class_name="a">
+        new ProgressiveProfile.default('progressive-profile');
+      </%static:require_module_async>
 
       <div class="profile-sidebar" id="profile-sidebar" role="region" aria-label="Account Status Info">
         <header class="profile">

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -159,6 +159,10 @@ from openedx.core.djangolib.markup import HTML, Text
         progressive profile goes here
       </div>
 
+      <%static:require_module module_name="common/js/vendor/progressive-profiles" class_name="asdf">
+        DashboardSearchFactory();
+      </%static:require_module>
+
       <div class="profile-sidebar" id="profile-sidebar" role="region" aria-label="Account Status Info">
         <header class="profile">
           <h2 class="account-status-title sr">${_("Account Status Info")}: </h2>

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "dependencies": {
     "backbone": "~1.3.2",
-    "backbone.paginator": "~2.0.3",
     "backbone-validation": "~0.11.5",
+    "backbone.paginator": "~2.0.3",
     "coffee-script": "1.6.1",
     "edx-pattern-library": "0.17.1",
+    "edx-profiles": "^0.1.0",
     "edx-ui-toolkit": "1.5.0",
     "jquery": "~2.2.0",
     "jquery-migrate": "^1.4.1",

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -59,6 +59,7 @@ NPM_INSTALLED_LIBRARIES = [
     'requirejs/require.js',
     'underscore.string/dist/underscore.string.js',
     'underscore/underscore.js',
+    'edx-profiles/build/static/js/progressive-profiles.js',
 ]
 
 # A list of NPM installed developer libraries that should be copied into the common

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -587,7 +587,7 @@ def _compile_sass(system, theme, debug, force, timing_info):
             timing_info.append((sass_source_dir, css_dir, duration))
     return True
 
-
+@task
 def process_npm_assets():
     """
     Process vendor libraries installed via NPM.


### PR DESCRIPTION
This is a proof of concept from Hackathon XV to demonstrate how to integrate an externally-bundled javascript component (e.g. a react app) into edx-platform.

### JS
The JS files are included via node_modules as a vendor library. Ideally something like this would be hosted on npm for ease of installation (although we didn't get to that point yet :eyes:). Webpack takes care of the bundling, so the only thing we need to add to the paver asset pipeline is a reference to our app's entry point. The progressive profile is just one widget, but it would also be possible to bundle multiple components for generic use throughout the application.

Once we've included the entry point, we can reference the modules therein via `require_module_async`.

### CSS
Each js module imports its own CSS file. This means we don't need to add anything to our current SCSS pipeline -- the CSS is bundled and sent as JS, then injected into the page once the module loads.

### HTML
It's all included within the JS files.

### React
See: https://github.com/bjacobel/edx-profiles.