### PR TITLE
WL-931 Allow for customization of course email template at the organization level

### DIFF
--- a/openedx/core/djangoapps/site_configuration/tests/mixins.py
+++ b/openedx/core/djangoapps/site_configuration/tests/mixins.py
@@ -16,7 +16,9 @@ class SiteMixin(object):
             site=self.site,
             values={
                 "SITE_NAME": self.site.domain,
-                "course_org_filter": "fakeX",
+                "course_email_from_addr": "fake@example.com",
+                "course_email_template_name": "fake_email_template",
+                "course_org_filter": "fakeX"
             }
         )
 


### PR DESCRIPTION
This change enables us to customize the email template used for bulk course email sent using the Instructor Dashboard on a per-organization basis. Currently, only per-site customization is possible.

This can be tested using the following courses. Each course will use a separate template and from address for sending course email.

https://mitpe.sandbox.edx.org/courses/course-v1:MITProfessionalX+SysEngx1+1T2017/instructor#view-send_email

https://mitpe.sandbox.edx.org/courses/course-v1:MITProfessionalX+IOTx+2016_T1/info