### PR TITLE
Include django-memcached-hashring to support consistent hashing.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -83,6 +83,7 @@ pygraphviz==1.1
 PyJWT==1.4.0
 pymongo==2.9.1
 python-memcached==1.48
+django-memcached-hashring==0.1.2
 python-openid==2.2.5
 python-dateutil==2.1
 


### PR DESCRIPTION
This literally just adds the dependency.  Actually switching over to using it involves changing the `CACHES` settings in the secure configuration.