### PR TITLE
TNL-6837 ORAs and Drag and Drop not supported in libraries, remove both from problem types in studio

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -308,8 +308,9 @@ def get_component_templates(courselike, library=False):
                             )
                         )
 
-        # Add any advanced problem types. Note that these are different xblocks being stored as Advanced Problems.
-        if category == 'problem':
+        # Add any advanced problem types. Note that these are different xblocks being stored as Advanced Problems,
+        # currently not supported in libraries .
+        if category == 'problem' and not library:
             disabled_block_names = [block.name for block in disabled_xblocks()]
             advanced_problem_types = [advanced_problem_type for advanced_problem_type in ADVANCED_PROBLEM_TYPES
                                       if advanced_problem_type['component'] not in disabled_block_names]

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -3,6 +3,7 @@ Unit tests for contentstore.views.library
 
 More important high-level tests are in contentstore/tests/test_libraries.py
 """
+from django.conf import settings
 from contentstore.tests.utils import AjaxEnabledTestClient, parse_json
 from contentstore.utils import reverse_course_url, reverse_library_url
 from contentstore.tests.utils import CourseTestCase
@@ -250,6 +251,24 @@ class UnitTestLibraries(CourseTestCase):
         self.assertIn('problem', templates)
         self.assertNotIn('discussion', templates)
         self.assertNotIn('advanced', templates)
+
+    def test_advanced_problem_types(self):
+        """
+        Verify that advanced problem types are not provided in problem component for libraries.
+        """
+        lib = LibraryFactory.create()
+        lib.save()
+
+        problem_type_templates = next(
+            (component['templates'] for component in get_component_templates(lib, library=True) if component['type'] == 'problem'),
+            []
+        )
+        # Each problem template has a category which shows whether problem is a 'problem'
+        # or which of the advanced problem type (e.g drag-and-drop-v2).
+        problem_type_categories = [problem_template['category'] for problem_template in problem_type_templates]
+
+        for advance_problem_type in settings.ADVANCED_PROBLEM_TYPES:
+            self.assertNotIn(advance_problem_type['component'], problem_type_categories)
 
     def test_manage_library_users(self):
         """


### PR DESCRIPTION
## [TNL-6837](https://openedx.atlassian.net/browse/TNL-6837)

### Description

ORAs and Drag and Drop components (xblocks as Advanced Problems) are not supported in libraries. Both are shown under advanced tab as problem types in studio. In case of library, as these components are not supported and can not be added, should not appear in list.
Implementation offered in this PR restricts unsupported problem types to be listed.

### How to Test?

**Stage** 

1. Open any library in studio
2. Select Problem under Add New Component
3. Select Advanced tab
4. Observe two listed problem type i.e Drag and Drop and Peer Assessment. (Both are not supported in libraries)

**Sandbox**
- [Studio](https://studio-library.sandbox.edx.org)

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @attiyaIshaque 
- [x] Code review: @adampalay 
- [x] Code review: @uzairr 

FYI: @cahrens 

### Post-review
- [x] Rebase and squash commits