### PR TITLE
Disable Django API browser

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2187,6 +2187,9 @@ CSRF_COOKIE_SECURE = False
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'openedx.core.lib.api.paginators.DefaultPagination',
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    ),
     'PAGE_SIZE': 10,
     'URL_FORMAT_OVERRIDE': None,
     'DEFAULT_THROTTLE_RATES': {

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -166,7 +166,7 @@ nose-exclude
 nose-ignore-docstring
 nose-randomly==1.2.0
 nosexcover==1.0.7
-pa11ycrawler==1.6.1
+pa11ycrawler==1.6.2
 pep8==1.5.7
 PyContracts==1.7.1
 python-subunit==0.0.16


### PR DESCRIPTION
## Overview

This code was originally introduced here: https://github.com/edx/edx-platform/pull/14552/files#diff-82bda515879c96ab0641bfcbe58631c3 

However, due to a11y build failures, the change was temporarily reverted. Now, with the help of this PR ( https://github.com/edx/pa11ycrawler/pull/71 ), pa11ycrawler can now parse JSON and no longer relies on the API Browser.

## Build Results Comparison

A platform build with the current version of Platform/ Pa11ycrawler can be found here: https://test-jenkins.testeng.edx.org/job/michaelyoungstrom-pa11y-jenkins/31/HTML_Report/

Here is the HTML result when enabling pa11ycrawler on this PR: https://build.testeng.edx.org/job/edx-platform-accessibility-pr/31636/artifact/edx-platform/reports/pa11ycrawler/html/index.html