### PR TITLE
Allow translating account settings error messages

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from django.contrib.auth.models import User
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.utils.translation import ungettext, ugettext
 
 from lms.djangoapps.badges.utils import badges_enabled
 from . import (
@@ -154,9 +155,11 @@ class AccountLegacyProfileSerializer(serializers.HyperlinkedModelSerializer, Rea
     def validate_name(self, new_name):
         """ Enforce minimum length for name. """
         if len(new_name) < NAME_MIN_LENGTH:
-            raise serializers.ValidationError(
-                "The name field must be at least {} characters long.".format(NAME_MIN_LENGTH)
-            )
+            raise serializers.ValidationError(ungettext(
+                "The name field must be at least {count} character long.",
+                "The name field must be at least {count} characters long.",
+                NAME_MIN_LENGTH
+            ).format(count=NAME_MIN_LENGTH))
         return new_name
 
     def validate_language_proficiencies(self, value):
@@ -164,7 +167,9 @@ class AccountLegacyProfileSerializer(serializers.HyperlinkedModelSerializer, Rea
         language_proficiencies = [language for language in value]
         unique_language_proficiencies = set(language["code"] for language in language_proficiencies)
         if len(language_proficiencies) != len(unique_language_proficiencies):
-            raise serializers.ValidationError("The language_proficiencies field must consist of unique languages")
+            raise serializers.ValidationError(
+                ugettext("The language_proficiencies field must consist of unique languages")
+            )
         return value
 
     def transform_gender(self, user_profile, value):  # pylint: disable=unused-argument

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -454,7 +454,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         ("country", "GB", "XY", u'"XY" is not a valid choice.'),
         ("year_of_birth", 2009, "not_an_int", u"A valid integer is required."),
         ("name", "bob", "z" * 256, u"Ensure this value has at most 255 characters (it has 256)."),
-        ("name", u"ȻħȺɍłɇs", "z   ", "The name field must be at least 2 characters long."),
+        ("name", u"ȻħȺɍłɇs", "z   ", u"The name field must be at least 2 characters long."),
         ("goals", "Smell the roses"),
         ("mailing_address", "Sesame Street"),
         # Note that we store the raw data, so it is up to client to escape the HTML.
@@ -686,7 +686,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         ),
         (
             [{u"code": u"kw"}, {u"code": u"el"}, {u"code": u"kw"}],
-            ['The language_proficiencies field must consist of unique languages']
+            [u'The language_proficiencies field must consist of unique languages']
         ),
     )
     @ddt.unpack


### PR DESCRIPTION
## Overview
The error messages in the account settings are not translated.

This is a bug that we've had it fixed in our repo for a while Edraak/edx-platform#222.

## Testing
 - [ ]  A review by an @Edraak member @Salomari1987
 - [ ] Manual testing on a Ficus devstack.
 - [x] Manually verified that the messages are added to the `*.po`. Please see the bash snippet below.


```bash
omar@mac:edx-platform $ manage.py lms makemessages --settings=devstack
<output omitted>
omar@mac:edx-platform $ cd conf/locale/ar/
omar@mac:ar $ git grep -e 'The language_proficiencies field' -- '*.po'
LC_MESSAGES/django.po:msgid "The language_proficiencies field must consist of unique languages"
omar@mac:ar $ git grep -e 'The name field must be at least {count} character long.' -- '*.po'
LC_MESSAGES/django.po:msgid "The name field must be at least {count} character long."
```

## Bug Screenshot
![image](https://cloud.githubusercontent.com/assets/645156/24611821/09515680-188c-11e7-84b5-c008c5491106.png)
