### PR TITLE
add course and user id to library content assigned

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -7,6 +7,7 @@ from openedx.core.lib.block_structure.transformer import BlockStructureTransform
 from xmodule.library_content_module import LibraryContentModule
 from xmodule.modulestore.django import modulestore
 from eventtracking import tracker
+from track import contexts
 
 
 class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransformer):
@@ -105,7 +106,14 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                     )
 
                 # publish events for analytics
-                self._publish_events(block_structure, block_key, previous_count, max_count, block_keys)
+                self._publish_events(
+                    block_structure,
+                    block_key,
+                    previous_count,
+                    max_count,
+                    block_keys,
+                    usage_info.user.id,
+                )
                 all_selected_children.update(usage_info.course_key.make_usage_key(s[0], s[1]) for s in selected)
 
         def check_child_removal(block_key):
@@ -145,8 +153,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
         except StudentModule.DoesNotExist:
             return None
 
-    @classmethod
-    def _publish_events(cls, block_structure, location, previous_count, max_count, block_keys):
+    def _publish_events(self, block_structure, location, previous_count, max_count, block_keys, user_id):
         """
         Helper method to publish events for analytics purposes
         """
@@ -171,10 +178,15 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 "location": unicode(location),
                 "previous_count": previous_count,
                 "result": result,
-                "max_count": max_count
+                "max_count": max_count,
             }
             event_data.update(kwargs)
-            tracker.emit("edx.librarycontentblock.content.{}".format(event_name), event_data)
+            context = contexts.course_context_from_course_id(location.course_key)
+            if user_id:
+                context['user_id'] = user_id
+            full_event_name = "edx.librarycontentblock.content.{}".format(event_name)
+            with tracker.get_tracker().context(full_event_name, context):
+                tracker.emit(full_event_name, event_data)
 
         LibraryContentModule.publish_selected_children_events(
             block_keys,

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -24,6 +24,7 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey, CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from requests.auth import HTTPBasicAuth
+from track import contexts
 from xblock.core import XBlock
 from xblock.django.request import django_to_webob_request, webob_to_django_response
 from xblock.exceptions import NoSuchHandlerError, NoSuchViewError
@@ -475,13 +476,16 @@ def get_module_system_for_user(user, student_data,  # TODO  # pylint: disable=to
                 only_if_higher=event.get('only_if_higher'),
             )
         else:
-            aside_context = {}
+            context = contexts.course_context_from_course_id(course_id)
+            if block.runtime.user_id:
+                context['user_id'] = block.runtime.user_id
+            context['asides'] = {}
             for aside in block.runtime.get_asides(block):
                 if hasattr(aside, 'get_event_context'):
                     aside_event_info = aside.get_event_context(event_type, event)
                     if aside_event_info is not None:
-                        aside_context[aside.scope_ids.block_type] = aside_event_info
-            with tracker.get_tracker().context('asides', {'asides': aside_context}):
+                        context['asides'][aside.scope_ids.block_type] = aside_event_info
+            with tracker.get_tracker().context(event_type, context):
                 track_function(event_type, event)
 
     def rebind_noauth_module_to_user(module, real_user):


### PR DESCRIPTION
## [TNL-6219](https://openedx.atlassian.net/browse/TNL-6219)

### Description

Adds course and user info to 'edx.librarycontentblock.content.assigned' events. Also adds user id to 'edx.librarycontentblock.content.removed' events, which seemed appropriate. As best I can tell, the runtime user ID corresponds to the logged-in user, and this event is emitted when a logged-in user accesses a content library block for the first time, which dynamically assigns a specific block within the library to the user.

### Testing
- [ ] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @nasthagiri 
- [x] Code review: @brianhw or @mulby 
- [x] Doc Review: @catong 

FYI @stroilova @sstack22 

### Post-review
- [x] Rebase and squash commits