### PR TITLE
Add resume indicator to course outline

### DIFF
--- a/common/test/acceptance/pages/lms/course_home.py
+++ b/common/test/acceptance/pages/lms/course_home.py
@@ -40,6 +40,11 @@ class CourseOutlinePage(PageObject):
 
     url = None
 
+    SECTION_SELECTOR = '.outline-item.section:nth-of-type({0})'
+    SECTION_TITLES_SELECTOR = '.section-name span'
+    SUBSECTION_SELECTOR = SECTION_SELECTOR + ' .subsection:nth-of-type({1}) .outline-item'
+    SUBSECTION_TITLES_SELECTOR = SECTION_SELECTOR + ' .subsection a span:first-child'
+
     def __init__(self, browser, parent_page):
         super(CourseOutlinePage, self).__init__(browser)
         self.parent_page = parent_page
@@ -105,9 +110,7 @@ class CourseOutlinePage(PageObject):
             return
 
         # Convert list indices (start at zero) to CSS indices (start at 1)
-        subsection_css = (
-            ".outline-item.section:nth-of-type({0}) .subsection:nth-of-type({1}) .outline-item"
-        ).format(section_index + 1, subsection_index + 1)
+        subsection_css = self.SUBSECTION_SELECTOR.format(section_index + 1, subsection_index + 1)
 
         # Click the subsection and ensure that the page finishes reloading
         self.q(css=subsection_css).first.click()
@@ -123,25 +126,15 @@ class CourseOutlinePage(PageObject):
         """
         Return a list of all section titles on the page.
         """
-        section_css = '.section-name span'
-        return self.q(css=section_css).map(lambda el: el.text.strip()).results
+        return self.q(css=self.SECTION_TITLES_SELECTOR).map(lambda el: el.text.strip()).results
 
     def _subsection_titles(self, section_index):
         """
         Return a list of all subsection titles on the page
         for the section at index `section_index` (starts at 1).
         """
-        # Retrieve the subsection title for the section
-        # Add one to the list index to get the CSS index, which starts at one
-        subsection_css = (
-            # TODO: TNL-6387: Will need to switch to this selector for subsections
-            # ".outline-item.section:nth-of-type({0}) .subsection span:nth-of-type(1)"
-            ".outline-item.section:nth-of-type({0}) .subsection a"
-        ).format(section_index)
-
-        return self.q(
-            css=subsection_css
-        ).map(
+        subsection_css = self.SUBSECTION_TITLES_SELECTOR.format(section_index)
+        return self.q(css=subsection_css).map(
             lambda el: el.get_attribute('innerHTML').strip()
         ).results
 

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -860,6 +860,16 @@ class HighLevelTabTest(UniqueCourseTest):
         bookmarks_page = BookmarksPage(self.browser, self.course_id)
         self.assertTrue(bookmarks_page.is_browser_on_page())
 
+        # Test "Resume Course" button from header
+        self.course_home_page.visit()
+        self.course_home_page.resume_course_from_header()
+        self.assertTrue(self.courseware_page.nav.is_on_section('Test Section 2', 'Test Subsection 3'))
+
+        # Test "Resume Course" button from within outline
+        self.course_home_page.visit()
+        self.course_home_page.outline.resume_course_from_outline()
+        self.assertTrue(self.courseware_page.nav.is_on_section('Test Section 2', 'Test Subsection 3'))
+
     @attr('a11y')
     def test_course_home_a11y(self):
         self.course_home_page.visit()

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -392,7 +392,7 @@ def course_info(request, course_id):
         # Get the URL of the user's last position in order to display the 'where you were last' message
         context['last_accessed_courseware_url'] = None
         if SelfPacedConfiguration.current().enable_course_home_improvements:
-            context['last_accessed_courseware_url'] = get_last_accessed_courseware(course, request, user)
+            context['last_accessed_courseware_url'], _ = get_last_accessed_courseware(course, request, user)
 
         now = datetime.now(UTC())
         effective_start = _adjust_start_date_for_beta_testers(user, course, course_key)
@@ -427,8 +427,8 @@ def course_info(request, course_id):
 
 def get_last_accessed_courseware(course, request, user):
     """
-    Return the courseware module URL that the user last accessed,
-    or None if it cannot be found.
+    Returns a tuple containing the courseware module (URL, id) that the user last accessed,
+    or (None, None) if it cannot be found.
     """
     field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
         course.id, request.user, course, depth=2
@@ -445,8 +445,8 @@ def get_last_accessed_courseware(course, request, user):
                 'chapter': chapter_module.url_name,
                 'section': section_module.url_name
             })
-            return url
-    return None
+            return (url, section_module.url_name)
+    return (None, None)
 
 
 class StaticCourseTabView(FragmentView):

--- a/lms/static/sass/features/_course-outline.scss
+++ b/lms/static/sass/features/_course-outline.scss
@@ -43,6 +43,14 @@
               text-decoration: none;
             }
           }
+
+          &.current {
+            border: 1px solid $lms-active-color;
+
+            .resume-right {
+              float: right;
+            }
+          }
         }
       }
     }

--- a/lms/static/sass/features/_course-outline.scss
+++ b/lms/static/sass/features/_course-outline.scss
@@ -48,7 +48,7 @@
             border: 1px solid $lms-active-color;
 
             .resume-right {
-              float: right;
+              @include float(right);
             }
           }
         }

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -27,13 +27,25 @@ from django.utils.translation import ugettext as _
                 </div>
                 <ol class="outline-item focusable" role="group" tabindex="0">
                     % for subsection in section.get('children') or []:
-                        <li class="subsection" role="treeitem" tabindex="-1" aria-expanded="true">
+                        <li
+                            class="subsection ${ 'current' if subsection['current'] else '' }"
+                            role="treeitem"
+                            tabindex="-1"
+                            aria-expanded="true"
+                        >
                             <a
                                 class="outline-item focusable"
                                 href="${ subsection['lms_web_url'] }"
                                 id="${ subsection['id'] }"
                             >
-                                ${ subsection['display_name'] }
+                                <span>${ subsection['display_name'] }</span>
+                                <span class="sr-only">This is your last visited course section.</span>
+                                % if subsection['current']:
+                                    <span class="resume-right">
+                                        <b>Resume Course</b>
+                                        <span class="icon fa fa-arrow-circle-right" aria-hidden="true"></span>
+                                    </span>
+                                %endif
                             </a>
                         </li>
                     % endfor

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -39,10 +39,10 @@ from django.utils.translation import ugettext as _
                                 id="${ subsection['id'] }"
                             >
                                 <span>${ subsection['display_name'] }</span>
-                                <span class="sr-only">This is your last visited course section.</span>
+                                <span class="sr-only">${ _("This is your last visited course section.") }</span>
                                 % if subsection['current']:
                                     <span class="resume-right">
-                                        <b>Resume Course</b>
+                                        <b>${ _("Resume Course") }</b>
                                         <span class="icon fa fa-arrow-circle-right" aria-hidden="true"></span>
                                     </span>
                                 %endif

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -71,6 +71,8 @@ class TestCourseOutlinePage(SharedModuleStoreTestCase):
 
             if course.last_accessed is not None:
                 self.assertIn('Resume Course', response_content)
+            else:
+                self.assertNotIn('Resume Course', response_content)
             for chapter in course.children:
                 self.assertIn(chapter.display_name, response_content)
                 for section in chapter.children:


### PR DESCRIPTION
## [LEARNER-35](https://openedx.atlassian.net/browse/LEARNER-35)

### Description

Adds a "Resume" action to your current course position on the new course outline.

### Sandbox
- [x] https://resume-outline.sandbox.edx.org

### Testing
- [x] i18n
- [x] RTL
- [x] safecommit violation code review process
- [x] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [x] Database migrations are backwards-compatible

### Post-review
- [ ] Rebase and squash commits