### PR TITLE
TNL-6203 Fix Duplicate button in Studio if user language is changed.

### DIFF
--- a/cms/static/js/views/xblock_outline.js
+++ b/cms/static/js/views/xblock_outline.js
@@ -322,7 +322,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
              */
             handleDuplicateEvent: function(event) {
                 var self = this,
-                    xblockType = XBlockViewUtils.getXBlockType(self.model.get('category'), self.parentView.model, true),
+                    xblockType = XBlockViewUtils.getXBlockType(self.model.get('category'), self.parentView.model),
                     xblockElement = $(event.currentTarget).closest('.outline-item'),
                     parentElement = self.getParentElement(xblockElement, xblockType);
 


### PR DESCRIPTION
## [TNL-6203](https://openedx.atlassian.net/browse/TNL-6203)

### Description

When a user changes his language to Español, In Studio, select the duplicate button on a section, subsection, or unit. I have done `The content duplicate`.


### How to Test?

**Stage**: 
- Go to the [User Account Setting Page](https://courses.stage.edx.org/account/settings)
-  Set your account language to Español
- Go to the [Course home Page](https://studio.stage.edx.org/course/course-v1:edx+TNL-6203+2016)
- Select the duplicate button on a section, subsection, or unit
-  No duplication. A pop-up error occurred.

**Sandbox**
- [tnl-6203.sandbox.edx.org](tnl-6203.sandbox.edx.org)
- Go to the [Update Language Page](https://tnl-6203.sandbox.edx.org/update_lang/)
- Enter the `eo` in Language Code Textbox and update the language. 
- Go to the [Studio Course Home Page](https://studio-tnl-6203.sandbox.edx.org/course/course-v1:edX+DemoX+Demo_Course)
-  Select the duplicate button on a section, subsection, or unit
- The Content Duplicates

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @mushtaqak  
- [x] @Qubad786  

### Post-review
- [x] Rebase and squash commits

