### PR TITLE
Removing unused fields on ProgramApiConfig model

### DIFF
--- a/common/test/acceptance/fixtures/programs.py
+++ b/common/test/acceptance/fixtures/programs.py
@@ -6,16 +6,9 @@ from common.test.acceptance.fixtures.config import ConfigModelFixture
 
 class ProgramsConfigMixin(object):
     """Mixin providing a method used to configure the programs feature."""
-    def set_programs_api_configuration(self, is_enabled=False, api_version=1):
+    def set_programs_api_configuration(self, is_enabled=False):
         """Dynamically adjusts the Programs config model during tests."""
-        # Update these paramters once fields are removed from model
         ConfigModelFixture('/config/programs', {
             'enabled': is_enabled,
-            'api_version_number': api_version,
-            'cache_ttl': 0,
             'marketing_path': '/foo',
-            'enable_student_dashboard': is_enabled,
-            'enable_certification': is_enabled,
-            'program_listing_enabled': is_enabled,
-            'program_details_enabled': is_enabled,
         }).install()

--- a/openedx/core/djangoapps/programs/migrations/0011_auto_20170301_1844.py
+++ b/openedx/core/djangoapps/programs/migrations/0011_auto_20170301_1844.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('programs', '0010_auto_20170204_2332'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='api_version_number',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='authoring_app_css_path',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='authoring_app_js_path',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='cache_ttl',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='enable_certification',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='enable_student_dashboard',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='enable_studio_tab',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='internal_service_url',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='max_retries',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='program_details_enabled',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='program_listing_enabled',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='public_service_url',
+        ),
+        migrations.RemoveField(
+            model_name='programsapiconfig',
+            name='xseries_ad_enabled',
+        ),
+    ]

--- a/openedx/core/djangoapps/programs/models.py
+++ b/openedx/core/djangoapps/programs/models.py
@@ -9,18 +9,10 @@ from config_models.models import ConfigurationModel
 
 class ProgramsApiConfig(ConfigurationModel):
     """
-    DEPRECATED. To be removed as part of ECOM-5136.
+    This model no longer fronts an API, but now sets a few config-related values for the idea of programs in general.
 
-    Manages configuration for connecting to the Programs service and using its API.
+    A rename to ProgramsConfig would be more accurate, but costly in terms of developer time.
     """
-    OAUTH2_CLIENT_NAME = 'programs'
-    CACHE_KEY = 'programs.api.data'
-    API_NAME = 'programs'
-
-    api_version_number = models.IntegerField(verbose_name=_("API Version"))
-
-    internal_service_url = models.URLField(verbose_name=_("Internal Service URL"), blank=True)
-    public_service_url = models.URLField(verbose_name=_("Public Service URL"), blank=True)
 
     marketing_path = models.CharField(
         max_length=255,
@@ -28,69 +20,4 @@ class ProgramsApiConfig(ConfigurationModel):
         help_text=_(
             'Path used to construct URLs to programs marketing pages (e.g., "/foo").'
         )
-    )
-
-    authoring_app_js_path = models.CharField(
-        verbose_name=_("Path to authoring app's JS"),
-        max_length=255,
-        blank=True,
-        help_text=_(
-            "This value is required in order to enable the Studio authoring interface."
-        )
-    )
-
-    authoring_app_css_path = models.CharField(
-        verbose_name=_("Path to authoring app's CSS"),
-        max_length=255,
-        blank=True,
-        help_text=_(
-            "This value is required in order to enable the Studio authoring interface."
-        )
-    )
-
-    cache_ttl = models.PositiveIntegerField(
-        verbose_name=_("Cache Time To Live"),
-        default=0,
-        help_text=_(
-            "Specified in seconds. Enable caching by setting this to a value greater than 0."
-        )
-    )
-
-    enable_student_dashboard = models.BooleanField(
-        verbose_name=_("Enable Student Dashboard Displays"),
-        default=False
-    )
-
-    enable_studio_tab = models.BooleanField(
-        verbose_name=_("Enable Studio Authoring Interface"),
-        default=False
-    )
-
-    enable_certification = models.BooleanField(
-        verbose_name=_("Enable Program Certificate Generation"),
-        default=False
-    )
-
-    max_retries = models.PositiveIntegerField(
-        verbose_name=_("Maximum Certification Retries"),
-        default=11,  # This gives about 30 minutes wait before the final attempt
-        help_text=_(
-            "When making requests to award certificates, make at most this many attempts "
-            "to retry a failing request."
-        )
-    )
-
-    xseries_ad_enabled = models.BooleanField(
-        verbose_name=_("Do we want to show xseries program advertising"),
-        default=False
-    )
-
-    program_listing_enabled = models.BooleanField(
-        verbose_name=_("Do we want to show program listing page"),
-        default=False
-    )
-
-    program_details_enabled = models.BooleanField(
-        verbose_name=_("Do we want to show program details pages"),
-        default=False
     )

--- a/openedx/core/djangoapps/programs/tests/mixins.py
+++ b/openedx/core/djangoapps/programs/tests/mixins.py
@@ -5,17 +5,8 @@ from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 class ProgramsApiConfigMixin(object):
     """Utilities for working with Programs configuration during testing."""
 
-    # Update these paramters once fields are removed from model
     DEFAULTS = {
         'enabled': True,
-        'api_version_number': 1,
-        'internal_service_url': 'http://internal.programs.org/',
-        'public_service_url': 'http://public.programs.org/',
-        'cache_ttl': 0,
-        'enable_studio_tab': True,
-        'enable_certification': True,
-        'program_listing_enabled': True,
-        'program_details_enabled': True,
         'marketing_path': 'foo',
     }
 


### PR DESCRIPTION
ECOM-7196

Updating model to only include the non-deprecated fields.  This work is a follow on to ECOM-7195 and SHOULD NOT be merged until that PR is merged.

@edx/ecommerce (especially @rlucioni) for review