### PR TITLE
TNL-5848 Fixed discussion header tab css in lms 

### DIFF
--- a/lms/static/sass/discussion/_build.scss
+++ b/lms/static/sass/discussion/_build.scss
@@ -13,7 +13,7 @@ $static-path: '../..' !default;
 @import '../shared-v2/variables';
 @import '../shared-v2/base';
 @import '../shared-v2/navigation';
-@import '../shared-v2/header';
+@import '../course/layout/courseware_header';
 @import '../shared-v2/footer';
 @import '../shared-v2/layouts';
 @import '../shared-v2/components';


### PR DESCRIPTION
**[TNL-5848](https://openedx.atlassian.net/browse/TNL-5848)**

**Description:**
The color and font in the discussion tab (on header "tab names") was different from all other tabs. Used courseware header css for discussion header to make them similar.

**Steps to Reproduce:**

1. Go to stage studio 
2. Go to any course page
3. Check the Color and font of header
4. Select the discussion tab from header
5. Check the Color and font

**Before Fix:** 
<img width="869" alt="screen shot 2017-04-19 at 4 21 22 pm" src="https://cloud.githubusercontent.com/assets/7721119/25177717/641179aa-251c-11e7-8989-d157122f56ee.png">
While Hovering another Tab
<img width="1185" alt="screen shot 2017-04-19 at 3 09 34 pm" src="https://cloud.githubusercontent.com/assets/7721119/25176849/1bd44dc8-2519-11e7-927a-307b72244d22.png">

**After Fix:**
<img width="1000" alt="screen shot 2017-04-19 at 4 20 16 pm" src="https://cloud.githubusercontent.com/assets/7721119/25177742/6bbe8c92-251c-11e7-8604-0798ce8d9acf.png">
While Hovering another Tab
<img width="1165" alt="screen shot 2017-04-19 at 3 51 26 pm" src="https://cloud.githubusercontent.com/assets/7721119/25176854/215f5f62-2519-11e7-8ebf-ee986cd6ee9b.png">


**Sandbox:**
[Sandbox](https://tnl-5848.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/info)

**Reviewers:**
- @attiyaIshaque 
- @uzairr 

**Post-Review**
- Update and squash commits.