### PR TITLE
Update django-celery, celeryutils

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,7 +16,7 @@ dealer==2.0.4
 defusedxml==0.4.1
 django-babel-underscore==0.5.1
 markey==0.8  # From django-babel-underscore
-django-celery==3.1.16
+django-celery==3.2.1
 django-config-models==0.1.3
 django-countries==4.0
 django-extensions==1.5.9
@@ -43,7 +43,7 @@ django-waffle==0.11.1
 djangorestframework-jwt==1.8.0
 djangorestframework-oauth==1.1.0
 edx-ccx-keys==0.2.1
-edx-celeryutils==0.1.3
+edx-celeryutils==0.2.1
 edx-drf-extensions==1.2.2
 edx-i18n-tools==0.3.7
 edx-lint==0.4.3


### PR DESCRIPTION
These are the merge-able results of my investigation at https://github.com/edx/edx-platform/pull/14951.

By moving from the djcelery backend to a bare memcached backend, we'll be able to take advantage of celery chords without doing any unperformant busy-waiting.

FYI @feanil @jmbowman 