### PR TITLE
Bugfix: behavior of import/export should works correct after modulestore().copy_from_template

### DIFF
--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -275,7 +275,7 @@ class CourseTestCase(ProceduralCourseTestMixin, ModuleStoreTestCase):
 
         return course
 
-    def assertCoursesEqual(self, course1_id, course2_id):
+    def assertCoursesEqual(self, course1_id, course2_id, include_default=False):
         """
         Verifies the content of the two given courses are equal
         """
@@ -313,7 +313,7 @@ class CourseTestCase(ProceduralCourseTestMixin, ModuleStoreTestCase):
                 self.assertEqual(course1_item.data, course2_item.data)
 
             # compare meta-data
-            self.assertEqual(own_metadata(course1_item), own_metadata(course2_item))
+            self.assertEqual(own_metadata(course1_item, include_default), own_metadata(course2_item, include_default))
 
             # compare children
             self.assertEqual(course1_item.has_children, course2_item.has_children)

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -698,7 +698,7 @@ class TestLibraryImportExport(CourseTestCase):
         )
 
         # Compare the two content libraries for equality.
-        self.assertCoursesEqual(source_library1_key, source_library2_key)
+        self.assertCoursesEqual(source_library1_key, source_library2_key, include_default=True)
 
 
 @ddt.ddt

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -258,12 +258,12 @@ def inherit_metadata(descriptor, inherited_data):
         pass
 
 
-def own_metadata(module):
+def own_metadata(module, include_default=False):
     """
     Return a JSON-friendly dictionary that contains only non-inherited field
     keys, mapped to their serialized values
     """
-    return module.get_explicitly_set_fields_by_scope(Scope.settings)
+    return module.get_explicitly_set_fields_by_scope(Scope.settings, include_default)
 
 
 class InheritingFieldData(KvsFieldData):

--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -236,7 +236,7 @@ class ImportTestCase(BaseCourseTestCase):
         with descriptor.runtime.export_fs.open('chapter/ch.xml') as f:
             chapter_xml = etree.fromstring(f.read())
         self.assertEqual(chapter_xml.tag, 'chapter')
-        self.assertNotIn('due', chapter_xml.attrib)
+        self.assertIn('due', chapter_xml.attrib)
 
     def test_metadata_import_export(self):
         """Two checks:

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -408,23 +408,30 @@ class XModuleMixin(XModuleFields, XBlock):
         """
         return self._asides
 
-    def get_explicitly_set_fields_by_scope(self, scope=Scope.content):
+    def get_explicitly_set_fields_by_scope(self, scope=Scope.content, include_default=False):
         """
         Get a dictionary of the fields for the given scope which are set explicitly on this xblock. (Including
         any set to None.)
         """
         result = {}
         for field in self.fields.values():
-            if field.scope == scope and field.is_set_on(self):
-                try:
-                    result[field.name] = field.read_json(self)
-                except TypeError as exception:
-                    exception_message = "{message}, Block-location:{location}, Field-name:{field_name}".format(
-                        message=exception.message,
-                        location=unicode(self.location),
-                        field_name=field.name
-                    )
-                    raise TypeError(exception_message)
+            if field.scope == scope:
+                if field.is_set_on(self):
+                    try:
+                        result[field.name] = field.read_json(self)
+                    except TypeError as exception:
+                        exception_message = "{message}, Block-location:{location}, Field-name:{field_name}".format(
+                            message=exception.message,
+                            location=unicode(self.location),
+                            field_name=field.name
+                        )
+                        raise TypeError(exception_message)
+                elif include_default:
+                    try:
+                        if self._unwrapped_field_data.default(self, field.name):
+                            result[field.name] = field.read_json(self)
+                    except KeyError:
+                        pass
         return result
 
     def has_children_at_depth(self, depth):

--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -458,10 +458,13 @@ class XmlParserMixin(object):
         node.tag = self.category
 
         # Add the non-inherited metadata
-        for attr in sorted(own_metadata(self)):
+        for attr in sorted(own_metadata(self, include_default=True)):
             # don't want e.g. data_dir
             if attr not in self.metadata_to_strip and attr not in self.metadata_to_export_to_policy:
-                val = serialize_field(self._field_data.get(self, attr))
+                try:
+                    val = serialize_field(self._field_data.get(self, attr))
+                except KeyError:
+                    val = serialize_field(self._field_data.default(self, attr))
                 try:
                     xml_object.set(attr, val)
                 except Exception:


### PR DESCRIPTION
Steps how to reproduce the problem:

1. Create new course **X** with chapter **"Test Chapter"** and sequential **"Test Sequential"**
2. Create new course **Y** with chapter **"Some Chapter"**
3. Use built-in `modulestore.copy_from_template` function to copy **"Test Sequential"** to **"Some Chapter"**:
```
m = modulestore()
m.copy_from_template([test_sequential_location], dest_key=some_chapter.location, user_id=user.id)
```
4. Make export of the course **Y**
5. Create new course **Z** through the import of **Y.tar.gz**

Expected result: course **Z** should contain blocks **"Some Chapter"/"Test Sequential"** but it contains **"Some Chapter"/"<some_hash>"** because sequential block was exported with an empty **display_name** field