### PR TITLE
Bump edx-enterprise tag to 0.21.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -51,7 +51,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.21.0
+edx-enterprise==0.21.2
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.2


### PR DESCRIPTION
Bumps the `edx-enterprise` version to the latest tag, to fix a production bug, and deploy the latest feature changes.

**JIRA tickets**: Deploys [ENT-97](https://openedx.atlassian.net/browse/ENT-97), [ENT-179](https://openedx.atlassian.net/browse/ENT-179)

**Sandbox URL**: sandbox is being provisioned.

* LMS: http://pr14509.sandbox.opencraft.hosting/
* Studio: http://studio-pr14509.sandbox.opencraft.hosting/

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: ASAP

**Testing instructions**:

Verification Instructions:

Ref [ENT-97](https://openedx.atlassian.net/browse/ENT-97?focusedCommentId=240127&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-240127):

1. Open a sandbox with the catalog service working in an incognito window.
1. Register a new account with a valid email address (yours).
1. Wait for the email and open the link in the incognito window activate your account
1. In a regular browser window, go to the "Manage Learners" view for any EnterpriseCustomer and login as "staff"
1. Use the "Link learners" tool to enroll your email address from step 1 into the course "course-v1:edX+DemoX+Demo_Course".
1. Select the "Audit" course mode
1. Ensure that "Notify learners of enrollment: Send email" is selected, then click Submit
1. You should receive a notification email

**Reviewers**
- [ ] @bdero
- [x] @mattdrayer 