### PR TITLE
MA-3052: avoid catalog integration for individual course when cached

### DIFF
--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -11,20 +11,40 @@ from openedx.core.djangoapps.catalog.utils import get_run_marketing_url
 log = logging.getLogger(__name__)
 
 
-def get_link_for_about_page(course_key, user, catalog_course_run=None):
+def get_link_for_about_page(course_key, user):
     """
     Returns the url to the course about page.
     """
     assert isinstance(course_key, CourseKey)
 
     if settings.FEATURES.get('ENABLE_MKTG_SITE'):
-        if catalog_course_run:
-            marketing_url = catalog_course_run.get('marketing_url')
-        else:
-            marketing_url = get_run_marketing_url(course_key, user)
+        marketing_url = get_run_marketing_url(course_key, user)
         if marketing_url:
             return marketing_url
 
+    return get_lms_course_about_page_url(course_key)
+
+
+def get_link_for_about_page_from_cache(course_key, catalog_course_run=None):
+    """
+    Returns the url to the course about page from already cached dict if marketing
+    site is enabled else returns lms course about url.
+    """
+    assert isinstance(course_key, CourseKey)
+
+    if settings.FEATURES.get('ENABLE_MKTG_SITE'):
+        if catalog_course_run:
+            marketing_url = catalog_course_run.get('marketing_url')
+            if marketing_url:
+                return marketing_url
+
+    return get_lms_course_about_page_url(course_key)
+
+
+def get_lms_course_about_page_url(course_key):
+    """
+    Returns lms about page url for course.
+    """
     return u"{about_base_url}/courses/{course_key}/about".format(
         about_base_url=settings.LMS_ROOT_URL,
         course_key=unicode(course_key)

--- a/common/djangoapps/util/tests/test_course.py
+++ b/common/djangoapps/util/tests/test_course.py
@@ -11,7 +11,7 @@ from openedx.core.djangoapps.catalog.utils import CatalogCacheUtility
 from openedx.core.djangoapps.catalog.tests.mixins import CatalogIntegrationMixin
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from student.tests.factories import UserFactory
-from util.course import get_link_for_about_page
+from util.course import get_link_for_about_page_from_cache, get_link_for_about_page
 
 
 @httpretty.activate
@@ -45,6 +45,9 @@ class CourseAboutLinkTestCase(CatalogIntegrationMixin, CacheIsolationTestCase):
             self.assertEquals(
                 get_link_for_about_page(self.course_key, self.user), self.lms_course_about_url
             )
+            self.assertEquals(
+                get_link_for_about_page_from_cache(self.course_key, self.course_run), self.lms_course_about_url
+            )
         with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
             self.register_catalog_course_run_response(
                 [self.course_key_string], [{"key": self.course_key_string, "marketing_url": None}]
@@ -68,6 +71,6 @@ class CourseAboutLinkTestCase(CatalogIntegrationMixin, CacheIsolationTestCase):
     @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True})
     def test_about_page_marketing_url_cached(self):
         self.assertEquals(
-            get_link_for_about_page(self.course_key, self.user, self.course_run),
+            get_link_for_about_page_from_cache(self.course_key, self.course_run),
             self.course_run["marketing_url"]
         )

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -6,7 +6,7 @@ from rest_framework.reverse import reverse
 from courseware.access import has_access
 from certificates.api import certificate_downloadable_status
 from student.models import CourseEnrollment, User
-from util.course import get_link_for_about_page
+from util.course import get_link_for_about_page_from_cache
 
 
 class CourseOverviewField(serializers.RelatedField):
@@ -50,8 +50,8 @@ class CourseOverviewField(serializers.RelatedField):
                 }
             },
             'course_image': course_overview.course_image_url,
-            'course_about': get_link_for_about_page(
-                course_overview.id, request.user, self.context.get('catalog_course_run')
+            'course_about': get_link_for_about_page_from_cache(
+                course_overview.id, self.context.get('catalog_course_run')
             ),
             'course_updates': reverse(
                 'course-updates-list',


### PR DESCRIPTION
Make catalog integration call for course run only when batch course run get and cache has not already been made.