### PR TITLE
TNl-6610 Fix "more" menu on discussion post for global staff.

### DIFF
--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -1405,6 +1405,26 @@ class PermissionsTestCase(ModuleStoreTestCase):
                 'can_report': True
             })
 
+    def test_get_ability_with_global_staff(self):
+        """
+        Tests that global staff has rights to report other user's post inspite
+        of enrolled in the course or not.
+        """
+        content = {'user_id': '1', 'type': 'thread'}
+
+        with mock.patch('django_comment_client.utils.check_permissions_by_view') as check_perm:
+            # check_permissions_by_view returns false because user is not enrolled in the course.
+            check_perm.return_value = False
+            global_staff = UserFactory(username='global_staff', email='global_staff@edx.org', is_staff=True)
+            self.assertEqual(utils.get_ability(None, content, global_staff), {
+                'editable': False,
+                'can_reply': False,
+                'can_delete': False,
+                'can_openclose': False,
+                'can_vote': False,
+                'can_report': True
+            })
+
     def test_is_content_authored_by(self):
         content = {}
         user = mock.Mock()

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -29,6 +29,7 @@ from openedx.core.djangoapps.course_groups.cohorts import (
 )
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
 from request_cache.middleware import request_cached
+from student.roles import GlobalStaff
 
 
 log = logging.getLogger(__name__)
@@ -525,12 +526,12 @@ def get_ability(course_id, content, user):
             content,
             "vote_for_thread" if content['type'] == 'thread' else "vote_for_comment"
         ),
-        'can_report': not is_content_authored_by(content, user) and check_permissions_by_view(
+        'can_report': not is_content_authored_by(content, user) and (check_permissions_by_view(
             user,
             course_id,
             content,
             "flag_abuse_for_thread" if content['type'] == 'thread' else "flag_abuse_for_comment"
-        )
+        ) or GlobalStaff().has_user(user))
     }
 
 # TODO: RENAME


### PR DESCRIPTION
## ["More" menu on discussion posts is empty - TNL-6610](https://openedx.atlassian.net/browse/TNL-6610)

### Description
This PR fixes the `more` menu dropdown in the upper right corner of discussion responses which was empty in the case that user is logged in with global staff account and is not enrolled in the course then user is not able to `report` other's post. There was issue with the permissions that if user is not enrolled in the course even it has global staff account then user has not the ability to `report` other's posts. I have made the changes in [get_ability](https://github.com/edx/edx-platform/blame/0ea6d098c79ea578ed7b17167568916ced7a7770/lms/djangoapps/django_comment_client/utils.py#L529-L535) function that if user is logged in as global staff account then staff has rights to report other's posts. 

### How to Test?

**Stage** 
1. Login to stage with Global Staff Account.
2. Enrolled yourself in the course https://courses.stage.edx.org/courses/course-v1:edx+CS101+2017_T1/info
3. Goto to the discussion dashboard of the course:  https://courses.stage.edx.org/courses/course-v1:edx+CS101+2017_T1/discussion/forum/
4. Add a new post.
5. Login to stage with another Global Staff Account.
6. Make sure you are not enrolled in this course.
7. Goto to the discussion dashboard of the course:  https://courses.stage.edx.org/courses/course-v1:edx+CS101+2017_T1/discussion/forum/
8. Open this thread and click on More context menu. https://courses.stage.edx.org/courses/course-v1:edx+CS101+2017_T1/discussion/forum/course/threads/58bd30cab08b0607b4000030
9. Observe dropdown is empty.

**Sandbox**
- [https://tnl-6610.sandbox.edx.org/courses/course-v1:edx+CS101+2017_T1/info](https://tnl-6610.sandbox.edx.org/courses/course-v1:edx+CS101+2017_T1/info)

**Screenshots**
Add screenshots before/after the fix.
Before Fix
<img width="1163" alt="before fix 2017-03-06 at 3 15 12 pm" src="https://cloud.githubusercontent.com/assets/13939335/23605867/2b98fbca-0280-11e7-9c0c-7431362e9eff.png">

After Fix
<img width="1178" alt="after fix 2017-03-06 at 3 16 13 pm" src="https://cloud.githubusercontent.com/assets/13939335/23605875/36d6fde8-0280-11e7-81a9-d4a39251e43f.png">

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Style and readability review: @awaisdar001 
- [ ] Code review: @awaisdar001 
- [ ] Code review: @bjacobel  

### Post-review
- [ ] Rebase and squash commits