### PR TITLE
Fixed Course handouts rejects deletion of all text

### DIFF
--- a/cms/static/coffee/spec/views/course_info_spec.coffee
+++ b/cms/static/coffee/spec/views/course_info_spec.coffee
@@ -232,6 +232,20 @@ define ["js/views/course_info_handout", "js/views/course_info_update", "js/model
 
                 @handoutsEdit.render()
 
+            it "saves <ol></ol> when content left empty", ->
+                requests = AjaxHelpers["requests"](this)
+
+                # Enter empty string in the handouts section, verifying that the model
+                # is saved with '<ol></ol>' instead of the empty string
+                @handoutsEdit.$el.find('.edit-button').click()
+                spyOn(@handoutsEdit.$codeMirror, 'getValue').and.returnValue('')
+                spyOn(@model, "save").and.callThrough()
+                @handoutsEdit.$el.find('.save-button').click()
+                expect(@model.save).toHaveBeenCalled()
+
+                contentSaved = JSON.parse(requests[requests.length - 1].requestBody).data
+                expect(contentSaved).toEqual('<ol></ol>')
+
             it "does not rewrite links on save", ->
                 requests = AjaxHelpers["requests"](this)
 

--- a/cms/static/js/views/course_info_handout.js
+++ b/cms/static/js/views/course_info_handout.js
@@ -50,10 +50,14 @@ define(['js/views/baseview', 'codemirror', 'common/js/components/views/feedback_
             },
 
             onSave: function(event) {
+                var handoutsContent = this.$codeMirror.getValue();
                 $('#handout_error').removeClass('is-shown');
                 $('.save-button').removeClass('is-disabled').attr('aria-disabled', false);
                 if ($('.CodeMirror-lines').find('.cm-error').length == 0) {
-                    this.model.set('data', this.$codeMirror.getValue());
+                    if (handoutsContent === '') {
+                        handoutsContent = '<ol></ol>';
+                    }
+                    this.model.set('data', handoutsContent);
                     var saving = new NotificationView.Mini({
                         title: gettext('Saving')
                     });


### PR DESCRIPTION
## [TNL-6046](https://openedx.atlassian.net/browse/TNL-6046)
### Description
According to the current implementation if all the content from the course handouts field is removed (including html tags), content is not updated and only the front-end is updated hence we see the section empty on the website initially, but refreshing the page causes the old content to reappear. I have changed the "onSave" method of "course_info_handout.js" to save `"<ol></ol>"` if the handouts content is empty.
### How to Test?
**Stage** 
 1. In Studio - Content - Updates - Course Handouts, add some simple text or html. Save. 
 2. Delete text, leaving blank handout field. Save. Observe text is deleted in Studio.
 3. View course 'Home' page in the LMS.
 Expect: No text in handouts
 Observe: Original text remains.
 4. Reload Studio's Updates page.
 Expect: No text in handouts.
 Observe: Original text reappears.

**Sandbox**
[asadazam](https://asadazam.sandbox.edx.org)

**Screenshots**
Not applicable
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @Qubad786 
- [ ] Code review: @awaisdar001 
- [x] Code review: @noraiz-anwar 
FYI: @adampalay 
### Post-review
- [ ] Rebase and squash commits