### PR TITLE
bump ora2 version

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -76,7 +76,7 @@ git+https://github.com/edx/XBlock.git@xblock-0.4.13#egg=XBlock==0.4.13
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@1.2.0#egg=ora2==1.2.0
+git+https://github.com/edx/edx-ora2.git@1.2.1#egg=ora2==1.2.1
 -e git+https://github.com/edx/edx-submissions.git@1.1.4#egg=edx-submissions==1.1.4
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/edx-val.git@0.0.12#egg=edxval==0.0.12


### PR DESCRIPTION
## [ORA2 1.2.1](https://github.com/edx/edx-ora2/compare/1.2.0...1.2.1)
### Description
Let's update ora2! 
It's 1.2.1 Now.
Here's the [diff](https://github.com/edx/edx-ora2/compare/1.2.0...1.2.1)


### Testing
- [x] Unit tests

### Reviewers
- [x] @efischer19 
- [x] @sanfordstudent 

### Post-review
- [x] Rebase and squash commits
