### PR TITLE
Unawaz/ecom 6949 sailthru cookie test

### DIFF
--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -50,12 +50,12 @@ def add_email_marketing_cookies(sender, response=None, user=None,
         'vars': {'last_login_date': datetime.datetime.now().strftime("%Y-%m-%d")}
     }
 
-    # get sailthru_content cookie to capture usage before logon
+    # get anonymous_interest cookie to capture usage before logon
     request = crum.get_current_request()
     if request:
-        sailthru_content = request.COOKIES.get('sailthru_content')
+        sailthru_content = request.COOKIES.get('anonymous_interest')
         if sailthru_content:
-            post_parms['cookies'] = {'sailthru_content': sailthru_content}
+            post_parms['cookies'] = {'anonymous_interest': sailthru_content}
 
     try:
         sailthru_client = SailthruClient(email_config.sailthru_key, email_config.sailthru_secret)

--- a/lms/djangoapps/email_marketing/tests/test_signals.py
+++ b/lms/djangoapps/email_marketing/tests/test_signals.py
@@ -87,13 +87,13 @@ class EmailMarketingTests(TestCase):
             "success": True,
             "redirect_url": 'test.com/test',
         })
-        self.request.COOKIES['sailthru_content'] = 'cookie_content'
+        self.request.COOKIES['anonymous_interest'] = 'cookie_content'
         mock_get_current_request.return_value = self.request
         mock_sailthru.return_value = SailthruResponse(JsonResponse({'keys': {'cookie': 'test_cookie'}}))
         add_email_marketing_cookies(None, response=response, user=self.user)
         mock_sailthru.assert_called_with('user',
                                          {'fields': {'keys': 1},
-                                          'cookies': {'sailthru_content': 'cookie_content'},
+                                          'cookies': {'anonymous_interest': 'cookie_content'},
                                           'id': TEST_EMAIL,
                                           'vars': {'last_login_date': ANY}})
         self.assertTrue('sailthru_hid' in response.cookies)


### PR DESCRIPTION
[ECOM-6949](https://openedx.atlassian.net/browse/ECOM-6949)
Cookie name updates for sailthru
Related [Marketing PR](https://github.com/edx/edx-mktg/pull/1116)
@schenedx Please help review.