### PR TITLE
Change CourseTeamMembership emit to use proper id

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -278,3 +278,4 @@ Casey Litton <caseylitton@gmail.com>
 Jhony Avella <jhony.avella@edunext.co>
 Tanmay Mohapatra <tanmaykm@gmail.com>
 Brian Mesick <bmesick@edx.org>
+Jeff LaJoie <jlajoie@edx.org>

--- a/lms/djangoapps/teams/models.py
+++ b/lms/djangoapps/teams/models.py
@@ -263,5 +263,5 @@ class CourseTeamMembership(models.Model):
         membership.team.save()
         membership.save()
         emit_team_event('edx.team.activity_updated', membership.team.course_id, {
-            'team_id': membership.team_id,
+            'team_id': membership.team.team_id,
         })

--- a/lms/djangoapps/teams/tests/test_models.py
+++ b/lms/djangoapps/teams/tests/test_models.py
@@ -172,7 +172,7 @@ class TeamSignalsTest(EventTestMixin, SharedModuleStoreTestCase):
             self.assertGreater(now, team_membership.last_activity_at)
             self.assert_event_emitted(
                 'edx.team.activity_updated',
-                team_id=team.id,
+                team_id=team.team_id,
             )
         else:
             self.assertEqual(team.last_activity_at, team_last_activity)


### PR DESCRIPTION
## [TNL-6186](https://openedx.atlassian.net/browse/TNL-6186)

### Description

The team_id that is emittd by the CourseTeamMembership was referencing the `membership.team_id` instead of the unique string identifier of the team itself, `membership.team.team_id`.

Steps to reproduce/verify on sandbox:
 
1. Bring up LMS, Studio, and Forums
2. [Create a team for a course](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/teams/teams_setup.html)
3. In the LMS, join the team you just created
4. As root tail the logs at ```/edx/var/log/tracking/tracking.log```
5. View the team, add a post as a Discussion
6. Expected event output in the logs should be similar to below, where the  event.team_id is a String: 

```{
	"username": "staff",
	"event_source": "server",
	"name": "edx.team.activity_updated",
	"accept_language": "en-US,en;q=0.8",
	"time": "2017-01-05T21:54:14.349710+00:00",
	"agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36",
	"page": null,
	"host": "precise64",
	"session": "3844e10a4eafaddfe29f76ef4d0f78de",
	"referer": "http://localhost:8000/courses/course-v1:edX+DemoX+Demo_Course/teams/",
	"context": {
		"course_user_tags": {},
		"user_id": 5,
		"org_id": "edX",
		"course_id": "course-v1:edX+DemoX+Demo_Course",
		"path": "/courses/course-v1:edX+DemoX+Demo_Course/discussion/7281a895d22b4fe5a8f7b4052128c2b2/threads/create"
	},
	"ip": "10.0.2.2",
	"event": {
		"team_id": "test-team-jeff-7281a895d22b4fe5a8f7b4052128c2b2"
	},
	"event_type": "edx.team.activity_updated"
}
```

### Sandbox
- [ ] https://jlajoie.sandbox.edx.org

Logs on sandbox following the above steps produce the following output:

```
{
	"username": "staff",
	"event_source": "server",
	"name": "edx.team.activity_updated",
	"accept_language": "en-US,en;q=0.8",
	"time": "2017-01-06T15:07:21.480373+00:00",
	"agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36",
	"page": null,
	"host": "jlajoie.sandbox.edx.org",
	"session": "250d9f4dd3804208a542b956e9ced3c7",
	"referer": "https://jlajoie.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/teams/",
	"context": {
		"course_user_tags": {},
		"user_id": 5,
		"org_id": "edX",
		"course_id": "course-v1:edX+DemoX+Demo_Course",
		"path": "/courses/course-v1:edX+DemoX+Demo_Course/discussion/07024c2194ed41ad95ccd0c550b9c33c/threads/create"
	},
	"ip": "18.189.110.165",
	"event": {
		"team_id": "test-team-name-07024c2194ed41ad95ccd0c550b9c33c"
	},
	"event_type": "edx.team.activity_updated"
}
```

### Testing
- [ ] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @staubina 
