### PR TITLE
TNL-6354 – Remove unnecessary screen readers from bookmark button

### DIFF
--- a/lms/static/js/bookmarks/views/bookmark_button.js
+++ b/lms/static/js/bookmarks/views/bookmark_button.js
@@ -5,9 +5,7 @@
             return Backbone.View.extend({
                 errorMessage: gettext('An error has occurred. Please try again.'),
 
-                srAddBookmarkText: gettext('Click to add'),
                 bookmarkText: gettext('Bookmark this page'),
-                srRemoveBookmarkText: gettext('Click to remove'),
                 bookmarkedText: gettext('Bookmarked'),
 
                 events: {
@@ -88,12 +86,10 @@
                         this.$el.addClass('bookmarked');
                         this.$el.attr('aria-pressed', 'true');
                         this.$el.find('.bookmark-text').text(this.bookmarkedText);
-                        this.$el.find('.bookmark-sr').text(this.srRemoveBookmarkText);
                     } else {
                         this.$el.removeClass('bookmarked');
                         this.$el.attr('aria-pressed', 'false');
                         this.$el.find('.bookmark-text').text(this.bookmarkText);
-                        this.$el.find('.bookmark-sr').text(this.srAddBookmarkText);
                     }
                 },
 

--- a/lms/static/js/fixtures/bookmarks/bookmark_button.html
+++ b/lms/static/js/fixtures/bookmarks/bookmark_button.html
@@ -6,7 +6,6 @@
       <button class="btn bookmark-button"
         aria-pressed="false"
         data-bookmark-id="bilbo,usage_1">
-         <span class="sr bookmark-sr"></span>&nbsp;
          <span class="bookmark-text">Bookmark this page</span>
         </button>
     </div>

--- a/lms/static/js/spec/courseware/bookmark_button_view_spec.js
+++ b/lms/static/js/spec/courseware/bookmark_button_view_spec.js
@@ -39,11 +39,9 @@ define(['backbone', 'jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helper
                 if (bookmarked) {
                     expect(view.$el).toHaveAttr('aria-pressed', 'true');
                     expect(view.$el).toHaveClass('bookmarked');
-                    expect(view.$el.find('.bookmark-sr').text()).toBe('Click to remove');
                 } else {
                     expect(view.$el).toHaveAttr('aria-pressed', 'false');
                     expect(view.$el).not.toHaveClass('bookmarked');
-                    expect(view.$el.find('.bookmark-sr').text()).toBe('Click to add');
                 }
                 expect(view.$el.data('bookmarkId')).toBe('bilbo,usage_1');
             };

--- a/lms/static/sass/views/_bookmarks.scss
+++ b/lms/static/sass/views/_bookmarks.scss
@@ -162,8 +162,4 @@ $bookmarked-icon: "\f02e"; // .fa-bookmark
 
   }
 
-  .bookmark-sr {
-    @include margin-right($baseline / 4);
-  }
-
 }

--- a/lms/templates/bookmark_button.html
+++ b/lms/templates/bookmark_button.html
@@ -5,7 +5,6 @@
   <button class="btn btn-link bookmark-button ${"bookmarked" if is_bookmarked else ""}"
     aria-pressed="${"true" if is_bookmarked else "false"}"
     data-bookmark-id="${bookmark_id}">
-     <span class="sr bookmark-sr">${_("Click to remove") if is_bookmarked else _("Click to add")}</span>
      <span class="bookmark-text">${_("Bookmarked") if is_bookmarked else _("Bookmark this page")}</span>
     </button>
 </div>


### PR DESCRIPTION
## [TNL-6354](https://openedx.atlassian.net/browse/TNL-6354)

### Description

This PR removes unnecessary screen reader from bookmark button on unit pages.

### Sandbox
- [x] [tnl-6354-remove-bookmark-sr.sandbox.edx.org](https://tnl-6354-remove-bookmark-sr.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/)

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @muzaffaryousaf 
- [x] Code review: @mushtaqak 
- [x] Accessibility review: @cptvitamin 

### Post-review
- [x] Rebase and squash commits