### PR TITLE
Fix safe template warning.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/capa/display.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.js
@@ -1043,7 +1043,8 @@
                     } else if (!$inputLabel.hasClass('choicegroup_correct')) {
                         // If the status HTML is not already present (due to clicking Submit), append
                         // the status HTML for correct answers.
-                        results.push($inputLabel.addClass('choicegroup_correct').append(correctStatusHtml));
+                        edx.HtmlUtils.append($inputLabel, edx.HtmlUtils.HTML(correctStatusHtml));
+                        results.push($inputLabel.addClass('choicegroup_correct'));
                     }
                 }
                 return results;


### PR DESCRIPTION
@jlajoie and @staubina I introduced a new safe template failure on my PR. I didn't notice because the capa code still has a lot of safe template issues, and my PR didn't fail.

Master currently is failing quality, so I'd like to get this in quickly. Here is a screenshot of it working on my devstack, and the bok choy tests I wrote will also verify that the HTML is injected. Can you please review?

![image](https://cloud.githubusercontent.com/assets/484484/22479579/3d359e44-e7bc-11e6-873d-2a6a7fa0b335.png)
