### PR TITLE
a11y test example path is wrong

### DIFF
--- a/docs/en_us/internal/testing.rst
+++ b/docs/en_us/internal/testing.rst
@@ -505,7 +505,7 @@ relative to the ``common/test/acceptance/tests`` directory. This is an example f
 
 ::
 
-    paver test_a11y -t test_lms_dashboard.py:LmsDashboardA11yTest.test_dashboard_course_listings_a11y
+    paver test_a11y -t lms/test_lms_dashboard.py:LmsDashboardA11yTest.test_dashboard_course_listings_a11y
 
 **Coverage**:
 


### PR DESCRIPTION
This test lives in `common/test/acceptance/tests/lms/test_lms_dashboard.py`, so the paver string should be `paver test_a11y -t lms/test_lms_d...`