### PR TITLE
Allow "masquerading as a group member" in Preview

### DIFF
--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -1,7 +1,6 @@
 """
 Helpers for courseware tests.
 """
-import crum
 import json
 
 from django.contrib.auth.models import User
@@ -10,6 +9,10 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 
 from courseware.access import has_access
+from courseware.masquerade import (
+    handle_ajax,
+    setup_masquerade
+)
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from student.models import Registration
 
@@ -178,3 +181,39 @@ class CourseAccessTestMixin(TestCase):
         """
         self.assertFalse(has_access(user, action, course))
         self.assertFalse(has_access(user, action, CourseOverview.get_from_id(course.id)))
+
+
+def masquerade_as_group_member(user, course, partition_id, group_id):
+    """
+    Installs a masquerade for the specified user and course, to enable
+    the user to masquerade as belonging to the specific partition/group
+    combination.
+
+    Arguments:
+        user (User): a user.
+        course (CourseDescriptor): a course.
+        partition_id (int): the integer partition id, referring to partitions already
+           configured in the course.
+        group_id (int); the integer group id, within the specified partition.
+
+    Returns: the status code for the AJAX response to update the user's masquerade for
+        the specified course.
+    """
+    request = _create_mock_json_request(
+        user,
+        data={"role": "student", "user_partition_id": partition_id, "group_id": group_id}
+    )
+    response = handle_ajax(request, unicode(course.id))
+    setup_masquerade(request, course.id, True)
+    return response.status_code
+
+
+def _create_mock_json_request(user, data, method='POST'):
+    """
+    Returns a mock JSON request for the specified user.
+    """
+    factory = RequestFactory()
+    request = factory.generic(method, '/', content_type='application/json', data=json.dumps(data))
+    request.user = user
+    request.session = {}
+    return request

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -6,7 +6,6 @@ import django.test
 from mock import patch
 from nose.plugins.attrib import attr
 
-from courseware.masquerade import handle_ajax, setup_masquerade
 from courseware.tests.test_masquerade import StaffMasqueradeTestCase
 from student.tests.factories import UserFactory
 from xmodule.partitions.partitions import Group, UserPartition, UserPartitionError
@@ -341,30 +340,17 @@ class TestMasqueradedGroup(StaffMasqueradeTestCase):
             scheme_id='cohort'
         )
         self.course.user_partitions.append(self.user_partition)
-        self.session = {}
         modulestore().update_item(self.course, self.test_user.id)
 
     def _verify_masquerade_for_group(self, group):
         """
         Verify that the masquerade works for the specified group id.
         """
-        # Send the request to set the masquerade
-        request_json = {
-            "role": "student",
-            "user_partition_id": self.user_partition.id,
-            "group_id": group.id if group is not None else None
-        }
-        request = self._create_mock_json_request(
-            self.test_user,
-            data=request_json,
-            session=self.session
+        self.ensure_masquerade_as_group_member(  # pylint: disable=no-member
+            self.user_partition.id,
+            group.id if group is not None else None
         )
-        response = handle_ajax(request, unicode(self.course.id))
-        # pylint has issues analyzing this class (maybe due to circular imports?)
-        self.assertEquals(response.status_code, 200)  # pylint: disable=no-member
 
-        # Now setup the masquerade for the test user
-        setup_masquerade(request, self.course.id, True)
         scheme = self.user_partition.scheme
         self.assertEqual(
             scheme.get_group_for_user(self.course.id, self.test_user, self.user_partition),


### PR DESCRIPTION
## [TNL-6050](https://openedx.atlassian.net/browse/TNL-6050)

### Description

Course staff would like to be able to Preview what a course will look like for members of content groups (in particular, for content that is not yet released). However, our code would allow staff access to **all** content in Preview mode, regardless of masquerading and group access.

I have moved the group access check before the staff access check so that in preview mode, group access/masquerading is taken into consideration.

_Note: since "Preview" has been used colloquially and in code to refer to View Live as Staff/masquerades, here is a picture of how you access "Preview" vs. "View Live" on the unit page in Studio. "Preview" will show you unpublished and unreleased content, while "View Live" shows the last published version of content._
![image](https://cloud.githubusercontent.com/assets/484484/22079742/e46ef8a4-dd8a-11e6-85ee-17cfc3cc6489.png)

### Sandbox
- [x] https://tnl6050.sandbox.edx.org/courses/course-v1:test+101+2017/courseware/a2e40c956cf148858ea1067852cd18e3/87f77ab8f4854bbfbe92130bcea8934b/

https://preview-tnl6050.sandbox.edx.org/courses/course-v1:test+101+2017/courseware/a2e40c956cf148858ea1067852cd18e3/87f77ab8f4854bbfbe92130bcea8934b/

This course is configured in the following way:
- There is an unreleased section/subsection and a released section/subsection.
- Each of those has content that is visibile to all students in the course, content that is visible only to Group 1, content that is visible to only Group 2, and content that is visible to both Group 1 and Group 2.
- "honor@example.com" is in Group 1 (via cohorts). "audit@example.com" is in Group 2 (via cohorts).

This means that "View Live" will show only the released section/subsection, unless you are viewing as staff. "Preview" will show draft versions all content, and you can view as a member of Group 1 or Group 2.

Note though that "View as Specific Student" only works in "View Live"; I verified that this is not new behavior-- you cannot Preview as a specific student on stage, nor on my devstack using master. 

### Testing
- [x] safecommit violation code review process
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @andy-armstrong 
- [x] Code review: @staubina 
- [x] Code review: @jlajoie 

FYI: @sstack22 @catong

### Post-review
- [ ] Rebase and squash commits