### PR TITLE
Remove flush command from our NoseTestSuiteRunner.

### DIFF
--- a/openedx/core/djangolib/nose.py
+++ b/openedx/core/djangolib/nose.py
@@ -13,9 +13,6 @@ class NoseTestSuiteRunner(django_nose.NoseTestSuiteRunner):
         """ Setup databases and then flush to remove data added by migrations. """
         return_value = super(NoseTestSuiteRunner, self).setup_databases()
 
-        # Delete all data added by data migrations. Unit tests should setup their own data using factories.
-        call_command('flush', verbosity=0, interactive=False, load_initial_data=False)
-
         # Through Django 1.8, auto increment sequences are not reset when calling flush on a SQLite db.
         # So we do it ourselves.
         # http://sqlite.org/autoinc.html


### PR DESCRIPTION
This call is redundant since the super call to `setup_databases()` also calls flush.