### PR TITLE
Safer "make clean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 # Do things in edx-platform
 
+# Careful with mktemp syntax: it has to work on Mac and Ubuntu, which have differences.
+PRIVATE_FILES := $(shell mktemp -u /tmp/private_files.XXXXXX)
+
 clean:
 	# Remove all the git-ignored stuff, but save and restore things marked
-	# by start-noclean/end-noclean.
+	# by start-noclean/end-noclean. Include Makefile in the tarball so that
+	# there's always at least one file even if there are no private files.
 	sed -n -e '/start-noclean/,/end-noclean/p' < .gitignore > /tmp/private-files
-	tar cf /tmp/private.tar `git ls-files --exclude-from=/tmp/private-files --ignored --others`
-	git clean -fdX
-	tar xf /tmp/private.tar
+	-tar cf $(PRIVATE_FILES) Makefile `git ls-files --exclude-from=/tmp/private-files --ignored --others`
+	-git clean -fdX
+	tar xf $(PRIVATE_FILES)
+	rm $(PRIVATE_FILES)


### PR DESCRIPTION
This would fail if the "git clean" step failed, and would not restore
your private files. Running it again would then fail to make an empty
tarball, clobbering the saved private files.  Now we are more resilient
to a number of failure modes.