### PR TITLE
Removing this line seems to make lms-coffee JS tests much less flaky

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -16,6 +16,7 @@
 'video/01_initialize.js',
 ['video/03_video_player.js', 'video/00_i18n.js', 'moment', 'underscore'],
 function(VideoPlayer, i18n, moment, _) {
+    var moment = moment || window.moment;
     /**
      * @function
      *

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -16,7 +16,6 @@
 'video/01_initialize.js',
 ['video/03_video_player.js', 'video/00_i18n.js', 'moment', 'underscore'],
 function(VideoPlayer, i18n, moment, _) {
-    var moment = moment || window.moment;
     /**
      * @function
      *

--- a/lms/static/lms/js/spec/main_requirejs_coffee.js
+++ b/lms/static/lms/js/spec/main_requirejs_coffee.js
@@ -33,6 +33,11 @@
     }
     requirejs.config({
         baseUrl: '/base/',
+        config: {
+            moment: {
+                wrapShim: true
+            }
+        },
         paths: {
             moment: 'xmodule_js/common_static/common/js/vendor/moment-with-locales',
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly',


### PR DESCRIPTION
The lms-coffee suite inside the JS tests will occasionally fail to start with an error like the following:

```
21:42:41  Running tests for lms-coffee javascript 
21:42:41 ========================================
21:42:44 14 12 2016 21:42:44.453:INFO [karma]: Karma v0.13.22 server started at http://localhost:9876/
21:42:44 14 12 2016 21:42:44.462:INFO [launcher]: Starting browser Firefox
21:42:46 14 12 2016 21:42:46.231:INFO [Firefox 42.0.0 (Linux 0.0.0)]: Connected on socket t0QrEuJYQeEyFL6FAAAA with id 35039011
21:42:46 14 12 2016 21:42:46.804:WARN [web-server]: 404: /moment.js
21:42:46 14 12 2016 21:42:46.806:WARN [web-server]: 404: /underscore.js
21:42:46 14 12 2016 21:42:46.808:WARN [web-server]: 404: /edx-ui-toolkit/js/utils/html-utils.js
21:42:46 14 12 2016 21:42:46.810:WARN [web-server]: 404: /draggabilly.js
21:42:46 Firefox 42.0.0 (Linux 0.0.0) ERROR
21:42:46   Error: Script error for "moment", needed by: video/01_initialize.js
21:42:46   http://requirejs.org/docs/errors.html#scripterror
21:42:46   at /home/jenkins/workspace/edx-platform-js-master/edx-platform/lms/static/common/js/vendor/require.js:168
21:42:46 Firefox 42.0.0 (Linux 0.0.0) ERROR
21:42:46   Error: Script error for "moment", needed by: video/01_initialize.js
21:42:46   http://requirejs.org/docs/errors.html#scripterror
21:42:46   at /home/jenkins/workspace/edx-platform-js-master/edx-platform/lms/static/common/js/vendor/require.js:168
```

I was able to reproduce this failure locally. After removing this line, I ran lms-coffee tests repeatedly* for about a half hour and was unable to reproduce it again. So it seems to help.

I'll keep digging, and ask others who might know about why this line exists and if it's completely safe to remove.


`*` you can replicate this by running `while paver test_js_run --suite lms-coffee; do :; done` - you will occasionally have to move your mouse over the Firefox window for it to realize it is connected to Karma