### PR TITLE
Allow for SiteConfiguration override of SESSION_COOKIE_DOMAIN setting in Studio

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -389,6 +389,9 @@ MIDDLEWARE_CLASSES = (
 
     # use Django built in clickjacking protection
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    # This must be last so that it runs first in the process_response chain
+    'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 )
 
 # Clickjacking protection can be enabled by setting this to 'DENY'


### PR DESCRIPTION
This PR adds the SessionCookieDomainOverrideMiddleware to Studio which allows users to log into a Studio instance with different site domains.