### PR TITLE
Remove flaky decorator from test_capa_module

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -13,7 +13,6 @@ import textwrap
 import unittest
 
 import ddt
-import flaky
 from lxml import etree
 from mock import Mock, patch, DEFAULT
 import webob
@@ -1412,7 +1411,6 @@ class CapaModuleTest(unittest.TestCase):
         RANDOMIZATION.ALWAYS,
         RANDOMIZATION.ONRESET
     )
-    @flaky.flaky  # TNL-6041
     def test_random_seed_with_reset(self, rerandomize):
         """
         Run the test for each possible rerandomize value
@@ -1470,13 +1468,13 @@ class CapaModuleTest(unittest.TestCase):
         # to another valid seed
         else:
 
-            # Since there's a small chance we might get the
-            # same seed again, give it 5 chances
+            # Since there's a small chance (expected) we might get the
+            # same seed again, give it 10 chances
             # to generate a different seed
-            success = _retry_and_check(5, lambda: _reset_and_get_seed(module) != seed)
+            success = _retry_and_check(10, lambda: _reset_and_get_seed(module) != seed)
 
             self.assertIsNotNone(module.seed)
-            msg = 'Could not get a new seed from reset after 5 tries'
+            msg = 'Could not get a new seed from reset after 10 tries'
             self.assertTrue(success, msg)
 
     @ddt.data(


### PR DESCRIPTION
## [TNL-6041](https://openedx.atlassian.net/browse/TNL-6041)

### Description

This test point was marked flaky based on exactly one failure between August 1 and November 11, 2016. I looked at the code and didn't see any issues-- it's actually expected that sometimes the same "random seed" will be returned (to allow the benefits from some caching).

I increased the number of attempts to 10, and ran this test 121 times in Jenkins, with all passing.

### Sandbox
N/A

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @staubina 
- [x] Code review: @jlajoie 