### PR TITLE
Pin PyParsing and setuptools to prevent sandbox install failures.

### DIFF
--- a/common/lib/calc/setup.py
+++ b/common/lib/calc/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.2",
     packages=["calc"],
     install_requires=[
-        "pyparsing==2.0.1",
+        "pyparsing==2.0.7",
         "numpy==1.6.2",
         "scipy==0.14.0",
     ],

--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.1.1",
     packages=["chem"],
     install_requires=[
-        "pyparsing==2.0.1",
+        "pyparsing==2.0.7",
         "numpy==1.6.2",
         "scipy==0.14.0",
         "nltk==2.0.6",

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -7,7 +7,7 @@
 numpy==1.6.2
 networkx==1.7
 sympy==0.7.1
-pyparsing==2.0.1
+pyparsing==2.0.7
 matplotlib==1.3.1
 
 # We forked NLTK just to make it work with setuptools instead of distribute

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -4,6 +4,10 @@
 #   * @edx/ospr - to check licensing
 #   * @edx/devops - to check system requirements
 
+# Pin packaging tools the same as edxapp.  Keep them in sync for our sanity.
+setuptools==18.0.1
+pip==7.1.2
+
 numpy==1.6.2
 networkx==1.7
 sympy==0.7.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -81,7 +81,7 @@ pygments==2.0.1
 pygraphviz==1.1
 PyJWT==1.4.0
 pymongo==2.9.1
-pyparsing==2.0.1
+pyparsing==2.0.7
 python-memcached==1.48
 python-openid==2.2.5
 python-dateutil==2.1

--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -4,7 +4,7 @@
 #   * @edx/ospr - to check licensing
 #   * @edx/devops - to check system requirements
 
-# Use a modern setuptools instead of distribute
+# This is an old version of setuptools, and we should upgrade when it is safe.
 setuptools==18.0.1
 
 # Numpy and scipy can't be installed in the same pip run.


### PR DESCRIPTION
This is the fix we have on ficus.master.