### PR TITLE
PLAT-1198 Fix flaky navigation buttons test

### DIFF
--- a/common/test/acceptance/pages/lms/courseware.py
+++ b/common/test/acceptance/pages/lms/courseware.py
@@ -115,8 +115,17 @@ class CoursewarePage(CoursePage):
         Arguments:
             sequential_position (int): position in sequential bar
         """
+        def is_at_new_position():
+            """
+            Returns whether the specified tab has become active. It is defensive
+            against the case where the page is still being loaded.
+            """
+            active_tab = self._active_sequence_tab
+            return active_tab and int(active_tab.attrs('data-element')[0]) == sequential_position
+
         sequential_position_css = '#sequence-list #tab_{0}'.format(sequential_position - 1)
         self.q(css=sequential_position_css).first.click()
+        EmptyPromise(is_at_new_position, "Position navigation fulfilled").fulfill()
 
     @property
     def sequential_position(self):

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -436,7 +436,6 @@ class CoursewareMultipleVerticalsTest(UniqueCourseTest, EventsTestMixin):
         self.courseware_page.visit()
         self.course_nav = CourseNavPage(self.browser)
 
-    @flaky  # TODO: fix this, see TNL-5762
     def test_navigation_buttons(self):
         # start in first section
         self.assert_navigation_state('Test Section 1', 'Test Subsection 1,1', 0, next_enabled=True, prev_enabled=False)


### PR DESCRIPTION
All of the recent failures I've seen for this test fail at the same point, when verifying the parameters for the event just after going to a tab specified by position.  Looking at the page object code, the methods for navigating via next and previous buttons have a built-in wait for the active tab to change, but there was nothing comparable for the `go_to_sequential_position()` method; the screenshot wasn't very useful because the events for a whole sequence of clicks were being verified after they all finished, but it seems likely that the test was sometimes trying to do the next click before the page had finished updating after that navigation action, so it didn't have the expected context.

Added an explicit wait to that page method for the chosen tab to become active, and removed the flaky decorator.