### PR TITLE
Block Transformers: Version Hash

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/tests/helpers.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/helpers.py
@@ -3,13 +3,14 @@ Test helpers for testing course block transformers.
 """
 from mock import patch
 from course_modes.models import CourseMode
+from lms.djangoapps.courseware.access import has_access
 from openedx.core.lib.block_structure.transformers import BlockStructureTransformers
+from openedx.core.lib.block_structure.tests.helpers import clear_registered_transformers_cache
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from lms.djangoapps.courseware.access import has_access
 
 from ...api import get_course_blocks
 
@@ -30,6 +31,7 @@ class TransformerRegistryTestMixin(object):
 
     def tearDown(self):
         self.patcher.stop()
+        clear_registered_transformers_cache()
 
 
 class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase):

--- a/openedx/core/lib/block_structure/tests/helpers.py
+++ b/openedx/core/lib/block_structure/tests/helpers.py
@@ -7,6 +7,7 @@ from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from ..block_structure import BlockStructureBlockData
 from ..transformer import BlockStructureTransformer, FilteringTransformerMixin
+from ..transformer_registry import TransformerRegistry
 
 
 class MockXBlock(object):
@@ -164,11 +165,19 @@ class MockFilteringTransformer(FilteringTransformerMixin, BlockStructureTransfor
         return [block_structure.create_universal_filter()]
 
 
+def clear_registered_transformers_cache():
+    """
+    Test helper to clear out any cached values of registered transformers.
+    """
+    TransformerRegistry.get_write_version_hash.cache.clear()
+
+
 @contextmanager
 def mock_registered_transformers(transformers):
     """
     Context manager for mocking the transformer registry to return the given transformers.
     """
+    clear_registered_transformers_cache()
     with patch(
         'openedx.core.lib.block_structure.transformer_registry.TransformerRegistry.get_registered_transformers'
     ) as mock_available_transforms:

--- a/openedx/core/lib/block_structure/tests/test_transformer_registry.py
+++ b/openedx/core/lib/block_structure/tests/test_transformer_registry.py
@@ -7,7 +7,7 @@ from nose.plugins.attrib import attr
 from unittest import TestCase
 
 from ..transformer_registry import TransformerRegistry
-from .helpers import MockTransformer, mock_registered_transformers
+from .helpers import MockTransformer, mock_registered_transformers, clear_registered_transformers_cache
 
 
 class TestTransformer1(MockTransformer):
@@ -37,6 +37,10 @@ class TransformerRegistryTestCase(TestCase):
     """
     Test cases for TransformerRegistry.
     """
+    def tearDown(self):
+        super(TransformerRegistryTestCase, self).tearDown()
+        clear_registered_transformers_cache()
+
     @ddt.data(
         # None case
         ([], []),
@@ -61,3 +65,18 @@ class TransformerRegistryTestCase(TestCase):
                 TransformerRegistry.find_unregistered(transformers),
                 set(expected_unregistered),
             )
+
+    def test_write_version_hash(self):
+        # hash with TestTransformer1
+        with mock_registered_transformers([TestTransformer1]):
+            version_hash_1 = TransformerRegistry.get_write_version_hash()
+            self.assertEqual(version_hash_1, '+2nc5o2YRerVfAtItQBQ/6jVkkw=')
+
+            # should return the same value again
+            self.assertEqual(version_hash_1, TransformerRegistry.get_write_version_hash())
+
+        # hash with TestTransformer1 and TestTransformer2
+        with mock_registered_transformers([TestTransformer1, TestTransformer2]):
+            version_hash_2 = TransformerRegistry.get_write_version_hash()
+            self.assertEqual(version_hash_2, '5GwhvmSM9hknjUslzPnKDA5QaCo=')
+            self.assertNotEqual(version_hash_1, version_hash_2)

--- a/openedx/core/lib/block_structure/tests/test_transformers.py
+++ b/openedx/core/lib/block_structure/tests/test_transformers.py
@@ -59,7 +59,7 @@ class TestBlockStructureTransformers(ChildrenMapTestMixin, TestCase):
             with patch(
                 'openedx.core.lib.block_structure.tests.helpers.MockTransformer.collect'
             ) as mock_collect_call:
-                self.transformers.collect(block_structure=MagicMock())
+                BlockStructureTransformers.collect(block_structure=MagicMock())
                 self.assertTrue(mock_collect_call.called)
 
     def test_transform(self):


### PR DESCRIPTION
## [TNL-6519](https://openedx.atlassian.net/browse/TNL-6519)

### Description

Implement TransformerRegistry.get_write_version_hash as a sub-task of the larger work for [Block Structure Cache Invalidation](https://openedx.atlassian.net/wiki/display/MA/Block+Structure+Cache+Invalidation+Proposal). 

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @jcdyer 
- [x] Code review: @sanfordstudent 

### Post-review
- [ ] Rebase and squash commits