### PR TITLE
ENT-265: Enterprise version upgrade from 0.32.0 to 0.32.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.32.0
+edx-enterprise==0.32.1
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.3


### PR DESCRIPTION
Hi @mattdrayer , @zubair-arbi , @asadiqbal08 

Please take a look, this version upgrade contains a bug fix explained in [ENT-265](https://openedx.atlassian.net/browse/ENT-265)

Here the set of changes included in version upgrade from 0.32.0 to 0.32.1: https://github.com/edx/edx-enterprise/compare/d8aa489...6e8bf5f