### PR TITLE
MA-3051: Add and use course-run cache field in CatalogIntegration

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -76,7 +76,7 @@ from student.auth import has_course_author_access, has_studio_write_access, has_
 from student.roles import (
     CourseInstructorRole, CourseStaffRole, CourseCreatorRole, GlobalStaff, UserBasedRole
 )
-from util.course import get_lms_link_for_about_page
+from util.course import get_link_for_about_page
 from util.date_utils import get_default_time_display
 from util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
 from util.milestones_helpers import (
@@ -1000,7 +1000,7 @@ def settings_handler(request, course_key_string):
             settings_context = {
                 'context_course': course_module,
                 'course_locator': course_key,
-                'lms_link_for_about_page': get_lms_link_for_about_page(course_key),
+                'lms_link_for_about_page': get_link_for_about_page(course_key, request.user),
                 'course_image_url': course_image_url(course_module, 'course_image'),
                 'banner_image_url': course_image_url(course_module, 'banner_image'),
                 'video_thumbnail_image_url': course_image_url(course_module, 'video_thumbnail_image'),

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -2,27 +2,30 @@
 Utility methods related to course
 """
 import logging
-from django.conf import settings
 
+from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
+
+from openedx.core.djangoapps.catalog.utils import get_run_marketing_url
 
 log = logging.getLogger(__name__)
 
 
-def get_lms_link_for_about_page(course_key):
+def get_link_for_about_page(course_key, user, catalog_course_run=None):
     """
     Returns the url to the course about page.
     """
     assert isinstance(course_key, CourseKey)
 
     if settings.FEATURES.get('ENABLE_MKTG_SITE'):
-        # Root will be "https://www.edx.org". The complete URL will still not be exactly correct,
-        # but redirects exist from www.edx.org to get to the Drupal course about page URL.
-        about_base = settings.MKTG_URLS['ROOT']
-    else:
-        about_base = settings.LMS_ROOT_URL
+        if catalog_course_run:
+            marketing_url = catalog_course_run.get('marketing_url')
+        else:
+            marketing_url = get_run_marketing_url(course_key, user)
+        if marketing_url:
+            return marketing_url
 
     return u"{about_base_url}/courses/{course_key}/about".format(
-        about_base_url=about_base,
-        course_key=course_key.to_deprecated_string()
+        about_base_url=settings.LMS_ROOT_URL,
+        course_key=unicode(course_key)
     )

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -11,20 +11,39 @@ from openedx.core.djangoapps.catalog.utils import get_run_marketing_url
 log = logging.getLogger(__name__)
 
 
-def get_link_for_about_page(course_key, user, catalog_course_run=None):
+def get_link_for_about_page(course_key, user):
     """
     Returns the url to the course about page.
     """
     assert isinstance(course_key, CourseKey)
 
     if settings.FEATURES.get('ENABLE_MKTG_SITE'):
-        if catalog_course_run:
-            marketing_url = catalog_course_run.get('marketing_url')
-        else:
-            marketing_url = get_run_marketing_url(course_key, user)
+        marketing_url = get_run_marketing_url(course_key, user)
         if marketing_url:
             return marketing_url
 
+    return get_lms_course_about_page_url(course_key)
+
+
+def get_link_for_about_page_from_cache(course_key, catalog_course_run=None):
+    """
+    Returns the url to the course about page from already cached dict if marketing
+    site is enabled else returns lms course about url.
+    """
+    assert isinstance(course_key, CourseKey)
+
+    if settings.FEATURES.get('ENABLE_MKTG_SITE') and catalog_course_run:
+        marketing_url = catalog_course_run.get('marketing_url')
+        if marketing_url:
+            return marketing_url
+
+    return get_lms_course_about_page_url(course_key)
+
+
+def get_lms_course_about_page_url(course_key):
+    """
+    Returns lms about page url for course.
+    """
     return u"{about_base_url}/courses/{course_key}/about".format(
         about_base_url=settings.LMS_ROOT_URL,
         course_key=unicode(course_key)

--- a/common/djangoapps/util/tests/test_course.py
+++ b/common/djangoapps/util/tests/test_course.py
@@ -11,7 +11,7 @@ from openedx.core.djangoapps.catalog.utils import CatalogCacheUtility
 from openedx.core.djangoapps.catalog.tests.mixins import CatalogIntegrationMixin
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from student.tests.factories import UserFactory
-from util.course import get_link_for_about_page
+from util.course import get_link_for_about_page, get_link_for_about_page_from_cache
 
 
 @httpretty.activate
@@ -45,6 +45,9 @@ class CourseAboutLinkTestCase(CatalogIntegrationMixin, CacheIsolationTestCase):
             self.assertEquals(
                 get_link_for_about_page(self.course_key, self.user), self.lms_course_about_url
             )
+            self.assertEquals(
+                get_link_for_about_page_from_cache(self.course_key, self.course_run), self.lms_course_about_url
+            )
         with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
             self.register_catalog_course_run_response(
                 [self.course_key_string], [{"key": self.course_key_string, "marketing_url": None}]
@@ -68,6 +71,6 @@ class CourseAboutLinkTestCase(CatalogIntegrationMixin, CacheIsolationTestCase):
     @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True})
     def test_about_page_marketing_url_cached(self):
         self.assertEquals(
-            get_link_for_about_page(self.course_key, self.user, self.course_run),
+            get_link_for_about_page_from_cache(self.course_key, self.course_run),
             self.course_run["marketing_url"]
         )

--- a/common/djangoapps/util/tests/test_course.py
+++ b/common/djangoapps/util/tests/test_course.py
@@ -1,36 +1,73 @@
 """
 Tests for course utils.
 """
-
-from django.test import TestCase, override_settings
+from django.core.cache import cache
+import httpretty
 import mock
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from util.course import get_lms_link_for_about_page
+from opaque_keys.edx.keys import CourseKey
+
+from openedx.core.djangoapps.catalog.tests import factories
+from openedx.core.djangoapps.catalog.utils import CatalogCacheUtility
+from openedx.core.djangoapps.catalog.tests.mixins import CatalogIntegrationMixin
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
+from student.tests.factories import UserFactory
+from util.course import get_link_for_about_page
 
 
-class LmsLinksTestCase(TestCase):
-    """ Tests for LMS links. """
+@httpretty.activate
+class CourseAboutLinkTestCase(CatalogIntegrationMixin, CacheIsolationTestCase):
+    """
+    Tests for Course About link.
+    """
 
-    def test_about_page(self):
-        """ Get URL for about page, no marketing site """
+    ENABLED_CACHES = ['default']
+
+    def setUp(self):
+        super(CourseAboutLinkTestCase, self).setUp()
+        self.user = UserFactory.create(password="password")
+
+        self.course_key_string = "foo/bar/baz"
+        self.course_key = CourseKey.from_string("foo/bar/baz")
+        self.course_run = factories.CourseRun(key=self.course_key_string)
+        self.lms_course_about_url = "http://localhost:8000/courses/foo/bar/baz/about"
+
+        self.catalog_integration = self.create_catalog_integration(
+            internal_api_url="http://catalog.example.com:443/api/v1",
+            cache_ttl=1
+        )
+        self.course_cache_key = "{}{}".format(CatalogCacheUtility.CACHE_KEY_PREFIX, self.course_key_string)
+
+    def test_about_page_lms(self):
+        """
+        Get URL for about page, no marketing site.
+        """
         with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
-            self.assertEquals(self.get_about_page_link(), "http://localhost:8000/courses/mitX/101/test/about")
+            self.assertEquals(
+                get_link_for_about_page(self.course_key, self.user), self.lms_course_about_url
+            )
+        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
+            self.register_catalog_course_run_response(
+                [self.course_key_string], [{"key": self.course_key_string, "marketing_url": None}]
+            )
+            self.assertEquals(get_link_for_about_page(self.course_key, self.user), self.lms_course_about_url)
 
-    @override_settings(MKTG_URLS={'ROOT': 'https://dummy-root'})
+    @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True})
     def test_about_page_marketing_site(self):
-        """ Get URL for about page, marketing root present. """
-        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
-            self.assertEquals(self.get_about_page_link(), "https://dummy-root/courses/mitX/101/test/about")
-        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
-            self.assertEquals(self.get_about_page_link(), "http://localhost:8000/courses/mitX/101/test/about")
+        """
+        Get URL for about page, marketing site enabled.
+        """
+        self.register_catalog_course_run_response([self.course_key_string], [self.course_run])
+        self.assertEquals(get_link_for_about_page(self.course_key, self.user), self.course_run["marketing_url"])
+        cached_data = cache.get_many([self.course_cache_key])
+        self.assertIn(self.course_cache_key, cached_data.keys())
 
-    @override_settings(MKTG_URLS={'ROOT': 'https://www.dummyhttps://x'})
-    def test_about_page_marketing_site_https__edge(self):
-        """ Get URL for about page """
-        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
-            self.assertEquals(self.get_about_page_link(), "https://www.dummyhttps://x/courses/mitX/101/test/about")
+        with mock.patch('openedx.core.djangoapps.catalog.utils.get_edx_api_data') as mock_method:
+            self.assertEquals(get_link_for_about_page(self.course_key, self.user), self.course_run["marketing_url"])
+            self.assertEqual(0, mock_method.call_count)
 
-    def get_about_page_link(self):
-        """ create mock course and return the about page link."""
-        course_key = SlashSeparatedCourseKey('mitX', '101', 'test')
-        return get_lms_link_for_about_page(course_key)
+    @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True})
+    def test_about_page_marketing_url_cached(self):
+        self.assertEquals(
+            get_link_for_about_page(self.course_key, self.user, self.course_run),
+            self.course_run["marketing_url"]
+        )

--- a/common/djangoapps/util/tests/test_course.py
+++ b/common/djangoapps/util/tests/test_course.py
@@ -33,7 +33,7 @@ class CourseAboutLinkTestCase(CatalogIntegrationMixin, CacheIsolationTestCase):
 
         self.catalog_integration = self.create_catalog_integration(
             internal_api_url="http://catalog.example.com:443/api/v1",
-            cache_ttl=1
+            course_run_cache_ttl=60
         )
         self.course_cache_key = "{}{}".format(CatalogCacheUtility.CACHE_KEY_PREFIX, self.course_key_string)
 

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -1,14 +1,12 @@
 """
 Serializer for user API
 """
-from opaque_keys.edx.keys import CourseKey
 from rest_framework import serializers
 from rest_framework.reverse import reverse
-
 from courseware.access import has_access
-from student.models import CourseEnrollment, User
 from certificates.api import certificate_downloadable_status
-from util.course import get_lms_link_for_about_page
+from student.models import CourseEnrollment, User
+from util.course import get_link_for_about_page
 
 
 class CourseOverviewField(serializers.RelatedField):
@@ -52,7 +50,9 @@ class CourseOverviewField(serializers.RelatedField):
                 }
             },
             'course_image': course_overview.course_image_url,
-            'course_about': get_lms_link_for_about_page(CourseKey.from_string(course_id)),
+            'course_about': get_link_for_about_page(
+                course_overview.id, request.user, self.context.get('catalog_course_run')
+            ),
             'course_updates': reverse(
                 'course-updates-list',
                 kwargs={'course_id': course_id},
@@ -85,7 +85,9 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
     certificate = serializers.SerializerMethodField()
 
     def get_certificate(self, model):
-        """Returns the information about the user's certificate in the course."""
+        """
+        Returns the information about the user's certificate in the course.
+        """
         certificate_info = certificate_downloadable_status(model.user, model.course_id)
         if certificate_info['is_downloadable']:
             return {

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -6,7 +6,7 @@ from rest_framework.reverse import reverse
 from courseware.access import has_access
 from certificates.api import certificate_downloadable_status
 from student.models import CourseEnrollment, User
-from util.course import get_link_for_about_page
+from util.course import get_link_for_about_page_from_cache
 
 
 class CourseOverviewField(serializers.RelatedField):
@@ -50,8 +50,8 @@ class CourseOverviewField(serializers.RelatedField):
                 }
             },
             'course_image': course_overview.course_image_url,
-            'course_about': get_link_for_about_page(
-                course_overview.id, request.user, self.context.get('catalog_course_run')
+            'course_about': get_link_for_about_page_from_cache(
+                course_overview.id, self.context.get('catalog_course_run')
             ),
             'course_updates': reverse(
                 'course-updates-list',

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -5,7 +5,9 @@ Tests for users API
 import datetime
 
 import ddt
+import httpretty
 from mock import patch
+import mock
 from nose.plugins.attrib import attr
 import pytz
 from django.conf import settings
@@ -26,6 +28,9 @@ from courseware.access_response import (
 )
 from course_modes.models import CourseMode
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
+from openedx.core.djangoapps.catalog.tests import factories
+from openedx.core.djangoapps.catalog.tests.mixins import CatalogIntegrationMixin
+from openedx.core.djangoapps.catalog.utils import get_course_runs
 from openedx.core.lib.courses import course_image_url
 from student.models import CourseEnrollment
 from util.milestones_helpers import set_prerequisite_courses
@@ -463,7 +468,8 @@ class TestCourseStatusPATCH(CourseStatusAPITestCase, MobileAuthUserTestMixin,
 @attr(shard=2)
 @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
 @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
-class TestCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin):
+@httpretty.activate
+class TestCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin, CatalogIntegrationMixin):
     """
     Test the course enrollment serializer
     """
@@ -472,6 +478,13 @@ class TestCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin)
         self.login_and_enroll()
         self.request = RequestFactory().get('/')
         self.request.user = self.user
+        self.catalog_integration = self.create_catalog_integration(
+            internal_api_url="http://catalog.example.com:443/api/v1",
+            cache_ttl=1
+        )
+        self.course_id_string = unicode(self.course.id)
+        self.course_run = factories.CourseRun(key=self.course_id_string)
+        self.course_keys = [self.course_id_string]
 
     def test_success(self):
         serialized = CourseEnrollmentSerializer(
@@ -493,3 +506,41 @@ class TestCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin)
         ).data
         self.assertEqual(serialized['course']['number'], self.course.display_coursenumber)
         self.assertEqual(serialized['course']['org'], self.course.display_organization)
+
+    @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True})
+    def test_course_about_marketing_url(self):
+        self.register_catalog_course_run_response(self.course_keys, [self.course_run])
+        catalog_course_runs_against_course_keys = get_course_runs(self.course_keys, self.request.user)
+        enrollment = CourseEnrollment.enrollments_for_user(self.user)[0]
+        serialized = CourseEnrollmentSerializer(
+            enrollment,
+            context={
+                'request': self.request,
+                "catalog_course_run": (
+                    catalog_course_runs_against_course_keys[unicode(enrollment.course_id)]
+                    if unicode(enrollment.course_id) in catalog_course_runs_against_course_keys else None
+                )
+            },
+        ).data
+        self.assertEqual(
+            serialized['course']['course_about'], self.course_run["marketing_url"]
+        )
+
+    @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False})
+    def test_course_about_lms_url(self):
+        self.register_catalog_course_run_response(self.course_keys, [self.course_run])
+        catalog_course_runs_against_course_keys = get_course_runs(self.course_keys, self.request.user)
+        enrollment = CourseEnrollment.enrollments_for_user(self.user)[0]
+        serialized = CourseEnrollmentSerializer(
+            enrollment,
+            context={
+                'request': self.request,
+                "catalog_course_run": (
+                    catalog_course_runs_against_course_keys[unicode(enrollment.course_id)]
+                    if unicode(enrollment.course_id) in catalog_course_runs_against_course_keys else None
+                )
+            },
+        ).data
+        self.assertEqual(
+            serialized['course']['course_about'], "http://localhost:8000/courses/{}/about".format(self.course_id_string)
+        )

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -480,7 +480,7 @@ class TestCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin,
         self.request.user = self.user
         self.catalog_integration = self.create_catalog_integration(
             internal_api_url="http://catalog.example.com:443/api/v1",
-            cache_ttl=1
+            course_run_cache_ttl=60
         )
         self.course_id_string = unicode(self.course.id)
         self.course_run = factories.CourseRun(key=self.course_id_string)

--- a/openedx/core/djangoapps/catalog/migrations/0003_catalogintegration_course_run_cache_ttl.py
+++ b/openedx/core/djangoapps/catalog/migrations/0003_catalogintegration_course_run_cache_ttl.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalog', '0002_catalogintegration_username'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='catalogintegration',
+            name='course_run_cache_ttl',
+            field=models.PositiveIntegerField(default=0, help_text='Specified in seconds. Enable caching of Course Run API response by setting this to a value greater than 0.', verbose_name='Cache Time To Live for Course Run Data'),
+        ),
+    ]

--- a/openedx/core/djangoapps/catalog/models.py
+++ b/openedx/core/djangoapps/catalog/models.py
@@ -6,7 +6,9 @@ from config_models.models import ConfigurationModel
 
 
 class CatalogIntegration(ConfigurationModel):
-    """Manages configuration for connecting to the catalog service and using its API."""
+    """
+    Manages configuration for connecting to the catalog service and using its API.
+    """
     API_NAME = 'catalog'
     CACHE_KEY = 'catalog.api.data'
 
@@ -25,6 +27,14 @@ class CatalogIntegration(ConfigurationModel):
         )
     )
 
+    course_run_cache_ttl = models.PositiveIntegerField(
+        verbose_name=_('Cache Time To Live for Course Run Data'),
+        default=0,
+        help_text=_(
+            'Specified in seconds. Enable caching of Course Run API response by setting this to a value greater than 0.'
+        )
+    )
+
     service_username = models.CharField(
         max_length=100,
         default="lms_catalog_service_user",
@@ -37,8 +47,17 @@ class CatalogIntegration(ConfigurationModel):
 
     @property
     def is_cache_enabled(self):
-        """Whether responses from the catalog API will be cached."""
+        """
+        Whether responses from the catalog API will be cached.
+        """
         return self.cache_ttl > 0
+
+    @property
+    def is_course_run_cache_enabled(self):
+        """
+        Whether responses from the catalog course run API will be cached.
+        """
+        return self.course_run_cache_ttl > 0
 
     def __unicode__(self):
         return self.internal_api_url

--- a/openedx/core/djangoapps/catalog/tests/mixins.py
+++ b/openedx/core/djangoapps/catalog/tests/mixins.py
@@ -1,9 +1,16 @@
 """Mixins to help test catalog integration."""
+import json
+import urllib
+
+import httpretty
+
 from openedx.core.djangoapps.catalog.models import CatalogIntegration
 
 
 class CatalogIntegrationMixin(object):
-    """Utility for working with the catalog service during testing."""
+    """
+    Utility for working with the catalog service during testing.
+    """
 
     DEFAULTS = {
         'enabled': True,
@@ -12,8 +19,27 @@ class CatalogIntegrationMixin(object):
     }
 
     def create_catalog_integration(self, **kwargs):
-        """Creates a new CatalogIntegration with DEFAULTS, updated with any provided overrides."""
+        """
+        Creates a new CatalogIntegration with DEFAULTS, updated with any provided overrides.
+        """
         fields = dict(self.DEFAULTS, **kwargs)
         CatalogIntegration(**fields).save()
 
         return CatalogIntegration.current()
+
+    def register_catalog_course_run_response(self, course_keys, catalog_course_run_data):
+        """
+        Register a mock response for GET on the catalog course run endpoint.
+        """
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://catalog.example.com:443/api/v1/course_runs/?keys={}&exclude_utm=1".format(
+                urllib.quote_plus(",".join(course_keys))
+            ),
+            body=json.dumps({
+                "results": catalog_course_run_data,
+                "next": ""
+            }),
+            content_type='application/json',
+            status=200
+        )

--- a/openedx/core/djangoapps/catalog/tests/mixins.py
+++ b/openedx/core/djangoapps/catalog/tests/mixins.py
@@ -32,9 +32,9 @@ class CatalogIntegrationMixin(object):
         Register a mock response for GET on the catalog course run endpoint.
         """
         course_run_url = "http://catalog.example.com:443/api/v1/course_runs/?keys={}&exclude_utm=1&limit=20"
+        next_page_url = course_run_url + "&offset={}".format(offset + 1) if offset else ""
         if offset:
             course_run_url = course_run_url + "&offset={}".format(offset)
-        next_page_url = course_run_url + "&offset={}".format(offset + 1) if offset else ""
         httpretty.register_uri(
             httpretty.GET,
             course_run_url.format(

--- a/openedx/core/djangoapps/catalog/tests/mixins.py
+++ b/openedx/core/djangoapps/catalog/tests/mixins.py
@@ -16,6 +16,7 @@ class CatalogIntegrationMixin(object):
         'enabled': True,
         'internal_api_url': 'https://catalog-internal.example.com/api/v1/',
         'cache_ttl': 0,
+        'course_run_cache_ttl': 0,
     }
 
     def create_catalog_integration(self, **kwargs):

--- a/openedx/core/djangoapps/catalog/tests/mixins.py
+++ b/openedx/core/djangoapps/catalog/tests/mixins.py
@@ -27,18 +27,22 @@ class CatalogIntegrationMixin(object):
 
         return CatalogIntegration.current()
 
-    def register_catalog_course_run_response(self, course_keys, catalog_course_run_data):
+    def register_catalog_course_run_response(self, course_keys, catalog_course_run_data, offset=None):
         """
         Register a mock response for GET on the catalog course run endpoint.
         """
+        course_run_url = "http://catalog.example.com:443/api/v1/course_runs/?keys={}&exclude_utm=1&limit=20"
+        if offset:
+            course_run_url = course_run_url + "&offset={}".format(offset)
+        next_page_url = course_run_url + "&offset={}".format(offset + 1) if offset else ""
         httpretty.register_uri(
             httpretty.GET,
-            "http://catalog.example.com:443/api/v1/course_runs/?keys={}&exclude_utm=1".format(
+            course_run_url.format(
                 urllib.quote_plus(",".join(course_keys))
             ),
             body=json.dumps({
                 "results": catalog_course_run_data,
-                "next": ""
+                "next": next_page_url
             }),
             content_type='application/json',
             status=200

--- a/openedx/core/djangoapps/catalog/tests/test_models.py
+++ b/openedx/core/djangoapps/catalog/tests/test_models.py
@@ -19,5 +19,6 @@ class TestCatalogIntegration(mixins.CatalogIntegrationMixin, TestCase):
     @ddt.unpack
     def test_cache_control(self, cache_ttl, is_cache_enabled, _mock_cache):
         """Test the behavior of the property controlling whether API responses are cached."""
-        catalog_integration = self.create_catalog_integration(cache_ttl=cache_ttl)
+        catalog_integration = self.create_catalog_integration(cache_ttl=cache_ttl, course_run_cache_ttl=cache_ttl)
         self.assertEqual(catalog_integration.is_cache_enabled, is_cache_enabled)
+        self.assertEqual(catalog_integration.is_course_run_cache_enabled, is_cache_enabled)

--- a/openedx/core/djangoapps/catalog/tests/test_utils.py
+++ b/openedx/core/djangoapps/catalog/tests/test_utils.py
@@ -245,7 +245,7 @@ class TestGetCourseRun(mixins.CatalogIntegrationMixin, CacheIsolationTestCase):
         self.user = UserFactory()
         self.catalog_integration = self.create_catalog_integration(
             internal_api_url="http://catalog.example.com:443/api/v1",
-            cache_ttl=1,
+            course_run_cache_ttl=60,
         )
         self.course_runs = [factories.CourseRun() for __ in range(4)]
         self.course_key_1 = CourseKey.from_string(self.course_runs[0]["key"])

--- a/openedx/core/djangoapps/catalog/tests/test_utils.py
+++ b/openedx/core/djangoapps/catalog/tests/test_utils.py
@@ -1,8 +1,12 @@
-"""Tests covering utilities for integrating with the catalog service."""
+"""
+Tests covering utilities for integrating with the catalog service.
+"""
 import uuid
 import copy
 
+from django.core.cache import cache
 from django.test import TestCase
+import httpretty
 import mock
 from opaque_keys.edx.keys import CourseKey
 
@@ -10,6 +14,8 @@ from openedx.core.djangoapps.catalog import utils
 from openedx.core.djangoapps.catalog.models import CatalogIntegration
 from openedx.core.djangoapps.catalog.tests import factories, mixins
 from student.tests.factories import UserFactory, AnonymousUserFactory
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
+
 
 UTILS_MODULE = 'openedx.core.djangoapps.catalog.utils'
 
@@ -18,7 +24,9 @@ UTILS_MODULE = 'openedx.core.djangoapps.catalog.utils'
 # ConfigurationModels use the cache. Make every cache get a miss.
 @mock.patch('config_models.models.cache.get', return_value=None)
 class TestGetPrograms(mixins.CatalogIntegrationMixin, TestCase):
-    """Tests covering retrieval of programs from the catalog service."""
+    """
+    Tests covering retrieval of programs from the catalog service.
+    """
     def setUp(self):
         super(TestGetPrograms, self).setUp()
 
@@ -28,7 +36,9 @@ class TestGetPrograms(mixins.CatalogIntegrationMixin, TestCase):
         self.catalog_integration = self.create_catalog_integration(cache_ttl=1)
 
     def assert_contract(self, call_args, program_uuid=None, type=None):  # pylint: disable=redefined-builtin
-        """Verify that API data retrieval utility is used correctly."""
+        """
+        Verify that API data retrieval utility is used correctly.
+        """
         args, kwargs = call_args
 
         for arg in (self.catalog_integration, self.user, 'programs'):
@@ -174,7 +184,9 @@ class TestGetPrograms(mixins.CatalogIntegrationMixin, TestCase):
 
 
 class TestMungeCatalogProgram(TestCase):
-    """Tests covering querystring stripping."""
+    """
+    Tests covering querystring stripping.
+    """
     catalog_program = factories.Program()
 
     def test_munge_catalog_program(self):
@@ -219,90 +231,173 @@ class TestMungeCatalogProgram(TestCase):
         self.assertEqual(munged, expected)
 
 
-@mock.patch(UTILS_MODULE + '.get_edx_api_data')
-@mock.patch('config_models.models.cache.get', return_value=None)
-class TestGetCourseRun(mixins.CatalogIntegrationMixin, TestCase):
-    """Tests covering retrieval of course runs from the catalog service."""
+@httpretty.activate
+class TestGetCourseRun(mixins.CatalogIntegrationMixin, CacheIsolationTestCase):
+    """
+    Tests covering retrieval of course runs from the catalog service.
+    """
+
+    ENABLED_CACHES = ['default']
+
     def setUp(self):
         super(TestGetCourseRun, self).setUp()
 
         self.user = UserFactory()
-        self.course_key = CourseKey.from_string('foo/bar/baz')
-        self.catalog_integration = self.create_catalog_integration()
+        self.catalog_integration = self.create_catalog_integration(
+            internal_api_url="http://catalog.example.com:443/api/v1",
+            cache_ttl=1,
+        )
+        self.course_runs = [factories.CourseRun() for __ in range(4)]
+        self.course_key_1 = CourseKey.from_string(self.course_runs[0]["key"])
+        self.course_key_2 = CourseKey.from_string(self.course_runs[1]["key"])
+        self.course_key_3 = CourseKey.from_string(self.course_runs[2]["key"])
+        self.course_key_4 = CourseKey.from_string(self.course_runs[3]["key"])
 
-    def assert_contract(self, call_args):
-        """Verify that API data retrieval utility is used correctly."""
-        args, kwargs = call_args
-
-        for arg in (self.catalog_integration, self.user, 'course_runs'):
-            self.assertIn(arg, args)
-
-        self.assertEqual(kwargs['resource_id'], unicode(self.course_key))
-        self.assertEqual(kwargs['api']._store['base_url'], self.catalog_integration.internal_api_url)  # pylint: disable=protected-access
-
-        return args, kwargs
-
-    def test_get_course_run(self, _mock_cache, mock_get_catalog_data):
-        course_run = factories.CourseRun()
-        mock_get_catalog_data.return_value = course_run
-
-        data = utils.get_course_run(self.course_key, self.user)
-
-        self.assert_contract(mock_get_catalog_data.call_args)
-        self.assertEqual(data, course_run)
-
-    def test_course_run_unavailable(self, _mock_cache, mock_get_catalog_data):
-        mock_get_catalog_data.return_value = []
-
-        data = utils.get_course_run(self.course_key, self.user)
-
-        self.assert_contract(mock_get_catalog_data.call_args)
-        self.assertEqual(data, {})
-
-    def test_cache_disabled(self, _mock_cache, mock_get_catalog_data):
-        utils.get_course_run(self.course_key, self.user)
-
-        _, kwargs = self.assert_contract(mock_get_catalog_data.call_args)
-
-        self.assertIsNone(kwargs['cache_key'])
-
-    def test_cache_enabled(self, _mock_cache, mock_get_catalog_data):
-        catalog_integration = self.create_catalog_integration(cache_ttl=1)
-
-        utils.get_course_run(self.course_key, self.user)
-
-        _, kwargs = mock_get_catalog_data.call_args
-
-        self.assertEqual(kwargs['cache_key'], catalog_integration.CACHE_KEY)
-
-    def test_config_missing(self, _mock_cache, _mock_get_catalog_data):
-        """Verify that no errors occur if this method is called when catalog config is missing."""
+    def test_config_missing(self):
+        """
+        Verify that no errors occur if this method is called when catalog config is missing.
+        """
         CatalogIntegration.objects.all().delete()
 
-        data = utils.get_course_run(self.course_key, self.user)
+        data = utils.get_course_runs([], self.user)
         self.assertEqual(data, {})
 
+    def test_get_course_run(self):
+        course_keys = [self.course_key_1]
+        course_key_strings = [self.course_runs[0]["key"]]
+        self.register_catalog_course_run_response(course_key_strings, [self.course_runs[0]])
 
-@mock.patch(UTILS_MODULE + '.get_course_run')
-class TestGetRunMarketingUrl(TestCase):
-    """Tests covering retrieval of course run marketing URLs."""
+        course_catalog_data_dict = utils.get_course_runs(course_keys, self.user)
+        expected_data = {self.course_runs[0]["key"]: self.course_runs[0]}
+        self.assertEqual(expected_data, course_catalog_data_dict)
+
+    def test_get_multiple_course_run(self):
+        course_key_strings = [self.course_runs[0]["key"], self.course_runs[1]["key"], self.course_runs[2]["key"]]
+        course_keys = [self.course_key_1, self.course_key_2, self.course_key_3]
+        self.register_catalog_course_run_response(
+            course_key_strings, [self.course_runs[0], self.course_runs[1], self.course_runs[2]]
+        )
+
+        course_catalog_data_dict = utils.get_course_runs(course_keys, self.user)
+        expected_data = {
+            self.course_runs[0]["key"]: self.course_runs[0],
+            self.course_runs[1]["key"]: self.course_runs[1],
+            self.course_runs[2]["key"]: self.course_runs[2],
+        }
+        self.assertEqual(expected_data, course_catalog_data_dict)
+
+    def test_course_run_unavailable(self):
+        course_key_strings = [self.course_runs[0]["key"], self.course_runs[3]["key"]]
+        course_keys = [self.course_key_1, self.course_key_4]
+        self.register_catalog_course_run_response(course_key_strings, [self.course_runs[0]])
+
+        course_catalog_data_dict = utils.get_course_runs(course_keys, self.user)
+        expected_data = {self.course_runs[0]["key"]: self.course_runs[0]}
+        self.assertEqual(expected_data, course_catalog_data_dict)
+
+    def test_cached_course_run_data(self):
+        course_key_strings = [self.course_runs[0]["key"], self.course_runs[1]["key"]]
+        course_keys = [self.course_key_1, self.course_key_2]
+        course_cached_keys = [
+            "{}{}".format(utils.CatalogCacheUtility.CACHE_KEY_PREFIX, self.course_runs[0]["key"]),
+            "{}{}".format(utils.CatalogCacheUtility.CACHE_KEY_PREFIX, self.course_runs[1]["key"]),
+        ]
+        self.register_catalog_course_run_response(course_key_strings, [self.course_runs[0], self.course_runs[1]])
+        expected_data = {
+            self.course_runs[0]["key"]: self.course_runs[0],
+            self.course_runs[1]["key"]: self.course_runs[1],
+        }
+
+        course_catalog_data_dict = utils.get_course_runs(course_keys, self.user)
+        self.assertEqual(expected_data, course_catalog_data_dict)
+        cached_data = cache.get_many(course_cached_keys)
+        self.assertEqual(set(course_cached_keys), set(cached_data.keys()))
+
+        with mock.patch('openedx.core.djangoapps.catalog.utils.get_edx_api_data') as mock_method:
+            course_catalog_data_dict = utils.get_course_runs(course_keys, self.user)
+            self.assertEqual(0, mock_method.call_count)
+            self.assertEqual(expected_data, course_catalog_data_dict)
+
+
+class TestGetRunMarketingUrl(TestCase, mixins.CatalogIntegrationMixin):
+    """
+    Tests covering retrieval of course run marketing URLs.
+    """
     def setUp(self):
         super(TestGetRunMarketingUrl, self).setUp()
-
-        self.course_key = CourseKey.from_string('foo/bar/baz')
         self.user = UserFactory()
+        self.course_runs = [factories.CourseRun() for __ in range(2)]
+        self.course_key_1 = CourseKey.from_string(self.course_runs[0]["key"])
 
-    def test_get_run_marketing_url(self, mock_get_course_run):
-        course_run = factories.CourseRun()
-        mock_get_course_run.return_value = course_run
+    def test_get_run_marketing_url(self):
+        with mock.patch('openedx.core.djangoapps.catalog.utils.get_course_runs', return_value={
+            self.course_runs[0]["key"]: self.course_runs[0],
+            self.course_runs[1]["key"]: self.course_runs[1],
+        }):
+            course_marketing_url = utils.get_run_marketing_url(self.course_key_1, self.user)
+            self.assertEqual(self.course_runs[0]["marketing_url"], course_marketing_url)
 
-        url = utils.get_run_marketing_url(self.course_key, self.user)
+    def test_marketing_url_catalog_course_run_not_found(self):
+        with mock.patch('openedx.core.djangoapps.catalog.utils.get_course_runs', return_value={
+            self.course_runs[0]["key"]: self.course_runs[0],
+        }):
+            course_marketing_url = utils.get_run_marketing_url(self.course_key_1, self.user)
+            self.assertEqual(self.course_runs[0]["marketing_url"], course_marketing_url)
 
-        self.assertEqual(url, course_run['marketing_url'])
+    def test_marketing_url_missing(self):
+        self.course_runs[1]["marketing_url"] = None
+        with mock.patch('openedx.core.djangoapps.catalog.utils.get_course_runs', return_value={
+            self.course_runs[0]["key"]: self.course_runs[0],
+            self.course_runs[1]["key"]: self.course_runs[1],
+        }):
+            course_marketing_url = utils.get_run_marketing_url(CourseKey.from_string("foo2/bar2/baz2"), self.user)
+            self.assertEqual(None, course_marketing_url)
 
-    def test_marketing_url_missing(self, mock_get_course_run):
-        mock_get_course_run.return_value = {}
 
-        url = utils.get_run_marketing_url(self.course_key, self.user)
+class TestGetRunMarketingUrls(TestCase, mixins.CatalogIntegrationMixin):
+    """
+    Tests covering retrieval of course run marketing URLs.
+    """
+    def setUp(self):
+        super(TestGetRunMarketingUrls, self).setUp()
+        self.user = UserFactory()
+        self.course_runs = [factories.CourseRun() for __ in range(2)]
+        self.course_keys = [
+            CourseKey.from_string(self.course_runs[0]["key"]),
+            CourseKey.from_string(self.course_runs[1]["key"]),
+        ]
 
-        self.assertEqual(url, None)
+    def test_get_run_marketing_url(self):
+        expected_data = {
+            self.course_runs[0]["key"]: self.course_runs[0]["marketing_url"],
+            self.course_runs[1]["key"]: self.course_runs[1]["marketing_url"],
+        }
+        with mock.patch('openedx.core.djangoapps.catalog.utils.get_course_runs', return_value={
+            self.course_runs[0]["key"]: self.course_runs[0],
+            self.course_runs[1]["key"]: self.course_runs[1],
+        }):
+            course_marketing_url_dict = utils.get_run_marketing_urls(self.course_keys, self.user)
+            self.assertEqual(expected_data, course_marketing_url_dict)
+
+    def test_marketing_url_catalog_course_run_not_found(self):
+        expected_data = {
+            self.course_runs[0]["key"]: self.course_runs[0]["marketing_url"],
+        }
+        with mock.patch('openedx.core.djangoapps.catalog.utils.get_course_runs', return_value={
+            self.course_runs[0]["key"]: self.course_runs[0],
+        }):
+            course_marketing_url_dict = utils.get_run_marketing_urls(self.course_keys, self.user)
+            self.assertEqual(expected_data, course_marketing_url_dict)
+
+    def test_marketing_url_missing(self):
+        expected_data = {
+            self.course_runs[0]["key"]: self.course_runs[0]["marketing_url"],
+            self.course_runs[1]["key"]: None,
+        }
+        self.course_runs[1]["marketing_url"] = None
+        with mock.patch('openedx.core.djangoapps.catalog.utils.get_course_runs', return_value={
+            self.course_runs[0]["key"]: self.course_runs[0],
+            self.course_runs[1]["key"]: self.course_runs[1],
+        }):
+            course_marketing_url_dict = utils.get_run_marketing_urls(self.course_keys, self.user)
+            self.assertEqual(expected_data, course_marketing_url_dict)

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -1,6 +1,12 @@
-"""Helper functions for working with the catalog service."""
+"""
+Helper functions for working with the catalog service.
+"""
+import abc
+import logging
+
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.cache import cache
 from edx_rest_api_client.client import EdxRestApiClient
 from opaque_keys.edx.keys import CourseKey
 
@@ -9,8 +15,13 @@ from openedx.core.lib.edx_api_utils import get_edx_api_data
 from openedx.core.lib.token_utils import JwtBuilder
 
 
+log = logging.getLogger(__name__)
+
+
 def create_catalog_api_client(user, catalog_integration):
-    """Returns an API client which can be used to make catalog API requests."""
+    """
+    Returns an API client which can be used to make catalog API requests.
+    """
     scopes = ['email', 'profile']
     expires_in = settings.OAUTH_ID_TOKEN_EXPIRATION
     jwt = JwtBuilder(user).build_token(scopes, expires_in)
@@ -32,7 +43,8 @@ def _get_service_user(user, service_username):
 
 
 def get_programs(user=None, uuid=None, type=None):  # pylint: disable=redefined-builtin
-    """Retrieve marketable programs from the catalog service.
+    """
+    Retrieve marketable programs from the catalog service.
 
     Keyword Arguments:
         uuid (string): UUID identifying a specific program.
@@ -77,7 +89,8 @@ def get_programs(user=None, uuid=None, type=None):  # pylint: disable=redefined-
 
 
 def get_program_types(user=None):  # pylint: disable=redefined-builtin
-    """Retrieve all program types from the catalog service.
+    """
+    Retrieve all program types from the catalog service.
 
     Returns:
         list of dict, representing program types.
@@ -103,7 +116,9 @@ def get_program_types(user=None):  # pylint: disable=redefined-builtin
 
 
 def get_programs_data(user=None):
-    """Return the list of Programs after adding the ProgramType Logo Image"""
+    """
+    Return the list of Programs after adding the ProgramType Logo Image.
+    """
 
     programs_list = get_programs(user)
     program_types = get_program_types(user)
@@ -117,7 +132,8 @@ def get_programs_data(user=None):
 
 
 def munge_catalog_program(catalog_program):
-    """Make a program from the catalog service look like it came from the programs service.
+    """
+    Make a program from the catalog service look like it came from the programs service.
 
     Catalog-based MicroMasters need to be displayed in the LMS. However, the LMS
     currently retrieves all program data from the soon-to-be-retired programs service.
@@ -170,38 +186,57 @@ def munge_catalog_program(catalog_program):
     }
 
 
-def get_course_run(course_key, user):
-    """Get a course run's data from the course catalog service.
-
-    Arguments:
-        course_key (CourseKey): Course key object identifying the run whose data we want.
-        user (User): The user to authenticate as when making requests to the catalog service.
-
-    Returns:
-        dict, empty if no data could be retrieved.
+def get_and_cache_course_runs(course_keys, user):
     """
+    Get course run's data from the course catalog service and cache it.
+    """
+    catalog_course_runs_against_course_keys = {}
     catalog_integration = CatalogIntegration.current()
-
     if catalog_integration.enabled:
         api = create_catalog_api_client(user, catalog_integration)
 
-        data = get_edx_api_data(
+        catalog_data = get_edx_api_data(
             catalog_integration,
             user,
             'course_runs',
-            resource_id=unicode(course_key),
-            cache_key=catalog_integration.CACHE_KEY if catalog_integration.is_cache_enabled else None,
             api=api,
-            querystring={'exclude_utm': 1},
+            querystring={'keys': ",".join(course_keys), 'exclude_utm': 1},
+        )
+        if catalog_data:
+            for catalog_course_run in catalog_data:
+                CatalogCacheUtility.cache_course_run(catalog_course_run)
+                catalog_course_runs_against_course_keys[catalog_course_run["key"]] = catalog_course_run
+    return catalog_course_runs_against_course_keys
+
+
+def get_course_runs(course_keys, user):
+    """
+    Get course run data from the course catalog service if not available in cache.
+
+    Arguments:
+        course_keys ([CourseKey]): A list of Course key object identifying the run whose data we want.
+        user (User): The user to authenticate as when making requests to the catalog service.
+
+    Returns:
+        dict of catalog course runs against course keys, empty if no data could be retrieved.
+    """
+    catalog_course_runs_against_course_keys = CatalogCacheUtility.get_cached_catalog_course_runs(
+        course_keys
+    )
+    if len(catalog_course_runs_against_course_keys.keys()) != len(course_keys):
+        missing_course_keys = CatalogCacheUtility.get_course_keys_not_found_in_cache(
+            course_keys, catalog_course_runs_against_course_keys.keys()
+        )
+        catalog_course_runs_against_course_keys.update(
+            get_and_cache_course_runs(missing_course_keys, user)
         )
 
-        return data if data else {}
-    else:
-        return {}
+    return catalog_course_runs_against_course_keys
 
 
 def get_run_marketing_url(course_key, user):
-    """Get a course run's marketing URL from the course catalog service.
+    """
+    Get a course run's marketing URL from the course catalog service.
 
     Arguments:
         course_key (CourseKey): Course key object identifying the run whose marketing URL we want.
@@ -210,5 +245,111 @@ def get_run_marketing_url(course_key, user):
     Returns:
         string, the marketing URL, or None if no URL is available.
     """
-    course_run = get_course_run(course_key, user)
-    return course_run.get('marketing_url')
+    course_marketing_urls = get_run_marketing_urls([course_key], user)
+    return course_marketing_urls.get(unicode(course_key))
+
+
+def get_run_marketing_urls(course_keys, user):
+    """
+    Get course run marketing URLs from the course catalog service against course keys.
+
+    Arguments:
+        course_keys ([CourseKey]): A list of Course key object identifying the run whose data we want.
+        user (User): The user to authenticate as when making requests to the catalog service.
+
+    Returns:
+        dict of run marketing URLs against course keys
+    """
+    course_marketing_urls = {}
+    course_catalog_dict = get_course_runs(course_keys, user)
+    if not course_catalog_dict:
+        return course_marketing_urls
+
+    for course_key in course_keys:
+        course_key_string = unicode(course_key)
+        if course_key_string in course_catalog_dict:
+            course_marketing_urls[course_key_string] = course_catalog_dict[course_key_string].get('marketing_url')
+
+    return course_marketing_urls
+
+
+class CatalogCacheUtility(object):
+    """
+    Non-instantiatable class housing utility methods for caching catalog API data.
+    """
+    __metaclass__ = abc.ABCMeta
+    CACHE_KEY_PREFIX = "catalog.course_runs."
+
+    @classmethod
+    def get_course_keys_not_found_in_cache(cls, course_keys, cached_course_run_keys):
+        """
+        Get course key strings for which course run data is not available in cache.
+
+        Arguments:
+            course_key (CourseKey): CourseKey object to create corresponding catalog cache key.
+
+        Returns:
+            list of string rep of course keys not found in catalog cache.
+        """
+        missing_course_keys = []
+        for course_key in course_keys:
+            course_key_string = unicode(course_key)
+            if course_key_string not in cached_course_run_keys:
+                missing_course_keys.append(course_key_string)
+
+        log.info("Cached catalog course run data missing for: '{}'".format(
+            ", ".join(missing_course_keys)
+        ))
+        return missing_course_keys
+
+    @classmethod
+    def get_cached_catalog_course_runs(cls, course_keys):
+        """
+        Get course runs from cache against course keys.
+
+        Arguments:
+            course_keys ([CourseKey]): List of CourseKey object identifying the run whose data we want.
+
+        Returns:
+            dict of catalog course run against course key string
+        """
+        course_catalog_run_cache_keys = [
+            cls._get_cache_key_name(course_key)
+            for course_key in course_keys
+        ]
+        cached_catalog_course_runs = cache.get_many(course_catalog_run_cache_keys)
+        return {
+            cls._extract_course_key_from_cache_key_name(cached_key): cached_course_run
+            for cached_key, cached_course_run in cached_catalog_course_runs.iteritems()
+        }
+
+    @classmethod
+    def cache_course_run(cls, catalog_course_run):
+        """
+        Caches catalog course run for course key.
+        """
+        cache.set(
+            cls._get_cache_key_name(catalog_course_run["key"]),
+            catalog_course_run,
+            CatalogIntegration.current().cache_ttl
+        )
+
+    @classmethod
+    def _get_cache_key_name(cls, course_key):
+        """
+        Returns key name to use to cache catalog course run data for course key.
+
+        Arguments:
+            course_key (CourseKey): CourseKey object to create corresponding catalog cache key.
+
+        Returns:
+            string, catalog cache key against course key.
+        """
+        return "{}{}".format(cls.CACHE_KEY_PREFIX, unicode(course_key))
+
+    @classmethod
+    def _extract_course_key_from_cache_key_name(cls, catalog_course_run_cache_key):
+        """
+        Returns course_key extracted from cache key of catalog course run data.
+        """
+        return catalog_course_run_cache_key.replace(cls.CACHE_KEY_PREFIX, '')

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -331,7 +331,7 @@ class CatalogCacheUtility(object):
         cache.set(
             cls._get_cache_key_name(catalog_course_run["key"]),
             catalog_course_run,
-            CatalogIntegration.current().cache_ttl
+            CatalogIntegration.current().course_run_cache_ttl
         )
 
     @classmethod

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -12,16 +12,17 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.text import slugify
+from edx_oauth2_provider.tests.factories import ClientFactory
 import httpretty
 import mock
 from nose.plugins.attrib import attr
 from opaque_keys.edx.keys import CourseKey
-from edx_oauth2_provider.tests.factories import ClientFactory
 from provider.constants import CONFIDENTIAL
 from pytz import utc
 
 from lms.djangoapps.certificates.api import MODES
 from lms.djangoapps.commerce.tests.test_utils import update_commerce_config
+from openedx.core.djangoapps.catalog.tests import factories as catalog_factories
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.credentials.tests import factories as credentials_factories
 from openedx.core.djangoapps.credentials.tests.mixins import CredentialsApiConfigMixin, CredentialsDataMixin
@@ -703,7 +704,9 @@ class TestProgramProgressMeter(ProgramsApiConfigMixin, TestCase):
 @skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @mock.patch(UTILS_MODULE + '.get_run_marketing_url', mock.Mock(return_value=MARKETING_URL))
 class TestProgramDataExtender(ProgramsApiConfigMixin, ModuleStoreTestCase):
-    """Tests of the program data extender utility class."""
+    """
+    Tests of the program data extender utility class.
+    """
     maxDiff = None
     sku = 'abc123'
     password = 'test'
@@ -721,6 +724,7 @@ class TestProgramDataExtender(ProgramsApiConfigMixin, ModuleStoreTestCase):
         self.course.start = datetime.datetime.now(utc) - datetime.timedelta(days=1)
         self.course.end = datetime.datetime.now(utc) + datetime.timedelta(days=1)
         self.course = self.update_course(self.course, self.user.id)  # pylint: disable=no-member
+        self.course_id_string = unicode(self.course.id)  # pylint: disable=no-member
 
         self.organization = factories.Organization()
         self.run_mode = factories.RunMode(course_key=unicode(self.course.id))  # pylint: disable=no-member
@@ -729,9 +733,12 @@ class TestProgramDataExtender(ProgramsApiConfigMixin, ModuleStoreTestCase):
             organizations=[self.organization],
             course_codes=[self.course_code]
         )
+        self.course_run = catalog_factories.CourseRun(key=self.course_id_string)
 
     def _assert_supplemented(self, actual, **kwargs):
-        """DRY helper used to verify that program data is extended correctly."""
+        """
+        DRY helper used to verify that program data is extended correctly.
+        """
         course_overview = CourseOverview.get_from_id(self.course.id)  # pylint: disable=no-member
         run_mode = dict(
             factories.RunMode(
@@ -765,7 +772,9 @@ class TestProgramDataExtender(ProgramsApiConfigMixin, ModuleStoreTestCase):
     @ddt.unpack
     @mock.patch(UTILS_MODULE + '.CourseMode.mode_for_course')
     def test_student_enrollment_status(self, is_enrolled, enrolled_mode, is_upgrade_required, mock_get_mode):
-        """Verify that program data is supplemented with the student's enrollment status."""
+        """
+        Verify that program data is supplemented with the student's enrollment status.
+        """
         expected_upgrade_url = '{root}/{path}?sku={sku}'.format(
             root=ECOMMERCE_URL_ROOT,
             path=self.checkout_path.strip('/'),
@@ -791,7 +800,9 @@ class TestProgramDataExtender(ProgramsApiConfigMixin, ModuleStoreTestCase):
 
     @ddt.data(MODES.audit, MODES.verified)
     def test_inactive_enrollment_no_upgrade(self, enrolled_mode):
-        """Verify that a student with an inactive enrollment isn't encouraged to upgrade."""
+        """
+        Verify that a student with an inactive enrollment isn't encouraged to upgrade.
+        """
         update_commerce_config(enabled=True, checkout_page=self.checkout_path)
 
         CourseEnrollmentFactory(
@@ -807,7 +818,9 @@ class TestProgramDataExtender(ProgramsApiConfigMixin, ModuleStoreTestCase):
 
     @mock.patch(UTILS_MODULE + '.CourseMode.mode_for_course')
     def test_ecommerce_disabled(self, mock_get_mode):
-        """Verify that the utility can operate when the ecommerce service is disabled."""
+        """
+        Verify that the utility can operate when the ecommerce service is disabled.
+        """
         update_commerce_config(enabled=False, checkout_page=self.checkout_path)
 
         mock_mode = mock.Mock()
@@ -843,7 +856,8 @@ class TestProgramDataExtender(ProgramsApiConfigMixin, ModuleStoreTestCase):
         )
 
     def test_no_enrollment_start_date(self):
-        """Verify that a closed course with no explicit enrollment start date doesn't cause an error.
+        """
+        Verify that a closed course with no explicit enrollment start date doesn't cause an error.
 
         Regression test for ECOM-4973.
         """
@@ -861,7 +875,9 @@ class TestProgramDataExtender(ProgramsApiConfigMixin, ModuleStoreTestCase):
     @mock.patch(UTILS_MODULE + '.certificate_api.certificate_downloadable_status')
     @mock.patch(CERTIFICATES_API_MODULE + '.has_html_certificates_enabled')
     def test_certificate_url_retrieval(self, is_uuid_available, mock_html_certs_enabled, mock_get_cert_data):
-        """Verify that the student's run mode certificate is included, when available."""
+        """
+        Verify that the student's run mode certificate is included, when available.
+        """
         test_uuid = uuid.uuid4().hex
         mock_get_cert_data.return_value = {'uuid': test_uuid} if is_uuid_available else {}
         mock_html_certs_enabled.return_value = True
@@ -886,7 +902,9 @@ class TestProgramDataExtender(ProgramsApiConfigMixin, ModuleStoreTestCase):
 
     @mock.patch(UTILS_MODULE + '.get_organization_by_short_name')
     def test_organization_logo_exists(self, mock_get_organization_by_short_name):
-        """ Verify the logo image is set from the organizations api """
+        """
+        Verify the logo image is set from the organizations api.
+        """
         mock_logo_url = 'edx/logo.png'
         mock_image = mock.Mock()
         mock_image.url = mock_logo_url
@@ -899,7 +917,9 @@ class TestProgramDataExtender(ProgramsApiConfigMixin, ModuleStoreTestCase):
 
     @mock.patch(UTILS_MODULE + '.get_organization_by_short_name')
     def test_organization_missing(self, mock_get_organization_by_short_name):
-        """ Verify the logo image is not set if the organizations api returns None """
+        """
+        Verify the logo image is not set if the organizations api returns None.
+        """
         mock_get_organization_by_short_name.return_value = None
         data = utils.ProgramDataExtender(self.program, self.user).extend()
         self.assertEqual(data['organizations'][0].get('img'), None)


### PR DESCRIPTION
## [MA-3051](https://openedx.atlassian.net/browse/MA-3051)
Add new course-run cache field in CatalogIntegration config model and use it to cache course run data.

### Testing
- [x] Unit
### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @nasthagiri 
- [ ] Code review: @rlucioni 
### Post-review
- [ ] Squash commits
