### PR TITLE
TNL-6436 Fix (capa) show answer disabled even after answer is no longer shown

### DIFF
--- a/common/lib/xmodule/xmodule/js/fixtures/checkbox_problem.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/checkbox_problem.html
@@ -1,0 +1,5 @@
+<div class="choicegroup">
+    <label for="input_1_1_1"><input type="checkbox" name="input_1_1" id="input_1_1_1" value="1"> One</label>
+    <label for="input_1_1_2" class="choicegroup_correct"><input type="checkbox" name="input_1_1" id="input_1_1_2" value="2"> Two <span class="status correct"></span></label>
+    <label for="input_1_1_3"><input type="checkbox" name="input_1_1" id="input_1_1_3" value="3"> Three</label>
+</div>

--- a/common/lib/xmodule/xmodule/js/fixtures/radiobutton_problem.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/radiobutton_problem.html
@@ -1,0 +1,5 @@
+<div class="choicegroup">
+    <label for="input_1_1_1"><input type="radio" name="input_1_1" id="input_1_1_1" value="1"> One</label>
+    <label for="input_1_1_2" class="choicegroup_correct"><input type="radio" name="input_1_1" id="input_1_1_2" value="2"> Two <span class="status correct"></span></label>
+    <label for="input_1_1_3"><input type="radio" name="input_1_1" id="input_1_1_3" value="3"> Three</label>
+</div>

--- a/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/capa/display_spec.coffee
@@ -258,6 +258,7 @@ describe 'Problem', ->
       expect(@problem.submitButton).not.toHaveAttr('disabled')
 
   describe 'submit button on problems', ->
+
     beforeEach ->
       @problem = new Problem($('.xblock-student_view'))
       @submitDisabled = (disabled) =>
@@ -274,15 +275,11 @@ describe 'Problem', ->
         @submitDisabled true
 
     describe 'some advanced tests for submit button', ->
+      radioButtonProblemHtml = readFixtures('radiobutton_problem.html')
+      checkboxProblemHtml = readFixtures('checkbox_problem.html')
+
       it 'should become enabled after a checkbox is checked', ->
-        html = '''
-        <div class="choicegroup">
-        <label for="input_1_1_1"><input type="checkbox" name="input_1_1" id="input_1_1_1" value="1"> One</label>
-        <label for="input_1_1_2"><input type="checkbox" name="input_1_1" id="input_1_1_2" value="2"> Two</label>
-        <label for="input_1_1_3"><input type="checkbox" name="input_1_1" id="input_1_1_3" value="3"> Three</label>
-        </div>
-        '''
-        $('#input_example_1').replaceWith(html)
+        $('#input_example_1').replaceWith(checkboxProblemHtml)
         @problem.submitAnswersAndSubmitButton true
         @submitDisabled true
         $('#input_1_1_1').click()
@@ -291,14 +288,7 @@ describe 'Problem', ->
         @submitDisabled true
 
       it 'should become enabled after a radiobutton is checked', ->
-        html = '''
-        <div class="choicegroup">
-        <label for="input_1_1_1"><input type="radio" name="input_1_1" id="input_1_1_1" value="1"> One</label>
-        <label for="input_1_1_2"><input type="radio" name="input_1_1" id="input_1_1_2" value="2"> Two</label>
-        <label for="input_1_1_3"><input type="radio" name="input_1_1" id="input_1_1_3" value="3"> Three</label>
-        </div>
-        '''
-        $('#input_example_1').replaceWith(html)
+        $('#input_example_1').replaceWith(radioButtonProblemHtml)
         @problem.submitAnswersAndSubmitButton true
         @submitDisabled true
         $('#input_1_1_1').attr('checked', true).trigger('click')
@@ -325,14 +315,7 @@ describe 'Problem', ->
         @submitDisabled true
 
       it 'should become enabled after a radiobutton is checked and a value is entered into the text box', ->
-        html = '''
-        <div class="choicegroup">
-        <label for="input_1_1_1"><input type="radio" name="input_1_1" id="input_1_1_1" value="1"> One</label>
-        <label for="input_1_1_2"><input type="radio" name="input_1_1" id="input_1_1_2" value="2"> Two</label>
-        <label for="input_1_1_3"><input type="radio" name="input_1_1" id="input_1_1_3" value="3"> Three</label>
-        </div>
-        '''
-        $(html).insertAfter('#input_example_1')
+        $(radioButtonProblemHtml).insertAfter('#input_example_1')
         @problem.submitAnswersAndSubmitButton true
         @submitDisabled true
         $('#input_1_1_1').attr('checked', true).trigger('click')
@@ -802,3 +785,40 @@ describe 'Problem', ->
 
       # verify that codemirror textarea has correct `aria-describedby` attribute value
       expect($(CodeMirrorTextArea).attr('aria-describedby')).toEqual('cm-editor-exit-message-101 status_101')
+
+
+  describe 'show answer button', ->
+
+    radioButtonProblemHtml = readFixtures('radiobutton_problem.html')
+    checkboxProblemHtml = readFixtures('checkbox_problem.html')
+
+    beforeEach ->
+      @problem = new Problem($('.xblock-student_view'))
+
+      @checkAssertionsAfterClickingAnotherOption = =>
+        # verify that 'show answer button is no longer disabled'
+        expect(@problem.el.find('.show').attr('disabled')).not.toEqual('disabled')
+
+        # verify that displayed answer disappears
+        expect(@problem.el.find('div.choicegroup')).not.toHaveClass('choicegroup_correct')
+
+        # verify that radio/checkbox label has no span having class '.status.correct'
+        expect(@problem.el.find('div.choicegroup')).not.toHaveAttr('span.status.correct')
+
+    it 'should become enabled after a radiobutton is selected', ->
+      $('#input_example_1').replaceWith(radioButtonProblemHtml)
+      # assume that 'ShowAnswer' button is clicked,
+      # clicking make it disabled.
+      @problem.el.find('.show').attr('disabled', 'disabled')
+      # bind click event to input fields
+      @problem.submitAnswersAndSubmitButton true
+      # selects option 2
+      $('#input_1_1_2').attr('checked', true).trigger('click')
+      @checkAssertionsAfterClickingAnotherOption()
+
+    it 'should become enabled after a checkbox is selected', ->
+      $('#input_example_1').replaceWith(checkboxProblemHtml)
+      @problem.el.find('.show').attr('disabled', 'disabled')
+      @problem.submitAnswersAndSubmitButton true
+      $('#input_1_1_2').click()
+      @checkAssertionsAfterClickingAnotherOption()

--- a/common/lib/xmodule/xmodule/js/src/capa/display.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.js
@@ -872,6 +872,7 @@
                         if (bind) {
                             $(checkboxOrRadio).on('click', function() {
                                 that.saveNotification.hide();
+                                that.el.find('.show').removeAttr('disabled');
                                 that.showAnswerNotification.hide();
                                 that.submitAnswersAndSubmitButton();
                             });
@@ -953,6 +954,7 @@
                             id: 'status_' + id
                         });
                     }
+                    $element.find('label').find('span.status.correct').remove();
                     return $element.find('label').removeAttr('class');
                 });
             },


### PR DESCRIPTION
## ["(Capa) Show answer" disabled even after answer is no longer shown - TNL-6436](https://openedx.atlassian.net/browse/TNL-6436)

### Description
This PR fixes the `Show answer` button in the lower right corner of multiple choice or checkbox problems. The issue was that `Show answer` is disabled once you have clicked it (until next page refresh).  However, if you change the selected answer for multiple choice and checkbox problems, the displayed answer is cleared. You then can't show the answer again without refreshing the page. I have made the changes in [CheckboxOrRadio click event](https://github.com/edx/edx-platform/blame/5cfc91be961f115fe0597f1bbfa61e36486181f5/common/lib/xmodule/xmodule/js/src/capa/display.js#L875-L875) and  [CheckboxOrRadio change event](https://github.com/edx/edx-platform/blame/5cfc91be961f115fe0597f1bbfa61e36486181f5/common/lib/xmodule/xmodule/js/src/capa/display.js#L957-L957) that whenever you change the selected answer then you can show the answer again without refreshing the page.

### How to Test?

**Stage** 
1. Login to stage.
2. Goto to the problem:  https://courses.stage.edx.org/courses/edX/DemoX.1/2014/courseware/770f83743344449183bc31539a0d9c1c/5bf70e7a6e07424195c6773f5008d921/
3. Select any option and Click on `Show Answer` button.
4. Change selected answer-- the displayed answer disappears.
5. Observe `Show Answer` button is disabled until page refresh.

**Sandbox**
- [https://tnl-6436.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/7c2c23646d2e42179fa2c6d1388277e9/2c8a7deeb1a94291b2838633ed4c671b/](https://tnl-6436.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/7c2c23646d2e42179fa2c6d1388277e9/2c8a7deeb1a94291b2838633ed4c671b/)

**Screenshots**
Multiple Choice problem before fix
<img width="901" alt="multiple choice before fix" src="https://cloud.githubusercontent.com/assets/13939335/24240787/a26fd06e-0fd4-11e7-85d3-c5e7aab3e548.png">

Multiple Choice problem after fix
<img width="899" alt="multiple choice after fix" src="https://cloud.githubusercontent.com/assets/13939335/24240828/c1ef3a06-0fd4-11e7-9091-ce73173b35b8.png">

Checkboxes problem before fix
<img width="900" alt="checkboxes before fix" src="https://cloud.githubusercontent.com/assets/13939335/24240846/d269a2e0-0fd4-11e7-847e-653d8a3c4a48.png">

Checkboxes problem after fix
<img width="899" alt="checkboxes after fix" src="https://cloud.githubusercontent.com/assets/13939335/24240864/e2d89f5a-0fd4-11e7-9adf-1dd211948d37.png">

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @noraiz-anwar 
- [x] Code review: @asadazam93 
- [x] Code review: @noraiz-anwar  

### Post-review
- [x] Rebase and squash commits


