### PR TITLE
More specific messaging for unsupported block types

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -535,16 +535,14 @@ def _deprecated_blocks_info(course_module, deprecated_block_types):
 
     Returns:
         Dict with following keys:
-        block_types (list): list containing types of all deprecated blocks
-        block_types_enabled (bool): True if any or all `deprecated_blocks` present in Advanced Module List else False
-        blocks (list): List of `deprecated_block_types` component names and their parent's url
+        deprecated_enabled_block_types (list): list containing all deprecated blocks types enabled on this course
+        blocks (list): List of `deprecated_enabled_block_types` instances and their parent's url
         advance_settings_url (str): URL to advance settings page
     """
     data = {
-        'block_types': deprecated_block_types,
-        'block_types_enabled': any(
-            block_type in course_module.advanced_modules for block_type in deprecated_block_types
-        ),
+        'deprecated_enabled_block_types': [
+            block_type for block_type in course_module.advanced_modules if block_type in deprecated_block_types
+        ],
         'blocks': [],
         'advance_settings_url': reverse_course_url('advanced_settings_handler', course_module.id)
     }

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -57,7 +57,7 @@ from openedx.core.djangolib.markup import HTML, Text
   </div>
   %endif
 
-    %if deprecated_blocks_info.get('blocks') or deprecated_blocks_info.get('block_types_enabled'):
+    %if deprecated_blocks_info.get('blocks') or deprecated_blocks_info.get('deprecated_enabled_block_types'):
       <div class="wrapper wrapper-alert wrapper-alert-error is-shown">
         <div class="alert announcement">
           <span class="feedback-symbol fa fa-warning" aria-hidden="true"></span><span class="sr">${_("Warning")}</span>
@@ -84,7 +84,7 @@ from openedx.core.djangolib.markup import HTML, Text
               </div>
             %endif
 
-            % if deprecated_blocks_info.get('block_types_enabled'):
+            % if deprecated_blocks_info.get('deprecated_enabled_block_types'):
               <div class="advance-modules-list">
                 <p class="advance-modules-remove-text">
                   ${Text(_("To avoid errors, {platform_name} strongly recommends that you remove unsupported features from the course advanced settings. To do this, go to the {link_start}Advanced Settings page{link_end}, locate the \"Advanced Module List\" setting, and then delete the following modules from the list.")).format(
@@ -95,7 +95,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 </p>
                 <nav class="nav-related" aria-label="${_('Unsupported Advance Modules')}">
                   <ul>
-                    % for block_type in deprecated_blocks_info['block_types']:
+                    % for block_type in deprecated_blocks_info['deprecated_enabled_block_types']:
                       <li class="nav-item">${block_type}</li>
                     % endfor
                   </ul>


### PR DESCRIPTION
A feature request in 2 pictures:

<img width="1196" alt="screen shot 2017-03-01 at 2 56 10 pm" src="https://cloud.githubusercontent.com/assets/7373924/23478420/531fac60-fe8f-11e6-979c-132dde9bbedb.png">
<img width="918" alt="screen shot 2017-03-01 at 2 56 34 pm" src="https://cloud.githubusercontent.com/assets/7373924/23478421/532006e2-fe8f-11e6-9ec2-4a531ba5487a.png">

Notice that despite only having a single unsupported feature in the list (edx-reverification-block), the messaging seems to indicate that you need to delete [every single unsupported component](https://github.com/edx/xblock-configuration/blob/master/xblock_configuration.json#L25). We have the ability to be much more specific here.

FYI @sstack22, who requested this. Turns out it was pretty easy to do!

I'm going to let Jenkins take a whack and see what fails, then add an additional test of my own before getting reviewers.