### PR TITLE
request-cache grades feature flag to avoid 400+ memcached hits

### DIFF
--- a/lms/djangoapps/grades/config/models.py
+++ b/lms/djangoapps/grades/config/models.py
@@ -6,6 +6,7 @@ from config_models.models import ConfigurationModel
 from django.conf import settings
 from django.db.models import BooleanField
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from request_cache.middleware import request_cached
 
 
 class PersistentGradesEnabledFlag(ConfigurationModel):
@@ -19,6 +20,7 @@ class PersistentGradesEnabledFlag(ConfigurationModel):
     enabled_for_all_courses = BooleanField(default=False)
 
     @classmethod
+    @request_cached
     def feature_enabled(cls, course_id=None):
         """
         Looks at the currently active configuration model to determine whether

--- a/lms/djangoapps/grades/config/tests/utils.py
+++ b/lms/djangoapps/grades/config/tests/utils.py
@@ -2,8 +2,9 @@
 Provides helper functions for tests that want
 to configure flags related to persistent grading.
 """
-from lms.djangoapps.grades.config.models import PersistentGradesEnabledFlag, CoursePersistentGradesFlag
 from contextlib import contextmanager
+from lms.djangoapps.grades.config.models import PersistentGradesEnabledFlag, CoursePersistentGradesFlag
+from request_cache.middleware import RequestCache
 
 
 @contextmanager
@@ -18,6 +19,7 @@ def persistent_grades_feature_flags(
     as they need to set the global setting and the course-specific
     setting for a single course.
     """
+    RequestCache.clear_request_cache()
     PersistentGradesEnabledFlag.objects.create(enabled=global_flag, enabled_for_all_courses=enabled_for_all_courses)
     if course_id:
         CoursePersistentGradesFlag.objects.create(course_id=course_id, enabled=enabled_for_course)


### PR DESCRIPTION
We are seeing too many memcached calls on Grades APIs/tasks.  This is because `ConfigurationModel`s cache the values in memcached, but not in the request-cache.  This PR addresses this issue just for Grades-config.  The more generic fix within `ConfigurationModel` is yet to be done.

FYI @ormsbee 