### PR TITLE
Revert "tnl-4141 only whitespaces not allowed in answer and fixed the…

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -190,10 +190,7 @@ class LoncapaResponse(object):
             raise LoncapaProblemError(msg)
 
         for prop in self.required_attributes:
-            prop_value = xml.get(prop)
-            if prop_value:  # Stripping off the empty strings
-                prop_value = prop_value.strip()
-            if not prop_value:
+            if not xml.get(prop):
                 msg = "Error in problem specification: %s missing required attribute %s" % (
                     unicode(self), prop)
                 msg += "\nSee XML source line %s" % getattr(

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -974,12 +974,12 @@ class StringResponseTest(ResponseTest):  # pylint: disable=missing-docstring
         hint = correct_map.get_hint('1_2_1')
         self.assertEqual(hint, self._get_random_number_result(problem.seed))
 
-    def test_empty_answer_problem_creation_not_allowed(self):
+    def test_empty_answer_graded_as_incorrect(self):
         """
-        Tests that empty answer string is not allowed to create a problem
+        Tests that problem should be graded incorrect if blank space is chosen as answer
         """
-        with self.assertRaises(LoncapaProblemError):
-            self.build_problem(answer=" ", case_sensitive=False, regexp=True)
+        problem = self.build_problem(answer=" ", case_sensitive=False, regexp=True)
+        self.assert_grade(problem, u" ", "incorrect")
 
 
 class CodeResponseTest(ResponseTest):  # pylint: disable=missing-docstring


### PR DESCRIPTION
… pep8 violation."

This reverts commit 3ad2f0923342a640d412ebfc03d81461427979cd.

## [TNL-6059](https://openedx.atlassian.net/browse/TNL-6059)

### Description

Reverts https://github.com/edx/edx-platform/pull/12898 and so problems with blank answer attributes no longer throw errors.

### How to Test?

**Stage** 
1. create a text response problem
2. edit in xml
3. set the `answer` parameter to a blank (non-empty) string `" "`
It should look something like:

```xml
<problem>
<stringresponse answer=" " type="ci">
  <textline size="20"/>
</stringresponse>
</problem>
```

**Screenshots**
Before:
![unspecified-34](https://cloud.githubusercontent.com/assets/2748698/21363462/b559056e-c6ba-11e6-89d9-6390bf18d061.png)

After:
![unspecified-32](https://cloud.githubusercontent.com/assets/2748698/21363404/797e3064-c6ba-11e6-9908-cfff616bd801.png)

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @nasthagiri 
- [ ] @cahrens 

### Post-review
- [ ] Rebase and squash commits