### PR TITLE
TNL-6011: Removes onChange save for dropdowns

### DIFF
--- a/common/test/acceptance/pages/lms/fields.py
+++ b/common/test/acceptance/pages/lms/fields.py
@@ -192,7 +192,7 @@ class FieldsMixin(object):
 
         return self.q(css='.u-field-{} .u-field-value .u-field-value-readonly'.format(field_id)).text[0]
 
-    def value_for_dropdown_field(self, field_id, value=None):
+    def value_for_dropdown_field(self, field_id, value=None, focus_out=False):
         """
         Get or set the value in a dropdown field.
         """
@@ -205,7 +205,7 @@ class FieldsMixin(object):
             return None
 
         if value is not None:
-            select_option_by_text(query, value)
+            select_option_by_text(query, value, focus_out)
 
         if self.mode_for_field(field_id) == 'edit':
             return get_selected_option_text(query)

--- a/common/test/acceptance/pages/lms/learner_profile.py
+++ b/common/test/acceptance/pages/lms/learner_profile.py
@@ -8,10 +8,12 @@ from bok_choy.page_object import PageObject
 from common.test.acceptance.pages.lms.fields import FieldsMixin
 from bok_choy.promise import EmptyPromise
 from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage
+from common.test.acceptance.tests.helpers import select_option_by_value
 from selenium.webdriver import ActionChains
 
 
 PROFILE_VISIBILITY_SELECTOR = '#u-field-select-account_privacy option[value="{}"]'
+PROFILE_VISIBILITY_INPUT = '#u-field-select-account_privacy'
 FIELD_ICONS = {
     'country': 'fa-map-marker',
     'language_proficiencies': 'fa-comment',
@@ -146,7 +148,8 @@ class LearnerProfilePage(FieldsMixin, PageObject):
         self.wait_for_element_visibility('select#u-field-select-account_privacy', 'Privacy dropdown is visible')
 
         if privacy != self.privacy:
-            self.q(css=PROFILE_VISIBILITY_SELECTOR.format(privacy)).first.click()
+            query = self.q(css=PROFILE_VISIBILITY_INPUT)
+            select_option_by_value(query, privacy, focus_out=True)
             EmptyPromise(lambda: privacy == self.privacy, 'Privacy is set to {}'.format(privacy)).fulfill()
             self.wait_for_ajax()
 

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -26,6 +26,7 @@ from openedx.core.lib.tests.assertions.events import assert_event_matches, is_ma
 from xmodule.partitions.partitions import UserPartition
 from xmodule.partitions.tests.test_partitions import MockUserPartitionScheme
 from selenium.common.exceptions import StaleElementReferenceException
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -213,7 +214,7 @@ def enable_css_animations(page):
     """)
 
 
-def select_option_by_text(select_browser_query, option_text):
+def select_option_by_text(select_browser_query, option_text, focus_out=False):
     """
     Chooses an option within a select by text (helper method for Select's select_by_visible_text method).
 
@@ -225,6 +226,8 @@ def select_option_by_text(select_browser_query, option_text):
         try:
             select = Select(query.first.results[0])
             select.select_by_visible_text(value)
+            if focus_out:
+                query.first.results[0].send_keys(Keys.TAB)
             return True
         except StaleElementReferenceException:
             return False
@@ -267,7 +270,7 @@ def generate_course_key(org, number, run):
     return CourseLocator(org, number, run, deprecated=(default_store == 'draft'))
 
 
-def select_option_by_value(browser_query, value):
+def select_option_by_value(browser_query, value, focus_out=False):
     """
     Selects a html select element by matching value attribute
     """
@@ -288,9 +291,10 @@ def select_option_by_value(browser_query, value):
                 if not opt.is_selected():
                     all_options_selected = False
                     opt.click()
-        # if value is not an option choice then it should return false
         if all_options_selected and not has_option:
             all_options_selected = False
+        if focus_out:
+            browser_query.first.results[0].send_keys(Keys.TAB)
         return all_options_selected
 
     # Make sure specified option is actually selected

--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -226,10 +226,13 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
         Test behaviour of a dropdown field.
         """
         self.assertEqual(self.account_settings_page.title_for_field(field_id), title)
-        self.assertEqual(self.account_settings_page.value_for_dropdown_field(field_id), initial_value)
+        self.assertEqual(self.account_settings_page.value_for_dropdown_field(field_id, focus_out=True), initial_value)
 
         for new_value in new_values:
-            self.assertEqual(self.account_settings_page.value_for_dropdown_field(field_id, new_value), new_value)
+            self.assertEqual(
+                self.account_settings_page.value_for_dropdown_field(field_id, new_value, focus_out=True),
+                new_value
+            )
             # An XHR request is made when changing the field
             self.account_settings_page.wait_for_ajax()
             if reloads_on_save:
@@ -237,7 +240,7 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
             else:
                 self.browser.refresh()
                 self.account_settings_page.wait_for_page()
-            self.assertEqual(self.account_settings_page.value_for_dropdown_field(field_id), new_value)
+            self.assertEqual(self.account_settings_page.value_for_dropdown_field(field_id, focus_out=True), new_value)
 
     def _test_link_field(self, field_id, title, link_title, field_type, success_message):
         """
@@ -387,7 +390,7 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
         Test behaviour of "Year of Birth" field.
         """
         # Note that when we clear the year_of_birth here we're firing an event.
-        self.assertEqual(self.account_settings_page.value_for_dropdown_field('year_of_birth', ''), '')
+        self.assertEqual(self.account_settings_page.value_for_dropdown_field('year_of_birth', '', focus_out=True), '')
 
         expected_events = [
             self.expected_settings_changed_event('year_of_birth', None, 1980),

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -44,8 +44,8 @@ class LearnerProfileTestMixin(EventsTestMixin):
         """
         Fill in the public profile fields of a user.
         """
-        profile_page.value_for_dropdown_field('language_proficiencies', 'English')
-        profile_page.value_for_dropdown_field('country', 'United Arab Emirates')
+        profile_page.value_for_dropdown_field('language_proficiencies', 'English', focus_out=True)
+        profile_page.value_for_dropdown_field('country', 'United Arab Emirates', focus_out=True)
         profile_page.set_value_for_textarea_field('bio', 'Nothing Special')
         # Waits here for text to appear/save on bio field
         profile_page.wait_for_ajax()
@@ -91,7 +91,7 @@ class LearnerProfileTestMixin(EventsTestMixin):
         account_settings_page.visit()
         account_settings_page.wait_for_page()
         self.assertEqual(
-            account_settings_page.value_for_dropdown_field('year_of_birth', str(birth_year)),
+            account_settings_page.value_for_dropdown_field('year_of_birth', str(birth_year), focus_out=True),
             str(birth_year)
         )
 
@@ -322,7 +322,7 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, AcceptanceTest):
         """
         Test behaviour of a dropdown field.
         """
-        profile_page.value_for_dropdown_field(field_id, new_value)
+        profile_page.value_for_dropdown_field(field_id, new_value, focus_out=True)
         self.assertEqual(profile_page.get_non_editable_mode_value(field_id), displayed_value)
         self.assertTrue(profile_page.mode_for_field(field_id), mode)
 

--- a/lms/static/js/spec/student_account/account_settings_fields_spec.js
+++ b/lms/static/js/spec/student_account/account_settings_fields_spec.js
@@ -86,6 +86,7 @@ define(['backbone',
 
                 // change country
                 countryView.$(baseSelector).val(countryChange[countryData.valueAttribute]).change();
+                countryView.$(baseSelector).focusout();
                 FieldViewsSpecHelpers.expectAjaxRequestWithData(requests, countryChange);
                 AjaxHelpers.respondWithJson(requests, {success: 'true'});
 
@@ -106,6 +107,7 @@ define(['backbone',
 
                 // select time zone option from option
                 timeZoneView.$(baseSelector).val(timeZoneChange[timeZoneData.valueAttribute]).change();
+                timeZoneView.$(baseSelector).focusout();
                 FieldViewsSpecHelpers.expectAjaxRequestWithData(requests, timeZoneChange);
                 AjaxHelpers.respondWithJson(requests, {success: 'true'});
                 timeZoneView.render();
@@ -130,6 +132,7 @@ define(['backbone',
 
                 var data = {'language': FieldViewsSpecHelpers.SELECT_OPTIONS[2][0]};
                 view.$(selector).val(data[fieldData.valueAttribute]).change();
+                view.$(selector).focusout();
                 FieldViewsSpecHelpers.expectAjaxRequestWithData(requests, data);
                 AjaxHelpers.respondWithNoContent(requests);
 
@@ -144,6 +147,7 @@ define(['backbone',
 
                 data = {'language': FieldViewsSpecHelpers.SELECT_OPTIONS[1][0]};
                 view.$(selector).val(data[fieldData.valueAttribute]).change();
+                view.$(selector).focusout();
                 FieldViewsSpecHelpers.expectAjaxRequestWithData(requests, data);
                 AjaxHelpers.respondWithNoContent(requests);
 
@@ -177,6 +181,7 @@ define(['backbone',
 
                 var data = {'language_proficiencies': [{'code': FieldViewsSpecHelpers.SELECT_OPTIONS[1][0]}]};
                 view.$(selector).val(FieldViewsSpecHelpers.SELECT_OPTIONS[1][0]).change();
+                view.$(selector).focusout();
                 FieldViewsSpecHelpers.expectAjaxRequestWithData(requests, data);
                 AjaxHelpers.respondWithNoContent(requests);
             });

--- a/lms/static/js/spec/views/fields_helpers.js
+++ b/lms/static/js/spec/views/fields_helpers.js
@@ -184,6 +184,7 @@ define(['backbone',
             }
 
             view.$(data.valueInputSelector).val(data.validValue).change();
+            view.$(data.valueInputSelector).focusout();
             // When the value in the field is changed
             expect(view.fieldValue()).toBe(data.validValue);
             expectMessageContains(view, view.indicators.inProgress);
@@ -203,6 +204,7 @@ define(['backbone',
             }
 
             view.$(data.valueInputSelector).val(data.invalidValue1).change();
+            view.$(data.valueInputSelector).focusout();
             request_data[data.valueAttribute] = data.invalidValue1;
             AjaxHelpers.expectJsonRequest(
                 requests, 'PATCH', url, request_data
@@ -214,6 +216,7 @@ define(['backbone',
             expect(view.el).toHaveClass('mode-edit');
 
             view.$(data.valueInputSelector).val(data.invalidValue2).change();
+            view.$(data.valueInputSelector).focusout();
             request_data[data.valueAttribute] = data.invalidValue2;
             AjaxHelpers.expectJsonRequest(
                 requests, 'PATCH', url, request_data
@@ -225,6 +228,7 @@ define(['backbone',
             expect(view.el).toHaveClass('mode-edit');
 
             view.$(data.valueInputSelector).val('').change();
+            view.$(data.valueInputSelector).focusout();
             // When the value in the field is changed
             expect(view.fieldValue()).toBe(data.defaultValue);
             request_data[data.valueAttribute] = data.defaultValue;

--- a/lms/static/js/spec/views/fields_spec.js
+++ b/lms/static/js/spec/views/fields_spec.js
@@ -231,6 +231,7 @@ define(['backbone', 'jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helper
                     }
                     expect(view.$(dropdownSelectClass).length).toBe(1);
                     view.$(dropdownSelectClass).val(FieldViewsSpecHelpers.SELECT_OPTIONS[0]).change();
+                    view.$(dropdownSelectClass).focusout();
                     expect(view.fieldValue()).toBe(FieldViewsSpecHelpers.SELECT_OPTIONS[0][0]);
 
                     AjaxHelpers.respondWithNoContent(requests);

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -364,7 +364,6 @@
 
             events: {
                 'click': 'startEditing',
-                'change select': 'finishEditing',
                 'focusout select': 'finishEditing'
             },
 


### PR DESCRIPTION
## [TNL-6011](https://openedx.atlassian.net/browse/TNL-6011)

### Description

This disables the onChange event listener for the select box. Windows keyboard users were unable to effectively use their keyboard to navigate the selects as the onChange event fired a save after every key input. What this does is no longer save when selecting an option and instead waits for the user to lose focus of the selected element. 

FYI for @cptvitamin I timeboxed an attempt to investigate adding onkeypress, and onclick to the internal option tags. Chrome did not support either, IE and Firefox only support onclick but did not register the event for keyboard users with Space or Enter, and adding the listeners to select only work when the dropdown is not open. I think the best way to get this functionality would be to write a custom implementation of a select-like menu.

These changes impacts the /account/settings page as well as /u/USERNAME page. Testing in IE can be done by setting up a VirtualBox image from https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/.

### Sandbox
- [x] http://jlajoie.sandbox.edx.org

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @staubina
- [ ] Code review: @cahrens
- [x] Accessibility review: @cptvitamin 

### Post-review
- [x] Rebase and squash commits