### PR TITLE
edx.org/login?next= should not be able to point to an asset

### DIFF
--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -1,7 +1,9 @@
 """ Test Student helpers """
 
 import logging
+import ddt
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -13,24 +15,34 @@ from student.helpers import get_next_url_for_login_page
 LOGGER_NAME = "student.helpers"
 
 
+@ddt.ddt
 class TestLoginHelper(TestCase):
     """Test login helper methods."""
     def setUp(self):
         super(TestLoginHelper, self).setUp()
         self.request = RequestFactory()
 
-    def test_unsafe_next(self):
+    @ddt.data(
+        ("https://www.amazon.com", "text/html"),
+        ("favicon.ico", "image/*"),
+        ("https://www.test.com/test.jpg", "image/*"),
+        (settings.STATIC_URL + "dummy.png", "image/*"),
+    )
+    @ddt.unpack
+    def test_unsafe_next(self, unsafe_url, http_accept):
         """ Test unsafe next parameter """
-        unsafe_url = "https://www.amazon.com"
-        with LogCapture(LOGGER_NAME, level=logging.ERROR) as logger:
+        with LogCapture(LOGGER_NAME, level=logging.WARNING) as logger:
             req = self.request.get(reverse("login") + "?next={url}".format(url=unsafe_url))
+            req.META["HTTP_ACCEPT"] = http_accept  # pylint: disable=no-member
             get_next_url_for_login_page(req)
             logger.check(
-                (LOGGER_NAME, "ERROR", u"Unsafe redirect parameter detected: u'{url}'".format(url=unsafe_url))
+                (LOGGER_NAME, "WARNING",
+                 u"Unsafe redirect parameter detected after login page: u'{url}'".format(url=unsafe_url))
             )
 
     def test_safe_next(self):
         """ Test safe next parameter """
         req = self.request.get(reverse("login") + "?next={url}".format(url="/dashboard"))
+        req.META["HTTP_ACCEPT"] = "text/html"  # pylint: disable=no-member
         next_page = get_next_url_for_login_page(req)
         self.assertEqual(next_page, u'/dashboard')

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -498,7 +498,7 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
         Should vary by course depending on its enrollment_domain
         """
         TARGET_URL = reverse('courseware', args=[self.course.id.to_deprecated_string()])            # pylint: disable=invalid-name
-        noshib_response = self.client.get(TARGET_URL, follow=True)
+        noshib_response = self.client.get(TARGET_URL, follow=True, HTTP_ACCEPT="text/html")
         self.assertEqual(noshib_response.redirect_chain[-1],
                          ('http://testserver/login?next={url}'.format(url=TARGET_URL), 302))
         self.assertContains(noshib_response, (u"Sign in or Register | {platform_name}"
@@ -509,7 +509,8 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
         shib_response = self.client.get(**{'path': TARGET_URL_SHIB,
                                            'follow': True,
                                            'REMOTE_USER': self.extauth.external_id,
-                                           'Shib-Identity-Provider': 'https://idp.stanford.edu/'})
+                                           'Shib-Identity-Provider': 'https://idp.stanford.edu/',
+                                           'HTTP_ACCEPT': "text/html"})
         # Test that the shib-login redirect page with ?next= and the desired page are part of the redirect chain
         # The 'courseware' page actually causes a redirect itself, so it's not the end of the chain and we
         # won't test its contents

--- a/common/djangoapps/student/tests/test_login_registration_forms.py
+++ b/common/djangoapps/student/tests/test_login_registration_forms.py
@@ -90,7 +90,7 @@ class LoginFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStoreTes
     def test_courseware_redirect(self, backend_name):
         # Try to access courseware while logged out, expecting to be
         # redirected to the login page.
-        response = self.client.get(self.courseware_url, follow=True)
+        response = self.client.get(self.courseware_url, follow=True, HTTP_ACCEPT="text/html")
         self.assertRedirects(
             response,
             u"{url}?next={redirect_url}".format(
@@ -118,7 +118,7 @@ class LoginFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStoreTes
             ('email_opt_in', 'true'),
             ('next', '/custom/final/destination'),
         ]
-        response = self.client.get(self.url, params)
+        response = self.client.get(self.url, params, HTTP_ACCEPT="text/html")
         expected_url = _third_party_login_url(
             backend_name,
             "login",
@@ -137,7 +137,7 @@ class LoginFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStoreTes
         ]
 
         # Get the login page
-        response = self.client.get(self.url, params)
+        response = self.client.get(self.url, params, HTTP_ACCEPT="text/html")
 
         # Verify that the parameters are sent on to the next page correctly
         post_login_handler = _finish_auth_url(params)
@@ -194,7 +194,7 @@ class RegisterFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStore
             ('email_opt_in', 'true'),
             ('next', '/custom/final/destination'),
         ]
-        response = self.client.get(self.url, params)
+        response = self.client.get(self.url, params, HTTP_ACCEPT="text/html")
         expected_url = _third_party_login_url(
             backend_name,
             "register",
@@ -213,7 +213,7 @@ class RegisterFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStore
         ]
 
         # Get the login page
-        response = self.client.get(self.url, params)
+        response = self.client.get(self.url, params, HTTP_ACCEPT="text/html")
 
         # Verify that the parameters are sent on to the next page correctly
         post_login_handler = _finish_auth_url(params)

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -336,7 +336,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         # The response should have a "Sign In" button with the URL
         # that preserves the querystring params
         with with_comprehensive_theme_context(theme):
-            response = self.client.get(reverse(url_name), params)
+            response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
 
         expected_url = '/login?{}'.format(self._finish_auth_url_param(params + [('next', '/dashboard')]))
         self.assertContains(response, expected_url)
@@ -352,7 +352,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
 
         # Verify that this parameter is also preserved
         with with_comprehensive_theme_context(theme):
-            response = self.client.get(reverse(url_name), params)
+            response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
 
         expected_url = '/login?{}'.format(self._finish_auth_url_param(params))
         self.assertContains(response, expected_url)
@@ -387,11 +387,11 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         if current_backend is not None:
             pipeline_target = "student_account.views.third_party_auth.pipeline"
             with simulate_running_pipeline(pipeline_target, current_backend):
-                response = self.client.get(reverse(url_name), params)
+                response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
 
         # Do NOT simulate a running pipeline
         else:
-            response = self.client.get(reverse(url_name), params)
+            response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
 
         # This relies on the THIRD_PARTY_AUTH configuration in the test settings
         expected_providers = [
@@ -424,7 +424,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
 
     def test_hinted_login(self):
         params = [("next", "/courses/something/?tpa_hint=oa2-google-oauth2")]
-        response = self.client.get(reverse('signin_user'), params)
+        response = self.client.get(reverse('signin_user'), params, HTTP_ACCEPT="text/html")
         self.assertContains(response, '"third_party_auth_hint": "oa2-google-oauth2"')
 
     @override_settings(SITE_NAME=settings.MICROSITE_TEST_HOSTNAME)

--- a/openedx/core/djangoapps/external_auth/tests/test_shib.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_shib.py
@@ -569,7 +569,8 @@ class ShibSPTestModifiedCourseware(ModuleStoreTestCase):
                           'data': dict(params),
                           'follow': False,
                           'REMOTE_USER': 'testuser@stanford.edu',
-                          'Shib-Identity-Provider': 'https://idp.stanford.edu/'}
+                          'Shib-Identity-Provider': 'https://idp.stanford.edu/',
+                          'HTTP_ACCEPT': "text/html"}
         response = self.client.get(**request_kwargs)
         # successful login is a redirect to the URL that handles auto-enrollment
         self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
ECOM-6463
## Manual testing Effort
For the testing of this issue, I created a separate HTML file with the image source like _src="http://0.0.0.0:8000/login?next=static file path"_. In the static asset path, I have used CDN hosted files, static files of platform and favicon.ico files. For these cases image source was not loaded as it used to be previously.
@schenedx please review