### PR TITLE
pa11ycrawler v1.5.8 runnable in devstack

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -170,7 +170,7 @@ nose-exclude
 nose-ignore-docstring
 nose-randomly==1.2.0
 nosexcover==1.0.7
-pa11ycrawler==1.5.4
+pa11ycrawler==1.5.8
 pep8==1.5.7
 PyContracts==1.7.1
 python-subunit==0.0.16


### PR DESCRIPTION
### What
This is essentially just a pa11ycrawler version bump. Code in `accessibility_tests.sh` is commented out only for the purposes of forcing pa11ycrawler to run on jenkins/a11y so reviewers can verify it works, and will be removed once someone has signed off it.

Associated JIRA is https://openedx.atlassian.net/browse/AC-708. Additional documentation for running locally now lives in [this wiki page](https://openedx.atlassian.net/wiki/display/A11Y/pa11ycrawler+Overview).

### Why
So we can use the shiny new functionality introduced in the newest versions of pa11ycrawler (better error catching, fewer dropped URLs, deduplication, etc.).

### Testing
Take a look at [the jenkins/a11y job running on this PR](https://build.testeng.edx.org/job/edx-platform-accessibility-pr/30292/console) to verify 1) it ran with pa11ycrawler v1.5.8, 2) it passed.