### PR TITLE
Ignore run publication status when requesting programs from the catalog

### DIFF
--- a/openedx/core/djangoapps/catalog/tests/test_utils.py
+++ b/openedx/core/djangoapps/catalog/tests/test_utils.py
@@ -50,7 +50,6 @@ class TestGetPrograms(mixins.CatalogIntegrationMixin, TestCase):
         querystring = {
             'marketable': 1,
             'exclude_utm': 1,
-            'published_course_runs_only': 1,
         }
         if type:
             querystring['type'] = type

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -58,7 +58,6 @@ def get_programs(user=None, uuid=None, type=None):  # pylint: disable=redefined-
         querystring = {
             'marketable': 1,
             'exclude_utm': 1,
-            'published_course_runs_only': 1,
         }
         if type:
             querystring['type'] = type


### PR DESCRIPTION
The programs service has no concept of run publication status. The catalog does, and many runs returned by the programs service are marked as unpublished in the catalog. To maintain existing behavior and continue displaying these runs as part of their respective programs, we need to ignore their publication status.

ECOM-6925

@edx/ecommerce 