### PR TITLE
Error while exporting course with too long filename

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -9,6 +9,7 @@ from mock import patch, Mock
 from django.test.utils import override_settings
 from django.conf import settings
 from django.utils import translation
+from django.utils.crypto import get_random_string
 
 from nose.plugins.skip import SkipTest
 
@@ -229,6 +230,17 @@ class TestDownloadYoutubeSubs(SharedModuleStoreTestCase):
         self.assertEqual(html5_ids[1], 'foo.1.bar')
         self.assertEqual(html5_ids[2], 'baz.1.4')
         self.assertEqual(html5_ids[3], 'foo')
+
+    def test_html5_id_length(self):
+        """
+        Test that html5_id is parsed with length less than 255, as html5 ids are
+        used as name for transcript objects and ultimately as filename while creating
+        file for transcript at the time of exporting a course.
+        Filename can't be longer than 255 characters.
+        150 chars is agreed length.
+        """
+        html5_ids = transcripts_utils.get_html5_ids([get_random_string(255)])
+        self.assertEqual(len(html5_ids[0]), 150)
 
     @patch('xmodule.video_module.transcripts_utils.requests.get')
     def test_fail_downloading_subs(self, mock_get):

--- a/cms/static/js/spec/video/transcripts/utils_spec.js
+++ b/cms/static/js/spec/video/transcripts/utils_spec.js
@@ -215,6 +215,42 @@ function($, _, Utils, _str) {
                     });
                 });
             });
+
+            describe('Too long arguments ', function() {
+                var longFileName = (function() {
+                        var text = '';
+                        var possibleChars = 'abcdefghijklmnopqrstuvwxyz';
+                        /* eslint vars-on-top: 0 */
+                        for (var i = 0; i < 255; i++) {
+                            text += possibleChars.charAt(Math.floor(Math.random() * possibleChars.length));
+                        }
+                        return text;
+                    }()),
+                    html5LongUrls = (function(videoName) {
+                        var links = [
+                            'http://somelink.com/%s?param=1&param=2#hash',
+                            'http://somelink.com/%s#hash',
+                            'http://somelink.com/%s?param=1&param=2',
+                            'http://somelink.com/%s',
+                            'ftp://somelink.com/%s',
+                            'https://somelink.com/%s',
+                            'https://somelink.com/sub/sub/%s',
+                            'http://cdn.somecdn.net/v/%s',
+                            'somelink.com/%s',
+                            '%s'
+                        ];
+                        return $.map(links, function(link) {
+                            return _str.sprintf(link, videoName);
+                        });
+                    }(longFileName));
+
+                $.each(html5LongUrls, function(index, link) {
+                    it(link, function() {
+                        var result = Utils.parseHTML5Link(link);
+                        expect(result.video.length).toBe(150);
+                    });
+                });
+            });
         });
 
         it('Method: getYoutubeLink', function() {

--- a/cms/static/js/views/video/transcripts/utils.js
+++ b/cms/static/js/views/video/transcripts/utils.js
@@ -110,6 +110,7 @@ define(['jquery', 'underscore', 'jquery.ajaxQueue'], function($) {
      */
         var _videoLinkParser = (function() {
             var cache = {};
+            var maxVideoNameLength = 150;
 
             return function(url) {
                 if (typeof url !== 'string') {
@@ -129,7 +130,10 @@ define(['jquery', 'underscore', 'jquery.ajaxQueue'], function($) {
                 match = link.pathname.match(/\/{1}([^\/]+)\.([^\/]+)$/);
                 if (match) {
                     cache[url] = {
-                        video: match[1],
+                        /* avoid too long video name, as it will be used as filename for video's transcript
+                        and a filename can not be more that 255 chars, limiting here to 150.
+                        */
+                        video: match[1].slice(0, maxVideoNameLength),
                         type: match[2]
                     };
                 } else {
@@ -139,7 +143,7 @@ define(['jquery', 'underscore', 'jquery.ajaxQueue'], function($) {
                     match = link.pathname.match(/\/{1}([^\/\.]+)$/);
                     if (match) {
                         cache[url] = {
-                            video: match[1],
+                            video: match[1].slice(0, maxVideoNameLength),
                             type: 'other'
                         };
                     }

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -296,9 +296,11 @@ def copy_or_rename_transcript(new_name, old_name, item, delete_old=False, user=N
 def get_html5_ids(html5_sources):
     """
     Helper method to parse out an HTML5 source into the ideas
-    NOTE: This assumes that '/' are not in the filename
+    NOTE: This assumes that '/' are not in the filename.
+    Slices each id by 150, restricting too long strings as video names.
     """
-    html5_ids = [x.split('/')[-1].rsplit('.', 1)[0] for x in html5_sources]
+    html5_ids = [x.split('/')[-1].rsplit('.', 1)[0][:150] for x in html5_sources]
+
     return html5_ids
 
 


### PR DESCRIPTION
## [TNL-6197](https://openedx.atlassian.net/browse/TNL-6197)

### Description

Generation of video name is restricted to less than 255 characters to avoid 'File name too long' error, as video name is eventually used to create transcript file while exporting course.
Firstly, transcript object is created with video name and at the time of export same name is used as a filename.

### How to Test?

**Stage** 
Following are the steps to follow in order to observe this behavior.
- In any course, create a video unit.
- Set any additional URL resource for this video, say www.abc.com/{give-any-name-more-than-255-chars-here}.mp4
- Upload a transcript for this video.
- Try to export this course.
You will not be able to export.

Note: One can use text from attached file to use in 'additional URL resource' to avoid typing.
[video_name.txt](https://github.com/edx/edx-platform/files/674120/video_name.txt)

  

**Sandbox**
Repeat above steps and observe course is successfully exported.
- [Studio](https://studio-noraiz-anwar.sandbox.edx.org)

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Style and readability review: @Ayub-Khan 
- [x] Code review: @attiyaIshaque 
- [x] Code review: @Qubad786

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [ ] Rebase and squash commits
