### PR TITLE
ENT-320: Fix OAuth2ProviderConfig to be keyed by `provider_slug`

### DIFF
--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -33,7 +33,7 @@ class OAuth2ProviderConfigAdmin(KeyedConfigurationModelAdmin):
     def get_list_display(self, request):
         """ Don't show every single field in the admin change list """
         return (
-            'name', 'enabled', 'site', 'backend_name', 'secondary', 'skip_registration_form',
+            'name', 'enabled', 'provider_slug', 'site', 'backend_name', 'secondary', 'skip_registration_form',
             'skip_email_verification', 'change_date', 'changed_by', 'edit_link',
         )
 

--- a/common/djangoapps/third_party_auth/provider.py
+++ b/common/djangoapps/third_party_auth/provider.py
@@ -22,9 +22,10 @@ class Registry(object):
         Helper method that returns a generator used to iterate over all providers
         of the current site.
         """
-        for backend_name in _PSA_OAUTH2_BACKENDS:
-            provider = OAuth2ProviderConfig.current(backend_name)
-            if provider.enabled_for_current_site:
+        oauth2_slugs = OAuth2ProviderConfig.key_values('provider_slug', flat=True)
+        for oauth2_slug in oauth2_slugs:
+            provider = OAuth2ProviderConfig.current(oauth2_slug)
+            if provider.enabled_for_current_site and provider.backend_name in _PSA_OAUTH2_BACKENDS:
                 yield provider
         if SAMLConfiguration.is_enabled(Site.objects.get_current(get_current_request())):
             idp_slugs = SAMLProviderConfig.key_values('idp_slug', flat=True)
@@ -103,9 +104,11 @@ class Registry(object):
             Instances of ProviderConfig.
         """
         if backend_name in _PSA_OAUTH2_BACKENDS:
-            provider = OAuth2ProviderConfig.current(backend_name)
-            if provider.enabled_for_current_site:
-                yield provider
+            oauth2_slugs = OAuth2ProviderConfig.key_values('provider_slug', flat=True)
+            for oauth2_slug in oauth2_slugs:
+                provider = OAuth2ProviderConfig.current(oauth2_slug)
+                if provider.backend_name == backend_name and provider.enabled_for_current_site:
+                    yield provider
         elif backend_name in _PSA_SAML_BACKENDS and SAMLConfiguration.is_enabled(
                 Site.objects.get_current(get_current_request())):
             idp_names = SAMLProviderConfig.key_values('idp_slug', flat=True)

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -148,6 +148,24 @@ class RegistryTest(testutil.TestCase):
         google_provider = self.configure_google_provider(enabled=True)
         self.assertEqual(google_provider.id, provider.Registry.get(google_provider.provider_id).id)
 
+    def test_oauth2_provider_keyed_by_provider_slug(self):
+        """
+        Regression test to ensure that the Registry properly fetches OAuth2ProviderConfigs that have a provider_slug
+        which doesn't match any of the possible backend_names.
+        """
+        google_provider = self.configure_google_provider(enabled=True, provider_slug='custom_slug')
+        self.assertIn(google_provider, provider.Registry._enabled_providers())
+        self.assertIn(google_provider, provider.Registry.get_enabled_by_backend_name('google-oauth2'))
+
+    def test_oauth2_enabled_only_for_supplied_backend(self):
+        """
+        Test to ensure that Registry.get_enabled_by_backend_name doesn't return OAuth2 providers with incorrect
+        backend_names.
+        """
+        facebook_provider = self.configure_facebook_provider(enabled=True)
+        self.configure_google_provider(enabled=True)
+        self.assertNotIn(facebook_provider, provider.Registry.get_enabled_by_backend_name('google-oauth2'))
+
     def test_get_returns_none_if_provider_not_enabled(self):
         linkedin_provider_id = "oa2-linkedin-oauth2"
         # At this point there should be no configuration entries at all so no providers should be enabled


### PR DESCRIPTION
This change fixes a bug where OAuth2 Provider Configs only show up on logistration if the provider's `provider_slug` matches a valid OAuth2 backend name.


**JIRA tickets**: Solves [ENT-320](https://openedx.atlassian.net/browse/ENT-320).

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**:

Verify the issue exists on `master` branch:

1. Setup a devstack with `ENABLE_THIRD_PARTY_AUTH` set to `true` in `lms.env.json`
1. Navigate to the [`Add Provider Configuration (OAuth)`](http://localhost:8000/admin/third_party_auth/oauth2providerconfig/add/) configuration provider section and click "Add Provider Configuration":
   1. Check "Enabled"
   1. Check "Visible"
   1. Type `test_provider` for the "Name"
   1. Select `dummy` as the "Backend name"
   1. Use `slug1` as the "Provider slug"
   1. Click "Save"
1. Open an incognito window and navigate to the Registration page
1. *Observe that there is no `test_provider` provider listed on the page*
1. Go back to the admin panel and click "Update" next to "test_provider" entry
1. Change the "Provider slug" to `dummy` (the same name as the selected "Backend name") and click "Save"
1. Observe that there are two OAuth2 providers listed; this is expected behavior since the OAuth2 configuration model is keyed by `provider_slug`
1. Return to the registration page in an incognito window again
1. Observe that this time, "test_provider" is listed at the top of the registration form:
   ![screenshot](https://i.imgur.com/N7UG3pS.png)

Verify that this issue is fixed:

1. After following the set of instructions above to verify the issue on `master`, checkout this PR's branch:
   ```
   git remote add open-craft git@github.com:open-craft/edx-platform.git
   git checkout open-craft/bdero/ent-320
   ```
1. Launch the LMS and navigate back to the Registration page
1. Observe that both of the `test_provider` entries from the Admin panel are now showing up at the top of the registration form:
   ![screenshot](https://i.imgur.com/aOxABiF.png)
   The reason this happens is because the OAuth2 configuration models are being properly selected by their unique `provider_slug` now, not the `backend_name`.


**Reviewers**
- [ ] @mtyaka 
- [ ] edX reviewer(s): TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```