### PR TITLE
Reintroduce Waffle

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -393,6 +393,8 @@ MIDDLEWARE_CLASSES = (
     # use Django built in clickjacking protection
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
+    'waffle.middleware.WaffleMiddleware',
+
     # This must be last so that it runs first in the process_response chain
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 )
@@ -820,6 +822,7 @@ INSTALLED_APPS = (
 
     # Database-backed configuration
     'config_models',
+    'waffle',
 
     # Monitor the status of services
     'openedx.core.djangoapps.service_status',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1187,6 +1187,8 @@ MIDDLEWARE_CLASSES = (
 
     'openedx.core.djangoapps.theming.middleware.CurrentSiteThemeMiddleware',
 
+    'waffle.middleware.WaffleMiddleware',
+
     # This must be last
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 )
@@ -1921,6 +1923,7 @@ INSTALLED_APPS = (
 
     # Database-backed configuration
     'config_models',
+    'waffle',
 
     # Monitor the status of services
     'openedx.core.djangoapps.service_status',

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -39,6 +39,7 @@ django-user-tasks==0.1.2
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
 django==1.8.17
+django-waffle==0.11.1
 djangorestframework-jwt==1.8.0
 djangorestframework-oauth==1.1.0
 edx-ccx-keys==0.2.1


### PR DESCRIPTION
Waffle serves as a complement to config models. It's useful in feature rollout situations where you may not want to incur the overhead of creating and committing a migration (required for adding a field to a config model), and also handles gradual, percentage-based rollouts.

ECOM-4422

@edx/ecommerce @cpennington we use Waffle in our other projects to manage feature rollout. I'd like to install it here to provide it as an option for feature rollout. I intend to use it to route traffic from the programs service to the catalog service as we switch over pages displaying program-based information.