### PR TITLE
Give the bok choy server more time to start up

### DIFF
--- a/pavelib/utils/test/bokchoy_utils.py
+++ b/pavelib/utils/test/bokchoy_utils.py
@@ -83,7 +83,7 @@ def wait_for_server(server, port):
     attempts = 0
     server_ok = False
 
-    while attempts < 20:
+    while attempts < 30:
         try:
             connection = httplib.HTTPConnection(server, port, timeout=10)
             connection.request('GET', '/')


### PR DESCRIPTION
@jmbowman 
@edx/testeng 

Here was my local output from devstack with print statements "trying" in the try block and "Sleeping ten..." in the new except block.

```
Confirming servers have started...
Checking server 0.0.0.0 on port 8003
trying
Sleeping ten...
trying
trying
Checking server 0.0.0.0 on port 8031
trying
Installing course fixture for forums
Bok-choy servers running. Press Ctrl-C to exit...
```
