### PR TITLE
Bumps edx-enterprise version to 0.29.0

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -319,6 +319,7 @@ AUTHENTICATION_BACKENDS = (
 
 LMS_BASE = None
 LMS_ROOT_URL = "http://localhost:8000"
+ENTERPRISE_API_URL = LMS_ROOT_URL + '/enterprise/api/v1/'
 
 # These are standard regexes for pulling out info like course_ids, usage_ids, etc.
 # They are used so that URLs with deprecated-format strings still work.
@@ -1250,3 +1251,7 @@ RETRY_ACTIVATION_EMAIL_TIMEOUT = 0.5
 
 # How long until database records about the outcome of a task and its artifacts get deleted?
 USER_TASKS_MAX_AGE = timedelta(days=7)
+
+############## Settings for the Enterprise App ######################
+
+ENTERPRISE_ENROLLMENT_API_URL = LMS_ROOT_URL + "/api/enrollment/v1/"

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.28.0
+edx-enterprise==0.29.0
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.3


### PR DESCRIPTION
Uses the `edx-enterprise` package built from https://github.com/edx/edx-enterprise/pull/69.

Also adds `cms.envs.common.ENTERPRISE_ENROLLMENT_API_URL`, because [edx-enterprise now uses `ENTERPRISE_ENROLLMENT_API_URL` as a class variable for `EnrollmentApiClient`](https://github.com/edx/edx-enterprise/pull/69/files#diff-9bc89aa1bcbe6bccd8de7bbeed2c2f4eR121).

**JIRA tickets**: [ENT-259](https://openedx.atlassian.net/browse/ENT-259)

**Dependencies**: None

**Sandbox URL**: (provisioning)

* LMS: https://pr14768.sandbox.opencraft.hosting/
* Studio: https://studio-pr14768.sandbox.opencraft.hosting/

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: 28 March 2017

**Testing instructions**:

cf https://github.com/edx/edx-enterprise/pull/69.

**Reviewers**
- [x] @e-kolpakov  CC @haikuginger 
- [ ] @mattdrayer 