### PR TITLE
WL-766 Program marketing page view

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1,7 +1,6 @@
 """
 Courseware views functions
 """
-
 import json
 import logging
 import urllib
@@ -77,7 +76,7 @@ from courseware.models import StudentModule, BaseStudentModuleHistory
 from courseware.url_helpers import get_redirect_url, get_redirect_url_for_global_staff
 from courseware.user_state_client import DjangoXBlockUserStateClient
 from edxmako.shortcuts import render_to_response, render_to_string, marketing_link
-from openedx.core.djangoapps.catalog.utils import get_programs_with_type
+from openedx.core.djangoapps.catalog.utils import get_programs, get_programs_with_type
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.coursetalk.helpers import inject_coursetalk_keys_into_context
 from openedx.core.djangoapps.credit.api import (
@@ -85,6 +84,7 @@ from openedx.core.djangoapps.credit.api import (
     is_user_eligible_for_credit,
     is_credit_course
 )
+from openedx.core.djangoapps.programs.utils import ProgramMarketingDataExtender
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from shoppingcart.utils import is_shopping_cart_enabled
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
@@ -767,6 +767,22 @@ def course_about(request, course_id):
         inject_coursetalk_keys_into_context(context, course_key)
 
         return render_to_response('courseware/course_about.html', context)
+
+
+@ensure_csrf_cookie
+@cache_if_anonymous()
+def program_marketing(request, program_uuid):
+    """
+    Display the program marketing page.
+    """
+    program_data = get_programs(uuid=program_uuid)
+
+    if not program_data:
+        raise Http404
+
+    return render_to_response('courseware/program_marketing.html', {
+        'program': ProgramMarketingDataExtender(program_data, request.user).extend()
+    })
 
 
 @transaction.non_atomic_requests

--- a/lms/templates/courseware/program_marketing.html
+++ b/lms/templates/courseware/program_marketing.html
@@ -1,0 +1,3 @@
+<%page expression_filter="h"/>
+
+## This page is intentionally left blank. You can add your own program marketing page using comprehensive theming (http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/enable_themes.html?highlight=theming).

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -426,6 +426,14 @@ urlpatterns += (
         name='student_progress',
     ),
 
+    url(
+        r'^programs/{}/about'.format(
+            r'(?P<program_uuid>[0-9a-f-]+)',
+        ),
+        'courseware.views.views.program_marketing',
+        name='program_marketing_view',
+    ),
+
     # rest api for grades
     url(
         r'^api/grades/',

--- a/openedx/core/djangoapps/catalog/tests/factories.py
+++ b/openedx/core/djangoapps/catalog/tests/factories.py
@@ -75,6 +75,12 @@ class OrganizationFactory(DictFactoryBase):
     uuid = factory.Faker('uuid4')
 
 
+class SeatFactory(DictFactoryBase):
+    type = factory.Faker('word')
+    price = factory.Faker('random_int')
+    currency = 'USD'
+
+
 class CourseRunFactory(DictFactoryBase):
     end = factory.LazyFunction(generate_zulu_datetime)
     enrollment_end = factory.LazyFunction(generate_zulu_datetime)
@@ -82,6 +88,7 @@ class CourseRunFactory(DictFactoryBase):
     image = ImageFactory()
     key = factory.LazyFunction(generate_course_run_key)
     marketing_url = factory.Faker('url')
+    seats = factory.LazyFunction(partial(generate_instances, SeatFactory))
     pacing_type = 'self_paced'
     short_description = factory.Faker('sentence')
     start = factory.LazyFunction(generate_zulu_datetime)


### PR DESCRIPTION
This change adds the URL configuration and Django view required to implement a program marketing page. It is left to theme builders to implement a template that fulfills their own UX requirements.

We have also refactored previous work on the ProgramDataExtender class, creating subclass ProgramMarketingDataExtender to extend with data needed on the program marketing page.