### PR TITLE
TNL-6419 Fix in file-checking code in Xmodule.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/capa/display.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.js
@@ -509,7 +509,7 @@
                     ref = element.files;
                     for (loopI = 0, loopLen = ref.length; loopI < loopLen; loopI++) {
                         file = ref[loopI];
-                        if (allowedFiles.length !== 0 && indexOfHelper.call(allowedFiles, file.name < 0)) {
+                        if (allowedFiles.length !== 0 && indexOfHelper.call(allowedFiles, file.name) < 0) {
                             unallowedFileSubmitted = true;
                             errors.push(edx.StringUtils.interpolate(
                                 gettext('You submitted {filename}; only {allowedFiles} are allowed.'), {


### PR DESCRIPTION
## [TNL-6419](https://openedx.atlassian.net/browse/TNL-6419)

### Description

Error in file-checking code in Xmodule.

### How to Test?

**Production** 
- Go to the link [https://courses.edx.org/courses/BerkeleyX/CS188x_1/1T2013/courseware/a1335497b2a04c0e934ec324563e69aa/1d6e5b5229b94619900b0196eae8e024/](https://courses.edx.org/courses/BerkeleyX/CS188x_1/1T2013/courseware/a1335497b2a04c0e934ec324563e69aa/1d6e5b5229b94619900b0196eae8e024/)
- Download these two files. **bustersAgents.py** and **inference.py**
- Go to the sequence *p4_tracking_submission*
- upload theses files and add `None` in a text field and submit it
- files not uploaded

**Sandbox**
 - Go to link [https://tnl-6419.sandbox.edx.org/courses/course-v1:Error_code+cs101+2016/courseware/a1335497b2a04c0e934ec324563e69aa/1d6e5b5229b94619900b0196eae8e024/](https://tnl-6419.sandbox.edx.org/courses/course-v1:Error_code+cs101+2016/courseware/a1335497b2a04c0e934ec324563e69aa/1d6e5b5229b94619900b0196eae8e024/)
- Download these two files. **bustersAgents.py** and **inference.py**
- Go to the sequence *p4_tracking_submission*
- upload theses files and add `None` in a text field and submit it
- files are uploaded

**Screenshots**
**Before the Fix.**
![screen shot 2017-01-31 at 4 10 59 pm](https://cloud.githubusercontent.com/assets/7627421/22462688/271bec80-e7d0-11e6-9622-df11f263d30e.png)

**After the Fix.**
![screen shot 2017-01-31 at 4 07 17 pm](https://cloud.githubusercontent.com/assets/7627421/22462701/36de4910-e7d0-11e6-9bce-b8277a25a59a.png)


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @noraiz-anwar 
- [x] Code review: @Qubad786 

FYI: @cahrens 

### Post-review
- [x] Rebase and squash commits