### PR TITLE
Update version of xblock-utils in requirements

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -84,7 +84,7 @@ git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd3
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/pmitros/DoneXBlock.git@release-2016-08-10#egg=done-xblock
 git+https://github.com/edx/edx-milestones.git@v0.1.10#egg=edx-milestones==0.1.10
-git+https://github.com/edx/xblock-utils.git@v1.0.4#egg=xblock-utils==1.0.4
+git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.2#egg=lti_consumer-xblock==1.1.2


### PR DESCRIPTION
@edx/devops
Code in xblock-utils repo has been updated and needs to get pulled in edx-platform to make it functional.