### PR TITLE
Bump problem builder to v2.6.9.

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@v2.6.5#egg=xblock-problem-builder==2.6.5
+git+https://github.com/open-craft/problem-builder.git@v2.6.9#egg=xblock-problem-builder==2.6.9
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
This is a follow-up to #14044, in which we fixed a bug that would cause problem-builder to fail in courses with long course keys (> 50 characters). Because the problem-builder xblock is used on edx.org and the affected production `problem_builder_answer` is large, we had to do the migration to extend the `course_key` column in two steps. For more info on that see https://github.com/edx/edx-platform/pull/14013.

The new problem-builder removes the temporary transition code and includes a migration that copies over values from the old deprecated `course_id` column to the new extended `course_key` column.

**IMPORTANT: Before deploying v2.6.9 to production, edX will have to fake this migration and manually copy course_id values into course_key in batches because the production problem_builder_answer table is large and performing the migration in one go would degrade performance!**

See the problem-builder PR included in the new release:
https://github.com/open-craft/problem-builder/pull/138

**Environments**: edx.org and edge.edx.org

**Partner information**: hosted on edX Edge (Davidson College)

**JIRA ticket**: [TNL-5932](https://openedx.atlassian.net/browse/TNL-5932)

**Dependencies**: https://github.com/open-craft/problem-builder/pull/138

**Testing instructions**:

This patch should not change problem-builder functionality in any way. Verify that problem-builder still works correctly on the sandbox.

**Sandbox**:

- LMS: http://pr14327.sandbox.opencraft.hosting/
- Studio: http://studio-pr14327.sandbox.opencraft.hosting/

**Reviewers**:

- [x] OpenCraft: @bdero 
- [x] DevOps: @maxrothman 

- - -
**Settings**
```yaml
EDXAPP_INSTALL_PRIVATE_REQUIREMENTS: true
COMMON_EDXAPP_SETTINGS: openstack
```
