### PR TITLE
Only use ecommerce hosted receipt page

### DIFF
--- a/lms/djangoapps/commerce/migrations/0006_remove_commerceconfiguration_receipt_page.py
+++ b/lms/djangoapps/commerce/migrations/0006_remove_commerceconfiguration_receipt_page.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('commerce', '0005_commerceconfiguration_enable_automatic_refund_approval'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='commerceconfiguration',
+            name='receipt_page',
+        ),
+    ]

--- a/lms/djangoapps/commerce/models.py
+++ b/lms/djangoapps/commerce/models.py
@@ -15,7 +15,6 @@ class CommerceConfiguration(ConfigurationModel):
 
     API_NAME = 'commerce'
     CACHE_KEY = 'commerce.api.data'
-    DEFAULT_RECEIPT_PAGE_URL = '/commerce/checkout/receipt/?orderNum='
 
     checkout_on_ecommerce_service = models.BooleanField(
         default=False,
@@ -33,11 +32,6 @@ class CommerceConfiguration(ConfigurationModel):
         help_text=_(
             'Specified in seconds. Enable caching by setting this to a value greater than 0.'
         )
-    )
-    receipt_page = models.CharField(
-        max_length=255,
-        default=DEFAULT_RECEIPT_PAGE_URL,
-        help_text=_('Path to order receipt page.')
     )
     enable_automatic_refund_approval = models.BooleanField(
         default=True,

--- a/lms/djangoapps/commerce/tests/test_utils.py
+++ b/lms/djangoapps/commerce/tests/test_utils.py
@@ -11,16 +11,11 @@ from openedx.core.lib.log_utils import audit_log
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from student.tests.factories import UserFactory
 
-TEST_SITE_CONFIGURATION = {
-    'ECOMMERCE_RECEIPT_PAGE_URL': '/checkout/receipt/?order_number='
-}
 
-
-def update_commerce_config(enabled=False, checkout_page='/test_basket/', receipt_page='/checkout/receipt/'):
+def update_commerce_config(enabled=False, checkout_page='/test_basket/'):
     """ Enable / Disable CommerceConfiguration model """
     CommerceConfiguration.objects.create(
         checkout_on_ecommerce_service=enabled,
-        receipt_page=receipt_page,
         single_course_checkout_page=checkout_page,
     )
 
@@ -83,7 +78,7 @@ class EcommerceServiceTests(TestCase):
         """Verify that the proper Receipt page URL is returned."""
         order_number = 'ORDER1'
         url = EcommerceService().get_receipt_page_url(order_number)
-        expected_url = '/checkout/receipt/{}'.format(order_number)
+        expected_url = 'http://ecommerce_url/checkout/receipt/?order_number={}'.format(order_number)
         self.assertEqual(url, expected_url)
 
     @override_settings(ECOMMERCE_PUBLIC_URL_ROOT='http://ecommerce_url')
@@ -92,19 +87,3 @@ class EcommerceServiceTests(TestCase):
         url = EcommerceService().checkout_page_url(self.SKU)
         expected_url = 'http://ecommerce_url/test_basket/?sku={}'.format(self.SKU)
         self.assertEqual(url, expected_url)
-
-    @override_settings(ECOMMERCE_PUBLIC_URL_ROOT='http://ecommerce_url')
-    @with_site_configuration(configuration=TEST_SITE_CONFIGURATION)
-    def test_get_receipt_page_url_with_site_configuration(self):
-        order_number = 'ORDER1'
-        config = CommerceConfiguration.current()
-        config.use_ecommerce_receipt_page = True
-        config.save()
-
-        receipt_page_url = EcommerceService().get_receipt_page_url(order_number)
-        expected_url = '{ecommerce_root}{receipt_page_url}{order_number}'.format(
-            ecommerce_root=settings.ECOMMERCE_PUBLIC_URL_ROOT,
-            order_number=order_number,
-            receipt_page_url=TEST_SITE_CONFIGURATION['ECOMMERCE_RECEIPT_PAGE_URL']
-        )
-        self.assertEqual(receipt_page_url, expected_url)

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from commerce.models import CommerceConfiguration
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
+RECEIPT_PAGE_URL = '/checkout/receipt/?order_number='
+
 
 class EcommerceService(object):
     """ Helper class for ecommerce service integration. """
@@ -38,11 +40,8 @@ class EcommerceService(object):
         Returns:
             Receipt page for the specified Order.
         """
-        ecommerce_receipt_page_url = configuration_helpers.get_value('ECOMMERCE_RECEIPT_PAGE_URL')
 
-        if ecommerce_receipt_page_url:
-            return self.get_absolute_ecommerce_url(ecommerce_receipt_page_url + order_number)
-        return self.config.receipt_page + order_number
+        return self.get_absolute_ecommerce_url(RECEIPT_PAGE_URL + order_number)
 
     def is_enabled(self, user):
         """

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -645,7 +645,7 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, TestCase, ProgramsApiConf
                 'number': order['number'],
                 'price': order['total_excl_tax'],
                 'order_date': 'Jan 01, 2016',
-                'receipt_url': '/commerce/checkout/receipt/?orderNum=' + order['number'],
+                'receipt_url': '/checkout/receipt/?order_number=' + order['number'],
                 'lines': order['lines'],
             }
             self.assertEqual(order_detail[i], expected)


### PR DESCRIPTION
No longer the need to use the LMS hosted receipt page.  All commerce related pages live in the e-commerce IDA.

LEARNER-616