### PR TITLE
Move Bug fixes

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -739,6 +739,8 @@ def _move_item(source_usage_key, target_parent_usage_key, user, target_index=Non
             error = 'You can not move an item into itself.'
         elif is_source_item_in_target_parents(source_item, target_parent):
             error = 'You can not move an item into it\'s child.'
+        elif target_parent_type == 'split_test':
+            error = 'You can not move an item directly into content experiment.'
         elif source_index is None:
             error = '{source_usage_key} not found in {parent_usage_key}.'.format(
                 source_usage_key=unicode(source_usage_key),
@@ -1119,7 +1121,8 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
     xblock_info = {
         'id': unicode(xblock.location),
         'display_name': xblock.display_name_with_default,
-        'category': xblock.category
+        'category': xblock.category,
+        'has_children': xblock.has_children
     }
     if is_concise:
         if child_info and len(child_info.get('children', [])) > 0:
@@ -1127,7 +1130,6 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         # Groups are labelled with their internal ids, rather than with the group name. Replace id with display name.
         group_display_name = get_group_display_name(user_partitions, xblock_info['display_name'])
         xblock_info['display_name'] = group_display_name if group_display_name else xblock_info['display_name']
-        xblock_info['has_children'] = xblock.has_children
     else:
         xblock_info.update({
             'edited_on': get_default_time_display(xblock.subtree_edited_on) if xblock.subtree_edited_on else None,

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -948,17 +948,17 @@ class TestMoveItem(ItemTest):
         """
         Test invalid move.
         """
-        parent_loc = self.store.get_parent_location(self.chapter_usage_key)
-        response = self._move_component(self.chapter_usage_key, self.usage_key)
+        parent_loc = self.store.get_parent_location(self.html_usage_key)
+        response = self._move_component(self.html_usage_key, self.seq_usage_key)
         self.assertEqual(response.status_code, 400)
         response = json.loads(response.content)
 
         expected_error = 'You can not move {source_type} into {target_type}.'.format(
-            source_type=self.chapter_usage_key.block_type,
-            target_type=self.usage_key.block_type
+            source_type=self.html_usage_key.block_type,
+            target_type=self.seq_usage_key.block_type
         )
         self.assertEqual(expected_error, response['error'])
-        new_parent_loc = self.store.get_parent_location(self.chapter_usage_key)
+        new_parent_loc = self.store.get_parent_location(self.html_usage_key)
         self.assertEqual(new_parent_loc, parent_loc)
 
     def test_move_current_parent(self):
@@ -1039,10 +1039,22 @@ class TestMoveItem(ItemTest):
 
     def test_move_into_content_experiment_groups(self):
         """
-        Test that a component can be moved to content experiment.
+        Test that a component can be moved to content experiment groups.
         """
         split_test = self.setup_and_verify_content_experiment(0)
         self.assert_move_item(self.html_usage_key, split_test.children[0])
+
+    def test_can_not_move_into_content_experiment_level(self):
+        """
+        Test that a component can not be moved directly to content experiment level.
+        """
+        self.setup_and_verify_content_experiment(0)
+        response = self._move_component(self.html_usage_key, self.split_test_usage_key)
+        self.assertEqual(response.status_code, 400)
+        response = json.loads(response.content)
+
+        self.assertEqual(response['error'], 'You can not move an item directly into content experiment.')
+        self.assertEqual(self.store.get_parent_location(self.html_usage_key), self.vert_usage_key)
 
     def test_can_not_move_content_experiment_into_its_children(self):
         """

--- a/cms/static/js/models/xblock_info.js
+++ b/cms/static/js/models/xblock_info.js
@@ -50,6 +50,10 @@ function(Backbone, _, str, ModuleUtils) {
              */
             'published_by': null,
             /**
+             * True if the xblock is a parentable xblock.
+             */
+            has_children: null,
+            /**
              * True if the xblock has changes.
              * Note: this is not always provided as a performance optimization. It is only provided for
              * verticals functioning as units.

--- a/cms/static/js/spec/views/pages/container_spec.js
+++ b/cms/static/js/spec/views/pages/container_spec.js
@@ -49,6 +49,9 @@ define(['jquery', 'underscore', 'underscore.string', 'edx-ui-toolkit/js/utils/sp
 
                 afterEach(function() {
                     EditHelpers.uninstallMockXBlock();
+                    if (containerPage !== undefined) {
+                        containerPage.remove();
+                    }
                 });
 
                 respondWithHtml = function(html) {

--- a/cms/static/js/spec/views/pages/container_subviews_spec.js
+++ b/cms/static/js/spec/views/pages/container_subviews_spec.js
@@ -35,6 +35,9 @@ define(['jquery', 'underscore', 'underscore.string', 'edx-ui-toolkit/js/utils/sp
 
             afterEach(function() {
                 delete window.course;
+                if (containerPage !== undefined) {
+                    containerPage.remove();
+                }
             });
 
             defaultXBlockInfo = {

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -2,11 +2,12 @@
  * XBlockContainerPage is used to display Studio's container page for an xblock which has children.
  * This page allows the user to understand and manipulate the xblock and its children.
  */
-define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'common/js/components/utils/view_utils',
-        'js/views/container', 'js/views/xblock', 'js/views/components/add_xblock', 'js/views/modals/edit_xblock',
-        'js/views/modals/move_xblock_modal', 'js/models/xblock_info', 'js/views/xblock_string_field_editor',
-        'js/views/pages/container_subviews', 'js/views/unit_outline', 'js/views/utils/xblock_utils'],
-    function($, _, gettext, BasePage, ViewUtils, ContainerView, XBlockView, AddXBlockComponent,
+define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/pages/base_page',
+        'common/js/components/utils/view_utils', 'js/views/container', 'js/views/xblock',
+        'js/views/components/add_xblock', 'js/views/modals/edit_xblock', 'js/views/modals/move_xblock_modal',
+        'js/models/xblock_info', 'js/views/xblock_string_field_editor', 'js/views/pages/container_subviews',
+        'js/views/unit_outline', 'js/views/utils/xblock_utils'],
+    function($, _, Backbone, gettext, BasePage, ViewUtils, ContainerView, XBlockView, AddXBlockComponent,
               EditXBlockModal, MoveXBlockModal, XBlockInfo, XBlockStringFieldEditor, ContainerSubviews,
               UnitOutlineView, XBlockUtils) {
         'use strict';
@@ -81,6 +82,8 @@ define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'common/j
                     });
                     this.unitOutlineView.render();
                 }
+
+                this.listenTo(Backbone, 'move:onXBlockMoved', this.onXBlockMoved);
             },
 
             getViewParameters: function() {
@@ -280,6 +283,13 @@ define(['jquery', 'underscore', 'gettext', 'js/views/pages/base_page', 'common/j
                 xblockView.acknowledgeXBlockDeletion(parent.data('locator'));
 
                 // Update publish and last modified information from the server.
+                this.model.fetch();
+            },
+
+            /*
+            After move operation is complete, updates the xblock information from server .
+             */
+            onXBlockMoved: function() {
                 this.model.fetch();
             },
 

--- a/cms/static/js/views/utils/xblock_utils.js
+++ b/cms/static/js/views/utils/xblock_utils.js
@@ -272,7 +272,8 @@ define(['jquery', 'underscore', 'gettext', 'common/js/components/utils/view_util
         findXBlockInfo = function(xblockWrapperElement, defaultXBlockInfo) {
             var xblockInfo = defaultXBlockInfo,
                 xblockElement,
-                displayName;
+                displayName,
+                hasChildren;
             if (xblockWrapperElement.length > 0) {
                 xblockElement = xblockWrapperElement.find('.xblock');
                 displayName = xblockWrapperElement.find(
@@ -283,11 +284,13 @@ define(['jquery', 'underscore', 'gettext', 'common/js/components/utils/view_util
                 if (!displayName) {
                     displayName = xblockElement.find('.component-header').text().trim();
                 }
+                hasChildren = defaultXBlockInfo ? defaultXBlockInfo.get('has_children') : false;
                 xblockInfo = new XBlockInfo({
                     id: xblockWrapperElement.data('locator'),
                     courseKey: xblockWrapperElement.data('course-key'),
                     category: xblockElement.data('block-type'),
-                    display_name: displayName
+                    display_name: displayName,
+                    has_children: hasChildren
                 });
             }
             return xblockInfo;

--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -229,6 +229,18 @@ class ContainerPage(PageObject, HelpMixin):
         self.q(css='.button-view').first.click()
         self._switch_to_lms()
 
+    def verify_publish_title(self, expected_title):
+        """
+        Waits for the publish title to change to the expected value.
+        """
+        def wait_for_title_change():
+            """
+            Promise function to check publish title.
+            """
+            return (self.publish_title == expected_title, self.publish_title)
+
+        Promise(wait_for_title_change, "Publish title incorrect. Found '" + self.publish_title + "'").fulfill()
+
     def preview(self):
         """
         Clicks "Preview", which will open the draft version of the unit page in the LMS.

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -664,7 +664,7 @@ class UnitPublishingTest(ContainerBase):
             And the last saved text contains "Last published"
         """
         unit = self.go_to_unit_page()
-        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
         # Start date set in course fixture to 1970.
         self._verify_release_date_info(
             unit, self.RELEASE_TITLE_RELEASED, 'Jan 01, 1970 at 00:00 UTC\nwith Section "Test Section"'
@@ -675,11 +675,11 @@ class UnitPublishingTest(ContainerBase):
 
         # Add a component to the page so it will have unpublished changes.
         add_discussion(unit)
-        self._verify_publish_title(unit, self.DRAFT_STATUS)
+        unit.verify_publish_title(self.DRAFT_STATUS)
         self._verify_last_published_and_saved(unit, self.LAST_PUBLISHED, self.LAST_SAVED)
         unit.publish_action.click()
         unit.wait_for_ajax()
-        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
         self._verify_last_published_and_saved(unit, self.LAST_PUBLISHED, self.LAST_PUBLISHED)
 
     def test_discard_changes(self):
@@ -696,9 +696,9 @@ class UnitPublishingTest(ContainerBase):
         """
         unit = self.go_to_unit_page()
         add_discussion(unit)
-        self._verify_publish_title(unit, self.DRAFT_STATUS)
+        unit.verify_publish_title(self.DRAFT_STATUS)
         unit.discard_changes()
-        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
 
     def test_view_live_no_changes(self):
         """
@@ -757,7 +757,7 @@ class UnitPublishingTest(ContainerBase):
             Then I see the content in the unit
         """
         unit = self.go_to_unit_page("Unlocked Section", "Unlocked Subsection", "Unlocked Unit")
-        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
         self.assertTrue(unit.currently_visible_to_students)
         self._verify_release_date_info(
             unit, self.RELEASE_TITLE_RELEASED, self.past_start_date_text + '\n' + 'with Section "Unlocked Section"'
@@ -783,7 +783,7 @@ class UnitPublishingTest(ContainerBase):
         self.assertTrue(checked)
         self.assertFalse(unit.currently_visible_to_students)
         self.assertFalse(unit.shows_inherited_staff_lock())
-        self._verify_publish_title(unit, self.LOCKED_STATUS)
+        unit.verify_publish_title(self.LOCKED_STATUS)
         self._view_published_version(unit)
         # Will initially be in staff view, locked component should be visible.
         self._verify_components_visible(['problem'])
@@ -802,7 +802,7 @@ class UnitPublishingTest(ContainerBase):
             Then I do not see any content in the unit
         """
         unit = self.go_to_unit_page("Section With Locked Unit", "Subsection With Locked Unit", "Locked Unit")
-        self._verify_publish_title(unit, self.LOCKED_STATUS)
+        unit.verify_publish_title(self.LOCKED_STATUS)
         self.assertFalse(unit.currently_visible_to_students)
         self._verify_release_date_info(
             unit, self.RELEASE_TITLE_RELEASE,
@@ -826,7 +826,7 @@ class UnitPublishingTest(ContainerBase):
         unit = self.go_to_unit_page("Section With Locked Unit", "Subsection With Locked Unit", "Locked Unit")
         checked = unit.toggle_staff_lock()
         self.assertFalse(checked)
-        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
         self.assertTrue(unit.currently_visible_to_students)
         self._view_published_version(unit)
         # Will initially be in staff view, components always visible.
@@ -894,10 +894,10 @@ class UnitPublishingTest(ContainerBase):
         component.edit()
         HtmlComponentEditorView(self.browser, component.locator).set_content_and_save(modified_content)
         self.assertEqual(component.student_content, modified_content)
-        self._verify_publish_title(unit, self.DRAFT_STATUS)
+        unit.verify_publish_title(self.DRAFT_STATUS)
         unit.publish_action.click()
         unit.wait_for_ajax()
-        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
         self._view_published_version(unit)
         self.assertIn(modified_content, self.courseware.xblock_component_html_content(0))
 
@@ -917,10 +917,10 @@ class UnitPublishingTest(ContainerBase):
         component.edit()
         HtmlComponentEditorView(self.browser, component.locator).set_content_and_cancel("modified content")
         self.assertEqual(component.student_content, "Body of HTML Unit.")
-        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
         self.browser.refresh()
         unit.wait_for_page()
-        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
 
     def test_delete_child_in_published_unit(self):
         """
@@ -936,10 +936,10 @@ class UnitPublishingTest(ContainerBase):
         """
         unit = self.go_to_unit_page()
         unit.delete(0)
-        self._verify_publish_title(unit, self.DRAFT_STATUS)
+        unit.verify_publish_title(self.DRAFT_STATUS)
         unit.publish_action.click()
         unit.wait_for_ajax()
-        self._verify_publish_title(unit, self.PUBLISHED_LIVE_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
         self._view_published_version(unit)
         self.assertEqual(0, self.courseware.num_xblock_components)
 
@@ -955,12 +955,12 @@ class UnitPublishingTest(ContainerBase):
             Then the title in the Publish information box is "Published (not yet released)"
         """
         unit = self.go_to_unit_page('Unreleased Section', 'Unreleased Subsection', 'Unreleased Unit')
-        self._verify_publish_title(unit, self.PUBLISHED_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_STATUS)
         add_discussion(unit)
-        self._verify_publish_title(unit, self.DRAFT_STATUS)
+        unit.verify_publish_title(self.DRAFT_STATUS)
         unit.publish_action.click()
         unit.wait_for_ajax()
-        self._verify_publish_title(unit, self.PUBLISHED_STATUS)
+        unit.verify_publish_title(self.PUBLISHED_STATUS)
 
     def _view_published_version(self, unit):
         """
@@ -1006,15 +1006,6 @@ class UnitPublishingTest(ContainerBase):
         """
         self.assertEqual(expected_title, unit.release_title)
         self.assertEqual(expected_date, unit.release_date)
-
-    def _verify_publish_title(self, unit, expected_title):
-        """
-        Waits for the publish title to change to the expected value.
-        """
-        def wait_for_title_change():
-            return (unit.publish_title == expected_title, unit.publish_title)
-
-        Promise(wait_for_title_change, "Publish title incorrect. Found '" + unit.publish_title + "'").fulfill()
 
     def _verify_last_published_and_saved(self, unit, expected_published_prefix, expected_saved_prefix):
         """
@@ -1144,6 +1135,9 @@ class MoveComponentTest(ContainerBase):
     """
     Tests of moving an XBlock to another XBlock.
     """
+    PUBLISHED_LIVE_STATUS = "Publishing Status\nPublished and Live"
+    DRAFT_STATUS = "Publishing Status\nDraft (Unpublished changes)"
+
     def setUp(self, is_staff=True):
         super(MoveComponentTest, self).setUp(is_staff=is_staff)
         self.container = ContainerPage(self.browser, None)
@@ -1181,25 +1175,35 @@ class MoveComponentTest(ContainerBase):
             )
         )
 
-    def verify_move_opertions(self, unit_page, source_component, operation, component_display_names_after_operation):
+    def verify_move_opertions(self, unit_page, source_component, operation, component_display_names_after_operation,
+                              should_verify_publish_title=True):
         """
         Verify move operations.
 
         Arguments:
             unit_page (Object)                                Unit container page.
-            source_component (Object)                         source XBlock object to be moved.
+            source_component (Object)                         Source XBlock object to be moved.
             operation (str),                                  `move` or `undo move` operation.
-            component_display_names_after_operation (dict)    display names of components after operation in source/dest
+            component_display_names_after_operation (dict)    Display names of components after operation in source/dest
+            should_verify_publish_title (Boolean)             Should verify publish title ot not. Default is True.
         """
         source_component.open_move_modal()
         self.move_modal_view.navigate_to_category(self.source_xblock_category, self.navigation_options)
         self.assertEqual(self.move_modal_view.is_move_button_enabled, True)
+
+        # Verify unit is in published state before move operation
+        if should_verify_publish_title:
+            self.container.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
 
         self.move_modal_view.click_move_button()
         self.container.verify_confirmation_message(
             self.message_move.format(display_name=self.source_component_display_name)
         )
         self.assertEqual(len(unit_page.displayed_children), 1)
+
+        # Verify unit in draft state now
+        if should_verify_publish_title:
+            self.container.verify_publish_title(self.DRAFT_STATUS)
 
         if operation == 'move':
             self.container.click_take_me_there_link()
@@ -1333,7 +1337,8 @@ class MoveComponentTest(ContainerBase):
             unit_page=group_container_page,
             source_component=components[0],
             operation='undo_move',
-            component_display_names_after_operation=['HTML 311', 'HTML 312']
+            component_display_names_after_operation=['HTML 311', 'HTML 312'],
+            should_verify_publish_title=False
         )
 
         # Verify move operation for content experiment.
@@ -1341,7 +1346,8 @@ class MoveComponentTest(ContainerBase):
             unit_page=group_container_page,
             source_component=components[0],
             operation='move',
-            component_display_names_after_operation=['HTML 21', 'HTML 22', 'HTML 311']
+            component_display_names_after_operation=['HTML 21', 'HTML 22', 'HTML 311'],
+            should_verify_publish_title=False
         )
 
     def test_a11y(self):


### PR DESCRIPTION
This PR fixes the bugs found in Move feature bug bash. Following are the bugs that are fixed :


1. Backend: Move component directly to content experiment level (component will now be the sibling of groups)

2. Fixed Move button is disabled when moving components inside conditional module

3. Fixed When navigating upward/backward, target parent is not set correct, resulting source to be moved in the previously selected parent

4. After a component is moved, Published version is not changed to Draft version unless user manually refreshes the page.

[Sandbox](https://studio-movecomponent.sandbox.edx.org)