### PR TITLE
Visually indicate fields in new post form are required (TNL-6364)

### DIFF
--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -33,7 +33,7 @@
         <label class="field-label">
             <span class="field-label-text"><%- gettext("Title") %></span>
             <div class="field-help" id="field_help_title">
-                <%- gettext("Add a clear and descriptive title to encourage participation.") %>
+                <%- gettext("Add a clear and descriptive title to encourage participation. (required)") %>
             </div>
             <div>
                 <input aria-describedby="field_help_title" type="text" class="js-post-title field-input" name="title">
@@ -42,7 +42,7 @@
     </div>
 
     <div>
-        <span class="field-label-text field-label-text-full" id="new-post-editor-description"><%- gettext('Your question or idea') %></span>
+        <span class="field-label-text field-label-text-full" id="new-post-editor-description"><%- gettext('Your question or idea (required)') %></span>
         <div class="js-post-body editor" aria-describedby="new-post-editor-description" name="body"></div>
     </div>
     <div class="post-options">

--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -33,7 +33,7 @@
         <label class="field-label">
             <span class="field-label-text"><%- gettext("Title") %></span>
             <div class="field-help" id="field_help_title">
-                <%- gettext("Add a clear and descriptive title to encourage participation. (required)") %>
+                <%- gettext("Add a clear and descriptive title to encourage participation. (Required)") %>
             </div>
             <div>
                 <input aria-describedby="field_help_title" type="text" class="js-post-title field-input" name="title">

--- a/common/static/common/templates/discussion/thread-type.underscore
+++ b/common/static/common/templates/discussion/thread-type.underscore
@@ -5,7 +5,7 @@
             <%- gettext("Post type") %>
         </span>
         <div class="field-help" id="field_help_post_type">
-            <%- gettext("Questions raise issues that need answers. Discussions share ideas and start conversations. (required)") %>
+            <%- gettext("Questions raise issues that need answers. Discussions share ideas and start conversations. (Required)") %>
         </div>
         <div class="field-label">
             <fieldset class="field-input">

--- a/common/static/common/templates/discussion/thread-type.underscore
+++ b/common/static/common/templates/discussion/thread-type.underscore
@@ -5,7 +5,7 @@
             <%- gettext("Post type") %>
         </span>
         <div class="field-help" id="field_help_post_type">
-            <%- gettext("Questions raise issues that need answers. Discussions share ideas and start conversations.") %>
+            <%- gettext("Questions raise issues that need answers. Discussions share ideas and start conversations. (required)") %>
         </div>
         <div class="field-label">
             <fieldset class="field-input">

--- a/common/static/common/templates/discussion/topic.underscore
+++ b/common/static/common/templates/discussion/topic.underscore
@@ -4,7 +4,7 @@
             <%- gettext("Topic area") %>
         </span>
         <div class="field-help" id="field_help_topic_area">
-            <%- gettext("Add your post to a relevant topic to help others find it. (required)") %>
+            <%- gettext("Add your post to a relevant topic to help others find it. (Required)") %>
         </div>
         <div class="field-input">
             <select class="post-topic field-input" aria-describedby="field_help_topic_area" required>

--- a/common/static/common/templates/discussion/topic.underscore
+++ b/common/static/common/templates/discussion/topic.underscore
@@ -4,7 +4,7 @@
             <%- gettext("Topic area") %>
         </span>
         <div class="field-help" id="field_help_topic_area">
-            <%- gettext("Add your post to a relevant topic to help others find it.") %>
+            <%- gettext("Add your post to a relevant topic to help others find it. (required)") %>
         </div>
         <div class="field-input">
             <select class="post-topic field-input" aria-describedby="field_help_topic_area" required>


### PR DESCRIPTION
## [TNL-6364](https://openedx.atlassian.net/browse/TNL-6364)

### Description

Visually indicate fields in new post form are required. Mark S recommended this approach over asterisks and would like it to be applied to _all_ the required fields in this form (not just the two the auditors noticed).

### Sandbox
- [x] [https://bjacobel-required.sandbox.edx.org](https://bjacobel-required.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/)

### Testing
UI strings only
