### PR TITLE
[ENT-200] Add many=True kwarg to get_edx_api_data to modify empty return value

### DIFF
--- a/openedx/core/lib/edx_api_utils.py
+++ b/openedx/core/lib/edx_api_utils.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 def get_edx_api_data(api_config, user, resource,
-                     api=None, resource_id=None, querystring=None, cache_key=None):
+                     api=None, resource_id=None, querystring=None, cache_key=None, many=True):
     """GET data from an edX REST API.
 
     DRY utility for handling caching and pagination.
@@ -31,19 +31,21 @@ def get_edx_api_data(api_config, user, resource,
         querystring (dict): Optional query string parameters.
         cache_key (str): Where to cache retrieved data. The cache will be ignored if this is omitted
             (neither inspected nor updated).
+        many (bool): Whether the resource requested is a collection of objects, or a single object.
+            If false, an empty dict will be returned in cases of failure rather than the default empty list.
 
     Returns:
         Data returned by the API. When hitting a list endpoint, extracts "results" (list of dict)
         returned by DRF-powered APIs.
     """
-    no_data = []
+    no_data = [] if many else {}
 
     if not api_config.enabled:
         log.warning('%s configuration is disabled.', api_config.API_NAME)
         return no_data
 
     if cache_key:
-        cache_key = '{}.{}'.format(cache_key, resource_id) if resource_id else cache_key
+        cache_key = '{}.{}'.format(cache_key, resource_id) if resource_id is not None else cache_key
 
         cached = cache.get(cache_key)
         if cached:
@@ -75,7 +77,7 @@ def get_edx_api_data(api_config, user, resource,
         querystring = querystring if querystring else {}
         response = endpoint(resource_id).get(**querystring)
 
-        if resource_id:
+        if resource_id is not None:
             results = response
         else:
             results = _traverse_pagination(response, endpoint, querystring, no_data)


### PR DESCRIPTION
This pull request adds a `many=True` default kwarg to the `get_edx_api_data` function to allow it to return either an empty dictionary (in cases where a specific item is being requested) or an empty list (by default).

**JIRA tickets**: Implements [ENT-200](https://openedx.atlassian.net/browse/ENT-200)

**Dependencies**: None

**Screenshots**: N/A

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: 13 March

**Testing instructions**:

1. With this branch, run `./manage.py shell --settings=devstack` in your devstack.
2. Run the following commands:
    ```python
    from openedx.core.djangoapps.catalog.models import CatalogIntegration
    catalog = CatalogIntegration.current()
    from django.contrib.auth.models import User
    staff = User.objects.get(username='staff')
    from openedx.core.lib.edx_api_utils import get_edx_api_data
    ```
3. Verify that each of the following commands produces the expected result:
    * `get_edx_api_data(catalog, staff, 'whatever')` should equal `[]`
    * `get_edx_api_data(catalog, staff, 'whatever', resource_id=1)` should equal `[]`
    * `get_edx_api_data(catalog, staff, 'whatever', many=False)` should equal `{}`
    * `get_edx_api_data(catalog, staff, 'whatever', resource_id=1, many=False)` should equal `{}`

**Author notes and concerns**:

1. There is a nicer way to do this - by detecting whether `resource_id` has been passed - which doesn't require an extra kwarg, but this would be a breaking API change. If requested by EdX, I'd be quite happy to implement this change and make the relevant changes to `edx-platform` and `edx-enterprise`, but there may be other repositories using this function that would break, and product owners for those repositories would have to fix their calls.

2. In addition to the changes strictly necessary for this feature, I've changed checks of `resource_id` to look for `None` rather than evaluate for falsiness - this prevents requests for specific valid IDs like the number `0` from being treated like an ID wasn't passed.

**Reviewers**
- [ ] @mtyaka 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```