### PR TITLE
Disable course marketing URL in mobile API

### DIFF
--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -278,8 +278,9 @@ class UserCourseEnrollmentsList(APIView):
                 is_active=True
             ).order_by('created').reverse()
         )
-        course_ids = [enrollment.course_id for enrollment in enrollments]
-        catalog_course_runs_against_course_keys = get_course_runs(course_ids, request.user)
+
+        # TODO MA-3052 Getting the course runs from the catalog service doesn't scale.
+        catalog_course_runs_against_course_keys = {}
 
         org = request.query_params.get('org', None)
 


### PR DESCRIPTION
I have created a ticket ([MA-3052](https://openedx.atlassian.net/browse/MA-3052)) to address the scalability issue introduced by https://github.com/edx/edx-platform/pull/13235.

This PR simply disables the code that calls the Catalog service.

FYI @wajeeha-khalid @cpennington 