### PR TITLE
Fix RTL video player and subtitles misplacement in full screen

### DIFF
--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -201,9 +201,9 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
     }
 
     .closed-captions {
+      @include left(5%);
       position: absolute;
       width: 85%;
-      left: 5%;
       top: 70%;
       text-align: center;
     }
@@ -259,6 +259,7 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
       object,
       iframe,
       video {
+        @include left(0);
         display: block;
         border: none;
         width: 100%;


### PR DESCRIPTION
# Overview
When opening a video an RTL interface. The video is misplaced in the fullscreen mode. This PR fixes the issue, we had this fix for a while in [our fork](https://github.com/Edraak/edx-platform/pull/237) by @ahmedaljazzar.

## Steps to Reproduce
 1. Open a video with subtitles
 2. Enable the transcripts (on the side).
 2. Enable the subtitles (the `CC` button, not the side transcripts. It's confusing, I know)
 3. Enable fullscreen mode

### Expected Results
 - It should look OK. Regardless.

### Actual Results
 - The video covers the transcripts.
 - The subtitles title is incorrect.

Screenshot is available below.

## TODO 
 - [x] Test on devstack
 - [x] Provide screenshots
 - [x] Additional review by an @Edraak member @ahmedaljazzar

### Before
![image](https://cloud.githubusercontent.com/assets/645156/24749377/8c44a538-1acb-11e7-8d7d-45abdd265f42.png)

### After
<img width="1440" alt="screen shot 2017-04-06 at 1 00 30 pm" src="https://cloud.githubusercontent.com/assets/645156/24748665/114d61aa-1ac9-11e7-9d04-e60477234eaa.png">


