### PR TITLE
Update embargo message with better language ECOM-7119

### DIFF
--- a/common/test/test-theme/lms/templates/static_templates/embargo.html
+++ b/common/test/test-theme/lms/templates/static_templates/embargo.html
@@ -12,9 +12,9 @@ from openedx.core.djangolib.markup import HTML, Text
     <section class="outside-app">
     <p>
     ${Text(_("Our system indicates that you are trying to access this {platform_name} "
-        "course from a country or region currently subject to U.S. economic and trade "
-        "sanctions. Unfortunately, at this time {platform_name} must comply with "
-        "export controls, and we cannot allow you to access this course."
+        "course from a country or region currently subject to U.S. economic and trade sanctions." 
+        "Unfortunately, because {platform_name} is required to comply with export controls," 
+        "we cannot allow you to access this course at this time."
       )).format(
         platform_name=Text(settings.PLATFORM_NAME),
       )}

--- a/lms/templates/static_templates/embargo.html
+++ b/lms/templates/static_templates/embargo.html
@@ -11,9 +11,9 @@ from openedx.core.djangolib.markup import HTML, Text
     <section class="outside-app">
     <p>
     ${Text(_("Our system indicates that you are trying to access this {platform_name} "
-        "course from a country or region currently subject to U.S. economic and trade "
-        "sanctions. Unfortunately, at this time {platform_name} must comply with "
-        "export controls, and we cannot allow you to access this course."
+        "course from a country or region currently subject to U.S. economic and trade sanctions." 
+        "Unfortunately, because {platform_name} is required to comply with export controls," 
+        "we cannot allow you to access this course at this time."
       )).format(
         platform_name=Text(settings.PLATFORM_NAME),
       )}


### PR DESCRIPTION
@edx/ecommerce Please help review

We just want to change the language for this embargo page

See screenshot for the new language:

![newembargomessage](https://cloud.githubusercontent.com/assets/16839373/22987719/c8609ac4-f37d-11e6-8565-6ebf841abb4f.jpeg)
