### PR TITLE
All modes are valid bulk email targets

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -637,7 +637,7 @@ def _section_send_email(course, access):
     course_modes = []
     from verified_track_content.models import VerifiedTrackCohortedCourse
     if not VerifiedTrackCohortedCourse.is_verified_track_cohort_enabled(course_key):
-        course_modes = CourseMode.modes_for_course(course_key)
+        course_modes = CourseMode.modes_for_course(course_key, include_expired=True, only_selectable=False)
     email_editor = fragment.content
     section_data = {
         'section_key': 'send_email',


### PR DESCRIPTION
# [TNL-6703](https://openedx.atlassian.net/browse/TNL-6703)

Per a conversation with @sstack22, the addition of course modes as bulk email targets is not working for old course runs. After some investigation, I realized that this is due to using the default values of `include_expired` and `only_selectable` parameters of `CourseMode.modes_for_course`.

This quick fix should stop the filtering that takes place [here](https://github.com/edx/edx-platform/blob/3614eb280031373d8bc9692530562540690e752d/common/djangoapps/course_modes/models.py#L294-L305), and keep all course modes in the context passed to our view.