### PR TITLE
Learner 243: Unauthenticated User Language Settings

### DIFF
--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -35,6 +35,7 @@ from commerce.models import CommerceConfiguration
 from commerce.tests import factories
 from commerce.tests.mocks import mock_get_orders
 from course_modes.models import CourseMode
+from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.oauth_dispatch.tests import factories as dot_factories
 from openedx.core.djangoapps.programs.tests.mixins import ProgramsApiConfigMixin
 from openedx.core.djangoapps.user_api.accounts.api import activate_account, create_account
@@ -520,6 +521,26 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         return urlencode({
             'next': '/account/finish_auth?{}'.format(urlencode(params))
         })
+
+    def test_english_by_default(self):
+        response = self.client.get(reverse('signin_user'), [], HTTP_ACCEPT="text/html")
+
+        self.assertEqual(response['Content-Language'], 'en')
+
+    def test_unsupported_language(self):
+        response = self.client.get(reverse('signin_user'), [], HTTP_ACCEPT="text/html", HTTP_ACCEPT_LANGUAGE="ts-zx")
+
+        self.assertEqual(response['Content-Language'], 'en')
+
+    def test_browser_language(self):
+        response = self.client.get(reverse('signin_user'), [], HTTP_ACCEPT="text/html", HTTP_ACCEPT_LANGUAGE="es")
+
+        self.assertEqual(response['Content-Language'], 'es-419')
+
+    def test_browser_language_dialent(self):
+        response = self.client.get(reverse('signin_user'), [], HTTP_ACCEPT="text/html", HTTP_ACCEPT_LANGUAGE="es-es")
+
+        self.assertEqual(response['Content-Language'], 'es-es')
 
 
 class AccountSettingsViewTest(ThirdPartyAuthTestMixin, TestCase, ProgramsApiConfigMixin):

--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -35,19 +35,3 @@ class LanguagePreferenceMiddleware(object):
                     request.session[LANGUAGE_SESSION_KEY] = user_pref
                 else:
                     delete_user_preference(request.user, LANGUAGE_KEY)
-        else:
-            preferred_language = request.META.get('HTTP_ACCEPT_LANGUAGE', '')
-            lang_headers = [seq[0] for seq in parse_accept_lang_header(preferred_language)]
-
-            prefixes = [prefix.split("-")[0] for prefix in system_released_languages]
-            # Setting the session language to the browser language, if it is supported.
-            for browser_lang in lang_headers:
-                if browser_lang in system_released_languages:
-                    pass
-                elif browser_lang in prefixes:
-                    browser_lang = system_released_languages[prefixes.index(browser_lang)]
-                else:
-                    continue
-                if request.session.get(LANGUAGE_SESSION_KEY, None) is None:
-                    request.session[LANGUAGE_SESSION_KEY] = unicode(browser_lang)
-                break

--- a/openedx/core/djangoapps/lang_pref/tests/test_api.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_api.py
@@ -4,20 +4,44 @@
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import translation
+from django.contrib.auth.models import User
+import ddt
+
+from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 
 from openedx.core.djangoapps.lang_pref import api as language_api
 
+EN = language_api.Language('en', 'English')
+ES_419 = language_api.Language('es-419', u'Español (Latinoamérica)')
 
+@ddt.ddt
 class LanguageApiTest(TestCase):
     """
     Tests of the language APIs.
     """
-    def test_released_languages(self):
+    @ddt.data(*[
+        ('en', [], [], []),
+        ('en', [EN], [], [EN]),
+        ('en', [EN, ES_419], [], [EN]),
+        ('en', [EN, ES_419], ['es-419'], [EN, ES_419]),
+        ('es-419', [EN, ES_419], ['es-419'], [ES_419]),
+        ('en', [EN, ES_419], ['es'], [EN]),
+    ])
+    @ddt.unpack
+    def test_released_languages(self, default_lang, languages, dark_lang_released, expected_languages):
         """
         Tests for the released languages.
         """
-        released_languages = language_api.released_languages()
-        self.assertGreaterEqual(len(released_languages), 1)
+        with override_settings(LANGUAGES=languages, LANGUAGE_CODE=default_lang):
+            user = User()
+            user.save()
+            DarkLangConfig(
+                released_languages=', '.join(dark_lang_released),
+                changed_by=user,
+                enabled=True
+            ).save()
+            released_languages = language_api.released_languages()
+            self.assertEqual(released_languages, expected_languages)
 
     @override_settings(ALL_LANGUAGES=[[u"cs", u"Czech"], [u"nl", u"Dutch"]])
     def test_all_languages(self):

--- a/openedx/core/djangoapps/lang_pref/tests/test_api.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_api.py
@@ -14,6 +14,7 @@ from openedx.core.djangoapps.lang_pref import api as language_api
 EN = language_api.Language('en', 'English')
 ES_419 = language_api.Language('es-419', u'Español (Latinoamérica)')
 
+
 @ddt.ddt
 class LanguageApiTest(TestCase):
     """

--- a/pavelib/utils/test/suites/nose_suite.py
+++ b/pavelib/utils/test/suites/nose_suite.py
@@ -119,6 +119,7 @@ class SystemTestSuite(NoseTestSuite):
 
         self.processes = kwargs.get('processes', None)
         self.randomize = kwargs.get('randomize', None)
+        self.settings = kwargs.get('settings', 'test')
 
         if self.processes is None:
             # Don't use multiprocessing by default
@@ -148,7 +149,7 @@ class SystemTestSuite(NoseTestSuite):
             '--verbosity={}'.format(self.verbosity),
             self.test_id,
         ] + self.test_options_flags + [
-            '--settings=test',
+            '--settings', self.settings,
             self.extra_args,
             '--xunitmp-file={}'.format(self.report_dir / "nosetests.xml"),
             '--with-database-isolation',


### PR DESCRIPTION
This changes the LMS so that when an unauthenticated user hits a page, their browser language selection will *not* be saved to their session (and thus be static for 2 weeks, even if they change their browser language). It does not affect the language setting in the session set by other means (such as the language selector).