### PR TITLE
ENT-325 Create a LogoutView that can redirect to a specified target

### DIFF
--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -157,22 +157,36 @@ class LogoutTests(TestCase):
         self.client.post(reverse('oauth2:capture'), data, follow=True)
         self.assertListEqual(self.client.session[AUTHORIZED_CLIENTS_SESSION_KEY], [oauth_client.client_id])
 
-    def assert_logout_redirects(self):
+    def assert_logout_redirects_to_root(self):
         """ Verify logging out redirects the user to the homepage. """
         response = self.client.get(reverse('logout'))
         self.assertRedirects(response, '/', fetch_redirect_response=False)
 
-    def test_switch(self):
+    def assert_logout_redirects_with_target(self):
+        """ Verify logging out with a redirect_url query param redirects the user to the target. """
+        url = '{}?{}'.format(reverse('logout'), 'redirect_url=/courses')
+        response = self.client.get(url)
+        self.assertRedirects(response, '/courses', fetch_redirect_response=False)
+
+    def test_switch_default(self):
         """ Verify the IDA logout functionality is disabled if the associated switch is disabled. """
         LogoutViewConfiguration.objects.create(enabled=False)
         oauth_client = self.create_oauth_client()
         self.authenticate_with_oauth(oauth_client)
-        self.assert_logout_redirects()
+        self.assert_logout_redirects_to_root()
+
+    def test_switch_with_redirect_url(self):
+        """ Verify the IDA logout functionality is disabled if the associated switch is disabled. """
+        LogoutViewConfiguration.objects.create(enabled=False)
+        oauth_client = self.create_oauth_client()
+        self.authenticate_with_oauth(oauth_client)
+        self.assert_logout_redirects_with_target()
 
     def test_without_session_value(self):
         """ Verify logout works even if the session does not contain an entry with
         the authenticated OpenID Connect clients."""
-        self.assert_logout_redirects()
+        self.assert_logout_redirects_to_root()
+        self.assert_logout_redirects_with_target()
 
     def test_client_logout(self):
         """ Verify the context includes a list of the logout URIs of the authenticated OpenID Connect clients.


### PR DESCRIPTION
For SAP, we need to have more granular ability to terminate user's sessions. This view will be used by some complementary code to be called when a user is coming in through SSO to a landing page with a tpa hint, so that we can ensure that any existing sessions are terminated properly.

Note that this view will only direct to targets that are on the same host, otherwise it will redirect to the home page.

**Testing Instructions**
1. Run this branch in a devstack or sandbox (ie https://brittneyexline.sandbox.edx.org/)
2. Log in with any account.
3. Hit <root>/logout?redirect_url=/courses. Observe that you are logged out and end up on the /courses page.
4. Log in again and hit <root>/logout?redirect_url=<root>/courses. Observe the same result as in step 3.
5. Log in again and hit <root>/logout?redirect_url=https://www.google.com. Observe that you are logged out and redirected to the home page.
6. Log in again and hit <root>/logout. Observe that you are logged out and redirected to the home page.