### PR TITLE
Set the MEDIA_ROOT and MEDIA_URL settings in the cms.envs.aws module

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -106,6 +106,10 @@ if STATIC_URL_BASE:
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = ENV_TOKENS.get('DEFAULT_COURSE_ABOUT_IMAGE_URL', DEFAULT_COURSE_ABOUT_IMAGE_URL)
 
+# MEDIA_ROOT specifies the directory where user-uploaded files are stored.
+MEDIA_ROOT = ENV_TOKENS.get('MEDIA_ROOT', MEDIA_ROOT)
+MEDIA_URL = ENV_TOKENS.get('MEDIA_URL', MEDIA_URL)
+
 # GITHUB_REPO_ROOT is the base directory
 # for course data
 GITHUB_REPO_ROOT = ENV_TOKENS.get('GITHUB_REPO_ROOT', GITHUB_REPO_ROOT)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -61,6 +61,10 @@ from lms.envs.common import (
     ENABLE_CREDIT_ELIGIBILITY, YOUTUBE_API_KEY,
     DEFAULT_COURSE_ABOUT_IMAGE_URL,
 
+    # User-uploaded content
+    MEDIA_ROOT,
+    MEDIA_URL,
+
     # Django REST framework configuration
     REST_FRAMEWORK,
 

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -10,7 +10,6 @@ from .aws import *  # pylint: disable=wildcard-import, unused-wildcard-import
 del DEFAULT_FILE_STORAGE
 COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 USER_TASKS_ARTIFACT_STORAGE = COURSE_IMPORT_EXPORT_STORAGE
-MEDIA_ROOT = "/edx/var/edxapp/uploads"
 
 DEBUG = True
 USE_I18N = True


### PR DESCRIPTION
In a [sandbox](https://openedx.atlassian.net/wiki/display/OpenOPS/Native+Open+edX+Ubuntu+16.04+64+bit+Installation) setup, the course export functionality throws this error if the file system is used as storage:
![local storage export error](https://cloud.githubusercontent.com/assets/560781/25507889/df296f80-2b6b-11e7-9dfb-b4e744039c74.png)
This is caused because the `MEDIA_ROOT` and `MEDIA_URL` settings are not set explicitly in the cms configuration and their default values (empty strings) are used to calculate the [base location](https://github.com/django/django/blob/1.8.18/django/utils/_os.py#L37-L38) of the storage, breaking the Celery task.

This PR reuses both settings from the `lms.envs.common` module and allows to override them through `ENV_TOKENS` fixing this permission issue.

**Sandbox URL**:

LMS: https://pr15005.sandbox.opencraft.hosting/
Studio: https://studio-pr15005.sandbox.opencraft.hosting/

**Testing instructions**

1. Set up a sandbox
2. Set `COURSE_IMPORT_EXPORT_BUCKET` to null in the `/edx/app/edxapp/cms.env.json` file. This will make the sandbox to use the file system as storage for the course exports.
3. Restart the supervisor service
4. Try to export the demo course and you should see the permission error in the screenshot above
5. Set this branch in `/edx/app/edxapp/edx-platform`
6. Restart the supervisor service
7. Exporting the demo course should work now  

**Reviewers**
- [ ] @bradenmacdonald 