### PR TITLE
Fix batch size error and kwargification of compute_v2.

### DIFF
--- a/lms/djangoapps/grades/management/commands/compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/compute_grades.py
@@ -94,12 +94,12 @@ class Command(BaseCommand):
         enrollment_count = CourseEnrollment.objects.filter(course_id=course_key).count()
         if enrollment_count == 0:
             log.warning("No enrollments found for {}".format(course_key))
-        for offset in six.moves.range(options['start_index'], enrollment_count, options['batch_size']):
+        batch_size = self._latest_settings().batch_size if options.get('from_settings') else options['batch_size']
+        for offset in six.moves.range(options['start_index'], enrollment_count, batch_size):
             # If the number of enrollments increases after the tasks are
             # created, the most recent enrollments may not get processed.
             # This is an acceptable limitation for our known use cases.
             task_options = {'routing_key': options['routing_key']} if options.get('routing_key') else {}
-            batch_size = self._latest_settings().batch_size if options.get('from_settings') else options['batch_size']
             kwargs = {
                 'course_key': six.text_type(course_key),
                 'offset': offset,

--- a/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
@@ -118,3 +118,29 @@ class TestComputeGrades(SharedModuleStoreTestCase):
                 },),
             ],
         )
+
+    @patch('lms.djangoapps.grades.tasks.compute_grades_for_course_v2')
+    def test_tasks_fired_from_settings(self, mock_task):
+        ComputeGradesSetting.objects.create(course_ids=self.course_keys[1], batch_size=2)
+        call_command('compute_grades', '--from_settings')
+        self.assertEqual(
+            mock_task.apply_async.call_args_list,
+            [
+                ({
+                    'kwargs': {
+                        'course_key': self.course_keys[1],
+                        'batch_size': 2,
+                        'offset': 0,
+                        'estimate_first_attempted': True
+                    },
+                },),
+                ({
+                    'kwargs': {
+                        'course_key': self.course_keys[1],
+                        'batch_size': 2,
+                        'offset': 2,
+                        'estimate_first_attempted': True
+                    },
+                },),
+            ],
+        )

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -55,7 +55,7 @@ class _BaseTask(PersistOnFailureTask, LoggedTask):  # pylint: disable=abstract-m
 
 
 @task(base=_BaseTask)
-def compute_grades_for_course_v2(course_key, offset, batch_size, **kwargs):
+def compute_grades_for_course_v2(**kwargs):
     """
     Compute grades for a set of students in the specified course.
 

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -31,7 +31,7 @@ from lms.djangoapps.grades.constants import ScoreDatabaseTableEnum
 from lms.djangoapps.grades.models import PersistentCourseGrade, PersistentSubsectionGrade
 from lms.djangoapps.grades.signals.signals import PROBLEM_WEIGHTED_SCORE_CHANGED
 from lms.djangoapps.grades.tasks import (
-    compute_grades_for_course,
+    compute_grades_for_course_v2,
     recalculate_subsection_grade_v3,
     RECALCULATE_GRADE_DELAY
 )
@@ -378,7 +378,7 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
 @ddt.ddt
 class ComputeGradesForCourseTest(HasCourseWithProblemsMixin, ModuleStoreTestCase):
     """
-    Test compute_grades_for_course task.
+    Test compute_grades_for_course_v2 task.
     """
 
     ENABLED_SIGNALS = ['course_published', 'pre_publish']
@@ -392,7 +392,7 @@ class ComputeGradesForCourseTest(HasCourseWithProblemsMixin, ModuleStoreTestCase
 
     @ddt.data(*xrange(0, 12, 3))
     def test_behavior(self, batch_size):
-        result = compute_grades_for_course.delay(
+        result = compute_grades_for_course_v2.delay(
             course_key=six.text_type(self.course.id),
             batch_size=batch_size,
             offset=4,
@@ -412,7 +412,7 @@ class ComputeGradesForCourseTest(HasCourseWithProblemsMixin, ModuleStoreTestCase
         per_user_queries = 17 * min(batch_size, 6)  # No more than 6 due to offset
         with self.assertNumQueries(5 + per_user_queries):
             with check_mongo_calls(1):
-                compute_grades_for_course.delay(
+                compute_grades_for_course_v2.delay(
                     course_key=six.text_type(self.course.id),
                     batch_size=batch_size,
                     offset=6,


### PR DESCRIPTION
Uncovering issues!

* The batch size was getting pulled from settings to calculate the batch size, but not to increment the offset. (so the offset always bumped by 100)
* The kwargs were messed up on compute_grades_for_course_v2.  This didn't show up yesterday, because apparently v2 was not available on stage yet.

## Reviewers 

- [x] @iloveagent57 
FYI: @edx/educator-neem 
