### PR TITLE
Checks access using the CCX course key instead of the base course key

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -156,9 +156,6 @@ def has_access(user, action, obj, course_key=None):
     if isinstance(obj, XBlock):
         return _has_access_descriptor(user, action, obj, course_key)
 
-    if isinstance(obj, CCXLocator):
-        return _has_access_ccx_key(user, action, obj)
-
     if isinstance(obj, CourseKey):
         return _has_access_course_key(user, action, obj)
 
@@ -619,16 +616,6 @@ def _has_access_course_key(user, action, course_key):
     }
 
     return _dispatch(checkers, action, user, course_key)
-
-
-def _has_access_ccx_key(user, action, ccx_key):
-    """Check if user has access to the course for this ccx_key
-
-    Delegates checking to _has_access_course_key
-    Valid actions: same as for that function
-    """
-    course_key = ccx_key.to_course_locator()
-    return _has_access_course_key(user, action, course_key)
 
 
 def _has_access_string(user, action, perm):

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -33,7 +33,8 @@ class LoginEnrollmentTestCase(TestCase):
             self.email,
             self.password,
         )
-        self.activate_user(self.email)
+        # activate_user re-fetches and returns the activated user record
+        self.user = self.activate_user(self.email)
         self.login(self.email, self.password)
 
     def assert_request_status_code(self, status_code, url, method="GET", **kwargs):
@@ -100,7 +101,10 @@ class LoginEnrollmentTestCase(TestCase):
         url = reverse('activate', kwargs={'key': activation_key})
         self.assert_request_status_code(200, url)
         # Now make sure that the user is now actually activated
-        self.assertTrue(User.objects.get(email=email).is_active)
+        user = User.objects.get(email=email)
+        self.assertTrue(user.is_active)
+        # And return the user we fetched.
+        return user
 
     def enroll(self, course, verify=False):
         """

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -30,7 +30,7 @@ from courseware.tests.factories import (
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from student.models import CourseEnrollment
-from student.roles import CourseCcxCoachRole
+from student.roles import CourseCcxCoachRole, CourseStaffRole
 from student.tests.factories import (
     AdminFactory,
     AnonymousUserFactory,
@@ -122,6 +122,23 @@ class CoachAccessTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
         # user dont have access as coach on ccx
         self.setup_user()
         self.assertFalse(access.has_ccx_coach_role(self.user, ccx_locator))
+
+    def test_ccx_coach_has_staff_role(self):
+        """
+        Assert that user has staff access on ccx.
+        """
+        ccx_locator = self.make_ccx()
+
+        # coach user has access as staff on ccx
+        self.assertTrue(access.has_access(self.coach, 'staff', ccx_locator))
+
+        # basic user doesn't have staff access on ccx..
+        self.setup_user()
+        self.assertFalse(access.has_access(self.user, 'staff', ccx_locator))
+
+        # until we give her a staff role.
+        CourseStaffRole(ccx_locator).add_users(self.user)
+        self.assertTrue(access.has_access(self.user, 'staff', ccx_locator))
 
     def test_access_student_progress_ccx(self):
         """


### PR DESCRIPTION
Currently, when a CCX Coach, or another user with a Staff role on a CCX course, tries to access Insights, they're unable to see their CCX courses in the list of available courses.  In the extreme case, users who only have Staff roles on CCX courses get a 403 when they visit Insights, because they have no staff permissions on any courses.

This change amends the CCX course permissions check to use the actual CCX course key, instead of the base course locator key, which does not contain the CCX details.

**JIRA tickets**: [OSPR-1623](https://openedx.atlassian.net/browse/OSPR-1623)

**Dependencies**: None

**Sandbox URL**:

* LMS: http://pr14104.sandbox.opencraft.hosting/

**Partner information**: DavidsonX, on edx.org

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: ASAP

**Testing instructions**:

1. Set up an [analytics devstack](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/analytics/install_analytics.html).
1. Enable the [`enable_ccx_courses` waffle switch](https://github.com/edx/edx-analytics-dashboard#feature-gating) on Insights.
1. Checkout the PR for this branch under edx-platform.
1. Run the [LMS and Insights services](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/devstack/start_devstack.html#starting-the-components).
1. Register and activate a new user: `ccx_coach`. This user should not have global staff or global superuser settings.
1. As the `staff` user in LMS (w global staff settings):
    * Enable CCX on a course via the Advanced Settings (the DemoX course should be enabled by default.)
    * Give `ccx_coach` a CCX Coach role on the base course via the LMS Instructor panel.
    * Let the `ccx_coach` create the CCX course as described below.
1. As the staff user in Insights:
    * Logout and in again, if there's a previously active Insights session.  This refreshes the course access cache.
    * Verify that the base Demo course and the CCX courses are shown on the home page list.
    * Verify that the base Demo course and CCX course pages work.
1. As the `ccx_coach` user in LMS:
    * Create a CCX course from the base course, e.g.: `ccx-v1:edX+DemoX+Demo_Course+ccx@1`
    * Enrol the `audit` user as a student on the CCX course, via the CCX Coach panel.
1. As the `ccx_coach` user in Insights:
    * Logout and in again.
    * Verify that the /courses home page shows the CCX course in the list.
    * Verify that the CCX course page displays correctly.
1. As the `audit` user in Insights (w Student role):
    * Logout and in again.
    * Verify that the /courses home page shows a 403 (or at least, that it doesn't show the CCX course in the list).
1. As the `staff` user in LMS (w global staff settings):
    * Visit the CCX course's Instructor > Membership page
    * Give the `audit` a Staff role.
1. As the `audit` user in Insights (w Staff role):
    * Logout and in again.
    * Verify that the /courses home page shows the CCX course in the list.
    * Verify that the CCX course page displays correctly.

**Author notes and concerns**:

1. Updated unit tests are coming.

**Reviewers**
- [x] @bdero 
- [ ] edX reviewer[s] TBD