### PR TITLE
Quiet Bourbon deprecation warnings, UXPL upgrade 0.18.1

### DIFF
--- a/lms/static/sass/course/base/_extends.scss
+++ b/lms/static/sass/course/base/_extends.scss
@@ -46,7 +46,7 @@ h1.top-header {
 }
 
 .content {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   display: table-cell;
   padding: 2em 2.5em;
   vertical-align: top;
@@ -58,7 +58,7 @@ h1.top-header {
 }
 
 .sidebar {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   display: table-cell;
   font-family: $sans-serif;
   font-size: 14px;
@@ -120,7 +120,7 @@ h1.top-header {
         display: block;
         line-height: lh();
         font-size: 1em;
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         padding: lh(.25) lh(0.5) lh(.25) 0;
 
         &:hover, &:focus {

--- a/lms/static/sass/course/base/_extends.scss
+++ b/lms/static/sass/course/base/_extends.scss
@@ -28,19 +28,19 @@ h1.top-header {
 
 .light-button, a.light-button, // only used in askbot as classes
 .gray-button {
-  @include button(simple, $gray-l5);
+  @include simple($gray-l5);
   @extend .button-reset;
   font-size: em(13);
 }
 
 .blue-button {
-  @include button(simple, $blue);
+  @include simple($blue);
   @extend .button-reset;
   font-size: em(13);
 }
 
 .pink-button {
-  @include button(simple, $pink);
+  @include simple($pink);
   @extend .button-reset;
   font-size: em(13);
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "backbone": "~1.3.2",
     "backbone.paginator": "~2.0.3",
     "coffee-script": "1.6.1",
-    "edx-pattern-library": "0.18.0",
+    "edx-pattern-library": "0.18.1",
     "edx-ui-toolkit": "1.5.1",
     "jquery": "~2.2.0",
     "jquery-migrate": "^1.4.1",


### PR DESCRIPTION
Resolves [FEDX-287](https://openedx.atlassian.net/browse/FEDX-287).

Removes three sources of Bourbon deprecation warnings:
- Bourbon had silently been upgraded to 4.3.x, which added a host of deprecation warnings for Bourbon 5.0 (which we don't ever plan on upgrading to) - the UXPL upgrade here pins Bourbon back to 4.2.x
- usage of the `box-sizing` mixin, which is [no longer needed by our supported browsers](http://caniuse.com/#feat=css3-boxsizing)
- usage of the `button` mixin, which is deprecated in Bourbon. This warning was silenced by using the private version of the mixin.