### PR TITLE
Add tests for context-sensitive Help button.

### DIFF
--- a/common/djangoapps/util/tests/test_help_context_processor.py
+++ b/common/djangoapps/util/tests/test_help_context_processor.py
@@ -1,0 +1,69 @@
+"""
+Tests for help_context_processor.py
+"""
+
+import ConfigParser
+from mock import patch
+
+from django.conf import settings
+from django.test import TestCase
+
+from util.help_context_processor import common_doc_url
+
+
+CONFIG_FILE = open(settings.REPO_ROOT / "docs" / "lms_config.ini")
+CONFIG = ConfigParser.ConfigParser()
+CONFIG.readfp(CONFIG_FILE)
+
+
+class HelpContextProcessorTest(TestCase):
+    """
+    Tests for help_context_processor.py
+    """
+
+    def setUp(self):
+        super(HelpContextProcessorTest, self).setUp()
+
+    @staticmethod
+    def _get_doc_url(page_token=None):
+        """ Helper method for getting the doc url. """
+        return common_doc_url(None, CONFIG)['get_online_help_info'](page_token)['doc_url']
+
+    @staticmethod
+    def _get_pdf_url():
+        """ Helper method for getting the pdf url. """
+        return common_doc_url(None, CONFIG)['get_online_help_info']()['pdf_url']
+
+    def test_get_doc_url(self):
+        # Test default values.
+        self.assertEqual(
+            "http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/index.html",
+            HelpContextProcessorTest._get_doc_url()
+        )
+
+        # Provide a known page_token.
+        self.assertEqual(
+            "http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/sfd_dashboard_profile/index.html",
+            HelpContextProcessorTest._get_doc_url('profile')
+        )
+
+        # Use settings.DOC_LINK_BASE_URL to override default base_url.
+        with patch('django.conf.settings.DOC_LINK_BASE_URL', 'settings_base_url'):
+            self.assertEqual(
+                "settings_base_url/en/latest/SFD_instructor_dash_help.html",
+                HelpContextProcessorTest._get_doc_url('instructor')
+            )
+
+    def test_get_pdf_url(self):
+        # Test default values.
+        self.assertEqual(
+            "https://media.readthedocs.org/pdf/open-edx-learner-guide/latest/open-edx-learner-guide.pdf",
+            HelpContextProcessorTest._get_pdf_url()
+        )
+
+        # Use settings.DOC_LINK_BASE_URL to override default base_url.
+        with patch('django.conf.settings.DOC_LINK_BASE_URL', 'settings_base_url'):
+            self.assertEqual(
+                "settings_base_url/latest/open-edx-learner-guide.pdf",
+                HelpContextProcessorTest._get_pdf_url()
+            )

--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -19,6 +19,12 @@ class InstructorDashboardPage(CoursePage):
     def is_browser_on_page(self):
         return self.q(css='div.instructor-dashboard-wrapper-2').present
 
+    def click_help(self):
+        """
+        Clicks the general Help button in the header.
+        """
+        self.q(css='.doc-link').first.click()
+
     def select_membership(self):
         """
         Selects the membership tab and returns the MembershipSection

--- a/common/test/acceptance/tests/lms/test_lms_help.py
+++ b/common/test/acceptance/tests/lms/test_lms_help.py
@@ -3,11 +3,12 @@ Test Help links in LMS
 """
 import json
 
-from flaky import flaky
 
-from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
+from common.test.acceptance.tests.lms.test_lms_instructor_dashboard import BaseInstructorDashboardTest
 from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage
+from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
 from common.test.acceptance.fixtures import LMS_BASE_URL
+from common.test.acceptance.fixtures.course import CourseFixture
 
 from common.test.acceptance.tests.helpers import (
     assert_link,
@@ -98,3 +99,26 @@ class TestCohortHelp(ContainerBase):
         data = json.dumps({'is_cohorted': True})
         response = course_fixture.session.patch(url, data=data, headers=course_fixture.headers)
         self.assertTrue(response.ok, "Failed to enable cohorts")
+
+
+class InstructorDashboardHelp(BaseInstructorDashboardTest):
+    """
+    Tests opening help from the general Help button in the instructor dashboard.
+    """
+
+    def setUp(self):
+        super(InstructorDashboardHelp, self).setUp()
+        self.course_fixture = CourseFixture(**self.course_info).install()
+        self.log_in_as_instructor()
+        self.instructor_dashboard_page = self.visit_instructor_dashboard()
+
+    def test_instructor_dashboard_help(self):
+        """
+        Scenario: Help button opens staff help
+        Given that I am viewing the Instructor Dashboard
+        When I click "Help"
+        Then I see help about the instructor dashboard in a new tab
+        """
+        href = 'http://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_instructor_dash_help.html'
+        self.instructor_dashboard_page.click_help()
+        assert_opened_help_link_is_correct(self, href)

--- a/docs/lms_config.ini
+++ b/docs/lms_config.ini
@@ -7,7 +7,7 @@ version = latest
 
 # below are the pdf settings for the pdf file
 [pdf_settings]
-pdf_base = https://media.readthedocs.io/pdf/open-edx-learner-guide
+pdf_base = https://media.readthedocs.org/pdf/open-edx-learner-guide
 pdf_file = open-edx-learner-guide.pdf
 
 

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -210,6 +210,7 @@ ECOMMERCE_API_URL = 'http://localhost:8043/api/v2/'
 ECOMMERCE_API_SIGNING_KEY = 'ecommerce-key'
 
 LMS_ROOT_URL = "http://localhost:8000"
+DOC_LINK_BASE_URL = 'http://edx.readthedocs.io/projects/edx-guide-for-students'
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.


### PR DESCRIPTION
### Description

The context-sensitive help feature previously had no tests. As part of #13657 (now closed), I wrote some simple unit tests and a single smoke bok choy test. I have modified these tests to work with what is currently in master, and I am submitting them to provide some test coverage for this feature.

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @nasthagiri (I don't think this needs a second reviewer)
- [x] Doc Review: @catong (mostly just an FYI)
