### PR TITLE
TNL-6666 Fix 500 error when entering courseware.

### DIFF
--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -388,9 +388,15 @@ class CoursewareIndex(View):
             if self.section.position and self.section.has_children:
                 display_items = self.section.get_display_items()
                 if display_items:
-                    courseware_context['sequence_title'] = display_items[self.section.position - 1] \
-                        .display_name_with_default
-
+                    try:
+                        courseware_context['sequence_title'] = display_items[self.section.position - 1] \
+                            .display_name_with_default
+                    except IndexError:
+                        log.info("Course section {} with position {} and total section display items: {}".format(
+                            self.section.display_name_with_default,
+                            self.section.position,
+                            len(display_items),
+                        ))
         return courseware_context
 
     def _add_entrance_exam_to_context(self, courseware_context):


### PR DESCRIPTION
# [In some cases, students see 500 error when entering courseware - TNL-6666](https://openedx.atlassian.net/browse/TNL-6666)

### Description

There are some cases where students hit a 500 error when trying to access the courseware. We are not sure what the cause is, or how to reproduce it. We have added a log to understand the nature of the problem a little deeper. Then we'll be more confident about what behavior we'll want to see in this case.

### How to Test?

**Stage** 
Not Applicable.

**Screenshots**
Not Applicable.


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @Ayub-Khan 

### Post-review
- [x] Rebase and squash commits