### PR TITLE
Bumps the xblock-poll version to v1.2.5

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -95,5 +95,5 @@ git+https://github.com/edx/edx-proctoring.git@0.17.0#egg=edx-proctoring==0.17.0
 
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
--e git+https://github.com/open-craft/xblock-poll@v1.2.3#egg=xblock-poll==1.2.3
+git+https://github.com/open-craft/xblock-poll@v1.2.5#egg=xblock-poll==1.2.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.14#egg=xblock-drag-and-drop-v2==2.0.14


### PR DESCRIPTION
..and removes the -e from the install, as per the [requirements file rules](https://github.com/open-craft/edx-platform/blob/5e9728c78f118a5d21fce11fab0cf6f718eb889d/requirements/edx/github.txt#L28).

[Changes made between v1.2.3 and v1.2.5](https://github.com/open-craft/xblock-poll/compare/v1.2.3...open-craft:v1.2.5):

* https://github.com/open-craft/xblock-poll/pull/19
* https://github.com/open-craft/xblock-poll/pull/21

**JIRA tickets**: [AC-711](https://openedx.atlassian.net/browse/AC-711), [WL-580](https://openedx.atlassian.net/browse/WL-580)

**Sandbox URL**: 

* LMS: http://pr14387.sandbox.opencraft.hosting/
* Studio: http://studio-pr14387.sandbox.opencraft.hosting/

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: None

**Testing instructions**:

1. Login to [sandbox LMS](http://pr14387.sandbox.opencraft.hosting/).
1. Enrol in the [Poll & Survey XBlocks course](https://pr14387.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+PollX+2017_01/about)
1. Ensure that the changes made for the above PRs appear in the xblock source. 

**Reviewers**
- [x] @arizzitano 

**Settings**
```yaml
COMMON_EDXAPP_SETTINGS: 'openstack'
```