### PR TITLE
Remove student_progress

### DIFF
--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -146,6 +146,7 @@ class CoachAccessTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
     def test_access_student_progress_ccx(self):
         """
         Assert that only a coach can see progress of student.
+        TODO: TNL-5047, remove or update this test
         """
         ccx_locator = self.make_ccx()
         student = UserFactory()

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -84,20 +84,7 @@ class TestViewAuth(ModuleStoreTestCase, LoginEnrollmentTestCase):
         for url in urls:
             self.assert_request_status_code(200, url)
 
-        # The student progress tab is not accessible to a student
-        # before launch, so the instructor view-as-student feature
-        # should return a 403.
-        # TODO (vshnayder): If this is not the behavior we want, will need
-        # to make access checking smarter and understand both the effective
-        # user (the student), and the requesting user (the prof)
-        url = reverse(
-            'student_progress',
-            kwargs={
-                'course_id': course.id.to_deprecated_string(),
-                'student_id': self.enrolled_user.id,
-            }
-        )
-        self.assert_request_status_code(403, url)
+        # TODO: TNL-5047 re-add some sort of check here
 
         # The courseware url should redirect, not 200
         url = self._reverse_urls(['courseware'], course)[0]

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1219,90 +1219,20 @@ class ProgressPageTests(ModuleStoreTestCase):
         self.assertEqual(resp.status_code, expected_status_code)
         return resp
 
-    def _get_student_progress_page(self, expected_status_code=200):
-        """
-        Gets the progress page for the user in the course.
-        """
-        resp = self.client.get(
-            reverse('student_progress', args=[unicode(self.course.id), self.user.id])
-        )
-        self.assertEqual(resp.status_code, expected_status_code)
-        return resp
-
     @ddt.data('"><script>alert(1)</script>', '<script>alert(1)</script>', '</script><script>alert(1)</script>')
     def test_progress_page_xss_prevent(self, malicious_code):
         """
         Test that XSS attack is prevented
         """
-        resp = self._get_student_progress_page()
+        resp = self._get_progress_page()
         # Test that malicious code does not appear in html
         self.assertNotIn(malicious_code, resp.content)
+
+    # TODO: add some more tests to replace the ones I just removed, TNL-5047
 
     def test_pure_ungraded_xblock(self):
         ItemFactory.create(category='acid', parent_location=self.vertical.location)
         self._get_progress_page()
-
-    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
-    def test_student_progress_with_valid_and_invalid_id(self, default_store):
-        """
-         Check that invalid 'student_id' raises Http404 for both old mongo and
-         split mongo courses.
-        """
-
-        # Create new course with respect to 'default_store'
-        # Enroll student into course
-        self.course = CourseFactory.create(default_store=default_store)
-        CourseEnrollmentFactory(user=self.user, course_id=self.course.id, mode=CourseMode.HONOR)
-
-        # Invalid Student Ids (Integer and Non-int)
-        invalid_student_ids = [
-            991021,
-            'azU3N_8$',
-        ]
-        for invalid_id in invalid_student_ids:
-
-            resp = self.client.get(
-                reverse('student_progress', args=[unicode(self.course.id), invalid_id])
-            )
-            self.assertEquals(resp.status_code, 404)
-
-        # Assert that valid 'student_id' returns 200 status
-        self._get_student_progress_page()
-
-    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
-    def test_unenrolled_student_progress_for_credit_course(self, default_store):
-        """
-         Test that student progress page does not break while checking for an unenrolled student.
-
-         Scenario: When instructor checks the progress of a student who is not enrolled in credit course.
-         It should return 200 response.
-        """
-        # Create a new course, a user which will not be enrolled in course, admin user for staff access
-        course = CourseFactory.create(default_store=default_store)
-        not_enrolled_user = UserFactory.create()
-        admin = AdminFactory.create()
-        self.assertTrue(self.client.login(username=admin.username, password='test'))
-
-        # Create and enable Credit course
-        CreditCourse.objects.create(course_key=course.id, enabled=True)
-
-        # Configure a credit provider for the course
-        CreditProvider.objects.create(
-            provider_id="ASU",
-            enable_integration=True,
-            provider_url="https://credit.example.com/request"
-        )
-
-        requirements = [{
-            "namespace": "grade",
-            "name": "grade",
-            "display_name": "Grade",
-            "criteria": {"min_grade": 0.52},
-        }]
-        # Add a single credit requirement (final grade)
-        set_credit_requirements(course.id, requirements)
-
-        self._get_student_progress_page()
 
     def test_non_ascii_grade_cutoffs(self):
         self._get_progress_page()

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -828,9 +828,10 @@ def _progress(request, course_key, student_id):
 
     staff_access = bool(has_access(request.user, 'staff', course))
 
+    masquerade = None
     if student_id is None or student_id == request.user.id:
-        # always allowed to see your own profile
-        student = request.user
+        # This will be a no-op for non-staff users, returning request.user
+        masquerade, student = setup_masquerade(request, course_key, staff_access, reset_masquerade_data=True)
     else:
         try:
             coach_access = has_ccx_coach_role(request.user, course_key)
@@ -871,7 +872,8 @@ def _progress(request, course_key, student_id):
         'student': student,
         'passed': is_course_passed(course, grade_summary),
         'credit_course_requirements': _credit_course_requirements(course_key, student),
-        'certificate_data': _get_cert_data(student, course, course_key, is_active, enrollment_mode)
+        'certificate_data': _get_cert_data(student, course, course_key, is_active, enrollment_mode),
+        'masquerade': masquerade
     }
 
     with outer_atomic():

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -154,7 +154,6 @@ INSTRUCTOR_POST_ENDPOINTS = set([
     'get_problem_responses',
     'get_proctored_exam_results',
     'get_registration_codes',
-    'get_student_progress_url',
     'get_students_features',
     'get_students_who_may_enroll',
     'get_user_invoice_preference',
@@ -365,7 +364,6 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
              {'identifiers': 'foo@example.org', 'action': 'enroll'}),
             ('get_grading_config', {}),
             ('get_students_features', {}),
-            ('get_student_progress_url', {'unique_student_identifier': self.user.username}),
             ('reset_student_attempts',
              {'problem_to_reset': self.problem_urlname, 'unique_student_identifier': self.user.email}),
             ('update_forum_role_membership',
@@ -3082,6 +3080,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
     def test_get_student_progress_url(self):
         """ Test that progress_url is in the successful response. """
+        # TODO TNL-5047: this endpoint no longer exists, use a masquerade
         url = reverse('get_student_progress_url', kwargs={'course_id': self.course.id.to_deprecated_string()})
         data = {'unique_student_identifier': self.students[0].email.encode("utf-8")}
         response = self.client.post(url, data)
@@ -3091,6 +3090,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
     def test_get_student_progress_url_from_uname(self):
         """ Test that progress_url is in the successful response. """
+        # TODO TNL-5047: this endpoint no longer exists, use a masquerade
         url = reverse('get_student_progress_url', kwargs={'course_id': self.course.id.to_deprecated_string()})
         data = {'unique_student_identifier': self.students[0].username.encode("utf-8")}
         response = self.client.post(url, data)
@@ -3100,12 +3100,14 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
     def test_get_student_progress_url_noparams(self):
         """ Test that the endpoint 404's without the required query params. """
+        # TODO TNL-5047: this endpoint no longer exists, use a masquerade
         url = reverse('get_student_progress_url', kwargs={'course_id': self.course.id.to_deprecated_string()})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
 
     def test_get_student_progress_url_nostudent(self):
         """ Test that the endpoint 400's when requesting an unknown email. """
+        # TODO TNL-5047: this endpoint no longer exists, use a masquerade
         url = reverse('get_student_progress_url', kwargs={'course_id': self.course.id.to_deprecated_string()})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1875,36 +1875,6 @@ def get_anon_ids(request, course_id):  # pylint: disable=unused-argument
     return csv_response(course_id.to_deprecated_string().replace('/', '-') + '-anon-ids.csv', header, rows)
 
 
-@require_POST
-@ensure_csrf_cookie
-@cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@common_exceptions_400
-@require_level('staff')
-@require_post_params(
-    unique_student_identifier="email or username of student for whom to get progress url"
-)
-def get_student_progress_url(request, course_id):
-    """
-    Get the progress url of a student.
-    Limited to staff access.
-
-    Takes query parameter unique_student_identifier and if the student exists
-    returns e.g. {
-        'progress_url': '/../...'
-    }
-    """
-    course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
-    user = get_student_from_identifier(request.POST.get('unique_student_identifier'))
-
-    progress_url = reverse('student_progress', kwargs={'course_id': course_id.to_deprecated_string(), 'student_id': user.id})
-
-    response_payload = {
-        'course_id': course_id.to_deprecated_string(),
-        'progress_url': progress_url,
-    }
-    return JsonResponse(response_payload)
-
-
 @transaction.non_atomic_requests
 @require_POST
 @ensure_csrf_cookie

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -37,8 +37,6 @@ urlpatterns = patterns(
         'lms.djangoapps.instructor.views.api.sale_validation', name="sale_validation"),
     url(r'^get_anon_ids$',
         'lms.djangoapps.instructor.views.api.get_anon_ids', name="get_anon_ids"),
-    url(r'^get_student_progress_url$',
-        'lms.djangoapps.instructor.views.api.get_student_progress_url', name="get_student_progress_url"),
     url(r'^reset_student_attempts$',
         'lms.djangoapps.instructor.views.api.reset_student_attempts', name="reset_student_attempts"),
     url(

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -529,7 +529,6 @@ def _section_student_admin(course, access):
         'section_display_name': _('Student Admin'),
         'access': access,
         'is_small_course': is_small_course,
-        'get_student_progress_url_url': reverse('get_student_progress_url', kwargs={'course_id': unicode(course_key)}),
         'enrollment_url': reverse('students_update_enrollment', kwargs={'course_id': unicode(course_key)}),
         'reset_student_attempts_url': reverse('reset_student_attempts', kwargs={'course_id': unicode(course_key)}),
         'reset_student_attempts_for_entrance_exam_url': reverse(

--- a/lms/static/js/fixtures/instructor_dashboard/student_admin.html
+++ b/lms/static/js/fixtures/instructor_dashboard/student_admin.html
@@ -15,6 +15,7 @@
 </div>
 
 <div class="student-specific-container action-type-container">
+  <!-- TODO: TNL-5047 kill this link-->
   <h2>Student-specific grade inspection</h2>
   <div class="request-response-error"></div>
   <br>

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -20,7 +20,7 @@ if active_page is None and active_page_context is not UNDEFINED:
 def selected(is_selected):
   return "selected" if is_selected else ""
 
-show_preview_menu = not disable_preview_menu and staff_access and active_page in ["courseware", "info"]
+show_preview_menu = not disable_preview_menu and staff_access and active_page in ["courseware", "info", "progress"]
 cohorted_user_partition = get_cohorted_user_partition(course)
 masquerade_user_name = masquerade.user_name if masquerade else None
 masquerade_group_id = masquerade.group_id if masquerade else None

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -25,6 +25,7 @@
     <br><br>
     <div class="progress-link-wrapper">
         <span name="progress-link">
+            <!---TODO: TNL-5047 kill this link-->
             <a href="" class="progress-link" data-endpoint="${ section_data['get_student_progress_url_url'] }">
                 ${_("View Progress Page")}
             </a>

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -417,15 +417,6 @@ urlpatterns += (
         name='progress',
     ),
 
-    # Takes optional student_id for instructor use--shows profile as that student sees it.
-    url(
-        r'^courses/{}/progress/(?P<student_id>[^/]*)/$'.format(
-            settings.COURSE_ID_PATTERN,
-        ),
-        'courseware.views.views.progress',
-        name='student_progress',
-    ),
-
     url(
         r'^programs/{}/about'.format(
             r'(?P<program_uuid>[0-9a-f-]+)',


### PR DESCRIPTION
# [TNL-5047](https://openedx.atlassian.net/browse/TNL-5047)

This PR is a follow-up to https://github.com/edx/edx-platform/pull/14641. Once that PR has merged and course teams are aware that masquerading the progress page is the way to inspect single-learner grades, take up the changes I've already made/marked with `TODO` in this PR to eliminate the old instructor dashboard `student_progress` feature.