### PR TITLE
Add a sidebar to the new course home page

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -278,7 +278,7 @@ def get_course_info_section(request, user, course, section_key):
     html = ''
     if info_module is not None:
         try:
-            html = info_module.render(STUDENT_VIEW).content
+            html = info_module.render(STUDENT_VIEW).content.strip()
         except Exception:  # pylint: disable=broad-except
             html = render_to_string('courseware/error-message.html', None)
             log.exception(

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -10,6 +10,7 @@ from django.utils.translation import ugettext as _, ugettext_noop
 from courseware.access import has_access
 from courseware.entrance_exams import user_can_skip_entrance_exam
 from openedx.core.lib.course_tabs import CourseTabPluginManager
+from openedx.features.course_experience import UNIFIED_COURSE_VIEW_FLAG
 from request_cache.middleware import RequestCache
 from student.models import CourseEnrollment
 from xmodule.tabs import CourseTab, CourseTabList, key_checker, link_reverse_func
@@ -43,7 +44,7 @@ class CoursewareTab(EnrolledTab):
         """
         Returns the main course URL for the current user.
         """
-        if waffle.flag_is_active(request, 'unified_course_view'):
+        if waffle.flag_is_active(request, UNIFIED_COURSE_VIEW_FLAG):
             return 'edx.course_experience.course_home'
         else:
             return 'courseware'

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -33,6 +33,7 @@ from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.monitoring_utils import set_custom_metrics_for_course_key
 from openedx.features.enterprise_support.api import data_sharing_consent_required
+from openedx.features.course_experience import UNIFIED_COURSE_VIEW_FLAG
 from request_cache.middleware import RequestCache
 from shoppingcart.models import CourseRegistrationCode
 from student.views import is_course_blocked
@@ -338,7 +339,7 @@ class CoursewareIndex(View):
             'disable_optimizely': True,
             'section_title': None,
             'sequence_title': None,
-            'disable_accordion': waffle.flag_is_active(request, 'unified_course_view')
+            'disable_accordion': waffle.flag_is_active(request, UNIFIED_COURSE_VIEW_FLAG),
         }
         table_of_contents = toc_for_course(
             self.effective_user,

--- a/lms/static/sass/features/_course-outline.scss
+++ b/lms/static/sass/features/_course-outline.scss
@@ -11,8 +11,6 @@
       padding: 0 ($baseline * 2);
 
       &:not(:first-child) {
-        border-top: 1px solid $lms-border-color;
-
         .section-name {
           margin-top: $baseline;
         }

--- a/lms/static/sass/shared-v2/_components.scss
+++ b/lms/static/sass/shared-v2/_components.scss
@@ -149,3 +149,7 @@
     }
   }
 }
+
+.section:not(:first-child) {
+    margin-top: $baseline;
+}

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext as _
 from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import HTML
+from openedx.features.course_experience import UNIFIED_COURSE_VIEW_FLAG
 %>
 <%
   include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and (course.enable_proctored_exams or course.enable_timed_exams)
@@ -157,7 +158,7 @@ ${HTML(fragment.foot_html())}
         <main id="main" tabindex="-1" aria-label="Content">
             <div
               class="path"
-              data-unified-course-view="${'true' if waffle.flag_is_active(request, 'unified_course_view') else 'false'}"
+              data-unified-course-view="${'true' if waffle.flag_is_active(request, UNIFIED_COURSE_VIEW_FLAG) else 'false'}"
             ></div>
             % if getattr(course, 'entrance_exam_enabled') and \
                getattr(course, 'entrance_exam_minimum_score_pct') and \

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -1,4 +1,8 @@
-# Unified course experience settings
+# Unified course experience settings.
 
+# Waffle flag to enable a single unified "Course" tab.
 UNIFIED_COURSE_EXPERIENCE_FLAG = 'unified_course_experience'
+
+# Waffle flag to enable the full screen course content view
+# along with a unified course home page.
 UNIFIED_COURSE_VIEW_FLAG = 'unified_course_view'

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -1,0 +1,4 @@
+# Unified course experience settings
+
+UNIFIED_COURSE_EXPERIENCE_FLAG = 'unified_course_experience'
+UNIFIED_COURSE_VIEW_FLAG = 'unified_course_view'

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -5,6 +5,8 @@
 
 <%!
 import json
+import waffle
+
 from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.template.defaultfilters import escapejs
@@ -13,6 +15,7 @@ from django.core.urlresolvers import reverse
 from django_comment_client.permissions import has_permission
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML
+from openedx.features.course_experience import UNIFIED_COURSE_EXPERIENCE_FLAG
 %>
 
 <%block name="content">
@@ -25,9 +28,11 @@ from openedx.core.djangolib.markup import HTML
         </div>
         <div class="page-header-secondary">
             <div class="form-actions">
-                <a class="btn action-show-bookmarks" href="${reverse('openedx.course_bookmarks.home', args=[course.id])}">
-                    ${_("Bookmarks")}
-                </a>
+                % if not waffle.flag_is_active(request, UNIFIED_COURSE_EXPERIENCE_FLAG):
+                    <a class="btn action-show-bookmarks" href="${reverse('openedx.course_bookmarks.home', args=[course.id])}">
+                        ${_("Bookmarks")}
+                    </a>
+                % endif
                 <a class="btn btn-brand action-resume-course" href="${reverse('courseware', kwargs={'course_id': unicode(course.id.to_deprecated_string())})}">
                     % if has_visited_course:
                         ${_("Resume Course")}
@@ -54,7 +59,26 @@ from openedx.core.djangolib.markup import HTML
         </div>
     </header>
     <div class="page-content">
-        ${HTML(outline_fragment.body_html())}
+        % if waffle.flag_is_active(request, UNIFIED_COURSE_EXPERIENCE_FLAG):
+            <div class="layout layout-1q3q">
+                <main class="layout-col layout-col-b">
+                    ${HTML(outline_fragment.body_html())}
+                </main>
+                <aside class="layout-col layout-col-a">
+                    <h3 class="hd-6">Course Tools</h3>
+                    <ul class="list-unstyled">
+                        <li>
+                            <a class="action-show-bookmarks" href="${reverse('openedx.course_bookmarks.home', args=[course.id])}">
+                                <span class="icon fa fa-bookmark" aria-hidden="true"></span>
+                                ${_("Bookmarks")}
+                            </a>
+                        </li>
+                    </ul>
+                </aside>
+            </div>
+        % else:
+            ${HTML(outline_fragment.body_html())}
+        % endif
     </div>
 </div>
 </%block>

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -65,15 +65,23 @@ from openedx.features.course_experience import UNIFIED_COURSE_EXPERIENCE_FLAG
                     ${HTML(outline_fragment.body_html())}
                 </main>
                 <aside class="layout-col layout-col-a">
-                    <h3 class="hd-6">Course Tools</h3>
-                    <ul class="list-unstyled">
-                        <li>
-                            <a class="action-show-bookmarks" href="${reverse('openedx.course_bookmarks.home', args=[course.id])}">
-                                <span class="icon fa fa-bookmark" aria-hidden="true"></span>
-                                ${_("Bookmarks")}
-                            </a>
-                        </li>
-                    </ul>
+                    <div class="section section-tools">
+                        <h3 class="hd-6">${_("Course Tools")}</h3>
+                        <ul class="list-unstyled">
+                            <li>
+                                <a class="action-show-bookmarks" href="${reverse('openedx.course_bookmarks.home', args=[course.id])}">
+                                    <span class="icon fa fa-bookmark" aria-hidden="true"></span>
+                                    ${_("Bookmarks")}
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                    % if handouts_html:
+                        <div class="section section-handouts">
+                            <h3 class="hd-6">${_("Course Handouts")}</h3>
+                            ${HTML(handouts_html)}
+                        </div>
+                    % endif
                 </aside>
             </div>
         % else:

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -9,7 +9,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 
-from courseware.courses import get_course_with_access, get_last_accessed_courseware
+from courseware.courses import get_course_info_section, get_course_with_access, get_last_accessed_courseware
 from lms.djangoapps.courseware.views.views import CourseTabView
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
@@ -56,11 +56,15 @@ class CourseHomeFragmentView(EdxFragmentView):
         # Get the last accessed courseware
         last_accessed_url, __ = get_last_accessed_courseware(course, request, request.user)
 
+        # Get the handouts
+        handouts_html = get_course_info_section(request, request.user, course, 'handouts')
+
         # Render the course home fragment
         context = {
             'csrf': csrf(request)['csrf_token'],
             'course': course,
             'outline_fragment': outline_fragment,
+            'handouts_html': handouts_html,
             'has_visited_course': last_accessed_url is not None,
             'disable_courseware_js': True,
             'uses_pattern_library': True,


### PR DESCRIPTION
## [LEARNER-368](https://openedx.atlassian.net/browse/LEARNER-368)

### Description

This change implements a new course sidebar, and renders the bookmarks and handouts into it.

![image](https://cloud.githubusercontent.com/assets/5985072/25355160/afe82438-2903-11e7-8c30-c811e215105a.png)

### Sandbox
- [ ] https://andy-armstrong.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/

Note: staff gets access to the new feature, while regular learners do not.

### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit violation code review process

FYI: @marcotuts @dianakhuang @robrap @catong 

### Post-review
- [ ] Rebase and squash commits