### PR TITLE
Allow masquerade on progress page

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -828,9 +828,10 @@ def _progress(request, course_key, student_id):
 
     staff_access = bool(has_access(request.user, 'staff', course))
 
+    masquerade = None
     if student_id is None or student_id == request.user.id:
-        # always allowed to see your own profile
-        student = request.user
+        # This will be a no-op for non-staff users, returning request.user
+        masquerade, student = setup_masquerade(request, course_key, staff_access, reset_masquerade_data=True)
     else:
         try:
             coach_access = has_ccx_coach_role(request.user, course_key)
@@ -871,7 +872,8 @@ def _progress(request, course_key, student_id):
         'student': student,
         'passed': is_course_passed(course, grade_summary),
         'credit_course_requirements': _credit_course_requirements(course_key, student),
-        'certificate_data': _get_cert_data(student, course, course_key, is_active, enrollment_mode)
+        'certificate_data': _get_cert_data(student, course, course_key, is_active, enrollment_mode),
+        'masquerade': masquerade
     }
 
     with outer_atomic():

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -20,7 +20,7 @@ if active_page is None and active_page_context is not UNDEFINED:
 def selected(is_selected):
   return "selected" if is_selected else ""
 
-show_preview_menu = not disable_preview_menu and staff_access and active_page in ["courseware", "info"]
+show_preview_menu = not disable_preview_menu and staff_access and active_page in ["courseware", "info", "progress"]
 cohorted_user_partition = get_cohorted_user_partition(course)
 masquerade_user_name = masquerade.user_name if masquerade else None
 masquerade_group_id = masquerade.group_id if masquerade else None


### PR DESCRIPTION
# [TNL-5047](https://openedx.atlassian.net/browse/TNL-5047)

This will allow staff users to masquerade as specific students while viewing the progress page. No work has been done to remove the `student_progress` endpoint.