### PR TITLE
Add logging for user cookie send for sailthru

### DIFF
--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -59,6 +59,11 @@ def add_email_marketing_cookies(sender, response=None, user=None,
 
     try:
         sailthru_client = SailthruClient(email_config.sailthru_key, email_config.sailthru_secret)
+        log.info(
+            'Sending to Sailthru the user interest cookie [%s] for user [%s]',
+            post_parms.get('cookies', ''),
+            user.email
+        )
         sailthru_response = \
             sailthru_client.api_post("user", post_parms)
     except SailthruClientError as exc:


### PR DESCRIPTION
ECOM-6327

Want to log what is the cookie we send to sailthru as a new user registers.

@edx/ecommerce Please help review