### PR TITLE
Update doc URLs for online help Bok Choy tests

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_help.py
+++ b/common/test/acceptance/tests/studio/test_studio_help.py
@@ -36,6 +36,20 @@ from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage
 
 from openedx.core.release import doc_version
 
+DOCUMENTATION_URL_TEMPLATE = (
+    'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/{doc_version}{path}'
+)
+
+
+def _get_expected_documentation_url(path):
+    """
+    Returns the expected URL for the building and running a course documentation.
+    """
+    return DOCUMENTATION_URL_TEMPLATE.format(
+        doc_version=doc_version(),
+        path=path,
+    )
+
 
 @attr(shard=10)
 class StudioHelpTest(StudioCourseTest):
@@ -94,20 +108,16 @@ class SignInHelpTest(AcceptanceTest):
         And I want help about the sign in
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'getting_started/get_started.html'
+        And help url should be correct
         """
         sign_in_page = self.index_page.click_sign_in()
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/getting_started/get_started.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/get_started.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=sign_in_page,
-            href=href,
+            href=expected_url,
             signed_in=False
         )
 
@@ -129,20 +139,16 @@ class SignUpHelpTest(AcceptanceTest):
         And I want help about the sign up
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'getting_started/get_started.html'
+        And help url should be correct
         """
         sign_up_page = self.index_page.click_sign_up()
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/getting_started/get_started.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/get_started.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=sign_up_page,
-            href=href,
+            href=expected_url,
             signed_in=False
         )
 
@@ -164,19 +170,15 @@ class HomeHelpTest(StudioCourseTest):
         And I want help about the courses
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'getting_started/get_started.html'
+        And help url should be correct
         """
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/getting_started/get_started.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/get_started.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.home_page,
-            href=href
+            href=expected_url
         )
 
     def test_course_home_side_bar_help(self):
@@ -186,19 +188,15 @@ class HomeHelpTest(StudioCourseTest):
         And I want help about the courses
         And I click the 'Getting Started with edX Studio' in the sidebar links
         Then Help link should open.
-        And help url should end with 'getting_started/get_started.html'
+        And help url should be correct
         """
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/getting_started/get_started.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/get_started.html')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.home_page,
-            href=href,
+            href=expected_url,
             help_text='Getting Started with edX Studio',
             as_list_item=True
         )
@@ -225,19 +223,15 @@ class NewCourseHelpTest(AcceptanceTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'getting_started/get_started.html'
+        And help url should be correct
         """
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
-            '/en/{}/getting_started/get_started.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/get_started.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.dashboard_page,
-            href=href
+            href=expected_url
         )
 
     def test_course_create_side_bar_help(self):
@@ -247,19 +241,15 @@ class NewCourseHelpTest(AcceptanceTest):
         And I want help about the process
         And I click the 'Getting Started with edX Studio' in the sidebar links
         Then Help link should open.
-        And help url should end with 'getting_started/get_started.html'
+        And help url should be correct
         """
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/getting_started/get_started.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/get_started.html')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.dashboard_page,
-            href=href,
+            href=expected_url,
             help_text='Getting Started with edX Studio',
             as_list_item=True
         )
@@ -286,19 +276,15 @@ class NewLibraryHelpTest(AcceptanceTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'getting_started/get_started.html'
+        And help url should be correct
         """
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/getting_started/get_started.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/get_started.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.dashboard_page,
-            href=href
+            href=expected_url
         )
 
     def test_library_create_side_bar_help(self):
@@ -308,19 +294,15 @@ class NewLibraryHelpTest(AcceptanceTest):
         And I want help about the process
         And I click the 'Getting Started with edX Studio' in the sidebar links
         Then Help link should open.
-        And help url should end with 'getting_started/get_started.html'
+        And help url should be correct
         """
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/getting_started/get_started.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/get_started.html')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.dashboard_page,
-            href=href,
+            href=expected_url,
             help_text='Getting Started with edX Studio',
             as_list_item=True
         )
@@ -345,21 +327,17 @@ class LibraryTabHelpTest(AcceptanceTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'getting_started/get_started.html'
+        And help url should be correct
         """
         self.assertTrue(self.dashboard_page.has_new_library_button)
         click_css(self.dashboard_page, '#course-index-tabs .libraries-tab', 0, False)
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/getting_started/get_started.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/get_started.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.dashboard_page,
-            href=href
+            href=expected_url
         )
 
 
@@ -381,20 +359,16 @@ class LibraryHelpTest(StudioLibraryTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'course/components/libraries.html'
+        And help url should be correct
         """
         self.library_page.visit()
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/course_components/libraries.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_components/libraries.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.library_page,
-            href=href
+            href=expected_url
         )
 
     def test_library_content_side_bar_help(self):
@@ -405,20 +379,16 @@ class LibraryHelpTest(StudioLibraryTest):
         And I want help about the process
         And I click the 'Learn more about content libraries' in the sidebar links
         Then Help link should open.
-        And help url should end with 'course/components/libraries.html'
+        And help url should be correct
         """
         self.library_page.visit()
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/course_components/libraries.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_components/libraries.html')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.library_page,
-            href=href,
+            href=expected_url,
             help_text='Learn more about content libraries'
         )
 
@@ -430,21 +400,18 @@ class LibraryHelpTest(StudioLibraryTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with
-        'creating_content/libraries.html#give-other-users-access-to-your-library'
+        And help url should be correct.
         """
         self.library_user_page.visit()
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/course_components/libraries.html#give-other-users-access-to-your-library'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url(
+            '/course_components/libraries.html#give-other-users-access-to-your-library'
+        )
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.library_user_page,
-            href=href
+            href=expected_url,
         )
 
 
@@ -465,19 +432,15 @@ class LibraryImportHelpTest(StudioLibraryTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'creating_content/libraries.html#import-a-library'
+        And help url should be correct
         """
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/'
-            '{}/course_components/libraries.html#import-a-library'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_components/libraries.html#import-a-library')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.library_import_page,
-            href=href
+            href=expected_url
         )
 
     def test_library_import_side_bar_help(self):
@@ -487,19 +450,15 @@ class LibraryImportHelpTest(StudioLibraryTest):
         And I want help about the process
         And I click the 'Learn more about importing a library' in the sidebar links
         Then Help link should open.
-        And help url should end with 'creating_content/libraries.html#import-a-library'
+        And help url should be correct
         """
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/'
-            '{}/course_components/libraries.html#import-a-library'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_components/libraries.html#import-a-library')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.library_import_page,
-            href=href,
+            href=expected_url,
             help_text='Learn more about importing a library'
         )
 
@@ -521,19 +480,15 @@ class LibraryExportHelpTest(StudioLibraryTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'creating_content/libraries.html#export-a-library'
+        And help url should be correct
         """
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/'
-            '{}/course_components/libraries.html#export-a-library'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_components/libraries.html#export-a-library')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.library_export_page,
-            href=href
+            href=expected_url
         )
 
     def test_library_export_side_bar_help(self):
@@ -543,19 +498,15 @@ class LibraryExportHelpTest(StudioLibraryTest):
         And I want help about the process
         And I click the 'Learn more about exporting a library' in the sidebar links
         Then Help link should open.
-        And help url should end with 'creating_content/libraries.html#export-a-library'
+        And help url should be correct
         """
-        # The href we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/'
-            '{}/course_components/libraries.html#export-a-library'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_components/libraries.html#export-a-library')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.library_export_page,
-            href=href,
+            href=expected_url,
             help_text='Learn more about exporting a library'
         )
 
@@ -583,18 +534,15 @@ class CourseOutlineHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'developing_course/course_outline.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
-            '/en/{}/developing_course/course_outline.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/developing_course/course_outline.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.course_outline_page,
-            href=href
+            href=expected_url
         )
 
     def test_course_outline_side_bar_help(self):
@@ -604,18 +552,15 @@ class CourseOutlineHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Learn more about the course outline' in the sidebar links
         Then Help link should open.
-        And help url should end with 'developing_course/course_outline.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
-            '/en/{}/developing_course/course_outline.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/developing_course/course_outline.html')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.course_outline_page,
-            href=href,
+            href=expected_url,
             help_text='Learn more about the course outline',
             index=0
         )
@@ -643,18 +588,15 @@ class CourseUpdateHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'course_assets/handouts_updates.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/course_assets/handouts_updates.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_assets/handouts_updates.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.course_update_page,
-            href=href
+            href=expected_url,
         )
 
 
@@ -680,18 +622,15 @@ class AssetIndexHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'course_assets/course_files.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/course_assets/course_files.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_assets/course_files.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.course_asset_index_page,
-            href=href
+            href=expected_url,
         )
 
     def test_asset_index_side_bar_help(self):
@@ -701,18 +640,15 @@ class AssetIndexHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Learn more about managing files' in the sidebar links
         Then Help link should open.
-        And help url should end with 'course_assets/course_files.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/course_assets/course_files.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_assets/course_files.html')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.course_asset_index_page,
-            href=href,
+            href=expected_url,
             help_text='Learn more about managing files'
         )
 
@@ -739,18 +675,15 @@ class CoursePagesHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'course_assets/pages.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/course_assets/pages.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_assets/pages.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.course_pages_page,
-            href=href
+            href=expected_url,
         )
 
 
@@ -776,18 +709,15 @@ class UploadTextbookHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'course_assets/textbooks.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
-            '/en/{}/course_assets/textbooks.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_assets/textbooks.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.course_textbook_upload_page,
-            href=href
+            href=expected_url,
         )
 
     def test_course_textbook_side_bar_help(self):
@@ -797,18 +727,15 @@ class UploadTextbookHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Learn more about textbooks' in the sidebar links
         Then Help link should open.
-        And help url should end with 'course_assets/textbooks.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
-            '/en/{}/course_assets/textbooks.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_assets/textbooks.html')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.course_textbook_upload_page,
-            href=href,
+            href=expected_url,
             help_text='Learn more about textbooks'
         )
 
@@ -849,19 +776,16 @@ class StudioUnitHelpTest(ContainerBase):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'developing_course/course_units.html'
+        And help url should be correct
         """
         unit_page = self.go_to_unit_page()
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
-            '/en/{}/developing_course/course_units.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/developing_course/course_units.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=unit_page,
-            href=href
+            href=expected_url,
         )
 
 
@@ -889,18 +813,15 @@ class SettingsHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'set_up_course/setting_up_student_view.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
-            '/en/{}/set_up_course/setting_up_student_view.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/set_up_course/setting_up_student_view.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.settings_page,
-            href=href
+            href=expected_url,
         )
 
 
@@ -928,18 +849,15 @@ class GradingPageHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'grading/index.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/grading/index.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/grading/index.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.grading_page,
-            href=href
+            href=expected_url,
         )
 
 
@@ -967,18 +885,15 @@ class CourseTeamSettingsHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'set_up_course/course_staffing.html#add-course-team-members'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/set_up_course/course_staffing.html#add-course-team-members'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/set_up_course/course_staffing.html#add-course-team-members')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.course_team_settings_page,
-            href=href
+            href=expected_url,
         )
 
 
@@ -1007,18 +922,15 @@ class CourseGroupConfigurationHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'index.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/index.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/index.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.course_group_configuration_page,
-            href=href
+            href=expected_url,
         )
 
     def test_course_group_conf_content_group_side_bar_help(self):
@@ -1029,18 +941,15 @@ class CourseGroupConfigurationHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Learn More' in the sidebar links
         Then Help link should open.
-        And help url should end with 'course_features/cohorts/cohorted_courseware.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/course_features/cohorts/cohorted_courseware.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/course_features/cohorts/cohorted_courseware.html')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.course_group_configuration_page,
-            href=href,
+            href=expected_url,
             help_text='Learn More'
         )
 
@@ -1069,18 +978,15 @@ class AdvancedSettingHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'index.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
-            '/en/{}/index.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/index.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.advanced_settings,
-            href=href
+            href=expected_url,
         )
 
 
@@ -1108,18 +1014,15 @@ class CertificatePageHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'set_up_course/creating_course_certificates.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
-            '/en/{}/set_up_course/creating_course_certificates.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/set_up_course/creating_course_certificates.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.certificates_page,
-            href=href
+            href=expected_url,
         )
 
     def test_certificate_page_side_bar_help(self):
@@ -1129,18 +1032,15 @@ class CertificatePageHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Learn more about certificates' in the sidebar links
         Then Help link should open.
-        And help url should end with 'set_up_course/creating_course_certificates.html'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
-            '/en/{}/set_up_course/creating_course_certificates.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/set_up_course/creating_course_certificates.html')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.certificates_page,
-            href=href,
+            href=expected_url,
             help_text='Learn more about certificates',
         )
 
@@ -1182,19 +1082,18 @@ class GroupExperimentConfigurationHelpTest(ContainerBase):
         And I want help about the process
         And I click the 'Learn More' in the sidebar links
         Then Help link should open.
-        And help url should end with
-        'content_experiments_configure.html#set-up-group-configurations-in-edx-studio'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/{}/course_features'
-            '/content_experiments/content_experiments_configure.html#set-up-group-configurations-in-edx-studio'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url(
+            '/course_features/content_experiments/content_experiments_configure.html'
+            '#set-up-group-configurations-in-edx-studio'
+        )
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.group_configuration_page,
-            href=href,
+            href=expected_url,
             help_text='Learn More',
         )
 
@@ -1223,18 +1122,15 @@ class ToolsImportHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'releasing_course/export_import_course.html#import-a-course'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/'
-            '{}/releasing_course/export_import_course.html#import-a-course'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/releasing_course/export_import_course.html#import-a-course')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.import_page,
-            href=href
+            href=expected_url,
         )
 
     def test_tools_import_side_bar_help(self):
@@ -1244,18 +1140,15 @@ class ToolsImportHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Learn more about importing a course' in the sidebar links
         Then Help link should open.
-        And help url should end with 'releasing_course/export_import_course.html#import-a-course'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/'
-            '{}/releasing_course/export_import_course.html#import-a-course'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/releasing_course/export_import_course.html#import-a-course')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.import_page,
-            href=href,
+            href=expected_url,
             help_text='Learn more about importing a course',
         )
 
@@ -1284,18 +1177,15 @@ class ToolsExportHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should end with 'releasing_course/export_import_course.html#export-a-course'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/'
-            '{}/releasing_course/export_import_course.html#export-a-course'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/releasing_course/export_import_course.html#export-a-course')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.export_page,
-            href=href
+            href=expected_url,
         )
 
     def test_tools_import_side_bar_help(self):
@@ -1305,18 +1195,15 @@ class ToolsExportHelpTest(StudioCourseTest):
         And I want help about the process
         And I click the 'Learn more about exporting a course' in the sidebar links
         Then Help link should open.
-        And help url should end with 'releasing_course/export_import_course.html#export-a-course'
+        And help url should be correct
         """
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/'
-            '{}/releasing_course/export_import_course.html#export-a-course'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/releasing_course/export_import_course.html#export-a-course')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(
             test=self,
             page=self.export_page,
-            href=href,
+            href=expected_url,
             help_text='Learn more about exporting a course',
         )
 
@@ -1338,18 +1225,14 @@ class StudioWelcomeHelpTest(AcceptanceTest):
         And I want help about the edx
         And I click the 'Help' in the navigation bar
         Then Help link should open.
-        And help url should contain 'getting_started/get_started.html'
+        And help url should be correct
         """
-        # The url we want to see in anchor help element.
-        href = (
-            'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/'
-            'en/{}/getting_started/get_started.html'
-        ).format(doc_version())
+        expected_url = _get_expected_documentation_url('/get_started.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
             test=self,
             page=self.index_page,
-            href=href,
+            href=expected_url,
             signed_in=False
         )

--- a/docs/cms_config.ini
+++ b/docs/cms_config.ini
@@ -15,7 +15,7 @@ pdf_file = edx-partner-course-staff.pdf
 #       in edx-platform/cms/djangoapps/contentstore/features/help.feature
 [pages]
 default = index.html
-home = getting_started/get_started.html
+home = get_started.html
 develop_course = developing_course/index.html
 outline = developing_course/course_outline.html
 unit = developing_course/course_units.html
@@ -34,9 +34,9 @@ import_library = course_components/libraries.html#import-a-library
 import_course = releasing_course/export_import_course.html#import-a-course
 export_library = course_components/libraries.html#export-a-library
 export_course = releasing_course/export_import_course.html#export-a-course
-welcome = getting_started/get_started.html
-login = getting_started/get_started.html
-register = getting_started/get_started.html
+welcome = get_started.html
+login = get_started.html
+register = get_started.html
 content_libraries = course_components/libraries.html
 content_groups = course_features/cohorts/cohorted_courseware.html
 group_configurations = course_features/content_experiments/content_experiments_configure.html#set-up-group-configurations-in-edx-studio


### PR DESCRIPTION
This PR updates a Studio online doc link that was changed, and updates the Bok Choy tests to expect the new URL. The edx-documentation change was here: https://github.com/edx/edx-documentation/commit/a4ae72eca9d19195d890ba4810656dcdac8413da

I've also added a helper function to make it simpler to create a valid URL in each test.

FYI @catong 