### PR TITLE
ECOM-6939 Fixed social auth false password-validation error

### DIFF
--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -877,10 +877,10 @@ class RegistrationView(APIView):
                                 field_name, default=field_overrides[field_name]
                             )
 
-                    # Hide the password field
+                    # Hide the password field and set random password
                     form_desc.override_field_properties(
                         "password",
-                        default="",
+                        default=third_party_auth.pipeline.make_random_password(),
                         field_type="hidden",
                         required=False,
                         label="",


### PR DESCRIPTION
## [ECOM-6939](https://openedx.atlassian.net/browse/ECOM-6939)

### Description

Registering via Third Party Social Auth occasionally raises a password validation error, prompting user that `A valid password is required`. There should be no such validation error as password is randomly generated at server for users creating an account using third party authentication.
This PR is made in effort to resolve this unexpected behavior.

### How to Test?

**Stage** 

- Got to https://courses.stage.edx.org/register and click one of the social auth provider, Google for example.
- After authentication from Google, a form should appear containing populated fields with your username, email etc.
- Wait for 5 minutes, then click `Create your account` button.
- Observe `A valid password is required` validation error.

**Sandbox**
Repeat steps mentioned above and observe there is no such error
- In progress
