### PR TITLE
ECOM-7522 Fix wrongly failed requirment to earn credit

### DIFF
--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -465,8 +465,15 @@ class CreditRequirementStatus(TimeStampedModel):
             defaults={"reason": reason, "status": status}
         )
         if not created:
+            # do not update status to `failed` if user has `satisfied` the requirement
+            if status == 'failed' and requirement_status.status == 'satisfied':
+                log.info(
+                    u'Can not change status of credit requirement "%s" from satisfied to failed ',
+                    requirement_status.requirement_id
+                )
+                return
             requirement_status.status = status
-            requirement_status.reason = reason if reason else {}
+            requirement_status.reason = reason
             requirement_status.save()
 
     @classmethod


### PR DESCRIPTION
## [ECOM-7522](https://openedx.atlassian.net/browse/ECOM-7522)

### Description

Credit requirement status of learner become inconsistent i.e false `failed`, if any update in problem's grade is made with following conditions met:

- Course end date has passed.
- One year time to purchase credit after being eligible for credit is passed.

One way to update a problem's grade is using instructor dashboard.
Fix offered in this PR restrict any update (setting it to failed) to Credit requirement status after a learner has satisfied all the requirements.

### How to Test?

**Stage** 
Following condition should be there in order to test:

- A course having credit seats with end date passed.
- A learner enrolled in that course have met all requirements for credit.
- One year from date, the requirements were met, has passed (CreditEligibility table).
 
Go to instructor dashboard and `Rescore Only If Score Improves` any problem. Go to progress page of learner and observe  `Verification Failed`.

**Sandbox**
LMS: https://credit-req.sandbox.edx.org
Ecommerce: https://ecommerce-credit-req.sandbox.edx.org/courses
Super user credentials:
username: super
email: super@example.com
password: edx

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @attiyaIshaque 
- [x] Code review: @awaisdar001 
- [x] Code review: @clintonb 

FYI: @adampalay 

### Post-review
- [ ] Rebase and squash commits