### PR TITLE
Upgrade eslint packages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "eslint-config-edx",
+  "extends": "eslint-config-edx-es5",
   "globals": {  // Try to avoid adding any new globals.
     // Old compatibility things and hacks
     "edx": true,

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "devDependencies": {
     "edx-custom-a11y-rules": "0.1.3",
-    "eslint": "^2.13.1",
-    "eslint-config-edx": "^1.2.1",
+    "eslint-config-edx": "^2.0.0",
+    "eslint-config-edx-es5": "^2.0.0",
     "jasmine-core": "^2.4.1",
     "jasmine-jquery": "^2.1.1",
     "karma": "^0.13.22",

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -12,7 +12,7 @@ set -e
 
 # Violations thresholds for failing the build
 export PYLINT_THRESHOLD=3600
-export ESLINT_THRESHOLD=9850
+export ESLINT_THRESHOLD=10106
 
 SAFELINT_THRESHOLDS=`cat scripts/safelint_thresholds.json`
 export SAFELINT_THRESHOLDS=${SAFELINT_THRESHOLDS//[[:space:]]/}


### PR DESCRIPTION
Upgrade to the two new ESLint packages I described in [this edx-releases post](https://groups.google.com/a/edx.org/d/msg/release-notifications/7TXduAsQgzY/fQuQ_oIoAgAJ).

Under the hood, this upgrades us to ESLint 3 (which is a prerequisite for being able to lint ES5 and ES2015 at the same time). However, ESLint 3 has some breaking changes which has raised the total number of violations by about 250.

The changes fall into two categories:
1. Previously, rules that mandated your variables be named a certain way would only count an error on the line where it that var was initialized. In ESLint 3, it's counted as an error both on the line where it's initialized and on all subsequent lines where it's used. So

    ```javascript
    var foo = $('.foo');
    foo.focus();
    ```

    is now two separate errors. So there are a ton more ` dollar-sign/dollar-sign` errors after this upgrade.

2. Similarly, this structure:

    ```javascript
    (function(define) {
        'use strict';
     
        define(['backbone',
                'jquery',
                'underscore',
                'gettext',
                'edx-ui-toolkit/js/utils/html-utils',
                'text!../../../templates/learner_dashboard/course_enroll.underscore'
               ],
             function(
                 Backbone,
                 $,
                 _,
                 gettext,
                 HtmlUtils,
                 pageTpl
             ) {
                 [...]
     ```

   used to just be one error (on the 5th line). In ESLint 3, lines 5-10 are all marked as separate errors for incorrect indentation. So there are a ton more `indent` errors.

I'm sure there's another few things that are now counted differently but going through it the new `dollar-sign` and `indent` errors seemed to be the vast majority of the diff.