### PR TITLE
Acceleration API v0 endpoint: /api/course_structure/v0/courses/

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1390,9 +1390,11 @@ class CourseSummary(object):
     A lightweight course summary class, which constructs split/mongo course summary without loading
     the course. It is used at cms for listing courses to global staff user.
     """
-    course_info_fields = ['display_name', 'display_coursenumber', 'display_organization']
+    course_info_fields = ['display_name', 'display_coursenumber', 'display_organization', 'start', 'end',
+                          'static_asset_path', 'course_image']
 
-    def __init__(self, course_locator, display_name=u"Empty", display_coursenumber=None, display_organization=None):
+    def __init__(self, course_locator, display_name=u"Empty", display_coursenumber=None, display_organization=None,
+                 start=None, end=None, static_asset_path=None, course_image=None):
         """
         Initialize and construct course summary
 
@@ -1413,6 +1415,12 @@ class CourseSummary(object):
         self.display_coursenumber = display_coursenumber
         self.display_organization = display_organization
         self.display_name = display_name
+
+        self.start = start
+        self.end = end
+        self.static_asset_path = static_asset_path
+        self.course_image = course_image
+        self.category = 'course'
 
         self.id = course_locator  # pylint: disable=invalid-name
         self.location = course_locator.make_usage_key('course', 'course')

--- a/lms/djangoapps/course_structure_api/v0/serializers.py
+++ b/lms/djangoapps/course_structure_api/v0/serializers.py
@@ -39,3 +39,19 @@ class CourseSerializer(serializers.Serializer):
     def get_image_url(self, course):
         """ Get the course image URL """
         return course_image_url(course)
+
+
+class CourseSummarySerializer(CourseSerializer):
+    """ Serializer for CourseSummary """
+
+    def get_org(self, course):
+        """ Gets the course org """
+        return course.location.org
+
+    def get_run(self, course):
+        """ Gets the course run """
+        return course.location.run
+
+    def get_course(self, course):
+        """ Gets the course """
+        return course.location.course

--- a/lms/djangoapps/course_structure_api/v0/views.py
+++ b/lms/djangoapps/course_structure_api/v0/views.py
@@ -151,7 +151,7 @@ class CourseList(CourseViewMixin, ListAPIView):
             * end: The course end date. If course end date is not specified, the
               value is null.
     """
-    serializer_class = serializers.CourseSerializer
+    serializer_class = serializers.CourseSummarySerializer
 
     def get_queryset(self):
         course_ids = self.request.query_params.get('course_id', None)
@@ -164,13 +164,10 @@ class CourseList(CourseViewMixin, ListAPIView):
                 course_descriptor = courses.get_course(course_key)
                 results.append(course_descriptor)
         else:
-            results = modulestore().get_courses()
-
-        # Ensure only course descriptors are returned.
-        results = (course for course in results if course.scope_ids.block_type == 'course')
+            results = modulestore().get_course_summaries()
 
         # Ensure only courses accessible by the user are returned.
-        results = (course for course in results if self.user_can_access_course(self.request.user, course))
+        results = (course for course in results if self.user_can_access_course(self.request.user, course.id))
 
         # Sort the results in a predictable manner.
         return sorted(results, key=lambda course: unicode(course.id))


### PR DESCRIPTION
The problem is that API v0 `/api/course_structure/v0/courses/` works very slow in case of the large number of courses (>400-500). This API is used in the edx analytics dashboard - the loading of the home page with the courses listing there could take about few minutes.

I've changed this API to use `modulestore().get_course_summaries()` instead of `modulestore().get_courses()` to improve performance.