### PR TITLE
Disabled system checks for the compile_sass management command

### DIFF
--- a/openedx/core/djangoapps/theming/management/commands/compile_sass.py
+++ b/openedx/core/djangoapps/theming/management/commands/compile_sass.py
@@ -19,6 +19,9 @@ class Command(BaseCommand):
 
     help = 'Compile and collect themed assets...'
 
+    # NOTE (CCB): This allows us to compile static assets in Docker containers without database access.
+    requires_system_checks = False
+
     def add_arguments(self, parser):
         """
             Add arguments for compile_sass command.


### PR DESCRIPTION
The system checks require database access, which is not available when building Docker images. This relaxes the check, allowing the command to execute without a database.

ECOM-6634