### PR TITLE
Bumps django-storage-swift to 1.2.15

### DIFF
--- a/requirements/edx/openstack.txt
+++ b/requirements/edx/openstack.txt
@@ -3,4 +3,4 @@
 #
 
 # OpenStack swift backend for django storage API
-django-storage-swift==1.2.12
+django-storage-swift==1.2.15


### PR DESCRIPTION
The latest version of `django-storage-swift` allows us to set `SWIFT_USE_TEMP_URLS` and  `SWIFT_TEMP_URL_KEY` in the cms.auth.json and use it to generate temporary URLs to private SWIFT storage objects.

Without this change, attempts to generate temporary URLs resulted in an error from HMAC, because `settings.SWIFT_TEMP_URL_KEY` is a unicode string, which HMAC doesn't allow to be used as a key.

**JIRA tickets**: [OSPR-1644](https://openedx.atlassian.net/browse/OSPR-1644)

**Sandbox URL**: 

* LMS: http://pr14305.sandbox.opencraft.hosting/
* Studio: http://studio-pr14305.sandbox.opencraft.hosting/

**Deployment targets**: Community Open edX Ficus and master Instances using SWIFT storage

**Merge deadline**: ASAP - we'd like to get this change into ficus. CC @nedbat 

**Testing instructions**:

1. Spin up an instance using the `edx-platform` and `configuration` branches, and the settings below to enable SWIFT support.  Alternatively, use the sandbox instance above.
1. Login as `staff@example.com`, and visit the DemoX course.
1. Ensure that you can download grade reports from the Instructor Dashboard, and that the links have the temporary URL query parameters appended, e.g. `?temp_url_sig=4a947f1d706ed5050ecbbdde49f5b011807156d8&temp_url_expires=1484217877`.  This checks the private container access is working.
1. Ensure that these links expire in 5 min, as advertised.

**Author notes and concerns**

1. To get SWIFT support working using edx-platform:master as a base, I had to provision the sandbox server using branches merged from a few open PRs.
    * [`edx-platform:jill/bump-django-storage-swift+add-swift-settings-to-cms`](https://github.com/open-craft/edx-platform/commits/jill/bump-django-storage-swift+add-swift-settings-to-cms) - based on [`master@`](https://github.com/open-craft/edx-platform/commit/2f9786caeb7c8365db325867012cfefa25bca261), includes changes from this PR and https://github.com/edx/edx-platform/pull/14015.
    * [`configuration:jill/optional-aws-opencraft-roles+edxapp-settings`](https://github.com/open-craft/configuration/tree/jill/optional-aws-opencraft-roles+edxapp-settings) - based on [`master@f257507`](https://github.com/open-craft/configuration/commit/f2575077c4d1c0a666f9bca088852787996b439b), includes changes from https://github.com/edx/configuration/pull/3522 and https://github.com/edx/configuration/pull/3601.

**Reviewers**
- [x] @mtyaka 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
# For this PR
EDXAPP_SWIFT_USE_TEMP_URLS: true
EDXAPP_SWIFT_TEMP_URL_KEY: redacted

# From mtyaka/optional-aws-opencraft-roles
COMMON_ENABLE_OPENSTACK_INTEGRATION: true
COMMON_SWIFT_LOG_SYNC: true

# From jill/edxapp-settings
COMMON_EDXAPP_SETTINGS: 'openstack'
XQUEUE_SETTINGS: 'openstack_settings'

VHOST_NAME: 'openstack'
# COMMON_VHOST_ROLE_NAME is deprecated; keeping it around for compatibility
COMMON_VHOST_ROLE_NAME: ''

EDXAPP_DEFAULT_FILE_STORAGE: 'swift.storage.SwiftStorage'
EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: 'public-container-name'
EDXAPP_SWIFT_AUTH_VERSION: '2'
EDXAPP_SWIFT_USERNAME: 'xx'
EDXAPP_SWIFT_KEY: 'xx'
EDXAPP_SWIFT_TENANT_NAME: 'xx'
EDXAPP_SWIFT_AUTH_URL: 'xx'
EDXAPP_SWIFT_REGION_NAME: 'xx'

EDXAPP_GRADE_STORAGE_CLASS: 'swift.storage.SwiftStorage'
EDXAPP_GRADE_STORAGE_KWARGS:
  name_prefix: 'grades-download/'

XQUEUE_SWIFT_USERNAME: 'xx'
XQUEUE_SWIFT_KEY: 'xx'
XQUEUE_SWIFT_TENANT_NAME: 'xx'
XQUEUE_SWIFT_AUTH_URL: 'xx'
XQUEUE_SWIFT_AUTH_VERSION: ''
XQUEUE_SWIFT_REGION_NAME: 'xx'
XQUEUE_UPLOAD_BUCKET: 'private-container-name'
XQUEUE_UPLOAD_PATH_PREFIX: 'xqueue'

# Tracking logs
COMMON_OBJECT_STORE_LOG_SYNC: true
COMMON_OBJECT_STORE_LOG_SYNC_BUCKET: 'private-container-name'
COMMON_OBJECT_STORE_LOG_SYNC_PREFIX: 'logs/tracking/'
SWIFT_LOG_SYNC_USERNAME: 'xx'
SWIFT_LOG_SYNC_PASSWORD: 'xx'
SWIFT_LOG_SYNC_TENANT_NAME: 'xx'
SWIFT_LOG_SYNC_AUTH_URL: 'xx'
SWIFT_LOG_SYNC_REGION_NAME: 'xx'
```