### PR TITLE
TNL-6470-Hide Add a post during discussion blackout period

### DIFF
--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -567,6 +567,12 @@ class InlineDiscussionPage(PageObject, DiscussionPageMixin):
         )
         self._find_within(selector).click()
 
+    def is_new_post_button_visible(self):
+        """
+        Check if new post button present and visible
+        """
+        return self._is_element_visible('.new-post-btn')
+
     @wait_for_js
     def _is_element_visible(self, selector):
         query = self._find_within(selector)

--- a/lms/templates/discussion/_discussion_inline.html
+++ b/lms/templates/discussion/_discussion_inline.html
@@ -26,6 +26,7 @@ var $$course_id = "${course_id | n, js_escaped_string}";
 
 function DiscussionInlineBlock(runtime, element) {
     'use strict';
-    new DiscussionInlineView({ el: $(element).find('.discussion-module') });
+    var el = $(element).find('.discussion-module');
+    new DiscussionInlineView({ el: el, readOnly: el.data('read-only') });
 }
 </script>


### PR DESCRIPTION
## [TNL-6470](https://openedx.atlassian.net/browse/TNL-6470)

### Description

Inline discussion has a button `Add a Post`.
<img width="884" alt="screen shot 2017-02-08 at 6 20 33 pm" src="https://cloud.githubusercontent.com/assets/22347092/22739014/a111b95a-ee2b-11e6-9eb9-f2727c2f2999.png">
This button should hide for students during discussion black out period. In this period student is not allowed to add new posts.
This button is showing up unexpectedly.
This PR is made in effort to hide this button when addition of new post is not permitted (discussion black out period).

### How to Test?

**Stage** 

- In course Advanced Settings set Discussion Blackout Dates to ["2016-01-22", "2027-01-22"].
- Add Discussion component in any unit.
- Go to that discussion component from lms.
- Click 'Show Discussion'
- Observe 'Add a Post' is visible.

**Sandbox**

- [Studio](https://studio-tnl-6470.sandbox.edx.org)
- [LMS](https://tnl-6470.sandbox.edx.org)

Repeat above steps and observe 'Add a Post' is not visible.

**Screenshots**
After fix
<img width="854" alt="screen shot 2017-02-08 at 6 43 31 pm" src="https://cloud.githubusercontent.com/assets/22347092/22739709/a25a59e0-ee2e-11e6-8b43-60fe8b5b10f8.png">


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Style and readability review: @attiyaIshaque 
- [x] Code review: @awaisdar001 
- [ ] Code review: @andy-armstrong 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [ ] Rebase and squash commits