### PR TITLE
ENT-247 Get enterprise logo image size limit from env configuration

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -916,6 +916,12 @@ ENTERPRISE_ENROLLMENT_API_URL = ENV_TOKENS.get(
     ENTERPRISE_ENROLLMENT_API_URL
 )
 
+# Enterprise logo image size limit in KB's
+ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE = ENV_TOKENS.get(
+    'ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE',
+    ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE
+)
+
 
 ############## ENTERPRISE SERVICE API CLIENT CONFIGURATION ######################
 # The LMS communicates with the Enterprise service via the EdxRestApiClient class

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3086,6 +3086,7 @@ ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = ENTERPRISE_ENROLLMENT_API_URL
 ENTERPRISE_API_URL = LMS_ROOT_URL + '/enterprise/api/v1/'
 ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
 ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
+ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE = 512   # Enterprise logo image size limit in KB's
 
 ############## Settings for Course Enrollment Modes ######################
 COURSE_ENROLLMENT_MODES = {

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.33.2
+edx-enterprise==0.33.6
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.4


### PR DESCRIPTION
@saleem-latif @asadiqbal08 @mattdrayer 

This is a related PR for [ENT-247](https://openedx.atlassian.net/browse/ENT-247) to get enterprise logo image size limit settings from `LMS` env configuration.

Updated the `edx-enterprise` version from `0.33.2` to `0.33.6`.
Here is the commits list from version `0.33.2` to `0.33.6`: https://github.com/edx/edx-enterprise/compare/ded30bb...2fac3ae

**Related PR:** [Increase the max size limit for enterprise logo](https://github.com/edx/edx-enterprise/pull/90)