### PR TITLE
An idempotent migration to add an email uniqueness constraint

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -959,6 +959,9 @@ INSTALLED_APPS = (
 
     # management of user-triggered async tasks (course import/export, etc.)
     'user_tasks',
+
+    # Unusual migrations
+    'database_fixups',
 )
 
 

--- a/common/djangoapps/database_fixups/__init__.py
+++ b/common/djangoapps/database_fixups/__init__.py
@@ -1,0 +1,3 @@
+"""
+This app exists solely to host unusual database migrations.
+"""

--- a/common/djangoapps/database_fixups/migrations/0001_initial.py
+++ b/common/djangoapps/database_fixups/migrations/0001_initial.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations
+from django.db import migrations, models
 
 # We used to have a uniqueness constraint on auth_user.email:
 # https://github.com/edx/edx-platform/commit/c52727b0e0fb241d8211900975d3b69fe5a1bd57
@@ -27,7 +27,6 @@ def add_email_uniqueness_constraint(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('student', '0010_auto_20170207_0458'),
     ]
 
     operations = [

--- a/common/djangoapps/student/migrations/0010_auto_20170207_0458.py
+++ b/common/djangoapps/student/migrations/0010_auto_20170207_0458.py
@@ -26,9 +26,5 @@ class Migration(migrations.Migration):
     # )
 
     operations = [
-        migrations.RunSQL(
-            # Do nothing:
-            "select 1",
-            "select 1"
-        )
+        # Nothing to do.
     ]

--- a/common/djangoapps/student/migrations/0011_auto_20170214_1200.py
+++ b/common/djangoapps/student/migrations/0011_auto_20170214_1200.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+# We used to have a uniqueness constraint on auth_user.email:
+# https://github.com/edx/edx-platform/commit/c52727b0e0fb241d8211900975d3b69fe5a1bd57
+#
+# That constraint was lost in the upgrade from Django 1.4->1.8.  This migration
+# adds it back.  But because it might already exist in databases created
+# long-enough ago, we have to do it idempotently.  So we check for the
+# existence of the constraint before creating it.
+
+def add_email_uniqueness_constraint(apps, schema_editor):
+    # Do we already have an email uniqueness constraint?
+    cursor = schema_editor.connection.cursor()
+    constraints = schema_editor.connection.introspection.get_constraints(cursor, "auth_user")
+    email_constraint = constraints.get("email", {})
+    if email_constraint.get("columns") == ["email"] and email_constraint.get("unique") == True:
+        # We already have the constraint, we're done.
+        return
+
+    # We don't have the constraint, make it.
+    schema_editor.execute("create unique index email on auth_user (email)")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('student', '0010_auto_20170207_0458'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_email_uniqueness_constraint)
+    ]

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2164,6 +2164,9 @@ INSTALLED_APPS = (
 
     # Ability to detect and special-case crawler behavior
     'openedx.core.djangoapps.crawlers',
+
+    # Unusual migrations
+    'database_fixups',
 )
 
 # Migrations which are not in the standard module "migrations"

--- a/openedx/core/lib/django_courseware_routers.py
+++ b/openedx/core/lib/django_courseware_routers.py
@@ -51,7 +51,7 @@ class StudentModuleHistoryExtendedRouter(object):
         """
         if model_name is not None:
             model = hints.get('model')
-            if self._is_csmh(model):
+            if model is not None and self._is_csmh(model):
                 return db == self.DATABASE_NAME
         if db == self.DATABASE_NAME:
             return False


### PR DESCRIPTION
Because the email uniqueness constraint used to exist in the code, there are systems (like edx.org production!) that already have the constraint.  So the migration to add it has to be idempotent, by checking if the constraint already exists.

Also, the updated multi-db code had a problem with non-None names but None models, as described here: https://github.com/edx/edx-platform/pull/14497/files#r100906924

Also also, the previous no-op'ed migration is no-op'ed better.