### PR TITLE
PLAT-1200 Upgrade to bok-choy 0.7.0 take 2

### DIFF
--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -25,6 +25,7 @@ from pymongo import MongoClient, ASCENDING
 from openedx.core.lib.tests.assertions.events import assert_event_matches, is_matching_event, EventMatchTolerates
 from xmodule.partitions.partitions import UserPartition
 from selenium.common.exceptions import StaleElementReferenceException
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait
@@ -709,6 +710,8 @@ class AcceptanceTest(WebAppTest):
     """
 
     def __init__(self, *args, **kwargs):
+        # Hack until we upgrade Firefox and install geckodriver in devstack and Jenkins
+        DesiredCapabilities.FIREFOX['marionette'] = False
         super(AcceptanceTest, self).__init__(*args, **kwargs)
 
         # Use long messages so that failures show actual and expected values

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -153,7 +153,7 @@ sqlparse>=0.2.0,<0.3.0
 
 # Used for testing
 before_after==0.1.3
-bok-choy==0.6.2
+bok-choy==0.7.0
 chrono==1.0.2
 ddt==0.8.0
 django-crum==0.5
@@ -164,6 +164,7 @@ freezegun==0.1.11
 mock-django==0.6.9
 mock==1.0.1
 moto==0.3.1
+needle==0.5.0
 nose==1.3.7
 nose-exclude
 nose-ignore-docstring
@@ -175,7 +176,7 @@ PyContracts==1.7.1
 python-subunit==0.0.16
 pyquery==1.2.9
 radon==1.3.2
-selenium==2.53.1
+selenium==3.3.1
 splinter==0.5.4
 testtools==0.9.34
 testfixtures==4.5.0


### PR DESCRIPTION
This gets us on a version of bok-choy which retries on WebDriverExceptions encountered during browser condition wait loops. 80% of the failures I inspected for the flaky test in PLAT-1200 were due to stale element reference exceptions resulting from unfortunate page refresh timing in such a wait loop; this should therefore at least help reduce the frequency of failures in that test (and potentially other tests as well).