### PR TITLE
TNL-5770 (non-)flaky test

### DIFF
--- a/common/test/acceptance/tests/lms/test_conditional.py
+++ b/common/test/acceptance/tests/lms/test_conditional.py
@@ -2,8 +2,6 @@
 Bok choy acceptance tests for conditionals in the LMS
 """
 
-from flaky import flaky
-
 from capa.tests.response_xml_factory import StringResponseXMLFactory
 from common.test.acceptance.tests.helpers import UniqueCourseTest
 from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
@@ -115,7 +113,6 @@ class ConditionalTest(UniqueCourseTest):
         conditional_page = ConditionalPage(self.browser)
         self.assertTrue(conditional_page.is_content_visible())
 
-    @flaky  # TNL-5770
     def test_conditional_handles_polls(self):
         self.install_course_fixture(block_type='poll')
         self.courseware_page.visit()


### PR DESCRIPTION
This test has passed 100+ times in a row for me locally and just passed 75 times on jenkins with the `@flaky(75, 75)` decorator ([see build here](https://build.testeng.edx.org/job/edx-platform-test-subset/687233/console))- I don't think it's really flaky. This PR removes the decorator.