### PR TITLE
Block Structure: Don't invalidate immediately upon course publish

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
@@ -1,15 +1,20 @@
 """
 Unit tests for the Course Blocks signals
 """
+import ddt
+from mock import patch
+from waffle.testutils import override_switch
 
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from ..api import get_block_structure_manager
+from ..signals import INVALIDATE_CACHE_ON_PUBLISH_SWITCH
 from .helpers import is_course_in_block_structure_cache
 
 
+@ddt.ddt
 class CourseBlocksSignalTest(ModuleStoreTestCase):
     """
     Tests for the Course Blocks signal
@@ -40,6 +45,17 @@ class CourseBlocksSignalTest(ModuleStoreTestCase):
             test_display_name,
             updated_block_structure.get_xblock_field(self.course_usage_key, 'display_name')
         )
+
+    @ddt.data(True, False)
+    @patch('openedx.core.lib.block_structure.manager.BlockStructureManager.clear')
+    def test_cache_invalidation(self, invalidate_cache_enabled, mock_bs_manager_clear):
+        test_display_name = "Jedi 101"
+
+        with override_switch(INVALIDATE_CACHE_ON_PUBLISH_SWITCH, active=invalidate_cache_enabled):
+            self.course.display_name = test_display_name
+            self.store.update_item(self.course, self.user.id)
+
+        self.assertEquals(mock_bs_manager_clear.called, invalidate_cache_enabled)
 
     def test_course_delete(self):
         bs_manager = get_block_structure_manager(self.course.id)

--- a/openedx/core/lib/block_structure/manager.py
+++ b/openedx/core/lib/block_structure/manager.py
@@ -95,24 +95,24 @@ class BlockStructureManager(object):
         )
         cache_miss = block_structure is None
         if cache_miss or BlockStructureTransformers.is_collected_outdated(block_structure):
-            with self._bulk_operations():
-                block_structure = BlockStructureFactory.create_from_modulestore(
-                    self.root_block_usage_key,
-                    self.modulestore
-                )
-                BlockStructureTransformers.collect(block_structure)
-                self.block_structure_cache.add(block_structure)
+            block_structure = self.update_collected()
         return block_structure
 
     def update_collected(self):
         """
         Updates the collected Block Structure for the root_block_usage_key.
 
-        Details: The cache is cleared and updated by collecting transformers
-        data from the modulestore.
+        Details: The cache is updated by collecting transformers data from
+        the modulestore.
         """
-        self.clear()
-        self.get_collected()
+        with self._bulk_operations():
+            block_structure = BlockStructureFactory.create_from_modulestore(
+                self.root_block_usage_key,
+                self.modulestore,
+            )
+            BlockStructureTransformers.collect(block_structure)
+            self.block_structure_cache.add(block_structure)
+            return block_structure
 
     def clear(self):
         """

--- a/openedx/core/lib/celery/routers.py
+++ b/openedx/core/lib/celery/routers.py
@@ -33,13 +33,6 @@ class AlternateEnvironmentRouter(object):
         If None is returned from this method, default routing logic is used.
         """
         alternate_env = self.alternate_env_tasks.get(task, None)
-        if 'update_course_in_cache' in task:
-            log.info("TNL-5408: task={task}, args={args}, alternate_env={alt_env}, queues={queues}".format(
-                task=task,
-                args=args,
-                alt_env=alternate_env,
-                queues=getattr(settings, 'CELERY_QUEUES', []).keys()
-            ))
         if alternate_env:
             return self.ensure_queue_env(alternate_env)
         return None


### PR DESCRIPTION
## [TNL-6323](https://openedx.atlassian.net/browse/TNL-6323)

### Description

This PR introduces a Waffle Switch that controls whether the Collected Block Structure should be invalidated immediately when a course is published, forcing all clients to either wait or recompute on their own.  When the Switch is off (the _default_), the Collected Block Structure is not immediately invalidated and all clients will use the updated structure only after its dedicated update-task has completed.  Until then, they continue to use an outdated version.

The code is behind a Waffle Switch so we may dynamically enable/disable this setting on production as needed.

See [Block Structure Cache Invalidation Proposal](https://openedx.atlassian.net/wiki/display/MA/Block+Structure+Cache+Invalidation+Proposal) for additional background information.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @jcdyer 
- [ ] Code review: @efischer19  or @sanfordstudent 

FYI: @jibsheet, @ormsbee 

### Post-review
- [ ] Rebase and squash commits
