### PR TITLE
Upgrade nodeenv to 1.1.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -181,7 +181,7 @@ splinter==0.5.4
 testtools==0.9.34
 testfixtures==4.5.0
 nose-faulthandler==0.1
-nodeenv==1.0.0
+nodeenv==1.1.1
 
 # Used for Segment analytics
 analytics-python==1.1.0


### PR DESCRIPTION
This fixes a bug in the Ansible provisioning process where an existing nodeenv could fail to be created when the node version was changed.

See https://github.com/edx/configuration/pull/3648 and https://github.com/ekalinin/nodeenv/pull/183 for more details.