### PR TITLE
Translate "discussion" in "discussion posted 2 minutes ago by X"

### DIFF
--- a/common/static/common/templates/discussion/thread-show.underscore
+++ b/common/static/common/templates/discussion/thread-show.underscore
@@ -25,16 +25,17 @@
                 {created_at: created_at},
                 true
             );
+            var postedTimeAgoMessage;
+            // Using a separate message to ensure proper translation for different languages
+            // thread_type describes the kind of post this is (e.g. "question" or "discussion");
+            // time_ago is how much time has passed since the post was created (e.g. "4 hours ago")
+            if (thread_type === 'discussion') {
+                postedTimeAgoMessage = gettext('discussion posted %(time_ago)s by %(author)s');
+            } else {
+                postedTimeAgoMessage = gettext('question posted %(time_ago)s by %(author)s');
+            }
             %>
-            <%=
-            interpolate(
-                // Translators: post_type describes the kind of post this is (e.g. "question" or "discussion");
-                // time_ago is how much time has passed since the post was created (e.g. "4 hours ago")
-                _.escape(gettext('%(post_type)s posted %(time_ago)s by %(author)s')),
-                {post_type: thread_type, time_ago: timeAgoHtml, author: author_display},
-                true
-            )
-            %>
+            <%= interpolate(_.escape(postedTimeAgoMessage), {time_ago: timeAgoHtml, author: author_display}, true) %>
             </p>
             <div class="post-labels">
                 <span class="post-label post-label-pinned">


### PR DESCRIPTION
# Overview
There are two types of forum threads: a) question, and b) discussion. In the thread view of each a message is displayed to indicate the time and author of the thread. This message is translated, however the `thread_type` is printed as is from the MongoDB without attempting to translating the type. This PR allows translating the message for each thread type separately to allow proper localization, especially with gendered languages such as Arabic. 

This is a long-standing issue that we had a rough patch for it in [our fork](https://github.com/Edraak/edx-platform/pull/106/files#diff-2dd7bd71154c4ffaa5a6a60938275b0cL20) by @ahmedaljazzar. This PR proposes a better solution.

# Steps to Reproduce

 1. Go to a course's discussion
 2. Create a discussion thread (or question)
 3. Switch to another language (from your account settings)

## Expected Results
 - The word `discussion` (or `question`) should be translated.
 - The whole `%(post_type)s posted by X` sentence should be translated as a whole in order to be valid in gendered languages.

## Actual Result
 - The word `discussion` is not translatable (check the screenshots below)
 - It is used as-is from the `cs_comments_service`

# Not TODO
There's another new bug that I've discovered here in which the "time ago" is not being translated either, this is a new issue that I won't fix in this PR to keep it atomic.

# Testing

 - [x] Unit tests passes (the CI will help with this, of course)
 - [x] Manual test on devstack to ensure the functionality still works
 - [x] Ensure that the strings are collectable with paver (see the command line output below)
 - [ ]  Additional review from @Edraak member @ahmedaljazzar

## Strings Extraction
```bash
$ paver i18n_extract
<output omitted>
$ grep -e posted -B2 -- conf/locale/en/LC_MESSAGES/underscore.po
#: common/static/common/templates/discussion/response-comment-show.underscore:25
#, python-format
msgid "posted %(time_ago)s by %(author)s"
--
#: common/static/common/templates/discussion/thread-show.underscore:33
#, python-format
msgid "discussion posted %(time_ago)s by %(author)s"
--
#: common/static/common/templates/discussion/thread-show.underscore:35
#, python-format
msgid "question posted %(time_ago)s by %(author)s"
```

# Screenshots
This is Russian, which I don't understand. But it is clear that both `discussion` and `question` are printed as is.

## Discussion
<img width="804" alt="screen shot 2017-04-13 at 6 15 59 pm" src="https://cloud.githubusercontent.com/assets/645156/25011231/58b398b4-2075-11e7-8574-8ac2c8bbe490.png">

## Question
<img width="785" alt="screen shot 2017-04-13 at 6 15 50 pm" src="https://cloud.githubusercontent.com/assets/645156/25011244/611e2bea-2075-11e7-9978-885196096865.png">
