### PR TITLE
Reduce urls.py resetting in Forums tests

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -203,12 +203,19 @@ class CertificatesListHandlerTestCase(
     """
     Test cases for certificates_list_handler.
     """
+    URLS_AUTO_RESET = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include FEATURES_WITH_CERTS_ENABLED views."""
+        super(CertificatesListHandlerTestCase, cls).setUpClass()
+        cls.reset_urls()
+
     def setUp(self):
         """
         Set up CertificatesListHandlerTestCase.
         """
         super(CertificatesListHandlerTestCase, self).setUp('contentstore.views.certificates.tracker')
-        self.reset_urls()
 
     def _url(self):
         """
@@ -432,12 +439,19 @@ class CertificatesDetailHandlerTestCase(
 
     _id = 0
 
+    URLS_AUTO_RESET = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include FEATURES_WITH_CERTS_ENABLED views."""
+        super(CertificatesDetailHandlerTestCase, cls).setUpClass()
+        cls.reset_urls()
+
     def setUp(self):  # pylint: disable=arguments-differ
         """
         Set up CertificatesDetailHandlerTestCase.
         """
         super(CertificatesDetailHandlerTestCase, self).setUp('contentstore.views.certificates.tracker')
-        self.reset_urls()
 
     def _url(self, cid=-1):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_header_menu.py
+++ b/cms/djangoapps/contentstore/views/tests/test_header_menu.py
@@ -19,12 +19,13 @@ class TestHeaderMenu(CourseTestCase, UrlResetMixin):
     """
     Unit tests for the course header menu.
     """
-    def setUp(self):
-        """
-        Set up the for the course header menu tests.
-        """
-        super(TestHeaderMenu, self).setUp()
-        self.reset_urls()
+    URLS_AUTO_RESET = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include FEATURES_WITH_CERTS_ENABLED views."""
+        super(TestHeaderMenu, cls).setUpClass()
+        cls.reset_urls()
 
     def test_header_menu_without_web_certs_enabled(self):
         """

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -35,6 +35,20 @@ class CourseModeViewTest(UrlResetMixin, ModuleStoreTestCase):
     Course Mode View tests
     """
     URLCONF_MODULES = ['course_modes.urls']
+    URLS_AUTO_RESET = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include MODE_CREATION_FOR_TESTING views."""
+        super(CourseModeViewTest, cls).setUpClass()
+        with patch.dict("django.conf.settings.FEATURES", {"MODE_CREATION_FOR_TESTING": True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(CourseModeViewTest, cls).tearDownClass()
+        cls.reset_urls()
 
     @patch.dict(settings.FEATURES, {'MODE_CREATION_FOR_TESTING': True})
     def setUp(self):
@@ -410,6 +424,20 @@ class TrackSelectionEmbargoTest(UrlResetMixin, ModuleStoreTestCase):
     """Test embargo restrictions on the track selection page. """
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
+    URLS_AUTO_RESET = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include EMBARGO views."""
+        super(TrackSelectionEmbargoTest, cls).setUpClass()
+        with patch.dict("django.conf.settings.FEATURES", {"EMBARGO": True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(TrackSelectionEmbargoTest, cls).tearDownClass()
+        cls.reset_urls()
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -1007,6 +1007,20 @@ class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestC
     PASSWORD = "edx"
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
+    URLS_AUTO_RESET = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include EMBARGO views."""
+        super(EnrollmentEmbargoTest, cls).setUpClass()
+        with patch.dict(settings.FEATURES, {"EMBARGO": True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(EnrollmentEmbargoTest, cls).tearDownClass()
+        cls.reset_urls()
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):

--- a/common/djangoapps/student/tests/test_auto_auth.py
+++ b/common/djangoapps/student/tests/test_auto_auth.py
@@ -35,6 +35,21 @@ class AutoAuthEnabledTestCase(AutoAuthTestCase):
         (COURSE_ID_SPLIT, CourseLocator.from_string(COURSE_ID_SPLIT)),
     )
 
+    URLS_AUTO_RESET = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include AUTO_AUTH views."""
+        super(AutoAuthEnabledTestCase, cls).setUpClass()
+        with patch.dict("django.conf.settings.FEATURES", {"AUTOMATIC_AUTH_FOR_TESTING": True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(AutoAuthEnabledTestCase, cls).tearDownClass()
+        cls.reset_urls()
+
     @patch.dict("django.conf.settings.FEATURES", {"AUTOMATIC_AUTH_FOR_TESTING": True})
     def setUp(self):
         # Patching the settings.FEATURES['AUTOMATIC_AUTH_FOR_TESTING']

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -33,12 +33,20 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
     EMAIL = "bob@example.com"
     PASSWORD = "edx"
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
+    URLS_AUTO_RESET = False
 
     @classmethod
     def setUpClass(cls):
         super(EnrollmentTest, cls).setUpClass()
         cls.course = CourseFactory.create()
         cls.course_limited = CourseFactory.create()
+        with patch.dict(settings.FEATURES, {'EMBARGO': True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(EnrollmentTest, cls).tearDownClass()
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):

--- a/common/djangoapps/student/tests/test_login_registration_forms.py
+++ b/common/djangoapps/student/tests/test_login_registration_forms.py
@@ -41,11 +41,21 @@ class LoginFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStoreTes
     """Test rendering of the login form. """
 
     URLCONF_MODULES = ['lms.urls']
+    URLS_AUTO_RESET = False
 
     @classmethod
     def setUpClass(cls):
+        """Reset the URLs to disable ENABLE_COMBINED_LOGIN_REGISTRATION views."""
         super(LoginFormTest, cls).setUpClass()
         cls.course = CourseFactory.create()
+        with patch.dict(settings.FEATURES, {"ENABLE_COMBINED_LOGIN_REGISTRATION": False}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(LoginFormTest, cls).tearDownClass()
+        cls.reset_urls()
 
     @patch.dict(settings.FEATURES, {"ENABLE_COMBINED_LOGIN_REGISTRATION": False})
     def setUp(self):
@@ -158,11 +168,21 @@ class RegisterFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStore
     """Test rendering of the registration form. """
 
     URLCONF_MODULES = ['lms.urls']
+    URLS_AUTO_RESET = False
 
     @classmethod
     def setUpClass(cls):
+        """Reset the URLs to disable ENABLE_COMBINED_LOGIN_REGISTRATION views."""
         super(RegisterFormTest, cls).setUpClass()
         cls.course = CourseFactory.create()
+        with patch.dict(settings.FEATURES, {"ENABLE_COMBINED_LOGIN_REGISTRATION": False}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(RegisterFormTest, cls).tearDownClass()
+        cls.reset_urls()
 
     @patch.dict(settings.FEATURES, {"ENABLE_COMBINED_LOGIN_REGISTRATION": False})
     def setUp(self):

--- a/common/djangoapps/util/testing.py
+++ b/common/djangoapps/util/testing.py
@@ -28,16 +28,17 @@ class UrlResetMixin(object):
     Doing this is expensive, so it should only be added to tests that modify settings
     that affect the contents of urls.py
     """
-
+    URLS_AUTO_RESET = True
     URLCONF_MODULES = None
 
-    def reset_urls(self, urlconf_modules=None):
+    @classmethod
+    def reset_urls(cls, urlconf_modules=None):
         """Reset `urls.py` for a set of Django apps."""
 
         if urlconf_modules is None:
             urlconf_modules = [settings.ROOT_URLCONF]
-            if self.URLCONF_MODULES is not None:
-                urlconf_modules.extend(self.URLCONF_MODULES)
+            if cls.URLCONF_MODULES is not None:
+                urlconf_modules.extend(cls.URLCONF_MODULES)
 
         for urlconf in urlconf_modules:
             if urlconf in sys.modules:
@@ -66,9 +67,9 @@ class UrlResetMixin(object):
 
         """
         super(UrlResetMixin, self).setUp()
-
-        self.reset_urls()
-        self.addCleanup(self.reset_urls)
+        if self.URLS_AUTO_RESET:
+            self.reset_urls()
+            self.addCleanup(self.reset_urls)
 
 
 class EventTestMixin(object):

--- a/lms/djangoapps/badges/api/tests.py
+++ b/lms/djangoapps/badges/api/tests.py
@@ -22,6 +22,13 @@ class UserAssertionTestCase(UrlResetMixin, ModuleStoreTestCase, ApiTestCase):
     """
     Mixin for badge API tests.
     """
+    URLS_AUTO_RESET = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to enable Badges views."""
+        super(UserAssertionTestCase, cls).setUpClass()
+        cls.reset_urls()
 
     def setUp(self, *args, **kwargs):
         super(UserAssertionTestCase, self).setUp(*args, **kwargs)

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -18,11 +18,14 @@ from django_comment_client.tests.group_id import (
     NonCohortedTopicGroupIdTestMixin,
 )
 from django_comment_client.tests.unicode import UnicodeTestMixin
-from django_comment_client.tests.utils import CohortedTestCase, ForumsEnableMixin
+from django_comment_client.tests.utils import (
+    CohortedTestCase,
+    ForumsEnableMixin,
+    ForumUrlResetMixin
+)
 from django_comment_client.utils import strip_none
 from lms.djangoapps.discussion import views
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
-from util.testing import UrlResetMixin
 from openedx.core.djangoapps.util.testing import ContentGroupTestCase
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -46,7 +49,7 @@ log = logging.getLogger(__name__)
 # pylint: disable=missing-docstring
 
 
-class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):
+class ViewsExceptionTestCase(ForumUrlResetMixin, ModuleStoreTestCase):
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -606,7 +609,7 @@ class SingleThreadGroupIdTestCase(CohortedTestCase, GroupIdAssertionMixin):
 
 
 @patch('requests.request', autospec=True)
-class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, ContentGroupTestCase):
+class SingleThreadContentGroupTestCase(ForumsEnableMixin, ForumUrlResetMixin, ContentGroupTestCase):
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -1103,7 +1106,7 @@ class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):
 
 
 @patch('requests.request', autospec=True)
-class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+class UserProfileTestCase(ForumsEnableMixin, ForumUrlResetMixin, ModuleStoreTestCase):
 
     TEST_THREAD_TEXT = 'userprofile-test-text'
     TEST_THREAD_ID = 'userprofile-test-thread-id'
@@ -1232,7 +1235,7 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
 
 
 @patch('requests.request', autospec=True)
-class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, ForumUrlResetMixin, ModuleStoreTestCase):
 
     CREATE_USER = False
 
@@ -1243,7 +1246,7 @@ class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, Mo
         username = "foo"
         password = "bar"
 
-        # Invoke UrlResetMixin
+        # Invoke ForumUrlResetMixin
         super(CommentsServiceRequestHeadersTestCase, self).setUp()
         self.course = CourseFactory.create(discussion_topics={'dummy discussion': {'id': 'dummy_discussion_id'}})
         self.student = UserFactory.create(username=username, password=password)
@@ -1364,7 +1367,7 @@ class ForumFormDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTes
 
 @ddt.ddt
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
-class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+class ForumDiscussionXSSTestCase(ForumsEnableMixin, ForumUrlResetMixin, ModuleStoreTestCase):
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super(ForumDiscussionXSSTestCase, self).setUp()

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -49,12 +49,11 @@ from django_comment_common.models import (
     FORUM_ROLE_STUDENT,
     Role,
 )
-from django_comment_client.tests.utils import ForumsEnableMixin
+from django_comment_client.tests.utils import ForumsEnableMixin, ForumUrlResetMixin
 from openedx.core.djangoapps.course_groups.models import CourseUserGroupPartitionGroup
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from openedx.core.lib.exceptions import CourseNotFoundError, PageNotFoundError
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
-from util.testing import UrlResetMixin
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -86,7 +85,7 @@ def _discussion_disabled_course_for(user):
 
 @attr(shard=2)
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
-class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase):
+class GetCourseTest(ForumsEnableMixin, ForumUrlResetMixin, SharedModuleStoreTestCase):
     """Test for get_course"""
 
     @classmethod
@@ -94,7 +93,6 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
         super(GetCourseTest, cls).setUpClass()
         cls.course = CourseFactory.create(org="x", course="y", run="z")
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super(GetCourseTest, self).setUp()
         self.user = UserFactory.create()
@@ -134,11 +132,10 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
 @attr(shard=2)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
-class GetCourseTestBlackouts(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+class GetCourseTestBlackouts(ForumsEnableMixin, ForumUrlResetMixin, ModuleStoreTestCase):
     """
     Tests of get_course for courses that have blackout dates.
     """
-
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super(GetCourseTestBlackouts, self).setUp()
@@ -178,8 +175,9 @@ class GetCourseTestBlackouts(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCa
 @attr(shard=2)
 @mock.patch.dict("django.conf.settings.FEATURES", {"DISABLE_START_DATES": False})
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
-class GetCourseTopicsTest(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+class GetCourseTopicsTest(ForumsEnableMixin, ForumUrlResetMixin, ModuleStoreTestCase):
     """Test for get_course_topics"""
+
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super(GetCourseTopicsTest, self).setUp()
@@ -552,7 +550,7 @@ class GetCourseTopicsTest(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
 @attr(shard=2)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
-class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMixin, SharedModuleStoreTestCase):
+class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, ForumUrlResetMixin, SharedModuleStoreTestCase):
     """Test for get_thread_list"""
 
     @classmethod
@@ -1403,7 +1401,7 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
 class CreateThreadTest(
         ForumsEnableMixin,
         CommentsServiceMockMixin,
-        UrlResetMixin,
+        ForumUrlResetMixin,
         SharedModuleStoreTestCase,
         MockSignalHandlerMixin
 ):
@@ -1631,7 +1629,7 @@ class CreateThreadTest(
 class CreateCommentTest(
         ForumsEnableMixin,
         CommentsServiceMockMixin,
-        UrlResetMixin,
+        ForumUrlResetMixin,
         SharedModuleStoreTestCase,
         MockSignalHandlerMixin
 ):
@@ -1900,7 +1898,7 @@ class CreateCommentTest(
 class UpdateThreadTest(
         ForumsEnableMixin,
         CommentsServiceMockMixin,
-        UrlResetMixin,
+        ForumUrlResetMixin,
         SharedModuleStoreTestCase,
         MockSignalHandlerMixin
 ):
@@ -2284,7 +2282,7 @@ class UpdateThreadTest(
 class UpdateCommentTest(
         ForumsEnableMixin,
         CommentsServiceMockMixin,
-        UrlResetMixin,
+        ForumUrlResetMixin,
         SharedModuleStoreTestCase,
         MockSignalHandlerMixin
 ):
@@ -2689,7 +2687,7 @@ class UpdateCommentTest(
 class DeleteThreadTest(
         ForumsEnableMixin,
         CommentsServiceMockMixin,
-        UrlResetMixin,
+        ForumUrlResetMixin,
         SharedModuleStoreTestCase,
         MockSignalHandlerMixin
 ):
@@ -2830,7 +2828,7 @@ class DeleteThreadTest(
 class DeleteCommentTest(
         ForumsEnableMixin,
         CommentsServiceMockMixin,
-        UrlResetMixin,
+        ForumUrlResetMixin,
         SharedModuleStoreTestCase,
         MockSignalHandlerMixin
 ):
@@ -2989,7 +2987,7 @@ class DeleteCommentTest(
 class RetrieveThreadTest(
         ForumsEnableMixin,
         CommentsServiceMockMixin,
-        UrlResetMixin,
+        ForumUrlResetMixin,
         SharedModuleStoreTestCase
 ):
     """Tests for get_thread"""

--- a/lms/djangoapps/discussion_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion_api/tests/test_serializers.py
@@ -27,15 +27,14 @@ from django_comment_common.models import (
 from lms.lib.comment_client.comment import Comment
 from lms.lib.comment_client.thread import Thread
 from student.tests.factories import UserFactory
-from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
-from django_comment_client.tests.utils import ForumsEnableMixin
+from django_comment_client.tests.utils import ForumsEnableMixin, ForumUrlResetMixin
 
 
 @ddt.ddt
-class SerializerTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMixin):
+class SerializerTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, ForumUrlResetMixin):
     @classmethod
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUpClass(cls):
@@ -397,7 +396,7 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
 class ThreadSerializerDeserializationTest(
         ForumsEnableMixin,
         CommentsServiceMockMixin,
-        UrlResetMixin,
+        ForumUrlResetMixin,
         SharedModuleStoreTestCase
 ):
     """Tests for ThreadSerializer deserialization."""

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -27,14 +27,14 @@ from discussion_api.tests.utils import (
     make_minimal_cs_thread,
     make_paginated_api_response,
     ProfileImageTestMixin)
-from django_comment_client.tests.utils import ForumsEnableMixin
+from django_comment_client.tests.utils import ForumsEnableMixin, ForumUrlResetMixin
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
-from util.testing import UrlResetMixin, PatchMediaTypeMixin
+from util.testing import PatchMediaTypeMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls, ItemFactory
 
 
-class DiscussionAPIViewTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMixin):
+class DiscussionAPIViewTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, ForumUrlResetMixin):
     """
     Mixin for common code in tests of Discussion API views. This includes
     creation of common structures (e.g. a course, user, and enrollment), logging

--- a/lms/djangoapps/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/django_comment_client/tests/utils.py
@@ -24,6 +24,30 @@ class ForumsEnableMixin(object):
         config.save()
 
 
+class ForumUrlResetMixin(UrlResetMixin):
+    """
+    Subclass of UrlResetMixin that is forums aware.
+
+    Since we just want forums URLs to always be active in these tests, there's
+    no need to reset between every test method, just once in the setUpClass /
+    tearDownClass steps.
+    """
+    URLS_AUTO_RESET = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include Forums views."""
+        super(ForumUrlResetMixin, cls).setUpClass()
+        with patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(ForumUrlResetMixin, cls).tearDownClass()
+        cls.reset_urls()
+
+
 class CohortedTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase):
     """
     Sets up a course with a student, a moderator and their cohorts.

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -25,6 +25,7 @@ from courseware.access_response import (
     VisibilityError,
 )
 from course_modes.models import CourseMode
+from django_comment_client.tests.utils import ForumUrlResetMixin
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from openedx.core.lib.courses import course_image_url
 from student.models import CourseEnrollment
@@ -75,7 +76,7 @@ class TestUserInfoApi(MobileAPITestCase, MobileAuthTestMixin):
 @attr(shard=2)
 @ddt.ddt
 @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
-class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTestMixin,
+class TestUserEnrollmentApi(ForumUrlResetMixin, MobileAPITestCase, MobileAuthUserTestMixin,
                             MobileCourseAccessTestMixin, MilestonesTestCaseMixin):
     """
     Tests for /api/mobile/v0.5/users/<user_name>/course_enrollments/

--- a/lms/djangoapps/notification_prefs/tests.py
+++ b/lms/djangoapps/notification_prefs/tests.py
@@ -9,15 +9,15 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from mock import Mock, patch
 
+from django_comment_client.tests.utils import ForumUrlResetMixin
 from notification_prefs import NOTIFICATION_PREF_KEY
 from notification_prefs.views import ajax_enable, ajax_disable, ajax_status, set_subscription, UsernameCipher
 from student.tests.factories import UserFactory
 from openedx.core.djangoapps.user_api.models import UserPreference
-from util.testing import UrlResetMixin
 
 
 @override_settings(SECRET_KEY="test secret key")
-class NotificationPrefViewTest(UrlResetMixin, TestCase):
+class NotificationPrefViewTest(ForumUrlResetMixin, TestCase):
     INITIALIZATION_VECTOR = "\x00" * 16
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})

--- a/lms/djangoapps/notifier_api/tests.py
+++ b/lms/djangoapps/notifier_api/tests.py
@@ -15,14 +15,13 @@ from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.models import UserPreference
 from openedx.core.djangoapps.user_api.tests.factories import UserPreferenceFactory
-from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @ddt.ddt
 @override_settings(EDX_API_KEY="test_api_key")
-class NotifierUsersViewSetTest(UrlResetMixin, ModuleStoreTestCase):
+class NotifierUsersViewSetTest(ModuleStoreTestCase):
     def setUp(self):
         super(NotifierUsersViewSetTest, self).setUp()
         self.courses = []

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -1847,6 +1847,7 @@ class RedeemCodeEmbargoTests(UrlResetMixin, ModuleStoreTestCase):
     PASSWORD = 'test'
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
+    URLS_AUTO_RESET = False
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):
@@ -1855,6 +1856,19 @@ class RedeemCodeEmbargoTests(UrlResetMixin, ModuleStoreTestCase):
         self.user = UserFactory.create(username=self.USERNAME, password=self.PASSWORD)
         result = self.client.login(username=self.user.username, password=self.PASSWORD)
         self.assertTrue(result, msg="Could not log in")
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include EMBARGO views."""
+        super(RedeemCodeEmbargoTests, cls).setUpClass()
+        with patch.dict("django.conf.settings.FEATURES", {"EMBARGO": True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(RedeemCodeEmbargoTests, cls).tearDownClass()
+        cls.reset_urls()
 
     @ddt.data('get', 'post')
     @patch.dict(settings.FEATURES, {'EMBARGO': True})

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -55,7 +55,7 @@ User = get_user_model()  # pylint:disable=invalid-name
 
 
 @ddt.ddt
-class StudentAccountUpdateTest(CacheIsolationTestCase, UrlResetMixin):
+class StudentAccountUpdateTest(CacheIsolationTestCase):
     """ Tests for the student account views that update the user's account information. """
 
     USERNAME = u"heisenberg"
@@ -85,8 +85,6 @@ class StudentAccountUpdateTest(CacheIsolationTestCase, UrlResetMixin):
     ]
 
     INVALID_KEY = u"123abc"
-
-    URLCONF_MODULES = ['student_accounts.urls']
 
     ENABLED_CACHES = ['default']
 
@@ -283,6 +281,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
     PASSWORD = "password"
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
+    URLS_AUTO_RESET = False
 
     @mock.patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):
@@ -302,6 +301,19 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
             enabled=True,
         )
         self.hidden_disabled_provider = self.configure_azure_ad_provider()
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include EMBARGO views."""
+        super(StudentAccountLoginAndRegistrationTest, cls).setUpClass()
+        with mock.patch.dict(settings.FEATURES, {"EMBARGO": True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(StudentAccountLoginAndRegistrationTest, cls).tearDownClass()
+        cls.reset_urls()
 
     @ddt.data(
         ("signin_user", "login"),

--- a/lms/djangoapps/student_profile/test/test_views.py
+++ b/lms/djangoapps/student_profile/test/test_views.py
@@ -12,7 +12,7 @@ from student.tests.factories import UserFactory
 from student_profile.views import learner_profile_context
 
 
-class LearnerProfileViewTest(UrlResetMixin, TestCase):
+class LearnerProfileViewTest(TestCase):
     """ Tests for the student profile view. """
 
     USERNAME = "username"

--- a/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
+++ b/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
@@ -14,7 +14,6 @@ class SoftwareSecureFakeViewTest(UrlResetMixin, TestCase):
     """
     Base class to test the fake software secure view.
     """
-
     URLCONF_MODULES = ['verify_student.urls']
 
     def setUp(self, **kwargs):

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -105,6 +105,20 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin):
     TOMORROW = NOW + timedelta(days=1)
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
+    URLS_AUTO_RESET = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to turn on Forums views."""
+        super(TestPayAndVerifyView, cls).setUpClass()
+        with mock.patch.dict("django.conf.settings.FEATURES", {'EMBARGO': True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(TestPayAndVerifyView, cls).tearDownClass()
+        cls.reset_urls()
 
     @mock.patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):

--- a/openedx/core/djangoapps/embargo/tests/test_api.py
+++ b/openedx/core/djangoapps/embargo/tests/test_api.py
@@ -244,12 +244,26 @@ class EmbargoMessageUrlApiTests(UrlResetMixin, ModuleStoreTestCase):
     """Test the embargo API calls for retrieving the blocking message URLs. """
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
+    URLS_AUTO_RESET = False
     ENABLED_CACHES = ['default', 'mongo_metadata_inheritance', 'loc_cache']
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):
         super(EmbargoMessageUrlApiTests, self).setUp()
         self.course = CourseFactory.create()
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include EMBARGO views."""
+        super(EmbargoMessageUrlApiTests, cls).setUpClass()
+        with patch.dict("django.conf.settings.FEATURES", {"EMBARGO": True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(EmbargoMessageUrlApiTests, cls).tearDownClass()
+        cls.reset_urls()
 
     @ddt.data(
         ('enrollment', '/embargo/blocked-message/enrollment/embargo/'),

--- a/openedx/core/djangoapps/embargo/tests/test_middleware.py
+++ b/openedx/core/djangoapps/embargo/tests/test_middleware.py
@@ -36,6 +36,7 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
     PASSWORD = 'secret'
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
+    URLS_AUTO_RESET = False
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):
@@ -53,6 +54,19 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
         # Clear the cache to avoid interference between tests
         django_cache.clear()
         config_cache.clear()
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include EMBARGO views."""
+        super(EmbargoMiddlewareAccessTests, cls).setUpClass()
+        with patch.dict(settings.FEATURES, {"EMBARGO": True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(EmbargoMiddlewareAccessTests, cls).tearDownClass()
+        cls.reset_urls()
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     @ddt.data(True, False)

--- a/openedx/core/djangoapps/embargo/tests/test_views.py
+++ b/openedx/core/djangoapps/embargo/tests/test_views.py
@@ -34,10 +34,24 @@ class CourseAccessMessageViewTest(CacheIsolationTestCase, UrlResetMixin):
     ENABLED_CACHES = ['default']
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
+    URLS_AUTO_RESET = False
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):
         super(CourseAccessMessageViewTest, self).setUp()
+
+    @classmethod
+    def setUpClass(cls):
+        """Reset the URLs to include EMBARGO views."""
+        super(CourseAccessMessageViewTest, cls).setUpClass()
+        with patch.dict("django.conf.settings.FEATURES", {"EMBARGO": True}):
+            cls.reset_urls()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset the URLs to the default."""
+        super(CourseAccessMessageViewTest, cls).tearDownClass()
+        cls.reset_urls()
 
     @ddt.data(*messages.ENROLL_MESSAGES.keys())
     def test_enrollment_messages(self, msg_key):


### PR DESCRIPTION
@nasthagiri: I was trying to get a decent profiling trace of what slowed down our test suite from those storage-backed block structures commits earlier, but the crazy import/reloading of urls.py associated with the forums tests was giving me really wacky results and making it hard to see what the real problem was. So I killed it.

Still haven't figured out what happened yet. :-P Will ping you when I do.