### PR TITLE
Revert "ENT-238: Version upgrade of edx-enterprise to 0.27.0"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.27.0
+edx-enterprise==0.26.3
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.3


### PR DESCRIPTION
Testing revert of #14683, as JS tests are failing on master since its merge.