### PR TITLE
No-op a migration that needs to be more clever

### DIFF
--- a/common/djangoapps/student/migrations/0010_auto_20170207_0458.py
+++ b/common/djangoapps/student/migrations/0010_auto_20170207_0458.py
@@ -10,9 +10,25 @@ class Migration(migrations.Migration):
         ('student', '0009_auto_20170111_0422'),
     ]
 
+    # This migration was to add a constraint that we lost in the Django
+    # 1.4->1.8 upgrade. But since the constraint used to be created, production
+    # would already have the constraint even before running the migration, and
+    # running the migration would fail. We needed to make the migration
+    # idempotent.  Instead of reverting this migration while we did that, we
+    # edited it to be a SQL no-op, so that people who had already applied it
+    # wouldn't end up with a ghost migration.
+
+    # It had been:
+    #
+    # migrations.RunSQL(
+    #   "create unique index email on auth_user (email);",
+    #   "drop index email on auth_user;"
+    # )
+
     operations = [
         migrations.RunSQL(
-            "create unique index email on auth_user (email);",
-            "drop index email on auth_user;"
+            # Do nothing:
+            "select 1",
+            "select 1"
         )
     ]


### PR DESCRIPTION
@cpennington @feanil 

/cc @ahsan-ul-haq @schenedx Sorry, I overlooked the need for this to succeed on production which already had the constraint.  I'll be making a new migration for this.