### PR TITLE
[ENT-225] Add consent declined banner to dashboard

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -102,6 +102,7 @@ from util.milestones_helpers import (
 )
 
 from util.password_policy_validators import validate_password_strength
+from util.enterprise_helpers import get_dashboard_consent_notification
 import third_party_auth
 from third_party_auth import pipeline, provider
 from student.helpers import (
@@ -684,6 +685,8 @@ def dashboard(request):
             {'email': user.email, 'platform_name': platform_name}
         )
 
+    enterprise_message = get_dashboard_consent_notification(request, user, course_enrollments)
+
     # Global staff can see what courses errored on their dashboard
     staff_access = False
     errored_courses = {}
@@ -804,6 +807,7 @@ def dashboard(request):
     display_sidebar_on_dashboard = len(order_history_list) or verification_status in valid_verification_statuses
 
     context = {
+        'enterprise_message': enterprise_message,
         'enrollment_message': enrollment_message,
         'redirect_message': redirect_message,
         'course_enrollments': course_enrollments,

--- a/common/templates/util/enterprise_consent_declined_notification.html
+++ b/common/templates/util/enterprise_consent_declined_notification.html
@@ -1,0 +1,12 @@
+<%page expression_filter="h"/>
+<div class="wrapper-msg urgency-info">
+    <div class="msg">
+        <span class="msg-icon fa fa-info-circle" aria-hidden="true"></span>
+        <div class="msg-content">
+            <h2 class="title">${ title }</h2>
+            <div class="copy">
+                <p class='consent-declined-message'>${ message }</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/lms/static/sass/elements/_system-feedback.scss
+++ b/lms/static/sass/elements/_system-feedback.scss
@@ -118,6 +118,20 @@
     }
   }
 
+  &.urgency-info {
+    background: $msg-bg;
+    .msg {
+      color: $white;
+    }
+    .msg-icon {
+      font-size: 2.5em;
+      padding: 20px;
+    }
+    .msg-content {
+      max-width: 80%;
+    }
+  }
+
   &.alert {
     border-top: 3px solid $alert-color;
   }

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -73,6 +73,12 @@ from openedx.core.djangolib.markup import HTML, Text
             ${enrollment_message | n,  decode.utf8}
         </div>
     %endif
+
+    %if enterprise_message:
+        <div class="dashboard-banner">
+            ${ enterprise_message | n, decode.utf8 }
+        </div>
+    %endif
 </div>
 
 <main id="main" aria-label="Content" tabindex="-1">

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.27.6
+edx-enterprise==0.28.0
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.3


### PR DESCRIPTION
This pull request adds a banner to the Dashboard that appears when a user is redirected to it by the Enterprise app after failing to consent at a required data sharing consent gate.

**JIRA tickets**: Implements [ENT-225](https://openedx.atlassian.net/browse/ENT-225)

**Dependencies**: Automatic behavior depends on edx/edx-enterprise#68

**Screenshots**:

<img width="1242" alt="screen shot 2017-03-16 at 5 17 19 pm" src="https://cloud.githubusercontent.com/assets/7773758/24019103/107e9dbe-0a6d-11e7-81e4-b7ed6d167859.png">

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: 27 March 2017

**Testing instructions**:

1. Using the admin panel, create an Enterprise Customer
2. Set the Enterprise Customer to require data sharing consent at enrollment
3. Using the Manage Learners Enterprise admin panel, enroll your user in the edX Demo Course
4. Go to the dashboard, and observe that there's no additional banner.
5. Click on the demo course, and observe that you're prompted for consent; decline to provide consent.
6. Observe that you're redirected back to the dashboard, and that a banner with contextual details about the course you declined to provide consent for is present.

**Author notes and concerns**:

1. I put styling inline with the HTML of the banner; given that we only want to style this very specific banner, it seemed like the best choice. In addition, this PR will likely remain in flux for some time; once styles settle, then they can be extracted to SASS if we decide that's appropriate.

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```