### PR TITLE
OSPR-1490: Upgrade to 1.1.1 release of xblock-lti-consumer

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -90,7 +90,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.3#egg=xblock-utils==1.0.3
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.0#egg=xblock-lti-consumer==1.1.0
+git+https://github.com/edx/xblock-lti-consumer.git@v1.1.1#egg=xblock-lti-consumer==1.1.1
 git+https://github.com/edx/edx-proctoring.git@0.17.0#egg=edx-proctoring==0.17.0
 
 # Third Party XBlocks


### PR DESCRIPTION
This is to test a potential release of xblock-lti-consumer.  It includes the @ziafazal's translation work, as well as OSPR-1490.  Here's a [link to the diff](https://github.com/edx/xblock-lti-consumer/compare/v1.1.0...89b72336603dfe59e2b269d630885c55f4a4ffc2).

Sandbox:
- [x] Sandbox: [https://robrap.sandbox.edx.org](https://robrap.sandbox.edx.org) (provisioning in progress...)

Before merge:
- [x] Add release tag for xblock-lti-consumer.
- [x] Update reference to new release tag.