### PR TITLE
Updated edx-oauth2-provider to 1.2.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -50,10 +50,9 @@ edx-lint==0.4.3
 # astroid 1.3.8 is an unmet dependency of the version of pylint used in edx-lint 0.4.3
 # when upgrading edx-lint, we should try to remove this from the platform
 astroid==1.3.8
-edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
 edx-enterprise==0.33.6
-edx-oauth2-provider==1.2.0
+edx-oauth2-provider==1.2.1
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.4
 edx-rest-api-client==1.7.1


### PR DESCRIPTION
This update fixes the nonce issue with the ID token, so that we conform to the OpenID Connect spec.

LEARNER-693