### PR TITLE
Student Dashboard CourseOverviews with one query.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -301,7 +301,7 @@ def get_course_enrollments(user, orgs_to_include, orgs_to_exclude):
         generator[CourseEnrollment]: a sequence of enrollments to be displayed
         on the user's dashboard.
     """
-    for enrollment in CourseEnrollment.enrollments_for_user(user):
+    for enrollment in CourseEnrollment.enrollments_for_user_with_overviews_preload(user):
 
         # If the course is missing or broken, log an error and skip it.
         course_overview = enrollment.course_overview

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -274,6 +274,27 @@ class CourseOverview(TimeStampedModel):
 
         return course_overview or cls.load_from_module_store(course_id)
 
+    @classmethod
+    def get_from_ids_if_exists(cls, course_ids):
+        """
+        Return a dict mapping course_ids to CourseOverviews, if they exist.
+
+        This method will *not* generate new CourseOverviews or delete outdated
+        ones. It exists only as a small optimization used when CourseOverviews
+        are known to exist, for common situations like the student dashboard.
+
+        Callers should assume that this list is incomplete and fall back to
+        get_from_id if they need to guarantee CourseOverview generation.
+        """
+        return {
+            overview.id: overview
+            for overview
+            in cls.objects.select_related('image_set').filter(
+                id__in=course_ids,
+                version__gte=cls.VERSION
+            )
+        }
+
     def clean_id(self, padding_char='='):
         """
         Returns a unique deterministic base32-encoded ID for the course.


### PR DESCRIPTION
Pre-load the course overviews attached to CourseEnrollments on the Student Dashboard, if possible. This will only grab the CourseOverviews that already exist, and will not generate new ones. Any missing
CourseOverviews fall back to the lazily-created one-at-a-time behavior they've always had. That's mostly because I wanted to optimize for the common case in the least invasive way possible, and I don't want to get caught up in locking issues.

@andy-armstrong, @nasthagiri: Hi folks. Not sure who to send this for review. It's just a minor optimization, to try to address the long load times that support folks are seeing on the student dashboard. Could you please point me to the right person/team?

@pwnage101: Review pls?