### PR TITLE
RTL fixes for HTML xmodule and the LMS reset file

### DIFF
--- a/common/lib/xmodule/xmodule/css/html/display.scss
+++ b/common/lib/xmodule/xmodule/css/html/display.scss
@@ -7,7 +7,7 @@ h1 {
     color: $baseFontColor;
     font: normal 2em/1.4em $sans-serif;
     letter-spacing: 1px;
-    margin: 0 0 1.416em 0;
+    @include margin: (0, 0, 1.416em, 0);
   }
 
 h2 {
@@ -19,7 +19,7 @@ h2 {
 }
 
 h3, h4, h5, h6 {
-  margin: 0 0 ($baseline/2) 0;
+  @include margin(0, 0, ($baseline/2), 0);
   font-weight: 600;
 }
 
@@ -72,7 +72,7 @@ blockquote {
 
 ol, ul {
   margin: 1em 0;
-  padding: 0 0 0 1em;
+  @include padding(0, 0, 0, 1em);
   color: $baseFontColor;
 
   li {

--- a/common/lib/xmodule/xmodule/css/html/display.scss
+++ b/common/lib/xmodule/xmodule/css/html/display.scss
@@ -6,14 +6,22 @@
 h1 {
     color: $baseFontColor;
     font: normal 2em/1.4em $sans-serif;
-    letter-spacing: 1px;
+
+    @include ltr {
+      letter-spacing: 1px;
+    }
+
     @include margin: (0, 0, 1.416em, 0);
   }
 
 h2 {
   color: #646464;
   font: normal 1.2em/1.2em $sans-serif;
-  letter-spacing: 1px;
+
+  @include ltr {
+    letter-spacing: 1px;
+  }
+
   margin-bottom: ($baseline*0.75);
   -webkit-font-smoothing: antialiased;
 }

--- a/lms/static/sass/base/_reset.scss
+++ b/lms/static/sass/base/_reset.scss
@@ -29,7 +29,7 @@ sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: b
 sup { top: -0.5em; }
 sub { bottom: -0.25em; }
 
-ul, ol { margin: 1em 0; padding: 0 0 0 40px; }
+ul, ol { @include padding(padding: 0, 0, 0, 40px;); margin: 1em 0; }
 dd { margin: 0 0 0 40px; }
 nav ul, nav ol { list-style: none; list-style-image: none; margin: 0; padding: 0; }
 
@@ -41,7 +41,8 @@ form { margin: 0; }
 fieldset { border: 0; margin: 0; padding: 0; }
 
 label { cursor: pointer; }
-legend { border: 0; *margin-left: -7px; padding: 0; white-space: normal; }
+legend { @include ltr { *margin-left: -7px; } @include rtl { *margin-right: -7px; } border: 0; padding: 0; white-space: normal; }
+
 button, input, select, textarea { font-size: 100%; margin: 0; vertical-align: baseline; *vertical-align: middle; }
 button, input { line-height: normal; }
 button, input[type="button"], input[type="reset"], input[type="submit"] { cursor: pointer; -webkit-appearance: button; *overflow: visible; }


### PR DESCRIPTION
## Overview

These are few bug which existed in the platform for a very long time. We used to fix it locally, but it's time to get it patched in the upstream repo.

### The `letter-spacing` attribute.
While it looks very cool on English other roman languages. It makes the Arabic, Farsi and Urdu text unreadable. I've places the `@include ltr { ... }` around it. There are lots of other letter-spacing in the platform, which I might fix later. But not in this PR.

### The `ol`, `ul` Elements
They're used all over the platform for all sorts of usages. The reset should be RTL'ized properly to avoid fixing each element locally

### The `legend` Element
Although I haven't seen an issue with the `legend`, but it has usages in the platform:

```
 git grep '<legend' | grep -v -E '\.(js|po|py|scss):' | egrep -v '\b(is-hidden|sr)\b'
```

## The `.ir` Class
Not sure what is this! So I didn't touch it. It's not even used in the platform as far as I know.
```
$ git grep 'class=["'']' | egrep '\bir\b'
```

## TODO
 - [ ] Add before and after screenshots.
 - [ ] Format the `_reset.scss` file? Please let me know if I should do this.

