### PR TITLE
Enable all products to be displayed on receipt page

### DIFF
--- a/lms/djangoapps/commerce/tests/mocks.py
+++ b/lms/djangoapps/commerce/tests/mocks.py
@@ -180,7 +180,12 @@ class mock_get_orders(mock_ecommerce_api_endpoint):
                         )])
                     ),
                 ]
-            )
+            ),
+            factories.OrderFactory(
+                lines=[
+                    factories.OrderLineFactory(product=factories.ProductFactory(product_class='Coupon'))
+                ]
+            ),
         ]
     }
     method = httpretty.GET

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -697,24 +697,6 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, TestCase, ProgramsApiConf
 
         self.assertEqual(len(order_detail), 1)
 
-    def test_order_history_with_coupon(self):
-        """
-        Verify that get_order_details returns empty receipt_url for coupon product.
-        """
-        response = {
-            'results': [
-                factories.OrderFactory(
-                    lines=[
-                        factories.OrderLineFactory(product=factories.ProductFactory(product_class='Coupon'))
-                    ]
-                )
-            ]
-        }
-        with mock_get_orders(response=response):
-            order_detail = get_user_orders(self.user)
-
-        self.assertEqual(order_detail[0]['receipt_url'], '')
-
 
 @override_settings(SITE_NAME=settings.MICROSITE_LOGISTRATION_HOSTNAME)
 class MicrositeLogistrationTests(TestCase):

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -351,16 +351,6 @@ def get_user_orders(user):
                 'receipt_url': EcommerceService().get_receipt_page_url(order['number']),
                 'lines': order['lines'],
             }
-
-            # If the order lines contain a product that is not a Seat
-            # we do not want to display the Order Details button. It
-            # will break the receipt page if used.
-            for order_line in order['lines']:
-                product = order_line.get('product')
-
-                if product and product.get('product_class') != 'Seat':
-                    order_data['receipt_url'] = ''
-                    break
             user_orders.append(order_data)
 
     return user_orders


### PR DESCRIPTION
[LEARNER-605](https://openedx.atlassian.net/browse/LEARNER-605)
I removed the line that removed the receipt url for non Seat products. This is necessary to enable users to see order receipts with coupons, enrolment codes and others in future.

Dependancy [PR](https://github.com/edx/ecommerce/pull/1250).