### PR TITLE
Fix more wiki a11y issues

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -581,13 +581,6 @@ class CourseWikiTest(UniqueCourseTest):
         self.course_wiki_page.open_editor()
         self.course_wiki_edit_page.wait_for_page()
 
-    def _check_for_accessibility_errors(self, page, custom_rules=None):
-        """ Run accessibility check with custom rules, if provided """
-        if custom_rules is not None:
-            page.a11y_audit.config.set_rules(custom_rules)
-
-        page.a11y_audit.check_for_accessibility_errors()
-
     @attr(shard=1)
     def test_edit_course_wiki(self):
         """
@@ -610,7 +603,7 @@ class CourseWikiTest(UniqueCourseTest):
         """
         Verify the basic accessibility of the wiki page as initially displayed.
         """
-        self._check_for_accessibility_errors(self.course_wiki_page)
+        self.course_wiki_page.a11y_audit.check_for_accessibility_errors()
 
     @attr('a11y')
     def test_edit_a11y(self):
@@ -618,7 +611,7 @@ class CourseWikiTest(UniqueCourseTest):
         Verify the basic accessibility of edit wiki page.
         """
         self._open_editor()
-        self._check_for_accessibility_errors(self.course_wiki_edit_page)
+        self.course_wiki_edit_page.a11y_audit.check_for_accessibility_errors()
 
     @attr('a11y')
     def test_changes_a11y(self):
@@ -628,7 +621,7 @@ class CourseWikiTest(UniqueCourseTest):
         self.course_wiki_page.show_history()
         history_page = CourseWikiHistoryPage(self.browser, self.course_id, self.course_info)
         history_page.wait_for_page()
-        self._check_for_accessibility_errors(history_page)
+        history_page.a11y_audit.check_for_accessibility_errors()
 
     @attr('a11y')
     def test_children_a11y(self):
@@ -638,13 +631,7 @@ class CourseWikiTest(UniqueCourseTest):
         self.course_wiki_page.show_children()
         children_page = CourseWikiChildrenPage(self.browser, self.course_id, self.course_info)
         children_page.wait_for_page()
-        custom_rules = {
-            'ignore': [
-                'label',  # TNL-6440
-                'data-table'  # TNL-6439
-            ]
-        }
-        self._check_for_accessibility_errors(children_page, custom_rules)
+        children_page.a11y_audit.check_for_accessibility_errors()
 
 
 @attr(shard=1)

--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -59,7 +59,6 @@ table {
 
 a {
   &:hover, &:focus {
-    color: $pink;
     text-decoration: none !important;
   }
 }

--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -8,6 +8,11 @@
     float: right;
   }
 
+  .form-search .input-prepend>label {
+    display: inline-block;
+    vertical-align: bottom;
+  }
+
   @include clearfix();
 
   .breadcrumbs-header {
@@ -746,17 +751,9 @@
   }
 
   .filter-clear {
-    margin-right: ($baseline/2);
+    margin-left: ($baseline/2);
     margin-top: ($baseline/2);
     font-size: .9em;
-
-    a {
-      color: $uxpl-gray-base;
-
-      &:hover, &:focus {
-        color: #777;
-      }
-    }
   }
 
   .table.table-striped {
@@ -771,6 +768,12 @@
 
     a.list-children {
       margin-left: 3px;
+    }
+
+    a {
+      &:hover, &:focus {
+        font-weight: bold;
+      }
     }
 
     tr:nth-child(even) {

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -47,7 +47,7 @@
 
 # Third-party:
 git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline==1.5.3
-git+https://github.com/edx/django-wiki.git@v0.0.9#egg=django-wiki==0.0.9
+git+https://github.com/edx/django-wiki.git@v0.0.10#egg=django-wiki==0.0.10
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
### Description

This PR, in conjunction with https://github.com/edx/django-wiki/pull/23, addresses [TNL-6440](https://openedx.atlassian.net/browse/TNL-6440) and [TNL-6439](https://openedx.atlassian.net/browse/TNL-6439).

1. The "Filter" placeholder text has been removed, and there is a label displayed in front of the input field.

2. The "(clear)" action that appears after you have filtered has been moved to the right (previously it was before the input field). There are still issues with how filtering works and the association between "(clear)" and the input field, but this PR does not change those things.

3. The problematic text (displayed in a table) in the case of no filter results have been completely removed. It is redundant with the existing "There are 0 articles in this level." message.

### Sandbox
- [x] https://wiki.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/wiki/edX.DemoX.Demo_Course/

Choose "See All Children" in the RHS to get to the view where these issues have been addressed. To see the "There are 0 articles..." case, click into a child wiki page and then select "See All Children" again.

### Testing
- [x] Unit, integration, acceptance tests as appropriate

Note that LTR issues do exist.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @staubina 
- [x] Code review: @jlajoie 
- [x] Doc Review: @catong (FYI)
- [x] UX review: @lizcohen
- [x] Product review: @sstack22 

FYI @cptvitamin 

### Post-review
- [ ] Rebase and squash commits

