### PR TITLE
[pa11ycrawler] update location of ignore rules file

### DIFF
--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -203,7 +203,7 @@ class TestPaverPa11yCrawlerCmd(unittest.TestCase):
         )
         ignore = (
             "pa11y_ignore_rules_url="
-            "https://raw.githubusercontent.com/singingwolfboy/"
+            "https://raw.githubusercontent.com/edx/"
             "pa11ycrawler-ignore/master/ignore.yaml"
         )
         expected_cmd = [

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -395,7 +395,7 @@ class Pa11yCrawler(BokChoyTestSuite):
         Runs pa11ycrawler as staff user against the test course.
         """
         data_dir = os.path.join(self.report_dir, 'data')
-        url = "https://raw.githubusercontent.com/singingwolfboy/pa11ycrawler-ignore/master/ignore.yaml"
+        url = "https://raw.githubusercontent.com/edx/pa11ycrawler-ignore/master/ignore.yaml"
         return [
             "scrapy",
             "crawl",


### PR DESCRIPTION
### What

Change the location of the pa11ycrawler ignore rules file. As the new linked file is identical to the currently linked file, no functional change will occur.

### Why

Our pa11ycrawler ignore rules now live in their own edX repo, https://github.com/edx/pa11ycrawler-ignore. This makes it possible for edX folks to easily add or change pa11ycrawler rules.