### PR TITLE
update xblock-poll version

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -91,5 +91,5 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.1.2#egg=lti_consumer-xbloc
 git+https://github.com/edx/edx-proctoring.git@0.18.0#egg=edx-proctoring==0.18.0
 
 # Third Party XBlocks
-git+https://github.com/open-craft/xblock-poll@v1.2.5#egg=xblock-poll==1.2.5
+git+https://github.com/open-craft/xblock-poll@v1.2.6#egg=xblock-poll==1.2.6
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.15#egg=xblock-drag-and-drop-v2==2.0.15


### PR DESCRIPTION
Updates the version of `xblock-poll` to include two new accessibility fixes introduced in https://github.com/open-craft/xblock-poll/pull/24. These fixes resolve [TNL-6359](https://openedx.atlassian.net/browse/TNL-6359) and [TNL-6360](https://openedx.atlassian.net/browse/TNL-6360).

The changes have already passed UAT (see above linked PR for discussion) but the sandbox is still up at https://arizzitano.sandbox.edx.org.