### PR TITLE
Upgrade Django from 1.8.17 to 1.8.18

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -38,7 +38,7 @@ django-user-tasks==0.1.4
 # We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
-django==1.8.17
+django==1.8.18
 django-waffle==0.11.1
 djangorestframework-jwt==1.8.0
 djangorestframework-oauth==1.1.0


### PR DESCRIPTION
Fixes several security defects with maximum severity "moderate".

https://docs.djangoproject.com/en/1.8/releases/1.8.18/