### PR TITLE
WIP: Ormsbee/test startup patch loaddata

### DIFF
--- a/openedx/core/djangolib/nose.py
+++ b/openedx/core/djangolib/nose.py
@@ -13,9 +13,6 @@ class NoseTestSuiteRunner(django_nose.NoseTestSuiteRunner):
         """ Setup databases and then flush to remove data added by migrations. """
         return_value = super(NoseTestSuiteRunner, self).setup_databases()
 
-        # Delete all data added by data migrations. Unit tests should setup their own data using factories.
-        call_command('flush', verbosity=0, interactive=False, load_initial_data=False)
-
         # Through Django 1.8, auto increment sequences are not reset when calling flush on a SQLite db.
         # So we do it ourselves.
         # http://sqlite.org/autoinc.html

--- a/openedx/core/djangolib/nose.py
+++ b/openedx/core/djangolib/nose.py
@@ -11,7 +11,19 @@ class NoseTestSuiteRunner(django_nose.NoseTestSuiteRunner):
 
     def setup_databases(self):
         """ Setup databases and then flush to remove data added by migrations. """
+
+        import django.core.management
+        real_call_command = django.core.management.call_command
+
+        def suppress_loaddata_call_command(name, *args, **kwargs):
+            if name == 'loaddata':
+                return 0
+            else:
+                return real_call_command
+
+        django.core.management.call_command = suppress_loaddata_call_command
         return_value = super(NoseTestSuiteRunner, self).setup_databases()
+        django.core.management.call_command = real_call_command
 
         # Through Django 1.8, auto increment sequences are not reset when calling flush on a SQLite db.
         # So we do it ourselves.

--- a/openedx/core/djangolib/nose.py
+++ b/openedx/core/djangolib/nose.py
@@ -19,7 +19,7 @@ class NoseTestSuiteRunner(django_nose.NoseTestSuiteRunner):
             if name == 'loaddata':
                 return 0
             else:
-                return real_call_command
+                return real_call_command(name, *args, **kwargs)
 
         django.core.management.call_command = suppress_loaddata_call_command
         return_value = super(NoseTestSuiteRunner, self).setup_databases()

--- a/openedx/core/djangolib/nose.py
+++ b/openedx/core/djangolib/nose.py
@@ -1,9 +1,15 @@
 """
 Utilities related to nose.
 """
+from __future__ import absolute_import
+
 from django.core.management import call_command
+from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS, connections, transaction
+from django_nose.plugin import DjangoSetUpPlugin, ResultPlugin, TestReorderer
 import django_nose
+import django_nose.runner
+import nose.core
 
 
 class NoseTestSuiteRunner(django_nose.NoseTestSuiteRunner):
@@ -19,6 +25,7 @@ class NoseTestSuiteRunner(django_nose.NoseTestSuiteRunner):
             if name == 'loaddata':
                 return 0
             else:
+                print name
                 return real_call_command(name, *args, **kwargs)
 
         django.core.management.call_command = suppress_loaddata_call_command
@@ -37,3 +44,30 @@ class NoseTestSuiteRunner(django_nose.NoseTestSuiteRunner):
                 )
 
         return return_value
+
+    def run_suite(self, nose_argv):
+        """
+        Run the suite, but be smarter about invoking django.setup() again.
+
+        This is almost identical to the superclass implementation, except that
+        we don't run django.setup() if settings are already configured, to save
+        on startup times.
+        """
+        result_plugin = ResultPlugin()
+        plugins_to_add = [
+            DjangoSetUpPlugin(self),
+            result_plugin,
+            TestReorderer()
+        ]
+
+        for plugin in django_nose.runner._get_plugins_from_settings():
+            plugins_to_add.append(plugin)
+
+        if not settings.configured:
+            django.setup()
+
+        nose.core.TestProgram(
+            argv=nose_argv, exit=False, addplugins=plugins_to_add
+        )
+
+        return result_plugin.result


### PR DESCRIPTION
This is a bit of an experiment with a horrible hack just to test if it breaks anything in the build. Basically, since we're not running with migrations (I should add a check for that), there are no data migrations to flush. I also don't think we actually use fixtures to loaddata in on database creation (that's deprecated anyhow), but the create database call will invoke the loaddata command them and look for fixtures for every model anyway.

@nasthagiri: With this change, I'm seeing real startup times of about 5s on my local devstack, when the page cache is warm. And 17s when it's not. The IO bound scenario seems to be getting caught up in model imports (`django.apps.config:import_models`). Not sure if that has to do with how Django scans for models, or if some of our models do weird disk IO in their initialization.

What's left in the CPU bound scenario is a handful of things of varying difficulty. The pyparsing lib init accounts for ~14%, URLValidator init takes ~20%, etc. But my main focus would be to reduce the IO stuff that causes the big outliers.

BTW, this is just a heads up, not a request for review at this time. Thank you. :-)