### PR TITLE
update_course_in_cache error handling cleanup.

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/tasks.py
+++ b/openedx/core/djangoapps/content/block_structure/tasks.py
@@ -2,13 +2,21 @@
 Asynchronous tasks related to the Course Blocks sub-application.
 """
 import logging
+from capa.responsetypes import LoncapaProblemError
 from celery.task import task
 from django.conf import settings
+from edxval.api import ValInternalError
+from lxml.etree import XMLSyntaxError
 from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from openedx.core.djangoapps.content.block_structure import api
 
 log = logging.getLogger('edx.celery.task')
+
+# TODO: TNL-5799 is ongoing; narrow these lists down until the general exception is no longer needed
+RETRY_TASKS = (ItemNotFoundError, TypeError, ValInternalError)
+NO_RETRY_TASKS = (XMLSyntaxError, LoncapaProblemError, UnicodeEncodeError)
 
 
 @task(
@@ -22,9 +30,14 @@ def update_course_in_cache(course_id):
     try:
         course_key = CourseKey.from_string(course_id)
         api.update_course_in_cache(course_key)
+    except NO_RETRY_TASKS as exc:
+        log.info("update_course_in_cache encountered unrecoverable error: {}".format(exc))
+        raise
+    except RETRY_TASKS as exc:
+        log.info("update_course_in_cache encounted expected error, retrying.")
+        raise update_course_in_cache.retry(args=[course_id], exc=exc)
     except Exception as exc:   # pylint: disable=broad-except
-        # TODO: TNL-5799, check splunk logs to narrow down the broad except above
-        log.info("update_course_in_cache. Retry #{} for this task, exception: {}".format(
+        log.info("update_course_in_cache encounted unknown error. Retry #{}, Exception: {}".format(
             update_course_in_cache.request.retries,
             repr(exc)
         ))


### PR DESCRIPTION
# [TNL-5799](https://openedx.atlassian.net/browse/TNL-5799)

Focus our retry logic on exceptions that might go away on retry.

FYI @jibsheet @nasthagiri @jcdyer @sanfordstudent @yro 

I've outlined my investigation and logic on the ticket, can 2 of you check that and review this PR to merge? I've got a few more error types to investigate, so wait until we discuss at planning before diving into review