### PR TITLE
Update edx-enterprise library to v27.6

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.27.4
+edx-enterprise==0.27.6
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.3


### PR DESCRIPTION
Updating the edx-enterprise library to the latest version, which includes the removal of the `OAuth2Authentication` class from the API viewsets.

@saleem-latif @clintonb FYI