### PR TITLE
TNL-6374 Fix checkbox partial credit rounds incorrectly with certain problem weights

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -803,6 +803,8 @@ class CapaMixin(CapaFields):
                 else:
                     answer_notification_message = _('Correct')
             elif answer_notification_type == 'partially-correct':
+                # representing values as a whole numbers
+                progress = Progress(round(progress.frac()[0], 1), progress.frac()[1])
                 if progress is not None:
                     answer_notification_message = ungettext(
                         "Partially correct ({progress} point)",

--- a/common/lib/xmodule/xmodule/js/src/capa/display.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/display.js
@@ -276,9 +276,9 @@
             }
             progress = interpolate(
                 progressTemplate, {
-                    earned: curScore,
+                    earned: Math.round(curScore,1),
                     num_points: totalScore,
-                    possible: totalScore
+                    possible: Math.round(totalScore,1)
                 }, true
             );
             return this.$('.problem-progress').text(progress);

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -154,7 +154,7 @@ from django.utils.http import urlquote_plus
                                 %for section in chapter['sections']:
                                     <div>
                                         <%
-                                        earned = section.all_total.earned
+                                        earned = round(section.all_total.earned,1)
                                         total = section.all_total.possible
                                         percentageString = "{0:.0%}".format( float(earned)/total) if earned > 0 and total > 0 else ""
                                         %>
@@ -183,7 +183,7 @@ from django.utils.http import urlquote_plus
                                         <dl class="scores">
                                             <dt class="hd hd-6">${ _("Problem Scores: ") if section.graded else _("Practice Scores: ")}</dt>
                                             %for score in section.problem_scores.values():
-                                            <dd>${"{0:.3n}/{1:.3n}".format(float(score.earned),float(score.possible))}</dd>
+                                            <dd>${"{0:.3n}/{1:.3n}".format(round(float(score.earned),1),float(score.possible))}</dd>
                                             %endfor
                                         </dl>
                                         %else:


### PR DESCRIPTION
# [Checkbox partial credit rounds incorrectly with certain problem weights - TNL-6374](https://openedx.atlassian.net/browse/TNL-6374)

### Description
This PR fixes the incorrect checkbox partial credit round off values. The issue was that answering 1/3 correct confers 0.99/3.0 points, and 2/3 correct gives 2.01/3.0 points. Now it will give us correct values i.e 1/3 and 2/3.


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Style and readability review: @attiyaIshaque 
- [ ] Code review: @noraiz-anwar  
- [ ] Code review: @adampalay 

### Post-review
- [x] Rebase and squash commits
