### PR TITLE
ECOM-7252-fix refund discrepancy after the course mode expiry

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -340,7 +340,7 @@ class CourseMode(models.Model):
         return {mode.slug: mode for mode in modes}
 
     @classmethod
-    def mode_for_course(cls, course_id, mode_slug, modes=None):
+    def mode_for_course(cls, course_id, mode_slug, modes=None, include_expired=False):
         """Returns the mode for the course corresponding to mode_slug.
 
         Returns only non-expired modes.
@@ -356,12 +356,15 @@ class CourseMode(models.Model):
                 of course modes.  This can be used to avoid an additional
                 database query if you have already loaded the modes list.
 
+            include_expired (bool): If True, expired course modes will be included
+                in the returned values. If False, these modes will be omitted.
+
         Returns:
             Mode
 
         """
         if modes is None:
-            modes = cls.modes_for_course(course_id)
+            modes = cls.modes_for_course(course_id, include_expired=include_expired)
 
         matched = [m for m in modes if m.slug == mode_slug]
         if matched:

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1557,6 +1557,7 @@ class CourseEnrollment(models.Model):
         # which calls this method to determine whether to refund the order.
         # This can't be set directly because refunds currently happen as a side-effect of unenrolling.
         # (side-effects are bad)
+
         if getattr(self, 'can_refund', None) is not None:
             return True
 
@@ -1570,10 +1571,13 @@ class CourseEnrollment(models.Model):
 
         # If it is after the refundable cutoff date they should not be refunded.
         refund_cutoff_date = self.refund_cutoff_date()
-        if refund_cutoff_date and datetime.now(UTC) > refund_cutoff_date:
+        # `refund_cuttoff_date` will be `None` if there is no order. If there is no order return `False`.
+        if refund_cutoff_date is None:
+            return False
+        if datetime.now(UTC) > refund_cutoff_date:
             return False
 
-        course_mode = CourseMode.mode_for_course(self.course_id, 'verified')
+        course_mode = CourseMode.mode_for_course(self.course_id, 'verified', include_expired=True)
         if course_mode is None:
             return False
         else:

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -911,9 +911,10 @@ class CertificateItemTest(ModuleStoreTestCase):
             'STORE_BILLING_INFO': True,
         }
     )
-    def test_refund_cert_callback_no_expiration(self):
+    @patch('student.models.CourseEnrollment.refund_cutoff_date')
+    def test_refund_cert_callback_no_expiration(self, cutoff_date):
         # When there is no expiration date on a verified mode, the user can always get a refund
-
+        cutoff_date.return_value = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1)
         # need to prevent analytics errors from appearing in stderr
         with patch('sys.stderr', sys.stdout.write):
             CourseEnrollment.enroll(self.user, self.course_key, 'verified')
@@ -952,7 +953,8 @@ class CertificateItemTest(ModuleStoreTestCase):
             'STORE_BILLING_INFO': True,
         }
     )
-    def test_refund_cert_callback_before_expiration(self):
+    @patch('student.models.CourseEnrollment.refund_cutoff_date')
+    def test_refund_cert_callback_before_expiration(self, cutoff_date):
         # If the expiration date has not yet passed on a verified mode, the user can be refunded
         many_days = datetime.timedelta(days=60)
 
@@ -965,6 +967,7 @@ class CertificateItemTest(ModuleStoreTestCase):
                                  expiration_datetime=(datetime.datetime.now(pytz.utc) + many_days))
         course_mode.save()
 
+        cutoff_date.return_value = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1)
         # need to prevent analytics errors from appearing in stderr
         with patch('sys.stderr', sys.stdout.write):
             CourseEnrollment.enroll(self.user, self.course_key, 'verified')
@@ -979,7 +982,8 @@ class CertificateItemTest(ModuleStoreTestCase):
         self.assertEquals(target_certs[0].order.status, 'refunded')
         self._assert_refund_tracked()
 
-    def test_refund_cert_callback_before_expiration_email(self):
+    @patch('student.models.CourseEnrollment.refund_cutoff_date')
+    def test_refund_cert_callback_before_expiration_email(self, cutoff_date):
         """ Test that refund emails are being sent correctly. """
         course = CourseFactory.create()
         course_key = course.id
@@ -998,6 +1002,7 @@ class CertificateItemTest(ModuleStoreTestCase):
         cart.purchase()
 
         mail.outbox = []
+        cutoff_date.return_value = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1)
         with patch('shoppingcart.models.log.error') as mock_error_logger:
             CourseEnrollment.unenroll(self.user, course_key)
             self.assertFalse(mock_error_logger.called)
@@ -1006,8 +1011,9 @@ class CertificateItemTest(ModuleStoreTestCase):
             self.assertEquals(settings.PAYMENT_SUPPORT_EMAIL, mail.outbox[0].from_email)
             self.assertIn('has requested a refund on Order', mail.outbox[0].body)
 
+    @patch('student.models.CourseEnrollment.refund_cutoff_date')
     @patch('shoppingcart.models.log.error')
-    def test_refund_cert_callback_before_expiration_email_error(self, error_logger):
+    def test_refund_cert_callback_before_expiration_email_error(self, error_logger, cutoff_date):
         # If there's an error sending an email to billing, we need to log this error
         many_days = datetime.timedelta(days=60)
 
@@ -1026,6 +1032,7 @@ class CertificateItemTest(ModuleStoreTestCase):
         CertificateItem.add_to_order(cart, course_key, self.cost, 'verified')
         cart.purchase()
 
+        cutoff_date.return_value = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1)
         with patch('shoppingcart.models.send_mail', side_effect=smtplib.SMTPException):
             CourseEnrollment.unenroll(self.user, course_key)
             self.assertTrue(error_logger.call_args[0][0].startswith('Failed sending email'))

--- a/lms/djangoapps/shoppingcart/tests/test_reports.py
+++ b/lms/djangoapps/shoppingcart/tests/test_reports.py
@@ -7,6 +7,7 @@ import datetime
 import pytz
 import StringIO
 from textwrap import dedent
+from mock import patch
 
 from django.conf import settings
 
@@ -26,9 +27,10 @@ class ReportTypeTests(ModuleStoreTestCase):
     """
     FIVE_MINS = datetime.timedelta(minutes=5)
 
-    def setUp(self):
+    @patch('student.models.CourseEnrollment.refund_cutoff_date')
+    def setUp(self, cutoff_date):
         super(ReportTypeTests, self).setUp()
-
+        cutoff_date.return_value = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1)
         # Need to make a *lot* of users for this one
         self.first_verified_user = UserFactory.create(profile__name="John Doe")
         self.second_verified_user = UserFactory.create(profile__name="Jane Deer")

--- a/lms/djangoapps/support/tests/test_refund.py
+++ b/lms/djangoapps/support/tests/test_refund.py
@@ -8,6 +8,8 @@ to the E-Commerce service is complete.
 
 """
 import datetime
+import pytz
+from mock import patch
 
 from django.test.client import Client
 
@@ -91,10 +93,12 @@ class RefundTests(ModuleStoreTestCase):
         response = self.client.post('/support/refund/', {'course_id': str(self.course_id), 'user': 'unknown@foo.com'})
         self.assertContains(response, 'User not found')
 
-    def test_not_refundable(self):
+    @patch('student.models.CourseEnrollment.refund_cutoff_date')
+    def test_not_refundable(self, cutoff_date):
         self._enroll()
         self.course_mode.expiration_datetime = datetime.datetime(2033, 4, 6)
         self.course_mode.save()
+        cutoff_date.return_value = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1)
         response = self.client.post('/support/refund/', self.form_pars)
         self.assertContains(response, 'not past the refund window')
 


### PR DESCRIPTION
## [ECOM-7252](https://openedx.atlassian.net/browse/ECOM-7252)

### Description

Several learners have contacted us stating that they are seeing a message that they will not receive a refund when unenrolling, even though they are within 14 days of their payment. 

This appears to happen in courses that have closed enrollment

In support with newly automated refunds we generally inform students on how to unenroll themselves to automatically receive refunds, but we currently need to be aware of these courses where this is not working properly and process these manually

*_Expected behavior_*

A learner unenrolling within 14 days of their payment or the first 14 days of a course will automatically receive a refund upon unenrolling from the verified track.

*_Actual Behavior_*

A learner unenrolling within 14 days of their payment or the first 14 days of a course when course enrollment has been closed sees the message: 

"Are you sure you want to unenroll from the verified Certificate of Achievement track of Supply Chain Fundamentals (CTL.SC1x_3)? The refund deadline for this course has passed, so you will not receive a refund."


### How to Test?

**Stage** 
i) Enroll in a course where course is going to end in the next 14 days
ii) Upgrade to 'Verified'
iii) Click on un-enroll
iv) you will see a message that 'Refund deadline has been passed so you will not be refunded'

**Sandbox**
- [https://refund.sandbox.edx.org/](https://refund.sandbox.edx.org/)

FYI: @adampalay 

### Post-review
- [ ] Rebase and squash commits