### PR TITLE
Fix BlockStructure log statements

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/models.py
+++ b/openedx/core/djangoapps/content/block_structure/models.py
@@ -111,7 +111,7 @@ class BlockStructureModel(TimeStampedModel):
         Returns the collected data for this instance.
         """
         serialized_data = self.data.read()
-        log.info("BlockStructure: Read data from store; %r, size: %d", self, len(serialized_data))
+        log.info("BlockStructure: Read data from store; %r, size: %d", unicode(self), len(serialized_data))
         return serialized_data
 
     @classmethod
@@ -139,7 +139,7 @@ class BlockStructureModel(TimeStampedModel):
         log.info(
             'BlockStructure: %s in store; %r, size: %d',
             'Created' if created else 'Updated',
-            bs_model,
+            unicode(bs_model),
             len(serialized_data),
         )
         if not created:

--- a/openedx/core/djangoapps/content/block_structure/store.py
+++ b/openedx/core/djangoapps/content/block_structure/store.py
@@ -108,7 +108,7 @@ class BlockStructureStore(object):
         bs_model = self._get_model(root_block_usage_key)
         self._cache.delete(self._encode_root_cache_key(bs_model))
         bs_model.delete()
-        logger.info("BlockStructure: Deleted from cache and store; %r.", bs_model)
+        logger.info("BlockStructure: Deleted from cache and store; %r.", unicode(bs_model))
 
     def is_up_to_date(self, root_block_usage_key, modulestore):
         """
@@ -157,7 +157,7 @@ class BlockStructureStore(object):
         """
         cache_key = self._encode_root_cache_key(bs_model)
         self._cache.set(cache_key, serialized_data, timeout=config.cache_timeout_in_seconds())
-        logger.info("BlockStructure: Added to cache; %r, size: %d", bs_model, len(serialized_data))
+        logger.info("BlockStructure: Added to cache; %r, size: %d", unicode(bs_model), len(serialized_data))
 
     def _get_from_cache(self, bs_model):
         """
@@ -170,10 +170,10 @@ class BlockStructureStore(object):
 
         serialized_data = self._cache.get(cache_key)
         if not serialized_data:
-            logger.info("BlockStructure: Not found in cache; %r.", bs_model)
+            logger.info("BlockStructure: Not found in cache; %r.", unicode(bs_model))
             raise BlockStructureNotFound(bs_model.data_usage_key)
         else:
-            logger.info("BlockStructure: Read from cache; %r, size: %d", bs_model, len(serialized_data))
+            logger.info("BlockStructure: Read from cache; %r, size: %d", unicode(bs_model), len(serialized_data))
         return serialized_data
 
     def _get_from_store(self, bs_model):


### PR DESCRIPTION
This PR fixes the `BlockStructure` log statements so the data from the `BlockStructureModel` is currently serialized in the logs.