### PR TITLE
DOC-3526 Clarify roles for cert activation

### DIFF
--- a/cms/templates/certificates.html
+++ b/cms/templates/certificates.html
@@ -92,7 +92,7 @@ CMS.User.isGlobalStaff = '${is_global_staff}'=='True' ? true : false;
             <p>${_("To view a sample certificate, choose a course mode and select {em_start}Preview Certificate{em_end}.").format(em_start='<strong>', em_end="</strong>")}</p>
 
             <h3 class="title-3">${_("Issuing Certificates to Learners")}</h3>
-            <p>${_("To begin issuing certificates, a course team member with the Admin role selects {em_start}Activate{em_end}. Only course team members with the Admin role can edit or delete an activated certificate.").format(em_start="<strong>", em_end="</strong>")}</p>
+            <p>${_("To begin issuing course certificates, a course team member with either the Staff or Admin role selects {em_start}Activate{em_end}. Only course team members with these roles can edit or delete an activated certificate.").format(em_start="<strong>", em_end="</strong>")}</p>
             <p>${_("{em_start}Do not{em_end} delete certificates after a course has started; learners who have already earned certificates will no longer be able to access them.").format(em_start="<strong>", em_end="</strong>")}</p>
             <p><a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about certificates")}</a></p>
           </div>


### PR DESCRIPTION
This PR updates the sidebar text on the Studio Certificates page to indicate that course team members with either the Staff OR Admin role can activate, edit, or delete certificates.

Reviewers:
- [x] Product: @marcotuts 
- [x] Doc sanity check: @srpearce 