### PR TITLE
Pass proper 'this' context to updateSidebar method so that sidebar co…

### DIFF
--- a/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
+++ b/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
@@ -53,7 +53,7 @@
                     el: this.$('.forum-search')
                 }).render();
                 this.renderBreadcrumbs();
-                $(window).bind('load scroll resize', this.updateSidebar);
+                $(window).bind('load scroll resize', _.bind(this.updateSidebar, this));
                 this.showBrowseMenu(true);
                 return this;
             },


### PR DESCRIPTION
This pull request has changes to pass the proper 'this' context to updateSidebar method so that Sidebar could properly resize on load and scroll. 

Previously in updateSidebar method, the variable 'this.sidebar_padding' was becoming undefined because of the incorrect 'this' object and it made the Sidebar not to update on load and scroll.

@andy-armstrong could you please review the change?