### PR TITLE
LMS user menu dropdown a11y issues

### DIFF
--- a/lms/templates/user_dropdown.html
+++ b/lms/templates/user_dropdown.html
@@ -54,8 +54,11 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
             </a>
         </li>
         <li class="primary">
-            <div role="group" aria-label="User menu" class="user-menu">
-                <button class="dropdown" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span><span class="fa fa-sort-desc" aria-hidden="true"></span></button>
+            <div class="user-menu">
+                <button class="dropdown" aria-expanded="false" aria-haspopup="true">
+                    <span class="sr">${_("More options")}</span>
+                    <span class="fa fa-sort-desc" aria-hidden="true"></span>
+                </button>
                 <ul class="dropdown-menu" aria-label="More Options" role="menu">
                     ${navigation_dropdown_menu_links()}
                     <li class="item"><a href="${reverse('logout')}" role="menuitem" class="dropdown-menuitem">${_("Sign Out")}</a></li>


### PR DESCRIPTION
ECOM-7312
## Issue
LMS user menu dropdown was not properly accessible to all users. The issues were as follows

- There should not be a role and the aria-label attributes in the dropdown icon div container.
- The word "dropdown" should not be with hidden text which is currently "More options dropdown".
- The dropdown button should have aria-haspopup="true". 

## Manual testing
I have used IOS voice over for going through the dropdown and it was working fine.

## Sandbox
Here is the link to sandbox https://user-menu-a11y.sandbox.edx.org/ if anyone interested to verify changes. 

### Reviewers
@AlasdairSwan @cptvitamin @schenedx please review