### PR TITLE
ensure that modified start/end are treated as UTC by django

### DIFF
--- a/lms/djangoapps/grades/management/commands/reset_grades.py
+++ b/lms/djangoapps/grades/management/commands/reset_grades.py
@@ -3,6 +3,7 @@ Reset persistent grades for learners.
 """
 from datetime import datetime
 import logging
+from pytz import utc
 from textwrap import dedent
 
 from django.core.management.base import BaseCommand, CommandError
@@ -58,12 +59,12 @@ class Command(BaseCommand):
         parser.add_argument(
             '--modified_start',
             dest='modified_start',
-            help='Starting range for modified date (inclusive): e.g. "2016-08-23 16:43"',
+            help='Starting range for modified date (inclusive): e.g. "2016-08-23 16:43"; expected in UTC.',
         )
         parser.add_argument(
             '--modified_end',
             dest='modified_end',
-            help='Ending range for modified date (inclusive): e.g. "2016-12-23 16:43"',
+            help='Ending range for modified date (inclusive): e.g. "2016-12-23 16:43"; expected in UTC.',
         )
         parser.add_argument(
             '--db_table',
@@ -84,12 +85,12 @@ class Command(BaseCommand):
             raise CommandError('Invalid value for db_table. Valid options are "subsection" or "course" only.')
 
         if options.get('modified_start'):
-            modified_start = datetime.strptime(options['modified_start'], DATE_FORMAT)
+            modified_start = utc.localize(datetime.strptime(options['modified_start'], DATE_FORMAT))
 
         if options.get('modified_end'):
             if not modified_start:
                 raise CommandError('Optional value for modified_end provided without a value for modified_start.')
-            modified_end = datetime.strptime(options['modified_end'], DATE_FORMAT)
+            modified_end = utc.localize(datetime.strptime(options['modified_end'], DATE_FORMAT))
 
         if courses_mode == 'courses':
             course_keys = parse_course_keys(options['courses'])


### PR DESCRIPTION
I found this feature/bug while trying to figure out why the dry run of our management command looked so different from the results of querying the read replica directly. The datetimes we created from our modified_start and modified_end options were timezone-unaware. I am making them timezone-aware so that they correspond to the times we store in the actual database and behave predictably.

Reviewers:

- [x] @efischer19 

FYI @jibsheet 