### PR TITLE
Use platform_name instead of site_name in password reset email

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -281,4 +281,5 @@ Brian Mesick <bmesick@edx.org>
 Jeff LaJoie <jlajoie@edx.org>
 Ivan Ivić <iivic@edx.org>
 Brandon Baker <bcbaker@wesleyan.edu>
+Salah Alomari <salomari@qrf.org>
 Shirley He <she@edx.org>

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -48,7 +48,7 @@ class PasswordResetFormNoActive(PasswordResetForm):
     def save(
             self,
             domain_override=None,
-            subject_template_name='registration/password_reset_subject.txt',
+            subject_template_name='emails/password_reset_subject.txt',
             email_template_name='registration/password_reset_email.html',
             use_https=False,
             token_generator=default_token_generator,

--- a/common/djangoapps/student/tests/test_reset_password.py
+++ b/common/djangoapps/student/tests/test_reset_password.py
@@ -185,18 +185,22 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
             req = self.request_factory.post(
                 '/password_reset/', {'email': self.user.email}
             )
+            req.is_secure = Mock(return_value=True)
             req.get_host = Mock(return_value=domain_override)
             req.user = self.user
             password_reset(req)
             _, msg, _, _ = send_email.call_args[0]
 
-            reset_msg = "you requested a password reset for your user account at {}"
-            if domain_override:
-                reset_msg = reset_msg.format(domain_override)
-            else:
-                reset_msg = reset_msg.format(settings.SITE_NAME)
+            reset_intro_msg = "you requested a password reset for your user account at {}".format(platform_name)
+            self.assertIn(reset_intro_msg, msg)
 
-            self.assertIn(reset_msg, msg)
+            reset_link = "https://{}/"
+            if domain_override:
+                reset_link = reset_link.format(domain_override)
+            else:
+                reset_link = reset_link.format(settings.SITE_NAME)
+
+            self.assertIn(reset_link, msg)
 
             sign_off = "The {} Team".format(platform_name)
             self.assertIn(sign_off, msg)
@@ -221,7 +225,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         password_reset(req)
         _, msg, from_addr, _ = send_email.call_args[0]
 
-        reset_msg = "you requested a password reset for your user account at openedx.localhost"
+        reset_msg = "you requested a password reset for your user account at {}".format(fake_get_value('platform_name'))
 
         self.assertIn(reset_msg, msg)
 

--- a/lms/templates/emails/password_reset_subject.txt
+++ b/lms/templates/emails/password_reset_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Password reset on {{ platform_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/registration/password_reset_email.html
+++ b/lms/templates/registration/password_reset_email.html
@@ -1,5 +1,5 @@
 {% load i18n %}{% autoescape off %}
-{% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+{% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ platform_name }}.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}


### PR DESCRIPTION
# Overview
When requesting a password reset, the email subject reads *"Password reset on {site_name}"*. The template used is from the Django Project. Inability to customise or alter translation, like using platform_name instead of site_name (for readability).

## Steps to Reproduce on local machine
1. Run devstack
1. Add 'ar, en' to DarkLang in Admin
1. Go to localhost:8000
1. Login with staff@example.com
1. Go to settings and change preference language to Arabic
1. Go back to home page
1. Click on Login
1. Click on "Forgot my password" or "نسيت كلمة السر"
1. Notice the email dump on terminal/CLI

On production you can repeat the step on edX platform without the first 2 steps.

## Expected Results
1. The email should read *"Password reset on **Your Platform Name Here**"*
1. The string appears in .po files after executing makemessages script
1. Altering the translation on transifex will be reflected.
1. Changing platform name in settings file will be reflected on email subject.

## History
* [Fix edX name hardcoded in password reset email #6278](https://github.com/edx/edx-platform/pull/6278) [OSPR-187](https://openedx.atlassian.net/browse/OSPR-187)

## Testing
[x] Test on devstack
[x] Provide screenshots
[ ] Review by Edraak member @OmarIthawi 
[ ] Translate after changes on edX transifex

## Screenshots
### Before
![before](https://cloud.githubusercontent.com/assets/19625384/24837226/d9196a7e-1d37-11e7-8b29-affc9fdbe538.png)
### After
![after](https://cloud.githubusercontent.com/assets/19625384/24837225/d8f9db3c-1d37-11e7-85aa-5cbb39deaacd.png)

