### PR TITLE
Add an empty course message to the course home page

### DIFF
--- a/lms/static/sass/_build-lms-v2.scss
+++ b/lms/static/sass/_build-lms-v2.scss
@@ -25,4 +25,4 @@
 
 // Features
 @import 'features/bookmarks';
-@import 'features/course-outline';
+@import 'features/course-experience';

--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -1,3 +1,10 @@
+// Course sidebar
+.course-sidebar {
+  @include margin-left(0);
+  @include padding-left($baseline);
+}
+
+// Course outline
 .course-outline {
   color: $lms-gray;
 

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -64,7 +64,7 @@ from openedx.features.course_experience import UNIFIED_COURSE_EXPERIENCE_FLAG
                 <main class="layout-col layout-col-b">
                     ${HTML(outline_fragment.body_html())}
                 </main>
-                <aside class="layout-col layout-col-a">
+                <aside class="course-sidebar layout-col layout-col-a">
                     <div class="section section-tools">
                         <h3 class="hd-6">${_("Course Tools")}</h3>
                         <ul class="list-unstyled">

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -5,7 +5,11 @@
 <%namespace name='static' file='../static_content.html'/>
 
 <%!
+from datetime import date
+
 from django.utils.translation import ugettext as _
+
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%static:require_module_async module_name="course_experience/js/course_outline_factory" class_name="CourseOutlineFactory">
@@ -13,65 +17,77 @@ from django.utils.translation import ugettext as _
 </%static:require_module_async>
 
 <main role="main" class="course-outline" id="main" tabindex="-1">
-    <ol class="block-tree" role="tree">
-        % for section in blocks.get('children') or []:
-            <li
-                aria-expanded="true"
-                class="outline-item focusable section"
-                id="${ section['id'] }"
-                role="treeitem"
-                tabindex="0"
-            >
-                <div class="section-name">
-                    <h3>${ section['display_name'] }</h3>
-                </div>
-                <ol class="outline-item focusable" role="group" tabindex="0">
-                    % for subsection in section.get('children') or []:
-                        <li
-                            class="subsection ${ 'current' if subsection['current'] else '' }"
-                            role="treeitem"
-                            tabindex="-1"
-                            aria-expanded="true"
-                        >
-                            <a
-                                class="outline-item focusable"
-                                href="${ subsection['lms_web_url'] }"
-                                id="${ subsection['id'] }"
+    % if blocks.get('children'):
+        <ol class="block-tree" role="tree">
+            % for section in blocks.get('children'):
+                <li
+                    aria-expanded="true"
+                    class="outline-item focusable section"
+                    id="${ section['id'] }"
+                    role="treeitem"
+                    tabindex="0"
+                >
+                    <div class="section-name">
+                        <h3>${ section['display_name'] }</h3>
+                    </div>
+                    <ol class="outline-item focusable" role="group" tabindex="0">
+                        % for subsection in section.get('children') or []:
+                            <li
+                                class="subsection ${ 'current' if subsection['current'] else '' }"
+                                role="treeitem"
+                                tabindex="-1"
+                                aria-expanded="true"
                             >
-                                <div class="subsection-text">
-                                    ## Subsection title
-                                    <span class="subsection-title">${ subsection['display_name'] }</span>
+                                <a
+                                    class="outline-item focusable"
+                                    href="${ subsection['lms_web_url'] }"
+                                    id="${ subsection['id'] }"
+                                >
+                                    <div class="subsection-text">
+                                        ## Subsection title
+                                        <span class="subsection-title">${ subsection['display_name'] }</span>
 
-                                    <div class="details">
-                                        ## There are behavior differences between rendering of subsections which have
-                                        ## exams (timed, graded, etc) and those that do not.
-                                        ##
-                                        ## Exam subsections expose exam status message field as well as a status icon
-                                        <%
-                                            if subsection.get('due') is None:
-                                                # examples: Homework, Lab, etc.
-                                                data_string = subsection.get('format')
-                                            else:
-                                                if 'special_exam_info' in subsection:
-                                                    data_string = _('due {date}')
+                                        <div class="details">
+                                            ## There are behavior differences between rendering of subsections which have
+                                            ## exams (timed, graded, etc) and those that do not.
+                                            ##
+                                            ## Exam subsections expose exam status message field as well as a status icon
+                                            <%
+                                                if subsection.get('due') is None:
+                                                    # examples: Homework, Lab, etc.
+                                                    data_string = subsection.get('format')
                                                 else:
-                                                    data_string = _("{subsection_format} due {{date}}").format(subsection_format=subsection.get('format'))
-                                        %>
-                                        % if subsection.get('format') or 'special_exam_info' in subsection:
-                                        <span class="subtitle">
-                                            % if 'special_exam' in subsection:
-                                                ## Display the exam status icon and status message
-                                                <span
-                                                    class="menu-icon icon fa ${subsection['special_exam_info'].get('suggested_icon', 'fa-pencil-square-o')} ${subsection['special_exam_info'].get('status', 'eligible')}"
-                                                    aria-hidden="true"
-                                                ></span>
-                                                <span class="subtitle-name">
-                                                    ${subsection['special_exam_info'].get('short_description', '')}
-                                                </span>
+                                                    if 'special_exam_info' in subsection:
+                                                        data_string = _('due {date}')
+                                                    else:
+                                                        data_string = _("{subsection_format} due {{date}}").format(subsection_format=subsection.get('format'))
+                                            %>
+                                            % if subsection.get('format') or 'special_exam_info' in subsection:
+                                            <span class="subtitle">
+                                                % if 'special_exam' in subsection:
+                                                    ## Display the exam status icon and status message
+                                                    <span
+                                                        class="menu-icon icon fa ${subsection['special_exam_info'].get('suggested_icon', 'fa-pencil-square-o')} ${subsection['special_exam_info'].get('status', 'eligible')}"
+                                                        aria-hidden="true"
+                                                    ></span>
+                                                    <span class="subtitle-name">
+                                                        ${subsection['special_exam_info'].get('short_description', '')}
+                                                    </span>
 
-                                                ## completed exam statuses should not show the due date
-                                                ## since the exam has already been submitted by the user
-                                                % if not subsection['special_exam_info'].get('in_completed_state', False):
+                                                    ## completed exam statuses should not show the due date
+                                                    ## since the exam has already been submitted by the user
+                                                    % if not subsection['special_exam_info'].get('in_completed_state', False):
+                                                        <span
+                                                            class="localized-datetime subtitle-name"
+                                                            data-datetime="${subsection.get('due')}"
+                                                            data-string="${data_string}"
+                                                            data-timezone="${user_timezone}"
+                                                            data-language="${user_language}"
+                                                        ></span>
+                                                    % endif
+                                                % else:
+                                                    ## non-graded section, we just show the exam format and the due date
+                                                    ## this is the standard case in edx-platform
                                                     <span
                                                         class="localized-datetime subtitle-name"
                                                         data-datetime="${subsection.get('due')}"
@@ -79,47 +95,69 @@ from django.utils.translation import ugettext as _
                                                         data-timezone="${user_timezone}"
                                                         data-language="${user_language}"
                                                     ></span>
-                                                % endif
-                                            % else:
-                                                ## non-graded section, we just show the exam format and the due date
-                                                ## this is the standard case in edx-platform
-                                                <span
-                                                    class="localized-datetime subtitle-name"
-                                                    data-datetime="${subsection.get('due')}"
-                                                    data-string="${data_string}"
-                                                    data-timezone="${user_timezone}"
-                                                    data-language="${user_language}"
-                                                ></span>
 
-                                                % if 'graded' in subsection and subsection['graded']:
-                                                    <span
-                                                        class="menu-icon icon fa fa-pencil-square-o"
-                                                        aria-hidden="true"
-                                                    ></span>
-                                                    <span class="sr">${_("This content is graded")}</span>
+                                                    % if 'graded' in subsection and subsection['graded']:
+                                                        <span
+                                                            class="menu-icon icon fa fa-pencil-square-o"
+                                                            aria-hidden="true"
+                                                        ></span>
+                                                        <span class="sr">${_("This content is graded")}</span>
+                                                    % endif
                                                 % endif
+                                            </span>
                                             % endif
-                                        </span>
-                                        % endif
-                                    </div> <!-- /details -->
-                                </div> <!-- /subsection-text -->
-                                <div class="subsection-actions">
-                                    ## Resume button (if last visited section)
-                                    % if subsection['current']:
-                                        <span class="sr-only">${ _("This is your last visited course section.") }</span>
-                                        <span class="resume-right">
-                                            <b>${ _("Resume Course") }</b>
-                                            <span class="icon fa fa-arrow-circle-right" aria-hidden="true"></span>
-                                        </span>
-                                    %endif
-                                </div>
-                            </a>
-                        </li>
-                    % endfor
-                </ol>
-            </li>
-        % endfor
-    </ol>
+                                        </div> <!-- /details -->
+                                    </div> <!-- /subsection-text -->
+                                    <div class="subsection-actions">
+                                        ## Resume button (if last visited section)
+                                        % if subsection['current']:
+                                            <span class="sr-only">${ _("This is your last visited course section.") }</span>
+                                            <span class="resume-right">
+                                                <b>${ _("Resume Course") }</b>
+                                                <span class="icon fa fa-arrow-circle-right" aria-hidden="true"></span>
+                                            </span>
+                                        %endif
+                                    </div>
+                                </a>
+                            </li>
+                        % endfor
+                    </ol>
+                </li>
+            % endfor
+        </ol>
+    % else:
+        <div class="well depth-0 message-area">
+            <div class="copy-large">
+                <span class="icon fa fa-calendar-o" aria-hidden="true"></span>
+                <%
+                course_started = course.start.date() <= date.today()
+                %>
+
+                % if course.start_date_is_still_default:
+                    ${_("This course has not started yet.")}
+                % elif course_started:
+                    ${_("We're still working on course content.")}
+                % else:
+                    ${Text(_("This course has not started yet, and will launch on {launch_date_html}.")).format(
+                        launch_date_html=HTML(
+                            '<span'
+                            '    class="localized-datetime start-date"'
+                            '    data-datetime="{start_date}"'
+                            '    data-format="shortDate"'
+                            '    data-timezone="{user_timezone}"'
+                            '    data-language="{user_language}"'
+                            '></span>'
+                        ).format(
+                            start_date=course.start,
+                            user_timezone=user_timezone,
+                            user_language=user_language,
+                        ),
+                    )}
+                % endif
+            </div>
+
+        </div>
+    % endif
 </main>
 
 <%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">


### PR DESCRIPTION
## [LEARNER-27](https://openedx.atlassian.net/browse/LEARNER-27)

### Description

This adds a simple message to the course home page when the course has no content.

![image](https://cloud.githubusercontent.com/assets/5985072/25410636/063ddfa2-29e6-11e7-93e7-1ba5438fc25f.png)

Note that the message varies for courses with start dates in the past, in the future, or with undefined start dates.

### Sandbox
I've created three empty courses on my sandbox:

- **No start date:** https://andy-armstrong.sandbox.edx.org/courses/course-v1:AndyA+EMPTY+101/course/
- **Future start date:** https://andy-armstrong.sandbox.edx.org/courses/course-v1:AndyA+EMPTY+102/course/
- **Past start date:** https://andy-armstrong.sandbox.edx.org/courses/course-v1:AndyA+EMPTY+103/course/

### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit violation code review process
- [ ] Unit, integration, acceptance tests as appropriate

FYI: @marcotuts 

### Post-review
- [ ] Rebase and squash commits