### PR TITLE
Allow uploading subtitles with unicode filenames

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -283,7 +283,7 @@ def copy_or_rename_transcript(new_name, old_name, item, delete_old=False, user=N
     If `old_name` is not found in storage, raises `NotFoundError`.
     If `delete_old` is True, removes `old_name` files from storage.
     """
-    filename = 'subs_{0}.srt.sjson'.format(old_name)
+    filename = u'subs_{0}.srt.sjson'.format(old_name)
     content_location = StaticContent.compute_location(item.location.course_key, filename)
     transcripts = contentstore().find(content_location).data
     save_subs_to_store(json.loads(transcripts), new_name, item)


### PR DESCRIPTION
This is a bug that we've had it fixed in our repo for a while https://github.com/Edraak/edx-platform/pull/216.

## Overview
The studio shows a vague error message when uploading a video subtitle with Unicode letters in the filename.

### Steps to Reproduce the Bug
 1. Go to studio 
 2. Go to any course
 3. Under any unit 
 4. Add video component 
 5. Click on "Edit" icon 
 6. Click on "upload new transcript"
 7. Upload transcript has a Unicode name (non-ascii letters) 
 8. Observe the error (screenshot is attached below)

#### Expected Result
Uploading a transcript with a Unicode filename should be acceptable or a clear validation message should be displayed.

#### Actual Result
A vague error message shows up "Error: Uploading failed".

![image](https://cloud.githubusercontent.com/assets/645156/24607066/bf8c0ada-1878-11e7-9df8-a296562f2ae7.png)

## Testing
 - [x] Tested manually on a Ficus devstack.
 - [x] Review by an @Edraak member @Salomari1987

