### PR TITLE
Transition program list and detail pages to the catalog

### DIFF
--- a/lms/djangoapps/learner_dashboard/views.py
+++ b/lms/djangoapps/learner_dashboard/views.py
@@ -13,6 +13,7 @@ from openedx.core.djangoapps.credentials.utils import get_programs_credentials
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.programs import utils
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
+import waffle
 
 
 @login_required
@@ -23,7 +24,8 @@ def program_listing(request):
     if not programs_config.show_program_listing:
         raise Http404
 
-    meter = utils.ProgramProgressMeter(request.user)
+    use_catalog = waffle.switch_is_active('get_programs_from_catalog')
+    meter = utils.ProgramProgressMeter(request.user, use_catalog=use_catalog)
 
     context = {
         'credentials': get_programs_credentials(request.user),

--- a/openedx/core/djangolib/testing/tests/test_utils.py
+++ b/openedx/core/djangolib/testing/tests/test_utils.py
@@ -5,8 +5,9 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.http.request import HttpRequest
 from django.test import TestCase
+from waffle.models import Switch
 
-from ..utils import get_mock_request
+from ..utils import get_mock_request, toggle_switch
 
 USER_MODEL = get_user_model()
 
@@ -27,3 +28,27 @@ class TestGetMockRequest(TestCase):
     def test_mock_request_without_user(self):
         request = get_mock_request()
         self.assertIsInstance(request.user, AnonymousUser)
+
+
+class TestToggleSwitch(TestCase):
+    """
+    Verify that the toggle_switch utility can be used to turn Waffle Switches
+    on and off.
+    """
+    def test_toggle_switch(self):
+        """Verify that a new switch can be turned on and off."""
+        name = 'foo'
+
+        switch = toggle_switch(name)
+
+        # Verify that the switch was saved.
+        self.assertEqual(switch, Switch.objects.get())
+
+        # Verify that the switch has the right name and is active.
+        self.assertEqual(switch.name, name)
+        self.assertTrue(switch.active)
+
+        switch = toggle_switch(name)
+
+        # Verify that the switch has been turned off.
+        self.assertFalse(switch.active)

--- a/openedx/core/djangolib/testing/utils.py
+++ b/openedx/core/djangolib/testing/utils.py
@@ -18,8 +18,8 @@ from django.core.cache import caches
 from django.test import RequestFactory, TestCase, override_settings
 from django.conf import settings
 from django.contrib import sites
-
 from nose.plugins import Plugin
+from waffle.models import Switch
 
 from request_cache.middleware import RequestCache
 
@@ -190,3 +190,25 @@ def skip_unless_lms(func):
     Only run the decorated test in the LMS test suite
     """
     return skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in LMS')(func)
+
+
+def toggle_switch(name, active=True):
+    """
+    Activate or deactivate a Waffle switch. The switch is created if it does not exist.
+
+    Arguments:
+        name (str): Name of the switch to be toggled.
+
+    Keyword Arguments:
+        active (bool): Whether a newly created switch should be on or off.
+
+    Returns:
+        Switch
+    """
+    switch, created = Switch.objects.get_or_create(name=name, defaults={'active': active})
+
+    if not created:
+        switch.active = not switch.active
+        switch.save()
+
+    return switch


### PR DESCRIPTION
Uses a Waffle Switch to route traffic between the programs and catalog services. A future commit will remove use of the switch and use the catalog exclusively.

ECOM-4422

@edx/ecommerce please review.