### PR TITLE
remove space around xsy avatar image

### DIFF
--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -163,6 +163,8 @@
       letter-spacing: 0;
 
       .user-image-frame {
+        margin: 0;
+        padding: 0;
         max-width: ($baseline*2);
         border-radius: 10%;
       }


### PR DESCRIPTION
[TNL-6563](https://openedx.atlassian.net/browse/TNL-6563)

## Description
A random internal image style sets the space around the xsy and that pushes the drop down menu lower

[Sandbox](https://alisan617.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/1414ffd5143b4b508f739b563ab468b7/workflow/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40934cc32c177d41b580c8413e561346b3)  

Tested with an internal image style in this "**edX exams**" unit .