### PR TITLE
Allow move for content experiment

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -283,6 +283,23 @@ def reverse_usage_url(handler_name, usage_key, kwargs=None):
     return reverse_url(handler_name, 'usage_key_string', usage_key, kwargs)
 
 
+def get_group_display_name(user_partitions, xblock_display_name):
+    """
+    Get the group name if matching group xblock is found.
+
+    Arguments:
+        user_partitions (Dict): Locator of source item.
+        xblock_display_name (String): Display name of group xblock.
+
+    Returns:
+        group name (String): Group name of the matching group.
+    """
+    for user_partition in user_partitions:
+        for group in user_partition['groups']:
+            if str(group['id']) in xblock_display_name:
+                return group['name']
+
+
 def get_user_partition_info(xblock, schemes=None, course=None):
     """
     Retrieve user partition information for an XBlock for display in editors.

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -274,6 +274,7 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'can_edit': context.get('can_edit', True),
             'can_edit_visibility': context.get('can_edit_visibility', True),
             'can_add': context.get('can_add', True),
+            'can_move': context.get('can_move', True)
         }
         html = render_to_string('studio_xblock_wrapper.html', template_context)
         frag = wrap_fragment(frag, html)

--- a/cms/djangoapps/contentstore/views/tests/utils.py
+++ b/cms/djangoapps/contentstore/views/tests/utils.py
@@ -41,34 +41,48 @@ class StudioPageTestCase(CourseTestCase):
         resp_content = json.loads(resp.content)
         return resp_content['html']
 
-    def validate_preview_html(self, xblock, view_name, can_add=True):
+    def validate_preview_html(self, xblock, view_name, can_add=True, can_reorder=True, can_move=True,
+                              can_edit=True, can_duplicate=True, can_delete=True):
         """
         Verify that the specified xblock's preview has the expected HTML elements.
         """
         html = self.get_preview_html(xblock, view_name)
-        self.validate_html_for_add_buttons(html, can_add)
-
-        # Verify drag handles always appear.
-        drag_handle_html = '<span data-tooltip="Drag to reorder" class="drag-handle action"></span>'
-        self.assertIn(drag_handle_html, html)
-
-        # Verify that there are no action buttons for public blocks
-        expected_button_html = [
-            '<button class="btn-default edit-button action-button">',
+        self.validate_html_for_action_button(
+            html,
+            '<div class="add-xblock-component new-component-item adding"></div>',
+            can_add
+        )
+        self.validate_html_for_action_button(
+            html,
+            '<span data-tooltip="Drag to reorder" class="drag-handle action"></span>',
+            can_reorder
+        )
+        self.validate_html_for_action_button(
+            html,
+            '<button data-tooltip="Move" class="btn-default move-button action-button">',
+            can_move
+        )
+        self.validate_html_for_action_button(
+            html,
+            'button class="btn-default edit-button action-button">',
+            can_edit
+        )
+        self.validate_html_for_action_button(
+            html,
             '<button data-tooltip="Delete" class="btn-default delete-button action-button">',
+            can_duplicate
+        )
+        self.validate_html_for_action_button(
+            html,
             '<button data-tooltip="Duplicate" class="btn-default duplicate-button action-button">',
-            '<button data-tooltip="Move" class="btn-default move-button action-button">'
-        ]
-        for button_html in expected_button_html:
-            self.assertIn(button_html, html)
+            can_delete
+        )
 
-    def validate_html_for_add_buttons(self, html, can_add=True):
+    def validate_html_for_action_button(self, html, expected_html, can_action=True):
         """
-        Validate that the specified HTML has the appropriate add actions for the current publish state.
+        Validate that the specified HTML has specific action..
         """
-        # Verify that there are no add buttons for public blocks
-        add_button_html = '<div class="add-xblock-component new-component-item adding"></div>'
-        if can_add:
-            self.assertIn(add_button_html, html)
+        if can_action:
+            self.assertIn(expected_html, html)
         else:
-            self.assertNotIn(add_button_html, html)
+            self.assertNotIn(expected_html, html)

--- a/cms/static/js/views/move_xblock_breadcrumb.js
+++ b/cms/static/js/views/move_xblock_breadcrumb.js
@@ -13,10 +13,6 @@ function($, Backbone, _, gettext, HtmlUtils, StringUtils, MoveXBlockBreadcrumbVi
     var MoveXBlockBreadcrumb = Backbone.View.extend({
         el: '.breadcrumb-container',
 
-        defaultRenderOptions: {
-            breadcrumbs: ['Course Outline']
-        },
-
         events: {
             'click .parent-nav-button': 'handleBreadcrumbButtonPress'
         },
@@ -29,7 +25,7 @@ function($, Backbone, _, gettext, HtmlUtils, StringUtils, MoveXBlockBreadcrumbVi
         render: function(options) {
             HtmlUtils.setHtml(
                 this.$el,
-                this.template(_.extend({}, this.defaultRenderOptions, options))
+                this.template(options)
             );
             Backbone.trigger('move:breadcrumbRendered');
             return this;

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -395,20 +395,21 @@
       }
 
       .component {
-        display: block;
+        display: inline-block;
         color: $black;
+        padding: ($baseline/4) ($baseline/2);
+      }
+
+      .xblock-displayname {
+        @include float(left);
       }
 
       .button-forward, .component {
         border: none;
-        padding: ($baseline/2);
       }
 
       .button-forward {
-        .xblock-displayname {
-          @include float(left);
-        }
-
+        padding: ($baseline/2);
         .forward-sr-icon {
           @include float(right);
 

--- a/cms/templates/js/move-xblock-list.underscore
+++ b/cms/templates/js/move-xblock-list.underscore
@@ -13,7 +13,7 @@
         <%- categoryText %>:
     </span>
 </div>
-<ul class="xblock-items-container">
+<ul class="xblock-items-container" data-items-category="<%- XBlocksCategory %>">
     <% for (var i = 0; i < xblocks.length; i++) {
         var xblock = xblocks[i];
     %>

--- a/cms/templates/js/move-xblock-list.underscore
+++ b/cms/templates/js/move-xblock-list.underscore
@@ -18,11 +18,7 @@
         var xblock = xblocks[i];
     %>
         <li class="xblock-item" data-item-index="<%- i %>">
-            <% if (XBlocksCategory === 'component') { %>
-                <span class="xblock-displayname component truncate">
-                    <%- xblock.get('display_name') %>
-                </span>
-            <% } else { %>
+            <% if (sourceXBlockId !== xblock.id && (xblock.get('child_info') || XBlocksCategory !== 'component')) { %>
                 <button class="button-forward" >
                     <span class="xblock-displayname truncate">
                         <%- xblock.get('display_name') %>
@@ -33,8 +29,19 @@
                         </span>
                     <% } %>
                     <span class="icon fa fa-arrow-right forward-sr-icon" aria-hidden="true"></span>
-                    <span class="sr forward-sr-text"><%- gettext("Click for children") %></span>
+                    <span class="sr forward-sr-text"><%- gettext("View child items") %></span>
                 </button>
+            <% } else { %>
+                <span class="component">
+                    <span class="xblock-displayname truncate">
+                        <%- xblock.get('display_name') %>
+                    </span>
+                    <% if(currentLocationIndex === i) { %>
+                        <span class="current-location">
+                            (<%- gettext('Currently selected') %>)
+                        </span>
+                    <% } %>
+                </span>
             <% } %>
         </li>
     <% } %>

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -89,7 +89,8 @@ messages = xblock.validate().to_json()
                                     <span class="sr">${_("Duplicate")}</span>
                                     </button>
                                 </li>
-
+                            % endif
+                            % if can_move:
                                 <li class="action-item action-move">
                                     <button data-tooltip="${_("Move")}" class="btn-default move-button action-button">
                                         <span class="stack-move-icon fa-stack fa-lg ">

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -338,6 +338,7 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
                     'display_name': self.display_name or self.url_name,
                 }))
                 context['can_edit_visibility'] = False
+                context['can_move'] = False
                 self.render_children(context, fragment, can_reorder=False, can_add=False)
         # else: When shown on a unit page, don't show any sort of preview -
         # just the status of this block in the validation area.

--- a/common/lib/xmodule/xmodule/library_root_xblock.py
+++ b/common/lib/xmodule/xmodule/library_root_xblock.py
@@ -80,6 +80,7 @@ class LibraryRoot(XBlock):
         children_to_show = self.children[item_start:item_end]  # pylint: disable=no-member
 
         force_render = context.get('force_render', None)
+        context['can_move'] = False
 
         for child_key in children_to_show:
             # Children must have a separate context from the library itself. Make a copy.

--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -291,7 +291,7 @@ class ContainerPage(PageObject, HelpMixin):
         """
         click_css(self, '#page-alert .alert.confirmation .nav-actions .action-primary')
 
-    def click_take_me_link(self):
+    def click_take_me_there_link(self):
         """
         Click take me there link.
         """

--- a/common/test/acceptance/pages/studio/move_xblock.py
+++ b/common/test/acceptance/pages/studio/move_xblock.py
@@ -1,0 +1,78 @@
+"""
+Move XBlock Modal Page Object
+"""
+from bok_choy.page_object import PageObject
+from common.test.acceptance.pages.common.utils import click_css
+
+
+class MoveModalView(PageObject):
+    """
+    A base class for move xblock
+    """
+
+    def __init__(self, browser):
+        """
+        Arguments:
+            browser (selenium.webdriver): The Selenium-controlled browser that this page is loaded in.
+        """
+        super(MoveModalView, self).__init__(browser)
+
+    def is_browser_on_page(self):
+        return self.q(css='.modal-window.move-modal').present
+
+    def url(self):
+        """
+        Returns None because this is not directly accessible via URL.
+        """
+        return None
+
+    def save(self):
+        """
+        Clicks save button.
+        """
+        click_css(self, 'a.action-save')
+
+    def cancel(self):
+        """
+        Clicks cancel button.
+        """
+        click_css(self, 'a.action-cancel', require_notification=False)
+
+    def click_forward_button(self, source_index):
+        """
+        Click forward button at specified `source_index`.
+        """
+        css = '.move-modal .xblock-items-container .xblock-item'
+        self.q(css='.button-forward').nth(source_index).click()
+        self.wait_for(
+            lambda: len(self.q(css=css).results) > 0, description='children are visible'
+        )
+
+    def click_move_button(self):
+        """
+        Click move button.
+        """
+        self.q(css='.modal-actions .action-move').first.click()
+
+    @property
+    def is_move_button_enabled(self):
+        """
+        Returns True if move button on modal is enabled else False.
+        """
+        return not self.q(css='.modal-actions .action-move.is-disabled').present
+
+    @property
+    def children_category(self):
+        """
+        Get displayed children category.
+        """
+        return self.q(css='.xblock-items-container').attrs('data-items-category')[0]
+
+    def navigate_to_category(self, category, navigation_options):
+        """
+        Navigates to specifec `category` for a specified `source_index`.
+        """
+        child_category = self.children_category
+        while child_category != category:
+            self.click_forward_button(navigation_options[child_category])
+            child_category = self.children_category

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -10,6 +10,7 @@ from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 from common.test.acceptance.pages.studio.component_editor import ComponentEditorView, ComponentVisibilityEditorView
 from common.test.acceptance.pages.studio.container import ContainerPage
 from common.test.acceptance.pages.studio.html_component_editor import HtmlComponentEditorView
+from common.test.acceptance.pages.studio.move_xblock import MoveModalView
 from common.test.acceptance.pages.studio.utils import add_discussion, drag
 from common.test.acceptance.pages.lms.courseware import CoursewarePage
 from common.test.acceptance.pages.lms.staff_view import StaffPage
@@ -1136,3 +1137,136 @@ class ProblemCategoryTabsTest(ContainerBase):
             "Text Input with Hints and Feedback",
         ]
         self.assertEqual(page.get_category_tab_components('problem', 1), expected_components)
+
+
+@attr(shard=1)
+class MoveComponentTest(ContainerBase):
+    """
+    Tests of moving an XBlock to another XBlock.
+    """
+    def setUp(self, is_staff=True):
+        super(MoveComponentTest, self).setUp(is_staff=is_staff)
+        self.container = ContainerPage(self.browser, None)
+        self.move_modal_view = MoveModalView(self.browser)
+
+        self.navigation_options = {
+            'section': 0,
+            'subsection': 0,
+            'unit': 1,
+        }
+        self.source_xblock_category = 'component'
+        self.message_move = 'Success! "HTML 11" has been moved.'
+        self.message_undo = 'Move cancelled. "HTML 11" has been moved back to its original location.'
+
+    def populate_course_fixture(self, course_fixture):
+        """
+        Sets up a course structure.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.unit_page1 = XBlockFixtureDesc('vertical', 'Test Unit 1').add_children(
+            XBlockFixtureDesc('html', 'HTML 11'),
+            XBlockFixtureDesc('html', 'HTML 12')
+        )
+        self.unit_page2 = XBlockFixtureDesc('vertical', 'Test Unit 2').add_children(
+            XBlockFixtureDesc('html', 'HTML 21'),
+            XBlockFixtureDesc('html', 'HTML 22')
+        )
+        course_fixture.add_children(
+            XBlockFixtureDesc('chapter', 'Test Section').add_children(
+                XBlockFixtureDesc('sequential', 'Test Subsection').add_children(
+                    self.unit_page1,
+                    self.unit_page2
+                )
+            )
+        )
+
+    def verify_move_opertions(self, operation, component_display_names_after_operation):
+        """
+        Verify move operations.
+
+        Arguments:
+            operation (str),                                  `move` or `undo move` operation
+            component_display_names_after_operation (dict)    display names of components after operation in source/dest
+        """
+        unit_page = self.go_to_unit_page(unit_name='Test Unit 1')
+        components = unit_page.displayed_children
+        self.assertEqual(len(components), 2)
+
+        components[0].open_move_modal()
+        self.move_modal_view.navigate_to_category(self.source_xblock_category, self.navigation_options)
+        self.assertEqual(self.move_modal_view.is_move_button_enabled, True)
+
+        self.move_modal_view.click_move_button()
+        self.container.verify_confirmation_message(self.message_move)
+        self.assertEqual(len(unit_page.displayed_children), 1)
+
+        if operation == 'move':
+            self.container.click_take_me_link()
+        elif operation == 'undo_move':
+            self.container.click_undo_move_link()
+            self.container.verify_confirmation_message(self.message_undo)
+
+        unit_page = ContainerPage(self.browser, self.unit_page2.locator)
+        components = unit_page.displayed_children
+        self.assertEqual(
+            [component.name for component in components],
+            component_display_names_after_operation
+        )
+
+    def test_move(self):
+        """
+        Test if we can move a component successfully.
+
+        Given I am a staff user
+        When I go to unit page in first section
+        Then I open the move modal
+        Then I navigate to unit in second section from within move modal
+        Then I see move button is enabled
+        Then I click on the move button
+        Then I see move operation successfull message
+        When I go to unit page in second section
+        Then I see move compoenent there
+        """
+        self.verify_move_opertions(
+            operation='move',
+            component_display_names_after_operation=['HTML 21', 'HTML 22', 'HTML 11']
+        )
+
+    def test_undo_move(self):
+        """
+        Test if we can undo move a component successfully.
+
+        Given I am a staff user
+        When I go to unit page in first section
+        Then I open the move modal
+        Then I click on the move button
+        Then I see move operation successfull message
+        When I clicked on undo move link
+        Then I verified that undo move operation is successfull
+        """
+        self.verify_move_opertions(
+            operation='undo_move',
+            component_display_names_after_operation=['HTML 11', 'HTML 12']
+        )
+
+    def test_a11y(self):
+        """
+        Verify move modal a11y.
+        """
+        unit_page = self.go_to_unit_page(unit_name='Test Unit 1')
+
+        unit_page.a11y_audit.config.set_scope(
+            include=[".modal-window.move-modal"]
+        )
+        unit_page.a11y_audit.config.set_rules({
+            'ignore': [
+                'color-contrast',
+                'link-href',
+            ]
+        })
+
+        unit_page.displayed_children[0].open_move_modal()
+
+        for category in ['section', 'subsection', 'component']:
+            self.move_modal_view.navigate_to_category(category, self.navigation_options)
+            unit_page.a11y_audit.check_for_accessibility_errors()


### PR DESCRIPTION
This PR adds ability to:
- Move Content Experiment in other unit.
- Move children of content experiment to other unit as well as other Content Experiment.
- Don't show move icon on [library page](https://studio-moveaction.sandbox.edx.org/library/library-v1:testlib+testlib)


[Sandbox Link](https://studio-moveaction.sandbox.edx.org/course/course-v1:edX+DemoX+Demo_Course)

@muhammad-ammar @muzaffaryousaf Please review.