### PR TITLE
Fix lettuce tests for Xenial compatibility and newer Chrome version.

### DIFF
--- a/cms/djangoapps/contentstore/features/html-editor.feature
+++ b/cms/djangoapps/contentstore/features/html-editor.feature
@@ -110,7 +110,7 @@ Feature: CMS.HTML Editor
     When I edit the page
     And I click font selection dropdown
     Then I should see a list of available fonts
-    And "Default" option sets "'Open Sans', Verdana, Arial, Helvetica, sans-serif" font family
+    And "Default" option sets the expected font family
     And all standard tinyMCE fonts should be available
 
 # Skipping in master due to brittleness JZ 05/22/2014

--- a/cms/djangoapps/contentstore/features/html-editor.py
+++ b/cms/djangoapps/contentstore/features/html-editor.py
@@ -12,6 +12,7 @@ CODEMIRROR_SELECTOR_PREFIX = "$('iframe').contents().find"
 
 @step('I have created a Blank HTML Page$')
 def i_created_blank_html_page(step):
+    # from nose.tools import set_trace; set_trace()
     step.given('I am in Studio editing a new unit')
     world.create_component_instance(
         step=step,
@@ -229,10 +230,13 @@ def font_selector_dropdown_is_shown(step):
     assert_equal(actual_fonts, expected_fonts)
 
 
-@step('"Default" option sets "(.*)" font family')
-def default_options_sets_expected_font_family(step, expected_font_family):
+@step('"Default" option sets the expected font family')
+def default_options_sets_expected_font_family(step):
     fonts = get_available_fonts(get_fonts_list_panel(world))
-    assert_equal(fonts.get("Default", None), expected_font_family)
+    fonts_found = fonts.get("Default", None)
+    expected_font_family = CUSTOM_FONTS.get('Default')
+    for expected_font in expected_font_family:
+        assert_in(expected_font, fonts_found)
 
 
 @step('all standard tinyMCE fonts should be available')
@@ -263,7 +267,7 @@ TINYMCE_FONTS = OrderedDict([
 ])
 
 CUSTOM_FONTS = OrderedDict([
-    ('Default', "'Open Sans', Verdana, Arial, Helvetica, sans-serif"),
+    ('Default', ['Open Sans', 'Verdana', 'Arial', 'Helvetica', 'sans-serif']),
 ])
 
 

--- a/cms/djangoapps/contentstore/features/html-editor.py
+++ b/cms/djangoapps/contentstore/features/html-editor.py
@@ -12,7 +12,6 @@ CODEMIRROR_SELECTOR_PREFIX = "$('iframe').contents().find"
 
 @step('I have created a Blank HTML Page$')
 def i_created_blank_html_page(step):
-    # from nose.tools import set_trace; set_trace()
     step.given('I am in Studio editing a new unit')
     world.create_component_instance(
         step=step,
@@ -231,7 +230,7 @@ def font_selector_dropdown_is_shown(step):
 
 
 @step('"Default" option sets the expected font family')
-def default_options_sets_expected_font_family(step):
+def default_options_sets_expected_font_family(step):  # pylint: disable=unused-argument, redefined-outer-name
     fonts = get_available_fonts(get_fonts_list_panel(world))
     fonts_found = fonts.get("Default", None)
     expected_font_family = CUSTOM_FONTS.get('Default')
@@ -242,28 +241,29 @@ def default_options_sets_expected_font_family(step):
 @step('all standard tinyMCE fonts should be available')
 def check_standard_tinyMCE_fonts(step):
     fonts = get_available_fonts(get_fonts_list_panel(world))
-    for label, expected_font in TINYMCE_FONTS.items():
-        assert_equal(fonts.get(label, None), expected_font)
+    for label, expected_fonts in TINYMCE_FONTS.items():
+        for expected_font in expected_fonts:
+            assert_in(expected_font, fonts.get(label, None))
 
 TINYMCE_FONTS = OrderedDict([
-    ("Andale Mono", "'andale mono', times"),
-    ("Arial", "arial, helvetica, sans-serif"),
-    ("Arial Black", "'arial black', 'avant garde'"),
-    ("Book Antiqua", "'book antiqua', palatino"),
-    ("Comic Sans MS", "'comic sans ms', sans-serif"),
-    ("Courier New", "'courier new', courier"),
-    ("Georgia", "georgia, palatino"),
-    ("Helvetica", "helvetica"),
-    ("Impact", "impact, chicago"),
-    ("Symbol", "symbol"),
-    ("Tahoma", "tahoma, arial, helvetica, sans-serif"),
-    ("Terminal", "terminal, monaco"),
-    ("Times New Roman", "'times new roman', times"),
-    ("Trebuchet MS", "'trebuchet ms', geneva"),
-    ("Verdana", "verdana, geneva"),
+    ("Andale Mono", ['andale mono', 'times']),
+    ("Arial", ['arial', 'helvetica', 'sans-serif']),
+    ("Arial Black", ['arial black', 'avant garde']),
+    ("Book Antiqua", ['book antiqua', 'palatino']),
+    ("Comic Sans MS", ['comic sans ms', 'sans-serif']),
+    ("Courier New", ['courier new', 'courier']),
+    ("Georgia", ['georgia', 'palatino']),
+    ("Helvetica", ['helvetica']),
+    ("Impact", ['impact', 'chicago']),
+    ("Symbol", ['symbol']),
+    ("Tahoma", ['tahoma', 'arial', 'helvetica', 'sans-serif']),
+    ("Terminal", ['terminal', 'monaco']),
+    ("Times New Roman", ['times new roman', 'times']),
+    ("Trebuchet MS", ['trebuchet ms', 'geneva']),
+    ("Verdana", ['verdana', 'geneva']),
     # tinyMCE does not set font-family on dropdown span for these two fonts
-    ("Webdings", ""),  # webdings
-    ("Wingdings", ""),  # wingdings, 'zapf dingbats'
+    ("Webdings", [""]),  # webdings
+    ("Wingdings", [""]),  # wingdings, 'zapf dingbats'
 ])
 
 CUSTOM_FONTS = OrderedDict([

--- a/common/djangoapps/terrain/browser.py
+++ b/common/djangoapps/terrain/browser.py
@@ -81,6 +81,9 @@ def initial_setup(server):
             desired_capabilities['loggingPrefs'] = {
                 'browser': 'ALL',
             }
+            desired_capabilities['chromeOptions'] = {
+                "args": ["--dns-prefetch-disable"]
+            }
         else:
             desired_capabilities = {}
 

--- a/common/djangoapps/terrain/browser.py
+++ b/common/djangoapps/terrain/browser.py
@@ -279,10 +279,9 @@ def after_each_step(step):
 
 
 @after.harvest
-def teardown_browser(total):
+def saucelabs_status(total):
     """
-    Quit the browser after executing the tests.
+    Collect data for saucelabs.
     """
     if world.LETTUCE_SELENIUM_CLIENT == 'saucelabs':
         set_saucelabs_job_status(world.jobid, total.scenarios_ran == total.scenarios_passed)
-    world.browser.quit()

--- a/common/djangoapps/terrain/browser.py
+++ b/common/djangoapps/terrain/browser.py
@@ -81,9 +81,6 @@ def initial_setup(server):
             desired_capabilities['loggingPrefs'] = {
                 'browser': 'ALL',
             }
-            desired_capabilities['chromeOptions'] = {
-                "args": ["--dns-prefetch-disable"]
-            }
         else:
             desired_capabilities = {}
 

--- a/common/djangoapps/terrain/setup_prereqs.py
+++ b/common/djangoapps/terrain/setup_prereqs.py
@@ -56,7 +56,7 @@ def stop_video_server(_total):
         video_server.shutdown()
 
 
-@before.all
+@before.all  # pylint: disable=no-member
 def start_stub_servers():
     """
     Start all stub servers

--- a/common/djangoapps/terrain/setup_prereqs.py
+++ b/common/djangoapps/terrain/setup_prereqs.py
@@ -56,12 +56,19 @@ def stop_video_server(_total):
         video_server.shutdown()
 
 
-@before.each_scenario  # pylint: disable=no-member
-def process_requires_tags(scenario):
+@before.all
+def start_stub_servers():
     """
-    Process the scenario tags to make sure that any
-    requirements are met prior to that scenario
-    being executed.
+    Start all stub servers
+    """
+
+    for stub in SERVICES.keys():
+        start_stub(stub)
+
+
+@before.each_scenario  # pylint: disable=no-member
+def skip_youtube_if_not_available(scenario):
+    """
 
     Scenario tags must be named with this convention:
     @requires_stub_bar, where 'bar' is the name of the stub service to start
@@ -85,7 +92,7 @@ def process_requires_tags(scenario):
                     scenario.steps = []
                     return
 
-            start_stub(requires.group('server'))
+    return
 
 
 def start_stub(name):
@@ -124,11 +131,13 @@ def is_youtube_available(urls):
     return True
 
 
-@after.each_scenario  # pylint: disable=no-member
+@after.all  # pylint: disable=no-member
 def stop_stubs(_scenario):
     """
-    Shut down any stub services that were started up for the scenario.
+    Shut down any stub services.
     """
+    # close browser to ensure no open connections to the stub servers
+    world.browser.quit()
     for name in SERVICES.keys():
         stub_server = getattr(world, name, None)
         if stub_server is not None:

--- a/common/djangoapps/terrain/stubs/http.py
+++ b/common/djangoapps/terrain/stubs/http.py
@@ -3,6 +3,7 @@ Stub implementation of an HTTP service.
 """
 
 from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+from SocketServer import ThreadingMixIn
 import urllib
 import urlparse
 import threading
@@ -233,7 +234,7 @@ class StubHttpRequestHandler(BaseHTTPRequestHandler, object):
         self.send_response(200)
 
 
-class StubHttpService(HTTPServer, object):
+class StubHttpService(ThreadingMixIn, HTTPServer, object):
     """
     Stub HTTP service implementation.
     """

--- a/common/djangoapps/terrain/stubs/lti.py
+++ b/common/djangoapps/terrain/stubs/lti.py
@@ -194,7 +194,7 @@ class StubLtiHandler(StubHttpRequestHandler):
                     <input type="submit" name="submit-button" value="Submit" id="submit-button">
                 </form>
                 <form action="{submit_url}/lti2_outcome" method="post">
-                    <input type="submit" name="submit-lti2-button" value="Submit" id="submit-lti-button">
+                    <input type="submit" name="submit-lti2-button" value="Submit" id="submit-lti2-button">
                 </form>
                 <form action="{submit_url}/lti2_delete" method="post">
                     <input type="submit" name="submit-lti2-delete-button" value="Submit" id="submit-lti-delete-button">

--- a/common/djangoapps/terrain/stubs/lti.py
+++ b/common/djangoapps/terrain/stubs/lti.py
@@ -191,13 +191,13 @@ class StubLtiHandler(StubHttpRequestHandler):
         if submit_url:
             submit_form = textwrap.dedent("""
                 <form action="{submit_url}/grade" method="post">
-                    <input type="submit" name="submit-button" value="Submit">
+                    <input type="submit" name="submit-button" value="Submit" id="submit-button">
                 </form>
                 <form action="{submit_url}/lti2_outcome" method="post">
-                    <input type="submit" name="submit-lti2-button" value="Submit">
+                    <input type="submit" name="submit-lti2-button" value="Submit" id="submit-lti-button">
                 </form>
                 <form action="{submit_url}/lti2_delete" method="post">
-                    <input type="submit" name="submit-lti2-delete-button" value="Submit">
+                    <input type="submit" name="submit-lti2-delete-button" value="Submit" id="submit-lti-delete-button">
                 </form>
             """).format(submit_url=submit_url)
         else:

--- a/lms/djangoapps/courseware/features/lti.py
+++ b/lms/djangoapps/courseware/features/lti.py
@@ -359,8 +359,9 @@ def click_grade(_step, version):
     location = world.scenario_dict['LTI'].location.html_id()
     iframe_name = 'ltiFrame-' + location
     with world.browser.get_iframe(iframe_name) as iframe:
-        world.wait_for_visible('#' + version_map[version]['selector'])
-        iframe.find_by_name(version_map[version]['selector']).first.click()
+        css_loc = '#' + version_map[version]['selector']
+        world.wait_for_visible(css_loc)
+        world.css_click(css_loc)
         assert iframe.is_text_present(version_map[version]['expected_text'])
 
 

--- a/lms/djangoapps/courseware/features/lti.py
+++ b/lms/djangoapps/courseware/features/lti.py
@@ -359,6 +359,7 @@ def click_grade(_step, version):
     location = world.scenario_dict['LTI'].location.html_id()
     iframe_name = 'ltiFrame-' + location
     with world.browser.get_iframe(iframe_name) as iframe:
+        world.wait_for_visible('#' + version_map[version]['selector'])
         iframe.find_by_name(version_map[version]['selector']).first.click()
         assert iframe.is_text_present(version_map[version]['expected_text'])
 

--- a/lms/djangoapps/courseware/features/lti.py
+++ b/lms/djangoapps/courseware/features/lti.py
@@ -9,7 +9,6 @@ from splinter.exceptions import ElementDoesNotExist
 from selenium.common.exceptions import NoAlertPresentException
 from nose.tools import assert_true, assert_equal, assert_in, assert_is_none
 from lettuce import world, step
-from selenium.webdriver.common.keys import Keys
 
 from courseware.tests.factories import InstructorFactory, BetaTesterFactory
 from courseware.access import has_access

--- a/lms/djangoapps/courseware/features/lti.py
+++ b/lms/djangoapps/courseware/features/lti.py
@@ -363,16 +363,7 @@ def click_grade(_step, version):
         css_ele = version_map[version]['selector']
         css_loc = '#' + css_ele
         world.wait_for_visible(css_loc)
-        print 'waiting..'
-        # from nose.tools import set_trace; set_trace()
-        world.wait(8)
-        print 'proceding'
-        # world.css_click(css_loc)
-        # ele = world.css_find(css_loc).first
-        # ele._element.send_keys(Keys.ENTER)
-        # world.browser.execute_script('document.getElementById("{}").click()'.format(css_ele))
         world.css_click(css_loc)
-        # world.css_click(css_loc)
         assert iframe.is_text_present(version_map[version]['expected_text'])
 
 

--- a/lms/djangoapps/courseware/features/lti.py
+++ b/lms/djangoapps/courseware/features/lti.py
@@ -9,6 +9,7 @@ from splinter.exceptions import ElementDoesNotExist
 from selenium.common.exceptions import NoAlertPresentException
 from nose.tools import assert_true, assert_equal, assert_in, assert_is_none
 from lettuce import world, step
+from selenium.webdriver.common.keys import Keys
 
 from courseware.tests.factories import InstructorFactory, BetaTesterFactory
 from courseware.access import has_access
@@ -359,9 +360,19 @@ def click_grade(_step, version):
     location = world.scenario_dict['LTI'].location.html_id()
     iframe_name = 'ltiFrame-' + location
     with world.browser.get_iframe(iframe_name) as iframe:
-        css_loc = '#' + version_map[version]['selector']
+        css_ele = version_map[version]['selector']
+        css_loc = '#' + css_ele
         world.wait_for_visible(css_loc)
+        print 'waiting..'
+        # from nose.tools import set_trace; set_trace()
+        world.wait(8)
+        print 'proceding'
+        # world.css_click(css_loc)
+        # ele = world.css_find(css_loc).first
+        # ele._element.send_keys(Keys.ENTER)
+        # world.browser.execute_script('document.getElementById("{}").click()'.format(css_ele))
         world.css_click(css_loc)
+        # world.css_click(css_loc)
         assert iframe.is_text_present(version_map[version]['expected_text'])
 
 

--- a/pavelib/utils/test/suites/acceptance_suite.py
+++ b/pavelib/utils/test/suites/acceptance_suite.py
@@ -93,6 +93,7 @@ class AcceptanceTest(TestSuite):
         report_file = self.report_dir / "{}.xml".format(self.system)
         report_args = ["--xunit-file {}".format(report_file)]
         return [
+            "DBUS_SESSION_BUS_ADDRESS=/dev/null",
             "DEFAULT_STORE={}".format(self.default_store),
             "./manage.py",
             self.system,

--- a/pavelib/utils/test/suites/acceptance_suite.py
+++ b/pavelib/utils/test/suites/acceptance_suite.py
@@ -94,6 +94,8 @@ class AcceptanceTest(TestSuite):
         report_args = ["--xunit-file {}".format(report_file)]
         return [
             "DBUS_SESSION_BUS_ADDRESS=/dev/null",
+            # 'LANG="en_US.UTF-8"',
+            'LC_NUMERIC="en_US.UTF-8"',
             "DEFAULT_STORE={}".format(self.default_store),
             "./manage.py",
             self.system,

--- a/pavelib/utils/test/suites/acceptance_suite.py
+++ b/pavelib/utils/test/suites/acceptance_suite.py
@@ -93,9 +93,8 @@ class AcceptanceTest(TestSuite):
         report_file = self.report_dir / "{}.xml".format(self.system)
         report_args = ["--xunit-file {}".format(report_file)]
         return [
+            # set DBUS_SESSION_BUS_ADDRESS to avoid hangs on Chrome
             "DBUS_SESSION_BUS_ADDRESS=/dev/null",
-            # 'LANG="en_US.UTF-8"',
-            'LC_NUMERIC="en_US.UTF-8"',
             "DEFAULT_STORE={}".format(self.default_store),
             "./manage.py",
             self.system,


### PR DESCRIPTION
Noteworthy changes & why:
* For Lettuce tests, setup and teardown all stub servers at the beginning of the entire test run, rather than per-test-as-needed. This is an optimization and makes Lettuce infrastructure more like bok-choy's.
* Change stub servers to run in multi-threaded mode. Recent Chrome versions are aggressive on connections and the single-threaded stub servers would choke due to connections still remaining open. Moving into multi-threaded will allow for higher volume on the stubs even beyond this problem, and could avoid other collisions if we multi-thread tests.
* For specific CMS test failing on Xenial, check the fonts as list items instead of one big string. This not only avoids nested quotation issues that we were encountering on Xenial, it also will make assertion failures clearer on what's missing.
* Refactor LTI stub and test to use an id identifier on the page. This is more "seleinum-esque" and makes for a more intuitive test-grok'ing experience.
