### PR TITLE
[WIP][BLOCKED][LEARNER-687] Expose course instructor data through courses API endpoint

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -1,7 +1,6 @@
 """
 Course API Serializers.  Representing course catalog data
 """
-
 import urllib
 
 from django.core.urlresolvers import reverse
@@ -62,6 +61,7 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     enrollment_start = serializers.DateTimeField()
     enrollment_end = serializers.DateTimeField()
     id = serializers.CharField()  # pylint: disable=invalid-name
+    instructors = serializers.ListField()
     media = _CourseApiMediaCollectionSerializer(source='*')
     name = serializers.CharField(source='display_name_with_default_escaped')
     number = serializers.CharField(source='display_number_with_default')

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -31,6 +31,19 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
     maxDiff = 5000  # long enough to show mismatched dicts, in case of error
     serializer_class = CourseSerializer
 
+    instructor_info = {
+        'instructors': [
+            {
+                'name': 'test-instructor1',
+                'organization': 'TextX',
+            },
+            {
+                'name': 'test-instructor2',
+                'organization': 'TextX',
+            }
+        ]
+    }
+
     ENABLED_SIGNALS = ['course_published']
 
     def setUp(self):
@@ -71,6 +84,7 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
             'pacing': 'instructor',
             'mobile_available': False,
             'hidden': False,
+            'instructors': [],
 
             # 'course_id' is a deprecated field, please use 'id' instead.
             'course_id': u'edX/toy/2012_Fall',
@@ -136,6 +150,11 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
         course = self.create_course(self_paced=self_paced)
         result = self._get_result(course)
         self.assertEqual(result['pacing'], expected_pacing)
+
+    def test_course_instructors(self):
+        course = self.create_course(instructor_info=self.instructor_info)
+        result = self._get_result(course)
+        self.assertEqual(result['instructors'], self.instructor_info['instructors'])
 
 
 class TestCourseDetailSerializer(TestCourseSerializer):  # pylint: disable=test-inherits-tests

--- a/openedx/core/djangoapps/content/course_overviews/migrations/0013_courseoverview__instructor_info.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0013_courseoverview__instructor_info.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_overviews', '0012_courseoverview_eligible_for_financial_aid'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseoverview',
+            name='_instructor_info',
+            field=models.TextField(default=b'{}'),
+        ),
+    ]

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -44,7 +44,7 @@ class CourseOverview(TimeStampedModel):
         app_label = 'course_overviews'
 
     # IMPORTANT: Bump this whenever you modify this model and/or add a migration.
-    VERSION = 4
+    VERSION = 5
 
     # Cache entry versioning.
     version = IntegerField()
@@ -100,6 +100,9 @@ class CourseOverview(TimeStampedModel):
     self_paced = BooleanField(default=False)
     marketing_url = TextField(null=True)
     eligible_for_financial_aid = BooleanField(default=True)
+
+    # Course instructors
+    _instructor_info = TextField(default='{}')
 
     @classmethod
     def _create_or_update(cls, course):
@@ -189,6 +192,8 @@ class CourseOverview(TimeStampedModel):
         course_overview.effort = CourseDetails.fetch_about_attribute(course.id, 'effort')
         course_overview.course_video_url = CourseDetails.fetch_video_url(course.id)
         course_overview.self_paced = course.self_paced
+
+        course_overview._instructor_info = json.dumps(course.instructor_info or {})
 
         return course_overview
 
@@ -472,6 +477,13 @@ class CourseOverview(TimeStampedModel):
         Returns a list of ID strings for this course's prerequisite courses.
         """
         return json.loads(self._pre_requisite_courses_json)
+
+    @property
+    def instructors(self):
+        """
+        Returns a dictionary containing information about course instructors.
+        """
+        return json.loads(self._instructor_info).get('instructors', [])
 
     @classmethod
     def get_select_courses(cls, course_keys):

--- a/openedx/core/djangoapps/content/course_overviews/tests.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests.py
@@ -178,6 +178,11 @@ class CourseOverviewTestCase(ModuleStoreTestCase):
                 lambda c, field_name: get_active_web_certificate(c) is not None,
                 getattr,
             ),
+            (
+                'instructors',
+                lambda c, field_name: getattr(c, 'instructor_info').get('instructors', []),
+                getattr,
+            )
         ]
         for attribute_name, course_accessor, course_overview_accessor in others_to_test:
             course_value = course_accessor(course, attribute_name)
@@ -206,6 +211,18 @@ class CourseOverviewTestCase(ModuleStoreTestCase):
                 ],
                 "static_asset_path": "/my/abs/path",        # Absolute path
                 "certificates_show_before_end": True,
+                "instructor_info": {
+                    'instructors': [
+                        {
+                            'name': 'test-instructor1',
+                            'organization': 'TextX',
+                        },
+                        {
+                            'name': 'test-instructor2',
+                            'organization': 'TextX',
+                        }
+                    ]
+                },
             },
             {
                 "display_name": "",                         # Empty display name
@@ -216,6 +233,7 @@ class CourseOverviewTestCase(ModuleStoreTestCase):
                 "static_asset_path": "my/relative/path",    # Relative asset path
                 "certificates_show_before_end": False,
                 "catalog_visibility": CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
+                "instructor_info": {},
             },
             {
                 "display_name": "",                         # Empty display name
@@ -226,6 +244,7 @@ class CourseOverviewTestCase(ModuleStoreTestCase):
                 "static_asset_path": "",                    # Empty asset path
                 "certificates_show_before_end": False,
                 "catalog_visibility": CATALOG_VISIBILITY_ABOUT,
+                "instructor_info": {'instructors': []},
             },
             {
                 #                                           # Don't set display name
@@ -236,6 +255,7 @@ class CourseOverviewTestCase(ModuleStoreTestCase):
                 "static_asset_path": None,                  # No asset path
                 "certificates_show_before_end": False,
                 "catalog_visibility": CATALOG_VISIBILITY_NONE,
+                "instructor_info": {'a': 1, 'b': 2, 'c': 3}
             }
         ],
         [ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split]


### PR DESCRIPTION
### Reviewers:
@edx/helio 

### JIRA ticket:
https://openedx.atlassian.net/browse/LEARNER-687

### Open questions:
Q1: Where will the instructor UUID be kept?

### To-do on Course Discovery:
- [ ] Refreshing course metadata should fetch the data about instructors from the LMS Course API endpoint. Each Instructor will be represented by the Person model. `CourseRunSerializer` will have to include instructors (which is a field currently marked as deprecated).

### To-do after deploying this code:
- [ ] Run the following command: `./manage.py lms generate_course_overview --settings=aws --all`