### PR TITLE
moving tabindex

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -70,7 +70,7 @@ ${HTML(fragment.foot_html())}
 </%block>
 
 <div class="course-wrapper">
-  <section class="course-content" id="course-content">
+  <section class="course-content" id="course-content" tabindex="-1">
     ${HTML(fragment.body_html())}
   </section>
 </div>

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -70,7 +70,7 @@ ${HTML(fragment.foot_html())}
 </%block>
 
 <div class="course-wrapper">
-  <section class="course-content" id="course-content" tabindex="-1">
+  <main class="course-content" id="main" tabindex="-1" aria-label="Content">
     ${HTML(fragment.body_html())}
   </section>
 </div>

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -70,8 +70,10 @@ ${HTML(fragment.foot_html())}
 </%block>
 
 <div class="course-wrapper">
-  <main class="course-content" id="main" tabindex="-1" aria-label="Content">
-    ${HTML(fragment.body_html())}
+  <section class="course-content" id="course-content">
+      <main id="main" tabindex="-1" aria-label="Content">
+        ${HTML(fragment.body_html())}
+      </main>
   </section>
 </div>
 % if course.show_calculator or is_edxnotes_enabled(course):

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -150,9 +150,8 @@ ${HTML(fragment.foot_html())}
 
     </div>
 % endif
-    <section class="course-content" id="course-content" tabindex="-1">
+    <main class="course-content" id="main" tabindex="-1" aria-label="Content">
         <div class="path"></div>
-        <main id="main" aria-label="Content">
         % if getattr(course, 'entrance_exam_enabled') and \
            getattr(course, 'entrance_exam_minimum_score_pct') and \
            entrance_exam_current_score is not UNDEFINED:
@@ -184,8 +183,7 @@ ${HTML(fragment.foot_html())}
         % endif
 
           ${HTML(fragment.body_html())}
-        </main>
-    </section>
+    </main>
 
     <section class="courseware-results-wrapper">
       <div id="loading-message" aria-live="polite" aria-relevant="all"></div>

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -150,9 +150,9 @@ ${HTML(fragment.foot_html())}
 
     </div>
 % endif
-    <section class="course-content" id="course-content">
+    <section class="course-content" id="course-content" tabindex="-1">
         <div class="path"></div>
-        <main id="main" aria-label="Content" tabindex="-1">
+        <main id="main" aria-label="Content">
         % if getattr(course, 'entrance_exam_enabled') and \
            getattr(course, 'entrance_exam_minimum_score_pct') and \
            entrance_exam_current_score is not UNDEFINED:

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -150,40 +150,42 @@ ${HTML(fragment.foot_html())}
 
     </div>
 % endif
-    <main class="course-content" id="main" tabindex="-1" aria-label="Content">
-        <div class="path"></div>
-        % if getattr(course, 'entrance_exam_enabled') and \
-           getattr(course, 'entrance_exam_minimum_score_pct') and \
-           entrance_exam_current_score is not UNDEFINED:
-            % if not entrance_exam_passed:
-            <p class="sequential-status-message">
-                ${_('To access course materials, you must score {required_score}% or higher on this \
-                exam. Your current score is {current_score}%.').format(
-                    required_score=int(round(course.entrance_exam_minimum_score_pct * 100)),
-                    current_score=int(round(entrance_exam_current_score * 100))
-                )}
-            </p>
-            <script type="text/javascript">
-            $(document).ajaxSuccess(function(event, xhr, settings) {
-                if (settings.url.indexOf("xmodule_handler/problem_check") > -1) {
-                    var data = JSON.parse(xhr.responseText);
-                    if (data.entrance_exam_passed){
-                        location.reload();
+    <section class="course-content" id="course-content">
+        <main id="main" tabindex="-1" aria-label="Content">
+            <div class="path"></div>
+            % if getattr(course, 'entrance_exam_enabled') and \
+               getattr(course, 'entrance_exam_minimum_score_pct') and \
+               entrance_exam_current_score is not UNDEFINED:
+                % if not entrance_exam_passed:
+                <p class="sequential-status-message">
+                    ${_('To access course materials, you must score {required_score}% or higher on this \
+                    exam. Your current score is {current_score}%.').format(
+                        required_score=int(round(course.entrance_exam_minimum_score_pct * 100)),
+                        current_score=int(round(entrance_exam_current_score * 100))
+                    )}
+                </p>
+                <script type="text/javascript">
+                $(document).ajaxSuccess(function(event, xhr, settings) {
+                    if (settings.url.indexOf("xmodule_handler/problem_check") > -1) {
+                        var data = JSON.parse(xhr.responseText);
+                        if (data.entrance_exam_passed){
+                            location.reload();
+                        }
                     }
-                }
-            });
-            </script>
-            % else:
-              <p class="sequential-status-message">
-                ${_('Your score is {current_score}%. You have passed the entrance exam.').format(
-                    current_score=int(round(entrance_exam_current_score * 100))
-                )}
-            </p>
+                });
+                </script>
+                % else:
+                  <p class="sequential-status-message">
+                    ${_('Your score is {current_score}%. You have passed the entrance exam.').format(
+                        current_score=int(round(entrance_exam_current_score * 100))
+                    )}
+                </p>
+                % endif
             % endif
-        % endif
 
-          ${HTML(fragment.body_html())}
-    </main>
+              ${HTML(fragment.body_html())}
+        </main>
+    </section>
 
     <section class="courseware-results-wrapper">
       <div id="loading-message" aria-live="polite" aria-relevant="all"></div>


### PR DESCRIPTION
## [TNL-6351](https://openedx.atlassian.net/browse/TNL-6351)

Currently, "skip to main content" skips past the next/previous buttons. This change moves focus to the container in which both the nav bar and main course content are presented so that screen reader users will know that the nav buttons are present before entering the course content.

Reviewers:

- [x] one of @yro @nasthagiri @jcdyer @efischer19 

- [x] one of @arizzitano @cptvitamin 

Sandbox: https://sanfordstudent.sandbox.edx.org (currently building)