### PR TITLE
Fix Text Subtitle charset

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -266,6 +266,7 @@ class VideoStudentViewHandlers(object):
             else:
                 response = Response(
                     transcript_content,
+                    charset='UTF-8',
                     headerlist=[
                         ('Content-Disposition', 'attachment; filename="{}"'.format(transcript_filename.encode('utf8'))),
                         ('Content-Language', self.transcript_language),


### PR DESCRIPTION
When trying to download subtitles in text format, LMS and CMS return an error:

"You cannot set the body to a text value without a charset"

For Text format charset must be defined.

Complete error output:

Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 22, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/preview.py", line 75, in preview_handler
    resp = instance.handle(handler, req, suffix)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/mixins.py", line 86, in handle
    return self.runtime.handle(self, handler_name, request, suffix)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1334, in handle
    return super(MetricsMixin, self).handle(block, handler_name, request, suffix=suffix)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 1025, in handle
    results = handler(request, suffix)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/video_handlers.py", line 271, in transcript
    ('Content-Language', self.transcript_language),
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/webob/response.py", line 310, in __init__
    "You cannot set the body to a text value without a "
TypeError: You cannot set the body to a text value without a charset