### PR TITLE
Fix for bulk_email target selection

### DIFF
--- a/lms/static/js/instructor_dashboard/send_email.js
+++ b/lms/static/js/instructor_dashboard/send_email.js
@@ -197,7 +197,7 @@
                     sendemail.$course_mode_targets.each(inputDisable);
                 } else {
                     sendemail.$cohort_targets.each(inputEnable);
-                    sendemail.$cohort_targets.each(inputEnable);
+                    sendemail.$course_mode_targets.each(inputEnable);
                 }
                 targets = [];
                 $('input[name="send_to"]:checked+label').each(function() {


### PR DESCRIPTION
While @catong was writing up docs for the release of https://github.com/edx/edx-platform/pull/14118, she noticed this bug. I just copied the line incorrectly in the previous PR.

This is on my sandbox at https://efischer19.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-send_email if you;d like to verify.

2 of @sanfordstudent @yro @jcdyer @nasthagiri to review, I'm hoping to merge this before the RC gets cut at 2