### PR TITLE
Disable course-run integration for marketing_url

### DIFF
--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -20,8 +20,9 @@ def get_link_for_about_page(course_key, user, catalog_course_run=None):
     if settings.FEATURES.get('ENABLE_MKTG_SITE'):
         if catalog_course_run:
             marketing_url = catalog_course_run.get('marketing_url')
-        else:
-            marketing_url = get_run_marketing_url(course_key, user)
+        # TODO MA-3052 Getting the course runs from the catalog service doesn't scale.
+        # else:
+        #     marketing_url = get_run_marketing_url(course_key, user)
         if marketing_url:
             return marketing_url
 

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -278,8 +278,10 @@ class UserCourseEnrollmentsList(APIView):
                 is_active=True
             ).order_by('created').reverse()
         )
-        course_ids = [enrollment.course_id for enrollment in enrollments]
-        catalog_course_runs_against_course_keys = get_course_runs(course_ids, request.user)
+        # TODO MA-3052 Getting the course runs from the catalog service doesn't scale.
+        # course_ids = [enrollment.course_id for enrollment in enrollments]
+        # catalog_course_runs_against_course_keys = get_course_runs(course_ids, request.user)
+        catalog_course_runs_against_course_keys = {}
 
         org = request.query_params.get('org', None)
 


### PR DESCRIPTION
Disables the code that calls the Catalog service to get course-run data for marketing_url.