### PR TITLE
Bugfix: modulestore().copy_from_template should works correct if the copied version copied anywhere else

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -2511,7 +2511,10 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             # Note that new_block_info now points to the same definition ID entry as source_block_info did
             existing_block_info = dest_structure['blocks'].get(new_block_key, BlockData())
             # Inherit the Scope.settings values from 'fields' to 'defaults'
-            new_block_info.defaults = new_block_info.fields
+            if new_block_info.defaults:
+                new_block_info.defaults.update(new_block_info.fields)
+            else:
+                new_block_info.defaults = new_block_info.fields
 
             # <workaround>
             # CAPA modules store their 'markdown' value (an alternate representation of their content)


### PR DESCRIPTION
Steps how to reproduce the problem:

1. Create new course **X** with chapter **"Test Chapter"** and sequential **"Test Sequential"**
2. Create new course **Y** with chapter **"Some Chapter"**
3. Create new course **Z** with chapter **"Some Chapter 2"**
4. Use built-in `modulestore.copy_from_template` function to copy **"Test Sequential"** from **"Test Chapter"** to **"Some Chapter"**:
```
m = modulestore()
m.copy_from_template([test_sequential_location], dest_key=some_chapter.location, user_id=user.id)
```
5. Use built-in `modulestore.copy_from_template` function to copy **"Test Sequential"** from **"Some Chapter"** to **"Some Chapter 2"**:
```
m = modulestore()
m.copy_from_template([new_sequential_location], dest_key=some_chapter2.location, user_id=user.id)
```
Expected result: course **Z** should contain blocks **"Some Chapter 2" / "Test Sequential"** but it contains **"Some Chapter 2" / "<some_hash>"** because the second time sequential block was copied wrong