### PR TITLE
Cherry-pick the email uniqueness constraint onto Ficus

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -956,6 +956,9 @@ INSTALLED_APPS = (
 
     # management of user-triggered async tasks (course import/export, etc.)
     'user_tasks',
+
+    # Unusual migrations
+    'database_fixups',
 )
 
 

--- a/common/djangoapps/database_fixups/__init__.py
+++ b/common/djangoapps/database_fixups/__init__.py
@@ -1,0 +1,3 @@
+"""
+This app exists solely to host unusual database migrations.
+"""

--- a/common/djangoapps/database_fixups/migrations/0001_initial.py
+++ b/common/djangoapps/database_fixups/migrations/0001_initial.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+# We used to have a uniqueness constraint on auth_user.email:
+# https://github.com/edx/edx-platform/commit/c52727b0e0fb241d8211900975d3b69fe5a1bd57
+#
+# That constraint was lost in the upgrade from Django 1.4->1.8.  This migration
+# adds it back.  But because it might already exist in databases created
+# long-enough ago, we have to do it idempotently.  So we check for the
+# existence of the constraint before creating it.
+
+def add_email_uniqueness_constraint(apps, schema_editor):
+    # Do we already have an email uniqueness constraint?
+    cursor = schema_editor.connection.cursor()
+    constraints = schema_editor.connection.introspection.get_constraints(cursor, "auth_user")
+    email_constraint = constraints.get("email", {})
+    if email_constraint.get("columns") == ["email"] and email_constraint.get("unique") == True:
+        # We already have the constraint, we're done.
+        return
+
+    # We don't have the constraint, make it.
+    schema_editor.execute("create unique index email on auth_user (email)")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.RunPython(add_email_uniqueness_constraint)
+    ]

--- a/common/djangoapps/student/migrations/0010_auto_20170207_0458.py
+++ b/common/djangoapps/student/migrations/0010_auto_20170207_0458.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('student', '0009_auto_20170111_0422'),
+    ]
+
+    # This migration was to add a constraint that we lost in the Django
+    # 1.4->1.8 upgrade. But since the constraint used to be created, production
+    # would already have the constraint even before running the migration, and
+    # running the migration would fail. We needed to make the migration
+    # idempotent.  Instead of reverting this migration while we did that, we
+    # edited it to be a SQL no-op, so that people who had already applied it
+    # wouldn't end up with a ghost migration.
+
+    # It had been:
+    #
+    # migrations.RunSQL(
+    #   "create unique index email on auth_user (email);",
+    #   "drop index email on auth_user;"
+    # )
+
+    operations = [
+        # Nothing to do.
+    ]

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2154,6 +2154,9 @@ INSTALLED_APPS = (
 
     # additional release utilities to ease automation
     'release_util',
+
+    # Unusual migrations
+    'database_fixups',
 )
 
 # Migrations which are not in the standard module "migrations"

--- a/openedx/core/lib/django_courseware_routers.py
+++ b/openedx/core/lib/django_courseware_routers.py
@@ -45,13 +45,15 @@ class StudentModuleHistoryExtendedRouter(object):
             return False
         return None
 
-    def allow_migrate(self, db, model):  # pylint: disable=unused-argument
+    def allow_migrate(self, db, app_label, model_name=None, **hints):  # pylint: disable=unused-argument
         """
         Only sync StudentModuleHistoryExtended to StudentModuleHistoryExtendedRouter.DATABASE_Name
         """
-        if self._is_csmh(model):
-            return db == self.DATABASE_NAME
-        elif db == self.DATABASE_NAME:
+        if model_name is not None:
+            model = hints.get('model')
+            if model is not None and self._is_csmh(model):
+                return db == self.DATABASE_NAME
+        if db == self.DATABASE_NAME:
             return False
 
         return None


### PR DESCRIPTION
Added unique constraint on email
ECOM-7085

(cherry picked from commit d141eb15b1687a1c493666c7cbec566b4f7c5c91)

No-op a migration that needs to be more clever

(cherry picked from commit 1e6a74e777fd66eba3238776c93e17551d71ad67)

model_name can be non-None, and model is still None

(cherry picked from commit 52ca02fdc4a7cdf14fc523428922d45a210181b8)

An idempotent migration to add an email uniqueness constraint

(cherry picked from commit 169414b734d4f2318786ae171ef1860316c888ce)

Make this no-op migration be a true no-op.

(cherry picked from commit 04557bbff362ae3b89e7dd98a1fb11e0aaeba50e)

A new django app for unicorn migrations

(cherry picked from commit 98b250b66ed53fd4f52a85f1e8e897652b2d29f8)