### PR TITLE
New Relic metric: Enrolled courses on dashboard.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -118,6 +118,8 @@ from openedx.core.djangoapps.embargo import api as embargo_api
 import analytics
 from eventtracking import tracker
 
+import newrelic_custom_metrics
+
 # Note that this lives in LMS, so this dependency should be refactored.
 from notification_prefs.views import enable_notifications
 
@@ -614,6 +616,10 @@ def dashboard(request):
     # longer exist (because the course IDs have changed). Still, we don't delete those
     # enrollments, because it could have been a data push snafu.
     course_enrollments = list(get_course_enrollments(user, course_org_filter, org_filter_out_set))
+
+    # Record how many courses there are so that we can get a better
+    # understanding of usage patterns on prod.
+    newrelic_custom_metrics.accumulate('num_courses', len(course_enrollments))
 
     # sort the enrollment pairs by the enrollment date
     course_enrollments.sort(key=lambda x: x.created, reverse=True)


### PR DESCRIPTION
This is so we can better map how student dashboard performance maps to number of enrolled courses.

@nasthagiri, @pwnage101: This is just a quick one liner to get more data on the dashboard page (which is one of our leading pages for slow queries). May I get a review?