### PR TITLE
 TNL-6725 Wrong Error message and missing edge case

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -714,7 +714,11 @@ def _move_item(source_usage_key, target_parent_usage_key, user, target_index=Non
 
     store = modulestore()
     with store.bulk_operations(source_usage_key.course_key):
-        source_item = store.get_item(source_usage_key)
+        if store.has_item(source_usage_key):
+            source_item = store.get_item(source_usage_key)
+        else:
+            error = _("{source_usage_key} not found.").format(source_usage_key=unicode(source_usage_key))
+            return JsonResponse({'error': error}, status=400)
         source_parent = source_item.get_parent()
         target_parent = store.get_item(target_parent_usage_key)
         source_type = source_item.category

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -1241,10 +1241,10 @@ class TestMoveItem(ItemTest):
             'parent_locator': unicode(self.vert2_usage_key)
         }
         response = self.client.patch(
-                reverse('contentstore.views.xblock_handler'),
-                json.dumps(data),
-                content_type='application/json'
-            )
+            reverse('contentstore.views.xblock_handler'),
+            json.dumps(data),
+            content_type='application/json'
+        )
         self.assertEqual(response.status_code, 400)
         response = json.loads(response.content)
         error = "{source_usage_key} not found.".format(source_usage_key=data['move_source_locator'])

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -1229,7 +1229,7 @@ class TestMoveItem(ItemTest):
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_move_item_not_found(self, store_type=ModuleStoreEnum.Type.mongo):
         """
-        Test that an item not found exception raised when an item is not found when getting the item.
+        Test that response status is 400 and proper message is shown when an item is not found when getting the item.
 
         Arguments:
             store_type (ModuleStoreEnum.Type): Type of modulestore to create test course in.
@@ -1240,12 +1240,15 @@ class TestMoveItem(ItemTest):
             'move_source_locator': unicode(self.usage_key.course_key.make_usage_key('html', 'html_test')),
             'parent_locator': unicode(self.vert2_usage_key)
         }
-        with self.assertRaises(ItemNotFoundError):
-            self.client.patch(
+        response = self.client.patch(
                 reverse('contentstore.views.xblock_handler'),
                 json.dumps(data),
                 content_type='application/json'
             )
+        self.assertEqual(response.status_code, 400)
+        response = json.loads(response.content)
+        error = "{source_usage_key} not found.".format(source_usage_key=data['move_source_locator'])
+        self.assertEqual(response['error'], error)
 
 
 class TestDuplicateItemWithAsides(ItemTest, DuplicateHelper):


### PR DESCRIPTION
**[TNL-6725](https://openedx.atlassian.net/browse/TNL-6725)**

**Description:**
If we move a component from Unit 1 to unit 2 and than delete it from unit 2 and try to undo the move from unit 1 we get a ambiguous error message. This code handles the item not found exception when move item is not found and shows a proper message.

**Steps to Reproduce:**

1. Go to stage studio and create a course
2. Create two units a and b in course
3. Add any component in unit b
4. Move component from unit b to a
5. Open unit a in new tab
6. Remove moved component from unit a
7. Try to undo the move process from unit b
8. Observe the error message

**Before Fix:** 
<img width="1073" alt="screen shot 2017-04-17 at 2 47 52 pm" src="https://cloud.githubusercontent.com/assets/7721119/25091138/f1e479da-23a0-11e7-8e1a-7485f339a544.png">

**After Fix:**
<img width="791" alt="screen shot 2017-04-17 at 2 59 40 pm" src="https://cloud.githubusercontent.com/assets/7721119/25091147/04a1197a-23a1-11e7-9300-090f1e16701b.png">

**Sandbox:**
[Sandbox](studio-tnl-6725.sandbox.edx.org)

**Reviewers:**
- @attiyaIshaque 
- @Rabia23 
- @muzaffaryousaf 

**Post-Review**
- Update and squash commits.