### PR TITLE
Remove dealer.git use for LMS.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -38,7 +38,6 @@ from warnings import simplefilter
 from django.utils.translation import ugettext_lazy as _
 
 from .discussionsettings import *
-import dealer.git
 from xmodule.modulestore.modulestore_settings import update_module_store_settings
 from xmodule.modulestore.edit_info import EditInfoMixin
 from xmodule.mixin import LicenseMixin
@@ -824,16 +823,6 @@ CONTACT_MAILING_ADDRESS = ''
 
 ADMINS = ()
 MANAGERS = ADMINS
-
-EDX_PLATFORM_REVISION = os.environ.get('EDX_PLATFORM_REVISION')
-
-if not EDX_PLATFORM_REVISION:
-    try:
-        # Get git revision of the current file
-        EDX_PLATFORM_REVISION = dealer.git.Backend(path=REPO_ROOT).revision
-    except TypeError:
-        # Not a git repository
-        EDX_PLATFORM_REVISION = 'unknown'
 
 # Static content
 STATIC_URL = '/static/'


### PR DESCRIPTION
We use the dealer.git library to determine the current revision of
edx-platform at startup time and store that as EDX_PLATFORM_REVISION in
our settings. This can take a surprisingly long time and involve a lot
of disk IO to initialize.

Studio still needs this functionality because it determines its static
asset folder based partly on the hash. This is horrible, because it
means all static assets are invalidated on every release instead of
just the ones that change. But that will be the subject of a different
PR.

LMS doesn't use EDX_PLATFORM_REVISION at all after it's set.