### PR TITLE
WIP: Experiments in speeding startup

### DIFF
--- a/common/djangoapps/util/password_policy_validators.py
+++ b/common/djangoapps/util/password_policy_validators.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
-import nltk
+#import nltk
 
 
 def validate_password_strength(value):

--- a/common/lib/chem/chem/chemcalc.py
+++ b/common/lib/chem/chem/chemcalc.py
@@ -2,8 +2,7 @@ from __future__ import division
 from fractions import Fraction
 
 from pyparsing import (Literal, StringEnd, OneOrMore, ParseException)
-import nltk
-from nltk.tree import Tree
+#from nltk.tree import Tree
 
 ARROWS = ('<->', '->')
 
@@ -239,6 +238,7 @@ def _get_final_tree(s):
 
     Raises pyparsing.ParseException if s is invalid.
     '''
+    import nltk
     global parser
     if parser is None:
         parser = nltk.ChartParser(nltk.parse_cfg(grammar))

--- a/common/lib/chem/chem/chemcalc.py
+++ b/common/lib/chem/chem/chemcalc.py
@@ -51,8 +51,8 @@ grammar = """
 
   suffixed -> unsuffixed | unsuffixed suffix
 """
-parser = nltk.ChartParser(nltk.parse_cfg(grammar))
-
+# This will be lazily loaded...
+parser = None
 
 def _clean_parse_tree(tree):
     ''' The parse tree contains a lot of redundant
@@ -239,6 +239,10 @@ def _get_final_tree(s):
 
     Raises pyparsing.ParseException if s is invalid.
     '''
+    global parser
+    if parser is None:
+        parser = nltk.ChartParser(nltk.parse_cfg(grammar))
+
     tokenized = tokenizer.parseString(s)
     parsed = parser.parse(tokenized)
     merged = _merge_children(parsed, {'S', 'group'})

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -437,6 +437,11 @@ def account_settings_context(request):
         # it will be broken if exception raised
         user_orders = []
 
+    time_zone_choices = sorted(
+        [(tz, get_display_time_zone(tz)) for tz in pytz.common_timezones],
+        key=lambda tz_tuple: tz_tuple[1]
+    )
+
     context = {
         'auth': {},
         'duplicate_provider': None,
@@ -457,7 +462,7 @@ def account_settings_context(request):
             }, 'preferred_language': {
                 'options': all_languages(),
             }, 'time_zone': {
-                'options': TIME_ZONE_CHOICES,
+                'options': time_zone_choices,
             }
         },
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -38,7 +38,7 @@ from warnings import simplefilter
 from django.utils.translation import ugettext_lazy as _
 
 from .discussionsettings import *
-import dealer.git
+#import dealer.git
 from xmodule.modulestore.modulestore_settings import update_module_store_settings
 from xmodule.modulestore.edit_info import EditInfoMixin
 from xmodule.mixin import LicenseMixin
@@ -822,12 +822,14 @@ MANAGERS = ADMINS
 EDX_PLATFORM_REVISION = os.environ.get('EDX_PLATFORM_REVISION')
 
 if not EDX_PLATFORM_REVISION:
-    try:
-        # Get git revision of the current file
-        EDX_PLATFORM_REVISION = dealer.git.Backend(path=REPO_ROOT).revision
-    except TypeError:
-        # Not a git repository
-        EDX_PLATFORM_REVISION = 'unknown'
+    EDX_PLATFORM_REVISION = 'unknown'
+
+#    try:
+#        # Get git revision of the current file
+#        EDX_PLATFORM_REVISION = dealer.git.Backend(path=REPO_ROOT).revision
+#    except TypeError:
+#        # Not a git repository
+#        EDX_PLATFORM_REVISION = 'unknown'
 
 # Static content
 STATIC_URL = '/static/'

--- a/manage.py
+++ b/manage.py
@@ -12,8 +12,8 @@ Any arguments not understood by this manage.py will be passed to django-admin.py
 """
 
 # Patch the xml libs before anything else.
-from safe_lxml import defuse_xml_libs
-defuse_xml_libs()
+#from safe_lxml import defuse_xml_libs
+#defuse_xml_libs()
 
 import os
 import sys

--- a/openedx/core/djangoapps/monitoring/signals.py
+++ b/openedx/core/djangoapps/monitoring/signals.py
@@ -48,88 +48,89 @@ def _model_tags(kwargs, key):
     return tags
 
 
-@receiver(post_init, dispatch_uid='edxapp.monitoring.post_init_metrics')
-def post_init_metrics(sender, **kwargs):
-    """
-    Record the number of times that django models are instantiated.
-
-    Args:
-        sender (Model): The model class sending the signals.
-        using (str): The name of the database being used for this initialization (optional).
-        instance (Model instance): The instance being initialized (optional).
-    """
-    tags = _database_tags('initialized', sender, kwargs)
-
-    dog_stats_api.increment('edxapp.db.model', tags=tags)
-
-
-@receiver(post_save, dispatch_uid='edxapp.monitoring.post_save_metrics')
-def post_save_metrics(sender, **kwargs):
-    """
-    Record the number of times that django models are saved (created or updated).
-
-    Args:
-        sender (Model): The model class sending the signals.
-        using (str): The name of the database being used for this update (optional).
-        instance (Model instance): The instance being updated (optional).
-    """
-    action = 'created' if kwargs.pop('created', False) else 'updated'
-
-    tags = _database_tags(action, sender, kwargs)
-    dog_stats_api.increment('edxapp.db.model', tags=tags)
-
-
-@receiver(post_delete, dispatch_uid='edxapp.monitoring.post_delete_metrics')
-def post_delete_metrics(sender, **kwargs):
-    """
-    Record the number of times that django models are deleted.
-
-    Args:
-        sender (Model): The model class sending the signals.
-        using (str): The name of the database being used for this deletion (optional).
-        instance (Model instance): The instance being deleted (optional).
-    """
-    tags = _database_tags('deleted', sender, kwargs)
-
-    dog_stats_api.increment('edxapp.db.model', tags=tags)
-
-
-@receiver(m2m_changed, dispatch_uid='edxapp.monitoring.m2m_changed_metrics')
-def m2m_changed_metrics(sender, **kwargs):
-    """
-    Record the number of times that Many2Many fields are updated. This is separated
-    from post_save and post_delete, because it's signaled by the database model in
-    the middle of the Many2Many relationship, rather than either of the models
-    that are the relationship participants.
-
-    Args:
-        sender (Model): The model class in the middle of the Many2Many relationship.
-        action (str): The action being taken on this Many2Many relationship.
-        using (str): The name of the database being used for this deletion (optional).
-        instance (Model instance): The instance whose many-to-many relation is being modified.
-        model (Model class): The model of the class being added/removed/cleared from the relation.
-    """
-    if 'action' not in kwargs:
-        return
-
-    action = {
-        'post_add': 'm2m.added',
-        'post_remove': 'm2m.removed',
-        'post_clear': 'm2m.cleared',
-    }.get(kwargs['action'])
-
-    if not action:
-        return
-
-    tags = _database_tags(action, sender, kwargs)
-
-    if 'model' in kwargs:
-        tags.append('target_class:{}'.format(kwargs['model'].__name__))
-
-    pk_set = kwargs.get('pk_set', []) or []
-
-    dog_stats_api.increment(
-        'edxapp.db.model',
-        value=len(pk_set),
-        tags=tags
-    )
+# @receiver(post_init, dispatch_uid='edxapp.monitoring.post_init_metrics')
+# def post_init_metrics(sender, **kwargs):
+#     """
+#     Record the number of times that django models are instantiated.
+#
+#     Args:
+#         sender (Model): The model class sending the signals.
+#         using (str): The name of the database being used for this initialization (optional).
+#         instance (Model instance): The instance being initialized (optional).
+#     """
+#     tags = _database_tags('initialized', sender, kwargs)
+#
+#     dog_stats_api.increment('edxapp.db.model', tags=tags)
+#
+#
+# @receiver(post_save, dispatch_uid='edxapp.monitoring.post_save_metrics')
+# def post_save_metrics(sender, **kwargs):
+#     """
+#     Record the number of times that django models are saved (created or updated).
+#
+#     Args:
+#         sender (Model): The model class sending the signals.
+#         using (str): The name of the database being used for this update (optional).
+#         instance (Model instance): The instance being updated (optional).
+#     """
+#     action = 'created' if kwargs.pop('created', False) else 'updated'
+#
+#     tags = _database_tags(action, sender, kwargs)
+#     dog_stats_api.increment('edxapp.db.model', tags=tags)
+#
+#
+# @receiver(post_delete, dispatch_uid='edxapp.monitoring.post_delete_metrics')
+# def post_delete_metrics(sender, **kwargs):
+#     """
+#     Record the number of times that django models are deleted.
+#
+#     Args:
+#         sender (Model): The model class sending the signals.
+#         using (str): The name of the database being used for this deletion (optional).
+#         instance (Model instance): The instance being deleted (optional).
+#     """
+#     tags = _database_tags('deleted', sender, kwargs)
+#
+#     dog_stats_api.increment('edxapp.db.model', tags=tags)
+#
+#
+# @receiver(m2m_changed, dispatch_uid='edxapp.monitoring.m2m_changed_metrics')
+# def m2m_changed_metrics(sender, **kwargs):
+#     """
+#     Record the number of times that Many2Many fields are updated. This is separated
+#     from post_save and post_delete, because it's signaled by the database model in
+#     the middle of the Many2Many relationship, rather than either of the models
+#     that are the relationship participants.
+#
+#     Args:
+#         sender (Model): The model class in the middle of the Many2Many relationship.
+#         action (str): The action being taken on this Many2Many relationship.
+#         using (str): The name of the database being used for this deletion (optional).
+#         instance (Model instance): The instance whose many-to-many relation is being modified.
+#         model (Model class): The model of the class being added/removed/cleared from the relation.
+#     """
+#     if 'action' not in kwargs:
+#         return
+#
+#     action = {
+#         'post_add': 'm2m.added',
+#         'post_remove': 'm2m.removed',
+#         'post_clear': 'm2m.cleared',
+#     }.get(kwargs['action'])
+#
+#     if not action:
+#         return
+#
+#     tags = _database_tags(action, sender, kwargs)
+#
+#     if 'model' in kwargs:
+#         tags.append('target_class:{}'.format(kwargs['model'].__name__))
+#
+#     pk_set = kwargs.get('pk_set', []) or []
+#
+#     dog_stats_api.increment(
+#         'edxapp.db.model',
+#         value=len(pk_set),
+#         tags=tags
+#     )
+#

--- a/openedx/core/lib/time_zone_utils.py
+++ b/openedx/core/lib/time_zone_utils.py
@@ -44,9 +44,3 @@ def get_display_time_zone(time_zone_name):
     tz_offset = get_time_zone_offset(time_zone)
 
     return "{name} ({abbr}, UTC{offset})".format(name=time_zone, abbr=tz_abbr, offset=tz_offset).replace("_", " ")
-
-
-TIME_ZONE_CHOICES = sorted(
-    [(tz, get_display_time_zone(tz)) for tz in common_timezones],
-    key=lambda tz_tuple: tz_tuple[1]
-)


### PR DESCRIPTION
I was poking at reducing test runtimes in various ways, and @nasthagiri suggested that I look at test startup times specifically, since those are more painful for local development where only small sets of tests are typically run at any given time. Please note that this PR is experimental and is _not_ something I intend to merge directly. I plan to have this as a place for discussion, but actual work to bring these optimizations to master will happen in smaller, separate PRs.

A few findings:

## Disk vs. CPU

* We're heavily IO bound in the sense that just reading the files to do the thousands of imports will dominate initial runs. Once things are cached, we're mostly CPU bound.
* I tried to use cachefilesd to mitigate the NFS read latency issues on devstack. This actually made things significantly worse (about 2X usually). I don't really understand why, and I dropped the approach.
* I later made a copy of edx-platform on devstack that was not in a network share. The IO latency spikes still occurred, but they were generally less (10-15s as opposed to 25s+).
* I installed edx-platform directly into a virtualenv on my OS X laptop (so no devstack at all). It still gives the occasional IO latency spike, but is far, far better than devstack in this regard.

## Optimizations done on this branch vs. master

On master, test startup takes about 7.5s in real clock time on my laptop. On this branch, it's about 5.5s. Most of this comes from CPU savings, but we also cut some IO. It does reduce the worst case scenarios somewhat, but I don't have clear measurements on that.

The optimizations played with here are:

* Disabling Datadog metrics gathering that was happening on model creation.
* Delay pyliner initialization (we use this for inline CSS in sending certain emails).
* Lazy-load or eliminate capa/chemcalc's nltk parser. This isn't really working right now, I just have it commented out to see what the effect on startup time is.
* Move time zone choice calculation out of the startup (this is surprisingly expensive)
* Remove defusedxml usage (should just happen during tests)
* Remove dealer.git usage (should just be during test?) -- this doesn't do much when file access has been cached, but it can make a big difference when starting cold, because it has to read the git index files as well.

## Optimizations we Should Make

* 1.3s is spent on django.contrib.auth creating Permissions objects for all the many models in our system. This is particularly irritating because we don't really use this functionality for the most part in the code, just for Django Admin delegation. I just don't know of a good way to turn it off. Disconnecting the signal handler for testing might work, but that seems iffy.
* 400ms is lost to URLValidator definition because it has a nasty regex and apparently adding re.IGNORECASE as an option makes it take 10X longer to compile it. This is in Django internals, and has been made lazy in Django 1.9+. We'll likely just wait for the upgrade here.
* 300ms is lost to pyuca sorting for django-countries, for user_api preferences -- we should see if we can just kill it altogether.
* 120ms is lost to loading the New Relic agent, which shouldn't be needed for the vast majority of tests. Some kind of lazy loading for that module would be best. It's used in seq_module and module_render to instrument our courseware with custom NR metrics.

That would take us down to the 3.5s range in real time for startup. Not great, but a lot better.

FYI: @cpennington