### PR TITLE
Fix calling convention for celery options

### DIFF
--- a/lms/djangoapps/grades/management/commands/compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/compute_grades.py
@@ -106,10 +106,7 @@ class Command(BaseCommand):
                 'batch_size': batch_size,
                 'estimate_first_attempted': options['estimate_first_attempted']
             }
-            result = tasks.compute_grades_for_course_v2.apply_async(
-                kwargs=kwargs,
-                options=task_options,
-            )
+            result = tasks.compute_grades_for_course_v2.apply_async(kwargs=kwargs, **task_options)
             log.info("Grades: Created {task_name}[{task_id}] with arguments {kwargs}".format(
                 task_name=tasks.compute_grades_for_course.name,
                 task_id=result.task_id,

--- a/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
@@ -101,19 +101,19 @@ class TestComputeGrades(SharedModuleStoreTestCase):
             mock_task.apply_async.call_args_list,
             [
                 ({
-                    'options': {'routing_key': 'key'},
+                    'routing_key': 'key',
                     'kwargs': _kwargs(self.course_keys[0], 0)
                 },),
                 ({
-                    'options': {'routing_key': 'key'},
+                    'routing_key': 'key',
                     'kwargs': _kwargs(self.course_keys[0], 2)
                 },),
                 ({
-                    'options': {'routing_key': 'key'},
+                    'routing_key': 'key',
                     'kwargs': _kwargs(self.course_keys[3], 0)
                 },),
                 ({
-                    'options': {'routing_key': 'key'},
+                    'routing_key': 'key',
                     'kwargs': _kwargs(self.course_keys[3], 2)
                 },),
             ],


### PR DESCRIPTION
As per documentation here: http://docs.celeryproject.org/en/latest/reference/celery.app.task.html#celery.app.task.Task.apply_async

- [x] @eric

FYI: @edx/educator-neem 
FYI: @jibsheet 