### PR TITLE
WIP Display programs relevant to site on learner dashboard

### DIFF
--- a/lms/djangoapps/learner_dashboard/views.py
+++ b/lms/djangoapps/learner_dashboard/views.py
@@ -15,6 +15,7 @@ from openedx.core.djangoapps.programs.utils import (
     ProgramProgressMeter,
     ProgramDataExtender,
 )
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 
 
@@ -26,7 +27,7 @@ def program_listing(request):
     if not programs_config.enabled:
         raise Http404
 
-    meter = ProgramProgressMeter(request.user)
+    meter = ProgramProgressMeter(request.user, partner=configuration_helpers.get_value('PARTNER_SHORT_CODE'))
 
     context = {
         'credentials': get_programs_credentials(request.user),

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -25,7 +25,7 @@ def create_catalog_api_client(user, catalog_integration):
     return EdxRestApiClient(catalog_integration.internal_api_url, jwt=jwt)
 
 
-def get_programs(uuid=None, types=None):  # pylint: disable=redefined-builtin
+def get_programs(uuid=None, types=None, partner=None):  # pylint: disable=redefined-builtin
     """Retrieve marketable programs from the catalog service.
 
     Keyword Arguments:
@@ -33,6 +33,7 @@ def get_programs(uuid=None, types=None):  # pylint: disable=redefined-builtin
         types (list of string): List of program type names used to filter programs by type
                                 (e.g., ["MicroMasters"] will only return MicroMasters programs,
                                 ["MicroMasters", "XSeries"] will return MicroMasters and XSeries programs).
+        partner (string): Partner short code used to filter programs
 
     Returns:
         list of dict, representing programs.
@@ -48,8 +49,9 @@ def get_programs(uuid=None, types=None):  # pylint: disable=redefined-builtin
         api = create_catalog_api_client(user, catalog_integration)
         types_param = ','.join(types) if types else None
 
-        cache_key = '{base}.programs{types}'.format(
+        cache_key = '{base}.programs{partner}{types}'.format(
             base=catalog_integration.CACHE_KEY,
+            partner='.' + partner if partner else '',
             types='.' + types_param if types_param else ''
         )
 
@@ -59,6 +61,8 @@ def get_programs(uuid=None, types=None):  # pylint: disable=redefined-builtin
         }
         if uuid:
             querystring['use_full_course_serializer'] = 1
+        if partner:
+            querystring['partner_short_code'] = partner
         if types_param:
             querystring['types'] = types_param
 

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -58,7 +58,7 @@ class ProgramProgressMeter(object):
     Keyword Arguments:
         enrollments (list): List of the user's enrollments.
     """
-    def __init__(self, user, enrollments=None):
+    def __init__(self, user, enrollments=None, partner=None):
         self.user = user
 
         self.enrollments = enrollments or list(CourseEnrollment.enrollments_for_user(self.user))
@@ -67,7 +67,7 @@ class ProgramProgressMeter(object):
         # enrollment.course_id is really a CourseKey (╯ಠ_ಠ）╯︵ ┻━┻
         self.course_run_ids = [unicode(e.course_id) for e in self.enrollments]
 
-        self.programs = attach_program_detail_url(get_programs())
+        self.programs = attach_program_detail_url(get_programs(partner=partner))
 
     def invert_programs(self):
         """Intersect programs and enrollments.


### PR DESCRIPTION
We need to restrict the programs visible on the learner dashboard
to those related to the given site. This checks a PARTNER_SHORT_CODE
SiteConfiguration value and uses it to filter calls made to the catalog
service for the program list.