### PR TITLE
Enable conditional module's configuration for show tags in studio

### DIFF
--- a/common/lib/xmodule/xmodule/conditional_module.py
+++ b/common/lib/xmodule/xmodule/conditional_module.py
@@ -368,7 +368,6 @@ class ConditionalDescriptor(ConditionalFields, SequenceDescriptor, StudioEditabl
             ConditionalDescriptor.is_proctored_enabled,
             ConditionalDescriptor.is_time_limited,
             ConditionalDescriptor.default_time_limit_minutes,
-            ConditionalDescriptor.show_tag_list,
             ConditionalDescriptor.exam_review_rules,
         ])
         return non_editable_fields


### PR DESCRIPTION
To let users be able to what configure conditional modules show when conditions are met.