### PR TITLE
TNL-6333 Log play_video event after seek_video event

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
@@ -78,6 +78,13 @@
                 new_time: 1,
                 type: 'any'
             });
+            expect(state.videoEventsPlugin.emitPlayVideoEvent).toBeTruthy();
+        });
+
+        it('can emit "play_video" event after "seek_video" event ', function() {
+            state.videoEventsPlugin.emitPlayVideoEvent = false;
+            state.el.trigger('seek', [1, 0, 'any']);
+            expect(state.videoEventsPlugin.emitPlayVideoEvent).toBeTruthy();
         });
 
         it('can emit "stop_video" event', function() {

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -94,6 +94,7 @@
                     new_time: time,
                     type: type
                 });
+                this.emitPlayVideoEvent = true;
             },
 
             onSpeedChange: function(event, newSpeed, oldSpeed) {


### PR DESCRIPTION
## [TNL-6333](https://openedx.atlassian.net/browse/TNL-6333)

### Description

'play_video' event was being called after 'seek_video' event but implementation in 'play_video' event was not allowing to log this event to server. Previous implementation was set in a way that it only allowed logging of 'play_video' event followed by 'stop_video' or 'pause_video' event.
I have enhanced this implementation to allow logging of 'play_video' after 'seek_video' event too.
Tests are added to ensure this change.

### How to Test?

**Stage** 
Seek video and observe XHR request.

- A URL '/event' is called in response of this activity. Event type is 'seek_video'

- No call is made for 'play_video' event after this.

**Sandbox**
[videoplayerseekevent.sandbox.edx.org](https://videoplayerseekevent.sandbox.edx.org/)

**Screenshots**
Not applicable.


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @asadazam93 
- [x] Code review: @Qubad786 
- [x] Code review: @Ayub-Khan 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [ ] Rebase and squash commits
