### PR TITLE
Add the Sailthru welcome email delay

### DIFF
--- a/lms/djangoapps/email_marketing/migrations/0004_emailmarketingconfiguration_welcome_email_send_delay.py
+++ b/lms/djangoapps/email_marketing/migrations/0004_emailmarketingconfiguration_welcome_email_send_delay.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('email_marketing', '0003_auto_20160715_1145'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='emailmarketingconfiguration',
+            name='welcome_email_send_delay',
+            field=models.IntegerField(default=600, help_text='Number of seconds to delay the sending of User Welcome email after user has been activated'),
+        ),
+    ]

--- a/lms/djangoapps/email_marketing/models.py
+++ b/lms/djangoapps/email_marketing/models.py
@@ -127,6 +127,16 @@ class EmailMarketingConfiguration(ConfigurationModel):
         )
     )
 
+    # The number of seconds to delay for welcome emails sending. This is needed to acommendate those
+    # learners who created user account during course enrollment so we can send a different message
+    # in our welcome email.
+    welcome_email_send_delay = models.fields.IntegerField(
+        default=600,
+        help_text=_(
+            "Number of seconds to delay the sending of User Welcome email after user has been activated"
+        )
+    )
+
     def __unicode__(self):
         return u"Email marketing configuration: New user list %s, Activation template: %s" % \
                (self.sailthru_new_user_list, self.sailthru_activation_template)

--- a/lms/djangoapps/email_marketing/tests/test_signals.py
+++ b/lms/djangoapps/email_marketing/tests/test_signals.py
@@ -1,6 +1,7 @@
 """Tests of email marketing signal handlers."""
 import ddt
 import logging
+import datetime
 
 from django.test import TestCase
 from django.contrib.auth.models import AnonymousUser
@@ -45,6 +46,7 @@ def update_email_marketing_config(enabled=True, key='badkey', secret='badsecret'
         sailthru_get_tags_from_sailthru=False,
         sailthru_enroll_cost=enroll_cost,
         sailthru_max_retries=0,
+        welcome_email_send_delay=600
     )
 
 
@@ -168,12 +170,14 @@ class EmailMarketingTests(TestCase):
         """
         mock_sailthru_post.return_value = SailthruResponse(JsonResponse({'ok': True}))
         mock_sailthru_get.return_value = SailthruResponse(JsonResponse({'lists': [{'name': 'new list'}], 'ok': True}))
+        expected_schedule = datetime.datetime.utcnow() + datetime.timedelta(seconds=600)
         update_user.delay({}, self.user.email, new_user=True, activation=True)
         # look for call args for 2nd call
         self.assertEquals(mock_sailthru_post.call_args[0][0], "send")
         userparms = mock_sailthru_post.call_args[0][1]
         self.assertEquals(userparms['email'], TEST_EMAIL)
         self.assertEquals(userparms['template'], "Activation")
+        self.assertEquals(userparms['schedule_time'], expected_schedule.strftime('%Y-%m-%dT%H:%M:%SZ'))
 
     @patch('email_marketing.tasks.log.error')
     @patch('email_marketing.tasks.SailthruClient.api_post')


### PR DESCRIPTION
This is for learners who registers and become active on LMS, we would like to send the welcome email from Sailthru with a 10 min delay
ECOM-6760