### PR TITLE
WL-977 | Set 'created_on_site' UserAttribute on account creation

### DIFF
--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -17,6 +17,7 @@ import pytz
 
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
+from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from notification_prefs import NOTIFICATION_PREF_KEY
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
 import student
@@ -43,7 +44,7 @@ TEST_CS_URL = 'https://comments.service.test:123/'
         ]
     }
 )
-class TestCreateAccount(TestCase):
+class TestCreateAccount(SiteMixin, TestCase):
     """Tests for account creation"""
 
     def setUp(self):
@@ -75,12 +76,12 @@ class TestCreateAccount(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(get_user_preference(user, LANGUAGE_KEY), lang)
 
-    def create_account_and_fetch_profile(self):
+    def create_account_and_fetch_profile(self, host='microsite.example.com'):
         """
         Create an account with self.params, assert that the response indicates
         success, and return the UserProfile object for the newly created user
         """
-        response = self.client.post(self.url, self.params, HTTP_HOST="microsite.example.com")
+        response = self.client.post(self.url, self.params, HTTP_HOST=host)
         self.assertEqual(response.status_code, 200)
         user = User.objects.get(username=self.username)
         return user.profile
@@ -224,6 +225,7 @@ class TestCreateAccount(TestCase):
         """
 
         request = self.request_factory.post(self.url, self.params)
+        request.site = self.site
         # now indicate we are doing ext_auth by setting 'ExternalAuthMap' in the session.
         request.session = import_module(settings.SESSION_ENGINE).SessionStore()  # empty session
         extauth = ExternalAuthMap(external_id='withmap@stanford.edu',
@@ -412,6 +414,10 @@ class TestCreateAccount(TestCase):
         """
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 403)
+
+    def test_created_on_site_user_attribute_set(self):
+        profile = self.create_account_and_fetch_profile(host=self.site.domain)
+        self.assertEqual(UserAttribute.get_user_attribute(profile.user, 'created_on_site'), self.site.domain)
 
 
 @ddt.ddt

--- a/common/djangoapps/student/tests/test_password_policy.py
+++ b/common/djangoapps/student/tests/test_password_policy.py
@@ -12,6 +12,7 @@ from django.test.utils import override_settings
 from django.conf import settings
 from mock import patch
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from student.views import create_account
 
 
@@ -252,6 +253,7 @@ class TestPasswordPolicy(TestCase):
         """
         self.url_params['password'] = 'aaa'  # shouldn't pass validation
         request = self.request_factory.post(self.url, self.url_params)
+        request.site = SiteFactory.create()
         # now indicate we are doing ext_auth by setting 'ExternalAuthMap' in the session.
         request.session = import_module(settings.SESSION_ENGINE).SessionStore()  # empty session
         extauth = ExternalAuthMap(external_id='withmap@stanford.edu',

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1541,7 +1541,7 @@ def user_signup_handler(sender, **kwargs):  # pylint: disable=unused-argument
             log.info(u'user {} originated from a white labeled "Microsite"'.format(kwargs['instance'].id))
 
 
-def _do_create_account(form, custom_form=None):
+def _do_create_account(form, custom_form=None, site=None):
     """
     Given cleaned post variables, create the User and UserProfile objects, as well as the
     registration for this user.
@@ -1582,6 +1582,10 @@ def _do_create_account(form, custom_form=None):
                 custom_model = custom_form.save(commit=False)
                 custom_model.user = user
                 custom_model.save()
+
+            if site:
+                # Set UserAttribute indicating the site the user account was created on.
+                UserAttribute.set_user_attribute(user, 'created_on_site', site.domain)
     except IntegrityError:
         # Figure out the cause of the integrity error
         if len(User.objects.filter(username=user.username)) > 0:
@@ -1718,7 +1722,7 @@ def create_account_with_params(request, params):
     # Perform operations within a transaction that are critical to account creation
     with transaction.atomic():
         # first, create the account
-        (user, profile, registration) = _do_create_account(form, custom_form)
+        (user, profile, registration) = _do_create_account(form, custom_form, site=request.site)
 
         # next, link the account with social auth, if provided via the API.
         # (If the user is using the normal register page, the social auth pipeline does the linking, not this code)
@@ -2072,7 +2076,7 @@ def auto_auth(request):
     # If successful, this will return a tuple containing
     # the new user object.
     try:
-        user, profile, reg = _do_create_account(form)
+        user, profile, reg = _do_create_account(form, site=request.site)
     except (AccountValidationError, ValidationError):
         # Attempt to retrieve the existing user.
         user = User.objects.get(username=username)

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -19,6 +19,7 @@ from social.apps.django_app import utils as social_utils
 from social.apps.django_app import views as social_views
 
 from lms.djangoapps.commerce.tests import TEST_API_URL
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from student import models as student_models
 from student import views as student_views
 from student.tests.factories import UserFactory
@@ -514,6 +515,7 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         request = self.request_factory.get(
             pipeline.get_complete_url(self.backend_name) +
             '?redirect_state=redirect_state_value&code=code_value&state=state_value')
+        request.site = SiteFactory.create()
         request.user = auth_models.AnonymousUser()
         request.session = cache.SessionStore()
         request.session[self.backend_name + '_state'] = 'state_value'

--- a/openedx/core/djangoapps/external_auth/tests/test_ssl.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_ssl.py
@@ -18,6 +18,7 @@ from django.test.utils import override_settings
 
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
 import openedx.core.djangoapps.external_auth.views as external_auth_views
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangolib.testing.utils import skip_unless_cms, skip_unless_lms
 from student.models import CourseEnrollment
 from student.roles import CourseStaffRole
@@ -54,6 +55,7 @@ class SSLClientTest(ModuleStoreTestCase):
         """Creates a basic request for SSL use."""
         request = self.factory.get(url)
         request.META['SSL_CLIENT_S_DN'] = self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL)
+        request.site = SiteFactory.create()
         request.user = AnonymousUser()
         middleware = SessionMiddleware()
         middleware.process_request(request)


### PR DESCRIPTION
@afzaledx @douglashall

[WL-977](https://openedx.atlassian.net/browse/WL-977)

We need to be able to identify the site from which a user account was created. This change sets a UserAttribute on account creation with a key of `created_on_site` and a value matching the current site of the account creation request.