### PR TITLE
Bump jenkins node version to match edx/configuration

### DIFF
--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -5,7 +5,7 @@ set -e
 source $HOME/jenkins_env
 
 NODE_ENV_DIR=$HOME/nenv
-NODE_VERSION=6.9.2
+NODE_VERSION=6.9.4
 
 NODE_INSTALL_COMMAND="nodeenv --node=$NODE_VERSION --prebuilt $NODE_ENV_DIR --force"
 


### PR DESCRIPTION
Upgrades the Node version used in Jenkins runs from 6.9.2 to 6.9.4, to match the upgrade done here: https://github.com/edx/configuration/pull/3648

@benpatterson, can you suggest another reviewer?