### PR TITLE
Prevent OpenBLAS from spawning worker threads. TNL-6456

### DIFF
--- a/common/lib/capa/capa/safe_exec/safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/safe_exec.py
@@ -14,6 +14,9 @@ import hashlib
 CODE_PROLOG = """\
 from __future__ import division
 
+import os
+os.environ["OPENBLAS_NUM_THREADS"] = "1"    # See TNL-6456
+
 import random as random_module
 import sys
 random = random_module.Random(%r)


### PR DESCRIPTION
The RLIMIT_NPROC limit that CodeJail uses to limit threads and sub-processes is per-user so simultaneous student submissions pile up and overflow the limit.  Setting this environment variable will prevent spawning any threads (the 1 means only have one thread, the already existing main thread).