### PR TITLE
Honor browser defined language preferences when possible

### DIFF
--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -39,9 +39,15 @@ class LanguagePreferenceMiddleware(object):
             preferred_language = request.META.get('HTTP_ACCEPT_LANGUAGE', '')
             lang_headers = [seq[0] for seq in parse_accept_lang_header(preferred_language)]
 
+            prefixes = [prefix.split("-")[0] for prefix in system_released_languages]
             # Setting the session language to the browser language, if it is supported.
             for browser_lang in lang_headers:
                 if browser_lang in system_released_languages:
-                    if request.session.get(LANGUAGE_SESSION_KEY, None) is None:
-                        request.session[LANGUAGE_SESSION_KEY] = unicode(browser_lang)
-                    break
+                    pass
+                elif browser_lang in prefixes:
+                    browser_lang = system_released_languages[prefixes.index(browser_lang)]
+                else:
+                    continue
+                if request.session.get(LANGUAGE_SESSION_KEY, None) is None:
+                    request.session[LANGUAGE_SESSION_KEY] = unicode(browser_lang)
+                break

--- a/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
@@ -100,3 +100,30 @@ class TestUserPreferenceMiddleware(TestCase):
         set_user_preference(self.user, LANGUAGE_KEY, 'eo')
         self.middleware.process_request(self.request)
         self.assertEqual(get_user_preference(self.request.user, LANGUAGE_KEY), None)
+
+    @mock.patch(
+        'openedx.core.djangoapps.lang_pref.middleware.released_languages',
+        mock.Mock(return_value=[('eu-es', 'euskara (Espainia)'), ('en', 'english')])
+    )
+    def test_supported_browser_language_prefix_in_session(self):
+        """
+        test: browser language should be set in user session if it's prefix is supported by system for
+        unathenticated users
+        """
+        self.request.META['HTTP_ACCEPT_LANGUAGE'] = 'eu;q=1.0'  # pylint: disable=no-member
+        self.request.user = self.anonymous_user
+        self.middleware.process_request(self.request)
+        self.assertEqual(self.request.session.get(LANGUAGE_SESSION_KEY), 'eu-es')  # pylint: disable=no-member
+
+    @mock.patch(
+        'openedx.core.djangoapps.lang_pref.middleware.released_languages',
+        mock.Mock(return_value=[('en', 'english')])
+    )
+    def test_unsupported_browser_language_prefix(self):
+        """
+        test: browser language should not be set in user session if it's prefix is not supported by system.
+        """
+        self.request.META['HTTP_ACCEPT_LANGUAGE'] = 'eu;q=1.0'  # pylint: disable=no-member
+        self.request.user = self.anonymous_user
+        self.middleware.process_request(self.request)
+        self.assertNotEqual(self.request.session.get(LANGUAGE_SESSION_KEY), 'eu-es')   # pylint: disable=no-member


### PR DESCRIPTION
My environment: Eucalyptus.rc2, devstack.

I want to be able to work with my devstack instance in Basque (eu-es language). I have been able to configure the application to show all the strings in eu-es but only after explicitly changing it with the language selector. By default, the home page is shown in English. I want to force Open edX to obey the browser-lang definition: if the user has Basque as his/her preferred language in the browser and it is one of the released languages in the edX instance, the home page (and any other page of the instance) should be shown in Basque by default.

Tracing the code I saw that common/djangoapps/lang_pref/middleware.py is where the system decides what language should it shown as default when the user is not authenticated:

```
   preferred_language = request.META.get('HTTP_ACCEPT_LANGUAGE', '')
   lang_headers = [seq[0] for seq in parse_accept_lang_header(preferred_language)]
```

So lang_headers are extracted from the HTTP Headers sent by the browser (HTTP_ACCEPT_LANGUAGE header).
This is an example of lang_headers content: ['eu', 'es', 'en-us', 'en', 'de']
The order of the languages is important: the user prefers to see pages in 'eu', and if they are not available, in 'es'. In turn, if they are not 'es' pages available, the user prefers 'en-us', 'en' and 'de'.

But then, this lang_headers is traversed searching for any language that is also presented in system_released_languages (the languages released by the Open edX instance, that in my case are: ['en', 'es-es', 'eu-es']).

This is when the weird behavior arises: edX uses eu-es name to define the Basque locale. But browsers like Chrome set the HTTP_ACCEPT_LANGUAGE to use the name "eu" for Basque. The same happens for the Spanish language. Chrome uses the name 'es' to define that _flavor_ of Spanish (that is, Spanish from Spain, not Spanish from Latin-America).

Briefly, the eu-es language (the preferred language for my case, and one of the released languages in system_released_languages) will never match the "eu" name from the HTTP_ACCEPT_LANGUAGE header. The same behavior is exhibited for the es-es versus 'es' names. At the end of the day, what happens is that Open edX (devstack) will always show all the pages, by default, in English ('en', because that is the only language that is both present in HTTP_ACCEPT_LANGUAGE header and system_released_languages variable).

In order to fix that, I propose this PR.
