### PR TITLE
Adds trailing_text id to input describedby

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -328,9 +328,16 @@ class InputTypeBase(object):
         }
 
         # Generate the list of ids to be used with the aria-describedby field.
+        descriptions = list()
+
+        # If there is trailing text, add the id as the first element to the list before adding the status id
+        if 'trailing_text' in self.loaded_attributes and self.loaded_attributes['trailing_text']:
+            trailing_text_id = 'trailing_text_' + self.input_id
+            descriptions.append(trailing_text_id)
+
         # Every list should contain the status id
         status_id = 'status_' + self.input_id
-        descriptions = list([status_id])
+        descriptions.append(status_id)
         descriptions.extend(self.response_data.get('descriptions', {}).keys())
         description_ids = ' '.join(descriptions)
         context.update(

--- a/common/lib/capa/capa/templates/formulaequationinput.html
+++ b/common/lib/capa/capa/templates/formulaequationinput.html
@@ -16,7 +16,7 @@
             size="${size}"
             % endif
             />
-        <span class="trailing_text">${trailing_text}</span>
+        <span class="trailing_text" id="trailing_text_${id}">${trailing_text}</span>
 
         <%include file="status_span.html" args="status=status, status_id=id"/>
 

--- a/common/lib/capa/capa/templates/textline.html
+++ b/common/lib/capa/capa/templates/textline.html
@@ -34,7 +34,7 @@
         style="display:none;"
     % endif
 />
-<span class="trailing_text">${trailing_text}</span>
+<span class="trailing_text" id="trailing_text_${id}">${trailing_text}</span>
 
 <%include file="status_span.html" args="status=status, status_id=id"/>
 

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -37,6 +37,8 @@ lookup_tag = inputtypes.registry.get_class_for_tag
 
 
 DESCRIBEDBY = HTML('aria-describedby="status_{status_id} desc-1 desc-2"')
+# Use TRAILING_TEXT_DESCRIBEDBY when trailing_text is not null
+TRAILING_TEXT_DESCRIBEDBY = HTML('aria-describedby="trailing_text_{trailing_text_id} status_{status_id} desc-1 desc-2"')
 DESCRIPTIONS = OrderedDict([('desc-1', 'description text 1'), ('desc-2', 'description text 2')])
 RESPONSE_DATA = {
     'label': 'question text 101',
@@ -361,7 +363,7 @@ class TextLineTest(unittest.TestCase):
                 'trailing_text': expected_text,
                 'preprocessor': None,
                 'response_data': RESPONSE_DATA,
-                'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
+                'describedby_html': TRAILING_TEXT_DESCRIBEDBY.format(trailing_text_id=prob_id, status_id=prob_id)
             }
             self.assertEqual(context, expected)
 
@@ -1295,7 +1297,7 @@ class FormulaEquationTest(unittest.TestCase):
                 'inline': False,
                 'trailing_text': expected_text,
                 'response_data': RESPONSE_DATA,
-                'describedby_html': DESCRIBEDBY.format(status_id=prob_id)
+                'describedby_html': TRAILING_TEXT_DESCRIBEDBY.format(trailing_text_id=prob_id, status_id=prob_id)
             }
 
             self.assertEqual(context, expected)


### PR DESCRIPTION
## [TNL-6095](https://openedx.atlassian.net/browse/TNL-6095)

### Description

Adds a trailing_text id and adds it to the input describedby when trailing_text is present on a problem.

### Sandbox
- [x] [Sandbox](https://jlajoie.sandbox.edx.org) (Enroll in the Test101 Supported Components Course)

[Direct link to course can be found here](https://jlajoie.sandbox.edx.org/courses/course-v1:edX+Test101+course/courseware/853011e62c8042b2af4e29b5d4c6d2f9/2519e471ed3040ebbc72f01b8dd5a23e/) 
Course -> Problems -> Common Problem Types -> Numerical Input && Text Input

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @staubina 
- [x] Accessibility review: @cptvitamin 