### PR TITLE
TNL-5461. Discussion breadcrumbs update after clicking "All topics".

### DIFF
--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -288,6 +288,33 @@ class DiscussionNavigationTest(BaseDiscussionTestCase):
         self.thread_page.q(css=".breadcrumbs .nav-item")[0].click()
         self.assertEqual(len(self.thread_page.q(css=".breadcrumbs .nav-item")), 1)
 
+    def test_breadcrumbs_toggle_browser_menu(self):
+        """
+        Scenario: If click the "All Topics" breadcrumb twice,
+            navigating away and back to a particular topic,
+            the breadcrumb is restored to that of the last topic.
+        """
+        topic_button = self.thread_page.q(
+            css=".forum-nav-browse-menu-item[data-discussion-id='{}']".format(self.discussion_id)
+        )
+        self.assertTrue(topic_button.visible)
+        self.assertEqual(len(self.thread_page.q(css=".breadcrumbs .nav-item")), 1)
+
+        topic_button.click()
+        self.assertEqual(len(self.thread_page.q(css=".breadcrumbs .nav-item")), 2)
+        self.assertEqual(self.thread_page.q(
+            css=".breadcrumbs .nav-item")[1].text, 'Test Discussion Topic')
+
+        # Verify clicking the first breadcrumb takes you back to all topics
+        self.thread_page.q(css=".breadcrumbs .nav-item")[0].click()
+        self.assertEqual(len(self.thread_page.q(css=".breadcrumbs .nav-item")), 1)
+
+        # Verify again clicking the first breadcrumb takes you back to previoulsy loaded topic
+        topic_button.click()
+        self.assertEqual(self.thread_page.q(
+            css=".breadcrumbs .nav-item")[1].text, 'Test Discussion Topic')
+        self.assertEqual(len(self.thread_page.q(css=".breadcrumbs .nav-item")), 2)
+
     def test_breadcrumbs_clear_search(self):
         self.thread_page.q(css=".search-input").fill("search text")
         self.thread_page.q(css=".search-btn").click()

--- a/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
+++ b/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
@@ -110,14 +110,15 @@
                 event.preventDefault();
                 event.stopPropagation();
                 if (this.isBrowseMenuVisible()) {
+                    this.breadcrumbs.model.set('contents', [this.breadcrumItem]);
                     this.hideBrowseMenu();
                 } else {
                     if (inputText !== '') {
                         this.filterTopics(inputText);
                     }
                     this.showBrowseMenu();
+                    this.breadcrumbs.model.set('contents', []);
                 }
-                this.breadcrumbs.model.set('contents', []);
                 this.clearSearch();
             },
 
@@ -304,7 +305,8 @@
                 var $item = $(event.target).closest('.forum-nav-browse-menu-item');
                 event.preventDefault();
                 this.hideBrowseMenu();
-                this.trigger('topic:selected', this.getBreadcrumbText($item));
+                this.breadcrumItem = this.getBreadcrumbText($item);
+                this.trigger('topic:selected', this.breadcrumItem);
                 return this.discussionThreadListView.selectTopic($(event.target));
             },
 


### PR DESCRIPTION
## [Discussion breadcrumbs not updated - TNL-5461](https://openedx.atlassian.net/browse/TNL-5461)

### Description
This PR fixes the discussion breadcrumbs that is updated after clicking "All Topics" twice.


### How to Test?

**Stage** 

1. Login to stage.
2. Go to the discussion https://courses.stage.edx.org/courses/course-v1:edx+CS101+2017_T1/discussion/forum/
3.  Navigate to particular topic i.e _**General**_ (topic displayed in breadcrumb) 
4. Click _**All Topics**_ to get back to full topic list 
5. Click _**All Topics**_ again to get back to the earlier individual topic 
6. Breadcrumb should show individual topic again

**Sandbox**
- https://tnl-5461.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Style and readability review: @asadazam93 
- [ ] Code review: @noraiz-anwar 
- [ ] Code review: @alisan617 

FYI: @awaisdar001 
### Post-review
- [ ] Rebase and squash commits