### PR TITLE
Asadazam/tnl 6637 updated log

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -829,15 +829,16 @@ def upload_grades_csv(_xmodule_instance_args, _entry_id, course_id, _task_input,
             course_grade.letter_grade,
             student.id in whitelisted_user_ids
         )
-        if certificate_info[0] == 'Y' and course_grade.letter_grade is None and student.id not in whitelisted_user_ids:
+        if certificate_info[0] == 'Y':
             TASK_LOG.info(
-                u'Student is marked eligible_for_certificate despite failing the course '
-                u'(user=%s, course_id=%s, grade_percent=%s gradecutoffs=%s, allow_certificate=%s)',
+                u'Student is marked eligible_for_certificate'
+                u'(user=%s, course_id=%s, grade_percent=%s gradecutoffs=%s, allow_certificate=%s, is_whitelisted=%s)',
                 student,
                 course_id,
                 course_grade.percent,
                 course_grade.course.grade_cutoffs,
-                student.profile.allow_certificate
+                student.profile.allow_certificate,
+                student.id in whitelisted_user_ids
             )
 
         grade_results = []


### PR DESCRIPTION
## [TNL-6637](https://openedx.atlassian.net/browse/TNL-6637)

### Description
Updated log so that we are able to track when a user is marked "Y" for eligible_for_certificate.

### How to Test?
Not Applicable

**Screenshots**
Not Applicable


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @attiyaIshaque  
- [x] Code review: @awaisdar001 
- [x] Code review: @adampalay  

### Post-review
- [x] Rebase and squash commits