### PR TITLE
TNL-5515. Fix discussion topic navigation and sorting option.

### DIFF
--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -43,6 +43,7 @@
                 this.course_settings = options.course_settings;
                 this.is_commentable_cohorted = options.is_commentable_cohorted;
                 this.topicId = options.topicId;
+                this.discussionBoardView = options.discussionBoardView;
             };
 
             NewPostView.prototype.render = function() {
@@ -161,8 +162,17 @@
                     },
                     error: DiscussionUtil.formErrorHandler(this.$('.post-errors')),
                     success: function(response) {
-                        var thread;
+                        var thread, discussionBreadcrumbsModel;
                         thread = new Thread(response.content);
+                        // Update the breadcrumbs and discussion Id(s) related to current topic
+                        if (self.discussionBoardView) {
+                            discussionBreadcrumbsModel = self.discussionBoardView.breadcrumbs.model;
+                            if (discussionBreadcrumbsModel.get('contents').length) {
+                                discussionBreadcrumbsModel.set('contents', self.topicView.topicText.split('/'));
+                            }
+                            self.discussionBoardView.discussionThreadListView.discussionIds =
+                                self.topicView.currentTopicId;
+                        }
                         self.$el.addClass('is-hidden');
                         self.resetForm();
                         self.trigger('newPost:createPost');

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -297,6 +297,22 @@ class DiscussionNavigationTest(BaseDiscussionTestCase):
         self.thread_page.q(css=".breadcrumbs .nav-item")[0].click()
         self.assertEqual(self.thread_page.q(css=".search-input").text[0], "")
 
+    def test_navigation_and_sorting(self):
+        """
+        Test that after adding the post, user sorting preference is changing properly
+        and recently added post is shown.
+        """
+        topic_button = self.thread_page.q(
+            css=".forum-nav-browse-menu-item[data-discussion-id='{}']".format(self.discussion_id)
+        )
+        self.assertTrue(topic_button.visible)
+        topic_button.click()
+        sort_page = DiscussionSortPreferencePage(self.browser, self.course_id)
+        for sort_type in ["votes", "comments", "activity"]:
+            sort_page.change_sort_preference(sort_type)
+            # Verify that recently added post titled "dummy thread title" is shown in each sorting preference
+            self.assertEqual(self.thread_page.q(css=".forum-nav-thread-title").text[0], 'dummy thread title')
+
 
 @attr(shard=2)
 class DiscussionTabSingleThreadTest(BaseDiscussionTestCase, DiscussionResponsePaginationTestMixin):

--- a/lms/djangoapps/discussion/static/discussion/js/discussion_board_factory.js
+++ b/lms/djangoapps/discussion/static/discussion/js/discussion_board_factory.js
@@ -57,6 +57,7 @@
                     el: $('.new-post-article'),
                     collection: discussion,
                     course_settings: courseSettings,
+                    discussionBoardView: discussionBoardView,
                     mode: 'tab',
                     startHeader: 2
                 });


### PR DESCRIPTION
## [Discussions topic navigation and sort option is incorrect - TNL-5515](https://openedx.atlassian.net/browse/TNL-5515)

### Description
This PR fixes the discussion topic navigation and the sorting option after adding the new post.

### How to Test?

**Stage** 

1. Go to the link https://courses.stage.edx.org/courses/course-v1:edx+aishaq+1T2017/discussion/forum/
2. Create a new post in any topic (i.e **_Topic-Level Student-Visible Label_**)
3. Use the left-hand topic navigation to navigate to **_General_** topic. 
4. Create a new post in the first topic _*Topic-Level Student-Visible Label*_ (not in General)
5. Navigation should automatically switch to the first topic and show both posts above. 
6. Switch sort from **_by recent activity_** to **_by most activity_**, or any other sort change. 
You will not see any post related to *Topic-Level Student-Visible Label* either you see no posts or posts in **_General_**

**Sandbox**
https://discussion-sorting.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/


### Tests
 - [x] Acceptance Test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x]  Style and readability review: @Rabia23 
- [x]  Code Review : @noraiz-anwar   
- [x] Code Review : @Ayub-Khan 

FYI: @robrap


### Post-review
- [x] Rebase and squash commits

