### PR TITLE
Default discussion topic

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -293,7 +293,10 @@ class CourseFields(object):
             '{"id": "i4x-InstitutionName-CourseNumber-course-CourseRun"}. For example, one discussion '
             'category may be "Lydian Mode": {"id": "i4x-UniversityX-MUS101-course-2015_T1"}. The "id" '
             'value for each category must be unique. In "id" values, the only special characters that are '
-            'supported are underscore, hyphen, and period.'
+            'supported are underscore, hyphen, and period. You can also specify a category as the default '
+            'for new posts in the Discussion page by setting its "default" attribute to true. For example, '
+            '"Lydian Mode": {"id": "i4x-UniversityX-MUS101-course-2015_T1", "default": true}.'
+
         ),
         scope=Scope.settings
     )

--- a/lms/djangoapps/discussion/static/discussion/js/discussion_board_factory.js
+++ b/lms/djangoapps/discussion/static/discussion/js/discussion_board_factory.js
@@ -59,7 +59,8 @@
                     course_settings: courseSettings,
                     discussionBoardView: discussionBoardView,
                     mode: 'tab',
-                    startHeader: 2
+                    startHeader: 2,
+                    topicId: options.defaultTopicId
                 });
                 newPostView.render();
 

--- a/lms/djangoapps/discussion/templates/discussion/discussion_board_js.template
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_board_js.template
@@ -57,7 +57,8 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
                 contentInfo: ${annotated_content_info | n, dump_js_escaped_json},
                 courseName: '${course.display_name_with_default | n, js_escaped_string}',
                 courseSettings: ${course_settings | n, dump_js_escaped_json},
-                isCommentableDivided: ${is_commentable_divided | n, dump_js_escaped_json}
+                isCommentableDivided: ${is_commentable_divided | n, dump_js_escaped_json},
+                defaultTopicId: '${discussion_default_topic_id | n, js_escaped_string}'
             });
         });
     });

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -32,6 +32,7 @@ from django_comment_common.models import CourseDiscussionSettings, ForumsConfig
 from django_comment_common.utils import ThreadContext
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.discussion import views
+from lms.djangoapps.discussion.views import _get_discussion_default_topic_id
 from lms.djangoapps.discussion.views import course_discussions_settings_handler
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory
 from lms.lib.comment_client.utils import CommentClientPaginatedResult
@@ -1884,3 +1885,35 @@ class CourseDiscussionsHandlerTestCase(DividedDiscussionsTestCase):
             CourseDiscussionSettings.COHORT, CourseDiscussionSettings.ENROLLMENT_TRACK
         ]
         self.assertEqual(response, expected_response)
+
+
+class DefaultTopicIdGetterTestCase(ModuleStoreTestCase):
+    """
+    Tests the `_get_discussion_default_topic_id` helper.
+    """
+
+    def test_no_default_topic(self):
+        discussion_topics = {
+            'dummy discussion': {
+                'id': 'dummy_discussion_id',
+            },
+        }
+        course = CourseFactory.create(discussion_topics=discussion_topics)
+        expected_id = None
+        result = _get_discussion_default_topic_id(course)
+        self.assertEqual(expected_id, result)
+
+    def test_default_topic_id(self):
+        discussion_topics = {
+            'dummy discussion': {
+                'id': 'dummy_discussion_id',
+            },
+            'another discussion': {
+                'id': 'another_discussion_id',
+                'default': True,
+            },
+        }
+        course = CourseFactory.create(discussion_topics=discussion_topics)
+        expected_id = 'another_discussion_id'
+        result = _get_discussion_default_topic_id(course)
+        self.assertEqual(expected_id, result)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -387,6 +387,12 @@ def _create_base_discussion_view_context(request, course_key):
     }
 
 
+def _get_discussion_default_topic_id(course):
+    for topic, entry in course.discussion_topics.items():
+        if entry.get('default') is True:
+            return entry['id']
+
+
 def _create_discussion_board_context(request, course_key, discussion_id=None, thread_id=None):
     """
     Returns the template context for rendering the discussion board.
@@ -447,6 +453,8 @@ def _create_discussion_board_context(request, course_key, discussion_id=None, th
         'upgrade_link': check_and_get_upgrade_link(request, user, course.id),
         'upgrade_price': get_cosmetic_verified_display_price(course),
         # ENDTODO
+        # If the default topic id is None the front-end code will look for a topic that contains "General"
+        'discussion_default_topic_id': _get_discussion_default_topic_id(course),
     })
     return context
 


### PR DESCRIPTION
This PR adds the ability to configure the default topic for new posts in the Discussion tab by setting a new attribute in the Discussion Topic Mapping field.

[Corresponding documentation PR](https://github.com/edx/edx-documentation/pull/1488)

**Dependencies**: None

**Screenshots**:
![studio](https://user-images.githubusercontent.com/560781/26912117-a965c4dc-4bcf-11e7-823c-4d62cf2892a7.png)
![lms](https://user-images.githubusercontent.com/560781/26912118-ae2d9684-4bcf-11e7-96cb-407b320ef306.png)


**Sandbox URL**:

LMS: https://oc2476.sandbox.opencraft.hosting/
Studio: https://studio-oc2476.sandbox.opencraft.hosting/

**Partner information**: 3rd party-hosted open edX instance

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: None

**Testing instructions**:

1. In Studio go to the demo course advanced settings.
2. Add a new category to the Discussion Topic Mapping with a "default" attribute set to true. For example:

```json
"Custom": {
    "id": "custom",
    "default": true
}
```

3. Save the changes
4. In the LMS go to the demo course Discussion tab.
5. Add a new post and check that the Topic area default value matches the setting.

**Author notes and concerns**:

We tried to add a JS spec test for the DiscussionBoardFactory change, but the DiscussionRouter interferes with the history of other spec tests. That's the reason why [the current test for the factory is disabled](https://github.com/replaceafill/edx-platform/blob/bfbc3241b396ec9591674983c176839cb6f46aeb/lms/djangoapps/discussion/static/discussion/js/spec/discussion_board_factory_spec.js#L66). 

**Reviewers**
- [ ] @pomegranited 
- [ ] @bdero 