### PR TITLE
[LEARNER-493] Add feature flag for Bundled Purchase - WL

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -374,6 +374,10 @@ FEATURES = {
 
     # Whether or not the dynamic EnrollmentTrackUserPartition should be registered.
     'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': False,
+
+    # Enable one click program purchase
+    # See LEARNER-493
+    'ENABLE_ONE_CLICK_PROGRAM_PURCHASE': False,
 }
 
 # Ignore static asset files on import which match this pattern


### PR DESCRIPTION
### Review:
@edx/helio 

### JIRA ticket:
https://openedx.atlassian.net/browse/LEARNER-493

### How it works:
1. By default, feature flag is set to `False`. Feature is disabled for all Sites.
2. Using the Site Configuration, we can override the feature flag's value to activate (or deactivate in future, once the feature flag's default value is set to `True`) the Bundled Purchase Feature per Site. See the screenshot below.

![screen shot 2017-04-13 at 10 04 48](https://cloud.githubusercontent.com/assets/6833568/24995864/b3f5a392-2030-11e7-88c0-92ec7fd0edc7.png) 

3. To use the flag per Site in the code, access it from SiteConfiguration. Here's the code snippet:
```
from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
configuration_helpers.get_value(
    'ENABLE_BUNDLED_PURCHASE_FUNCTIONALITY',
    settings.FEATURES.get('ENABLE_BUNDLED_PURCHASE_FUNCTIONALITY', False)
)
```

### To do:
- [ ]  Get permission to edit https://openedx.atlassian.net/wiki/display/EdxOps/edX+Feature+Flags
- [ ]  Add the feature flag to the doc page mentioned in the previous task

