### PR TITLE
Add query count tests for old and new course pages

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -495,11 +495,12 @@ class CourseTabView(EdxFragmentView):
         Displays a course tab page that contains a web fragment.
         """
         course_key = CourseKey.from_string(course_id)
-        course = get_course_with_access(request.user, 'load', course_key)
-        tab = CourseTabList.get_tab_by_type(course.tabs, tab_type)
-        page_context = self.create_page_context(request, course=course, tab=tab, **kwargs)
-        set_custom_metrics_for_course_key(course_key)
-        return super(CourseTabView, self).get(request, course=course, page_context=page_context, **kwargs)
+        with modulestore().bulk_operations(course_key):
+            course = get_course_with_access(request.user, 'load', course_key)
+            tab = CourseTabList.get_tab_by_type(course.tabs, tab_type)
+            page_context = self.create_page_context(request, course=course, tab=tab, **kwargs)
+            set_custom_metrics_for_course_key(course_key)
+            return super(CourseTabView, self).get(request, course=course, page_context=page_context, **kwargs)
 
     def create_page_context(self, request, course=None, tab=None, **kwargs):
         """

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -1,0 +1,71 @@
+"""
+Tests for the course home page.
+"""
+from django.core.urlresolvers import reverse
+
+from openedx.core.djangoapps.content.block_structure.api import get_course_in_cache
+from student.models import CourseEnrollment
+from student.tests.factories import UserFactory
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
+
+TEST_PASSWORD = 'test'
+
+
+def course_home_url(course):
+    """
+    Returns the URL for the course's home page
+    """
+    return reverse(
+        'edx.course_experience.course_home',
+        kwargs={
+            'course_id': unicode(course.id),
+        }
+    )
+
+
+class TestCourseHomePage(SharedModuleStoreTestCase):
+    """
+    Test the course home page.
+    """
+    @classmethod
+    def setUpClass(cls):
+        """Set up the simplest course possible."""
+        # setUpClassAndTestData() already calls setUpClass on SharedModuleStoreTestCase
+        # pylint: disable=super-method-not-called
+        with super(TestCourseHomePage, cls).setUpClassAndTestData():
+            with cls.store.default_store(ModuleStoreEnum.Type.split):
+                cls.course = CourseFactory.create()
+                with cls.store.bulk_operations(cls.course.id):
+                    chapter = ItemFactory.create(category='chapter', parent_location=cls.course.location)
+                    section = ItemFactory.create(category='sequential', parent_location=chapter.location)
+                    section2 = ItemFactory.create(category='sequential', parent_location=chapter.location)
+                    ItemFactory.create(category='vertical', parent_location=section.location)
+                    ItemFactory.create(category='vertical', parent_location=section2.location)
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up and enroll our fake user in the course."""
+        cls.user = UserFactory(password=TEST_PASSWORD)
+        CourseEnrollment.enroll(cls.user, cls.course.id)
+
+    def setUp(self):
+        """
+        Set up for the tests.
+        """
+        super(TestCourseHomePage, self).setUp()
+        self.client.login(username=self.user.username, password=TEST_PASSWORD)
+
+    def test_queries(self):
+        """
+        Verify that the view's query count doesn't regress.
+        """
+        # Pre-fill the course blocks cache
+        get_course_in_cache(self.course.id)
+
+        # Fetch the view and verify the query counts
+        with self.assertNumQueries(36):
+            with check_mongo_calls(3):
+                url = course_home_url(self.course)
+                self.client.get(url)

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -13,19 +13,9 @@ from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
+from .test_course_home import course_home_url
+
 TEST_PASSWORD = 'test'
-
-
-def course_home_url(course):
-    """
-    Returns the URL for the course's home page
-    """
-    return reverse(
-        'edx.course_experience.course_home',
-        kwargs={
-            'course_id': unicode(course.id),
-        }
-    )
 
 
 class TestCourseOutlinePage(SharedModuleStoreTestCase):


### PR DESCRIPTION
This adds simple query count tests for the new course home page, as well as adding SQL counts for the old one.

FYI @dianakhuang @robrap 