### PR TITLE
generate sequence-specific titles server-side

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/sequence/display.js
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.js
@@ -57,8 +57,8 @@
             this.ajaxUrl = this.el.data('ajax-url');
             this.nextUrl = this.el.data('next-url');
             this.prevUrl = this.el.data('prev-url');
-            this.base_page_title = ' | ' + document.title;
             this.keydownHandler($(element).find('#sequence-list .tab'));
+            this.base_page_title = ($('title').data('base-title') || '').trim();
             this.bind();
             this.render(parseInt(this.el.data('position'), 10));
         }
@@ -136,10 +136,15 @@
 
         Sequence.prototype.updatePageTitle = function() {
             // update the page title to include the current section
-            var positionLink = this.link_for(this.position);
+            var currentSectionTitle,
+                positionLink = this.link_for(this.position);
 
             if (positionLink && positionLink.data('page-title')) {
-                document.title = positionLink.data('page-title') + this.base_page_title;
+                currentSectionTitle = positionLink.data('page-title') + ' | ' + this.base_page_title;
+
+                if (currentSectionTitle !== document.title) {
+                    document.title = currentSectionTitle;
+                }
             }
         };
 

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1824,6 +1824,7 @@ class ViewCheckerBlock(XBlock):
     """
     has_children = True
     state = String(scope=Scope.user_state)
+    position = 0
 
     def student_view(self, context):  # pylint: disable=unused-argument
         """

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -388,6 +388,8 @@ class CoursewareIndex(View):
             'bookmarks_api_url': reverse('bookmarks'),
             'language_preference': self._get_language_preference(),
             'disable_optimizely': True,
+            'section_title': None,
+            'sequence_title': None
         }
         table_of_contents = toc_for_course(
             self.effective_user,
@@ -437,6 +439,11 @@ class CoursewareIndex(View):
                 table_of_contents['next_of_active_section'],
             )
             courseware_context['fragment'] = self.section.render(STUDENT_VIEW, section_context)
+            if self.section.position and self.section.has_children:
+                display_items = self.section.get_display_items()
+                if display_items:
+                    courseware_context['sequence_title'] = display_items[self.section.position - 1] \
+                        .display_name_with_default
 
         return courseware_context
 

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -19,13 +19,11 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 
 <%block name="bodyclass">view-in-course view-courseware courseware ${course.css_class or ''}</%block>
 
-<%block name="title"><title>
-    % if section_title:
-${static.get_page_title_breadcrumbs(section_title, course_name())}
-    % else:
-${static.get_page_title_breadcrumbs(course_name())}
-    %endif
-</title></%block>
+<%block name="title">
+<title data-base-title="${static.get_page_title_breadcrumbs(section_title, course_name())}">
+  ${static.get_page_title_breadcrumbs(sequence_title, section_title, course_name())}
+</title>
+</%block>
 
 <%block name="header_extras">
 

--- a/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/openedx/core/djangoapps/site_configuration/helpers.py
@@ -211,6 +211,7 @@ def page_title_breadcrumbs(*crumbs, **kwargs):
     """
     platform_name = get_value('platform_name', settings.PLATFORM_NAME)
     separator = kwargs.get("separator", " | ")
+    crumbs = [c for c in crumbs if c is not None]
     if crumbs:
         return u'{}{}{}'.format(separator.join(crumbs), separator, platform_name)
     else:


### PR DESCRIPTION
### What

Include the name of the selected sequence item (if it exists) in the courseware page title when the page is rendered server-side, instead of doing it on the fly with JS after the page has already loaded. Update the client-side method for updating the title to account for the existing sequence item title.

### Why

Updating the page title on the fly [breaks the pa11ycrawler](https://openedx.atlassian.net/browse/AC-695) and is unnecessary. We already have the full page context server-side so there's no need to wait till the page loads to update the title. Furthermore, changing the title without changing the content of the page constitutes an unnecessary change of context (https://www.w3.org/TR/UNDERSTANDING-WCAG20/consistent-behavior-no-extreme-changes-context.html) which could confuse screen reader users.

### Sandbox

https://arizzitano.sandbox.edx.org/

### Post-Review
- [x] squash
- [ ] merge