### PR TITLE
Fix cohort IntegrityErrors

### DIFF
--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -6,6 +6,7 @@ forums, and to the cohort admin views.
 import logging
 import random
 
+from django.db import IntegrityError, transaction
 from django.db.models.signals import post_save, m2m_changed
 from django.dispatch import receiver
 from django.http import Http404
@@ -194,11 +195,22 @@ def get_cohort(user, course_key, assign=True, use_cached=False):
             return None
 
     # Otherwise assign the user a cohort.
-    membership = CohortMembership.objects.create(
-        user=user,
-        course_user_group=get_random_cohort(course_key)
-    )
-    return request_cache.data.setdefault(cache_key, membership.course_user_group)
+    try:
+        with transaction.atomic():
+            membership = CohortMembership.objects.create(
+                user=user,
+                course_user_group=get_random_cohort(course_key)
+            )
+            return request_cache.data.setdefault(cache_key, membership.course_user_group)
+    except IntegrityError as integrity_error:
+        # An IntegrityError is raised when multiple workers attempt to
+        # create the same row in one of the cohort model entries:
+        # CourseCohort, CohortMembership.
+        log.info(
+            "HANDLING_INTEGRITY_ERROR: IntegrityError encountered for course '%s' and user '%s': %s",
+            course_key, user.id, unicode(integrity_error)
+        )
+        return get_cohort(user, course_key, assign, use_cached)
 
 
 def get_random_cohort(course_key):


### PR DESCRIPTION
## [TNL-5725](https://openedx.atlassian.net/browse/TNL-5725)

### Description

Fix handling of expected IntegrityErrors with lazy cohort assignment.

- Moved the exception handling down into the `get_cohort` method so it is handled for all callers of that method.  Currently, it was only handled by the auto-track-cohorting feature.

- Per Splunk, there were 128 events in the last week impacted by this issue (excluding the auto-track-cohorting feature).  These include viewing Courseware and Progress pages.

- Also, wrapped the exceptional code in a `transaction.atomic` call, per [django instructions](https://docs.djangoproject.com/en/1.10/topics/db/transactions/#controlling-transactions-explicitly).

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @efischer19 
- [ ] Code review: @sanfordstudent 

### Post-review
- [ ] Rebase and squash commits