### PR TITLE
only show nav utils if populated

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -74,17 +74,18 @@ ${HTML(fragment.foot_html())}
     ${HTML(fragment.body_html())}
   </section>
 </div>
+% if course.show_calculator or is_edxnotes_enabled(course):
+    <nav class="nav-utilities ${"has-utility-calculator" if course.show_calculator else ""}" aria-label="${_('Course Utilities')}">
+      ## Utility: Notes
+      % if is_edxnotes_enabled(course):
+        <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
+      % endif
 
-<nav class="nav-utilities ${"has-utility-calculator" if course.show_calculator else ""}" aria-label="${_('Course Utilities')}">
-  ## Utility: Notes
-  % if is_edxnotes_enabled(course):
-    <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
-  % endif
-
-  ## Utility: Calc
-  % if course.show_calculator:
-    <%include file="/calculator/toggle_calculator.html" />
-  % endif
-</nav>
+      ## Utility: Calc
+      % if course.show_calculator:
+        <%include file="/calculator/toggle_calculator.html" />
+      % endif
+    </nav>
+% endif
 
 <%include file="../modal/accessible_confirm.html" />

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -207,17 +207,17 @@ ${HTML(fragment.foot_html())}
     </div>
   % endif
 </div>
+% if course.show_calculator or is_edxnotes_enabled(course):
+    <nav class="nav-utilities ${"has-utility-calculator" if course.show_calculator else ""}" aria-label="${_('Course Utilities')}">
+      ## Utility: Notes
+      % if is_edxnotes_enabled(course):
+        <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
+      % endif
 
-<nav class="nav-utilities ${"has-utility-calculator" if course.show_calculator else ""}" aria-label="${_('Course Utilities')}">
-  ## Utility: Notes
-  % if is_edxnotes_enabled(course):
-    <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
-  % endif
-
-  ## Utility: Calc
-  % if course.show_calculator:
-    <%include file="/calculator/toggle_calculator.html" />
-  % endif
-</nav>
-
+      ## Utility: Calc
+      % if course.show_calculator:
+        <%include file="/calculator/toggle_calculator.html" />
+      % endif
+    </nav>
+% endif
 <%include file="../modal/accessible_confirm.html" />


### PR DESCRIPTION
## [TNL-6349](https://openedx.atlassian.net/browse/TNL-6349)

Previously, an html nav element 'nav-utilities' always appeared in the DOM, regardless of whether it was populated. The element has an aria label, leading to confusing behavior for users of screen readers. This element now appears only when edx notes is enabled or the course has the 'show calculator' advanced setting enabled.

Sandbox: sanfordstudent.sandbox.edx.org

Testing: The demo course currently has the calculator enabled, so the nav-utilities element should be (and is) present in the DOM. To verify my change, go to studio-sanfordstudent.sandbox.edx.org and turn off the "Show Calculator" advanced setting, then return to the course. The nav-utilities element should be gone.

Reviewers:

- [x] One of @nasthagiri @yro @efischer19 @jcdyer 

- [x] One of @cptvitamin @arizzitano 