### PR TITLE
[ENT-327] Allow per-SSO-provider session expiration limits

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0009_auto_20170415_1144.py
+++ b/common/djangoapps/third_party_auth/migrations/0009_auto_20170415_1144.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0008_auto_20170413_1455'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='max_session_length',
+            field=models.PositiveIntegerField(default=None, help_text='If this option is set, then users logging in using this SSO provider will have their session length limited to no longer than this value. If set to 0 (zero), the session will expire upon the user closing their browser. If left blank, the Django platform session default length will be used.', null=True, verbose_name=b'Max session length (seconds)', blank=True),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='max_session_length',
+            field=models.PositiveIntegerField(default=None, help_text='If this option is set, then users logging in using this SSO provider will have their session length limited to no longer than this value. If set to 0 (zero), the session will expire upon the user closing their browser. If left blank, the Django platform session default length will be used.', null=True, verbose_name=b'Max session length (seconds)', blank=True),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='max_session_length',
+            field=models.PositiveIntegerField(default=None, help_text='If this option is set, then users logging in using this SSO provider will have their session length limited to no longer than this value. If set to 0 (zero), the session will expire upon the user closing their browser. If left blank, the Django platform session default length will be used.', null=True, verbose_name=b'Max session length (seconds)', blank=True),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -148,6 +148,18 @@ class ProviderConfig(ConfigurationModel):
             "URL query parameter mapping to this provider is included in the request."
         )
     )
+    max_session_length = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        default=None,
+        verbose_name='Max session length (seconds)',
+        help_text=_(
+            "If this option is set, then users logging in using this SSO provider will have "
+            "their session length limited to no longer than this value. If set to 0 (zero), "
+            "the session will expire upon the user closing their browser. If left blank, the "
+            "Django platform session default length will be used."
+        )
+    )
     prefix = None  # used for provider_id. Set to a string value in subclass
     backend_name = None  # Set to a field or fixed value in subclass
     accepts_logins = True  # Whether to display a sign-in button when the provider is enabled

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -32,7 +32,7 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
         try:
             return self._config.get_setting(name)
         except KeyError:
-            return self.strategy.setting(name, default)
+            return self.strategy.setting(name, default, backend=self)
 
     def auth_url(self):
         """

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -144,7 +144,7 @@ class IntegrationTestMixin(object):
         """
         raise NotImplementedError
 
-    def _test_return_login(self, user_is_activated=True):
+    def _test_return_login(self, user_is_activated=True, previous_session_timed_out=False):
         """ Test logging in to an account that is already linked. """
         # Make sure we're not logged in:
         dashboard_response = self.client.get(reverse('dashboard'))
@@ -156,12 +156,14 @@ class IntegrationTestMixin(object):
         # The user should be redirected to the provider:
         self.assertEqual(try_login_response.status_code, 302)
         login_response = self.do_provider_login(try_login_response['Location'])
-        # There will be one weird redirect required to set the login cookie:
-        self.assertEqual(login_response.status_code, 302)
-        self.assertEqual(login_response['Location'], self.url_prefix + self.complete_url)
-        # And then we should be redirected to the dashboard:
-        login_response = self.client.get(login_response['Location'])
-        self.assertEqual(login_response.status_code, 302)
+        # If the previous session was manually logged out, there will be one weird redirect
+        # required to set the login cookie (it sticks around if the main session times out):
+        if not previous_session_timed_out:
+            self.assertEqual(login_response.status_code, 302)
+            self.assertEqual(login_response['Location'], self.url_prefix + self.complete_url)
+            # And then we should be redirected to the dashboard:
+            login_response = self.client.get(login_response['Location'])
+            self.assertEqual(login_response.status_code, 302)
         if user_is_activated:
             url_expected = reverse('dashboard')
         else:

--- a/common/djangoapps/third_party_auth/tests/test_admin.py
+++ b/common/djangoapps/third_party_auth/tests/test_admin.py
@@ -66,6 +66,9 @@ class Oauth2ProviderConfigAdminTest(testutil.TestCase):
         # Remove the icon_image from the POST data, to simulate unchanged icon_image
         post_data = models.model_to_dict(provider1)
         del post_data['icon_image']
+        # Remove max_session_length; it has a default null value which must be POSTed
+        # back as an absent value, rather than as a "null-like" included value.
+        del post_data['max_session_length']
 
         # Change the name, to verify POST
         post_data['name'] = 'Another name'

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -90,7 +90,10 @@ python-memcached==1.48
 django-memcached-hashring==0.1.2
 python-openid==2.2.5
 python-dateutil==2.1
-python-social-auth==0.2.21
+# We need to be able to set a maximum session length on our third-party auth providers;
+# our goal is to upstream these changes and return to the canonical version ASAP.
+# python-social-auth==0.2.21
+git+https://github.com/edx/python-social-auth@758985102cee98f440fae44ed99617b7cfef3473#egg=python-social-auth==0.2.21.edx.a
 pytz==2016.7
 pysrt==0.4.7
 PyYAML==3.10


### PR DESCRIPTION
This pull request takes advantage of the changes in edx/python-social-auth#1 to allow individual SSO providers to set a maximum session expiration time for users who log in through those providers. When set to 0 (zero), the session will end on browser close.

**JIRA tickets**: [ENT-327](https://openedx.atlassian.net/browse/ENT-327)

**Dependencies**: edx/python-social-auth#1

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

1. Create and configure an SSO provider
2. Leave the "max session length" parameter blank.
3. In a test browser (in non-incognito mode), log in using the SSO provider.
4. Quit and re-open the browser, and verify that you're still logged in to the LMS.
5. In the test browser, log out.
6. In your main browser, configure the SSO provider "max session length" parameter to a small value - like 30.
7. In the test browser, log in using the SSO provider.
8. Click around for a little bit, and verify that when the 30 seconds (or whatever) are up, you're signed out.
9. In your main browser, configure the SSO provider "max session length" parameter to 0 (zero).
10. In the test browser, log in using the SSO provider.
11. Quit and re-open the test browser, and verify that you're no longer logged into the LMS.

**Author notes and concerns**:

1. This requires a temporary fork of python-social-auth, which may be difficult to upstream due to the change in the upstream repo from the `python-social-auth` monorepo to `social-core`, `social-app-django`, and others. However, getting this change (or one to similar effect) upstream will become a requirement for us to upgrade to the newer architecture.

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
  ENABLE_THIRD_PARTY_AUTH: true
```