### PR TITLE
Add Enrollment tracks to component visibility dialog

### DIFF
--- a/cms/djangoapps/contentstore/course_group_config.py
+++ b/cms/djangoapps/contentstore/course_group_config.py
@@ -8,8 +8,8 @@ from util.db import generate_int_id, MYSQL_MAX_INT
 
 from django.utils.translation import ugettext as _
 from contentstore.utils import reverse_usage_url
-from xmodule.partitions.partitions import UserPartition
-from xmodule.partitions.partitions_service import get_all_partitions_for_course, MINIMUM_STATIC_PARTITION_ID
+from xmodule.partitions.partitions import UserPartition, MINIMUM_STATIC_PARTITION_ID
+from xmodule.partitions.partitions_service import get_all_partitions_for_course
 from xmodule.split_test_module import get_split_user_partitions
 from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition
 
@@ -18,11 +18,11 @@ MINIMUM_GROUP_ID = MINIMUM_STATIC_PARTITION_ID
 RANDOM_SCHEME = "random"
 COHORT_SCHEME = "cohort"
 
-# Note: the following content group configuration strings are not
-# translated since they are not visible to users.
-CONTENT_GROUP_CONFIGURATION_DESCRIPTION = 'The groups in this configuration can be mapped to cohort groups in the LMS.'
+CONTENT_GROUP_CONFIGURATION_DESCRIPTION = _(
+    'The groups in this configuration can be mapped to cohorts in the Instructor Dashboard.'
+)
 
-CONTENT_GROUP_CONFIGURATION_NAME = 'Content Group Configuration'
+CONTENT_GROUP_CONFIGURATION_NAME = _('Content Groups')
 
 log = logging.getLogger(__name__)
 

--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -510,7 +510,7 @@ class GetUserPartitionInfoTest(ModuleStoreTestCase):
         self.assertEqual(len(groups), 3)
         self.assertEqual(groups[2], {
             "id": 3,
-            "name": "Deleted group",
+            "name": "Deleted Group",
             "selected": True,
             "deleted": True
         })

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -8,7 +8,7 @@ import ddt
 from mock import patch
 
 from contentstore.utils import reverse_course_url, reverse_usage_url
-from contentstore.course_group_config import GroupConfiguration
+from contentstore.course_group_config import GroupConfiguration, CONTENT_GROUP_CONFIGURATION_NAME
 from contentstore.tests.utils import CourseTestCase
 from xmodule.partitions.partitions import Group, UserPartition
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -240,7 +240,7 @@ class GroupConfigurationsListHandlerTestCase(CourseTestCase, GroupConfigurations
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'First name')
         self.assertContains(response, 'Group C')
-        self.assertContains(response, 'Content Group Configuration')
+        self.assertContains(response, CONTENT_GROUP_CONFIGURATION_NAME)
 
     def test_unsupported_http_accept_header(self):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -44,8 +44,9 @@ from xblock.exceptions import NoSuchHandlerError
 from xblock_django.user_service import DjangoXBlockUserService
 from opaque_keys.edx.keys import UsageKey, CourseKey
 from opaque_keys.edx.locations import Location
-from xmodule.partitions.partitions import Group, UserPartition
-from xmodule.partitions.partitions_service import ENROLLMENT_TRACK_PARTITION_ID, MINIMUM_STATIC_PARTITION_ID
+from xmodule.partitions.partitions import (
+    Group, UserPartition, ENROLLMENT_TRACK_PARTITION_ID, MINIMUM_STATIC_PARTITION_ID
+)
 
 
 class AsideTest(XBlockAside):
@@ -348,9 +349,9 @@ class GetItemTest(ItemTest):
         self.course.user_partitions = [
             UserPartition(
                 id=MINIMUM_STATIC_PARTITION_ID,
-                name="Verification user partition",
-                scheme=UserPartition.get_scheme("verification"),
-                description="Verification user partition",
+                name="Random user partition",
+                scheme=UserPartition.get_scheme("random"),
+                description="Random user partition",
                 groups=[
                     Group(id=MINIMUM_STATIC_PARTITION_ID + 1, name="Group A"),  # See note above.
                     Group(id=MINIMUM_STATIC_PARTITION_ID + 2, name="Group B"),  # See note above.
@@ -370,7 +371,7 @@ class GetItemTest(ItemTest):
         self.assertEqual(result["user_partitions"], [
             {
                 "id": ENROLLMENT_TRACK_PARTITION_ID,
-                "name": "Enrollment Track Partition",
+                "name": "Enrollment Tracks",
                 "scheme": "enrollment_track",
                 "groups": [
                     {
@@ -383,8 +384,8 @@ class GetItemTest(ItemTest):
             },
             {
                 "id": MINIMUM_STATIC_PARTITION_ID,
-                "name": "Verification user partition",
-                "scheme": "verification",
+                "name": "Random user partition",
+                "scheme": "random",
                 "groups": [
                     {
                         "id": MINIMUM_STATIC_PARTITION_ID + 1,

--- a/cms/static/js/models/xblock_info.js
+++ b/cms/static/js/models/xblock_info.js
@@ -256,19 +256,6 @@ function(Backbone, _, str, ModuleUtils) {
         */
         isEditableOnCourseOutline: function() {
             return this.isSequential() || this.isChapter() || this.isVertical();
-        },
-
-       /*
-        * Check whether any verification checkpoints are defined in the course.
-        * Verification checkpoints are defined if there exists a user partition
-        * that uses the verification partition scheme.
-        */
-        hasVerifiedCheckpoints: function() {
-            var partitions = this.get('user_partitions') || [];
-
-            return Boolean(_.find(partitions, function(p) {
-                return p.scheme === 'verification';
-            }));
         }
     });
     return XBlockInfo;

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -15,7 +15,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
     'use strict';
     var CourseOutlineXBlockModal, SettingsXBlockModal, PublishXBlockModal, AbstractEditor, BaseDateEditor,
         ReleaseDateEditor, DueDateEditor, GradingEditor, PublishEditor, AbstractVisibilityEditor, StaffLockEditor,
-        ContentVisibilityEditor, VerificationAccessEditor, TimedExaminationPreferenceEditor, AccessEditor;
+        ContentVisibilityEditor, TimedExaminationPreferenceEditor, AccessEditor;
 
     CourseOutlineXBlockModal = BaseModal.extend({
         events: _.extend({}, BaseModal.prototype.events, {
@@ -720,109 +720,6 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         }
     });
 
-    VerificationAccessEditor = AbstractEditor.extend({
-        templateName: 'verification-access-editor',
-        className: 'edit-verification-access',
-
-        // This constant MUST match the group ID
-        // defined by VerificationPartitionScheme on the backend!
-        ALLOW_GROUP_ID: 1,
-
-        getSelectedPartition: function() {
-            var hasRestrictions = $('#verification-access-checkbox').is(':checked'),
-                selectedPartitionID = null;
-
-            if (hasRestrictions) {
-                selectedPartitionID = $('#verification-partition-select').val();
-            }
-
-            return parseInt(selectedPartitionID, 10);
-        },
-
-        getGroupAccess: function() {
-            var groupAccess = _.clone(this.model.get('group_access')) || [],
-                userPartitions = this.model.get('user_partitions') || [],
-                selectedPartition = this.getSelectedPartition(),
-                that = this;
-
-            // We display a simplified UI to course authors.
-            // On the backend, each verification checkpoint is associated
-            // with a user partition that has two groups.  For example,
-            // if two checkpoints were defined, they might look like:
-            //
-            // Midterm A: |-- ALLOW --|-- DENY --|
-            // Midterm B: |-- ALLOW --|-- DENY --|
-            //
-            // To make life easier for course authors, we display
-            // *one* option for each checkpoint:
-            //
-            // [X] Must complete verification checkpoint
-            //     Dropdown:
-            //        * Midterm A
-            //        * Midterm B
-            //
-            // This is where we map the simplified UI to
-            // the underlying user partition.  If the user checked
-            // the box, that means there *is* a restriction,
-            // so only the "ALLOW" group for the selected partition has access.
-            // Otherwise, all groups in the partition have access.
-            //
-            _.each(userPartitions, function(partition) {
-                if (partition.scheme === 'verification') {
-                    if (selectedPartition === partition.id) {
-                        groupAccess[partition.id] = [that.ALLOW_GROUP_ID];
-                    } else {
-                        delete groupAccess[partition.id];
-                    }
-                }
-            });
-
-            return groupAccess;
-        },
-
-        getRequestData: function() {
-            var groupAccess = this.getGroupAccess(),
-                hasChanges = !_.isEqual(groupAccess, this.model.get('group_access'));
-
-            return hasChanges ? {
-                publish: 'republish',
-                metadata: {
-                    group_access: groupAccess
-                }
-            } : {};
-        },
-
-        getContext: function() {
-            var partitions = this.model.get('user_partitions'),
-                hasRestrictions = false,
-                verificationPartitions = [],
-                isSelected = false;
-
-            // Display a simplified version of verified partition schemes.
-            // Although there are two groups defined (ALLOW and DENY),
-            // we show only the ALLOW group.
-            // To avoid searching all the groups, we're assuming that the editor
-            // either sets the ALLOW group or doesn't set any groups (implicitly allow all).
-            _.each(partitions, function(item) {
-                if (item.scheme === 'verification') {
-                    isSelected = _.any(_.pluck(item.groups, 'selected'));
-                    hasRestrictions = hasRestrictions || isSelected;
-
-                    verificationPartitions.push({
-                        'id': item.id,
-                        'name': item.name,
-                        'selected': isSelected
-                    });
-                }
-            });
-
-            return {
-                'hasVerificationRestrictions': hasRestrictions,
-                'verificationPartitions': verificationPartitions
-            };
-        }
-    });
-
     return {
         getModal: function(type, xblockInfo, options) {
             if (type === 'edit') {
@@ -837,10 +734,6 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             var editors = [];
             if (xblockInfo.isVertical()) {
                 editors = [StaffLockEditor];
-
-                if (xblockInfo.hasVerifiedCheckpoints()) {
-                    editors.push(VerificationAccessEditor);
-                }
             } else {
                 tabs = [
                     {

--- a/cms/static/sass/_build-v1.scss
+++ b/cms/static/sass/_build-v1.scss
@@ -91,3 +91,5 @@
 // CAPA Problem Feedback
 @import 'edx-pattern-library-shims/buttons';
 
+@import 'edx-pattern-library-shims/base/variables';
+

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -1,6 +1,8 @@
 // studio - elements - modal-window
 // ========================
 
+@import 'edx-pattern-library-shims/base/variables';
+
 // start with the view/body
 [class*="view-"] {
 
@@ -482,59 +484,59 @@
   // MODAL TYPE: component - visibility modal
   .xblock-visibility_view {
 
-    .visibility-controls-secondary {
-      max-height: 100%;
-      overflow-y: auto;
-      @include margin(($baseline*0.75), 0, 0, $baseline);
+    // We don't wish the dialog to resize for the common case of 2 groups.
+    min-height: 190px;
+
+    .visibility-header {
+      padding-bottom: $baseline;
+      margin-bottom: 0;
+      color: $gray-d3;
     }
 
-    .visibility-controls-group {
-      @extend %wipe-last-child;
-      margin-bottom: $baseline;
+    .current-visibility-title {
+      font-weight: font-weight(semi-bold);
+
+      .icon {
+        @include margin-right($baseline/8);
+      }
+    }
+
+    .group-select-title {
+      font-weight: font-weight(semi-bold);
+      font-size: inherit;
+    }
+
+    .partition-visibility {
+        padding-top: $baseline;
     }
 
     // UI: form fields
-    .list-fields {
+    .partition-group-control {
+
+      padding-top: ($baseline/2);
 
       .field {
-        @extend %wipe-last-child;
-        margin-bottom: ($baseline/4);
-
-        label {
-          @extend %t-copy-sub1;
-        }
-      }
-
-      // UI: radio and checkbox inputs
-      .field-radio, .field-checkbox {
+        margin-top: ($baseline/4);
 
         label {
           @include margin-left($baseline/4);
+          font-size: inherit;
         }
       }
     }
 
-    .field-visibility-verification {
-      .note {
-        @extend %t-copy-sub2;
-        @extend %t-regular;
-        margin: 14px 0 0 24px;
-        display: block;
-      }
-    }
-
-    // CASE: content group has been removed
-    .field-visibility-content-group.was-removed {
+    // CASE: content or enrollment group has been removed
+    .partition-group-visibility.was-removed {
 
       .input-checkbox:checked ~ label {
-        color: $color-error;
+        color: $error-color;
       }
 
       .note {
         @extend %t-copy-sub2;
         @extend %t-regular;
         display: block;
-        color: $color-error;
+        color: $error-color;
       }
     }
 
@@ -698,7 +700,7 @@
     }
 
     // UI: staff lock section
-    .edit-staff-lock, .edit-settings-timed-examination, .edit-verification-access {
+    .edit-staff-lock, .edit-settings-timed-examination {
 
       .checkbox-cosmetic .input-checkbox {
         @extend %cont-text-sr;
@@ -727,13 +729,6 @@
         @extend %t-regular;
         margin: 14px 0 0 21px;
         display: block;
-      }
-    }
-
-    .verification-access {
-      .checkbox-cosmetic .label {
-        @include float(left);
-        margin: 2px 6px 0 0;
       }
     }
 

--- a/cms/templates/js/publish-xblock.underscore
+++ b/cms/templates/js/publish-xblock.underscore
@@ -86,7 +86,7 @@ var visibleToStaffOnly = visibilityState === 'staff_only';
             <% if (hasContentGroupComponents) { %>
                 <p class="note-visibility">
                     <span class="icon fa fa-eye" aria-hidden="true"></span>
-                    <span class="note-copy"><%- gettext("Some content in this unit is visible only to particular content groups") %></span>
+                    <span class="note-copy"><%- gettext("Some content in this unit is visible only to specific groups of learners.") %></span>
                 </p>
             <% } %>
         <ul class="actions-inline">

--- a/cms/templates/visibility_editor.html
+++ b/cms/templates/visibility_editor.html
@@ -1,25 +1,29 @@
+<%page expression_filter="h"/>
 <%
+from django.conf import settings
 from django.utils.translation import ugettext as _
-from openedx.core.djangoapps.credit.partition_schemes import VerificationPartitionScheme
 from contentstore.utils import ancestor_has_staff_lock, get_visibility_partition_info
+from openedx.core.djangolib.markup import HTML, Text
 
 partition_info = get_visibility_partition_info(xblock)
-user_partitions = partition_info["user_partitions"]
-cohort_partitions = partition_info["cohort_partitions"]
-verification_partitions = partition_info["verification_partitions"]
-has_selected_groups = partition_info["has_selected_groups"]
-selected_verified_partition_id = partition_info["selected_verified_partition_id"]
+selectable_partitions = partition_info["selectable_partitions"]
+selected_partition_index = partition_info["selected_partition_index"]
+selected_groups_label = partition_info["selected_groups_label"]
 
 is_staff_locked = ancestor_has_staff_lock(xblock)
 %>
 
 <div class="modal-section visibility-summary">
-    % if len(user_partitions) == 0:
+    % if len(selectable_partitions) == 0:
         <div class="is-not-configured has-actions">
-            <h4 class="title">${_('No content groups exist')}</h4>
-
+            <h3 class="title">${_('No visibility settings')}</h3>
             <div class="copy">
-                <p>${_('Use content groups to give groups of students access to a specific set of course content. Create one or more content groups, and make specific components visible to them.')}</p>
+                <p>${_('No visibility settings are defined for this component, but visibility might be affected by inherited settings.')}</p>
+                % if settings.FEATURES.get('ENABLE_ENROLLMENT_TRACK_USER_PARTITION'):
+                <p>${_('You can make this component visible only to specific groups of learners based either on their enrollment track, or by content groups that you create.')}</p>
+                % else:
+                <p>${_('You can make this component visible only to specific groups of learners based on content groups that you create.')}</p>
+                % endif
             </div>
 
             <div class="actions">
@@ -31,11 +35,11 @@ is_staff_locked = ancestor_has_staff_lock(xblock)
             <span class="icon fa fa-exclamation-triangle" aria-hidden="true"></span>
             <p class="copy">
                 ## Translators: Any text between {screen_reader_start} and {screen_reader_end} is only read by screen readers and never shown in the browser.
-                ${_(
-                    "{screen_reader_start}Warning:{screen_reader_end} The Unit this component is contained in is hidden from students. Visibility settings here will be trumped by this."
-                    ).format(
-                        screen_reader_start='<span class="sr">',
-                        screen_reader_end='</span>',
+                ${Text(_(
+                    "{screen_reader_start}Warning:{screen_reader_end} The unit that contains this component is hidden from learners. The unit setting overrides the component visibility settings defined here."
+                    )).format(
+                        screen_reader_start=HTML('<span class="sr">'),
+                        screen_reader_end=HTML('</span>'),
                     )
                 }
             </p>
@@ -43,95 +47,65 @@ is_staff_locked = ancestor_has_staff_lock(xblock)
     % endif
 </div>
 
-% if len(user_partitions) > 0:
+% if len(selectable_partitions) > 0:
     <form class="visibility-controls-form" method="post" action="">
-
+        <div role="group" aria-labelledby="visibility-title">
         <div class="modal-section visibility-controls">
-            <h3 class="modal-section-title">${_('Make visible to:')}</h3>
-
-            <div class="modal-section-content">
-
-                <section class="visibility-controls-primary">
-                    <div class="list-fields list-radio">
-                        <div class="field field-radio field-visibility-level">
-                            <input type="radio" id="visibility-level-all" name="visibility-level" value="" class="input input-radio visibility-level-all" ${'checked="checked"' if not has_selected_groups else ''} />
-                            <label for="visibility-level-all" class="label">${_('All Students and Staff')}</label>
-                        </div>
-
-                        <div class="field field-radio field-visibility-level">
-                            <input type="radio" id="visibility-level-specific" name="visibility-level" value="" class="input input-radio visibility-level-specific"  ${'checked="checked"' if has_selected_groups else ''} />
-                            <label for="visibility-level-specific" class="label">${_('Specific Content Groups')}</label>
-                        </div>
-                    </div>
-                </section>
-
-                <div class="wrapper-visibility-specific">
-                    <section class="visibility-controls-secondary">
-                        <div class="visibility-controls-group">
-                            <h4 class="visibility-controls-title modal-subsection-title sr">${_('Content Groups')}</h4>
-                            <div class="list-fields list-checkbox">
-                            % for partition in cohort_partitions:
-                                % for group in partition["groups"]:
-                                    <div class="field field-checkbox field-visibility-content-group ${'was-removed' if group["deleted"] else ''}">
-                                        <input type="checkbox"
-                                            id="visibility-content-group-${partition["id"]}-${group["id"]}"
-                                            name="visibility-content-group"
-                                            value="${partition["id"]}-${group["id"]}"
-                                            class="input input-checkbox"
-                                            ${'checked="checked"' if group["selected"] else ''}
-                                        />
-                                        % if group["deleted"]:
-                                            <label for="visibility-content-group-${partition["id"]}-${group["id"]}" class="label">
-                                                ${_('Deleted Content Group')}
-                                                <span class="note">${_('Content group no longer exists. Please choose another or allow access to All Students and staff')}</span>
-                                            </label>
-                                        % else:
-                                            <label for="visibility-content-group-${partition["id"]}-${group["id"]}" class="label">${group["name"] | h}</label>
-                                        % endif
-                                    </div>
-                                % endfor
-                            % endfor
-
-                            ## Allow only one verification checkpoint to be selected at a time.
-                            % if verification_partitions:
-                                <div role="group" aria-labelledby="verification-access-title">
-                                    <div id="verification-access-title" class="sr">${_('Verification Checkpoint')}</div>
-                                    <div class="field field-checkbox field-visibility-verification">
-                                        <input type="checkbox"
-                                            id="verification-access-checkbox"
-                                            name="verification-access-checkbox"
-                                            class="input input-checkbox"
-                                            value=""
-                                            aria-describedby="verification-help-text"
-                                            ${'checked="checked"' if selected_verified_partition_id is not None else ''}
-                                        />
-                                        <label for="verification-access-checkbox" class="label">
-                                            ${_('Verification Checkpoint')}:
-                                        </label>
-
-                                        <label class="sr" for="verification-access-dropdown">
-                                            ${_('Verification checkpoint to complete')}
-                                        </label>
-
-                                        <select id="verification-access-dropdown">
-                                            % for partition in verification_partitions:
-                                            <option
-                                                value="${partition["id"]}"
-                                                ${ "selected" if partition["id"] == selected_verified_partition_id else ""}
-                                            >${partition["name"]}</option>
-                                            % endfor
-                                        </select>
-
-                                        <div class="note" id="verification-help-text">
-                                            ${_("Learners who require verification must pass the selected checkpoint to see the content in this component. Learners who do not require verification see this content by default.")}
-                                        </div>
-                                    </div>
-                                </div>
+            <h3 class="modal-section-title visibility-header" id="visibility-title">
+                <span class="current-visibility-title">
+                    <span class="icon fa fa-eye" aria-hidden="true"></span>
+                    <span>${_('Currently visible to:')}</span>
+                </span>
+                % if selected_partition_index == -1:
+                <span>${_('All Learners and Staff')}</span>
+                % else:
+                <span>${selected_groups_label}</span>
+                % endif
+            </h3>
+            <div class="modal-section-content partition-visibility">
+                <label class="group-select-title">${_('Change visibility to:')}
+                    <select>
+                        <option value="-1" selected ="selected">
+                            % if selected_partition_index == -1:
+                                ${_('Choose one')}
+                            % else:
+                                ${_('All Learners and Staff')}
                             % endif
-                            </div>
-                        </div>
-                    </section>
+                        </option>
+                        % for index, partition in enumerate(selectable_partitions):
+                            <option value="${partition["id"]}" id="visibility-partition-${partition["id"]}" ${'selected="selected"' if selected_partition_index == index else ''}}>
+                                ${partition["name"]}
+                            </option>
+                        % endfor
+                    </select>
+                </label>
+
+                % for index, partition in enumerate(selectable_partitions):
+                <div role="group" aria-labelledby="partition-group-directions-${partition["id"]}" aria-describedby="visibility-partition-${partition["id"]}"
+                    class="partition-group-control partition-group-control-${partition["id"]} ${'is-hidden' if selected_partition_index != index else ''}">
+                    <div class="partition-group-directions" id="partition-group-directions-${partition["id"]}">${_('Select one or more groups:')}
+                        % for group in partition["groups"]:
+                        <div class="field partition-group-visibility partition-group-visibility-${partition["id"]} ${'was-removed' if group["deleted"] else ''}">
+                            <input type="checkbox"
+                                id="visibility-group-${partition["id"]}-${group["id"]}"
+                                name="visibility-group"
+                                value="${group["id"]}"
+                                class="input input-checkbox"
+                                ${'checked="checked"' if group["selected"] else ''}
+                            />
+                            % if group["deleted"]:
+                            <label for="visibility-group-${partition["id"]}-${group["id"]}" class="label">
+                                ${_("Deleted Group")}
+                                <span class="note">${_('This group no longer exists. Choose another group or make this component visible to All Learners and Staff.')}</span>
+                            </label>
+                            % else:
+                            <label for="visibility-group-${partition["id"]}-${group["id"]}" class="label">${group["name"]}</label>
+                            % endif
+                         </div>
+                        % endfor
+                    </div>
                 </div>
+                % endfor
             </div>
         </div>
     </form>

--- a/common/lib/xmodule/xmodule/partitions/partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions.py
@@ -8,6 +8,16 @@ from stevedore.extension import ExtensionManager
 # pylint: disable=redefined-builtin
 
 
+# UserPartition IDs must be unique. The Cohort and Random UserPartitions (when they are
+# created via Studio) choose an unused ID in the range of 100 (historical) to MAX_INT. Therefore the
+# dynamic UserPartitionIDs must be under 100, and they have to be hard-coded to ensure
+# they are always the same whenever the dynamic partition is added (since the UserPartition
+# ID is stored in the xblock group_access dict).
+ENROLLMENT_TRACK_PARTITION_ID = 50
+
+MINIMUM_STATIC_PARTITION_ID = 100
+
+
 class UserPartitionError(Exception):
     """
     Base Exception for when an error was found regarding user partitions.

--- a/common/lib/xmodule/xmodule/partitions/partitions_service.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions_service.py
@@ -7,21 +7,11 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 import logging
 
-from xmodule.partitions.partitions import UserPartition, UserPartitionError
+from xmodule.partitions.partitions import UserPartition, UserPartitionError, ENROLLMENT_TRACK_PARTITION_ID
 from xmodule.modulestore.django import modulestore
 
 
 log = logging.getLogger(__name__)
-
-
-# UserPartition IDs must be unique. The Cohort and Random UserPartitions (when they are
-# created via Studio) choose an unused ID in the range of 100 (historical) to MAX_INT. Therefore the
-# dynamic UserPartitionIDs must be under 100, and they have to be hard-coded to ensure
-# they are always the same whenever the dynamic partition is added (since the UserPartition
-# ID is stored in the xblock group_access dict).
-ENROLLMENT_TRACK_PARTITION_ID = 50
-
-MINIMUM_STATIC_PARTITION_ID = 100
 
 
 # settings will not be available when running nosetests.
@@ -84,7 +74,7 @@ def _create_enrollment_track_partition(course):
 
     partition = enrollment_track_scheme.create_user_partition(
         id=ENROLLMENT_TRACK_PARTITION_ID,
-        name=_(u"Enrollment Track Partition"),
+        name=_(u"Enrollment Tracks"),
         description=_(u"Partition for segmenting users by enrollment track"),
         parameters={"course_id": unicode(course.id)}
     )

--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -9,10 +9,11 @@ from mock import Mock
 from opaque_keys.edx.locator import CourseLocator
 from stevedore.extension import Extension, ExtensionManager
 from xmodule.partitions.partitions import (
-    Group, UserPartition, UserPartitionError, NoSuchUserPartitionGroupError, USER_PARTITION_SCHEME_NAMESPACE
+    Group, UserPartition, UserPartitionError, NoSuchUserPartitionGroupError,
+    USER_PARTITION_SCHEME_NAMESPACE, ENROLLMENT_TRACK_PARTITION_ID
 )
 from xmodule.partitions.partitions_service import (
-    PartitionService, get_all_partitions_for_course, ENROLLMENT_TRACK_PARTITION_ID, FEATURES
+    PartitionService, get_all_partitions_for_course, FEATURES
 )
 
 

--- a/common/lib/xmodule/xmodule/tests/test_split_test_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_split_test_module.py
@@ -13,8 +13,7 @@ from xmodule.tests import get_test_system
 from xmodule.x_module import AUTHOR_VIEW, STUDENT_VIEW
 from xmodule.validation import StudioValidationMessage
 from xmodule.split_test_module import SplitTestDescriptor, SplitTestFields, get_split_user_partitions
-from xmodule.partitions.partitions import Group, UserPartition
-from xmodule.partitions.partitions_service import MINIMUM_STATIC_PARTITION_ID
+from xmodule.partitions.partitions import Group, UserPartition, MINIMUM_STATIC_PARTITION_ID
 
 
 class SplitTestModuleFactory(xml.XmlImportFactory):

--- a/common/test/acceptance/tests/lms/test_lms_cohorted_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_cohorted_courseware_search.py
@@ -174,22 +174,18 @@ class CoursewareSearchCohortTest(ContainerBase):
         """
         container_page = self.go_to_unit_page()
 
-        def set_visibility(html_block_index, content_group, second_content_group=None):
+        def set_visibility(html_block_index, groups):
             """
             Set visibility on html blocks to specified groups.
             """
             html_block = container_page.xblocks[html_block_index]
             html_block.edit_visibility()
-            if second_content_group:
-                ComponentVisibilityEditorView(self.browser, html_block.locator).select_option(
-                    second_content_group, save=False
-                )
-            ComponentVisibilityEditorView(self.browser, html_block.locator).select_option(content_group)
+            visibility_dialog = ComponentVisibilityEditorView(self.browser, html_block.locator)
+            visibility_dialog.select_groups_in_partition_scheme(visibility_dialog.CONTENT_GROUP_PARTITION, groups)
 
-        set_visibility(1, self.content_group_a)
-        set_visibility(2, self.content_group_b)
-        set_visibility(3, self.content_group_a, self.content_group_b)
-        set_visibility(4, 'All Students and Staff')  # Does not work without this
+        set_visibility(1, [self.content_group_a])
+        set_visibility(2, [self.content_group_b])
+        set_visibility(3, [self.content_group_a, self.content_group_b])
 
         container_page.publish_action.click()
 

--- a/common/test/acceptance/tests/test_cohorted_courseware.py
+++ b/common/test/acceptance/tests/test_cohorted_courseware.py
@@ -17,7 +17,6 @@ from common.test.acceptance.pages.lms.courseware import CoursewarePage
 from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage as LmsAutoAuthPage
 from common.test.acceptance.tests.lms.test_lms_user_preview import verify_expected_problem_visibility
 
-from bok_choy.promise import EmptyPromise
 from bok_choy.page_object import XSS_INJECTION
 
 
@@ -121,18 +120,15 @@ class EndToEndCohortedCoursewareTest(ContainerBase):
         """
         container_page = self.go_to_unit_page()
 
-        def set_visibility(problem_index, content_group, second_content_group=None):
+        def set_visibility(problem_index, groups):
             problem = container_page.xblocks[problem_index]
             problem.edit_visibility()
-            if second_content_group:
-                ComponentVisibilityEditorView(self.browser, problem.locator).select_option(
-                    second_content_group, save=False
-                )
-            ComponentVisibilityEditorView(self.browser, problem.locator).select_option(content_group)
+            visibility_dialog = ComponentVisibilityEditorView(self.browser, problem.locator)
+            visibility_dialog.select_groups_in_partition_scheme(visibility_dialog.CONTENT_GROUP_PARTITION, groups)
 
-        set_visibility(1, self.content_group_a)
-        set_visibility(2, self.content_group_b)
-        set_visibility(3, self.content_group_a, self.content_group_b)
+        set_visibility(1, [self.content_group_a])
+        set_visibility(2, [self.content_group_b])
+        set_visibility(3, [self.content_group_a, self.content_group_b])
 
         container_page.publish_action.click()
 

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -44,8 +44,7 @@ from xmodule.course_module import (
     CATALOG_VISIBILITY_NONE,
 )
 from xmodule.error_module import ErrorDescriptor
-from xmodule.partitions.partitions import Group, UserPartition
-from xmodule.partitions.partitions_service import MINIMUM_STATIC_PARTITION_ID
+from xmodule.partitions.partitions import Group, UserPartition, MINIMUM_STATIC_PARTITION_ID
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -15,6 +15,9 @@ from xmodule.partitions.partitions import NoSuchUserPartitionError, NoSuchUserPa
 # more information can be found here: https://openedx.atlassian.net/browse/PLAT-902
 _ = lambda text: text
 
+INVALID_USER_PARTITION_VALIDATION = _(u"This component's visibility settings refer to deleted or invalid group configurations.")
+INVALID_USER_PARTITION_GROUP_VALIDATION = _(u"This component's visibility settings refer to deleted or invalid groups.")
+
 
 class GroupAccessDict(Dict):
     """Special Dict class for serializing the group_access field"""
@@ -165,14 +168,14 @@ class LmsBlockMixin(XBlockMixin):
             validation.add(
                 ValidationMessage(
                     ValidationMessage.ERROR,
-                    _(u"This component refers to deleted or invalid content group configurations.")
+                    INVALID_USER_PARTITION_VALIDATION
                 )
             )
         if has_invalid_groups:
             validation.add(
                 ValidationMessage(
                     ValidationMessage.ERROR,
-                    _(u"This component refers to deleted or invalid content groups.")
+                    INVALID_USER_PARTITION_GROUP_VALIDATION
                 )
             )
         return validation

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -4,6 +4,7 @@ Tests of the LMS XBlock Mixin
 import ddt
 from nose.plugins.attrib import attr
 
+from lms_xblock.mixin import INVALID_USER_PARTITION_VALIDATION, INVALID_USER_PARTITION_GROUP_VALIDATION
 from xblock.validation import ValidationMessage
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.factories import CourseFactory, ToyCourseFactory, ItemFactory
@@ -90,7 +91,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         self.assertEqual(len(validation.messages), 1)
         self.verify_validation_message(
             validation.messages[0],
-            u"This component refers to deleted or invalid content group configurations.",
+            INVALID_USER_PARTITION_VALIDATION,
             ValidationMessage.ERROR,
         )
 
@@ -102,7 +103,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         self.assertEqual(len(validation.messages), 1)
         self.verify_validation_message(
             validation.messages[0],
-            u"This component refers to deleted or invalid content group configurations.",
+            INVALID_USER_PARTITION_VALIDATION,
             ValidationMessage.ERROR,
         )
 
@@ -115,7 +116,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         self.assertEqual(len(validation.messages), 1)
         self.verify_validation_message(
             validation.messages[0],
-            u"This component refers to deleted or invalid content groups.",
+            INVALID_USER_PARTITION_GROUP_VALIDATION,
             ValidationMessage.ERROR,
         )
 
@@ -125,7 +126,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         self.assertEqual(len(validation.messages), 1)
         self.verify_validation_message(
             validation.messages[0],
-            u"This component refers to deleted or invalid content groups.",
+            INVALID_USER_PARTITION_GROUP_VALIDATION,
             ValidationMessage.ERROR,
         )
 

--- a/openedx/core/djangoapps/verified_track_content/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/verified_track_content/tests/test_partition_scheme.py
@@ -12,8 +12,7 @@ from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.partitions.partitions import UserPartition
-from xmodule.partitions.partitions_service import MINIMUM_STATIC_PARTITION_ID
+from xmodule.partitions.partitions import UserPartition, MINIMUM_STATIC_PARTITION_ID
 
 
 class EnrollmentTrackUserPartitionTest(SharedModuleStoreTestCase):
@@ -160,7 +159,7 @@ def create_enrollment_track_partition(course):
     enrollment_track_scheme = UserPartition.get_scheme("enrollment_track")
     partition = enrollment_track_scheme.create_user_partition(
         id=1,
-        name="TestEnrollment Track Partition",
+        name="Test Enrollment Track Partition",
         description="Test partition for segmenting users by enrollment track",
         parameters={"course_id": unicode(course.id)}
     )


### PR DESCRIPTION
## [TNL-6744](https://openedx.atlassian.net/browse/TNL-6744)

### Description

This PR exposes the Enrollment Track partition to the component visibility dialog (if the feature flag is enabled, which is not currently the case in production).

### Sandbox
- [x] Sandbox for testing:
1) This unit has components limiting visibility to enrollment tracks or content groups (user "verified" is in the verified enrollment track). Note that it also shows what happens with a missing group (scroll down to bottom of unit). https://studio-tnl6744.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@79ed941f1ef5480293e4bdc84a18f5af

2) This course has NO content groups and only a single enrollment track, so the visibility dialog only has a message about "no visibility settings" existing. https://studio-tnl6744.sandbox.edx.org/container/block-v1:DemoX+PERF101+course+type@vertical+block@fe036a7f07364a79ba47bf2f7fddb0a9

### Testing
- [x] i18n
- [x] RTL
- [x] safecommit violation code review process
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @staubina 
- [x] Code review: @jlajoie 
- [x] Doc Review: @catong 
- [x] UX review: @roderickmorales 
- [x] Accessibility review: @cptvitamin 
- [x] Product review: @sstack22 

### Post-review
- [x] Rebase and squash commits (and remove the temporary commit to enable feature flags!)