### PR TITLE
added log for refund cutoff date

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1571,6 +1571,11 @@ class CourseEnrollment(models.Model):
         # If it is after the refundable cutoff date they should not be refunded.
         refund_cutoff_date = self.refund_cutoff_date()
         if refund_cutoff_date and datetime.now(UTC) > refund_cutoff_date:
+            log.info(
+                u"user [%s] cannot be refunded because his/her cutoff date [%s] has passed",
+                self.username,
+                refund_cutoff_date
+            )
             return False
 
         course_mode = CourseMode.mode_for_course(self.course_id, 'verified')


### PR DESCRIPTION
## [ECOM-7252](https://openedx.atlassian.net/browse/ECOM-7252)

### Description

Several users have reported stating that they are seeing a message that they will not receive a refund when unenrolling, even though they are within 14 days of their payment. We were not able to reproduce this issue. However we have added a log so that we can identify and rectify this issue if it occurs again in the future

### How to Test?

**Stage** 
Not Applicable.

**Screenshots**
Not Applicable.


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @Ayub-Khan 

FYI: @adampalay 

### Post-review
- [ ] Rebase and squash commits