### PR TITLE
TNL-6188 Escaping in course outline section & subsection.

### DIFF
--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -19,7 +19,7 @@ else:
 <a href="#${chapter['display_id']}-child" role="button" class="button-chapter chapter ${active_class}" id="${chapter['display_id']}-parent" aria-controls="${chapter['display_id']}-child" aria-expanded="false">
     <span class="group-heading ${active_class}" aria-label="${aria_label}">
         <span class="icon fa fa-caret-right" aria-hidden="true"></span>
-        ${chapter['display_name']}
+        ${HTML(chapter['display_name'])}
     </span>
 </a>
 <div class="chapter-content-container" id="${chapter['display_id']}-child" tabindex="-1" role="region" aria-label="${chapter['display_name']} submenu">
@@ -27,7 +27,7 @@ else:
         % for section in chapter['sections']:
         <div class="menu-item ${'active' if 'active' in section and section['active'] else ''} ${'graded'  if 'graded' in section and section['graded'] else ''}">
             <a class="accordion-nav" href="${reverse('courseware_section', args=[course_id, chapter['url_name'], section['url_name']])}">
-                <p class="accordion-display-name">${section['display_name']} ${Text(_('{span_start}current section{span_end}')).format(
+                <p class="accordion-display-name">${HTML(section['display_name'])} ${Text(_('{span_start}current section{span_end}')).format(
                         span_start=HTML('<span class="sr">'),
                         span_end=HTML('</span>'),
                     ) if 'active' in section and section['active'] else ''}</p>


### PR DESCRIPTION
## [Section & Subsection title double escaped in course outline TNL-6188](https://openedx.atlassian.net/browse/TNL-6188)

### Description
This PR fixes the double escaping in the course outline.


### How to Test?

**Stage** 

1. Login to stage.
2. Go to the course https://courses.stage.edx.org/courses/course-v1:XSS+XS103+2015/courseware/8997af40308047ecbc3b99eae9fa8cb6/6c1d6607623542f6b74fe07d45fc2bbc/
3.  See the _**Section**_ and _**Subsection**_ in the LHS.
4. Titles are not escaped.

**Sandbox**
- https://tnl-5461.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/9fca584977d04885bc911ea76a9ef29e/07bc32474380492cb34f76e5f9d9a135/

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @noraiz-anwar 
- [x] Code review: @awaisdar001 

FYI: @awaisdar001 
### Post-review
- [x] Rebase and squash commits