### PR TITLE
Unclean Grades

### DIFF
--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -8,7 +8,6 @@ from lms.djangoapps.instructor.enrollment import reset_student_attempts
 from lms.djangoapps.instructor_task.api import submit_rescore_problem_for_student
 from mock import patch
 from openedx.core.djangolib.testing.utils import get_mock_request
-from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
@@ -28,8 +27,10 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
     of the grading infrastructure.
     """
     @classmethod
-    def setUpClass(cls):
-        super(GradesEventIntegrationTest, cls).setUpClass()
+    def reset_course(cls):
+        """
+        Sets up the course anew.
+        """
         with cls.store.default_store(ModuleStoreEnum.Type.split):
             cls.course = CourseFactory.create()
             cls.chapter = ItemFactory.create(
@@ -63,6 +64,7 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
             )
 
     def setUp(self):
+        self.reset_course()
         super(GradesEventIntegrationTest, self).setUp()
         self.request = get_mock_request(UserFactory())
         self.student = self.request.user

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -9,7 +9,6 @@ from hashlib import sha1
 import json
 from mock import patch
 
-from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from django.test import TestCase
 from django.utils.timezone import now
@@ -228,7 +227,7 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
             )
             self.assertEqual(created_grade, read_grade)
             self.assertEqual(read_grade.visible_blocks.blocks, self.block_records)
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(IntegrityError):
             PersistentSubsectionGrade.create_grade(**self.params)
 
     @ddt.data('course_version', 'subtree_edited_timestamp')
@@ -237,12 +236,12 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
         PersistentSubsectionGrade.create_grade(**self.params)
 
     @ddt.data(
-        ("user_id", ValidationError),
+        ("user_id", IntegrityError),
         ("usage_key", KeyError),
-        ("earned_all", ValidationError),
-        ("possible_all", ValidationError),
-        ("earned_graded", ValidationError),
-        ("possible_graded", ValidationError),
+        ("earned_all", IntegrityError),
+        ("possible_all", IntegrityError),
+        ("earned_graded", IntegrityError),
+        ("possible_graded", IntegrityError),
         ("visible_blocks", KeyError),
         ("attempted", KeyError),
     )
@@ -275,18 +274,6 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
         self.assertIsNone(grade.first_attempted)
         self.assertEqual(grade.earned_all, 0.0)
         self.assertEqual(grade.earned_graded, 0.0)
-
-    def test_create_inconsistent_unattempted(self):
-        self.params['attempted'] = False
-        with self.assertRaises(ValidationError):
-            PersistentSubsectionGrade.create_grade(**self.params)
-
-    def test_update_or_create_inconsistent_unattempted(self):
-        self.params['attempted'] = False
-        self.params['earned_all'] = 1.0
-        self.params['earned_graded'] = 1.0
-        with self.assertRaises(ValidationError):
-            PersistentSubsectionGrade.update_or_create_grade(**self.params)
 
     def test_first_attempted_not_changed_on_update(self):
         PersistentSubsectionGrade.create_grade(**self.params)

--- a/lms/djangoapps/grades/tests/test_new.py
+++ b/lms/djangoapps/grades/tests/test_new.py
@@ -214,7 +214,7 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
                 'lms.djangoapps.grades.new.subsection_grade.SubsectionGradeFactory._get_bulk_cached_grade',
                 wraps=self.subsection_grade_factory._get_bulk_cached_grade
             ) as mock_get_bulk_cached_grade:
-                with self.assertNumQueries(14):
+                with self.assertNumQueries(12):
                     grade_a = self.subsection_grade_factory.create(self.sequence)
                 self.assertTrue(mock_get_bulk_cached_grade.called)
                 self.assertTrue(mock_create_grade.called)


### PR DESCRIPTION
Per discussions had as a result of https://github.com/edx/edx-platform/pull/14523, we've decided to yank all of the `clean` calls that were added.

We're confident this is safe, as the error that would be logged if our validation caught anything [does not appear in splunk at all](https://splunk.edx.org/en-US/app/search/search?sid=1487191216.4299444)

Tests have been updated as well.