### PR TITLE
backend changes to support hls

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -78,7 +78,7 @@ git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 git+https://github.com/edx/edx-ora2.git@1.2.2#egg=ora2==1.2.2
 -e git+https://github.com/edx/edx-submissions.git@1.1.5#egg=edx-submissions==1.1.5
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
-git+https://github.com/edx/edx-val.git@0.0.12#egg=edxval==0.0.12
+git+https://github.com/edx/edx-val.git@0.0.13#egg=edxval==0.0.13
 git+https://github.com/pmitros/RecommenderXBlock.git@v1.1#egg=recommender-xblock==1.1
 git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock


### PR DESCRIPTION
[TNL-6541](https://openedx.atlassian.net/browse/TNL-6541)
[edxval PR](https://github.com/edx/edx-val/pull/69)

[Sandbox](https://studio-hls-backend.sandbox.edx.org) 

These changes are part of an ongoing work to support `HLS` playback in video player.
* Request `hls` profile url from edx-val alongwith existing profiles.
* Exclude `HLS` video urls from downloading 