### PR TITLE
Return only error value to students when codejail raises an exception

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1232,8 +1232,12 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
             # Otherwise, display just an error message,
             # without a stack trace
             else:
-                # Translators: {msg} will be replaced with a problem's error message.
-                msg = inst.message
+                escaped_message = cgi.escape(inst.args[0])
+                try:
+                    # only return the error value of the exception
+                    msg = escaped_message.split("\\n")[-2].split(": ", 1)[1]
+                except IndexError:
+                    msg = escaped_message
 
             return {'success': msg}
 


### PR DESCRIPTION
Fixes a bug that returns an empty string to the student instead of the error value when a custom problem raises an exception.

If this worked as expected, it would be a useful behavior as it gives the course author a way to return an error to the student without costing them a submission. 

### Steps to Reproduce

1. Create an advanced problem (customresponse) with the following XML:

```
<problem display_name="Error Raising">
<script type="text/python" system_path="python_lib">

def gradeit(solution, answer):
    raise ValueError("Bad entry!")
  
</script>

  <p>Enter 1 in the box below.</p>
  
<customresponse cfn="gradeit" expect="1">
  <textline size="45" correct_answer="1" math="1"/>
</customresponse>

</problem>
```

2. As a staff member, enter a value in the input box and submit. You will get a full stack trace that ends with the exception error message, "Bad entry!"

3. As a student, enter a value in the input box and submit

### Expected Behavior

(Based on the original code) The expectation is that the learner would get a response of "Error: " followed by the error message. In this case "Error: Bad entry!"

### Actual Behavior

No error message is returned, and the learner only see "Error:"

### What this PR does

Based on the code and the tests, it appears that the expectation was that the error message would be returned. However, because the error in this case is a stack trace generated by code jail, the message isn't passed all the way back. This PR makes sure that the original message is retrieved, and it also attempts to omit the stack trace (at least confusion, and possibly leaking too much information to the leaner) and limit the return to just the error message. 

