### PR TITLE
Adds ENTERPRISE_PUBLIC_ENROLLMENT_API_URL to settings

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -904,7 +904,15 @@ DOC_LINK_BASE_URL = ENV_TOKENS.get('DOC_LINK_BASE_URL', DOC_LINK_BASE_URL)
 
 ############## Settings for the Enterprise App ######################
 
+# Publicly-accessible enrollment URL, for use on the client side.
+ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = ENV_TOKENS.get(
+    'ENTERPRISE_PUBLIC_ENROLLMENT_API_URL',
+    (LMS_ROOT_URL or '') + '/api/enrollment/v1/'
+)
+
+# Enrollment URL used on the server-side.
+# If not overridden in ENV_TOKENS, then fallback to the value set in env/common.py
 ENTERPRISE_ENROLLMENT_API_URL = ENV_TOKENS.get(
     'ENTERPRISE_ENROLLMENT_API_URL',
-    (LMS_ROOT_URL or '') + '/api/enrollment/v1/'
+    ENTERPRISE_ENROLLMENT_API_URL
 )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3062,3 +3062,4 @@ DOC_LINK_BASE_URL = None
 ############## Settings for the Enterprise App ######################
 
 ENTERPRISE_ENROLLMENT_API_URL = LMS_ROOT_URL + "/api/enrollment/v1/"
+ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = ENTERPRISE_ENROLLMENT_API_URL

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.27.3
+edx-enterprise==0.27.4
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.3


### PR DESCRIPTION
cf https://github.com/edx/edx-enterprise/pull/67

* `ENTERPRISE_PUBLIC_ENROLLMENT_API_URL`'s hostname uses the ENV-configured, fully-qualified `LMS_ROOT_URL`, so it can be used when making external, client-side requests to the Enrollment API.
* `ENTERPRISE_ENROLLMENT_API_URL`'s hostname uses `localhost:8000`, for use when making internal, server-side requests to the Enrollment API.

**Sandbox URL**:

* LMS: https://pr14671.sandbox.opencraft.hosting/
* Studio: https://studio-pr14671.sandbox.opencraft.hosting/

Running 036715c

**Deployment targets**: edx.org and edge.edx.org

**Testing Instructions:**

See https://github.com/edx/edx-enterprise/pull/67

**Reviewers**:

- [x] @haikuginger 
- [x] @mattdrayer 