### PR TITLE
Fix course completion logic when determining program completion

### DIFF
--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -257,12 +257,6 @@ class ProgramProgressMeter(object):
             Modify the structure of a course run dict to facilitate comparison
             with course run certificates.
             """
-            course_run_type = course_run['type']
-
-            # Treat no-id-professional enrollments as professional
-            if course_run_type == CourseMode.NO_ID_PROFESSIONAL_MODE:
-                course_run_type = CourseMode.PROFESSIONAL
-
             return {
                 'course_run_id': course_run['key'],
                 # A course run's type is assumed to indicate which mode must be
@@ -272,7 +266,7 @@ class ProgramProgressMeter(object):
                 # count towards completion of a course in a program). This may change
                 # in the future to make use of the more rigid set of "applicable seat
                 # types" associated with each program type in the catalog.
-                'type': course_run_type,
+                'type': course_run['type'],
             }
 
         return any(reshape(course_run) in self.completed_course_runs for course_run in course['course_runs'])
@@ -306,16 +300,25 @@ class ProgramProgressMeter(object):
             dict with a list of completed and failed runs
         """
         course_run_certificates = certificate_api.get_certificates_for_user(self.user.username)
+
         completed_runs, failed_runs = [], []
         for certificate in course_run_certificates:
+            certificate_type = certificate['type']
+
+            # Treat "no-id-professional" certificates as "professional" certificates
+            if certificate_type == CourseMode.NO_ID_PROFESSIONAL_MODE:
+                certificate_type = CourseMode.PROFESSIONAL
+
             course_data = {
                 'course_run_id': unicode(certificate['course_key']),
-                'type': certificate['type']
+                'type': certificate_type
             }
+
             if certificate_api.is_passing_status(certificate['status']):
                 completed_runs.append(course_data)
             else:
                 failed_runs.append(course_data)
+
         return {'completed': completed_runs, 'failed': failed_runs}
 
     def _is_course_enrolled(self, course):


### PR DESCRIPTION
We want to treat professional certificates equally for the purposes of program completion.

LEARNER-601

@clintonb it turns out I didn't read https://github.com/edx/edx-platform/pull/14889 closely enough. Your intent in that PR was correct, but the mode remapping was added in the wrong place. I still need to add tests to this, but I'm opening it now to illustrate the problem.

@edx/learner-growth FYI.