### PR TITLE
Collect data needed for program progress sidebar

### DIFF
--- a/lms/djangoapps/learner_dashboard/tests/test_programs.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_programs.py
@@ -184,9 +184,9 @@ class TestProgramListing(ProgramsApiConfigMixin, CredentialsApiConfigMixin, Shar
             expected_url = reverse('program_details_view', kwargs={'program_uuid': expected_program['uuid']})
             self.assertEqual(actual_program['detail_url'], expected_url)
 
-    @mock.patch(CREDENTIALS_UTILS_MODULE + '.get_user_credentials')
+    @mock.patch(CREDENTIALS_UTILS_MODULE + '.get_credentials')
     @mock.patch(CREDENTIALS_UTILS_MODULE + '.get_programs')
-    def test_certificates_listed(self, mock_get_programs, mock_get_user_credentials, __):
+    def test_certificates_listed(self, mock_get_programs, mock_get_credentials, __):
         """
         Verify that the response contains accurate certificate data when certificates are available.
         """
@@ -209,7 +209,7 @@ class TestProgramListing(ProgramsApiConfigMixin, CredentialsApiConfigMixin, Shar
         )
 
         credentials_data = sorted([first_credential, second_credential], key=self.credential_sort_key)
-        mock_get_user_credentials.return_value = credentials_data
+        mock_get_credentials.return_value = credentials_data
 
         response = self.client.get(self.url)
         actual = self.load_serialized_data(response, 'certificatesData')

--- a/lms/djangoapps/learner_dashboard/views.py
+++ b/lms/djangoapps/learner_dashboard/views.py
@@ -14,6 +14,7 @@ from openedx.core.djangoapps.programs.utils import (
     get_program_marketing_url,
     ProgramProgressMeter,
     ProgramDataExtender,
+    get_certificates,
 )
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 
@@ -76,12 +77,15 @@ def program_details(request, program_uuid):
     }
 
     if waffle.switch_is_active('new_program_progress'):
-        course_progress = meter.progress(programs=[program_data], count_only=False)[0]
+        course_data = meter.progress(programs=[program_data], count_only=False)[0]
+        certificate_data = get_certificates(request.user, program_data)
+
         program_data.pop('courses')
 
         context.update({
             'program_data': program_data,
-            'course_progress': course_progress,
+            'course_data': course_data,
+            'certificate_data': certificate_data,
         })
 
         return render_to_response('learner_dashboard/program_details_2017.html', context)

--- a/lms/templates/learner_dashboard/program_details_2017.html
+++ b/lms/templates/learner_dashboard/program_details_2017.html
@@ -15,6 +15,8 @@ from openedx.core.djangolib.js_utils import (
 <%static:require_module module_name="js/learner_dashboard/program_details_factory_2017" class_name="ProgramDetailsFactory2017">
 ProgramDetailsFactory2017({
     programData: ${program_data | n, dump_js_escaped_json},
+    courseData: ${course_data | n, dump_js_escaped_json},
+    certificateData: ${certificate_data | n, dump_js_escaped_json},
     urls: ${urls | n, dump_js_escaped_json},
     userPreferences: ${user_preferences | n, dump_js_escaped_json},
 });

--- a/openedx/core/djangoapps/credentials/tests/test_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_utils.py
@@ -12,7 +12,7 @@ from openedx.core.djangoapps.catalog.tests.factories import ProgramFactory
 from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
 from openedx.core.djangoapps.credentials.tests.mixins import CredentialsApiConfigMixin, CredentialsDataMixin
 from openedx.core.djangoapps.credentials.utils import (
-    get_user_credentials,
+    get_credentials,
     get_user_program_credentials,
     get_programs_credentials,
     get_programs_for_credentials
@@ -57,25 +57,25 @@ class TestCredentialsRetrieval(CredentialsApiConfigMixin, CredentialsDataMixin, 
         ]
 
     @httpretty.activate
-    def test_get_user_credentials(self):
+    def test_get_credentials(self):
         """Verify user credentials data can be retrieve."""
         self.create_credentials_config()
         self.mock_credentials_api(self.user)
 
-        actual = get_user_credentials(self.user)
+        actual = get_credentials(self.user)
         self.assertEqual(actual, self.CREDENTIALS_API_RESPONSE['results'])
 
     @httpretty.activate
-    def test_get_user_credentials_caching(self):
+    def test_get_credentials_caching(self):
         """Verify that when enabled, the cache is used for non-staff users."""
         self.create_credentials_config(cache_ttl=1)
         self.mock_credentials_api(self.user)
 
         # Warm up the cache.
-        get_user_credentials(self.user)
+        get_credentials(self.user)
 
         # Hit the cache.
-        get_user_credentials(self.user)
+        get_credentials(self.user)
 
         # Verify only one request was made.
         self.assertEqual(len(httpretty.httpretty.latest_requests), 1)
@@ -84,7 +84,7 @@ class TestCredentialsRetrieval(CredentialsApiConfigMixin, CredentialsDataMixin, 
 
         # Hit the Credentials API twice.
         for _ in range(2):
-            get_user_credentials(staff_user)
+            get_credentials(staff_user)
 
         # Verify that three requests have been made (one for student, two for staff).
         self.assertEqual(len(httpretty.httpretty.latest_requests), 3)

--- a/openedx/core/djangoapps/programs/tasks/v1/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks/v1/tasks.py
@@ -10,7 +10,7 @@ from edx_rest_api_client.client import EdxRestApiClient
 from provider.oauth2.models import Client
 
 from openedx.core.djangoapps.credentials.models import CredentialsApiConfig
-from openedx.core.djangoapps.credentials.utils import get_user_credentials
+from openedx.core.djangoapps.credentials.utils import get_credentials
 from openedx.core.djangoapps.programs.utils import ProgramProgressMeter
 from openedx.core.lib.token_utils import JwtBuilder
 
@@ -83,7 +83,7 @@ def get_certified_programs(student):
 
     """
     certified_programs = []
-    for credential in get_user_credentials(student):
+    for credential in get_credentials(student):
         if 'program_uuid' in credential['credential']:
             certified_programs.append(credential['credential']['program_uuid'])
     return certified_programs

--- a/openedx/core/djangoapps/programs/tasks/v1/tests/test_tasks.py
+++ b/openedx/core/djangoapps/programs/tasks/v1/tests/test_tasks.py
@@ -69,19 +69,19 @@ class GetAwardedCertificateProgramsTestCase(TestCase):
         result.update(**kwargs)
         return result
 
-    @mock.patch(TASKS_MODULE + '.get_user_credentials')
-    def test_get_certified_programs(self, mock_get_user_credentials):
+    @mock.patch(TASKS_MODULE + '.get_credentials')
+    def test_get_certified_programs(self, mock_get_credentials):
         """
         Ensure the API is called and results handled correctly.
         """
         student = UserFactory(username='test-username')
-        mock_get_user_credentials.return_value = [
+        mock_get_credentials.return_value = [
             self.make_credential_result(status='awarded', credential={'program_uuid': 1}),
             self.make_credential_result(status='awarded', credential={'course_id': 2}),
         ]
 
         result = tasks.get_certified_programs(student)
-        self.assertEqual(mock_get_user_credentials.call_args[0], (student, ))
+        self.assertEqual(mock_get_credentials.call_args[0], (student, ))
         self.assertEqual(result, [1])
 
 


### PR DESCRIPTION
This includes a count-only representation of the user's progress towards completing each course in the program (the same as the one used on the list page), and a list of any course and/or program certificates the user has earned.

ECOM-7386

@edx/learner-growth FYI. Tangentially related: completion and release of the sidebar on this page means we can remove the list of credential links on the listing page. I spoke with Lauren about this and she's on board.