### PR TITLE
Open Response Assessment tab for Instructor Dashboard

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -321,6 +321,30 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         # Max number of student per page is one.  Patched setting MAX_STUDENTS_PER_PAGE_GRADE_BOOK = 1
         self.assertEqual(len(response.mako_context['students']), 1)  # pylint: disable=no-member
 
+    def test_open_response_assessment_page(self):
+        """
+        Test that Open Responses is available only if course contains at least one ORA block
+        """
+        ora_section = (
+            '<li class="nav-item">'
+            '<button type="button" class="btn-link" data-section="open_response_assessment">'
+            'Open Responses'
+            '</button>'
+            '</li>'
+        )
+
+        response = self.client.get(self.url)
+        self.assertNotIn(ora_section, response.content)
+
+        course = ItemFactory.create(
+            parent_location=self.course.location,
+            category="course",
+            display_name="Test course",
+        )
+        ItemFactory.create(parent_location=course.location, category="openassessment")
+        response = self.client.get(self.url)
+        self.assertIn(ora_section, response.content)
+
 
 @ddt.ddt
 class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTestCase, XssTestMixin):

--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -190,6 +190,9 @@ such that the value can be defined later than this assignment (file load order).
             }, {
                 constructor: window.InstructorDashboard.sections.Certificates,
                 $element: idashContent.find('.' + CSS_IDASH_SECTION + '#certificates')
+            }, {
+                constructor: window.InstructorDashboard.sections.OpenResponseAssessment,
+                $element: idashContent.find('.' + CSS_IDASH_SECTION + '#open_response_assessment')
             }
         ];
         if (edx.instructor_dashboard.proctoring !== void 0) {

--- a/lms/static/js/instructor_dashboard/open_response_assessment.js
+++ b/lms/static/js/instructor_dashboard/open_response_assessment.js
@@ -1,0 +1,40 @@
+/* globals _ */
+
+(function(_) {
+    'use strict';
+
+    var OpenResponseAssessment = (function() {
+        function OpenResponseAssessmentBlock($section) {
+            this.$section = $section;
+            this.$section.data('wrapper', this);
+        }
+
+        OpenResponseAssessmentBlock.prototype.onClickTitle = function() {
+            var block = this.$section.find('.open-response-assessment');
+            XBlock.initializeBlock($(block).find('.xblock')[0]);
+        };
+
+        return OpenResponseAssessmentBlock;
+    }());
+
+    if (typeof window.setup_debug === 'undefined') {
+        // eslint-disable-next-line no-unused-vars, camelcase
+        window.setup_debug = function(element_id, edit_link, staff_context) {
+            // stub function.
+        };
+    }
+
+    _.defaults(window, {
+        InstructorDashboard: {}
+    });
+
+    _.defaults(window.InstructorDashboard, {
+        sections: {}
+    });
+
+    _.defaults(window.InstructorDashboard.sections, {
+        OpenResponseAssessment: OpenResponseAssessment
+    });
+
+    this.OpenResponseAssessment = OpenResponseAssessment;
+}).call(this, _);

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1482,6 +1482,14 @@
   }
 }
 
+// view - student admin
+// --------------------
+.instructor-dashboard-wrapper-2 section.idash-section#open_response_assessment {
+  .open-response-assessment {
+    padding-top: 20px;
+  }
+}
+
 input[name="subject"] {
   width:600px;
 }

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -5,6 +5,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from openedx.core.djangolib.markup import HTML
 %>
 <%block name="bodyclass">view-in-course view-instructordash</%block>
 
@@ -63,6 +64,19 @@ from django.core.urlresolvers import reverse
   <script type="text/javascript" src="${static.url('js/views/notification.js')}"></script>
   <script type="text/javascript" src="${static.url('js/views/file_uploader.js')}"></script>
   <script type="text/javascript" src="${static.url('js/utils/animation.js')}"></script>
+  % for section_data in sections:
+    % if 'fragment' in section_data:
+      ${HTML(section_data['fragment'].head_html())}
+    % endif
+  % endfor
+</%block>
+
+<%block name="js_extra">
+  % for section_data in sections:
+    % if 'fragment' in section_data:
+      ${HTML(section_data['fragment'].foot_html())}
+    % endif
+  % endfor
 </%block>
 
 ## Include Underscore templates

--- a/lms/templates/instructor/instructor_dashboard_2/open_response_assessment.html
+++ b/lms/templates/instructor/instructor_dashboard_2/open_response_assessment.html
@@ -1,0 +1,6 @@
+<%page args="section_data" expression_filter="h"/>
+<%! from openedx.core.djangolib.markup import HTML %>
+
+<section class="open-response-assessment">
+    ${HTML(section_data['fragment'].body_html())}
+</section>


### PR DESCRIPTION
New Open Response Assessment tab in the Instructor Dashboard of LMS:
https://projects.invisionapp.com/share/YKA6S7VH8#/216097426_Course_-Instructor_-AppsAndTools

This PR is the last step of implementation this feature: https://github.com/edx/edx-platform/pull/14372
Connected PRs (dependencies):
**1.** New OraAggregateData.collect_ora2_responses method: https://github.com/edx/edx-ora2/pull/973
**2.** New auxiliary view "grade_available_responses_view": https://github.com/edx/edx-ora2/pull/979

Screenshots:
![ora1](https://cloud.githubusercontent.com/assets/1876893/23224398/5218d878-f93f-11e6-9f65-f20b02ea773f.jpg)

![ora2](https://cloud.githubusercontent.com/assets/1876893/23224397/52163302-f93f-11e6-93c2-37edaf5b038e.jpg)

![ora3](https://cloud.githubusercontent.com/assets/1876893/23224399/521b02e2-f93f-11e6-8c3f-9dfee13641d6.jpg)
