### PR TITLE
Allow specifying waffle switch on compute_grades

### DIFF
--- a/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
@@ -17,6 +17,8 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from lms.djangoapps.grades.config.models import ComputeGradesSetting
+from openedx.core.djangolib.waffle_utils import WaffleSwitchPlus
+from lms.djangoapps.grades.config.waffle import ESTIMATE_FIRST_ATTEMPTED
 from lms.djangoapps.grades.management.commands import compute_grades
 
 
@@ -72,35 +74,47 @@ class TestComputeGrades(SharedModuleStoreTestCase):
         with self.assertRaises(CommandError):
             self.command._get_course_keys({'from_settings': True})
 
-    @patch('lms.djangoapps.grades.tasks.compute_grades_for_course')
-    def test_tasks_fired(self, mock_task):
-        call_command(
+    @ddt.data(True, False)
+    @patch('lms.djangoapps.grades.tasks.compute_grades_for_course_v2')
+    def test_tasks_fired(self, estimate_first_attempted, mock_task):
+        command = [
             'compute_grades',
             '--routing_key=key',
             '--batch_size=2',
+        ]
+        courses = [
             '--courses',
             self.course_keys[0],
             self.course_keys[3],
             'd/n/e'  # No tasks created for nonexistent course, because it has no enrollments
-        )
+        ]
+        if not estimate_first_attempted:
+            command.append('--no_estimate_first_attempted')
+        call_command(*(command + courses))
+        _kwargs = lambda course_key, offset: {
+            'course_key': course_key,
+            'batch_size': 2,
+            'offset': offset,
+            'estimate_first_attempted': estimate_first_attempted
+        }
         self.assertEqual(
             mock_task.apply_async.call_args_list,
             [
                 ({
                     'options': {'routing_key': 'key'},
-                    'kwargs': {'course_key': self.course_keys[0], 'batch_size': 2, 'offset': 0}
+                    'kwargs': _kwargs(self.course_keys[0], 0)
                 },),
                 ({
                     'options': {'routing_key': 'key'},
-                    'kwargs': {'course_key': self.course_keys[0], 'batch_size': 2, 'offset': 2}
+                    'kwargs': _kwargs(self.course_keys[0], 2)
                 },),
                 ({
                     'options': {'routing_key': 'key'},
-                    'kwargs': {'course_key': self.course_keys[3], 'batch_size': 2, 'offset': 0}
+                    'kwargs': _kwargs(self.course_keys[3], 0)
                 },),
                 ({
                     'options': {'routing_key': 'key'},
-                    'kwargs': {'course_key': self.course_keys[3], 'batch_size': 2, 'offset': 2}
+                    'kwargs': _kwargs(self.course_keys[3], 2)
                 },),
             ],
         )


### PR DESCRIPTION
# [TNL-6841](https://openedx.atlassian.net/browse/TNL-6841)

If `--estimate_first_attempted` is passed, it can force enabling or disabling the ENABLE_FIRST_ATTEMPTED waffle switch.

## Reviewers

- [x] @nasthagiri 
- FYI @edx/educator-neem 