### PR TITLE
D quraini/staff debug info dialog positioning

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -279,3 +279,4 @@ Jhony Avella <jhony.avella@edunext.co>
 Tanmay Mohapatra <tanmaykm@gmail.com>
 Brian Mesick <bmesick@edx.org>
 Jeff LaJoie <jlajoie@edx.org>
+Dania AlQuraini <dalquraini@qrf.org>

--- a/common/static/js/vendor/jquery.leanModal.js
+++ b/common/static/js/vendor/jquery.leanModal.js
@@ -40,11 +40,23 @@
                         "display": "block",
                         "position": "fixed",
                         "opacity": 0,
-                        "z-index": 11000,
-                        "left": 50 + "%",
-                        "margin-left": -(modal_width / 2) + "px",
-                        "top": o.top + "px"
+                        "z-index": 11000
                     });
+
+                    $.fn.center= function () {
+                         $(modal_id).position({
+                            my: "center",
+                            at: "center",
+                            of: window
+                        });
+                    };
+
+                    $(modal_id).center();
+
+                    $(window).resize(function() {
+                        $(modal_id).center();
+                    });
+
                     $(modal_id).fadeTo(200, 1);
                     e.preventDefault()
                 })


### PR DESCRIPTION
## Problem Statement:
The position of the "Staff Debug Info" dialog is appearing out of view from the right side.(see image below)

![debug-info-issue](https://cloud.githubusercontent.com/assets/26089068/24080766/1bff38fe-0cae-11e7-84b1-ac455a863bbc.png)

## Issue and Fix Explanation:
The issue is a result of a having the "var modal_width = $(modal_id).outerWidth();" in line 33 of the "jquery.leanModal.js " return with a wrong width value. The reason of having this issue is related to the timing the width is retrieved. As a result, the negative left margin did not provide the required positioning due to being dependant on the width in line 45 ""margin-left": -(modal_width / 2) + "px"".
To fix this I have discarded the use of the width and replace that with the "position" jQuery function along with the "resize" to keep the centring dynamic. See the image below which is after having the fix applied.

![degug-staff-info-fixed-2017-03-19 14-28-49](https://cloud.githubusercontent.com/assets/26089068/24080882/740a36c8-0cb0-11e7-8b53-39c38c36f8c3.png)

## Components Affected:
This fix affects any component using the "jquery.leanModal.js " file for positioning.