### PR TITLE
ENT-293: Add SAML metadata refresh control flag

### DIFF
--- a/common/djangoapps/third_party_auth/management/commands/saml.py
+++ b/common/djangoapps/third_party_auth/management/commands/saml.py
@@ -25,14 +25,19 @@ class Command(BaseCommand):
         log = logging.getLogger('third_party_auth.tasks')
         log.propagate = False
         log.addHandler(log_handler)
-        num_changed, num_failed, num_total, failure_messages = fetch_saml_metadata()
+        total, skipped, attempted, updated, failed, failure_messages = fetch_saml_metadata()
         self.stdout.write(
-            "\nDone. Fetched {num_total} total. {num_changed} were updated and {num_failed} failed.\n".format(
-                num_changed=num_changed, num_failed=num_failed, num_total=num_total
+            "\nDone."
+            "\n{total} provider(s) found in database."
+            "\n{skipped} skipped and {attempted} attempted."
+            "\n{updated} updated and {failed} failed.\n".format(
+                total=total,
+                skipped=skipped, attempted=attempted,
+                updated=updated, failed=failed,
             )
         )
 
-        if num_failed > 0:
+        if failed > 0:
             raise CommandError(
                 "Command finished with the following exceptions:\n\n{failures}".format(
                     failures="\n\n".join(failure_messages)

--- a/common/djangoapps/third_party_auth/migrations/0006_samlproviderconfig_automatic_refresh_enabled.py
+++ b/common/djangoapps/third_party_auth/migrations/0006_samlproviderconfig_automatic_refresh_enabled.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0005_add_site_field'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='automatic_refresh_enabled',
+            field=models.BooleanField(default=True, help_text=b"When checked, the SAML provider's metadata will be included in the automatic refresh job, if configured.", verbose_name=b'Enable automatic metadata refresh'),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -347,6 +347,9 @@ class SAMLProviderConfig(ProviderConfig):
     attr_email = models.CharField(
         max_length=128, blank=True, verbose_name="Email Attribute",
         help_text="URN of SAML attribute containing the user's email address[es]. Leave blank for default.")
+    automatic_refresh_enabled = models.BooleanField(
+        default=True, verbose_name="Enable automatic metadata refresh",
+        help_text="When checked, the SAML provider's metadata will be included in the automatic refresh job, if configured.")
     debug_mode = models.BooleanField(
         default=False, verbose_name="Debug Mode",
         help_text=(

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -149,11 +149,13 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
         kwargs.setdefault('attr_email', 'urn:oid:1.3.6.1.4.1.5923.1.1.1.6')  # eduPersonPrincipalName
         self.configure_saml_provider(**kwargs)
         self.assertTrue(httpretty.is_enabled())
-        num_changed, num_failed, num_total, failure_messages = fetch_saml_metadata()
+        num_total, num_skipped, num_attempted, num_updated, num_failed, failure_messages = fetch_saml_metadata()
+        self.assertEqual(num_total, 1)
+        self.assertEqual(num_skipped, 0)
+        self.assertEqual(num_attempted, 1)
+        self.assertEqual(num_updated, 1)
         self.assertEqual(num_failed, 0)
         self.assertEqual(len(failure_messages), 0)
-        self.assertEqual(num_changed, 1)
-        self.assertEqual(num_total, 1)
 
     def _freeze_time(self, timestamp):
         """ Mock the current time for SAML, so we can replay canned requests/responses """
@@ -177,12 +179,14 @@ class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
 
         if fetch_metadata:
             self.assertTrue(httpretty.is_enabled())
-            num_changed, num_failed, num_total, failure_messages = fetch_saml_metadata()
+            num_total, num_skipped, num_attempted, num_updated, num_failed, failure_messages = fetch_saml_metadata()
             if assert_metadata_updates:
+                self.assertEqual(num_total, 1)
+                self.assertEqual(num_skipped, 0)
+                self.assertEqual(num_attempted, 1)
+                self.assertEqual(num_updated, 1)
                 self.assertEqual(num_failed, 0)
                 self.assertEqual(len(failure_messages), 0)
-                self.assertEqual(num_changed, 1)
-                self.assertEqual(num_total, 1)
 
     def do_provider_login(self, provider_redirect_url):
         """ Mocked: the user logs in to TestShib and then gets redirected back """


### PR DESCRIPTION
@bradenmacdonald -- here is the control flag we discussed for indicating whether or not a particular SAML provider configuration should be included in the SAML pull job.