### PR TITLE
ziafazal/WL-755: disable password reset button after click

### DIFF
--- a/lms/static/js/spec/student_account/account_settings_fields_spec.js
+++ b/lms/static/js/spec/student_account/account_settings_fields_spec.js
@@ -31,11 +31,14 @@ define(['backbone',
 
                 var fieldData = FieldViewsSpecHelpers.createFieldData(AccountSettingsFieldViews.PasswordFieldView, {
                     linkHref: '/password_reset',
-                    emailAttribute: 'email'
+                    emailAttribute: 'email',
+                    valueAttribute: 'password'
                 });
 
                 var view = new AccountSettingsFieldViews.PasswordFieldView(fieldData).render();
+                expect(view.$('.u-field-value > button').is(':disabled')).toBe(false);
                 view.$('.u-field-value > button').click();
+                expect(view.$('.u-field-value > button').is(':disabled')).toBe(true);
                 AjaxHelpers.expectRequest(requests, 'POST', '/password_reset', 'email=legolas%40woodland.middlearth');
                 AjaxHelpers.respondWithJson(requests, {'success': 'true'});
                 FieldViewsSpecHelpers.expectMessageContains(

--- a/lms/static/js/student_account/views/account_settings_fields.js
+++ b/lms/static/js/student_account/views/account_settings_fields.js
@@ -151,6 +151,7 @@
                 },
                 linkClicked: function(event) {
                     event.preventDefault();
+                    this.toggleDisableButton(true);
                     this.resetPassword(event);
                 },
                 resetPassword: function() {
@@ -169,8 +170,15 @@
                         error: function(xhr) {
                             view.showErrorMessage(xhr);
                             view.setMessageTimeout();
+                            view.toggleDisableButton(false);
                         }
                     });
+                },
+                toggleDisableButton: function(disabled) {
+                    var button = this.$('#u-field-link-' + this.options.valueAttribute);
+                    if (button) {
+                        button.prop('disabled', disabled);
+                    }
                 },
                 setMessageTimeout: function() {
                     var view = this;


### PR DESCRIPTION
This PR has changes to disable password reset button after being clicked to avoid sending multiple emails if user clicks reset password button multiple times.
[WL-755](https://openedx.atlassian.net/browse/WL-755) has more details on the issue it addresses.

@ayesha-baig would you please review.