### PR TITLE
[DELAY MERGE] TNL-6319: Upgrade edx-search for ES 1.x upgrade.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -57,7 +57,7 @@ edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.4
 edx-rest-api-client==1.7.1
-edx-search==0.1.2
+edx-search==1.0.1
 facebook-sdk==0.4.0
 feedparser==5.1.3
 firebase-token-generator==1.3.2


### PR DESCRIPTION
This should enable teams against ES 1.x.

Here is a link to the [changes to edx-search](https://github.com/edx/edx-search/compare/ab5aa45d29e56ed81f984f657a73146dd00c5f3b...003e1fcbf695ac893a11399456ebd80143720b16).

As far as I can understand, some of these changes were merged into edx-search without complete testing.  There are some changes which concern me without proper testing, which we will be doing.  For example, [this deleted code](https://github.com/edx/edx-search/compare/ab5aa45d29e56ed81f984f657a73146dd00c5f3b...003e1fcbf695ac893a11399456ebd80143720b16#diff-34600c93f262cd34ae4f1e2efb70fb60L260), which may be ok, but not sure without testing.

Sandbox:
- [X] Sandbox [https://es-test.sandbox.edx.org/](https://es-test.sandbox.edx.org/)

Before merge:
- [ ] Tag new release of edx-search (see https://github.com/edx/edx-search/pull/46).
- [ ] Update to point to 1.0.1 release.
- [ ] Rebase and squash.