### PR TITLE
Fix duplicated ids in discussion action menus

### DIFF
--- a/common/static/common/templates/discussion/forum-actions.underscore
+++ b/common/static/common/templates/discussion/forum-actions.underscore
@@ -1,13 +1,13 @@
 <% if (!readOnly) { %>
-    <ul class="<%= contentType %>-actions-list">
+    <ul class="<%- contentType %>-actions-list">
         <% _.each(primaryActions, function(action) { print(_.template($('#forum-action-' + action).html())({})) }) %>
         <li class="actions-item is-visible">
             <div class="more-wrapper">
-                <button class="btn-link action-button action-more" aria-label="<%- gettext('More') %>" aria-haspopup="true" aria-controls="action-menu-<%= contentType %>-<%= contentId %>">
+                <button class="btn-link action-button action-more" aria-label="<%- gettext('More') %>" aria-haspopup="true" aria-controls="action-menu-<%- contentType %>-<%- contentId %>">
                     <span class="action-label"><%- gettext('More') %></span>
                     <span class="action-icon"><span class="icon fa fa-ellipsis-h" aria-hidden="true"></span></span>
                 </button>
-                <div class="actions-dropdown" id="action-menu-<%= contentType %>-<%= contentId %>" aria-expanded="false">
+                <div class="actions-dropdown" id="action-menu-<%- contentType %>-<%- contentId %>" aria-expanded="false">
                   <ul class="actions-dropdown-list">
                     <% _.each(secondaryActions, function(action) { print(_.template($('#forum-action-' + action).html())({})) }) %>
                   </ul>

--- a/common/static/common/templates/discussion/forum-actions.underscore
+++ b/common/static/common/templates/discussion/forum-actions.underscore
@@ -3,11 +3,11 @@
         <% _.each(primaryActions, function(action) { print(_.template($('#forum-action-' + action).html())({})) }) %>
         <li class="actions-item is-visible">
             <div class="more-wrapper">
-                <button class="btn-link action-button action-more" aria-label="<%- gettext('More') %>" aria-haspopup="true" aria-controls="action-menu-<%= contentType %>">
+                <button class="btn-link action-button action-more" aria-label="<%- gettext('More') %>" aria-haspopup="true" aria-controls="action-menu-<%= contentType %>-<%= contentId %>">
                     <span class="action-label"><%- gettext('More') %></span>
                     <span class="action-icon"><span class="icon fa fa-ellipsis-h" aria-hidden="true"></span></span>
                 </button>
-                <div class="actions-dropdown" id="action-menu-<%= contentType %>" aria-expanded="false">
+                <div class="actions-dropdown" id="action-menu-<%= contentType %>-<%= contentId %>" aria-expanded="false">
                   <ul class="actions-dropdown-list">
                     <% _.each(secondaryActions, function(action) { print(_.template($('#forum-action-' + action).html())({})) }) %>
                   </ul>


### PR DESCRIPTION
## [TNL-6583](https://openedx.atlassian.net/browse/TNL-6583)

### Description
Appends a unique string to an id used for accessibility in the Discussions post/comment action menu.

### Sandbox
I'm not going to do a sandbox for this one unless someone really wants to see one because it's so small.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- @robrap 
- @alisan617 