### PR TITLE
ENT-112: Update settings for edx-enterprise (v0.19.1) configurations.

### DIFF
--- a/common/djangoapps/util/enterprise_helpers.py
+++ b/common/djangoapps/util/enterprise_helpers.py
@@ -7,7 +7,7 @@ import logging
 
 try:
     from enterprise.models import EnterpriseCustomer
-    from enterprise import api as enterprise_api
+    from enterprise import utils as enterprise_utils
     from enterprise.tpa_pipeline import (
         active_provider_requests_data_sharing,
         active_provider_enforces_data_sharing,
@@ -142,9 +142,9 @@ def get_enterprise_customer_logo_url(request):
     ec_uuid = parameter.get('ec_uuid', None)
 
     if provider_id:
-        branding_info = enterprise_api.get_enterprise_branding_info_by_provider_id(provider_id=provider_id)
+        branding_info = enterprise_utils.get_enterprise_branding_info_by_provider_id(identity_provider_id=provider_id)
     elif ec_uuid:
-        branding_info = enterprise_api.get_enterprise_branding_info_by_ec_uuid(ec_uuid=ec_uuid)
+        branding_info = enterprise_utils.get_enterprise_branding_info_by_ec_uuid(ec_uuid=ec_uuid)
 
     logo_url = None
     if branding_info and branding_info.logo:

--- a/common/djangoapps/util/tests/test_enterprise_helpers.py
+++ b/common/djangoapps/util/tests/test_enterprise_helpers.py
@@ -177,12 +177,12 @@ class TestEnterpriseHelpers(unittest.TestCase):
         )
 
         set_enterprise_branding_filter_param(request, provider_id=None)
-        with mock.patch('enterprise.api.get_enterprise_branding_info_by_ec_uuid', return_value=branding_info):
+        with mock.patch('enterprise.utils.get_enterprise_branding_info_by_ec_uuid', return_value=branding_info):
             logo_url = get_enterprise_customer_logo_url(request)
             self.assertEqual(logo_url, '/test/image.png')
 
         set_enterprise_branding_filter_param(request, provider_id)
-        with mock.patch('enterprise.api.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
+        with mock.patch('enterprise.utils.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
             logo_url = get_enterprise_customer_logo_url(request)
             self.assertEqual(logo_url, '/test/image.png')
 
@@ -195,7 +195,7 @@ class TestEnterpriseHelpers(unittest.TestCase):
         branding_info = mock.Mock()
 
         set_enterprise_branding_filter_param(request, 'test-idp')
-        with mock.patch('enterprise.api.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
+        with mock.patch('enterprise.utils.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
             logo_url = get_enterprise_customer_logo_url(request)
             self.assertEqual(logo_url, None)
 
@@ -209,6 +209,6 @@ class TestEnterpriseHelpers(unittest.TestCase):
         branding_info = mock.Mock()
 
         set_enterprise_branding_filter_param(request, provider_id=None)
-        with mock.patch('enterprise.api.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
+        with mock.patch('enterprise.utils.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
             logo_url = get_enterprise_customer_logo_url(request)
             self.assertEqual(logo_url, None)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2187,6 +2187,10 @@ REST_FRAMEWORK = {
     ),
     'PAGE_SIZE': 10,
     'URL_FORMAT_OVERRIDE': None,
+    'DEFAULT_THROTTLE_RATES': {
+        'user': '60/minute',
+        'service_user': '120/minute',
+    },
 }
 
 
@@ -2830,6 +2834,7 @@ ECOMMERCE_API_URL = None
 ECOMMERCE_API_SIGNING_KEY = None
 ECOMMERCE_API_TIMEOUT = 5
 ECOMMERCE_SERVICE_WORKER_USERNAME = 'ecommerce_worker'
+ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
 
 COURSE_CATALOG_API_URL = None
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-i18n-tools==0.3.7
 edx-lint==0.4.3
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.9.0
+edx-enterprise==0.19.1
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.2


### PR DESCRIPTION
@mattdrayer , @asadiqbal08 , @zubair-arbi, @bradenmacdonald 

PR is ready for review,

__Description of changes:___
Here is the list of changes included in this PR

1. update `edx-enterprise` version to `0.19.1`
2. Functions from `enterprise.api` are moved to `enterprise.utils`, so we need to update its references in edx-platform.
3. Argument for `get_enterprise_branding_info_by_provider_id ` was renamed from `provider_id ` to `identity_provider_id `.
4. Added the defaults for throttle scopes and enterprise service user.
    ```
    'DEFAULT_THROTTLE_RATES': {
        'user': '60/minute',
        'service_user': '120/minute',
    }
    ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
    ```