### PR TITLE
TNL-6639 Add timeout in request to xqueue

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -8,6 +8,7 @@ Tests of the Capa XModule
 import datetime
 import json
 import random
+import requests
 import os
 import textwrap
 import unittest
@@ -241,6 +242,22 @@ class CapaModuleTest(unittest.TestCase):
         # not visible.
         problem = CapaFactory.create()
         self.assertFalse(problem.answer_available())
+
+    @ddt.data(
+        (requests.exceptions.ReadTimeout, (1, 'failed to read from the server')),
+        (requests.exceptions.ConnectionError, (1, 'cannot connect to server')),
+    )
+    @ddt.unpack
+    def test_xqueue_request_exception(self, exception, result):
+        """
+        Makes sure that platform will raise appropriate exception in case of
+        connect/read timeout(s) to request to xqueue
+        """
+        xqueue_interface = XQueueInterface("http://example.com/xqueue", Mock())
+        with patch.object(xqueue_interface.session, 'post', side_effect=exception):
+            # pylint: disable = protected-access
+            response = xqueue_interface._http_post('http://some/fake/url', {})
+            self.assertEqual(response, result)
 
     def test_showanswer_attempted(self):
         problem = CapaFactory.create(showanswer='attempted')

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -818,7 +818,7 @@ class ProblemWithUploadedFilesTest(TestSubmittingProblems):
         self.assertEqual(name, "post")
         self.assertEqual(len(args), 1)
         self.assertTrue(args[0].endswith("/submit/"))
-        self.assertItemsEqual(kwargs.keys(), ["files", "data"])
+        self.assertItemsEqual(kwargs.keys(), ["files", "data", "timeout"])
         self.assertItemsEqual(kwargs['files'].keys(), filenames.split())
 
 


### PR DESCRIPTION
## [TNL-6639](https://openedx.atlassian.net/browse/TNL-6639)

### Description

We've had a couple of xqueue outages this week which caused cascading failures in the LMS. One of the major contributors to the LMS issues was the lack of timeouts when making requests to XQueue. This tied up worker processes until we exhausted the pool, and also caused locking issues on CSM.
To fix this, all calls to requests.get/post/put/delete to xqueue should specify timeout values for both the initial connection as well as the response.

### Fix

Add timeouts to requests to xqueue:
connect timeout: 3.05
read timeout: 10

### How to Test?
In case of timeouts, raised timeout exceptions are properly handled

FYI: @adampalay 

### Post-review
- [ ] Rebase and squash commits