### PR TITLE
Compute grades asynchronously although PersistentGrades is disabled

### DIFF
--- a/lms/djangoapps/grades/new/subsection_grade.py
+++ b/lms/djangoapps/grades/new/subsection_grade.py
@@ -247,34 +247,33 @@ class SubsectionGradeFactory(object):
         """
         # Save ourselves the extra queries if the course does not persist
         # subsection grades.
-        if not PersistentGradesEnabledFlag.feature_enabled(self.course.id):
-            return
-
         self._log_event(log.warning, u"update, subsection: {}".format(subsection.location), subsection)
 
         calculated_grade = SubsectionGrade(subsection).init_from_structure(
             self.student, self.course_structure, self._submissions_scores, self._csm_scores,
         )
 
-        if only_if_higher:
-            try:
-                grade_model = PersistentSubsectionGrade.read_grade(self.student.id, subsection.location)
-            except PersistentSubsectionGrade.DoesNotExist:
-                pass
-            else:
-                orig_subsection_grade = SubsectionGrade(subsection).init_from_model(
-                    self.student, grade_model, self.course_structure, self._submissions_scores, self._csm_scores,
-                )
-                if not is_score_higher_or_equal(
-                        orig_subsection_grade.graded_total.earned,
-                        orig_subsection_grade.graded_total.possible,
-                        calculated_grade.graded_total.earned,
-                        calculated_grade.graded_total.possible,
-                ):
-                    return orig_subsection_grade
+        if PersistentGradesEnabledFlag.feature_enabled(self.course.id):
+            if only_if_higher:
+                try:
+                    grade_model = PersistentSubsectionGrade.read_grade(self.student.id, subsection.location)
+                except PersistentSubsectionGrade.DoesNotExist:
+                    pass
+                else:
+                    orig_subsection_grade = SubsectionGrade(subsection).init_from_model(
+                        self.student, grade_model, self.course_structure, self._submissions_scores, self._csm_scores,
+                    )
+                    if not is_score_higher_or_equal(
+                            orig_subsection_grade.graded_total.earned,
+                            orig_subsection_grade.graded_total.possible,
+                            calculated_grade.graded_total.earned,
+                            calculated_grade.graded_total.possible,
+                    ):
+                        return orig_subsection_grade
 
-        grade_model = calculated_grade.update_or_create_model(self.student)
-        self._update_saved_subsection_grade(subsection.location, grade_model)
+            grade_model = calculated_grade.update_or_create_model(self.student)
+            self._update_saved_subsection_grade(subsection.location, grade_model)
+
         return calculated_grade
 
     @lazy

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -25,7 +25,6 @@ from track.event_transaction_utils import (
 from util.date_utils import from_timestamp
 from xmodule.modulestore.django import modulestore
 
-from .config.models import PersistentGradesEnabledFlag
 from .constants import ScoreDatabaseTableEnum
 from .new.subsection_grade import SubsectionGradeFactory
 from .signals.signals import SUBSECTION_SCORE_CHANGED
@@ -91,9 +90,6 @@ def _recalculate_subsection_grade(self, **kwargs):
     """
     try:
         course_key = CourseLocator.from_string(kwargs['course_id'])
-        if not PersistentGradesEnabledFlag.feature_enabled(course_key):
-            return
-
         scored_block_usage_key = UsageKey.from_string(kwargs['usage_id']).replace(course_key=course_key)
 
         newrelic.agent.add_custom_parameter('course_id', unicode(course_key))

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1775,7 +1775,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 3,
             'skipped': 2
         }
-        with self.assertNumQueries(169):
+        with self.assertNumQueries(168):
             self.assertCertificatesGenerated(task_input, expected_results)
 
         expected_results = {


### PR DESCRIPTION
### Description
This PR changes the semantics of the PersistentGradesEnabledFlag so it still controls whether grades are persisted, but doesn't control whether grades are asynchronously computed.

This change is needed since the following subsequent PRs rely on asynchronous computation of grades:

- [Fix grading for Gated Subsections](https://github.com/edx/edx-platform/pull/14689)
- [Fix grading for Entrance Exams](https://github.com/edx/edx-platform/pull/14690)

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 

FYI @edx/educator-neem 

### Post-review
- [ ] Rebase and squash commits
