### PR TITLE
ziafazal/SOL-2107: Allow selection of seat type during manual enrolment 

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -155,6 +155,15 @@ class CourseEnrollmentAdmin(admin.ModelAdmin):
         model = CourseEnrollment
 
 
+class CourseEnrollmentAllowedAdmin(admin.ModelAdmin):
+    """ Admin interface for the CourseEnrollmentAllowed model. """
+    list_display = ('email', 'course_id', 'mode', 'auto_enroll',)
+    search_fields = ('email', 'course_id', 'mode',)
+
+    class Meta(object):
+        model = CourseEnrollmentAllowed
+
+
 class UserProfileInline(admin.StackedInline):
     """ Inline admin interface for UserProfile model. """
     model = UserProfile
@@ -180,7 +189,7 @@ class UserAttributeAdmin(admin.ModelAdmin):
 
 
 admin.site.register(UserTestGroup)
-admin.site.register(CourseEnrollmentAllowed)
+admin.site.register(CourseEnrollmentAllowed, CourseEnrollmentAllowedAdmin)
 admin.site.register(Registration)
 admin.site.register(PendingNameChange)
 admin.site.register(DashboardConfiguration, ConfigurationModelAdmin)

--- a/common/djangoapps/student/migrations/0008_courseenrollmentallowed_mode.py
+++ b/common/djangoapps/student/migrations/0008_courseenrollmentallowed_mode.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('student', '0007_registrationcookieconfiguration'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseenrollmentallowed',
+            name='mode',
+            field=models.CharField(default=b'audit', max_length=100),
+        ),
+    ]

--- a/common/djangoapps/student/migrations/0009_courseenrollmentallowed_mode.py
+++ b/common/djangoapps/student/migrations/0009_courseenrollmentallowed_mode.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('student', '0007_registrationcookieconfiguration'),
+        ('student', '0008_auto_20161117_1209'),
     ]
 
     operations = [

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1247,7 +1247,7 @@ class CourseEnrollment(models.Model):
 
         Also emits relevant events for analytics purposes.
         """
-        if mode is None:
+        if not mode:
             mode = _default_course_mode(unicode(course_key))
         # All the server-side checks for whether a user is allowed to enroll.
         try:
@@ -1737,6 +1737,8 @@ class CourseEnrollmentAllowed(models.Model):
     email = models.CharField(max_length=255, db_index=True)
     course_id = CourseKeyField(max_length=255, db_index=True)
     auto_enroll = models.BooleanField(default=0)
+    # Represents the course mode in which user is allowed to enroll
+    mode = models.CharField(default=CourseMode.DEFAULT_MODE_SLUG, max_length=100)
 
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)
 
@@ -1744,7 +1746,7 @@ class CourseEnrollmentAllowed(models.Model):
         unique_together = (('email', 'course_id'),)
 
     def __unicode__(self):
-        return "[CourseEnrollmentAllowed] %s: %s (%s)" % (self.email, self.course_id, self.created)
+        return '%s: %s [%s] (%s)' % (self.email, self.course_id, self.mode, self.created)
 
     @classmethod
     def may_enroll_and_unenrolled(cls, course_id):

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -146,6 +146,7 @@ class CourseEnrollmentAllowedFactory(DjangoModelFactory):
 
     email = 'test@edx.org'
     course_id = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+    mode = 'audit'
 
 
 class PendingEmailChangeFactory(DjangoModelFactory):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1875,10 +1875,14 @@ def _enroll_user_in_pending_courses(student):
     """
     Enroll student in any pending courses he/she may have.
     """
-    ceas = CourseEnrollmentAllowed.objects.filter(email=student.email)
-    for cea in ceas:
-        if cea.auto_enroll:
-            enrollment = CourseEnrollment.enroll(student, cea.course_id)
+    course_enrollment_allowed_list = CourseEnrollmentAllowed.objects.filter(email=student.email)
+    for course_enrollment_allowed in course_enrollment_allowed_list:
+        if course_enrollment_allowed.auto_enroll:
+            enrollment = CourseEnrollment.enroll(
+                user=student,
+                course_key=course_enrollment_allowed.course_id,
+                mode=course_enrollment_allowed.mode,
+            )
             manual_enrollment_audit = ManualEnrollmentAudit.get_manual_enrollment_by_email(student.email)
             if manual_enrollment_audit is not None:
                 # get the enrolled by user and reason from the ManualEnrollmentAudit table.

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -1089,6 +1089,10 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         # verify that there are now two course modes 'honor' and 'verified'
         self.assertEqual(len(CourseMode.modes_for_course_dict(self.course.id)), 2)
 
+        # login with global staff user to auto enroll learner in verified track
+        admin_user = AdminFactory.create()
+        self.client.login(username=admin_user, password="test")
+
         # now use enrollment api to enroll a student in 'verified' mode directly
         url = reverse('students_update_enrollment', kwargs={'course_id': unicode(self.course.id)})
         response = self.client.post(
@@ -1329,6 +1333,10 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
 
         # verify that there are now two course modes 'honor' and 'verified'
         self.assertEqual(len(CourseMode.modes_for_course_dict(self.course.id)), 2)
+
+        # login with global staff user to auto enroll learner in verified track
+        admin_user = AdminFactory.create()
+        self.client.login(username=admin_user, password="test")
 
         # now use enrollment api to enroll a student in 'verified' mode directly
         url = reverse('students_update_enrollment', kwargs={'course_id': unicode(self.course.id)})

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -575,6 +575,7 @@ def students_update_enrollment(request, course_id):
     - email_students is a boolean (defaults to false)
         If email_students is true, students will be sent email notification
         If email_students is false, students will not be sent email notification
+    - course_mode is a string identifier for the selected course mode, e.g. 'honor', 'verified' etc
 
     Returns an analog to this JSON structure: {
         "action": "enroll",
@@ -599,6 +600,7 @@ def students_update_enrollment(request, course_id):
     }
     """
     course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
+    course_mode = request.POST.get('course_mode')
     action = request.POST.get('action')
     identifiers_raw = request.POST.get('identifiers')
     identifiers = _split_input_list(identifiers_raw)
@@ -643,7 +645,13 @@ def students_update_enrollment(request, course_id):
             validate_email(email)  # Raises ValidationError if invalid
             if action == 'enroll':
                 before, after, enrollment_obj = enroll_email(
-                    course_id, email, auto_enroll, email_students, email_params, language=language
+                    course_id,
+                    email,
+                    auto_enroll,
+                    email_students,
+                    email_params,
+                    language=language,
+                    course_mode=course_mode
                 )
                 before_enrollment = before.to_dict()['enrollment']
                 before_user_registered = before.to_dict()['user']

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -466,6 +466,7 @@ def _section_course_info(course, access):
 def _section_membership(course, access, is_white_label):
     """ Provide data for the corresponding dashboard section """
     course_key = course.id
+    course_modes = CourseMode.modes_for_course_dict(course_key)
     ccx_enabled = settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx
     section_data = {
         'section_key': 'membership',
@@ -481,6 +482,7 @@ def _section_membership(course, access, is_white_label):
         'modify_access_url': reverse('modify_access', kwargs={'course_id': unicode(course_key)}),
         'list_forum_members_url': reverse('list_forum_members', kwargs={'course_id': unicode(course_key)}),
         'update_forum_role_membership_url': reverse('update_forum_role_membership', kwargs={'course_id': unicode(course_key)}),
+        'course_modes': course_modes,
     }
     return section_data
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -474,6 +474,7 @@ def _section_membership(course, access, is_white_label):
         'access': access,
         'ccx_is_enabled': ccx_enabled,
         'is_white_label': is_white_label,
+        'has_professional_mode': CourseMode.has_professional_mode(course_modes),
         'enroll_button_url': reverse('students_update_enrollment', kwargs={'course_id': unicode(course_key)}),
         'unenroll_button_url': reverse('students_update_enrollment', kwargs={'course_id': unicode(course_key)}),
         'upload_student_csv_button_url': reverse('register_and_enroll_students', kwargs={'course_id': unicode(course_key)}),

--- a/lms/static/js/fixtures/instructor_dashboard/batchenrollment.html
+++ b/lms/static/js/fixtures/instructor_dashboard/batchenrollment.html
@@ -1,0 +1,76 @@
+<section id="membership" class="idash-section active-section" aria-labelledby="header-membership">
+    <h2 class="hd hd-2" id="header-membership">Membership</h2>
+
+    <fieldset class="batch-enrollment membership-section">
+        <legend id="heading-batch-enrollment" class="hd hd-3">Batch Enrollment</legend>
+        <label>
+            Enter email addresses and/or usernames separated by new lines or commas.
+            You will not receive notifications for messages that cannot be delivered, so be sure to double-check
+            spelling.
+            <textarea rows="6" name="student-ids" placeholder="Email Addresses/Usernames" spellcheck="false"></textarea>
+        </label>
+        <input id="is_course_white_label" value="False" type="hidden">
+        <div class="enroll-option">
+            <label for="course-modes-list-selector" class="has-hint">Select a course mode:
+                <select id="course-modes-list-selector" name="course_mode" class="course-modes-list-selector">
+                <option value="honor">Honor code certificate</option>
+                <option value="verified">Verified certificate</option>
+                </select>
+
+                <div class="hint dropdown-hint auto-enroll-hint">
+                    <span class="hint-caret"></span>
+                    <p id="auto-enroll-tip">
+                        Learners will be automatically enrolled in the course mode that you select.
+                        <br><br>
+                        If you select <b>Unenroll</b> below, you do not need to select a course mode.
+                    </p>
+                </div>
+            </label>
+        </div>
+        <div class="enroll-option">
+            <label class="has-hint">
+                <input name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes"
+                       aria-describedby="heading-batch-enrollment" type="checkbox">
+                <span class="label-text">Enroll learners automatically</span>
+                <div class="hint auto-enroll-hint">
+                    <span class="hint-caret"></span>
+                    <p id="auto-enroll-tip">
+                        If you select this option, learners will be automatically enrolled in the course. If a learner
+                        does not yet have an account on Devstack, the learner will be automatically enrolled in the
+                        course when the learner registers and activates an account.
+                        If you do not select this option, learners will not be automatically enrolled in the course. If
+                        a learner does not yet have an account on Devstack, the learner can enroll in the course after
+                        the learner registers and activates an account.
+                        <br><br>
+                        If you select <b>Unenroll</b> below, you do not need to select this option.
+                    </p>
+                </div>
+            </label>
+        </div>
+        <div class="enroll-option">
+            <label class="has-hint">
+                <input name="email-students" id="email-students" value="Notify-students-by-email" checked="yes"
+                       aria-describedby="heading-batch-enrollment" type="checkbox">
+                <span class="label-text">Notify learners by email</span>
+                <div class="hint email-students-hint">
+                    <span class="hint-caret"></span>
+                    <p id="email-students-tip">
+                        If you select this option, learners receive an email message when they are successfully enrolled
+                        in your course.
+                    </p>
+                </div>
+            </label>
+        </div>
+        <div>
+            <input name="enrollment-button" class="enrollment-button" value="Enroll"
+                   data-endpoint="/courses/course-v1:edX+TEST_01+2016_R1/instructor/api/students_update_enrollment"
+                   data-action="enroll" type="button">
+            <input name="enrollment-button" class="enrollment-button" value="Unenroll"
+                   data-endpoint="/courses/course-v1:edX+TEST_01+2016_R1/instructor/api/students_update_enrollment"
+                   data-action="unenroll" type="button">
+        </div>
+        <div class="request-response"></div>
+        <div class="request-response-error"></div>
+    </fieldset>
+
+</section>

--- a/lms/static/js/instructor_dashboard/membership.js
+++ b/lms/static/js/instructor_dashboard/membership.js
@@ -536,6 +536,7 @@ such that the value can be defined later than this assignment (file load order).
             this.$enrollment_button = this.$container.find('.enrollment-button');
             this.$is_course_white_label = this.$container.find('#is_course_white_label').val();
             this.$reason_field = this.$container.find("textarea[name='reason-field']");
+            this.$course_mode = this.$container.find('select#course-modes-list-selector');
             this.$checkbox_autoenroll = this.$container.find("input[name='auto-enroll']");
             this.$checkbox_emailstudents = this.$container.find("input[name='email-students']");
             this.$task_response = this.$container.find('.request-response');
@@ -553,6 +554,7 @@ such that the value can be defined later than this assignment (file load order).
                     action: $(event.target).data('action'),
                     identifiers: batchEnroll.$identifier_input.val(),
                     auto_enroll: batchEnroll.$checkbox_autoenroll.is(':checked'),
+                    course_mode: batchEnroll.$course_mode.val(),
                     email_students: emailStudents,
                     reason: batchEnroll.$reason_field.val()
                 };
@@ -575,6 +577,7 @@ such that the value can be defined later than this assignment (file load order).
             this.$identifier_input.val('');
             this.$reason_field.val('');
             this.$checkbox_emailstudents.attr('checked', true);
+            this.$course_mode.find('option:eq(0)').prop('selected', true);
             return this.$checkbox_autoenroll.attr('checked', true);
         };
 

--- a/lms/static/js/spec/instructor_dashboard/batch_enrollment_spec.js
+++ b/lms/static/js/spec/instructor_dashboard/batch_enrollment_spec.js
@@ -1,0 +1,50 @@
+define([
+    'jquery',
+    'js/instructor_dashboard/membership'
+],
+    function($) {
+        'use strict';
+        describe('BatchEnrollment', function() {
+            beforeEach(function(done) {
+                loadFixtures('js/fixtures/instructor_dashboard/batchenrollment.html');
+
+                this.membershipSection = $('section#membership');
+                window.InstructorDashboard.sections.Membership(this.membershipSection);
+
+                jasmine.waitUntil(function() {
+                    return $('section#membership').find('.enrollment-button').is(':visible');
+                }).always(done);
+            });
+
+            it('sends an enrollment ajax call with provided data and selected course mode', function() {
+                var courseMode = 'verified',
+                    userForEnrollment = 'test_user',
+                    studentIdsInput = this.membershipSection.find('textarea[name="student-ids"]'),
+                    courseModeSelector = this.membershipSection.find('select#course-modes-list-selector'),
+                    enrollButton = this.membershipSection.find('.enrollment-button[value="Enroll"]');
+
+                spyOn($, 'ajax');
+                // add the test user in batch enrollment list
+                studentIdsInput.val(userForEnrollment);
+                // select the course mode 'verified' from course modes dropdown
+                courseModeSelector.val(courseMode);
+                // click on the button 'Enroll'
+                enrollButton.click();
+
+                // now verify that the last ajax POST request has desired parameters
+                expect($.ajax.calls.mostRecent().args[0].type).toEqual('POST');
+                expect($.ajax.calls.mostRecent().args[0].data).toEqual({
+                    action: 'enroll',
+                    identifiers: userForEnrollment,
+                    auto_enroll: true,
+                    course_mode: courseMode,
+                    email_students: true,
+                    reason: void 0  // set to 'undefined' by default
+                });
+                expect($.ajax.calls.mostRecent().args[0].url).toEqual(
+                    enrollButton.data('endpoint')
+                );
+            });
+        });
+    }
+);

--- a/lms/static/lms/js/spec/main.js
+++ b/lms/static/lms/js/spec/main.js
@@ -734,6 +734,7 @@
         'js/spec/edxnotes/views/visibility_decorator_spec.js',
         'js/spec/financial-assistance/financial_assistance_form_view_spec.js',
         'js/spec/groups/views/cohorts_spec.js',
+        'js/spec/instructor_dashboard/batch_enrollment_spec.js',
         'js/spec/instructor_dashboard/certificates_bulk_exception_spec.js',
         'js/spec/instructor_dashboard/certificates_exception_spec.js',
         'js/spec/instructor_dashboard/certificates_invalidation_spec.js',

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -621,7 +621,7 @@
       top: ($baseline/2);
       left: -9999em;
       padding: ($baseline/2);
-      width: 50%;
+      width: 40%;
       background-color: $light-gray3;
       box-shadow: 2px 2px 3px $shadow;
 
@@ -641,11 +641,20 @@
      * Ideally we want to handle functionality with JS.
      * This functionality should eventually be moved into CS/JS, and out of here. */ 
     .has-hint:hover > .hint {    
-        @include left($baseline*10);
+        @include left($baseline*15);
     }
     
     .has-hint input:focus ~ .hint {
-        @include left($baseline*10);
+        @include left($baseline*15);
+    }
+    .has-hint:hover > .dropdown-hint {
+        width: 30%;
+        @include left($baseline*20);
+    }
+
+    .has-hint input:focus ~ .dropdown-hint {
+        width: 30%;
+        @include left($baseline*20);
     }
     /* *** */
   }

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -33,6 +33,7 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
   </div>
 </script>
 
+%if not section_data['has_professional_mode'] or section_data['access']['admin']:
 <fieldset class="batch-enrollment membership-section">
     <legend id="heading-batch-enrollment" class="hd hd-3">${_("Batch Enrollment")}</legend>
     <label>
@@ -49,24 +50,28 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
             <textarea rows="2" id="reason-field-id" name="reason-field" placeholder="${_('Reason')}" spellcheck="false"></textarea>
         </label>
     %endif
-    <div class="enroll-option">
-        <label for="course-modes-list-selector" class="has-hint">${_("Select a course mode: ")}
-            <select id="course-modes-list-selector" name="course_mode" class="course-modes-list-selector">
-                %for mode_name, mode_data in section_data['course_modes'].items():
-                    <option value="${mode_name}">${mode_data.name}</option>
-                %endfor
-            </select>
 
-            <div class="hint dropdown-hint auto-enroll-hint">
-                <span class="hint-caret"></span>
-                <p id="auto-enroll-tip">
-                    ${_("Learners will be automatically enrolled in the course mode that you select.")}
-                    <br /><br />
-                    ${_("If you select {b_start}Unenroll{b_end} below, you do not need to select a course mode.").format(b_start="<b>", b_end="</b>")}
-                </p>
-            </div>
-        </label>
-    </div>
+    % if section_data['access']['admin']:
+        <div class="enroll-option">
+            <label for="course-modes-list-selector" class="has-hint">${_("Select a course mode: ")}
+                <select id="course-modes-list-selector" name="course_mode" class="course-modes-list-selector">
+                    %for mode_name, mode_data in section_data['course_modes'].items():
+                        <option value="${mode_name}">${mode_data.name}</option>
+                    %endfor
+                </select>
+                <br clear="both" />
+                <div class="hint dropdown-hint auto-enroll-hint">
+                    <span class="hint-caret"></span>
+                    <p id="auto-enroll-tip">
+                        ${_("Learners will be automatically enrolled in the course mode that you select.")}
+                        <br /><br />
+                        ${_("If you select {b_start}Unenroll{b_end} below, you do not need to select a course mode.").format(b_start="<b>", b_end="</b>")}
+                    </p>
+                </div>
+            </label>
+        </div>
+    %endif
+
     <div class="enroll-option">
         <label class="has-hint">
             <input type="checkbox" name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes" aria-describedby="heading-batch-enrollment">
@@ -101,6 +106,7 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
     <div class="request-response"></div>
     <div class="request-response-error"></div>
 </fieldset>
+%endif
 
 %if static.get_value('ALLOW_AUTOMATED_SIGNUPS', settings.FEATURES.get('ALLOW_AUTOMATED_SIGNUPS', False)):
 <hr class="divider" />

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -37,7 +37,7 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
     <legend id="heading-batch-enrollment" class="hd hd-3">${_("Batch Enrollment")}</legend>
     <label>
         ${_("Enter email addresses and/or usernames separated by new lines or commas.")}
-        ${_("You will not get notification for emails that bounce, so please double-check spelling.")}
+        ${_("You will not receive notifications for messages that cannot be delivered, so be sure to double-check spelling.")}
         <textarea rows="6" name="student-ids" placeholder="${_("Email Addresses/Usernames")}" spellcheck="false"></textarea>
     </label>
     <input type="hidden" id="is_course_white_label" value="${section_data['is_white_label']}">
@@ -50,16 +50,34 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
         </label>
     %endif
     <div class="enroll-option">
+        <label for="course-modes-list-selector" class="has-hint">${_("Select a course mode: ")}
+            <select id="course-modes-list-selector" name="course_mode" class="course-modes-list-selector">
+                %for mode_name, mode_data in section_data['course_modes'].items():
+                    <option value="${mode_name}">${mode_data.name}</option>
+                %endfor
+            </select>
+
+            <div class="hint dropdown-hint auto-enroll-hint">
+                <span class="hint-caret"></span>
+                <p id="auto-enroll-tip">
+                    ${_("Learners will be automatically enrolled in the course mode that you select.")}
+                    <br /><br />
+                    ${_("If you select {b_start}Unenroll{b_end} below, you do not need to select a course mode.").format(b_start="<b>", b_end="</b>")}
+                </p>
+            </div>
+        </label>
+    </div>
+    <div class="enroll-option">
         <label class="has-hint">
             <input type="checkbox" name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes" aria-describedby="heading-batch-enrollment">
-            <span class="label-text">${_("Auto Enroll")}</span>
+            <span class="label-text">${_("Enroll learners automatically")}</span>
             <div class="hint auto-enroll-hint">
                 <span class="hint-caret"></span>
                 <p id="auto-enroll-tip">
-                    ${_("If this option is <em>checked</em>, users who have not yet registered for {platform_name} will be automatically enrolled.").format(platform_name=settings.PLATFORM_NAME)}
-                    ${_("If this option is left <em>unchecked</em>, users who have not yet registered for {platform_name} will not be enrolled, but will be allowed to enroll once they make an account.").format(platform_name=settings.PLATFORM_NAME)}
+                    ${_("If you select this option, learners will be automatically enrolled in the course. If a learner does not yet have an account on {platform_name}, the learner will be automatically enrolled in the course when the learner registers and activates an account.").format(platform_name=settings.PLATFORM_NAME)}
+                    ${_("If you do not select this option, learners will not be automatically enrolled in the course. If a learner does not yet have an account on {platform_name}, the learner can enroll in the course after the learner registers and activates an account.").format(platform_name=settings.PLATFORM_NAME)}
                     <br /><br />
-                    ${_("Checking this box has no effect if 'Unenroll' is selected.")}
+                    ${_("If you select {b_start}Unenroll{b_end} below, you do not need to select this option.").format(b_start="<b>", b_end="</b>")}
                 </p>
             </div>
         </label>
@@ -67,11 +85,11 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
     <div class="enroll-option">
         <label class="has-hint">
             <input type="checkbox" name="email-students" id="email-students" value="Notify-students-by-email" checked="yes" aria-describedby="heading-batch-enrollment">
-            <span class="label-text">${_("Notify users by email")}</span>
+            <span class="label-text">${_("Notify learners by email")}</span>
             <div class="hint email-students-hint">
                 <span class="hint-caret"></span>
                 <p id="email-students-tip">
-                    ${_("If this option is <em>checked</em>, users will receive an email notification.")}
+                    ${_("If you select this option, learners receive an email message when they are successfully enrolled in your course.")}
                 </p>
             </div>
         </label>


### PR DESCRIPTION
This PR has changes to support selection of seat type during manual enrolment. 

These changes allow course teams to add learners to free tracks of courses, and bar them from adding learners to the paid track of any course. Only the edX Staff role should be add learners to the paid track of courses. That means for courses that do not have a free Audit track (ProfEd), course teams cannot manually add learners to the course.

[SOL-2107](https://openedx.atlassian.net/browse/SOL-2107) has more details.