### PR TITLE
a11y footer links to ul

### DIFF
--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -35,7 +35,7 @@ footer#footer-edx-v3 {
 
   .site-nav,
   .legal-notices {
-    a {
+    li {
       @include font-size(14);
       @include line-height(14);
       @include margin-right(20px);
@@ -83,7 +83,9 @@ footer#footer-edx-v3 {
       width: 100%;
     }
   }
-  
+
+  .about-links,
+  .legal-links,
   .social-media-links,
   .mobile-app-links {
       @extend %ui-no-list;

--- a/themes/edx.org/lms/templates/footer.html
+++ b/themes/edx.org/lms/templates/footer.html
@@ -27,14 +27,22 @@
 
       <div class="site-details">
           <nav class="site-nav" aria-label="${_("About edX")}">
-              % for link in footer["navigation_links"]:
-              <a href="${link['url']}">${link['title']}</a>
-              % endfor
+            <ul class="about-links">
+                % for link in footer["navigation_links"]:
+                <li class="list-item">
+                  <a href="${link['url']}">${link['title']}</a>
+                </li>
+                % endfor
+            </ul>
           </nav>
           <nav class="legal-notices" aria-label="${_("Legal")}">
+            <ul class="legal-links">
               % for link in footer["legal_links"]:
-              <a href="${link['url']}">${link['title']}</a>
+                <li class="list-item">
+                  <a href="${link['url']}">${link['title']}</a>
+                </li>
               % endfor
+            </ul>
           </nav>
           <p class="copyright">${_(
           u"\u00A9 2012-{year} edX Inc.  All rights reserved except where noted.  "


### PR DESCRIPTION
# [ECOM-6902](https://openedx.atlassian.net/browse/ECOM-6902)

The links in the footer of the edx.org theme needed to be in a list. This updates the markup in the footer template and adjusts the styles accordingly.

## Sandbox
https://ecom6902.sandbox.edx.org/
## Reviewers
- [x] @cptvitamin 
- [x] @AlasdairSwan?
fyi @schenedx 
