### PR TITLE
RTL fixes for HTML xmodule and the LMS reset file

### DIFF
--- a/common/lib/xmodule/xmodule/css/html/display.scss
+++ b/common/lib/xmodule/xmodule/css/html/display.scss
@@ -7,7 +7,7 @@ h1 {
     color: $baseFontColor;
     font: normal 2em/1.4em $sans-serif;
     letter-spacing: 1px;
-    margin: 0 0 1.416em 0;
+    @include margin(0, 0, 1.416em, 0);
   }
 
 h2 {
@@ -19,7 +19,7 @@ h2 {
 }
 
 h3, h4, h5, h6 {
-  margin: 0 0 ($baseline/2) 0;
+  @include margin(0, 0, ($baseline/2), 0);
   font-weight: 600;
 }
 
@@ -71,8 +71,9 @@ blockquote {
 }
 
 ol, ul {
+  // Using the lower level Bi App Sass mixin to avoid @padding conflicts with bourbon.
+  @include bi-app-compact(padding, 0, 0, 0, 1em);
   margin: 1em 0;
-  padding: 0 0 0 1em;
   color: $baseFontColor;
 
   li {

--- a/lms/static/sass/base/_reset.scss
+++ b/lms/static/sass/base/_reset.scss
@@ -29,7 +29,7 @@ sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: b
 sup { top: -0.5em; }
 sub { bottom: -0.25em; }
 
-ul, ol { margin: 1em 0; padding: 0 0 0 40px; }
+ul, ol { @include padding(0, 0, 0, 40px); margin: 1em 0; }
 dd { margin: 0 0 0 40px; }
 nav ul, nav ol { list-style: none; list-style-image: none; margin: 0; padding: 0; }
 


### PR DESCRIPTION
## Overview
This is a bug that has been in the platform for a long time, it is mostly visible for the `ul, ol` elements.

### Bug Screenshots
`ul` and `ol` are used all over the platform for all sorts of usages. The reset should be RTL'ized properly to avoid fixing each element locally.

#### Studio Before
<kbd>![image](https://cloud.githubusercontent.com/assets/645156/24588426/693e9dc6-17d0-11e7-94cf-9afa63848456.png)</kbd>

#### Studio After
<kbd>![image](https://cloud.githubusercontent.com/assets/645156/24588423/5c73687e-17d0-11e7-8697-d4b341afa386.png)</kbd>

#### LMS Before
<kbd>![image](https://cloud.githubusercontent.com/assets/645156/24588439/93984306-17d0-11e7-8394-dc74bce00667.png)</kbd>

#### LMS After
<kbd>![image](https://cloud.githubusercontent.com/assets/645156/24588452/00d77680-17d1-11e7-982f-0def1765ec9c.png)</kbd>


## TODO
 - [x] Add before and after screenshots.
 - [ ] Format the `_reset.scss` file? Please let me know if I should do this.
 - [ ] A review by an @Edraak member @Salomari1987


## TODO Not
1. This pull request won't fix the TinyMCE content padding issue with `ul, ol`:
    <kbd><img width="1132" alt="screen shot 2017-04-02 at 5 35 17 pm" src="https://cloud.githubusercontent.com/assets/645156/24588111/eb2c0f4a-17ca-11e7-8406-ecedf6e56ce3.png"></kbd>
 
 3. **The `.ir` Class** Not sure what is this! So I didn't touch it. It's not even used in the platform as far as I know. ```$ git grep 'class=["'']' | egrep '\bir\b'```

 4. The `legend` element should have some issues in the `*margin-left`, but I haven't face them! So I can't fix it. ```$ git grep '<legend' | grep -v -E '\.(js|po|py|scss):' | egrep -v '\b(is-hidden|sr)\b'```

 5. As mentioned in the code comment, both `bourbon` and `bi-app-sass` defines a mixin named `@padding`. At the `_reset.scss` file `bourbon` takes precedence. The solution was to use an alternative method to avoid naming clash.
     It could be solved by reversing the inclusion order of bourbon and bi-app-sass but this has a platform-wide effect that needs a lot of further testing, which is a bit out of the scope of this PR.

----

This is a re-open for a previous pull request (#14785) which has been rejected by the @edx-webhook.