### PR TITLE
add blankTitle option

### DIFF
--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -421,7 +421,7 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
         self._test_dropdown_field(
             u'time_zone',
             u'Time Zone',
-            u'',
+            u'Default (Local Time Zone)',
             [
                 u'Europe/Kiev ({abbr}, UTC{offset})'.format(abbr=kiev_abbr, offset=kiev_offset),
                 u'US/Pacific ({abbr}, UTC{offset})'.format(abbr=pacific_abbr, offset=pacific_offset),

--- a/lms/static/js/spec/student_account/account_settings_fields_spec.js
+++ b/lms/static/js/spec/student_account/account_settings_fields_spec.js
@@ -54,7 +54,8 @@ define(['backbone',
                     valueAttribute: 'time_zone',
                     groupOptions: [{
                         groupTitle: gettext('All Time Zones'),
-                        selectOptions: FieldViewsSpecHelpers.SELECT_OPTIONS
+                        selectOptions: FieldViewsSpecHelpers.SELECT_OPTIONS,
+                        blankTitle: 'Default (Local Time Zone)'
                     }],
                     persistChanges: true,
                     required: true
@@ -97,7 +98,7 @@ define(['backbone',
 
                 // expect time zone dropdown to have two subheaders (country/all time zone sub-headers) with new values
                 expect(timeZoneView.$(groupsSelector).length).toBe(2);
-                expect(timeZoneView.$(groupOptionsSelector).length).toBe(5);
+                expect(timeZoneView.$(groupOptionsSelector).length).toBe(6);
                 expect(timeZoneView.$(groupOptionsSelector)[0].value).toBe('America/Guyana');
 
                 // select time zone option from option

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -118,7 +118,8 @@
                                 helpMessage: gettext('Select the time zone for displaying course dates. If you do not specify a time zone, course dates, including assignment deadlines, will be displayed in your browser\'s local time zone.'), // eslint-disable-line max-len
                                 groupOptions: [{
                                     groupTitle: gettext('All Time Zones'),
-                                    selectOptions: fieldsData.time_zone.options
+                                    selectOptions: fieldsData.time_zone.options,
+                                    blankTitle: gettext('Default (Local Time Zone)')
                                 }],
                                 persistChanges: true
                             })

--- a/lms/templates/fields/field_dropdown_account.underscore
+++ b/lms/templates/fields/field_dropdown_account.underscore
@@ -20,16 +20,20 @@
         <span class="u-field-value-readonly"></span>
     <% } else { %>
         <select name="select" id="u-field-select-<%- id %>" aria-describedby="u-field-help-message-<%- id %>">
-            <% if (showBlankOption) { %>
-                <option value=""></option>
-            <% } %>
             <% _.each(groupOptions, function(groupOption) { %>
-                <% if (groupOption.groupTitle != null) { %>
-                    <optgroup label="<%- groupOption.groupTitle %>">
+                <% if (showBlankOption) { %>
+                    <% if (groupOption.blankTitle) { %>
+                        <option value=""><%- groupOption.blankTitle %></option>
+                    <% } else { %>
+                        <option value=""></option>
+                    <% } %>
                 <% } %>
-                <% _.each(groupOption.selectOptions, function(selectOption) { %>
-                    <option value="<%- selectOption[0] %>"><%- selectOption[1] %></option>
-                <% }); %>
+                    <% if (groupOption.groupTitle != null) { %>
+                        <optgroup label="<%- groupOption.groupTitle %>">
+                    <% } %>
+                    <% _.each(groupOption.selectOptions, function(selectOption) { %>
+                        <option value="<%- selectOption[0] %>"><%- selectOption[1] %></option>
+                    <% }); %>
             <% }); %>
         </select>
         <span class="icon-caret-down" aria-hidden="true"></span>


### PR DESCRIPTION
## [TNL-5839](https://openedx.atlassian.net/browse/TNL-5839)

### Description

Add default time settings text to time zone dropdown in student account.

NOTE:
The showBlankOption for the account_settings_factory appears to be set in js/views/fields.js, and needs an override in the underscore template. A variable 'blankTitle' is now passed as part of the group options, and corresponds to 'null'.

### Testing
- [ ] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @jcdyer 
- [x] Code review: @sanfordstudent 

FYI: @catong 

### Post-review
- [x] Rebase and squash commits
