### PR TITLE
Revert #14225 hide_after_due for self-paced courses

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -981,7 +981,6 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         "release_date": release_date,
         "visibility_state": visibility_state,
         "has_explicit_staff_lock": xblock.fields['visible_to_staff_only'].is_set_on(xblock),
-        "self_paced": is_self_paced(course),
         "start": xblock.fields['start'].to_json(xblock.start),
         "graded": xblock.graded,
         "due_date": get_default_time_display(xblock.due),

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -712,10 +712,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             return $.extend(
                 {},
                 AbstractVisibilityEditor.prototype.getContext.call(this),
-                {
-                    hide_after_due: this.modelVisibility() === 'hide_after_due',
-                    self_paced: this.model.get('self_paced') === true
-                }
+                {hide_after_due: this.modelVisibility() === 'hide_after_due'}
             );
         }
     });

--- a/cms/templates/js/content-visibility-editor.underscore
+++ b/cms/templates/js/content-visibility-editor.underscore
@@ -12,19 +12,9 @@
         <li class="field-radio">
             <label class="label">
                 <input class="input input-radio" name="content-visibility" type="radio" value="hide_after_due" aria-described-by="hide_after_due_description">
-                <% if (self_paced) { %>
-                    <%- gettext('Hide content after course end date') %>
-                <% } else { %>
-                    <%- gettext('Hide content after due date') %>
-                <% } %>
+                <%- gettext('Hide content after due date') %>
             </label>
-            <p class='field-message' id='hide_after_due_description'>
-                <% if (self_paced) { %>
-                    <%- gettext('After the course\'s end date has passed, learners can no longer access subsection content. The subsection remains included in grade calculations.') %>
-                <% } else { %>
-                    <%- gettext('After the subsection\'s due date has passed, learners can no longer access its content. The subsection remains included in grade calculations.') %>
-                <% } %>
-            </p>
+            <p class='field-message' id='hide_after_due_description'> <%- gettext('After the subsection\'s due date has passed, learners can no longer access its content. The subsection remains included in grade calculations.') %> </p>
         </li>
         <li class="field-radio">
             <label class="label">
@@ -39,7 +29,7 @@
     <% if (hasExplicitStaffLock && !ancestorLocked) { %>
         <p class="tip tip-warning">
             <%- interpolate(
-                gettext('If you select an option other than "%(hide_label)s", published units in this subsection become available to learners unless they are explicitly hidden.'),
+                gettext('If you select an option other than "%(hide_label)s", after the subsection release date has passed, published units in this subsection will become available to learners unless units are explicitly hidden.'),
                 { hide_label: hide_label },
                 true
             ) %>

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -201,12 +201,7 @@ if (is_proctored_exam) {
                 <p>
                     <% if (xblockInfo.get('hide_after_due')) { %>
                         <span class="icon fa fa-eye-slash" aria-hidden="true"></span>
-                        <span class="status-hide-after-due-value">
-                        <% if (course.get('self_paced')) { %>
-                            <%- gettext("Subsection is hidden after course end date") %> </span>
-                        <% } else { %>
-                            <%- gettext("Subsection is hidden after due date") %> </span>
-                        <% } %>
+                        <span class="status-hide-after-due-value"> <%- gettext("Subsection is hidden after due date") %> </span>
                     <% } %>
                 </p>
             </div>

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -202,16 +202,16 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
         raise NotFoundError('Unexpected dispatch type')
 
     @classmethod
-    def verify_current_content_visibility(cls, date, hide_after_date):
+    def verify_current_content_visibility(cls, due, hide_after_due):
         """
         Returns whether the content visibility policy passes
-        for the given date and hide_after_date values and
+        for the given due date and hide_after_due values and
         the current date-time.
         """
         return (
-            not date or
-            not hide_after_date or
-            datetime.now(UTC()) < date
+            not due or
+            not hide_after_due or
+            datetime.now(UTC()) < due
         )
 
     def student_view(self, context):
@@ -246,17 +246,20 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
         runtime user. If so, returns a banner_text or the fragment to
         display depending on whether staff is masquerading.
         """
-        course = self._get_course()
-        if not self._can_user_view_content(course):
-            if course.self_paced:
-                banner_text = _("Because the course has ended, this assignment is hidden from the learner.")
-            else:
-                banner_text = _("Because the due date has passed, this assignment is hidden from the learner.")
+        if not self._can_user_view_content():
+            subsection_format = (self.format or _("subsection")).lower()  # pylint: disable=no-member
+
+            # Translators: subsection_format refers to the assignment
+            # type of the subsection, such as Homework, Lab, Exam, etc.
+            banner_text = _(
+                "Because the due date has passed, "
+                "this {subsection_format} is hidden from the learner."
+            ).format(subsection_format=subsection_format)
 
             hidden_content_html = self.system.render_template(
                 'hidden_content.html',
                 {
-                    'self_paced': course.self_paced,
+                    'subsection_format': subsection_format,
                     'progress_url': context.get('progress_url'),
                 }
             )
@@ -277,15 +280,14 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             if content_milestones and self.runtime.user_is_staff:
                 return banner_text
 
-    def _can_user_view_content(self, course):
+    def _can_user_view_content(self):
         """
         Returns whether the runtime user can view the content
         of this sequential.
         """
-        hidden_date = course.end if course.self_paced else self.due
         return (
             self.runtime.user_is_staff or
-            self.verify_current_content_visibility(hidden_date, self.hide_after_due)
+            self.verify_current_content_visibility(self.due, self.hide_after_due)
         )
 
     def _student_view(self, context, banner_text=None):

--- a/common/test/acceptance/pages/lms/courseware.py
+++ b/common/test/acceptance/pages/lms/courseware.py
@@ -209,13 +209,13 @@ class CoursewarePage(CoursePage):
         """
         return self.q(css="div.proctored-exam.completed").visible
 
-    def content_hidden_past_due_date(self):
+    def content_hidden_past_due_date(self, content_type="subsection"):
         """
         Returns whether the "the due date for this ___ has passed" message is present.
         ___ is the type of the hidden content, and defaults to subsection.
         This being true implies "the ___ contents are hidden because their due date has passed".
         """
-        message = "this assignment is no longer available"
+        message = "The due date for this {0} has passed.".format(content_type)
         if self.q(css="div.seq_content").is_present():
             return False
         for html in self.q(css="div.hidden-content").html:

--- a/lms/djangoapps/course_blocks/transformers/hidden_content.py
+++ b/lms/djangoapps/course_blocks/transformers/hidden_content.py
@@ -25,7 +25,7 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
 
     Staff users are exempted from hidden content rules.
     """
-    VERSION = 2
+    VERSION = 1
     MERGED_DUE_DATE = 'merged_due_date'
     MERGED_HIDE_AFTER_DUE = 'merged_hide_after_due'
 
@@ -41,7 +41,7 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
     def _get_merged_hide_after_due(cls, block_structure, block_key):
         """
         Returns whether the block with the given block_key in the
-        given block_structure should be hidden after due date per
+        given block_structure should be visible to staff only per
         computed value from ancestry chain.
         """
         return block_structure.get_transformer_block_field(
@@ -81,8 +81,6 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
             func_merge_ancestors=min,
         )
 
-        block_structure.request_xblock_fields(u'self_paced', u'end')
-
     def transform_block_filters(self, usage_info, block_structure):
         # Users with staff access bypass the Visibility check.
         if usage_info.has_staff_access:
@@ -99,10 +97,6 @@ class HiddenContentTransformer(FilteringTransformerMixin, BlockStructureTransfor
         Returns whether the block with the given block_key should
         be hidden, given the current time.
         """
+        due = self._get_merged_due_date(block_structure, block_key)
         hide_after_due = self._get_merged_hide_after_due(block_structure, block_key)
-        self_paced = block_structure[block_structure.root_block_usage_key].self_paced
-        if self_paced:
-            hidden_date = block_structure[block_structure.root_block_usage_key].end
-        else:
-            hidden_date = self._get_merged_due_date(block_structure, block_key)
-        return not SequenceModule.verify_current_content_visibility(hidden_date, hide_after_due)
+        return not SequenceModule.verify_current_content_visibility(due, hide_after_due)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -199,7 +199,7 @@ class IndexQueryTestCase(ModuleStoreTestCase):
     NUM_PROBLEMS = 20
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 9),
+        (ModuleStoreEnum.Type.mongo, 8),
         (ModuleStoreEnum.Type.split, 4),
     )
     @ddt.unpack

--- a/lms/templates/hidden_content.html
+++ b/lms/templates/hidden_content.html
@@ -5,35 +5,22 @@ from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <div class="sequence hidden-content proctored-exam completed">
-    <h3>
-        % if self_paced:
-            ${_("The course has ended.")}
-        % else:
-            ${_("The due date for this assignment has passed.")}
-        % endif
-    </h3>
-    <hr>
-    <p>
-        % if self_paced:
-            ${Text(_(
-                "Because the course has ended, this assignment is no longer "
-                "available.{line_break}If you have completed this assignment, your "
-                "grade is available on the {link_start}progress page{link_end}."
-            )).format(
-                line_break=HTML("<br>"),
-                link_start=HTML("<a href='{}'>").format(progress_url),
-                link_end=HTML("</a>"),
-            )}
-        % else:
-            ${Text(_(
-                "Because the due date has passed, this assignment is no longer "
-                "available.{line_break}If you have completed this assignment, your "
-                "grade is available on the {link_start}progress page{link_end}."
-            )).format(
-                line_break=HTML("<br>"),
-                link_start=HTML("<a href='{}'>").format(progress_url),
-                link_end=HTML("</a>"),
-            )}
-        % endif
-    </p>
+  <h3>
+      ${_("The due date for this {subsection_format} has passed.").format(
+        subsection_format=subsection_format,
+      )}
+  </h3>
+  <hr>
+  <p>
+      ${Text(_(
+          "Because the due date has passed, this {subsection_format} "
+          "is no longer available.{line_break}If you have completed this {subsection_format}, "
+          "your grade is available on the {link_start}progress page{link_end}."
+        )).format(
+          subsection_format=subsection_format,
+          line_break=HTML("<br>"),
+          link_start=HTML("<a href='{}'>").format(progress_url),
+          link_end=HTML("</a>"),
+      )}
+  </p>
 </div>


### PR DESCRIPTION
Per conversation with devops, we want to have a better understanding of the performance hit before releasing the change to the block structure transformer.

@nasthagiri @jcdyer @sanfordstudent @yro @feanil @jibsheet @catong @sstack22 