### PR TITLE
Fix problem rescore 

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -514,8 +514,8 @@ def rescore_problem_module_state(xmodule_instance_args, module_descriptor, stude
                 loc=usage_key,
                 student=student
             )
-            TASK_LOG.debug(msg)
-            raise UpdateProblemModuleStateError(msg)
+            TASK_LOG.warning(msg)
+            return UPDATE_STATUS_FAILED
 
         if not hasattr(instance, 'rescore_problem'):
             # This should also not happen, since it should be already checked in the caller,

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -222,6 +222,23 @@ class TestInstructorTasks(InstructorTaskModuleTestCase):
 class TestRescoreInstructorTask(TestInstructorTasks):
     """Tests problem-rescoring instructor task."""
 
+    def assert_task_output(self, output, **expected_output):
+        """
+        Check & compare output of the task
+        """
+        self.assertEqual(output.get('total'), expected_output.get('total'))
+        self.assertEqual(output.get('attempted'), expected_output.get('attempted'))
+        self.assertEqual(output.get('succeeded'), expected_output.get('succeeded'))
+        self.assertEqual(output.get('skipped'), expected_output.get('skipped'))
+        self.assertEqual(output.get('failed'), expected_output.get('failed'))
+        self.assertEqual(output.get('action_name'), expected_output.get('action_name'))
+        self.assertGreater(output.get('duration_ms'), expected_output.get('duration_ms', 0))
+
+    def get_task_output(self, task_id):
+        """Get and load instructor task output"""
+        entry = InstructorTask.objects.get(id=task_id)
+        return json.loads(entry.task_output)
+
     def test_rescore_missing_current_task(self):
         self._test_missing_current_task(rescore_problem)
 
@@ -261,7 +278,32 @@ class TestRescoreInstructorTask(TestInstructorTasks):
         self.assertEquals(output['message'], "Specified problem does not support rescoring.")
         self.assertGreater(len(output['traceback']), 0)
 
+    def test_rescoring_unaccessable(self):
+        """
+        Tests rescores a problem in a course, for all students fails if user has answered a
+        problem to which user does not have access to.
+        """
+        input_state = json.dumps({'done': True})
+        num_students = 1
+        self._create_students_with_state(num_students, input_state)
+        task_entry = self._create_input_entry()
+        with patch('lms.djangoapps.instructor_task.tasks_helper.get_module_for_descriptor_internal', return_value=None):
+            self._run_task_with_mock_celery(rescore_problem, task_entry.id, task_entry.task_id)
+
+        self.assert_task_output(
+            output=self.get_task_output(task_entry.id),
+            total=num_students,
+            attempted=num_students,
+            succeeded=0,
+            skipped=0,
+            failed=num_students,
+            action_name='rescored'
+        )
+
     def test_rescoring_success(self):
+        """
+        Tests rescores a problem in a course, for all students succeeds.
+        """
         input_state = json.dumps({'done': True})
         num_students = 10
         self._create_students_with_state(num_students, input_state)
@@ -277,17 +319,21 @@ class TestRescoreInstructorTask(TestInstructorTasks):
         with patch('lms.djangoapps.instructor_task.tasks_helper.get_module_for_descriptor_internal') as mock_get_module:
             mock_get_module.return_value = mock_instance
             self._run_task_with_mock_celery(rescore_problem, task_entry.id, task_entry.task_id)
-        # check return value
-        entry = InstructorTask.objects.get(id=task_entry.id)
-        output = json.loads(entry.task_output)
-        self.assertEquals(output.get('attempted'), num_students)
-        self.assertEquals(output.get('succeeded'), num_students)
-        self.assertEquals(output.get('total'), num_students)
-        self.assertEquals(output.get('action_name'), 'rescored')
-        self.assertGreater(output.get('duration_ms'), 0)
+
+        self.assert_task_output(
+            output=self.get_task_output(task_entry.id),
+            total=num_students,
+            attempted=num_students,
+            succeeded=num_students,
+            skipped=0,
+            failed=0,
+            action_name='rescored'
+        )
 
     def test_rescoring_bad_result(self):
-        # Confirm that rescoring does not succeed if "success" key is not an expected value.
+        """
+        Tests and confirm that rescoring does not succeed if "success" key is not an expected value.
+        """
         input_state = json.dumps({'done': True})
         num_students = 10
         self._create_students_with_state(num_students, input_state)
@@ -297,17 +343,21 @@ class TestRescoreInstructorTask(TestInstructorTasks):
         with patch('lms.djangoapps.instructor_task.tasks_helper.get_module_for_descriptor_internal') as mock_get_module:
             mock_get_module.return_value = mock_instance
             self._run_task_with_mock_celery(rescore_problem, task_entry.id, task_entry.task_id)
-        # check return value
-        entry = InstructorTask.objects.get(id=task_entry.id)
-        output = json.loads(entry.task_output)
-        self.assertEquals(output.get('attempted'), num_students)
-        self.assertEquals(output.get('succeeded'), 0)
-        self.assertEquals(output.get('total'), num_students)
-        self.assertEquals(output.get('action_name'), 'rescored')
-        self.assertGreater(output.get('duration_ms'), 0)
+
+        self.assert_task_output(
+            output=self.get_task_output(task_entry.id),
+            total=num_students,
+            attempted=num_students,
+            succeeded=0,
+            skipped=0,
+            failed=num_students,
+            action_name='rescored'
+        )
 
     def test_rescoring_missing_result(self):
-        # Confirm that rescoring does not succeed if "success" key is not returned.
+        """
+        Tests and confirm that rescoring does not succeed if "success" key is not returned.
+        """
         input_state = json.dumps({'done': True})
         num_students = 10
         self._create_students_with_state(num_students, input_state)
@@ -317,14 +367,16 @@ class TestRescoreInstructorTask(TestInstructorTasks):
         with patch('lms.djangoapps.instructor_task.tasks_helper.get_module_for_descriptor_internal') as mock_get_module:
             mock_get_module.return_value = mock_instance
             self._run_task_with_mock_celery(rescore_problem, task_entry.id, task_entry.task_id)
-        # check return value
-        entry = InstructorTask.objects.get(id=task_entry.id)
-        output = json.loads(entry.task_output)
-        self.assertEquals(output.get('attempted'), num_students)
-        self.assertEquals(output.get('succeeded'), 0)
-        self.assertEquals(output.get('total'), num_students)
-        self.assertEquals(output.get('action_name'), 'rescored')
-        self.assertGreater(output.get('duration_ms'), 0)
+
+        self.assert_task_output(
+            output=self.get_task_output(task_entry.id),
+            total=num_students,
+            attempted=num_students,
+            succeeded=0,
+            skipped=0,
+            failed=num_students,
+            action_name='rescored'
+        )
 
 
 @attr(shard=3)


### PR DESCRIPTION
## [TNL-6199](https://openedx.atlassian.net/browse/TNL-6199) - Unable to rescore problem for entire class in MIT course

### Description

The course Supply Chain Analytics is setup with **2 Content Groups (General, Verified)**  and Cohorts. 
I see a user **_Esteban_Mascarino_** found to be in **Default Group Cohort** which is assigned **General Content Group**.

The [Mid Term:Problem 2:Question 2](https://studio.edx.org/container/block-v1:MITx+CTL.SC0x+3T2016+type@problem+block@4b113f0528374737a0ba03409d39e629): is assigned **Verified Content group** which means it should not be available for **_Esteban_Mascarino_** to view or answer. But somehow **_Esteban_Mascarino_** was able to access it and answer it and now it is not accessible to him.

### Fix
We agreed to make the code resilient to access changes made to any block.
Also we agree to  @adampalay's suggestion to replace the raise exception on that line to returning a failure status.
### How to Test?

**Stage** 
Here is how it can be reproduced locally or on stage.
https://awaisdar001.sandbox.edx.org/

**Verified on stage.**
https://awaisdar001.sandbox.edx.org/courses/course-v1:DemoX+PERF101+course/courseware/cac5bd504ad948508aa28e2351067685/41b75254e5214c5ebe456139d8a7bf22/
```
CG1 => Content Group 1
CG2 => Content Group 2
P1 => Problem1
P2 => Problem2
U1 => User1
U2 => User2
```

- Create two Content Groups **CG1** and **CG2** in Studio. 
- Create the problem **P1** and assign it **CG1** Content Group.
- Enable Cohorts from Instructor tab and Add a user **U1** in **CG1**
- Answer the problem **P1** as U1.
- Change the problem **P1** visibility from Content Group **CG1** to Content Group **CG2**
- Go to Instructor Dashboard - Student Admin
- Under the "**_Adjust all enrolled learners' grades for a specific problem_**" area, input the problem **P1** location.
- Expect the error


**Sandbox**
Build a sandbox for your branch and add a link here and mention if how to verify the fix.


**Screenshots**
_Not Applicable_


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @attiyaIshaque 
- [x] Code review: @Qubad786 
- [x] Code review:  @attiyaIshaque

FYI: @adampalay @nasthagiri 

### Post-review
- [ ] Rebase and squash commits