### PR TITLE
Discussion Selector fixes. 

### DIFF
--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -136,8 +136,8 @@
                 title = this.$('.js-post-title').val();
                 body = this.$('.js-post-body').find('.wmd-input').val();
                 group = this.$('.js-group-select option:selected').attr('value');
-                anonymous = false || this.$('.js-anon').is(':checked');
-                anonymousToPeers = false || this.$('.js-anon-peers').is(':checked');
+                anonymous = false || this.$('input[name=anonymous]').is(':checked');
+                anonymousToPeers = false || this.$('input[name=anonymous_to_peers]').is(':checked');
                 follow = false || this.$('input[name=follow]').is(':checked');
                 topicId = this.isTabMode() ? this.topicView.getCurrentTopicId() : this.topicId;
                 url = DiscussionUtil.urlFor('create_thread', topicId);


### PR DESCRIPTION
I have fixed a selector which was updated in https://github.com/edx/edx-platform/pull/14467

This is affecting all the courses. @adampalay  the tests were already been updated in the mentioned PR.
 [TNL-6648](https://openedx.atlassian.net/browse/TNL-6648)

### How to Test?

**Stage** 
1. Login to stage
2. Go to the discussion and add a new post. https://courses.stage.edx.org/courses/course-v1:MattX+CS-123+2016_t1/discussion/forum/
3. Create a new post and click **post anonymously**.
4. Observe post is not posted anonymously. 


**Sandbox**
[anon.sandbox.edx.org](https://anon.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/)

**Screenshots**
Add screenshots before/after the fix.
Before
![screen shot 2017-03-07 at 11 03 05 am](https://cloud.githubusercontent.com/assets/4252738/23643838/f96f5ecc-0325-11e7-9f92-819ac22b6f55.jpg)

After
![screen shot 2017-03-07 at 11 03 15 am](https://cloud.githubusercontent.com/assets/4252738/23643839/f972b91e-0325-11e7-9dc3-165e299094bb.jpg)



### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @noraiz-anwar 
- [x] Code review: @noraiz-anwar 
- [x] Code review: @attiyaIshaque 

FYI: @andy-armstrong @bjacobel @alisan617

### Post-review
- [x] Rebase and squash commits
