### PR TITLE
Removes ANALYTICS_DASHBOARD_URL = None from lms.env.devstack

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -44,10 +44,6 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 ANALYTICS_SERVER_URL = "http://127.0.0.1:9000/"
 ANALYTICS_API_KEY = ""
 
-# Set this to the dashboard URL in order to display the link from the
-# dashboard to the Analytics Dashboard.
-ANALYTICS_DASHBOARD_URL = None
-
 ############################ PYFS XBLOCKS SERVICE #############################
 # Set configuration for Django pyfilesystem
 


### PR DESCRIPTION
Allows `setting.ANALYTICS_DASHBOARD_URL` from `lms.env.aws` to be used on devstacks.  This is useful when developing/testing CCX features.

**Screenshots**:

![screen shot 2017-01-12 at 10 39 16 am](https://cloud.githubusercontent.com/assets/7556571/21871656/8708faa6-d8b3-11e6-96fe-af7d9bf62479.png)

**Sandbox URL**:

* LMS: http://pr14313.sandbox.opencraft.hosting/
* Studio: http://studio-pr14313.sandbox.opencraft.hosting/

**Partner information**: DavidsonX

**Deployment targets**: edx.org and edge.edx.org - though these sites will not be affected by this change, since `lms.env.devstack` is only used on devstacks.

**Merge deadline**: None

**Testing instructions**:

*Note*: These steps have already been performed on the sandbox instance, using `https://insights.edx.org` as the `ANALYTICS_DASHBOARD_URL`.

1. Provision a devstack using the following settings set in `lms.env.json`:

    ```
    {
      "ANALYTICS_DASHBOARD_URL": "http://localhost:18110/courses",
      ...
      "FEATURES": {
          "CUSTOM_COURSES_EDX": true,
          "ENABLE_CCX_ANALYTICS_DASHBOARD_URL": true,
          ...
      }
    }
    ```
1. Login to Studio as `staff`.  Go to the Demo course, Advanced Settings, and set Enable CCX to "true".
1. In the LMS as `staff`, go to the Demo course's Instructor Dashboard, Membership tab, and add one of the student users (e.g. `honor@example.com`) as a CCX Coach.
1. Login to LMS as `honor`, go to the Demo course's CCX Coach tab, and create a CCX course.
1. Go to the Instructor Dashboard.  You should see an Analytics tab, with an Insights link that matches the `ANALYTICS_DASHBOARD_URL` you gave above.

**Author notes and concerns**:

1. Standard devstacks do not include the Insights service, and so following the Insights link enabled by this PR will result in a 404.  However on Analytics devstacks, the default link will work.

**Reviewers**
- [ ] @bdero 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_ANALYTICS_DASHBOARD_URL: "http://insights.edx.org"
EDXAPP_FEATURES:
  CUSTOM_COURSES_EDX: true
  ENABLE_CCX_ANALYTICS_DASHBOARD_URL: true
```