### PR TITLE
Bumps pyparser version to 2.0.2 from 2.0.1

### DIFF
--- a/common/lib/calc/setup.py
+++ b/common/lib/calc/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.2",
     packages=["calc"],
     install_requires=[
-        "pyparsing==2.0.1",
+        "pyparsing==2.0.2",
         "numpy==1.6.2",
         "scipy==0.14.0",
     ],

--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.1.1",
     packages=["chem"],
     install_requires=[
-        "pyparsing==2.0.1",
+        "pyparsing==2.0.2",
         "numpy==1.6.2",
         "scipy==0.14.0",
         "nltk==2.0.6",

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -7,7 +7,7 @@
 numpy==1.6.2
 networkx==1.7
 sympy==0.7.1
-pyparsing==2.0.1
+pyparsing==2.0.2
 matplotlib==1.3.1
 
 # We forked NLTK just to make it work with setuptools instead of distribute


### PR DESCRIPTION
Avoids error during setup:
```
Collecting pyparsing==2.0.1 (from -r /edx/app/edxapp/edx-platform/requirements/edx-sandbox/base.txt (line 10))
  Downloading pyparsing-2.0.1.tar.gz (1.1MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File \"<string>\", line 1, in <module>
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/__init__.py\", line 12, in <module>
        import setuptools.version
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/version.py\", line 1, in <module>
        import pkg_resources
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/pkg_resources/__init__.py\", line 72, in <module>
        import packaging.requirements
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/packaging/requirements.py\", line 59, in <module>
        MARKER_EXPR = originalTextFor(MARKER_EXPR())(\"marker\")
    TypeError: __call__() takes exactly 2 arguments (1 given)
```

**Sandbox URL**:

* LMS: http://pr14388.sandbox.opencraft.hosting/
* Studio: http://studio-pr14388.sandbox.opencraft.hosting/

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: ASAP - This issue is breaking our sandbox deployments.

**Testing instructions**:

To verify the issue:
1. Provision a fresh sandbox server using `edx-configuration:master` `edx_sandbox.yml` and current `edx-platform:master`.
1. Note error from description which occurs at ansible step
    ```
    TASK [edxapp : code sandbox | Install base sandbox requirements and create sandbox virtualenv]
   fatal: [137.74.28.184]: FAILED! => {"changed": false, "cmd": "/edx/app/edxapp/venvs/edxapp-sandbox/bin/pip2 install -i https://pypi.python.org/simple --exists-action w -r /edx/app/edxapp/edx-platform/requirements/edx-sandbox/base.txt", "failed": true, "msg": "stdout: New python executable in /edx/app/edxapp/venvs/edxapp-sandbox/bin/python\nInstalling setuptools, pip, wheel...done.\nCollecting numpy==1.6.2 (from -r /edx/app/edxapp/edx-platform/requirements/edx-sandbox/base.txt (line 7))\n  Downloading numpy-1.6.2-cp27-cp27mu-manylinux1_x86_64.whl (13.6MB)\nCollecting networkx==1.7 (from -r /edx/app/edxapp/edx-platform/requirements/edx-sandbox/base.txt (line 8))\n  Downloading networkx-1.7.zip (1.0MB)\nCollecting sympy==0.7.1 (from -r /edx/app/edxapp/edx-platform/requirements/edx-sandbox/base.txt (line 9))\n  Downloading sympy-0.7.1.tar.gz (3.6MB)\nCollecting pyparsing==2.0.1 (from -r /edx/app/edxapp/edx-platform/requirements/edx-sandbox/base.txt (line 10))\n  Downloading pyparsing-2.0.1.tar.gz (1.1MB)\n    Complete output from command python setup.py egg_info:\n    Traceback (most recent call last):\n      File \"<string>\", line 1, in <module>\n      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/__init__.py\", line 12, in <module>\n        import setuptools.version\n      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/version.py\", line 1, in <module>\n        import pkg_resources\n      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/pkg_resources/__init__.py\", line 72, in <module>\n        import packaging.requirements\n      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/packaging/requirements.py\", line 59, in <module>\n        MARKER_EXPR = originalTextFor(MARKER_EXPR())(\"marker\")\n    TypeError: __call__() takes exactly 2 arguments (1 given)\n    \n    ----------------------------------------\n\n:stderr: Command \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-VyZsTS/pyparsing/\n"}
    ```

To test this fix:
1. Provision a fresh sandbox server using this branch.
1. Note that ansible runs to completion.

**Author notes and concerns**:

1. I have no idea why this issue is happening now!  The `edx-sandbox/requirements` haven't changed for over a year.

**Reviewers**
- [x] @mtyaka 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
COMMON_EDXAPP_SETTINGS: 'openstack'
```