### PR TITLE
Added filter to the cohort user count data to show the counts of only

### DIFF
--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -90,7 +90,8 @@ def _get_cohort_representation(cohort, course):
     return {
         'name': cohort.name,
         'id': cohort.id,
-        'user_count': cohort.users.count(),
+        'user_count': cohort.users.filter(courseenrollment__course_id=course.location.course_key,
+                                          courseenrollment__is_active=1).count(),
         'assignment_type': assignment_type,
         'user_partition_id': partition_id,
         'group_id': group_id,


### PR DESCRIPTION
active users

## [TNL-6603](https://openedx.atlassian.net/browse/TNL-6603)

### Description
Corrected a bug where the cohort user group user count in the Instructor Dashboard would not match the downloaded data.

### Sandbox
- [x] Build a sandbox for your branch and add a link here
https://staubina-cohort.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-cohort_management

### Testing
- [x] safecommit violation code review process
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @cahrens 
- [x] Code review: @jlajoie 

FYI: @efischer19 @sstack22 

### Post-review
- [x] Rebase and squash commits