### PR TITLE
Hide previous next buttons in sequence nav from screen reader

### DIFF
--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -13,7 +13,7 @@
     </div>
   % endif
   <div class="sequence-nav">
-    <button class="sequence-nav-button button-previous">
+    <button class="sequence-nav-button button-previous" aria-hidden="true">
       <span class="icon fa fa-chevron-prev" aria-hidden="true"></span>
       <span>${_('Previous')}</span>
     </button>
@@ -41,7 +41,7 @@
         % endfor
       </ol>
     </nav>
-    <button class="sequence-nav-button button-next">
+    <button class="sequence-nav-button button-next" aria-hidden="true">
       <span>${_('Next')}</span>
       <span class="icon fa fa-chevron-next" aria-hidden="true"></span>
     </button>


### PR DESCRIPTION
[TNL-5918](https://openedx.atlassian.net/browse/TNL-5918)

## Description
- Hide previous next buttons of sequence nav from screen reader.

## Sandbox
[https://alisan617.sandbox.edx.org](https://alisan617.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/19a30717eff543078a5d94ae9d6c18a5/)

## Reviewers
- [x] @bjacobel 
- [ ] @andy-armstrong 
- [x] @cptvitamin 
- [ ] @catong FYI only