### PR TITLE
Flaky video translations test fix.

### DIFF
--- a/common/test/acceptance/pages/lms/video/video.py
+++ b/common/test/acceptance/pages/lms/video/video.py
@@ -629,7 +629,7 @@ class VideoPage(PageObject):
         """
         self.wait_for_ajax()
 
-        # Yes, I feel unclean putting this in:
+        # TODO remove this sleep and wait for the right thing to finish rendering
         time.sleep(1)
 
         # mouse over to transcript button

--- a/common/test/acceptance/pages/lms/video/video.py
+++ b/common/test/acceptance/pages/lms/video/video.py
@@ -629,14 +629,19 @@ class VideoPage(PageObject):
         """
         self.wait_for_ajax()
 
+        # Yes, I feel unclean putting this in:
+        time.sleep(1)
+
         # mouse over to transcript button
-        cc_button_selector = self.get_element_selector(VIDEO_BUTTONS["transcript"])
+        cc_button_selector = self.get_element_selector(VIDEO_BUTTONS["transcript_button"])
         element_to_hover_over = self.q(css=cc_button_selector).results[0]
         ActionChains(self.browser).move_to_element(element_to_hover_over).perform()
 
         language_selector = VIDEO_MENUS["language"] + ' li[data-lang-code="{code}"]'.format(code=code)
         language_selector = self.get_element_selector(language_selector)
         self.wait_for_element_visibility(language_selector, 'language menu is visible')
+        hover_target = self.q(css=language_selector).results[0]
+        ActionChains(self.browser).move_to_element(hover_target).perform()
         self.q(css=language_selector).first.click()
 
         # Sometimes language is not clicked correctly. So, if the current language code
@@ -887,7 +892,7 @@ class VideoPage(PageObject):
         Wait until captions rendered completely.
         """
         captions_rendered_selector = self.get_element_selector(CSS_CLASS_NAMES['captions_rendered'])
-        self.wait_for_element_presence(captions_rendered_selector, 'Captions Rendered')
+        self.wait_for_element_visibility(captions_rendered_selector, 'Captions Rendered')
 
     def wait_for_closed_captions(self):
         """

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -1014,6 +1014,7 @@ class Html5VideoTest(VideoBaseTest):
         unicode_text = "好 各位同学".decode('utf-8')
         self.assertTrue(self.video.downloaded_transcript_contains_text('srt', unicode_text))
 
+    @flaky(max_runs=10, min_passes=10)
     def test_download_button_two_transcript_languages(self):
         """
         Scenario: Download button works correctly for multiple transcript languages in HTML5 mode
@@ -1030,10 +1031,13 @@ class Html5VideoTest(VideoBaseTest):
         self.metadata = self.metadata_for_mode('html5', additional_data=data)
 
         # go to video
+        # from nose.tools import set_trace; set_trace()
         self.navigate_to_video()
 
         # check if "Welcome to edX." text in the captions
         self.assertIn('Welcome to edX.', self.video.captions_text)
+
+        self.video.wait_for_element_visibility('.transcript-end', 'Transcript has loaded')
 
         # check if we can download transcript in "srt" format that has text "Welcome to edX."
         self.assertTrue(self.video.downloaded_transcript_contains_text('srt', 'Welcome to edX.'))

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -1014,7 +1014,6 @@ class Html5VideoTest(VideoBaseTest):
         unicode_text = "好 各位同学".decode('utf-8')
         self.assertTrue(self.video.downloaded_transcript_contains_text('srt', unicode_text))
 
-    @flaky(max_runs=10, min_passes=10)
     def test_download_button_two_transcript_languages(self):
         """
         Scenario: Download button works correctly for multiple transcript languages in HTML5 mode
@@ -1031,7 +1030,6 @@ class Html5VideoTest(VideoBaseTest):
         self.metadata = self.metadata_for_mode('html5', additional_data=data)
 
         # go to video
-        # from nose.tools import set_trace; set_trace()
         self.navigate_to_video()
 
         # check if "Welcome to edX." text in the captions


### PR DESCRIPTION
Sadly, I introduce a time.sleep here. The hovering over the elements is
particularly brittle, and there is no obvious signal for when the page is
done rendering. I'm putting a sleep in here so we can more-quickly support
Firefox 45.