### PR TITLE
Add sort key to customise order of courses returned by the API.

### DIFF
--- a/lms/djangoapps/branding/__init__.py
+++ b/lms/djangoapps/branding/__init__.py
@@ -40,7 +40,7 @@ def get_visible_courses(org=None, filter_=None):
     else:
         courses = CourseOverview.get_all_courses(filter_=filter_)
 
-    courses = sorted(courses, key=lambda course: course.number)
+    courses = sorted(courses, key=lambda course: (course.sort_key, course.number))
 
     # Filtering can stop here.
     if current_site_orgs:

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -100,6 +100,9 @@ class CourseOverview(TimeStampedModel):
     marketing_url = TextField(null=True)
     eligible_for_financial_aid = BooleanField(default=True)
 
+    # Sort key used to override the order of courses returned by the API.
+    sort_key = IntegerField(default=0)
+
     @classmethod
     def _create_from_course(cls, course):
         """


### PR DESCRIPTION
This PR is a prototype.

The mobile apps show courses on the "Find Courses" page in the order returned by the Courses API (which returns courses ordered by course number).  This change allows to customise the course order by setting `sort_key` on some or all courses (e.g. via the Django admin interface).