### PR TITLE
ECOM-7537 Priortize advertised start date to diplay on learner's dashboard

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard.py
@@ -305,6 +305,39 @@ class LmsDashboardPageTest(BaseLmsDashboardTest):
         # and course starts within 5 days
         self.assertEqual(course_date, expected_course_date)
 
+    def test_advertised_start_date(self):
+
+        """
+        Scenario:
+            Course Date should be advertised start date
+            if the course on student dashboard has `Course Advertised Start` set.
+
+        As a Student,
+        Given that I have enrolled to a course
+        And the course has `Course Advertised Start` set.
+        When I visit dashboard page
+        Then the advertised start date should be displayed rather course start date"
+        """
+        course_start_date = self.now + datetime.timedelta(days=2)
+        course_advertised_start = "Winter 2018"
+
+        self.course_fixture.add_course_details({
+            'start_date': course_start_date,
+        })
+        self.course_fixture.configure_course()
+
+        self.course_fixture.add_advanced_settings({
+            u"advertised_start": {u"value": course_advertised_start}
+        })
+        self.course_fixture._add_advanced_settings()
+
+        expected_course_date = "Starts - {start_date}".format(start_date=course_advertised_start)
+
+        self.dashboard_page.visit()
+        course_date = self.dashboard_page.get_course_date()
+
+        self.assertEqual(course_date, expected_course_date)
+
     def test_profile_img_alt_empty(self):
         """
         Validate value of profile image alt attribue is null

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -109,19 +109,19 @@ from student.helpers import (
                     course_date = course_overview.end
                 elif course_overview.has_started():
                     container_string = _("Started - {date}")
-                    course_date = course_overview.start
+                    course_date = course_overview.dashboard_start_display
                 elif course_overview.starts_within(days=5):
                     container_string = _("Starts - {date}")
-                    course_date = course_overview.start
+                    course_date = course_overview.dashboard_start_display
                     format = 'defaultFormat'
                 else: ## hasn't started yet
                     container_string = _("Starts - {date}")
-                    course_date = course_overview.start
+                    course_date = course_overview.dashboard_start_display
                 endif
             endif
           %>
 
-                % if isinstance(course_date, str):
+                % if isinstance(course_date, basestring):
                     <span class="info-date-block" data-tooltip="Hi">${_(container_string).format(date=course_date)}</span>
                 % elif course_date is not None:
                     <%

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -361,6 +361,13 @@ class CourseOverview(TimeStampedModel):
         """
         return block_metadata_utils.display_name_with_default_escaped(self)
 
+    @property
+    def dashboard_start_display(self):
+        """
+         Return start date to diplay on learner's dashboard, preferably `Course Advertised Start`
+        """
+        return self.advertised_start or self.start
+
     def has_started(self):
         """
         Returns whether the the course has started.


### PR DESCRIPTION
## [ECOM-7537](https://openedx.atlassian.net/browse/ECOM-7537)

### Description

`Course Advertised Start` is an Advanced Setting for a course. This date should display as a course start date if it set (not null) for enrolled courses listed at learner's dashboard.
This PR is offered as an implementation for above mentioned behavior.

### How to Test?

**Stage** 

- On stage (Studio) go to Advanced setting of any course (which is not ended).
- Set `Course Advertised Start`. (Value would be any string you want to show as course start date).
- Enroll in this course.
- Go to your dashboard.
- Find the course you just edited from list of enrolled courses.
- Observe `Course Advertised Start` is not showing up.


**Sandbox**
Sandbox with fix:
- https://advertised-date.sandbox.edx.org

**Screenshots**
After fix:
<img width="878" alt="screen shot 2017-04-14 at 6 52 54 pm" src="https://cloud.githubusercontent.com/assets/22347092/25045119/edfca95a-2143-11e7-9314-84774c19194c.png">


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @Ayub-Khan 
- [x] Code review: @adampalay 
- [ ] Code review: @yro

FYI: @sstack22 

### Post-review
- [ ] Rebase and squash commits

