### PR TITLE
Fix get xblock settings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -279,3 +279,4 @@ Jhony Avella <jhony.avella@edunext.co>
 Tanmay Mohapatra <tanmaykm@gmail.com>
 Brian Mesick <bmesick@edx.org>
 Jeff LaJoie <jlajoie@edx.org>
+Ivan Ivić <iivic@edx.org>

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -51,6 +51,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.draft_and_published import DIRECT_ONLY_CATEGORIES
 from xmodule.modulestore.exceptions import ItemNotFoundError, InvalidLocationError
 from xmodule.modulestore.inheritance import own_metadata
+from xmodule.services import SettingsService
 from xmodule.tabs import CourseTabList
 from xmodule.x_module import PREVIEW_VIEWS, STUDIO_VIEW, STUDENT_VIEW, DEPRECATION_VSCOMPAT_EVENT
 
@@ -266,6 +267,8 @@ class StudioEditModuleRuntime(object):
                 return DjangoXBlockUserService(self._user)
             if service_name == "studio_user_permissions":
                 return StudioPermissionsService(self._user)
+            if service_name == "settings":
+                return SettingsService()
         return None
 
 

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -48,6 +48,9 @@ update_module_store_settings(
     default_store=os.environ.get('DEFAULT_STORE', 'draft'),
 )
 
+# Needed to enable licensing on video modules
+XBLOCK_SETTINGS.update({'VideoDescriptor': {'licensing_enabled': True}})
+
 ############################ STATIC FILES #############################
 
 # Enable debug so that static assets are served by Django

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -109,11 +109,7 @@ FEATURES['ENTRANCE_EXAMS'] = True
 ################################ COURSE LICENSES ################################
 FEATURES['LICENSING'] = True
 # Needed to enable licensing on video modules
-XBLOCK_SETTINGS = {
-    "VideoDescriptor": {
-        "licensing_enabled": True
-    }
-}
+XBLOCK_SETTINGS.update({'VideoDescriptor': {'licensing_enabled': True}})
 
 ################################ SEARCH INDEX ################################
 FEATURES['ENABLE_COURSEWARE_INDEX'] = True


### PR DESCRIPTION
After the `XBlock` was extended with `XBlockWithSettingsMixin` and the settings required with `@XBlock.needs('settings')` we should be able to call `self.get_xblock_settings()` and acquire the settings but this is currently not working because the setting service is not available in the studio edit modal (it works in the student preview window).

I noticed that the `XBLOCK_SETTINGS` was declared in the `devstack.py` file instead of being updated. This disabled the `XBlock` to retrieve the settings.

This PR should fix the mentioned issues.