### PR TITLE
Remove a number of unneeded super()-delegation methods

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_export.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_export.py
@@ -17,9 +17,6 @@ class TestArgParsingCourseExport(unittest.TestCase):
     """
     Tests for parsing arguments for the `export` management command
     """
-    def setUp(self):
-        super(TestArgParsingCourseExport, self).setUp()
-
     def test_no_args(self):
         """
         Test export command with no arguments

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -86,9 +86,6 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
     """
     Tests for modifying content on the first course settings page (course dates, overview, etc.).
     """
-    def setUp(self):
-        super(CourseDetailsViewTest, self).setUp()
-
     def alter_field(self, url, details, field, val):
         """
         Change the one field to the given value and then invoke the update post to see if it worked.

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -131,9 +131,6 @@ class MixedWithOptionsTestCase(MixedSplitTestCase):
     INDEX_NAME = None
     DOCUMENT_TYPE = None
 
-    def setUp(self):
-        super(MixedWithOptionsTestCase, self).setUp()
-
     def setup_course_base(self, store):
         """ base version of setup_course_base is a no-op """
         pass

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -95,9 +95,6 @@ class PreviewModuleSystem(ModuleSystem):  # pylint: disable=abstract-method
     # they are being rendered for preview (i.e. in Studio)
     is_author_mode = True
 
-    def __init__(self, **kwargs):
-        super(PreviewModuleSystem, self).__init__(**kwargs)
-
     def handler_url(self, block, handler_name, suffix='', query='', thirdparty=False):
         return reverse('preview_handler', kwargs={
             'usage_key_string': unicode(block.scope_ids.usage_id),

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -210,12 +210,6 @@ class GroupConfigurationsListHandlerTestCase(CourseTestCase, GroupConfigurations
     """
     Test cases for group_configurations_list_handler.
     """
-    def setUp(self):
-        """
-        Set up GroupConfigurationsListHandlerTestCase.
-        """
-        super(GroupConfigurationsListHandlerTestCase, self).setUp()
-
     def _url(self):
         """
         Return url for the handler.
@@ -609,10 +603,6 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
     """
     Tests for usage information of configurations and content groups.
     """
-
-    def setUp(self):
-        super(GroupConfigurationsUsageInfoTestCase, self).setUp()
-
     def _get_user_partition(self, scheme):
         """
         Returns the first user partition with the specified scheme.
@@ -947,9 +937,6 @@ class GroupConfigurationsValidationTestCase(CourseTestCase, HelperMethods):
     """
     Tests for validation in Group Configurations.
     """
-    def setUp(self):
-        super(GroupConfigurationsValidationTestCase, self).setUp()
-
     @patch('xmodule.split_test_module.SplitTestDescriptor.validate_split_test')
     def verify_validation_add_usage_info(self, expected_result, mocked_message, mocked_validation_messages):
         """

--- a/common/djangoapps/microsite_configuration/tests/backends/test_database.py
+++ b/common/djangoapps/microsite_configuration/tests/backends/test_database.py
@@ -40,10 +40,7 @@ class DatabaseMicrositeBackendTests(DatabaseMicrositeTestCase):
     """
     def setUp(self):
         super(DatabaseMicrositeBackendTests, self).setUp()
-
-    def tearDown(self):
-        super(DatabaseMicrositeBackendTests, self).tearDown()
-        microsite.clear()
+        self.addCleanup(microsite.clear)
 
     def test_get_value(self):
         """

--- a/common/djangoapps/microsite_configuration/tests/test_logic.py
+++ b/common/djangoapps/microsite_configuration/tests/test_logic.py
@@ -22,9 +22,6 @@ class TestMicrosites(DatabaseMicrositeTestCase):
     Run through some Microsite logic
     """
 
-    def setUp(self):
-        super(TestMicrosites, self).setUp()
-
     @ddt.data(*MICROSITE_BACKENDS)
     def test_get_value_for_org_when_microsite_has_no_org(self, site_backend):
         """

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -236,9 +236,6 @@ class CanonicalContentTest(SharedModuleStoreTestCase):
     set, CDN not set, etc.
     """
 
-    def setUp(self):
-        super(CanonicalContentTest, self).setUp()
-
     @classmethod
     def setUpClass(cls):
         cls.courses = {}

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -214,8 +214,7 @@ class OrgRole(RoleBase):
     """
     A named role in a particular org independent of course
     """
-    def __init__(self, role, org):
-        super(OrgRole, self).__init__(role, org)
+    pass
 
 
 @register_access_role

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -94,9 +94,6 @@ class ActivationEmailTests(TestCase):
         "This email message was automatically sent by edx.org"
     ]
 
-    def setUp(self):
-        super(ActivationEmailTests, self).setUp()
-
     def test_activation_email(self):
         self._create_account()
         self._assert_activation_email(self.ACTIVATION_SUBJECT, self.OPENEDX_FRAGMENTS)

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -41,12 +41,6 @@ class CapaModule(CapaMixin, XModule):
     js_module_name = "Problem"
     css = {'scss': [resource_string(__name__, 'css/capa/display.scss')]}
 
-    def __init__(self, *args, **kwargs):
-        """
-        Accepts the same arguments as xmodule.x_module:XModule.__init__
-        """
-        super(CapaModule, self).__init__(*args, **kwargs)
-
     def author_view(self, context):
         """
         Renders the Studio preview view.

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -341,9 +341,6 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
         key = UsageKey.from_string(ref_string)
         return key.replace(run=self.modulestore.fill_in_run(key.course_key).run)
 
-    def __setattr__(self, name, value):
-        return super(CachingDescriptorSystem, self).__setattr__(name, value)
-
     def _convert_reference_fields_to_keys(self, class_, course_key, jsonfields):
         """
         Find all fields of type reference and convert the payload into UsageKeys

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -2039,12 +2039,6 @@ class TestPublish(SplitModuleTest):
     """
     Test the publishing api
     """
-    def setUp(self):
-        super(TestPublish, self).setUp()
-
-    def tearDown(self):
-        SplitModuleTest.tearDown(self)
-
     @patch('xmodule.tabs.CourseTab.from_json', side_effect=mock_tab_from_json)
     def test_publish_safe(self, _from_json):
         """

--- a/common/test/acceptance/pages/lms/dashboard.py
+++ b/common/test/acceptance/pages/lms/dashboard.py
@@ -11,14 +11,6 @@ class DashboardPage(PageObject):
     Student dashboard, where the student can view
     courses she/he has registered for.
     """
-    def __init__(self, browser):
-        """Initialize the page.
-
-        Arguments:
-            browser (Browser): The browser instance.
-        """
-        super(DashboardPage, self).__init__(browser)
-
     url = "{base}/dashboard".format(base=BASE_URL)
 
     def is_browser_on_page(self):

--- a/common/test/acceptance/pages/lms/index.py
+++ b/common/test/acceptance/pages/lms/index.py
@@ -14,14 +14,6 @@ class IndexPage(PageObject):
     """
     LMS index (home) page, the default landing page for Open edX users when they are not logged in
     """
-    def __init__(self, browser):
-        """Initialize the page.
-
-        Arguments:
-            browser (Browser): The browser instance.
-        """
-        super(IndexPage, self).__init__(browser)
-
     url = "{base}/".format(base=BASE_URL)
 
     def is_browser_on_page(self):

--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -71,9 +71,6 @@ class ResetPasswordPage(PageObject):
     """
     url = BASE_URL + "/login#forgot-password-modal"
 
-    def __init__(self, browser):
-        super(ResetPasswordPage, self).__init__(browser)
-
     def is_browser_on_page(self):
         return (
             self.q(css="#login-anchor").is_present() and

--- a/common/test/acceptance/pages/lms/pay_and_verify.py
+++ b/common/test/acceptance/pages/lms/pay_and_verify.py
@@ -171,9 +171,6 @@ class FakeSoftwareSecureVerificationPage(PageObject):
 
     url = BASE_URL + '/verify_student/software-secure-fake-response'
 
-    def __init__(self, browser):
-        super(FakeSoftwareSecureVerificationPage, self).__init__(browser)
-
     def is_browser_on_page(self):
         """ Determine if browser is on the page. """
         message = self.q(css='BODY').text[0]

--- a/common/test/acceptance/pages/studio/move_xblock.py
+++ b/common/test/acceptance/pages/studio/move_xblock.py
@@ -10,13 +10,6 @@ class MoveModalView(PageObject):
     A base class for move xblock
     """
 
-    def __init__(self, browser):
-        """
-        Arguments:
-            browser (selenium.webdriver): The Selenium-controlled browser that this page is loaded in.
-        """
-        super(MoveModalView, self).__init__(browser)
-
     def is_browser_on_page(self):
         return self.q(css='.modal-window.move-modal').present
 

--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -1109,9 +1109,6 @@ class SubsectionOutlineModal(CourseOutlineModal):
     Subclass to handle a few special cases with subsection modals.
     """
 
-    def __init__(self, page):
-        super(SubsectionOutlineModal, self).__init__(page)
-
     @property
     def is_explicitly_locked(self):
         """

--- a/common/test/acceptance/pages/xblock/crowdsourcehinter_problem.py
+++ b/common/test/acceptance/pages/xblock/crowdsourcehinter_problem.py
@@ -11,13 +11,6 @@ class CrowdsourcehinterProblemPage(PageObject):
 
     url = None
 
-    def __init__(self, browser):
-        """
-        Args:
-            browser (selenium.webdriver): The Selenium-controlled browser that this page is loaded in.
-        """
-        super(CrowdsourcehinterProblemPage, self).__init__(browser)
-
     def is_browser_on_page(self):
         return len(self.browser.find_elements_by_class_name('crowdsourcehinter_block')) > 0
 

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -723,12 +723,6 @@ class UniqueCourseTest(AcceptanceTest):
     Test that provides a unique course ID.
     """
 
-    def __init__(self, *args, **kwargs):
-        """
-        Create a unique course ID.
-        """
-        super(UniqueCourseTest, self).__init__(*args, **kwargs)
-
     def setUp(self):
         super(UniqueCourseTest, self).setUp()
 

--- a/common/test/acceptance/tests/lms/test_bookmarks.py
+++ b/common/test/acceptance/tests/lms/test_bookmarks.py
@@ -132,12 +132,6 @@ class BookmarksTest(BookmarksTestMixin):
     Tests to verify bookmarks functionality.
     """
 
-    def setUp(self):
-        """
-        Initialize test setup.
-        """
-        super(BookmarksTest, self).setUp()
-
     def _breadcrumb(self, num_units, modified_name=None):
         """
         Creates breadcrumbs for the first `num_units`

--- a/common/test/acceptance/tests/lms/test_lms_course_home.py
+++ b/common/test/acceptance/tests/lms/test_lms_course_home.py
@@ -127,9 +127,6 @@ class CourseHomeA11yTest(CourseHomeBaseTest):
     Tests the accessibility of the course home page with course outline.
     """
 
-    def setUp(self):
-        super(CourseHomeA11yTest, self).setUp()
-
     def test_course_home_a11y(self):
         """
         Test the accessibility of the course home page with course outline.

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -1239,9 +1239,6 @@ class EcommerceTest(BaseInstructorDashboardTest):
     """
     Bok Choy tests for the "E-Commerce" tab.
     """
-    def setUp(self):
-        super(EcommerceTest, self).setUp()
-
     def setup_course(self, course_number):
         """
         Sets up the course

--- a/common/test/acceptance/tests/video/test_studio_video_editor.py
+++ b/common/test/acceptance/tests/video/test_studio_video_editor.py
@@ -13,9 +13,6 @@ class VideoEditorTest(CMSVideoBaseTest):
     CMS Video Editor Test Class
     """
 
-    def setUp(self):
-        super(VideoEditorTest, self).setUp()
-
     def _create_video_component(self, subtitles=False):
         """
         Create a video component and navigate to unit page

--- a/common/test/acceptance/tests/video/test_studio_video_transcript.py
+++ b/common/test/acceptance/tests/video/test_studio_video_transcript.py
@@ -28,9 +28,6 @@ class VideoTranscriptTest(CMSVideoBaseTest):
     CMS Video Transcript Test Class
     """
 
-    def setUp(self):
-        super(VideoTranscriptTest, self).setUp()
-
     def _create_video_component(self, subtitles=False, subtitle_id='3_yD_cEKoCk'):
         """
         Create a video component and navigate to unit page

--- a/common/test/acceptance/tests/video/test_video_handout.py
+++ b/common/test/acceptance/tests/video/test_video_handout.py
@@ -13,9 +13,6 @@ class VideoHandoutTest(CMSVideoBaseTest):
     CMS Video Handout Test Class
     """
 
-    def setUp(self):
-        super(VideoHandoutTest, self).setUp()
-
     def _create_course_unit_with_handout(self, handout_filename, save_settings=True):
         """
         Create a course with unit and also upload handout

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -218,9 +218,6 @@ class VideoBaseTest(UniqueCourseTest):
 class YouTubeVideoTest(VideoBaseTest):
     """ Test YouTube Video Player """
 
-    def setUp(self):
-        super(YouTubeVideoTest, self).setUp()
-
     def test_youtube_video_rendering_wo_html5_sources(self):
         """
         Scenario: Video component is rendered in the LMS in Youtube mode without HTML5 sources
@@ -944,9 +941,6 @@ class YouTubeVideoTest(VideoBaseTest):
 class YouTubeHtml5VideoTest(VideoBaseTest):
     """ Test YouTube HTML5 Video Player """
 
-    def setUp(self):
-        super(YouTubeHtml5VideoTest, self).setUp()
-
     @flaky  # TODO fix this, see TNL-1642
     def test_youtube_video_rendering_with_unsupported_sources(self):
         """
@@ -965,9 +959,6 @@ class YouTubeHtml5VideoTest(VideoBaseTest):
 @attr(shard=4)
 class Html5VideoTest(VideoBaseTest):
     """ Test HTML5 Video Player """
-
-    def setUp(self):
-        super(Html5VideoTest, self).setUp()
 
     def test_autoplay_disabled_for_video_component(self):
         """
@@ -1154,9 +1145,6 @@ class Html5VideoTest(VideoBaseTest):
 class YouTubeQualityTest(VideoBaseTest):
     """ Test YouTube Video Quality Button """
 
-    def setUp(self):
-        super(YouTubeQualityTest, self).setUp()
-
     @skip_if_browser('firefox')
     def test_quality_button_visibility(self):
         """
@@ -1204,9 +1192,6 @@ class DragAndDropTest(VideoBaseTest):
     """
     Tests draggability of closed captions within videos.
     """
-    def setUp(self):
-        super(DragAndDropTest, self).setUp()
-
     def test_if_captions_are_draggable(self):
         """
         Loads transcripts so that closed-captioning is available.

--- a/common/test/acceptance/tests/video/test_video_times.py
+++ b/common/test/acceptance/tests/video/test_video_times.py
@@ -7,9 +7,6 @@ from common.test.acceptance.tests.video.test_video_module import VideoBaseTest
 class VideoTimesTest(VideoBaseTest):
     """ Test Video Player Times """
 
-    def setUp(self):
-        super(VideoTimesTest, self).setUp()
-
     def test_video_start_time(self):
         """
         Scenario: Start time works for Youtube video

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -630,9 +630,6 @@ class GenerateExampleCertificatesTest(TestCase):
 
     COURSE_KEY = CourseLocator(org='test', course='test', run='test')
 
-    def setUp(self):
-        super(GenerateExampleCertificatesTest, self).setUp()
-
     def test_generate_example_certs(self):
         # Generate certificates for the course
         CourseModeFactory.create(course_id=self.COURSE_KEY, mode_slug=CourseMode.HONOR)
@@ -717,9 +714,6 @@ class CertificatesBrandingTest(TestCase):
     """Test certificates branding. """
 
     COURSE_KEY = CourseLocator(org='test', course='test', run='test')
-
-    def setUp(self):
-        super(CertificatesBrandingTest, self).setUp()
 
     @set_microsite(settings.MICROSITE_CONFIGURATION['test_site']['domain_prefix'])
     def test_certificate_header_data(self):

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -257,12 +257,6 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleSt
             data="OOGIE BLOOGIE", display_name="overview"
         )
 
-    def setUp(self):
-        """
-        Set up the tests
-        """
-        super(AboutWithCappedEnrollmentsTestCase, self).setUp()
-
     def test_enrollment_cap(self):
         """
         This test will make sure that enrollment caps are enforced
@@ -310,9 +304,6 @@ class AboutWithInvitationOnly(SharedModuleStoreTestCase):
             display_name="overview"
         )
 
-    def setUp(self):
-        super(AboutWithInvitationOnly, self).setUp()
-
     def test_invitation_only(self):
         """
         Test for user not logged in, invitation only course.
@@ -359,9 +350,6 @@ class AboutTestCaseShibCourse(LoginEnrollmentTestCase, SharedModuleStoreTestCase
             category="about", parent_location=cls.course.location,
             data="OOGIE BLOOGIE", display_name="overview"
         )
-
-    def setUp(self):
-        super(AboutTestCaseShibCourse, self).setUp()
 
     def test_logged_in_shib_course(self):
         """

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -169,10 +169,6 @@ class TestLTIModuleListing(SharedModuleStoreTestCase):
             publish_item=False,
         )
 
-    def setUp(self):
-        """Create course, 2 chapters, 2 sections"""
-        super(TestLTIModuleListing, self).setUp()
-
     def expected_handler_url(self, handler):
         """convenience method to get the reversed handler urls"""
         return "https://{}{}".format(settings.SITE_NAME, reverse(

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -59,9 +59,6 @@ class TestSites(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             emit_signals=True,
         )
 
-    def setUp(self):
-        super(TestSites, self).setUp()
-
     def setup_users(self):
         # Create student accounts and activate them.
         for i in range(len(self.STUDENT_INFO)):

--- a/lms/djangoapps/courseware/tests/test_middleware.py
+++ b/lms/djangoapps/courseware/tests/test_middleware.py
@@ -22,9 +22,6 @@ class CoursewareMiddlewareTestCase(SharedModuleStoreTestCase):
         super(CoursewareMiddlewareTestCase, cls).setUpClass()
         cls.course = CourseFactory.create()
 
-    def setUp(self):
-        super(CoursewareMiddlewareTestCase, self).setUp()
-
     def test_process_404(self):
         """A 404 should not trigger anything"""
         request = RequestFactory().get("dummy_url")

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -1155,9 +1155,6 @@ class CreateThreadUnicodeTestCase(
         cls.student = UserFactory.create()
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
-    def setUp(self):
-        super(CreateThreadUnicodeTestCase, self).setUp()
-
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request,):
         """
@@ -1199,9 +1196,6 @@ class UpdateThreadUnicodeTestCase(
         seed_permissions_roles(cls.course.id)
         cls.student = UserFactory.create()
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
-
-    def setUp(self):
-        super(UpdateThreadUnicodeTestCase, self).setUp()
 
     @patch('django_comment_client.utils.get_discussion_categories_ids', return_value=["test_commentable"])
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
@@ -1245,9 +1239,6 @@ class CreateCommentUnicodeTestCase(
         seed_permissions_roles(cls.course.id)
         cls.student = UserFactory.create()
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
-
-    def setUp(self):
-        super(CreateCommentUnicodeTestCase, self).setUp()
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
@@ -1297,9 +1288,6 @@ class UpdateCommentUnicodeTestCase(
         cls.student = UserFactory.create()
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
 
-    def setUp(self):
-        super(UpdateCommentUnicodeTestCase, self).setUp()
-
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
         self._set_mock_request_data(mock_request, {
@@ -1340,9 +1328,6 @@ class CreateSubCommentUnicodeTestCase(
         seed_permissions_roles(cls.course.id)
         cls.student = UserFactory.create()
         CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
-
-    def setUp(self):
-        super(CreateSubCommentUnicodeTestCase, self).setUp()
 
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def _test_unicode_data(self, text, mock_request):
@@ -1667,9 +1652,6 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
         cls.student.roles.add(Role.objects.get(name="Student", course_id=cls.course.id))
         CourseAccessRoleFactory(course_id=cls.course.id, user=cls.student, role='Wizard')
 
-    def setUp(self):
-        super(ForumEventTestCase, self).setUp()
-
     @patch('eventtracking.tracker.emit')
     @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
     def test_thread_event(self, __, mock_emit):
@@ -1851,9 +1833,6 @@ class UsersEndpointTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockRe
         cls.enrollment = CourseEnrollmentFactory(user=cls.student, course_id=cls.course.id)
         cls.other_user = UserFactory.create(username="other")
         CourseEnrollmentFactory(user=cls.other_user, course_id=cls.course.id)
-
-    def setUp(self):
-        super(UsersEndpointTestCase, self).setUp()
 
     def set_post_counts(self, mock_request, threads_count=1, comments_count=1):
         """

--- a/lms/djangoapps/grades/new/course_grade.py
+++ b/lms/djangoapps/grades/new/course_grade.py
@@ -181,9 +181,6 @@ class ZeroCourseGrade(CourseGradeBase):
     Course Grade class for Zero-value grades when no problems were
     attempted in the course.
     """
-    def __init__(self, user, course_data):
-        super(ZeroCourseGrade, self).__init__(user, course_data)
-
     def _get_subsection_grade(self, subsection):
         return ZeroSubsectionGrade(subsection, self.course_data)
 

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -88,9 +88,6 @@ class BlockRecordTest(GradesModelTestCase):
     """
     Test the BlockRecord model.
     """
-    def setUp(self):
-        super(BlockRecordTest, self).setUp()
-
     def test_creation(self):
         """
         Tests creation of a BlockRecord.

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -733,9 +733,6 @@ class TestGetEmailParams(SharedModuleStoreTestCase):
         cls.course_about_url = cls.course_url + 'about'
         cls.registration_url = u'https://{}/register'.format(site)
 
-    def setUp(self):
-        super(TestGetEmailParams, self).setUp()
-
     def test_normal_params(self):
         # For a normal site, what do we expect to get for the URLs?
         # Also make sure `auto_enroll` is properly passed through.

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -172,12 +172,6 @@ class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCa
     """
     SUCCESS_ENROLLED_STAFF_MONGO_COUNT = 9
 
-    def setUp(self):
-        """
-        Set up tests
-        """
-        super(LtiLaunchTestRender, self).setUp()
-
     def get_response(self, usage_key, url_encoded_params=None):
         """
         Overridable method to get the response from the endpoint that is being tested.

--- a/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
+++ b/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
@@ -11,9 +11,6 @@ class TestMobilePlatform(TestCase):
     """
     Tests for platform against mobile app request
     """
-    def setUp(self):
-        super(TestMobilePlatform, self).setUp()
-
     @ddt.data(
         ("edX/org.edx.mobile (0.1.5; OS Version 9.2 (Build 13C75))", "iOS", "0.1.5"),
         ("edX/org.edx.mobile (1.01.1; OS Version 9.2 (Build 13C75))", "iOS", "1.01.1"),

--- a/lms/djangoapps/mobile_api/tests/test_model.py
+++ b/lms/djangoapps/mobile_api/tests/test_model.py
@@ -13,9 +13,6 @@ class TestAppVersionConfigModel(TestCase):
     """
     Tests for app version configuration model
     """
-    def setUp(self):
-        super(TestAppVersionConfigModel, self).setUp()
-
     def set_app_version_config(self):
         """ Creates configuration data for platform versions """
         AppVersionConfig(platform="ios", version="1.1.1", expire_at=None, enabled=True).save()

--- a/openedx/core/djangoapps/bookmarks/tests/test_api.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_api.py
@@ -43,9 +43,6 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
     """
     These tests cover the parts of the API methods.
     """
-    def setUp(self):
-        super(BookmarksAPITests, self).setUp()
-
     def test_get_bookmark(self):
         """
         Verifies that get_bookmark returns data as expected.

--- a/openedx/core/djangoapps/bookmarks/tests/test_models.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_models.py
@@ -431,9 +431,6 @@ class XBlockCacheModelTest(ModuleStoreTestCase):
         [unicode(SECTION2_USAGE_KEY), 'Section 2'],
     ]
 
-    def setUp(self):
-        super(XBlockCacheModelTest, self).setUp()
-
     def assert_xblock_cache_data(self, xblock_cache, data):
         """
         Assert that the XBlockCache object values match.

--- a/openedx/core/djangoapps/xmodule_django/models.py
+++ b/openedx/core/djangoapps/xmodule_django/models.py
@@ -18,13 +18,6 @@ class NoneToEmptyManager(models.Manager):
     A :class:`django.db.models.Manager` that has a :class:`NoneToEmptyQuerySet`
     as its `QuerySet`, initialized with a set of specified `field_names`.
     """
-    def __init__(self):
-        """
-        Args:
-            field_names: The list of field names to initialize the :class:`NoneToEmptyQuerySet` with.
-        """
-        super(NoneToEmptyManager, self).__init__()
-
     def get_queryset(self):
         """
         Returns the result of NoneToEmptyQuerySet instead of a regular QuerySet.

--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -53,9 +53,6 @@ class TestXblockUtils(SharedModuleStoreTestCase):
             run='2015'
         )
 
-    def setUp(self):
-        super(TestXblockUtils, self).setUp()
-
     def create_fragment(self, content=None):
         """
         Create a fragment.

--- a/openedx/tests/xblock_integration/xblock_testcase.py
+++ b/openedx/tests/xblock_integration/xblock_testcase.py
@@ -370,12 +370,6 @@ class XBlockTestCase(XBlockStudentTestCaseMixin,
             raise unittest.SkipTest('Test only valid in lms')
         super(XBlockTestCase, cls).setUpClass()
 
-    def setUp(self):
-        """
-        Call setups of all parents
-        """
-        super(XBlockTestCase, self).setUp()
-
     def get_handler_url(self, handler, xblock_name=None):
         """
         Get url for the specified xblock handler


### PR DESCRIPTION
There's no need to define a method which only has one line, a call to super() with the same arguments.  Get rid of them.