### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -197,7 +197,7 @@ pynliner==0.5.2
 sailthru-client==2.2.3
 
 # Release utils for the edx release pipeline
-edx-django-release-util==0.2.0
+edx-django-release-util==0.3.0
 
 # Used to communicate with Neo4j, which is used internally for
 # modulestore inspection


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.3.0.

@edx-ops/pipeline-team Please review and tag appropriate parties.