### PR TITLE
Add i18n to date in certificate web

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -98,7 +98,7 @@ def _update_certificate_context(context, user_certificate, platform_name):
 
     # Translators:  The format of the date includes the full name of the month
     context['certificate_date_issued'] = _('{month} {day}, {year}').format(
-        month=strftime_localized(user_certificate.modified_date,"%B"),
+        month=strftime_localized(user_certificate.modified_date, "%B"),
         day=user_certificate.modified_date.day,
         year=user_certificate.modified_date.year
     )

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -97,8 +97,26 @@ def _update_certificate_context(context, user_certificate, platform_name):
     )
 
     # Translators:  The format of the date includes the full name of the month
+    MONTHS={
+        'january': _('January'),
+        'february': _('February'),
+        'march': _('March'),
+        'april': _('April'),
+        'may': _('Mayy'),
+        'june': _('June'),
+        'july': _('July'),
+        'august': _('August'),
+        'september': _('September'),
+        'october': _('October'),
+        'november': _('November'),
+        'december': _('December')
+    }
+
+    def getTranslatedMonth(month):
+        return MONTHS[month.lower()]
+
     context['certificate_date_issued'] = _('{month} {day}, {year}').format(
-        month=_(user_certificate.modified_date.strftime("%B")),
+        month=getTranslatedMonth(user_certificate.modified_date.strftime("%B")),
         day=user_certificate.modified_date.day,
         year=user_certificate.modified_date.year
     )

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -97,26 +97,8 @@ def _update_certificate_context(context, user_certificate, platform_name):
     )
 
     # Translators:  The format of the date includes the full name of the month
-    MONTHS={
-        'january': _('January'),
-        'february': _('February'),
-        'march': _('March'),
-        'april': _('April'),
-        'may': _('May'),
-        'june': _('June'),
-        'july': _('July'),
-        'august': _('August'),
-        'september': _('September'),
-        'october': _('October'),
-        'november': _('November'),
-        'december': _('December')
-    }
-
-    def getTranslatedMonth(month):
-        return MONTHS[month.lower()]
-
     context['certificate_date_issued'] = _('{month} {day}, {year}').format(
-        month=getTranslatedMonth(user_certificate.modified_date.strftime("%B")),
+        month=strftime_localized(user_certificate.modified_date,"%B"),
         day=user_certificate.modified_date.day,
         year=user_certificate.modified_date.year
     )

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -98,7 +98,7 @@ def _update_certificate_context(context, user_certificate, platform_name):
 
     # Translators:  The format of the date includes the full name of the month
     context['certificate_date_issued'] = _('{month} {day}, {year}').format(
-        month=user_certificate.modified_date.strftime("%B"),
+        month=_(user_certificate.modified_date.strftime("%B")),
         day=user_certificate.modified_date.day,
         year=user_certificate.modified_date.year
     )

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -102,7 +102,7 @@ def _update_certificate_context(context, user_certificate, platform_name):
         'february': _('February'),
         'march': _('March'),
         'april': _('April'),
-        'may': _('Mayy'),
+        'may': _('May'),
         'june': _('June'),
         'july': _('July'),
         'august': _('August'),


### PR DESCRIPTION
The month in the date of generated certificates is not being translated by the strings pulled from Transifex. The string in Transifex is like this:

```
{month} {day}, {year}
```

We can only change the format of the date without translating the month name. 

In this commit, the translation of the month is being added before the assignment of the value of the month into the date format.

For example, the English date `April 6, 2017`, in Spanish appears as `April 6, 2017`. By adding the translation of the date format in Transifex, from `{month} {day}, {year}` in English to `{day} {month} {year}` in Spanish, we still have the name of the month in English language, `6 April 2017`. With this commit, this problem is being solved and now the date in Spanish appears as `6 abril 2017`.

**NOTE:** @mreyk have wrote to Molly de Blanc to add my user @pepeportela as contributor into the TELTEK Entity Contributor Agreement.
