### PR TITLE
TNL-6284 Empty subcategory will not render in inline discussion modules.

### DIFF
--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -178,6 +178,22 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
         assertThreadCorrect(threads[0], self.discussion1, "Chapter / Discussion 1")
         assertThreadCorrect(threads[1], self.discussion2, "Subsection / Discussion 2")
 
+    def test_empty_discussion_subcategory_title(self):
+        """
+        Test that for empty subcategory inline discussion modules,
+        the divider " / " is not rendered on a post or inline discussion topic label.
+        """
+        discussion = ItemFactory.create(
+            parent_location=self.course.location,
+            category="discussion",
+            discussion_id="discussion",
+            discussion_category="Chapter",
+            discussion_target=""  # discussion-subcategory
+        )
+        thread = {"commentable_id": discussion.discussion_id}
+        utils.add_courseware_context([thread], self.course, self.user)
+        self.assertNotIn('/', thread.get("courseware_title"))
+
     @ddt.data((ModuleStoreEnum.Type.mongo, 2), (ModuleStoreEnum.Type.split, 1))
     @ddt.unpack
     def test_get_accessible_discussion_xblocks(self, modulestore_type, expected_discussion_xblocks):

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -147,7 +147,7 @@ def get_discussion_id_map_entry(xblock):
         xblock.discussion_id,
         {
             "location": xblock.location,
-            "title": xblock.discussion_category.split("/")[-1].strip() + " / " + xblock.discussion_target
+            "title": xblock.discussion_category.split("/")[-1].strip() + (" / " + xblock.discussion_target if xblock.discussion_target else "")
         }
     )
 

--- a/lms/templates/discussion/_discussion_inline.html
+++ b/lms/templates/discussion/_discussion_inline.html
@@ -15,7 +15,11 @@ from openedx.core.djangolib.js_utils import js_escaped_string
     data-read-only="${'false' if can_create_thread else 'true'}">
     <div class="discussion-module-header">
         <h3 class="hd hd-3 discussion-module-title">${_(display_name)}</h3>
-        <div class="inline-discussion-topic"><span class="inline-discussion-topic-title">${_("Topic:")}</span> ${discussion_category} / ${discussion_target}</div>
+        <div class="inline-discussion-topic"><span class="inline-discussion-topic-title">${_("Topic:")}</span> ${discussion_category}
+              % if discussion_target:
+                    / ${discussion_target}
+              %endif
+           </div>
     </div>
     <button class="discussion-show btn" data-discussion-id="${discussion_id}">
         <span class="button-text">${_("Show Discussion")}</span>

--- a/lms/templates/discussion/_filter_dropdown.html
+++ b/lms/templates/discussion/_filter_dropdown.html
@@ -23,7 +23,9 @@ from openedx.core.djangolib.markup import HTML
         data-cohorted="${str(entries[entry]['is_cohorted']).lower()}"
         role="option"
     >
+         % if entry:
         <span class="forum-nav-browse-title">${entry}</span>
+         %endif
     </li>
 </%def>
 


### PR DESCRIPTION
## [Empty Subcategory will not be shown in inline discussion and discussion topic list - TNL-6284](https://openedx.atlassian.net/browse/TNL-6284)

### Description
This PR fixes if we have empty subcategory in the inline discussion module, the `divider " / "` is not rendered on a post and discussion topic label.


### How to Test?

**Stage** 
1. I have added empty subcategory in discussion inline module.
2. Go to the link https://courses.stage.edx.org/courses/course-v1:edx+aishaq+1T2017/courseware/9b8835821eec467584df4abfa165652c/d65410be4a854c29a5095b3b4cfd4708/ and see discussion module 
<img width="866" alt="screen shot 2017-04-05 at 11 32 05 am" src="https://cloud.githubusercontent.com/assets/7627421/24692677/9f9f1632-19f3-11e7-80ec-1f7d611ff69a.png">

3. Go to the link https://courses.stage.edx.org/courses/course-v1:edx+aishaq+1T2017/discussion/forum/ and see discussion list
<img width="380" alt="screen shot 2017-04-05 at 11 35 01 am" src="https://cloud.githubusercontent.com/assets/7627421/24692773/06b59382-19f4-11e7-8c61-99f6223f90b6.png">

4. Go to the link https://courses.stage.edx.org/courses/course-v1:edx+aishaq+1T2017/discussion/forum/16eb644f1130510f74bfc2b2e14b53afdfa66d1e/threads/58e490e8568c460730000033 and see discussion topic list 
<img width="757" alt="screen shot 2017-04-05 at 11 39 02 am" src="https://cloud.githubusercontent.com/assets/7627421/24692920/9da114c4-19f4-11e7-972f-660c33575719.png">


**Sandbox**
- Here are the links:

1. https://tnl-6284.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40vertical_0270f6de40fc
2. https://tnl-6284.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/9a1efca605d757c26b4304bc9eab74d2d6d589e3/threads/58e4941ac1c769382d000000
3. Also you can check the empty subcategory in the given link https://studio-tnl-6284.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc

### Testing
- [x] Unit test


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @noraiz-anwar 
- [x] Code review: @robrap 
- [x]  Product standpoint: @marcotuts

FYI: @robrap 

### Post-review
- [x] Rebase and squash commits