### PR TITLE
[ECOM-7520] Fix Low Color Contrast

### DIFF
--- a/lms/static/sass/elements/_controls.scss
+++ b/lms/static/sass/elements/_controls.scss
@@ -147,7 +147,7 @@
   color: $white;
 
   &:hover, &:active, &:focus {
-    background: $m-blue-d1;
+    background: $uxpl-blue-hover-active;
     color: $white;
   }
 
@@ -203,7 +203,7 @@
   color: $white;
 
   &:hover, &:active, &:focus {
-    background: $m-green-s1;
+    background: $uxpl-green-hover-active;
     color: $white;
   }
 

--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -1143,7 +1143,7 @@
       padding: ($baseline/2) ($baseline*1.5);
       background: white;
       text-align: center;
-      color: $m-gray-l2;
+      color: $gray-d2;
     }
   }
 


### PR DESCRIPTION
### JIRA Ticket: 
[[ECOM-7520] Low Color Contrast](https://openedx.atlassian.net/browse/ECOM-7520)
1st part of the ticket. 2nd part of the ticket will be a part of the larger PR that will address the a11y issues found on the new Basket page hosted by the ecommerce service.

### Reviewers:

- [x] @cptvitamin
- [x] @mjfrey

### Screenshots:
**Track Choice Page**
![screencapture-localhost-8000-course_modes-choose-course-v1-edx-course-100-1489675121757](https://cloud.githubusercontent.com/assets/6833568/24001729/3cd23fd2-0a5f-11e7-8a13-61cc2d84d17e.png)

### Changes

1. Verified green button (hover state background) from ![](https://placehold.it/15/60bc61/000000?text=+) `#60bc61` to ![](https://placehold.it/15/009b00/000000?text=+) `#009b00`
2. Audit blue button (hover state background) from ![](https://placehold.it/15/1790c7/000000?text=+) `#1790c7` to ![](https://placehold.it/15/065683/000000?text=+) `#065683`
3. `or` text color from ![](https://placehold.it/15/a4aca8/000000?text=+) `#a4a6a8` to ![](https://placehold.it/15/414141/000000?text=+) `#414141`