### PR TITLE
Restrict block ID comparison slightly to avoid false positives

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1205,7 +1205,10 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             for block_id, block in course.structure['blocks'].iteritems():
                 # Don't do an in comparison blindly; first check to make sure
                 # that the name qualifier we're looking at isn't a plain string;
-                # if it is a string, then it should match exactly.
+                # if it is a string, then it should match exactly. If it's other
+                # than a string, we check whether it contains the block ID; this
+                # is so a list or other iterable can be passed with multiple
+                # valid qualifiers.
                 if isinstance(block_name, six.string_types):
                     name_matches = block_id.id == block_name
                 else:

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -629,7 +629,7 @@ class SplitModuleCourseTests(SplitModuleTest):
             course.advertised_start, "Fall 2013",
             "advertised_start"
         )
-        self.assertEqual(len(course.children), 3, "children")
+        self.assertEqual(len(course.children), 4, "children")
         # check dates and graders--forces loading of descriptor
         self.assertEqual(course.edited_by, "testassist@edx.org")
         self.assertDictEqual(course.grade_cutoffs, {"Pass": 0.45})
@@ -735,7 +735,7 @@ class SplitModuleCourseTests(SplitModuleTest):
         self.assertEqual(len(course.tabs), 6)
         self.assertEqual(course.display_name, "The Ancient Greek Hero")
         self.assertEqual(course.advertised_start, "Fall 2013")
-        self.assertEqual(len(course.children), 3)
+        self.assertEqual(len(course.children), 4)
         # check dates and graders--forces loading of descriptor
         self.assertEqual(course.edited_by, "testassist@edx.org")
         self.assertDictEqual(course.grade_cutoffs, {"Pass": 0.45})
@@ -1103,7 +1103,7 @@ class SplitModuleItemTests(SplitModuleTest):
             self.assertEqual(len(block.tabs), 6, "wrong number of tabs")
             self.assertEqual(block.display_name, "The Ancient Greek Hero")
             self.assertEqual(block.advertised_start, "Fall 2013")
-            self.assertEqual(len(block.children), 3)
+            self.assertEqual(len(block.children), 4)
             # check dates and graders--forces loading of descriptor
             self.assertEqual(block.edited_by, "testassist@edx.org")
             self.assertDictEqual(
@@ -1253,7 +1253,7 @@ class SplitModuleItemTests(SplitModuleTest):
         block = modulestore().get_item(locator)
         children = block.get_children()
         expected_ids = [
-            "chapter1", "chapter2", "chapter3"
+            "chapter1", "chap", "chapter2", "chapter3"
         ]
         for child in children:
             self.assertEqual(child.category, "chapter")

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -267,6 +267,15 @@ class SplitModuleTest(unittest.TestCase):
                             },
                         },
                         {
+                            "id": "chap",
+                            "parent": "head12345",
+                            "parent_type": "course",
+                            "category": "chapter",
+                            "fields": {
+                                "display_name": "Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo"
+                            },
+                        },
+                        {
                             "id": "chapter2",
                             "parent": "head12345",
                             "parent_type": "course",
@@ -1189,13 +1198,14 @@ class SplitModuleItemTests(SplitModuleTest):
         locator = CourseLocator(org='testx', course='GreekHero', run="run", branch=BRANCH_NAME_DRAFT)
         # get all modules
         matches = modulestore().get_items(locator)
-        self.assertEqual(len(matches), 7)
+        self.assertEqual(len(matches), 8)
         matches = modulestore().get_items(locator)
-        self.assertEqual(len(matches), 7)
+        self.assertEqual(len(matches), 8)
         matches = modulestore().get_items(locator, qualifiers={'category': 'chapter'})
-        self.assertEqual(len(matches), 3)
+        self.assertEqual(len(matches), 4)
         matches = modulestore().get_items(locator, qualifiers={'category': 'garbage'})
         self.assertEqual(len(matches), 0)
+        # Test that we don't accidentally get an item with a similar name.
         matches = modulestore().get_items(locator, qualifiers={'name': 'chapter1'})
         self.assertEqual(len(matches), 1)
         matches = modulestore().get_items(locator, qualifiers={'name': ['chapter1', 'chapter2']})
@@ -1209,7 +1219,7 @@ class SplitModuleItemTests(SplitModuleTest):
         matches = modulestore().get_items(locator, settings={'group_access': {'$exists': True}})
         self.assertEqual(len(matches), 1)
         matches = modulestore().get_items(locator, settings={'group_access': {'$exists': False}})
-        self.assertEqual(len(matches), 6)
+        self.assertEqual(len(matches), 7)
 
     def test_get_parents(self):
         '''


### PR DESCRIPTION
This PR restricts the `get_items()` method in the split module store to better compare block IDs when a name is passed as a qualifier.

**JIRA tickets**: [OSPR-1638](https://openedx.atlassian.net/browse/OSPR-1638)

**Dependencies**: None

**Sandbox URL**: https://pr14284.sandbox.opencraft.hosting/

**Partner information**: DavidsonX on EdX.org

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: ASAP

**Testing instructions**:

1. Create a course that has at least two blocks; the ID of one block should be a string subset of the ID of the other block. This can be accomplished by manually editing the OLX by hand.
2. Observe that without this patch, calling `modulestore().get_items()` with a `name` qualifier matching the ID of the longer-named block will also return the block with the shorter ID.
3. Apply this patch and test again, observing that the same call now only returns the item with an exact match.

**UI instructions**:

1. Using the `staff` user on the sandbox, [browse to the test course](https://pr14284.sandbox.opencraft.hosting/courses/course-v1:course2+course3+course4/courseware/004b11d047fb48f6b9e37bf81df4da34/pb/), and use the Instructor Tool to search specifically for questions "How do you feel?" and "Are you sure?". Note that search for each specifically yields only a single result for each question, and that result is, indeed, from that question.

2. To break the fix and observe the previous behavior (if you're an OpenCraft employee):

    ```bash
        ssh 213.32.78.3
        sudo -Hu edxapp bash
        cd ~/edx-platform
        git checkout b8befaf756af91b99a502e778c4efec5d8038582
        exit
        sudo supervisorctl restart edxapp:
        sudo supervisorctl restart edxapp_worker:
    ```

3. Again, [browse to the test course](https://pr14284.sandbox.opencraft.hosting/courses/course-v1:course2+course3+course4/courseware/004b11d047fb48f6b9e37bf81df4da34/pb/), and make the same searches.
    - Observe that the search for "How do you feel?" reveals answers for both questions.
    - Observe that the search for "Are you sure?" still only reveals answers for that question in particular.

4. If unable to use the sandbox, most of the above instructions apply; import the following course, and ensure that you've performed the following commands inside your devstack's edxapp venv:

    ```bash
        pip install -e git+https://github.com/open-craft/problem-builder.git#egg=problem-builder
        ./manage.py lms migrate --settings=devstack
    ```
    [course.tar.gz](https://github.com/edx/edx-platform/files/694791/course.tar.gz)

Once you've done that, you should be able to reproduce the failure and success modes by restarting your devstack server at the appropriate commit hashes.


**Reviewers**
- [ ] @bradenmacdonald 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```