### PR TITLE
Fix mongo query count for Grades API

### DIFF
--- a/lms/djangoapps/grades/api/tests/test_views.py
+++ b/lms/djangoapps/grades/api/tests/test_views.py
@@ -16,7 +16,7 @@ from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, StaffF
 from lms.djangoapps.grades.tests.utils import mock_get_score
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase, TEST_DATA_SPLIT_MODULESTORE
 
 
@@ -68,34 +68,35 @@ class CurrentGradeViewTest(SharedModuleStoreTestCase, APITestCase):
         super(CurrentGradeViewTest, cls).setUpClass()
 
         cls.course = CourseFactory.create(display_name='test course', run="Testing_course")
+        with cls.store.bulk_operations(cls.course.id):
 
-        chapter = ItemFactory.create(
-            category='chapter',
-            parent_location=cls.course.location,
-            display_name="Chapter 1",
-        )
-        # create a problem for each type and minimum count needed by the grading policy
-        # A section is not considered if the student answers less than "min_count" problems
-        for grading_type, min_count in (("Homework", 12), ("Lab", 12), ("Midterm Exam", 1), ("Final Exam", 1)):
-            for num in xrange(min_count):
-                section = ItemFactory.create(
-                    category='sequential',
-                    parent_location=chapter.location,
-                    due=datetime(2013, 9, 18, 11, 30, 00),
-                    display_name='Sequential {} {}'.format(grading_type, num),
-                    format=grading_type,
-                    graded=True,
-                )
-                vertical = ItemFactory.create(
-                    category='vertical',
-                    parent_location=section.location,
-                    display_name='Vertical {} {}'.format(grading_type, num),
-                )
-                ItemFactory.create(
-                    category='problem',
-                    parent_location=vertical.location,
-                    display_name='Problem {} {}'.format(grading_type, num),
-                )
+            chapter = ItemFactory.create(
+                category='chapter',
+                parent_location=cls.course.location,
+                display_name="Chapter 1",
+            )
+            # create a problem for each type and minimum count needed by the grading policy
+            # A section is not considered if the student answers less than "min_count" problems
+            for grading_type, min_count in (("Homework", 12), ("Lab", 12), ("Midterm Exam", 1), ("Final Exam", 1)):
+                for num in xrange(min_count):
+                    section = ItemFactory.create(
+                        category='sequential',
+                        parent_location=chapter.location,
+                        due=datetime(2013, 9, 18, 11, 30, 00, tzinfo=UTC),
+                        display_name='Sequential {} {}'.format(grading_type, num),
+                        format=grading_type,
+                        graded=True,
+                    )
+                    vertical = ItemFactory.create(
+                        category='vertical',
+                        parent_location=section.location,
+                        display_name='Vertical {} {}'.format(grading_type, num),
+                    )
+                    ItemFactory.create(
+                        category='problem',
+                        parent_location=vertical.location,
+                        display_name='Problem {} {}'.format(grading_type, num),
+                    )
 
         cls.course_key = cls.course.id
 
@@ -141,8 +142,14 @@ class CurrentGradeViewTest(SharedModuleStoreTestCase, APITestCase):
         """
         Test that a user can successfully request her own grade.
         """
-        resp = self.client.get(self.get_url(self.student.username))
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        with check_mongo_calls(6):
+            resp = self.client.get(self.get_url(self.student.username))
+            self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # redo with block structure now in the cache
+        with check_mongo_calls(3):
+            resp = self.client.get(self.get_url(self.student.username))
+            self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     def test_nonexistent_user(self):
         """
@@ -383,8 +390,8 @@ class GradingPolicyTestMixin(object):
         The view should be addressable by course-keys from both module stores.
         """
         course = CourseFactory.create(
-            start=datetime(2014, 6, 16, 14, 30),
-            end=datetime(2015, 1, 16),
+            start=datetime(2014, 6, 16, 14, 30, tzinfo=UTC),
+            end=datetime(2015, 1, 16, tzinfo=UTC),
             org="MTD",
             default_store=modulestore_type,
         )

--- a/lms/djangoapps/grades/new/course_grade.py
+++ b/lms/djangoapps/grades/new/course_grade.py
@@ -31,8 +31,8 @@ class CourseGrade(object):
     def __init__(self, student, course, course_structure):
         self.student = student
         self.course = course
-        self.course_version = getattr(course, 'course_version', None)
-        self.course_edited_timestamp = getattr(course, 'subtree_edited_on', None)
+        self.course_version = getattr(course_structure, 'course_version', None)
+        self.course_edited_timestamp = getattr(course_structure, 'subtree_edited_on', None)
         self.course_structure = course_structure
         self._percent = None
         self._letter_grade = None

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -16,7 +16,6 @@ from openedx.core.djangoapps.celery_utils.persist_on_failure import PersistOnFai
 from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locator import CourseLocator
 from submissions import api as sub_api
-from student.models import anonymous_id_for_user
 from track.event_transaction_utils import (
     set_event_transaction_type,
     set_event_transaction_id,


### PR DESCRIPTION
We are seeing a large number of mongo queries from the Grades API in [New Relic](https://rpm.newrelic.com/accounts/88178/applications/3343327/transactions#id=5b225765625472616e73616374696f6e2f46756e6374696f6e2f6c6d732e646a616e676f617070732e6772616465732e6170692e76696577733a557365724772616465566965772e676574222c22225d).

This is unexpected behavior.  The root problem was that the grades code retrieved `subtree_edited_on` from the course object instead of from the course-structure object.  

When retrieving `subtree_edited_on` from the course-object, it is computed in the [CachingDescriptorSystem](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py#L351), which recurses down the tree to compute the maximum value.  Since the code is not within a `bulk_operation` transaction, it repeatedly accesses the course's active_version document from Mongo.  This is costly for courses with a large number of blocks.

(**Side note on incorrect assumptions made:** I thought SplitModulestore was automatically caching active_version documents on the request thread.  I also thought `subtree_edited_on` was stored on the course object itself and not dynamically computed.)

However, when `subtree_edited_on` is retrieved from the course-structure object, that value has already been computed in the collect phase and cached in BlockStructure object.  Since the Grades code already uses BlockStructures, there's no additional (=zero) cost to retrieving the data from there.

Reviewers: 2 of  @sanfordstudent @efischer19 @jcdyer 
FYI @ormsbee 