### PR TITLE
Bump problem-builder to v2.6.5.

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@v2.6.1#egg=xblock-problem-builder==2.6.1
+git+https://github.com/open-craft/problem-builder.git@v2.6.5#egg=xblock-problem-builder==2.6.5
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
This cherry-picks changes from #14044 into the `release-candidate` branch to fix a bug in problem-builder.

It includes support for course keys longer than 50 characters (see: https://github.com/open-craft/problem-builder/pull/131).

**Environments**:  edx.org and edge.edx.org

**Merge deadline**: ASAP - this is blocking a course on Edge

**JIRA tickets**: [TNL-5932](https://openedx.atlassian.net/browse/TNL-5932)

**Discussions**: https://github.com/edx/edx-platform/pull/14044, https://github.com/edx/edx-platform/pull/14013, https://github.com/open-craft/problem-builder/pull/131 and [TNL-5932](https://openedx.atlassian.net/browse/TNL-5932)

**Partner information**: hosted on edX Edge (Davidson College)
