### PR TITLE
Add /me endpoint for retrieving own username when logged in.

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -35,7 +35,16 @@ class AccountViewSet(ViewSet):
 
             PATCH /api/user/v1/accounts/{username}/{"key":"value"} "application/merge-patch+json"
 
-        **Response Values for GET**
+        **Response Values for GET requests to the /me endpoint**
+            If the user is not logged in, an HTTP 401 "Not Authorized" response
+            is returned.
+
+            Otherwise, an HTTP 200 "OK" response is returned. The response
+            contains the following value:
+
+            * username: The username associated with the account.
+
+        **Response Values for GET requests to /accounts endpoints**
 
             If no user exists with the specified username, an HTTP 404 "Not
             Found" response is returned.
@@ -152,13 +161,7 @@ class AccountViewSet(ViewSet):
         """
         GET /api/user/v1/me
         """
-        try:
-            account_settings = get_account_settings(
-                request, [request.user.username], view=request.query_params.get('view'))
-        except UserNotFound:
-            return Response(status=status.HTTP_403_FORBIDDEN if request.user.is_staff else status.HTTP_404_NOT_FOUND)
-
-        return Response(account_settings[0])
+        return Response({'username': request.user.username})
 
     def list(self, request):
         """

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -29,6 +29,7 @@ class AccountViewSet(ViewSet):
 
         **Example Requests**
 
+            GET /api/user/v1/me[?view=shared]
             GET /api/user/v1/accounts?usernames={username1,username2}[?view=shared]
             GET /api/user/v1/accounts/{username}/[?view=shared]
 
@@ -146,6 +147,18 @@ class AccountViewSet(ViewSet):
     )
     permission_classes = (permissions.IsAuthenticated,)
     parser_classes = (MergePatchParser,)
+
+    def get(self, request):
+        """
+        GET /api/user/v1/me
+        """
+        try:
+            account_settings = get_account_settings(
+                request, [request.user.username], view=request.query_params.get('view'))
+        except UserNotFound:
+            return Response(status=status.HTTP_403_FORBIDDEN if request.user.is_staff else status.HTTP_404_NOT_FOUND)
+
+        return Response(account_settings[0])
 
     def list(self, request):
         """

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -25,7 +25,7 @@ ACCOUNT_DETAIL = AccountViewSet.as_view({
 
 urlpatterns = patterns(
     '',
-    url(r'^v1/me$', ME, name='account_api'),
+    url(r'^v1/me$', ME, name='own_username_api'),
     url(r'^v1/accounts/{}$'.format(settings.USERNAME_PATTERN), ACCOUNT_DETAIL, name='accounts_api'),
     url(r'^v1/accounts$', ACCOUNT_LIST, name='accounts_detail_api'),
     url(

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -10,6 +10,9 @@ from .accounts.views import AccountViewSet
 from .preferences.views import PreferencesView, PreferencesDetailView
 from .verification_api.views import PhotoVerificationStatusView
 
+ME = AccountViewSet.as_view({
+    'get': 'get',
+})
 
 ACCOUNT_LIST = AccountViewSet.as_view({
     'get': 'list',
@@ -22,6 +25,7 @@ ACCOUNT_DETAIL = AccountViewSet.as_view({
 
 urlpatterns = patterns(
     '',
+    url(r'^v1/me$', ME, name='account_api'),
     url(r'^v1/accounts/{}$'.format(settings.USERNAME_PATTERN), ACCOUNT_DETAIL, name='accounts_api'),
     url(r'^v1/accounts$', ACCOUNT_LIST, name='accounts_detail_api'),
     url(


### PR DESCRIPTION
Based on @renevatium's work in https://github.com/edx/edx-platform/pull/13423, adds an endpoint where a logged-in user can retrieve their own username for use with an array of other APIs.

The original PR has already been reviewed; I am creating this one so I can squash commits without affecting the original branch.