### PR TITLE
Fix i18n string extraction for txt files in themes directory

### DIFF
--- a/conf/locale/babel_mako.cfg
+++ b/conf/locale/babel_mako.cfg
@@ -28,5 +28,5 @@ input_encoding = utf-8
 input_encoding = utf-8
 [mako: themes/**.html]
 input_encoding = utf-8
-[mako: themes/**.html]
+[mako: themes/**.txt]
 input_encoding = utf-8


### PR DESCRIPTION
Updates the babel_mako.cfg file so that strings may be extracted from .txt files in the themes directory.

https://openedx.atlassian.net/browse/LEARNER-534