### PR TITLE
Upgrade celery to 3.1.25 to prepare for move to 4.x

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -209,7 +209,7 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):
                     # Normally, we don't want lots of exception traces in our logs from common
                     # content problems.  But if you're debugging the xml loading code itself,
                     # uncomment the next line.
-                    # exc_info=True
+                    exc_info=True
                 )
 
                 msg = msg % (unicode(err)[:200])

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -9,14 +9,14 @@ beautifulsoup==3.2.1
 bleach==1.4
 html5lib==0.999
 boto==2.39.0
-celery==3.1.18
+celery==3.1.25
 cryptography==1.5.3
 cssselect==0.9.1
 dealer==2.0.4
 defusedxml==0.4.1
 django-babel-underscore==0.5.1
 markey==0.8  # From django-babel-underscore
-django-celery==3.1.16
+django-celery==3.1.17
 django-config-models==0.1.3
 django-countries==4.0
 django-extensions==1.5.9

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,7 +16,7 @@ dealer==2.0.4
 defusedxml==0.4.1
 django-babel-underscore==0.5.1
 markey==0.8  # From django-babel-underscore
-django-celery==3.1.17
+django-celery==3.1.16
 django-config-models==0.1.3
 django-countries==4.0
 django-extensions==1.5.9

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -76,7 +76,7 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.13#egg=XBlock==0.4.13
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@1.2.0#egg=ora2==1.2.0
+git+https://github.com/edx/edx-ora2.git@cdyer/celery-3.1.25#egg=ora2==1.2.1a1
 -e git+https://github.com/edx/edx-submissions.git@1.1.4#egg=edx-submissions==1.1.4
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/edx-val.git@0.0.12#egg=edxval==0.0.12


### PR DESCRIPTION
Test drive

FYI @jibsheet.  This isn't necessarily going anywhere just yet.  I just wanted to see if any issues jump out when we upgrade celery to the latest 3.1.x (which is recommended before moving to 4.x, because the communication protocol has been upgraded, and workers running 3.1.24 or .25 can understand the v2 protocol.

