### PR TITLE
Fix Django 1.9 deprecation warnings by adding app_label.

### DIFF
--- a/openedx/core/djangoapps/crawlers/migrations/0002_auto_20170419_0018.py
+++ b/openedx/core/djangoapps/crawlers/migrations/0002_auto_20170419_0018.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('crawlers', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='crawlersconfig',
+            options={},
+        ),
+    ]

--- a/openedx/core/djangoapps/crawlers/models.py
+++ b/openedx/core/djangoapps/crawlers/models.py
@@ -9,6 +9,9 @@ from config_models.models import ConfigurationModel
 
 class CrawlersConfig(ConfigurationModel):
     """Configuration for the crawlers django app."""
+    class Meta(object):
+        app_label = "crawlers"
+
     known_user_agents = models.TextField(
         blank=True,
         help_text="A comma-separated list of known crawler user agents.",

--- a/openedx/core/djangoapps/programs/migrations/0012_auto_20170419_0018.py
+++ b/openedx/core/djangoapps/programs/migrations/0012_auto_20170419_0018.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('programs', '0011_auto_20170301_1844'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='programsapiconfig',
+            options={},
+        ),
+    ]

--- a/openedx/core/djangoapps/programs/models.py
+++ b/openedx/core/djangoapps/programs/models.py
@@ -13,6 +13,8 @@ class ProgramsApiConfig(ConfigurationModel):
 
     A rename to ProgramsConfig would be more accurate, but costly in terms of developer time.
     """
+    class Meta(object):
+        app_label = "programs"
 
     marketing_path = models.CharField(
         max_length=255,


### PR DESCRIPTION
Just a couple of app_label additions to remove log spam.