### PR TITLE
(WIP) test eslint/es5 dependency upgrade

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@arizzitano/eslint-config-edx-es5",
+  "extends": "eslint-config-edx-es5",
   "globals": {  // Try to avoid adding any new globals.
     // Old compatibility things and hacks
     "edx": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "eslint-config-edx-es5",
+  "extends": "@arizzitano/eslint-config-edx-es5",
   "globals": {  // Try to avoid adding any new globals.
     // Old compatibility things and hacks
     "edx": true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "edx-custom-a11y-rules": "0.1.3",
     "eslint-config-edx": "^2.0.0",
-    "@arizzitano/eslint-config-edx-es5": "^2.0.1",
+    "@arizzitano/eslint-config-edx-es5": "^2.0.2",
     "jasmine-core": "^2.4.1",
     "jasmine-jquery": "^2.1.1",
     "karma": "^0.13.22",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "edx-custom-a11y-rules": "0.1.3",
     "eslint-config-edx": "^2.0.0",
-    "@ari/eslint-config-edx-es5": "^2.0.0",
+    "@arizzitano/eslint-config-edx-es5": "^2.0.0",
     "jasmine-core": "^2.4.1",
     "jasmine-jquery": "^2.1.1",
     "karma": "^0.13.22",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "edx-custom-a11y-rules": "0.1.3",
     "eslint-config-edx": "^2.0.0",
-    "eslint-config-edx-es5": "^2.0.0",
+    "@ari/eslint-config-edx-es5": "^2.0.0",
     "jasmine-core": "^2.4.1",
     "jasmine-jquery": "^2.1.1",
     "karma": "^0.13.22",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "edx-custom-a11y-rules": "0.1.3",
     "eslint-config-edx": "^2.0.0",
-    "@arizzitano/eslint-config-edx-es5": "^2.0.2",
+    "eslint-config-edx-es5": "^3.0.0",
     "jasmine-core": "^2.4.1",
     "jasmine-jquery": "^2.1.1",
     "karma": "^0.13.22",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "edx-custom-a11y-rules": "0.1.3",
     "eslint-config-edx": "^2.0.0",
-    "@arizzitano/eslint-config-edx-es5": "^2.0.0",
+    "@arizzitano/eslint-config-edx-es5": "^2.0.1",
     "jasmine-core": "^2.4.1",
     "jasmine-jquery": "^2.1.1",
     "karma": "^0.13.22",

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -12,7 +12,7 @@ set -e
 
 # Violations thresholds for failing the build
 export PYLINT_THRESHOLD=3600
-export ESLINT_THRESHOLD=10122
+export ESLINT_THRESHOLD=10285
 
 SAFELINT_THRESHOLDS=`cat scripts/safelint_thresholds.json`
 export SAFELINT_THRESHOLDS=${SAFELINT_THRESHOLDS//[[:space:]]/}

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -12,7 +12,7 @@ set -e
 
 # Violations thresholds for failing the build
 export PYLINT_THRESHOLD=3600
-export ESLINT_THRESHOLD=10285
+export ESLINT_THRESHOLD=14677
 
 SAFELINT_THRESHOLDS=`cat scripts/safelint_thresholds.json`
 export SAFELINT_THRESHOLDS=${SAFELINT_THRESHOLDS//[[:space:]]/}


### PR DESCRIPTION
Here's what happens when we upgrade `eslint-config-edx-es5`'s `eslint-config-airbnb` dep from 3.x to 11.x: 4555 new violations.

Although it's easy to turn up the violation threshold, we will want to fix these violations eventually. If we can get everything up to date now, future eslint dependency upgrades will be much less painful. I'd recommend we bump up the threshold for now and tackle autofixing the violations in separate follow-on PRs.

cc @bjacobel @benpatterson @andy-armstrong 