### PR TITLE
Add aria-disabled to WMD undo/redo buttons

### DIFF
--- a/lms/static/js/Markdown.Editor.js
+++ b/lms/static/js/Markdown.Editor.js
@@ -1408,10 +1408,18 @@
                         }
                     });
                 }
+                // This line does not appear in vanilla WMD. It was added by edX to improve accessibility.
+                // It should become a separate commit applied to WMD's official HEAD if we remove this edited version
+                // of WMD from Git and install it from NPM / a maintained public fork.
+                button.removeAttribute('aria-disabled');
             }
             else {
                 image.style.backgroundPosition = button.XShift + ' ' + disabledYShift;
                 button.onmouseover = button.onmouseout = button.onclick = function() { };
+                // This line does not appear in vanilla WMD. It was added by edX to improve accessibility.
+                // It should become a separate commit applied to WMD's official HEAD if we remove this edited version
+                // of WMD from Git and install it from NPM / a maintained public fork.
+                button.setAttribute('aria-disabled', true);
             }
         }
 


### PR DESCRIPTION
## [TNL-6365](https://openedx.atlassian.net/browse/TNL-6365)

### Description
Add aria-disabled to WMD undo/redo buttons when the undo/redo stacks are empty and the buttons are visually greyed out.

FWIW, I just want to go on record one last time as being uncomfortable with editing this third-party (abandoned) code directly. It doesn't feel like the right thing to do for the long-term maintainability of Platform.

### Sandbox
- [x] https://bjacobel-wmd-aria.sandbox.edx.org (online by Wednesday morning).

### Post-review
- [ ] Rebase and squash commits