### PR TITLE
ECOM-6206 Fix firefox issue for email field with extra whitespaces

### DIFF
--- a/lms/static/js/student_account/views/FormView.js
+++ b/lms/static/js/student_account/views/FormView.js
@@ -157,6 +157,12 @@
                         $label = $form.find('label[for=' + $el.attr('id') + ']');
                         key = $el.attr('name') || false;
 
+                        // Due to a bug in firefox, whitespaces in email type field are not removed.
+                        // TODO: Remove this code once firefox bug is resolved.
+                        if (key === 'email') {
+                            $el.val($el.val().trim());
+                        }
+
                         if (key) {
                             test = this.validate(elements[i]);
                             if (test.isValid) {


### PR DESCRIPTION
## [ECOM-6206](https://openedx.atlassian.net/browse/ECOM-6206)

### Description

Firefox has a bug related to input tag with field type email. Using firefox, at the time of login/register, if email has white spaces (at beginning or after) a validation error is raised by edx-platform. In other browsers, email type field is trimmed i.e all white spaces are removed automatically when form is submitted. 

In order to cater this corner case scenario, email field is trimmed at every form submit.


### How to Test?

**Stage** 
- Go to https://courses.stage.edx.org/login in firefox.
- Write your email address with spaces beginning or/and after it.
- Try to login.
- Observe `The email address you've provided isn't formatted correctly.` error.

**Sandbox**
- https://firefox.sandbox.edx.org/login

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @Rabia23 
- [x] Code review: @Ayub-Khan 
- [x] Code review: @adampalay 

### Post-review
- [x] Rebase and squash commits