### PR TITLE
Send activation email to un-activated user

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -15,7 +15,7 @@ log = logging.getLogger('edx.celery.task')
 @task(bind=True)
 def send_activation_email(self, subject, message, from_address, dest_addr):
     """
-    Sending an activation email to the users.
+    Sending an activation email to the user.
     """
     max_retries = settings.RETRY_ACTIVATION_EMAIL_MAX_ATTEMPTS
     retries = self.request.retries

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -573,6 +573,38 @@ def is_course_blocked(request, redeemed_registration_codes, course_key):
     return blocked
 
 
+def compose_and_send_activation_email(user, profile, user_registration=None):
+    """
+    Construct all the required params and send the activation email
+    through celery task
+
+    Arguments:
+        user: current logged-in user
+        profile: profile object of the current logged-in user
+        user_registration: registration of the current logged-in user
+    """
+    dest_addr = user.email
+    if user_registration is None:
+        user_registration = Registration.objects.get(user=user)
+    context = {
+        'name': profile.name,
+        'key': user_registration.activation_key,
+    }
+    subject = render_to_string('emails/activation_email_subject.txt', context)
+    # Email subject *must not* contain newlines
+    subject = ''.join(subject.splitlines())
+    message_for_activation = render_to_string('emails/activation_email.txt', context)
+    from_address = configuration_helpers.get_value(
+        'email_from_address',
+        settings.DEFAULT_FROM_EMAIL
+    )
+    if settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL'):
+        dest_addr = settings.FEATURES['REROUTE_ACTIVATION_EMAIL']
+        message_for_activation = ("Activation for %s (%s): %s\n" % (user, user.email, profile.name) +
+                                  '-' * 80 + '\n\n' + message_for_activation)
+    send_activation_email.delay(subject, message_for_activation, from_address, dest_addr)
+
+
 @login_required
 @ensure_csrf_cookie
 def dashboard(request):
@@ -1354,7 +1386,6 @@ def login_user(request, error=""):  # pylint: disable=too-many-statements,unused
                 }
             }
         )
-
     if user is not None and user.is_active:
         try:
             # We do not log here, because we have a handler registered
@@ -1842,27 +1873,7 @@ def create_account_with_params(request, params):
         )
     )
     if send_email:
-        dest_addr = user.email
-        context = {
-            'name': profile.name,
-            'key': registration.activation_key,
-        }
-
-        # composes activation email
-        subject = render_to_string('emails/activation_email_subject.txt', context)
-        # Email subject *must not* contain newlines
-        subject = ''.join(subject.splitlines())
-        message = render_to_string('emails/activation_email.txt', context)
-
-        from_address = configuration_helpers.get_value(
-            'email_from_address',
-            settings.DEFAULT_FROM_EMAIL
-        )
-        if settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL'):
-            dest_addr = settings.FEATURES['REROUTE_ACTIVATION_EMAIL']
-            message = ("Activation for %s (%s): %s\n" % (user, user.email, profile.name) +
-                       '-' * 80 + '\n\n' + message)
-        send_activation_email.delay(subject, message, from_address, dest_addr)
+        compose_and_send_activation_email(user, profile, registration)
     else:
         registration.activate()
         _enroll_user_in_pending_courses(user)  # Enroll student in any pending courses

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -10,6 +10,8 @@ import social
 from social.apps.django_app.views import complete
 from social.apps.django_app.utils import load_strategy, load_backend
 from social.utils import setting_name
+from student.models import UserProfile
+from student.views import compose_and_send_activation_email
 from .models import SAMLConfiguration
 
 URL_NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
@@ -28,6 +30,8 @@ def inactive_user_view(request):
     # 'next' may be set to '/account/finish_auth/.../' if this user needs to be auto-enrolled
     # in a course. Otherwise, just redirect them to the dashboard, which displays a message
     # about activating their account.
+    profile = UserProfile.objects.get(user=request.user)
+    compose_and_send_activation_email(request.user, profile)
     return redirect(request.GET.get('next', 'dashboard'))
 
 


### PR DESCRIPTION
**ECOM-6757 :**
Unactivated user(logged-in) through social-auth sees a banner stated "activation email has been sent to ..." but actually platform doesn't send the activation email.This PR will send the email to such users.

**Steps to Reproduce:**

1. create a new account - ignore activation email 
2. try to upgrade 
3. Link social auth account 
4. sign out 
5. try to sign in with social auth 
6. log out - try to sign in with email.
**Expected :**
Unactivated learner clicks upgrade to verified or signs in via social auth
Sees message that an activation email has been sent
Platform sends activation email
**Actual :**
Unactivated learner clicks upgrade to verified or signs in with social auth
Sees message that an activation email has been sent
No email is sent. learner is left waiting until they contact support

**sandbox**
https://ecom-6757.sandbox.edx.org/
i) create a new account
ii) enable social-auth like google etc and logout
iii) you will get an activation email each time you will login through social-auth
Note: Ignore the activation email in the whole scenario.  

**Test Explanation**
Test is using "settings.SOCIAL_AUTH_INACTIVE_USER_URL" to create the request so that inactive user will be redirected to the social-auth view.

**fyi @adampalay** 
### Post-review
- [ ] Rebase and squash commits