### PR TITLE
Fix asides to copy them during publish operation

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -3190,6 +3190,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 new_block.definition,
                 destination_version,
                 raw=True,
+                asides=new_block.asides,
                 block_defaults=new_block.defaults
             )
             # Extend the block's new edit_info with any extra edit_info fields from the source (e.g. original_usage):
@@ -3246,11 +3247,12 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         :param definition_id: the pointer to the content scoped fields
         :param new_id: the structure's version id
         :param raw: true if this block already has all references serialized
+        :param asides: dict information related to the connected xblock asides
         """
         if not raw:
             block_fields = self._serialize_fields(category, block_fields)
         if not asides:
-            asides = []
+            asides = {}
         document = {
             'block_type': category,
             'definition': definition_id,

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -3395,13 +3395,17 @@ class TestAsidesWithMixedModuleStore(CommonMixedModuleStoreSetup):
         _check_asides(item)
 
         # Private -> Public
-        self.store.publish(item_location, self.user_id)
+        published_block = self.store.publish(item_location, self.user_id)
+        _check_asides(published_block)
+
         item = self.store.get_item(item_location)
         self.assertTrue(self.store.has_published_version(item))
         _check_asides(item)
 
         # Public -> Private
-        self.store.unpublish(item_location, self.user_id)
+        unpublished_block = self.store.unpublish(item_location, self.user_id)
+        _check_asides(unpublished_block)
+
         item = self.store.get_item(item_location)
         self.assertFalse(self.store.has_published_version(item))
         _check_asides(item)


### PR DESCRIPTION
Fixed bug in [modulestore/split_mongo/split.py:SplitMongoModuleStore._copy_subdag](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py#L3150) method

@cpennington could you please take a look
