### PR TITLE
Fix Block Transformer version checking so cache can be pre-populated

### DIFF
--- a/openedx/core/lib/block_structure/tests/test_manager.py
+++ b/openedx/core/lib/block_structure/tests/test_manager.py
@@ -169,8 +169,10 @@ class TestBlockStructureManager(TestCase, ChildrenMapTestMixin):
 
     def test_get_collected_outdated_data(self):
         self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
-        TestTransformer1.VERSION += 1
+        TestTransformer1.VERSION += 1  # transformer code requires new schema version
         self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
+        TestTransformer1.VERSION -= 1  # old transformer code works with new schema version
+        self.collect_and_verify(expect_modulestore_called=False, expect_cache_updated=False)
         self.assertEquals(TestTransformer1.collect_call_count, 2)
 
     def test_get_collected_version_update(self):

--- a/openedx/core/lib/block_structure/transformers.py
+++ b/openedx/core/lib/block_structure/transformers.py
@@ -90,7 +90,7 @@ class BlockStructureTransformers(object):
         outdated_transformers = []
         for transformer in TransformerRegistry.get_registered_transformers():
             version_in_block_structure = block_structure._get_transformer_data_version(transformer)  # pylint: disable=protected-access
-            if transformer.VERSION != version_in_block_structure:
+            if transformer.VERSION > version_in_block_structure:
                 outdated_transformers.append(transformer)
 
         if outdated_transformers:


### PR DESCRIPTION
## [TNL-6375](https://openedx.atlassian.net/browse/TNL-6375)

### Description

To allow Collected Block Structures to be pre-cached for newer versions of Transformers, we need to relax the version checking in the Block Transformers code.  The current code checks for equality of versions, rather than allowing newer schemas to be backward compatible for older versions.

This change requires Block Transformer schema changes to be backwards compatible for older Block Transformer code versions - at least 1 version back to allow smooth deployments in a multi-version setting.

See [Block Structure Cache Invalidation Proposal](https://openedx.atlassian.net/wiki/display/MA/Block+Structure+Cache+Invalidation+Proposal) for additional background information.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @jcdyer 
- [ ] Code review: One of: @efischer19 @sanfordstudent @yro 

FYI: @jibsheet, @ormsbee 

### Post-review
- [ ] Rebase and squash commits
