### PR TITLE
Bump xblock-drag-and-drop-v2 to v2.0.15

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -95,4 +95,4 @@ git+https://github.com/edx/edx-proctoring.git@0.17.0#egg=edx-proctoring==0.17.0
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 git+https://github.com/open-craft/xblock-poll@v1.2.5#egg=xblock-poll==1.2.5
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.14#egg=xblock-drag-and-drop-v2==2.0.14
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.15#egg=xblock-drag-and-drop-v2==2.0.15


### PR DESCRIPTION
Deploy the a11y change introduced by https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/116.

**JIRA tickets**: [TNL-6358](https://openedx.atlassian.net/browse/TNL-6358)

**Screenshots**:

See https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/116

**Sandbox URL**:

Deployed using eb3367e684976b8aba4eb6ff26c839f15ebb5806

* LMS: http://pr14449.sandbox.opencraft.hosting
* Studio: http://studio-pr14449.sandbox.opencraft.hosting

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: ASAP - we'd like to get this into Ficus.

**Testing instructions**:

See https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/116

**Reviewers**
- [x] @bdero
- [x] edX reviewer[s] TBD
