### PR TITLE
[WIP] [ENT-314] Support SAML single-logout

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0008_auto_20170412_2043.py
+++ b/common/djangoapps/third_party_auth/migrations/0008_auto_20170412_2043.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0007_auto_20170406_0912'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='samlproviderdata',
+            name='slo_binding',
+            field=models.CharField(blank=True, max_length=100, null=True, verbose_name=b'SLO binding type', choices=[('', '---------'), (b'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect', b'HTTP-Redirect'), (b'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST', b'HTTP-POST')]),
+        ),
+        migrations.AddField(
+            model_name='samlproviderdata',
+            name='slo_url',
+            field=models.URLField(null=True, verbose_name=b'Single Log-Out URL', blank=True),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models.fields import BLANK_CHOICE_DASH
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 import json
@@ -551,6 +552,17 @@ class SAMLProviderData(models.Model):
 
     entity_id = models.CharField(max_length=255, db_index=True)  # This is the key for lookups in this table
     sso_url = models.URLField(verbose_name="SSO URL")
+    slo_url = models.URLField(verbose_name="Single Log-Out URL", null=True, blank=True)
+    slo_binding = models.CharField(
+        max_length=100,
+        choices=BLANK_CHOICE_DASH + [
+            ('urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect', 'HTTP-Redirect'),
+            ('urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST', 'HTTP-POST')
+        ],
+        null=True,
+        blank=True,
+        verbose_name="SLO binding type",
+    )
     public_key = models.TextField()
 
     class Meta(object):

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -110,6 +110,7 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
         """
         return super(SAMLAuthBackend, self).generate_saml_config(idp=idp)
 
+
 class SapSuccessFactorsIdentityProvider(SAMLIdentityProvider):
     """
     Customized version of SAMLIdentityProvider that knows how to retrieve user details

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -97,6 +97,18 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
         from .models import SAMLConfiguration
         return SAMLConfiguration.current(Site.objects.get_current(get_current_request()))
 
+    def generate_saml_config(self, idp=None):
+        """
+        Add code here to add the following details to the base config:
+        We don't have to set the binding; python-saml will take care of that.
+
+            {
+                "SingleLogoutService": {
+                    "url": "whatever"
+                }
+            }
+        """
+        return super(SAMLAuthBackend, self).generate_saml_config(idp=idp)
 
 class SapSuccessFactorsIdentityProvider(SAMLIdentityProvider):
     """

--- a/common/djangoapps/third_party_auth/urls.py
+++ b/common/djangoapps/third_party_auth/urls.py
@@ -2,12 +2,19 @@
 
 from django.conf.urls import include, patterns, url
 
-from .views import inactive_user_view, saml_metadata_view, lti_login_and_complete_view, post_to_custom_auth_form
+from .views import (
+	inactive_user_view,
+	saml_logout_view,
+	saml_metadata_view,
+	lti_login_and_complete_view,
+	post_to_custom_auth_form
+)
 
 urlpatterns = patterns(
     '',
     url(r'^auth/inactive', inactive_user_view, name="third_party_inactive_redirect"),
     url(r'^auth/custom_auth_entry', post_to_custom_auth_form, name='tpa_post_to_custom_auth_form'),
+    url(r'^auth/saml/logout/$', saml_logout_view),
     url(r'^auth/saml/metadata.xml', saml_metadata_view),
     url(r'^auth/login/(?P<backend>lti)/$', lti_login_and_complete_view),
     url(r'^auth/', include('social.apps.django_app.urls', namespace='social')),

--- a/common/djangoapps/third_party_auth/urls.py
+++ b/common/djangoapps/third_party_auth/urls.py
@@ -3,11 +3,11 @@
 from django.conf.urls import include, patterns, url
 
 from .views import (
-	inactive_user_view,
-	saml_logout_view,
-	saml_metadata_view,
-	lti_login_and_complete_view,
-	post_to_custom_auth_form
+    inactive_user_view,
+    saml_logout_view,
+    saml_metadata_view,
+    lti_login_and_complete_view,
+    post_to_custom_auth_form
 )
 
 urlpatterns = patterns(

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -9,6 +9,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseServerError, Http404, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
 from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import View
 
 import social
 from social.apps.django_app.views import complete
@@ -21,6 +22,31 @@ from .models import SAMLConfiguration
 
 URL_NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
 log = logging.getLogger(__name__)
+
+
+class SamlSingleLogoutView(View):
+    """
+    View handles requests to log out a user linked to a SAML SSO session.
+    """
+
+    def get(self, request):
+        """
+        Handles requests of the 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect' type
+        """
+        pass
+
+    def post(self, request):
+        """
+        Handles requests of the 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST' type
+        """
+        pass
+
+    def get_thing(self):
+        pass
+
+    def current_user_matches_logout_request(self, request):
+        pass
+
 
 def inactive_user_view(request):
     """

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -1,21 +1,26 @@
 """
 Extra views required for SSO
 """
+import logging
+
 from django.conf import settings
+from django.contrib.auth import logout
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseServerError, Http404, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
 from django.views.decorators.csrf import csrf_exempt
+
 import social
 from social.apps.django_app.views import complete
 from social.apps.django_app.utils import load_strategy, load_backend
 from social.utils import setting_name
+
 from student.models import UserProfile
 from student.views import compose_and_send_activation_email
 from .models import SAMLConfiguration
 
 URL_NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
-
+log = logging.getLogger(__name__)
 
 def inactive_user_view(request):
     """
@@ -33,6 +38,42 @@ def inactive_user_view(request):
     profile = UserProfile.objects.get(user=request.user)
     compose_and_send_activation_email(request.user, profile)
     return redirect(request.GET.get('next', 'dashboard'))
+
+def saml_logout_view(request):
+    """
+    Terminate the Open edX learner's session.  This view is mapped to the
+    SAML Single Logout (SLO) URL included in the metadata response payload.
+
+    Note: The current implementation does not take OIDC sessions into account.  For a more
+    robust implementation we should combine the workflow executed here with the LogoutView
+    mechanism found in common/student/views.py ~L2650.
+    """
+
+    # Ensure SAML support is enabled for this Open edX installation
+    if not SAMLConfiguration.is_enabled(request.site):
+        message = "SAML session termination attempted for {0}, but SAML is not enabled.".format(
+            request.site.name
+        )
+        log.error(message)
+
+    # Ensure there is an authenticated user included in the request
+    if not hasattr(request, "user") or not request.user.is_authenticated():
+        message = "SAML session termination attempted for {0}, but no user was provided.".format(
+            request.site.name
+        )
+        log.info(message)
+
+    # If none of the guards were tripped, we are clear to terminate the learner's session
+    if not message:
+
+        # There is a system handler registered to perform logging on successful logouts.
+        request.is_from_logout = True
+
+        # Now perform the actual application session termination
+        logout(request)
+
+    # Instruct the browser to send the user back to the origination point
+    redirect()
 
 
 def saml_metadata_view(request):


### PR DESCRIPTION
This is a work-in-progress PR to enable single-logout support for integrated SAML providers. This stub will be replaced with meaningful phrasing and important wording as soon as there's code to support same.

What we have:
- Database support for SLO metadata
- IdP metadata parsing to retrieve SLO metadata
- Framework for SAML SLO view

What we need:
- Testing for SLO metadata parsing
- Add SLO endpoint to SP metadata
- Logic to verify a received `LogoutRequest`
- Logic to determine whether the logged-in user matches the assertion in a received `LogoutRequest`
- Logic to create a `LogoutResponse`
- Logic to do a full logout of all OIDC services, followed by submitting a `LogoutResponse` 
- Testing for any logic that hasn't been written yet