### PR TITLE
TNL-6421 – strip video id on saving the video

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -497,6 +497,7 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
                     break
 
         if metadata_was_changed_by_user:
+            self.edx_video_id = self.edx_video_id.strip()
             manage_video_subtitles_save(
                 self,
                 user,

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -9,6 +9,7 @@ from path import Path as path
 from lxml import etree
 from mock import patch, MagicMock, Mock
 from nose.plugins.attrib import attr
+from uuid import uuid4
 
 from django.conf import settings
 from django.test import TestCase
@@ -1048,6 +1049,27 @@ class TestEditorSavedMethod(BaseTestXmodule):
         with patch('xmodule.video_module.video_module.manage_video_subtitles_save') as manage_video_subtitles_save:
             item.editor_saved(self.user, old_metadata, None)
             self.assertFalse(manage_video_subtitles_save.called)
+
+    @ddt.data(TEST_DATA_MONGO_MODULESTORE, TEST_DATA_SPLIT_MODULESTORE)
+    def test_editor_saved_with_unstripped_video_id(self, default_store):
+        """
+        Verify editor saved when video id contains spaces/tabs.
+        """
+        self.MODULESTORE = default_store
+        stripped_video_id = unicode(uuid4())
+        unstripped_video_id = u'{video_id}{tabs}'.format(video_id=stripped_video_id, tabs=u'\t\t\t')
+        self.metadata.update({
+            'edx_video_id': unstripped_video_id
+        })
+        self.initialize_module(metadata=self.metadata)
+        item = self.store.get_item(self.item_descriptor.location)
+        self.assertEqual(item.edx_video_id, unstripped_video_id)
+
+        # Now, modifying and saving the video module should strip the video id.
+        old_metadata = own_metadata(item)
+        item.display_name = u'New display name'
+        item.editor_saved(self.user, old_metadata, None)
+        self.assertEqual(item.edx_video_id, stripped_video_id)
 
 
 @ddt.ddt


### PR DESCRIPTION
## [TNL-6421](https://openedx.atlassian.net/browse/TNL-6421)

### Description
With this PR, modifying and saving the video component from studio will strip the `edx_video_id` set on video descriptor.

### Testing
- [x] Unit Tests
### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @mushtaqak 
- [x] Code review: @muzaffaryousaf 

FYI: Tag anyone who might be interested in this PR here.
### Post-review
- [x] Rebase and squash commits