### PR TITLE
Add feature flag to disable email address changes.

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -193,3 +193,7 @@ else:
 <%def name="get_tech_support_email_address()"><%
     return get_value('email_from_address', settings.TECH_SUPPORT_EMAIL)
 %></%def>
+
+<%def name="get_contact_email_address()"><%
+    return get_value('email_from_address', settings.CONTACT_EMAIL)
+%></%def>

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -387,6 +387,9 @@ FEATURES = {
 
     # Whether to display account activation notification on dashboard.
     'DISPLAY_ACCOUNT_ACTIVATION_MESSAGE_ON_SIDEBAR': False,
+
+    # Allow users to change their email address.
+    'ALLOW_EMAIL_ADDRESS_CHANGE': True,
 }
 
 # Ignore static asset files on import which match this pattern

--- a/lms/static/js/spec/student_account/account_settings_factory_spec.js
+++ b/lms/static/js/spec/student_account/account_settings_factory_spec.js
@@ -22,7 +22,10 @@ define(['backbone',
                     Helpers.PASSWORD_RESET_SUPPORT_LINK,
                     Helpers.USER_ACCOUNTS_API_URL,
                     Helpers.USER_PREFERENCES_API_URL,
-                    Helpers.PLATFORM_NAME
+                    1,
+                    Helpers.PLATFORM_NAME,
+                    Helpers.CONTACT_EMAIL,
+                    true
                 );
                 return context.accountSettingsView;
             };

--- a/lms/static/js/spec/student_account/helpers.js
+++ b/lms/static/js/spec/student_account/helpers.js
@@ -9,6 +9,7 @@ define(['underscore'], function(_) {
     var FIND_COURSES_URL = '/courses';
     var PASSWORD_RESET_SUPPORT_LINK = 'https://support.edx.org/hc/en-us/articles/206212088-What-if-I-did-not-receive-a-password-reset-message-'; // eslint-disable-line max-len
     var PLATFORM_NAME = 'edX';
+    var CONTACT_EMAIL = 'info@example.com';
     var PROFILE_IMAGE = {
         image_url_large: '/media/profile-images/image.jpg',
         has_image: true
@@ -160,6 +161,7 @@ define(['underscore'], function(_) {
         IMAGE_REMOVE_API_URL: IMAGE_REMOVE_API_URL,
         PASSWORD_RESET_SUPPORT_LINK: PASSWORD_RESET_SUPPORT_LINK,
         PLATFORM_NAME: PLATFORM_NAME,
+        CONTACT_EMAIL: CONTACT_EMAIL,
         PROFILE_IMAGE: PROFILE_IMAGE,
         FIELD_OPTIONS: FIELD_OPTIONS,
         TIME_ZONE_RESPONSE: TIME_ZONE_RESPONSE,

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -17,11 +17,14 @@
             userAccountsApiUrl,
             userPreferencesApiUrl,
             accountUserId,
-            platformName
+            platformName,
+            contactEmail,
+            allowEmailChange
         ) {
             var accountSettingsElement, userAccountModel, userPreferencesModel, aboutSectionsData,
                 accountsSectionData, ordersSectionData, accountSettingsView, showAccountSettingsPage,
-                showLoadingError, orderNumber, getUserField, userFields, timeZoneDropdownField, countryDropdownField;
+                showLoadingError, orderNumber, getUserField, userFields, timeZoneDropdownField, countryDropdownField,
+                emailFieldView;
 
             accountSettingsElement = $('.wrapper-account-settings');
 
@@ -30,6 +33,33 @@
 
             userPreferencesModel = new UserPreferencesModel();
             userPreferencesModel.url = userPreferencesApiUrl;
+
+            if (allowEmailChange) {
+                emailFieldView = {
+                    view: new AccountSettingsFieldViews.EmailFieldView({
+                        model: userAccountModel,
+                        title: gettext('Email Address'),
+                        valueAttribute: 'email',
+                        helpMessage: StringUtils.interpolate(
+                            gettext('The email address you use to sign in. Communications from {platform_name} and your courses are sent to this address.'),  // eslint-disable-line max-len
+                            {platform_name: platformName}
+                        ),
+                        persistChanges: true
+                    })
+                };
+            } else {
+                emailFieldView = {
+                    view: new AccountSettingsFieldViews.ReadonlyFieldView({
+                        model: userAccountModel,
+                        title: gettext('Email Address'),
+                        valueAttribute: 'email',
+                        helpMessage: StringUtils.interpolate(
+                            gettext('The email address you use to sign in. Communications from {platform_name} and your courses are sent to this address.  To change the email address, please contact {contact_email}.'),  // eslint-disable-line max-len
+                            {platform_name: platformName, contact_email: contactEmail}
+                        )
+                    })
+                };
+            }
 
             aboutSectionsData = [
                 {
@@ -58,18 +88,7 @@
                                 persistChanges: true
                             })
                         },
-                        {
-                            view: new AccountSettingsFieldViews.EmailFieldView({
-                                model: userAccountModel,
-                                title: gettext('Email Address'),
-                                valueAttribute: 'email',
-                                helpMessage: StringUtils.interpolate(
-                                    gettext('The email address you use to sign in. Communications from {platform_name} and your courses are sent to this address.'),  // eslint-disable-line max-len
-                                    {platform_name: platformName}
-                                ),
-                                persistChanges: true
-                            })
-                        },
+                        emailFieldView,
                         {
                             view: new AccountSettingsFieldViews.PasswordFieldView({
                                 model: userAccountModel,

--- a/lms/static/sass/views/_account-settings.scss
+++ b/lms/static/sass/views/_account-settings.scss
@@ -184,7 +184,9 @@
                         line-height: normal;
                     }
 
-                    #u-field-value-username {
+                    // This should only apply for the email field if email address
+                    // changes are disabled, so we explicitly specify "span".
+                    #u-field-value-username, span#u-field-value-email {
                         padding-top: ($baseline/2);
                     }
                 }

--- a/lms/static/sass/views/_account-settings.scss
+++ b/lms/static/sass/views/_account-settings.scss
@@ -183,12 +183,6 @@
                         padding: 11px 14px;
                         line-height: normal;
                     }
-
-                    // This should only apply for the email field if email address
-                    // changes are disabled, so we explicitly specify "span".
-                    #u-field-value-username, span#u-field-value-email {
-                        padding-top: ($baseline/2);
-                    }
                 }
 
                 .u-field-order {
@@ -323,6 +317,10 @@
                     border-bottom: none;
                     margin-bottom: ($baseline*2);
                 }
+            }
+
+            .u-field-readonly .u-field-value {
+                padding-top: ($baseline/2);
             }
 
             .u-field-orderHistory {

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -33,9 +33,11 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 <%block name="js_extra">
 <%static:require_module module_name="js/student_account/views/account_settings_factory" class_name="AccountSettingsFactory">
     var fieldsData = ${ fields | n, dump_js_escaped_json },
-    ordersHistoryData = ${ order_history | n, dump_js_escaped_json },
-    authData = ${ auth | n, dump_js_escaped_json },
-    platformName = '${ static.get_platform_name() | n, js_escaped_string }';
+        ordersHistoryData = ${ order_history | n, dump_js_escaped_json },
+        authData = ${ auth | n, dump_js_escaped_json },
+        platformName = '${ static.get_platform_name() | n, js_escaped_string }',
+        contactEmail = '${ static.get_contact_email_address() | n, js_escaped_string }',
+        allowEmailChange = ${ bool(settings.FEATURES['ALLOW_EMAIL_ADDRESS_CHANGE']) | n, dump_js_escaped_json };
 
     AccountSettingsFactory(
         fieldsData,
@@ -45,7 +47,9 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         '${ user_accounts_api_url | n, js_escaped_string }',
         '${ user_preferences_api_url | n, js_escaped_string }',
         ${ user.id | n, dump_js_escaped_json },
-        platformName
+        platformName,
+        contactEmail,
+        allowEmailChange
     );
 </%static:require_module>
 </%block>

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -231,6 +231,8 @@ def update_account_settings(requesting_user, update, username=None):
 
     # And try to send the email change request if necessary.
     if changing_email:
+        if not settings.FEATURES['ALLOW_EMAIL_ADDRESS_CHANGE']:
+            raise AccountUpdateError(u"Email address changes have been disabled by the site operators.")
         try:
             student_views.do_email_change_request(existing_user, new_email)
         except ValueError as err:

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -193,6 +193,16 @@ class TestAccountApi(UserSettingsEventTestMixin, TestCase):
         account_settings = get_account_settings(self.default_request)[0]
         self.assertEqual("Mickey Mouse", account_settings["name"])
 
+    @patch.dict(settings.FEATURES, dict(ALLOW_EMAIL_ADDRESS_CHANGE=False))
+    def test_email_changes_disabled(self):
+        """
+        Test that email address changes are rejected when ALLOW_EMAIL_ADDRESS_CHANGE is not set.
+        """
+        disabled_update = {"email": "valid@example.com"}
+        with self.assertRaises(AccountUpdateError) as context_manager:
+            update_account_settings(self.user, disabled_update)
+        self.assertIn("Email address changes have been disabled", context_manager.exception.developer_message)
+
     @patch('openedx.core.djangoapps.user_api.accounts.serializers.AccountUserSerializer.save')
     def test_serializer_save_fails(self, serializer_save):
         """


### PR DESCRIPTION
One of our customers tracks users externally to Open edX by email address.  If a user changes their email address in Open edX, they can't match them up anymore to their other records, so they want to users to contact them about email address changes.  This PR adds a feature flag to disable email address changes by the user.

**JIRA tickets**: [OSPR-1735](https://openedx.atlassian.net/browse/OSPR-1735)

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:

With email address changes enabled (current):
![screenshot-email-2](https://cloud.githubusercontent.com/assets/249196/24748699/ca5be378-1ac0-11e7-8f59-161834e0307d.png)

With email address changes disabled:
![screenshot-email-1](https://cloud.githubusercontent.com/assets/249196/24748698/ca5a0094-1ac0-11e7-84d7-631c1b4e5a5a.png)

**Sandbox URL**: https://pr14831.sandbox.opencraft.hosting/account/settings

**Merge deadline**: None

**Testing instructions**:

In the sandbox, you can log in as one of the standard users and go to the account settings page.  The email address can't be edited.

In devstack, you can do more comprehensive testing:
1. First start the LMS with `ALLOW_EMAIL_ADDRESS_CHANGE: true` (the default).
1. Navigate to the account settings page and verify that modifying the email address still works, results in a confirmation message and an email shown in the console.  Leave the page open.
1. Change `ALLOW_EMAIL_ADDRESS_CHANGE` to `false` in `lms.env.json` and restart the LMS.
1. In the account settings page that is still open, try to modify the email address again and verify that the API refuses the change (either in the developer tools or in the console log).
1. Reload the page, and verify that the email address field can't be edited anymore.

**Author notes and concerns**: N/A

**Reviewers**
- [x] @mtyaka
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ALLOW_EMAIL_ADDRESS_CHANGE: false
```