### PR TITLE
Fix Studio help links affected by guide reorg

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_help.py
+++ b/common/test/acceptance/tests/studio/test_studio_help.py
@@ -55,6 +55,7 @@ def _get_expected_documentation_url(path):
 class StudioHelpTest(StudioCourseTest):
     """Tests for Studio help."""
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_studio_help_links(self):
         """Test that the help links are present and have the correct content."""
         page = DashboardPage(self.browser)
@@ -101,6 +102,7 @@ class SignInHelpTest(AcceptanceTest):
         self.index_page = IndexPage(self.browser)
         self.index_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_sign_in_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Sign In' page.
@@ -132,6 +134,7 @@ class SignUpHelpTest(AcceptanceTest):
         self.index_page = IndexPage(self.browser)
         self.index_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_sign_up_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Sign Up' page.
@@ -163,6 +166,7 @@ class HomeHelpTest(StudioCourseTest):
         self.home_page = HomePage(self.browser)
         self.home_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_home_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Home'(Courses tab) page.
@@ -181,6 +185,7 @@ class HomeHelpTest(StudioCourseTest):
             href=expected_url
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_home_side_bar_help(self):
         """
         Scenario: Help link in sidebar links is working on 'Home'(Courses tab) page.
@@ -216,6 +221,7 @@ class NewCourseHelpTest(AcceptanceTest):
         self.assertTrue(self.dashboard_page.new_course_button.present)
         self.dashboard_page.click_new_course_button()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_create_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Create a New Course' page in the dashboard.
@@ -234,6 +240,7 @@ class NewCourseHelpTest(AcceptanceTest):
             href=expected_url
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_create_side_bar_help(self):
         """
         Scenario: Help link in sidebar links is working on 'Create a New Course' page in the dashboard.
@@ -269,6 +276,7 @@ class NewLibraryHelpTest(AcceptanceTest):
         self.assertTrue(self.dashboard_page.has_new_library_button)
         self.dashboard_page.click_new_library()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_library_create_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Create a New Library' page in the dashboard.
@@ -287,6 +295,7 @@ class NewLibraryHelpTest(AcceptanceTest):
             href=expected_url
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_library_create_side_bar_help(self):
         """
         Scenario: Help link in sidebar links is working on 'Create a New Library' page in the dashboard.
@@ -320,6 +329,7 @@ class LibraryTabHelpTest(AcceptanceTest):
         self.auth_page.visit()
         self.dashboard_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_library_tab_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Home'(Courses tab) page.
@@ -351,6 +361,7 @@ class LibraryHelpTest(StudioLibraryTest):
         self.library_page = LibraryPage(self.browser, self.library_key)
         self.library_user_page = LibraryUsersPage(self.browser, self.library_key)
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_library_content_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on content
@@ -371,6 +382,7 @@ class LibraryHelpTest(StudioLibraryTest):
             href=expected_url
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_library_content_side_bar_help(self):
         """
         Scenario: Help link in sidebar links is working on
@@ -392,6 +404,7 @@ class LibraryHelpTest(StudioLibraryTest):
             help_text='Learn more about content libraries'
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_library_user_access_setting_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'User Access'
@@ -425,6 +438,7 @@ class LibraryImportHelpTest(StudioLibraryTest):
         self.library_import_page = ImportLibraryPage(self.browser, self.library_key)
         self.library_import_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_library_import_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Library import page.
@@ -443,6 +457,7 @@ class LibraryImportHelpTest(StudioLibraryTest):
             href=expected_url
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_library_import_side_bar_help(self):
         """
         Scenario: Help link in sidebar links is working on Library import page.
@@ -473,6 +488,7 @@ class LibraryExportHelpTest(StudioLibraryTest):
         self.library_export_page = ExportLibraryPage(self.browser, self.library_key)
         self.library_export_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_library_export_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Library export page.
@@ -491,6 +507,7 @@ class LibraryExportHelpTest(StudioLibraryTest):
             href=expected_url
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_library_export_side_bar_help(self):
         """
         Scenario: Help link in sidebar links is working on Library export page.
@@ -545,6 +562,7 @@ class CourseOutlineHelpTest(StudioCourseTest):
             href=expected_url
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_outline_side_bar_help(self):
         """
         Scenario: Help link in sidebar links is working on Course Outline page
@@ -581,6 +599,7 @@ class CourseUpdateHelpTest(StudioCourseTest):
         )
         self.course_update_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_update_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Course Update' page
@@ -615,6 +634,7 @@ class AssetIndexHelpTest(StudioCourseTest):
         )
         self.course_asset_index_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_asset_index_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Files & Uploads' page
@@ -633,6 +653,7 @@ class AssetIndexHelpTest(StudioCourseTest):
             href=expected_url,
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_asset_index_side_bar_help(self):
         """
         Scenario: Help link in sidebar links is working on 'Files & Uploads' page
@@ -668,6 +689,7 @@ class CoursePagesHelpTest(StudioCourseTest):
         )
         self.course_pages_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_page_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Pages' page
@@ -702,6 +724,7 @@ class UploadTextbookHelpTest(StudioCourseTest):
         )
         self.course_textbook_upload_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_textbook_upload_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Textbooks' page
@@ -720,6 +743,7 @@ class UploadTextbookHelpTest(StudioCourseTest):
             href=expected_url,
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_textbook_side_bar_help(self):
         """
         Scenario: Help link in sidebar links is working on 'Textbooks' page
@@ -769,6 +793,7 @@ class StudioUnitHelpTest(ContainerBase):
             )
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_unit_page_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Unit page.
@@ -806,6 +831,7 @@ class SettingsHelpTest(StudioCourseTest):
 
         self.settings_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_settings_page_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Settings page.
@@ -842,6 +868,7 @@ class GradingPageHelpTest(StudioCourseTest):
 
         self.grading_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_grading_page_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Grading page.
@@ -878,6 +905,7 @@ class CourseTeamSettingsHelpTest(StudioCourseTest):
 
         self.course_team_settings_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_course_team_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Course Team settings page
@@ -914,6 +942,7 @@ class CourseGroupConfigurationHelpTest(StudioCourseTest):
 
         self.course_group_configuration_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_group_conf_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on
@@ -933,6 +962,7 @@ class CourseGroupConfigurationHelpTest(StudioCourseTest):
             href=expected_url,
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_group_conf_content_group_side_bar_help(self):
         """
         Scenario: Help link in side bar under the 'content group' is working
@@ -971,6 +1001,7 @@ class AdvancedSettingHelpTest(StudioCourseTest):
 
         self.advanced_settings.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_advanced_settings_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Advanced Settings page.
@@ -1007,6 +1038,7 @@ class CertificatePageHelpTest(StudioCourseTest):
 
         self.certificates_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_certificate_page_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Certificate settings page
@@ -1025,6 +1057,7 @@ class CertificatePageHelpTest(StudioCourseTest):
             href=expected_url,
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_certificate_page_side_bar_help(self):
         """
         Scenario: Help link in side bar is working Certificate settings page
@@ -1074,6 +1107,7 @@ class GroupExperimentConfigurationHelpTest(ContainerBase):
             {u"advanced_modules": {"value": ["split_test"]}}
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_course_group_configuration_experiment_side_bar_help(self):
         """
         Scenario: Help link in side bar under the 'Experiment Group Configurations'
@@ -1115,6 +1149,7 @@ class ToolsImportHelpTest(StudioCourseTest):
         )
         self.import_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_tools_import_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on tools Library import page
@@ -1133,6 +1168,7 @@ class ToolsImportHelpTest(StudioCourseTest):
             href=expected_url,
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_tools_import_side_bar_help(self):
         """
         Scenario: Help link in side bar is working on tools Library import page
@@ -1170,6 +1206,7 @@ class ToolsExportHelpTest(StudioCourseTest):
         )
         self.export_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_tools_import_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on tools Library export page
@@ -1188,6 +1225,7 @@ class ToolsExportHelpTest(StudioCourseTest):
             href=expected_url,
         )
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_tools_import_side_bar_help(self):
         """
         Scenario: Help link in side bar is working on tools Library export page
@@ -1218,6 +1256,7 @@ class StudioWelcomeHelpTest(AcceptanceTest):
         self.index_page = IndexPage(self.browser)
         self.index_page.visit()
 
+    @skip("Disabled as edx.org help links are now different than Open edX (@catong can advise)")
     def test_welcome_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on 'Welcome' page (User not logged in).

--- a/docs/cms_config.ini
+++ b/docs/cms_config.ini
@@ -12,10 +12,10 @@ pdf_file = edx-partner-course-staff.pdf
 
 # below are the sub-paths to the documentation for the various pages
 # NOTE: If any of these page settings change, then their corresponding test should be updated
-#       in edx-platform/cms/djangoapps/contentstore/features/help.feature
+#       in edx-platform/common/test/acceptance/tests/studio/test_studio.help.py
 [pages]
 default = index.html
-home = get_started.html
+home = getting_started/CA_get_started_Studio.html
 develop_course = developing_course/index.html
 outline = developing_course/course_outline.html
 unit = developing_course/course_units.html
@@ -29,14 +29,14 @@ grading = grading/index.html
 team_course = set_up_course/course_staffing.html#add-course-team-members
 team_library = course_components/libraries.html#give-other-users-access-to-your-library
 advanced = index.html
-checklist = set_up_course/creating_new_course.html#use-the-course-checklist
+checklist = set_up_course/creating_new_course.html
 import_library = course_components/libraries.html#import-a-library
 import_course = releasing_course/export_import_course.html#import-a-course
 export_library = course_components/libraries.html#export-a-library
 export_course = releasing_course/export_import_course.html#export-a-course
-welcome = get_started.html
-login = get_started.html
-register = get_started.html
+welcome = getting_started/index.html
+login = getting_started/index.html
+register = getting_started/index.html
 content_libraries = course_components/libraries.html
 content_groups = course_features/cohorts/cohorted_courseware.html
 group_configurations = course_features/content_experiments/content_experiments_configure.html#set-up-group-configurations-in-edx-studio

--- a/docs/lms_config.ini
+++ b/docs/lms_config.ini
@@ -12,7 +12,7 @@ pdf_file = open-edx-learner-guide.pdf
 
 # below are the sub-paths to the documentation for the various pages
 # NOTE: If any of these page settings change, then their corresponding test should be updated
-#       in edx-platform/cms/djangoapps/contentstore/features/help.feature
+#       in edx-platform/common/test/acceptance/tests/lms/test_lms_help.py
 [pages]
 default = index.html
 


### PR DESCRIPTION
Fix Studio help links affected by reorg of intro topics in the Learner's Guide and shared guides.
FYI: @edx/doc 