### PR TITLE
Set COPYRIGHT_YEAR dynamically

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -49,7 +49,7 @@ import lms.envs.common
 # Although this module itself may not use these imported variables, other dependent modules may.
 from lms.envs.common import (
     USE_TZ, TECH_SUPPORT_EMAIL, PLATFORM_NAME, BUGS_EMAIL, DOC_STORE_CONFIG, DATA_DIR, ALL_LANGUAGES, WIKI_ENABLED,
-    update_module_store_settings, ASSET_IGNORE_REGEX, COPYRIGHT_YEAR,
+    update_module_store_settings, ASSET_IGNORE_REGEX,
     PARENTAL_CONSENT_AGE_LIMIT, COMPREHENSIVE_THEME_DIRS, REGISTRATION_EMAIL_PATTERNS_ALLOWED,
     # The following PROFILE_IMAGE_* settings are included as they are
     # indirectly accessed through the email opt-in API, which is

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -1,6 +1,9 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from datetime import datetime
+from django.conf import settings
+import pytz
 %>
 
 <div class="wrapper-footer wrapper">
@@ -8,7 +11,7 @@ from django.core.urlresolvers import reverse
 
     <div class="footer-content-primary">
       <div class="colophon">
-        <p>&copy; ${settings.COPYRIGHT_YEAR} <a data-rel="edx.org" href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
+        <p>&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} <a data-rel="edx.org" href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
       </div>
 
       % if is_any_marketing_link_set(['TOS', 'PRIVACY']):

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -5,6 +5,7 @@ Certificate HTML webview.
 import logging
 import urllib
 from datetime import datetime
+import pytz
 from uuid import uuid4
 
 from django.conf import settings
@@ -153,7 +154,7 @@ def _update_context_with_basic_info(context, course_id, platform_name, configura
     # Translators:  'All rights reserved' is a legal term used in copyrighting to protect published content
     reserved = _("All rights reserved")
     context['copyright_text'] = u'&copy; {year} {platform_name}. {reserved}.'.format(
-        year=settings.COPYRIGHT_YEAR,
+        year=datetime.now(pytz.timezone(settings.TIME_ZONE)).year,
         platform_name=platform_name,
         reserved=reserved
     )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -47,8 +47,6 @@ from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 # The display name of the platform to be used in templates/emails/etc.
 PLATFORM_NAME = "Your Platform Name Here"
 CC_MERCHANT_NAME = PLATFORM_NAME
-# Shows up in the platform footer, eg "(c) COPYRIGHT_YEAR"
-COPYRIGHT_YEAR = "2017"
 
 PLATFORM_FACEBOOK_ACCOUNT = "http://www.facebook.com/YourPlatformFacebookAccount"
 PLATFORM_TWITTER_ACCOUNT = "@YourPlatformTwitterAccount"

--- a/themes/red-theme/lms/templates/footer.html
+++ b/themes/red-theme/lms/templates/footer.html
@@ -3,6 +3,11 @@
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
+from django.conf import settings
+
+from datetime import datetime
+import pytz
+
 from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
 %>
 
@@ -58,7 +63,7 @@ from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_en
         </p>
       </div>
 
-      <p class="copyright">&copy; ${settings.COPYRIGHT_YEAR} ${static.get_platform_name()}.</p>
+      <p class="copyright">&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} ${static.get_platform_name()}.</p>
 
       ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
       <p class="copyright">


### PR DESCRIPTION
# Overview
Whenever a new year comes, a new PR has to be created to change the common.py variable COPYRIGHT_YEAR manually to the following year. At first I changed the date from inside common.py, but as @OmarIthawi pointed out, since this variable will only be evaluated once the server is deployed and never again, it means that the server needs a restart at new years or redeploy for the change to take effect. Thus I switched to dynamically assigning the copyright year inside the templates using datetime.now, this way it is lazily evaluated, and I ditched the COPYRIGHT_YEAR variable altogether.

## Steps to Reproduce on local machine
1. Run devstack
1. Check studio footer

## Expected Results
Whenever the year changes, the footer copyright_year will be automatically updated.

## Testing
- [x] Test on devstack
- [ ] Review by Edraak member @OmarIthawi 
- [ ] Translate after changes on edX transifex (update po files as well)
