### PR TITLE
TNL-6601 – Create or update course overview on a course publish

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/signals.py
@@ -13,7 +13,6 @@ def _listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable
     Catches the signal that a course has been published in Studio and
     updates the corresponding CourseOverview cache entry.
     """
-    CourseOverview.objects.filter(id=course_key).delete()
     CourseOverview.load_from_module_store(course_key)
 
 


### PR DESCRIPTION
## [TNL-6601](https://openedx.atlassian.net/browse/TNL-6601)

### Background
> Course overview invalidation. As currently implemented, a course's entry in the course-overview table is immediately deleted upon course publish. This was fine until now since there was only a single source for the cache: the modulestore. But by introducing another source of data (Catalog service), this logic should be revisited. When the entry is deleted and re-created, any previously synchronized data from the catalog service will automatically get wiped out - and will be re-populated only when the background synchronization process is next run. A few solutions to this would be: (1) no longer delete upon course publish - only update, or (2) make a blocking call (with graceful degradation) to the Catalog service to populate the CMU when the entry is re-created. The issue with option 2 (currently) is that this sometimes happens in a user-facing web-worker process.

### Description
With this PR, `CourseOverview` will _**not**_ be discarded and reloaded from the `ModuleStore` on every `course_published` signal, instead it will be updated if already exists.

**Sandbox**
- build in progress: https://update-overview.sandbox.edx.org/

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @nasthagiri 
- [ ] Code review: @muzaffaryousaf 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [ ] Rebase and squash commits