### PR TITLE
Update BlockStructureModel to support Old Mongo courses

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/migrations/0004_blockstructuremodel_usagekeywithrun.py
+++ b/openedx/core/djangoapps/content/block_structure/migrations/0004_blockstructuremodel_usagekeywithrun.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import openedx.core.djangoapps.xmodule_django.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('block_structure', '0003_blockstructuremodel_storage'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='blockstructuremodel',
+            name='data_usage_key',
+            field=openedx.core.djangoapps.xmodule_django.models.UsageKeyWithRunField(unique=True, max_length=255, verbose_name='Identifier of the data being collected.'),
+        ),
+    ]

--- a/openedx/core/djangoapps/content/block_structure/models.py
+++ b/openedx/core/djangoapps/content/block_structure/models.py
@@ -11,7 +11,7 @@ from django.db import models, transaction
 from logging import getLogger
 
 from model_utils.models import TimeStampedModel
-from openedx.core.djangoapps.xmodule_django.models import UsageKeyField
+from openedx.core.djangoapps.xmodule_django.models import UsageKeyWithRunField
 from openedx.core.storage import get_storage
 
 from . import config
@@ -33,9 +33,12 @@ def _directory_name(data_usage_key):
     Returns the directory name for the given
     data_usage_key.
     """
+    # replace any '/' in the usage key so they aren't interpreted
+    # as folder separators.
+    encoded_usage_key = unicode(data_usage_key).replace('/', '_')
     return '{}{}'.format(
         settings.BLOCK_STRUCTURES_SETTINGS.get('DIRECTORY_PREFIX', ''),
-        unicode(data_usage_key),
+        encoded_usage_key,
     )
 
 
@@ -133,7 +136,7 @@ class BlockStructureModel(TimeStampedModel):
     class Meta(object):
         db_table = 'block_structure'
 
-    data_usage_key = UsageKeyField(
+    data_usage_key = UsageKeyWithRunField(
         u'Identifier of the data being collected.',
         blank=False,
         max_length=255,

--- a/openedx/core/djangoapps/xmodule_django/models.py
+++ b/openedx/core/djangoapps/xmodule_django/models.py
@@ -7,6 +7,8 @@ import logging
 from django.db import models
 from django.core.exceptions import ValidationError
 from opaque_keys.edx.keys import CourseKey, UsageKey, BlockTypeKey
+from xmodule.modulestore.django import modulestore
+
 
 log = logging.getLogger(__name__)
 
@@ -179,6 +181,18 @@ class UsageKeyField(OpaqueKeyField):
     """
     description = "A Location object, saved to the DB in the form of a string"
     KEY_CLASS = UsageKey
+
+
+class UsageKeyWithRunField(UsageKeyField):
+    """
+    Subclass of UsageKeyField that automatically fills in
+    missing `run` values, for old Mongo courses.
+    """
+    def to_python(self, value):
+        value = super(UsageKeyWithRunField, self).to_python(value)
+        if value is not None and value.run is None:
+            value = value.replace(course_key=modulestore().fill_in_run(value.course_key))
+        return value
 
 
 class LocationKeyField(UsageKeyField):


### PR DESCRIPTION
## [TNL-6645](https://openedx.atlassian.net/browse/TNL-6645)

### Description

This PR addresses an issue found when testing Storage-backed Block Structures on Stage: namely the `\` in the file name for old-Mongo courses was interpreted as folder separators and resulted in a nested folder structure instead of a single folder per course.

Additionally, further testing of old-Mongo courses surfaced the issue with the "run" value in the `UsageKey` disappearing upon serialization/deserialization.  This PR currently addresses that issue by calling the modulestore's `fill_in_run` method upon deserialization of the `UsageKey`.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @sanfordstudent 

FYI @edx/educator-neem 

### Devops assistance
FYI @jibsheet 

### Post-review
- [x] Rebase and squash commits