### PR TITLE
fix issue where orphaned openassessment blocks cause 500 errors on th…

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -336,14 +336,27 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
         self.assertNotIn(ora_section, response.content)
 
-        course = ItemFactory.create(
-            parent_location=self.course.location,
-            category="course",
-            display_name="Test course",
-        )
-        ItemFactory.create(parent_location=course.location, category="openassessment")
+        ItemFactory.create(parent_location=self.course.location, category="openassessment")
         response = self.client.get(self.url)
         self.assertIn(ora_section, response.content)
+
+    def test_open_response_assessment_page_orphan(self):
+        """
+        Tests that the open responses tab loads if the course contains an
+        orphaned openassessment block
+        """
+        # create non-orphaned openassessment block
+        ItemFactory.create(
+            parent_location=self.course.location,
+            category="openassessment",
+        )
+        # create orphan
+        self.store.create_item(
+            self.user.id, self.course.id, 'openassessment', "orphan"
+        )
+        response = self.client.get(self.url)
+        # assert we don't get a 500 error
+        self.assertEqual(200, response.status_code)
 
 
 @ddt.ddt

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -192,7 +192,13 @@ def instructor_dashboard_2(request, course_id):
     if certs_enabled and access['admin']:
         sections.append(_section_certificates(course))
 
-    openassessment_blocks = modulestore().get_items(course_key, qualifiers={'category': 'openassessment'})
+    openassessment_blocks = modulestore().get_items(
+        course_key, qualifiers={'category': 'openassessment'}
+    )
+    # filter out orphaned openassessment blocks
+    openassessment_blocks = [
+        block for block in openassessment_blocks if block.parent is not None
+    ]
     if len(openassessment_blocks) > 0:
         sections.append(_section_open_response_assessment(request, course, openassessment_blocks, access))
 


### PR DESCRIPTION
…e instructor dashboard (TNL-6797)

## [TNL-6797](https://openedx.atlassian.net/browse/TNL-6797)

### Orphaned openassessment blocks in the published branch of a course causes instructor dashboards to throw a 500 error

The fix is to filter out orphans from the openassessment blocks that the instructor dashboard loads. This issue was introduced in #14562 

### How to Test?

**Stage** 
Unfortunately, I couldn't create a published orphan on stage (I could only create a draft orphan), so I can't reproduce this error on stage.

**Sandbox**
ditto

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @uzairr 
- [ ] Code review: @efischer19 

FYI: @dmitry-viskov 

### Post-review
- [ ] Rebase and squash commits