### PR TITLE
Bump xblock-vectordraw to 0.2.1.

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -34,5 +34,5 @@ git+https://github.com/open-craft/problem-builder.git@v2.6.5#egg=xblock-problem-
 ubcpi-xblock==0.5.3
 
 # Vector Drawing and ActiveTable XBlocks (Davidson)
--e git+https://github.com/open-craft/xblock-vectordraw.git@v0.2#egg=xblock-vectordraw==0.2
+-e git+https://github.com/open-craft/xblock-vectordraw.git@v0.2.1#egg=xblock-vectordraw==0.2.1
 -e git+https://github.com/open-craft/xblock-activetable.git@1786a2c8fc06ca3ecfac1972464048982bd486ff#egg=xblock-activetable


### PR DESCRIPTION
**Description**:

The new version includes a minor fix for the problem icon.

Vector Draw blocks were using the "default" icon in the LMS navigation bar. The new version makes it use the "problem" icon, which makes more sense.

![screenshot](https://cloud.githubusercontent.com/assets/9010790/13765980/7704e200-ea34-11e5-9070-a45c4e634418.png)

See https://github.com/open-craft/xblock-vectordraw/pull/14 for more info.

**JIRA Ticket**: [OSPR-1653](https://openedx.atlassian.net/browse/OSPR-1653)

**Sandboxes**:

- http://pr14363.sandbox.opencraft.hosting/
- http://studio-pr14363.sandbox.opencraft.hosting/

**Testing Instructions**:

Log into https://pr14363.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+VectorDraw+Test/courseware and observe that the icon used for the unit that contains the VectorDraw component is the expected ("problem") icon, the same icon that is used by the MCQ unit.

Alternatively:

1. Run Studio and LMS
1. Navigate to a course, and then "Settings > Advanced Settings".
1. Update the "Advanced Module List" field to contain `"vectordraw"`.
1. Navigate to the outline and create a new Section, Subsection, and Unit. You will be redirected to the Unit authoring view.
1. Select "Advanced > Vector Drawing" to create a new Vector Drawing problem.
1. Click "Preview" and observe the problem icon in the LMS sequence navigation bar. The new version of `xblock-vectordraw` uses the "problem" icon; the old version used the "default" icon.

**Reviewers**:
- [x] OpenCraft: @pomegranited 
- [ ] edX: ?

- - -
**Settings**
```yaml
EDXAPP_INSTALL_PRIVATE_REQUIREMENTS: true
```

