### PR TITLE
Add course_name to enrollment api responses

### DIFF
--- a/common/djangoapps/enrollment/api.py
+++ b/common/djangoapps/enrollment/api.py
@@ -37,8 +37,9 @@ def get_enrollments(user_id):
                 "mode": "honor",
                 "is_active": True,
                 "user": "Bob",
-                "course": {
+                "course_details": {
                     "course_id": "edX/DemoX/2014T2",
+                    "course_name": "edX Demonstration Course",
                     "enrollment_end": "2014-12-20T20:18:00Z",
                     "enrollment_start": "2014-10-15T20:18:00Z",
                     "course_start": "2015-02-03T00:00:00Z",
@@ -64,8 +65,9 @@ def get_enrollments(user_id):
                 "mode": "verified",
                 "is_active": True,
                 "user": "Bob",
-                "course": {
+                "course_details": {
                     "course_id": "edX/edX-Insider/2014T2",
+                    "course_name": "edX Insider Course",
                     "enrollment_end": "2014-12-20T20:18:00Z",
                     "enrollment_start": "2014-10-15T20:18:00Z",
                     "course_start": "2015-02-03T00:00:00Z",
@@ -111,8 +113,9 @@ def get_enrollment(user_id, course_id):
             "mode": "honor",
             "is_active": True,
             "user": "Bob",
-            "course": {
+            "course_details": {
                 "course_id": "edX/DemoX/2014T2",
+                "course_name": "edX Demonstration Course",
                 "enrollment_end": "2014-12-20T20:18:00Z",
                 "enrollment_start": "2014-10-15T20:18:00Z",
                 "course_start": "2015-02-03T00:00:00Z",
@@ -163,8 +166,9 @@ def add_enrollment(user_id, course_id, mode=None, is_active=True):
             "mode": "audit",
             "is_active": True,
             "user": "Bob",
-            "course": {
+            "course_details": {
                 "course_id": "edX/DemoX/2014T2",
+                "course_name": "edX Demonstration Course",
                 "enrollment_end": "2014-12-20T20:18:00Z",
                 "enrollment_start": "2014-10-15T20:18:00Z",
                 "course_start": "2015-02-03T00:00:00Z",
@@ -217,8 +221,9 @@ def update_enrollment(user_id, course_id, mode=None, is_active=None, enrollment_
             "mode": "honor",
             "is_active": True,
             "user": "Bob",
-            "course": {
+            "course_details": {
                 "course_id": "edX/DemoX/2014T2",
+                "course_name": "edX Demonstration Course",
                 "enrollment_end": "2014-12-20T20:18:00Z",
                 "enrollment_start": "2014-10-15T20:18:00Z",
                 "course_start": "2015-02-03T00:00:00Z",
@@ -282,6 +287,7 @@ def get_course_enrollment_details(course_id, include_expired=False):
         >>> get_course_enrollment_details("edX/DemoX/2014T2")
         {
             "course_id": "edX/DemoX/2014T2",
+            "course_name": "edX Demonstration Course",
             "enrollment_end": "2014-12-20T20:18:00Z",
             "enrollment_start": "2014-10-15T20:18:00Z",
             "course_start": "2015-02-03T00:00:00Z",

--- a/common/djangoapps/enrollment/serializers.py
+++ b/common/djangoapps/enrollment/serializers.py
@@ -36,6 +36,7 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     """
 
     course_id = serializers.CharField(source="id")
+    course_name = serializers.CharField(source="display_name_with_default")
     enrollment_start = serializers.DateTimeField(format=None)
     enrollment_end = serializers.DateTimeField(format=None)
     course_start = serializers.DateTimeField(source="start", format=None)

--- a/common/djangoapps/enrollment/tests/test_data.py
+++ b/common/djangoapps/enrollment/tests/test_data.py
@@ -71,6 +71,7 @@ class EnrollmentDataTest(ModuleStoreTestCase):
         # Confirm the returned enrollment and the data match up.
         self.assertEqual(course_mode, enrollment['mode'])
         self.assertEqual(is_active, enrollment['is_active'])
+        self.assertEqual(self.course.display_name_with_default, enrollment['course_details']['course_name'])
 
     def test_unenroll(self):
         # Enroll the user in the course

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -191,8 +191,13 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
             )
 
         # Create an enrollment
-        self.assert_enrollment_status()
+        resp = self.assert_enrollment_status()
 
+        # Verify that the response contains the correct course_name
+        data = json.loads(resp.content)
+        self.assertEqual(self.course.display_name_with_default, data['course_details']['course_name'])
+
+        # Verify that the enrollment was created correctly
         self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))
         course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
         self.assertTrue(is_active)
@@ -212,6 +217,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = json.loads(resp.content)
         self.assertEqual(unicode(self.course.id), data['course_details']['course_id'])
+        self.assertEqual(self.course.display_name_with_default, data['course_details']['course_name'])
         self.assertEqual(CourseMode.DEFAULT_MODE_SLUG, data['mode'])
         self.assertTrue(data['is_active'])
 
@@ -329,8 +335,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = json.loads(response.content)
         self.assertItemsEqual(
-            [enrollment['course_details']['course_id'] for enrollment in data],
-            [unicode(course.id) for course in courses]
+            [(datum['course_details']['course_id'], datum['course_details']['course_name']) for datum in data],
+            [(unicode(course.id), course.display_name_with_default) for course in courses]
         )
 
     def test_enrollment_list_permissions(self):
@@ -411,6 +417,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase):
 
         data = json.loads(resp.content)
         self.assertEqual(unicode(self.course.id), data['course_id'])
+        self.assertEqual(self.course.display_name_with_default, data['course_name'])
         mode = data['course_modes'][0]
         self.assertEqual(mode['slug'], CourseMode.HONOR)
         self.assertEqual(mode['sku'], '123')

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -99,6 +99,7 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
                 * course_end: The date and time when the course closes. If
                   null, the course never ends.
                 * course_id: The unique identifier for the course.
+                * course_name: The name of the course.
                 * course_modes: An array of data about the enrollment modes
                   supported for the course. If the request uses the parameter
                   include_expired=1, the array also includes expired
@@ -216,6 +217,7 @@ class EnrollmentCourseDetailView(APIView):
                 * course_end: The date and time when the course closes. If
                   null, the course never ends.
                 * course_id: The unique identifier for the course.
+                * course_name: The name of the course.
                 * course_modes: An array of data about the enrollment modes
                   supported for the course. If the request uses the parameter
                   include_expired=1, the array also includes expired
@@ -399,6 +401,8 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                   null, the course never ends.
 
                 * course_id: The unique identifier for the course.
+
+                * course_name: The name of the course.
 
                 * course_modes: An array of data about the enrollment modes
                   supported for the course. If the request uses the parameter

--- a/docs/en_us/platform_api/source/enrollment/enrollment.rst
+++ b/docs/en_us/platform_api/source/enrollment/enrollment.rst
@@ -33,6 +33,7 @@ Get the User's Enrollment Status in a Course
         "is_active": true,
         "course_details": {
             "course_id": "edX/DemoX/Demo_Course",
+            "course_name": "edX Demonstration Course",
             "enrollment_end": null,
             "course_modes": [
                 {
@@ -70,6 +71,7 @@ Get the User's Enrollment Information for a Course
 
     {
         "course_id": "edX/DemoX/Demo_Course",
+        "course_name": "edX Demonstration Course",
         "enrollment_end": null,
         "course_modes": [
             {
@@ -112,6 +114,7 @@ View a User's Enrollments or Enroll a User in a Course
             "is_active": true,
             "course_details": {
                 "course_id": "edX/DemoX/Demo_Course",
+                "course_name": "edX Demonstration Course",
                 "enrollment_end": null,
                 "course_modes": [
                     {
@@ -135,6 +138,7 @@ View a User's Enrollments or Enroll a User in a Course
             "is_active": true,
             "course_details": {
                 "course_id": "ArbisoftX/BulkyEmail101/2014-15",
+                "course_name": "Course Name Here",
                 "enrollment_end": null,
                 "course_modes": [
                     {


### PR DESCRIPTION
This PR introduces a change to the enrollment API that would result in the course display_name being included in the course_details portion of the response object. This is necessary for the changes requested in https://openedx.atlassian.net/browse/ECOM-5936.

@edx/ecommerce please review.