### PR TITLE
Added given and family name fields to profile scope

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
@@ -67,8 +67,12 @@ class AccessTokenMixin(object):
             except UserProfile.DoesNotExist:
                 name = None
 
-            expected['name'] = name
-            expected['administrator'] = user.is_staff
+            expected.update({
+                'name': name,
+                'administrator': user.is_staff,
+                'family_name': user.last_name,
+                'given_name': user.first_name,
+            })
 
         self.assertDictContainsSubset(expected, payload)
 

--- a/openedx/core/lib/token_utils.py
+++ b/openedx/core/lib/token_utils.py
@@ -93,6 +93,8 @@ class JwtBuilder(object):
 
         payload.update({
             'name': name,
+            'family_name': self.user.last_name,
+            'given_name': self.user.first_name,
             'administrator': self.user.is_staff,
         })
 


### PR DESCRIPTION
This information mirrors the fields returned in our ID token for OpenID
Connect (OIDC). Including this information will allow us to eventually
migrate toward replacing OIDC with OAuth 2.0 + JWT.

ECOM-3628