### PR TITLE
Select related users when returning enrollments.

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1439,7 +1439,7 @@ class CourseEnrollment(models.Model):
 
     @classmethod
     def enrollments_for_user(cls, user):
-        return cls.objects.filter(user=user, is_active=1)
+        return cls.objects.filter(user=user, is_active=1).select_related('user')
 
     @classmethod
     def enrollment_status_hash_cache_key(cls, user):


### PR DESCRIPTION
Modify CourseEnrollment.enrollments_for_user to select the related user object. This saves us from a bunch of redundant queries on the student dashboard.

@andy-armstrong: This saves about 1 database query per enrolled course. Jennifer Akana brought it to my attention this past week that the student dashboard is excruciatingly slow for our support folks who can be enrolled in hundreds or even a thousand courses. This query isn't the worst one, but it is probably the easiest to fix. I'll be trickling in more of these in my spare time as I can. Please let me know if I should tag someone else for review.

@pwnage101: Can you please be my second reviewer on this?