### PR TITLE
Allow codejail threads TNL-6291

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -72,7 +72,7 @@ git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 
 # Our libraries:
 git+https://github.com/edx/XBlock.git@xblock-0.4.13#egg=XBlock==0.4.13
--e git+https://github.com/edx/codejail.git@6b17c33a89bef0ac510926b1d7fea2748b73aadd#egg=codejail
+-e git+https://github.com/edx/codejail.git@0b2dc694f05ddc8fee3e65d837cee57b6ce51a6b#egg=codejail==0.0
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock


### PR DESCRIPTION
We are using a branch in CodeJail, because edx-platform doesn't yet use the latest CodeJail code.