### PR TITLE
Add utm parameters to course sharing url

### DIFF
--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -2,9 +2,34 @@
 Utility methods related to course
 """
 import logging
+import urllib
+
 from django.conf import settings
 
 log = logging.getLogger(__name__)
+
+COURSE_SHARING_UTM_PARAMETERS = {
+    'facebook': {
+        'utm_medium': 'social-post',
+        'utm_campaign': 'social-sharing',
+        'utm_source': 'facebook',
+    },
+    'twitter': {
+        'utm_medium': 'social-post',
+        'utm_campaign': 'social-sharing',
+        'utm_source': 'twitter',
+    },
+}
+
+
+def get_encoded_course_sharing_utm_params():
+    """
+    Returns encoded Course Sharing UTM Parameters.
+    """
+    return {
+        utm_source: urllib.urlencode(utm_params)
+        for utm_source, utm_params in COURSE_SHARING_UTM_PARAMETERS.iteritems()
+    }
 
 
 def get_link_for_about_page(course):

--- a/common/test/acceptance/tests/lms/test_lms_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard.py
@@ -153,7 +153,8 @@ class LmsDashboardPageTest(BaseLmsDashboardTest):
         Validate the behavior of the social sharing feature
         """
         twitter_widget = self.dashboard_page.get_course_social_sharing_widget('twitter')
-        twitter_url = "https://twitter.com/intent/tweet?text=Testing+feature%3A%20http%3A%2F%2Fcustom%2Fcourse%2Furl"
+        twitter_url = ("https://twitter.com/intent/tweet?text=Testing+feature%3A%20http%3A%2F%2Fcustom%2Fcourse%2Furl"
+                       "%3Futm_campaign%3Dsocial-sharing%26utm_medium%3Dsocial-post%26utm_source%3Dtwitter")
         self.assertEqual(twitter_widget.attrs('title')[0], 'Share on Twitter')
         self.assertEqual(twitter_widget.attrs('data-tooltip')[0], 'Share on Twitter')
         self.assertEqual(twitter_widget.attrs('aria-haspopup')[0], 'true')
@@ -163,8 +164,9 @@ class LmsDashboardPageTest(BaseLmsDashboardTest):
         self.assertIn(twitter_url, twitter_widget.attrs('onclick')[0])
 
         facebook_widget = self.dashboard_page.get_course_social_sharing_widget('facebook')
-        facebook_url = ('https://www.facebook.com/sharer/sharer.php?'
-                        'u=http%3A%2F%2Fcustom%2Fcourse%2Furl&quote=I%27m+taking')
+        facebook_url = ("https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fcustom%2Fcourse%2Furl%3F"
+                        "utm_campaign%3Dsocial-sharing%26utm_medium%3Dsocial-post%26utm_source%3Dfacebook&"
+                        "quote=I%27m+taking+Test")
         self.assertEqual(facebook_widget.attrs('title')[0], 'Share on Facebook')
         self.assertEqual(facebook_widget.attrs('data-tooltip')[0], 'Share on Facebook')
         self.assertEqual(facebook_widget.attrs('aria-haspopup')[0], 'true')

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -8,7 +8,7 @@ from rest_framework.reverse import reverse
 from certificates.api import certificate_downloadable_status
 from courseware.access import has_access
 from student.models import CourseEnrollment, User
-from util.course import get_link_for_about_page
+from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_params
 
 
 class CourseOverviewField(serializers.RelatedField):
@@ -53,6 +53,7 @@ class CourseOverviewField(serializers.RelatedField):
             },
             'course_image': course_overview.course_image_url,
             'course_about': get_link_for_about_page(course_overview),
+            'course_sharing_utm_parameters': get_encoded_course_sharing_utm_params(),
             'course_updates': reverse(
                 'course-updates-list',
                 kwargs={'course_id': course_id},

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -486,6 +486,13 @@ class TestCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin)
         self.assertEqual(serialized['course']['number'], self.course.id.course)
         self.assertEqual(serialized['course']['org'], self.course.id.org)
 
+        # Assert utm parameters
+        expected_utm_parameters = {
+            'twitter': 'utm_campaign=social-sharing&utm_medium=social-post&utm_source=twitter',
+            'facebook': 'utm_campaign=social-sharing&utm_medium=social-post&utm_source=facebook'
+        }
+        self.assertEqual(serialized['course']['course_sharing_utm_parameters'], expected_utm_parameters)
+
     def test_with_display_overrides(self):
         self.course.display_coursenumber = "overridden_number"
         self.course.display_organization = "overridden_org"

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -229,6 +229,7 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
           including any access errors.
 
           * course_about: The URL to the course about page.
+          * course_sharing_utm_parameters: Encoded UTM parameters to be included in course sharing url
           * course_handouts: The URI to get data for course handouts.
           * course_image: The path to the course image.
           * course_updates: The URI to get data for course updates.

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -19,7 +19,7 @@ from student.helpers import (
   VERIFY_STATUS_NEED_TO_REVERIFY,
   DISABLE_UNENROLL_CERT_STATES,
 )
-from util.course import get_link_for_about_page
+from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_params
 %>
 
 <%
@@ -151,13 +151,15 @@ from util.course import get_link_for_about_page
               % if share_settings:
                 <%
                   share_url = get_link_for_about_page(course_overview)
+                  encoded_utm_parameters = get_encoded_course_sharing_utm_params()
                   share_window_name = 'shareWindow'
                   share_window_config = 'toolbar=no, location=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=640, height=480'
                 %>
                 % if share_settings.get('DASHBOARD_FACEBOOK', False):
                   <%
+                      facebook_share_url = "{url}?{utm_params}".format(url=share_url, utm_params=encoded_utm_parameters['facebook'])
                       share_text = _("I'm taking {course_name} online with edX.org. Check it out!").format(course_name=course_overview.display_name_with_default)
-                      query_params = urllib.urlencode((('u', share_url), ('quote', share_text.encode('utf-8')),))
+                      query_params = urllib.urlencode((('u', facebook_share_url), ('quote', share_text.encode('utf-8')),))
                       facebook_url = 'https://www.facebook.com/sharer/sharer.php?{query}'.format(query=query_params)
                   %>
                     <a
@@ -176,9 +178,10 @@ from util.course import get_link_for_about_page
                 % endif
                 % if share_settings.get('DASHBOARD_TWITTER', False):
                   <%
+                      twitter_share_url = "{url}?{utm_params}".format(url=share_url, utm_params=encoded_utm_parameters['twitter'])
                       default_share_text = _("I'm taking {course_name} online with @edxonline. Check it out!").format(course_name=course_overview.display_name_with_default)
                       share_text = urllib.quote_plus(share_settings.get('DASHBOARD_TWITTER_TEXT', default_share_text.encode('utf-8')))
-                      twitter_url = 'https://twitter.com/intent/tweet?text=' + share_text + '%20' + urllib.quote_plus(share_url)
+                      twitter_url = 'https://twitter.com/intent/tweet?text=' + share_text + '%20' + urllib.quote_plus(twitter_share_url)
                   %>
                     <a
                       data-tooltip="${_('Share on Twitter')}"


### PR DESCRIPTION
This PR adds utm parameters to course sharing url for utm based eventing. For mobile end, `course_sharing_utm_parameters` has been introduced in `CourseOverviewField `.

Sandbox: https://course-sharing-utm-params.sandbox.edx.org