### PR TITLE
[ENT-101] Add course-specific data sharing consent hooks for Enterprise app

### DIFF
--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -188,6 +188,7 @@ class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseT
     @override_settings(
         XBLOCK_FIELD_DATA_WRAPPERS=[],
         MODULESTORE_FIELD_OVERRIDE_PROVIDERS=[],
+        ENABLE_ENTERPRISE_INTEGRATION=False,
     )
     def test_field_overrides(self, overrides, course_width, enable_ccx, view_as_ccx):
         """

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -197,6 +197,29 @@ class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
             )
         )
 
+    @patch('courseware.views.index.get_course_specific_consent_url')
+    @patch('courseware.views.index.consent_needed_for_course')
+    def test_redirection_missing_enterprise_consent(self, mock_consent_needed, mock_get_url):
+        """
+        Verify that enrolled students are redirected to the Enterprise consent
+        URL if a linked Enterprise Customer requires data sharing consent
+        and it has not yet been provided.
+        """
+        mock_consent_needed.return_value = True
+        mock_get_url.return_value = reverse('dashboard')
+        self.login(self.enrolled_user)
+        response = self.client.get(
+            reverse(
+                'courseware',
+                kwargs={'course_id': self.course.id.to_deprecated_string()}
+            )
+        )
+        self.assertRedirects(
+            response,
+            reverse('dashboard')
+        )
+        mock_consent_needed.assert_called_once_with(self.enrolled_user, unicode(self.course.id))
+
     def test_instructor_page_access_nonstaff(self):
         """
         Verify non-staff cannot load the instructor

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1130,6 +1130,7 @@ class StartDateTests(ModuleStoreTestCase):
 
 # pylint: disable=protected-access, no-member
 @attr(shard=1)
+@override_settings(ENABLE_ENTERPRISE_INTEGRATION=False)
 @ddt.ddt
 class ProgressPageTests(ModuleStoreTestCase):
     """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-i18n-tools==0.3.7
 edx-lint==0.4.3
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.19.1
+edx-enterprise==0.21.0
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.2


### PR DESCRIPTION
This pull request, in conjunction with edx/edx-enterprise#34, provides the ability to require consent from learners attempting to access courses they've been manually enrolled in by EnterpriseCustomer administrators.

**JIRA tickets**: Implements [ENT-101](https://openedx.atlassian.net/browse/ENT-101)

**Dependencies**: Depends on edx/edx-enterprise#34.

**Screenshots**: TBD

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: 30 January 2017

**Testing instructions**:

1. Navigate to the Enterprise section of the Django Admin site.
2. Create a new Enterprise Customer.
    1. Ensure that data sharing consent is enabled.
    2. Ensure that data sharing consent enforcement is set to "at enrollment".
3. In the edit page for the new Enterprise Customer, click "Manage Learners".
4. Attach an existing LMS user to the Enterprise Customer, and simultaneously enroll them in a course.
    1. Enter a user's email address (e.g., `staff@example.com`) in the box labeled "Type in email or username..."
    2. Enter a course ID (e.g., `course-v1:edX+DemoX+Demo_Course`) in the box labeled "Also enroll these learners in this course".
    3. Select an appropriate course enrollment mode.
    4. Click Submit.
5. Log into the LMS using the account you just linked.
6. Note that the course you enrolled this user in appears on the Dashboard.
7. Click on the course to open its info page; note that you are able to see the info page.
8. Click on the "Course" tab in an attempt to navigate to the courseware.
    1. Observe that you are redirected to a view requesting data sharing consent.
    2. Observe that all the messaging in the page is specific to the course you were attempting to view.
    3. Observe that if you submit the form without providing consent, a warning message appears, and if you proceed, you are redirected to the Dashboard.
9. Repeating steps 7 and 8, this time check the box consenting to data sharing, and click Submit
    1. Observe that you are redirected to the course content after submitting the form, and that subsequent attempts to view the course do not prompt you for data sharing consent.

**Author notes and concerns**:

1. This is still in progress, in that it cannot be wholly finalized until edx/edx-enterprise#34 is merged, and tests for this functionality do not yet exist.

2. This PR currently has a requirement specified to use a particular hash on an `edx-enterprise` development branch; prior to merge, this will be changed back to a PyPI version containing the necessary changes.

**Reviewers**
- [ ] @smarnach 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```