### PR TITLE
Increment BlockStructureBlockData.VERSION

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/block_structure.py
+++ b/openedx/core/djangoapps/content/block_structure/block_structure.py
@@ -401,7 +401,7 @@ class BlockStructureBlockData(BlockStructure):
     # update this value whenever the data structure changes. Dependent storage
     # layers can then use this value when serializing/deserializing block
     # structures, and invalidating any previously cached/stored data.
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self, root_block_usage_key):
         super(BlockStructureBlockData, self).__init__(root_block_usage_key)


### PR DESCRIPTION
A [previous PR](https://github.com/edx/edx-platform/pull/14606) recently consolidated the block structure into a single folder.  However, when doing so, it inadvertently also changed the pickling format of the block structure.  This caused a backward compatibility issue after deployment.

This PR increments the version number for the `BlockStructureBlockData` class.  Since this version number is included in the cache-key, new workers will create/require newly serialized pickled data and old workers will continue to use the cached data of the previous version.

Please review @jcdyer 