### PR TITLE
hide_after_due for self paced courses

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -981,6 +981,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         "release_date": release_date,
         "visibility_state": visibility_state,
         "has_explicit_staff_lock": xblock.fields['visible_to_staff_only'].is_set_on(xblock),
+        "self_paced": is_self_paced(course),
         "start": xblock.fields['start'].to_json(xblock.start),
         "graded": xblock.graded,
         "due_date": get_default_time_display(xblock.due),

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -712,7 +712,10 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             return $.extend(
                 {},
                 AbstractVisibilityEditor.prototype.getContext.call(this),
-                {hide_after_due: this.modelVisibility() === 'hide_after_due'}
+                {
+                    hide_after_due: this.modelVisibility() === 'hide_after_due',
+                    self_paced: this.model.get('self_paced') === true
+                }
             );
         }
     });

--- a/cms/templates/js/content-visibility-editor.underscore
+++ b/cms/templates/js/content-visibility-editor.underscore
@@ -12,9 +12,19 @@
         <li class="field-radio">
             <label class="label">
                 <input class="input input-radio" name="content-visibility" type="radio" value="hide_after_due" aria-described-by="hide_after_due_description">
-                <%- gettext('Hide content after due date') %>
+                <% if (self_paced) { %>
+                    <%- gettext('Hide content after course end date') %>
+                <% } else { %>
+                    <%- gettext('Hide content after due date') %>
+                <% } %>
             </label>
-            <p class='field-message' id='hide_after_due_description'> <%- gettext('After the subsection\'s due date has passed, learners can no longer access its content. The subsection remains included in grade calculations.') %> </p>
+            <p class='field-message' id='hide_after_due_description'>
+                <% if (self_paced) { %>
+                    <%- gettext('After the course\'s end date has passed, learners can no longer access subsection content. The subsection remains included in grade calculations.') %>
+                <% } else { %>
+                    <%- gettext('After the subsection\'s due date has passed, learners can no longer access its content. The subsection remains included in grade calculations.') %>
+                <% } %>
+            </p>
         </li>
         <li class="field-radio">
             <label class="label">
@@ -29,7 +39,7 @@
     <% if (hasExplicitStaffLock && !ancestorLocked) { %>
         <p class="tip tip-warning">
             <%- interpolate(
-                gettext('If you select an option other than "%(hide_label)s", after the subsection release date has passed, published units in this subsection will become available to learners unless units are explicitly hidden.'),
+                gettext('If you select an option other than "%(hide_label)s", published units in this subsection become available to learners unless they are explicitly hidden.'),
                 { hide_label: hide_label },
                 true
             ) %>

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -201,7 +201,12 @@ if (is_proctored_exam) {
                 <p>
                     <% if (xblockInfo.get('hide_after_due')) { %>
                         <span class="icon fa fa-eye-slash" aria-hidden="true"></span>
-                        <span class="status-hide-after-due-value"> <%- gettext("Subsection is hidden after due date") %> </span>
+                        <span class="status-hide-after-due-value">
+                        <% if (course.get('self_paced')) { %>
+                            <%- gettext("Subsection is hidden after course end date") %> </span>
+                        <% } else { %>
+                            <%- gettext("Subsection is hidden after due date") %> </span>
+                        <% } %>
                     <% } %>
                 </p>
             </div>

--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -3,49 +3,46 @@ Tests for sequence module.
 """
 # pylint: disable=no-member
 from datetime import timedelta
-import ddt
 from django.utils.timezone import now
 from freezegun import freeze_time
-from mock import Mock
+from mock import Mock, patch
+from xmodule.seq_module import SequenceModule
 from xmodule.tests import get_test_system
 from xmodule.tests.helpers import StubUserService
-from xmodule.tests.xml import XModuleXmlImportTest
-from xmodule.tests.xml import factories as xml
+from xmodule.tests.xml import factories as xml, XModuleXmlImportTest
 from xmodule.x_module import STUDENT_VIEW
-from xmodule.seq_module import SequenceModule
+
+TODAY = now()
+DUE_DATE = TODAY + timedelta(days=7)
+PAST_DUE_BEFORE_END_DATE = TODAY + timedelta(days=14)
+COURSE_END_DATE = TODAY + timedelta(days=21)
 
 
-@ddt.ddt
 class SequenceBlockTestCase(XModuleXmlImportTest):
     """
-    Tests for the Sequence Module.
+    Base class for tests of Sequence Module.
     """
-    TODAY = now()
-    TOMORROW = TODAY + timedelta(days=1)
-    DAY_AFTER_TOMORROW = TOMORROW + timedelta(days=1)
+    def setUp(self):
+        super(SequenceBlockTestCase, self).setUp()
 
-    @classmethod
-    def setUpClass(cls):
-        super(SequenceBlockTestCase, cls).setUpClass()
+        course_xml = self._set_up_course_xml()
+        self.course = self.process_xml(course_xml)
+        self._set_up_module_system(self.course)
 
-        course_xml = cls._set_up_course_xml()
-        cls.course = cls.process_xml(course_xml)
-        cls._set_up_module_system(cls.course)
-
-        for chapter_index in range(len(cls.course.get_children())):
-            chapter = cls._set_up_block(cls.course, chapter_index)
-            setattr(cls, 'chapter_{}'.format(chapter_index + 1), chapter)
+        for chapter_index in range(len(self.course.get_children())):
+            chapter = self._set_up_block(self.course, chapter_index)
+            setattr(self, 'chapter_{}'.format(chapter_index + 1), chapter)
 
             for sequence_index in range(len(chapter.get_children())):
-                sequence = cls._set_up_block(chapter, sequence_index)
-                setattr(cls, 'sequence_{}_{}'.format(chapter_index + 1, sequence_index + 1), sequence)
+                sequence = self._set_up_block(chapter, sequence_index)
+                setattr(self, 'sequence_{}_{}'.format(chapter_index + 1, sequence_index + 1), sequence)
 
-    @classmethod
-    def _set_up_course_xml(cls):
+    @staticmethod
+    def _set_up_course_xml():
         """
         Sets up and returns XML course structure.
         """
-        course = xml.CourseFactory.build()
+        course = xml.CourseFactory.build(end=str(COURSE_END_DATE))
 
         chapter_1 = xml.ChapterFactory.build(parent=course)  # has 2 child sequences
         xml.ChapterFactory.build(parent=course)  # has 0 child sequences
@@ -58,7 +55,7 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         xml.SequenceFactory.build(  # sequence_4_1
             parent=chapter_4,
             hide_after_due=str(True),
-            due=str(cls.TOMORROW),
+            due=str(DUE_DATE),
         )
 
         for _ in range(3):
@@ -66,14 +63,13 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
 
         return course
 
-    @classmethod
-    def _set_up_block(cls, parent, index_in_parent):
+    def _set_up_block(self, parent, index_in_parent):
         """
         Sets up the stub sequence module for testing.
         """
         block = parent.get_children()[index_in_parent]
 
-        cls._set_up_module_system(block)
+        self._set_up_module_system(block)
 
         block.xmodule_runtime._services['bookmarks'] = Mock()  # pylint: disable=protected-access
         block.xmodule_runtime._services['user'] = StubUserService()  # pylint: disable=protected-access
@@ -81,14 +77,35 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         block.parent = parent.location
         return block
 
-    @classmethod
-    def _set_up_module_system(cls, block):
+    def _set_up_module_system(self, block):
         """
         Sets up the test module system for the given block.
         """
         module_system = get_test_system()
         module_system.descriptor_runtime = block._runtime  # pylint: disable=protected-access
         block.xmodule_runtime = module_system
+
+    def _get_rendered_student_view(self, sequence, requested_child=None, extra_context=None, self_paced=False):
+        """
+        Returns the rendered student view for the given sequence and the
+        requested_child parameter.
+        """
+        context = {'requested_child': requested_child}
+        if extra_context:
+            context.update(extra_context)
+
+        # The render operation will ask modulestore for the current course to get some data. As these tests were
+        # originally not written to be compatible with a real modulestore, we've mocked out the relevant return values.
+        with patch.object(SequenceModule, '_get_course') as mock_course:
+            self.course.self_paced = self_paced
+            mock_course.return_value = self.course
+            return sequence.xmodule_runtime.render(sequence, STUDENT_VIEW, context).content
+
+    def _assert_view_at_position(self, rendered_html, expected_position):
+        """
+        Verifies that the rendered view contains the expected position.
+        """
+        self.assertIn("'position': {}".format(expected_position), rendered_html)
 
     def test_student_view_init(self):
         seq_module = SequenceModule(runtime=Mock(position=2), descriptor=Mock(), scope_ids=Mock())
@@ -112,22 +129,6 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         html = self._get_rendered_student_view(self.sequence_3_1, requested_child='last')
         self._assert_view_at_position(html, expected_position=3)
 
-    def _get_rendered_student_view(self, sequence, requested_child=None, extra_context=None):
-        """
-        Returns the rendered student view for the given sequence and the
-        requested_child parameter.
-        """
-        context = {'requested_child': requested_child}
-        if extra_context:
-            context.update(extra_context)
-        return sequence.xmodule_runtime.render(sequence, STUDENT_VIEW, context).content
-
-    def _assert_view_at_position(self, rendered_html, expected_position):
-        """
-        Verifies that the rendered view contains the expected position.
-        """
-        self.assertIn("'position': {}".format(expected_position), rendered_html)
-
     def test_tooltip(self):
         html = self._get_rendered_student_view(self.sequence_3_1, requested_child=None)
         for child in self.sequence_3_1.children:
@@ -138,26 +139,18 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         self.assertIn("seq_module.html", html)
         self.assertIn("'banner_text': None", html)
 
-    @freeze_time(DAY_AFTER_TOMORROW)
-    @ddt.data(
-        (None, 'subsection'),
-        ('Homework', 'homework'),
-    )
-    @ddt.unpack
-    def test_hidden_content_past_due(self, format_type, expected_text):
+    @freeze_time(COURSE_END_DATE)
+    def test_hidden_content_past_due(self):
         progress_url = 'http://test_progress_link'
-        self._set_sequence_format(self.sequence_4_1, format_type)
         html = self._get_rendered_student_view(
             self.sequence_4_1,
             extra_context=dict(progress_url=progress_url),
         )
         self.assertIn("hidden_content.html", html)
         self.assertIn(progress_url, html)
-        self.assertIn("'subsection_format': '{}'".format(expected_text), html)
 
-    @freeze_time(DAY_AFTER_TOMORROW)
+    @freeze_time(COURSE_END_DATE)
     def test_masquerade_hidden_content_past_due(self):
-        self._set_sequence_format(self.sequence_4_1, "Homework")
         html = self._get_rendered_student_view(
             self.sequence_4_1,
             extra_context=dict(specific_masquerade=True),
@@ -165,13 +158,23 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         self.assertIn("seq_module.html", html)
         self.assertIn(
             "'banner_text': 'Because the due date has passed, "
-            "this homework is hidden from the learner.'",
+            "this assignment is hidden from the learner.'",
             html
         )
 
-    def _set_sequence_format(self, sequence, format_type):
-        """
-        Sets the format field on the given sequence to the
-        given value.
-        """
-        sequence._xmodule.format = format_type  # pylint: disable=protected-access
+    @freeze_time(PAST_DUE_BEFORE_END_DATE)
+    def test_hidden_content_self_paced_past_due_before_end(self):
+        html = self._get_rendered_student_view(self.sequence_4_1, self_paced=True)
+        self.assertIn("seq_module.html", html)
+        self.assertIn("'banner_text': None", html)
+
+    @freeze_time(COURSE_END_DATE + timedelta(days=7))
+    def test_hidden_content_self_paced_past_end(self):
+        progress_url = 'http://test_progress_link'
+        html = self._get_rendered_student_view(
+            self.sequence_4_1,
+            extra_context=dict(progress_url=progress_url),
+            self_paced=True,
+        )
+        self.assertIn("hidden_content.html", html)
+        self.assertIn(progress_url, html)

--- a/common/test/acceptance/pages/lms/courseware.py
+++ b/common/test/acceptance/pages/lms/courseware.py
@@ -209,13 +209,13 @@ class CoursewarePage(CoursePage):
         """
         return self.q(css="div.proctored-exam.completed").visible
 
-    def content_hidden_past_due_date(self, content_type="subsection"):
+    def content_hidden_past_due_date(self):
         """
         Returns whether the "the due date for this ___ has passed" message is present.
         ___ is the type of the hidden content, and defaults to subsection.
         This being true implies "the ___ contents are hidden because their due date has passed".
         """
-        message = "The due date for this {0} has passed.".format(content_type)
+        message = "this assignment is no longer available"
         if self.q(css="div.seq_content").is_present():
             return False
         for html in self.q(css="div.hidden-content").html:

--- a/lms/djangoapps/course_blocks/transformers/hidden_content.py
+++ b/lms/djangoapps/course_blocks/transformers/hidden_content.py
@@ -25,7 +25,7 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
 
     Staff users are exempted from hidden content rules.
     """
-    VERSION = 1
+    VERSION = 2
     MERGED_DUE_DATE = 'merged_due_date'
     MERGED_HIDE_AFTER_DUE = 'merged_hide_after_due'
 
@@ -41,7 +41,7 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
     def _get_merged_hide_after_due(cls, block_structure, block_key):
         """
         Returns whether the block with the given block_key in the
-        given block_structure should be visible to staff only per
+        given block_structure should be hidden after due date per
         computed value from ancestry chain.
         """
         return block_structure.get_transformer_block_field(
@@ -81,6 +81,8 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
             func_merge_ancestors=min,
         )
 
+        block_structure.request_xblock_fields(u'self_paced', u'end')
+
     def transform_block_filters(self, usage_info, block_structure):
         # Users with staff access bypass the Visibility check.
         if usage_info.has_staff_access:
@@ -97,6 +99,10 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
         Returns whether the block with the given block_key should
         be hidden, given the current time.
         """
-        due = self._get_merged_due_date(block_structure, block_key)
         hide_after_due = self._get_merged_hide_after_due(block_structure, block_key)
-        return not SequenceModule.verify_current_content_visibility(due, hide_after_due)
+        self_paced = block_structure[block_structure.root_block_usage_key].self_paced
+        if self_paced:
+            hidden_date = block_structure[block_structure.root_block_usage_key].end
+        else:
+            hidden_date = self._get_merged_due_date(block_structure, block_key)
+        return not SequenceModule.verify_current_content_visibility(hidden_date, hide_after_due)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -199,7 +199,7 @@ class IndexQueryTestCase(ModuleStoreTestCase):
     NUM_PROBLEMS = 20
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 8),
+        (ModuleStoreEnum.Type.mongo, 9),
         (ModuleStoreEnum.Type.split, 4),
     )
     @ddt.unpack

--- a/lms/templates/hidden_content.html
+++ b/lms/templates/hidden_content.html
@@ -5,22 +5,35 @@ from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <div class="sequence hidden-content proctored-exam completed">
-  <h3>
-      ${_("The due date for this {subsection_format} has passed.").format(
-        subsection_format=subsection_format,
-      )}
-  </h3>
-  <hr>
-  <p>
-      ${Text(_(
-          "Because the due date has passed, this {subsection_format} "
-          "is no longer available.{line_break}If you have completed this {subsection_format}, "
-          "your grade is available on the {link_start}progress page{link_end}."
-        )).format(
-          subsection_format=subsection_format,
-          line_break=HTML("<br>"),
-          link_start=HTML("<a href='{}'>").format(progress_url),
-          link_end=HTML("</a>"),
-      )}
-  </p>
+    <h3>
+        % if self_paced:
+            ${_("The course has ended.")}
+        % else:
+            ${_("The due date for this assignment has passed.")}
+        % endif
+    </h3>
+    <hr>
+    <p>
+        % if self_paced:
+            ${Text(_(
+                "Because the course has ended, this assignment is no longer "
+                "available.{line_break}If you have completed this assignment, your "
+                "grade is available on the {link_start}progress page{link_end}."
+            )).format(
+                line_break=HTML("<br>"),
+                link_start=HTML("<a href='{}'>").format(progress_url),
+                link_end=HTML("</a>"),
+            )}
+        % else:
+            ${Text(_(
+                "Because the due date has passed, this assignment is no longer "
+                "available.{line_break}If you have completed this assignment, your "
+                "grade is available on the {link_start}progress page{link_end}."
+            )).format(
+                line_break=HTML("<br>"),
+                link_start=HTML("<a href='{}'>").format(progress_url),
+                link_end=HTML("</a>"),
+            )}
+        % endif
+    </p>
 </div>


### PR DESCRIPTION
# [TNL-6108](https://openedx.atlassian.net/browse/TNL-6108)

`hide_after_due` does not function in self-paced courses, as due dates are suppressed. Instead, we ought to check against the course end date in these scenarios.