### PR TITLE
fix invalid numeric ids, bump edx-sga, bump custom a11y rules

### DIFF
--- a/common/lib/capa/capa/templates/choicegroup.html
+++ b/common/lib/capa/capa/templates/choicegroup.html
@@ -9,7 +9,7 @@
 <div class="choicegroup capa_inputtype" id="inputtype_${id}">
     <fieldset ${describedby_html}>
       % if response_data['label']:
-        <legend id="${id}-legend" class="response-fieldset-legend field-group-hd">${response_data['label']}</legend>
+        <legend id="legend-${id}" class="response-fieldset-legend field-group-hd">${response_data['label']}</legend>
       % endif
       % for description_id, description_text in response_data['descriptions'].items():
         <p class="question-description" id="${description_id}">${description_text}</p>
@@ -20,7 +20,7 @@
               label_class = 'response-label field-label label-inline'
             %>
 
-            <label id="${id}-${choice_id}-label"
+            <label id="label-${id}-${choice_id}"
                 ## If the student has selected this choice...
                 % if is_radio_input(choice_id):
 
@@ -62,6 +62,6 @@
     <div class="capa_alert">${submitted_message}</div>
     %endif
     % if msg:
-    <span class="message" aria-describedby="${id}-legend" tabindex="-1">${HTML(msg)}</span>
+    <span class="message" aria-describedby="legend-${id}" tabindex="-1">${HTML(msg)}</span>
     % endif
 </div>

--- a/common/lib/capa/capa/templates/choicetext.html
+++ b/common/lib/capa/capa/templates/choicetext.html
@@ -24,7 +24,7 @@ from openedx.core.djangolib.markup import HTML
                 % endif
             % endif
             >
-            <input class="ctinput" type="${input_type}" name="choiceinput_${id}" id="${choice_id}" value="${choice_id}"
+            <input class="ctinput" type="${input_type}" name="choiceinput_${id}" id="ctinput_${choice_id}" value="${choice_id}"
 
             % if choice_id in value:
             checked="true"
@@ -39,7 +39,7 @@ from openedx.core.djangolib.markup import HTML
                 % else:
                     <% my_id = content_node.get('contents','') %>
                     <% my_val = value.get(my_id,'') %>
-                    <input class="ctinput" type="text" name="${content_node['contents']}" id="${content_node['contents']}" value="${my_val|h}"/>
+                    <input class="ctinput" type="text" name="${content_node['contents']}" id="ctinput_${content_node['contents']}" value="${my_val|h}"/>
                 %endif
                 <span class="mock_label">
                     ${content_node['tail_text']}

--- a/common/static/js/capa/choicetextinput.js
+++ b/common/static/js/capa/choicetextinput.js
@@ -10,15 +10,15 @@
         var all_inputs = $('input.ctinput', parent);
         var user_inputs = {};
         $(all_inputs).each(function(index, elt) {
-            var node = $(elt);
-            var name = node.attr('id');
-            var val = node.val();
-            var radio_value = node.attr('value');
-            var type = node.attr('type');
-            var is_checked = node.attr('checked');
+            var $node = $(elt);
+            var name = $node.attr('id').replace('ctinput_', '');
+            var val = $node.val();
+            var radioValue = $node.attr('value');
+            var type = $node.attr('type');
+            var isChecked = $node.attr('checked');
             if (type === 'radio' || type === 'checkbox') {
-                if (is_checked === 'checked' || is_checked === 'true') {
-                    user_inputs[name] = radio_value;
+                if (isChecked === 'checked' || isChecked === 'true') {
+                    user_inputs[name] = radioValue;
                 }
             } else {
                 user_inputs[name] = val;

--- a/lms/djangoapps/courseware/features/problems_setup.py
+++ b/lms/djangoapps/courseware/features/problems_setup.py
@@ -390,7 +390,7 @@ def inputfield(course, problem_type, choice=None, input_num=1):
     ptype = problem_type.replace(" ", "_")
     # this is necessary due to naming requirement for this problem type
     if problem_type in ("radio_text", "checkbox_text"):
-        selector_template = "input#{}_2_{input}"
+        selector_template = "input#ctinput_{}_2_{input}"
     else:
         selector_template = "input#input_{}_2_{input}"
 
@@ -404,7 +404,7 @@ def inputfield(course, problem_type, choice=None, input_num=1):
         sel = sel + base + str(choice)
 
     # If the input element doesn't exist, fail immediately
-    assert world.is_css_present(sel)
+    assert world.is_css_present(sel, wait_time=4)
 
     # Retrieve the input element
     return sel
@@ -446,7 +446,7 @@ def assert_choicetext_values(course, problem_type, choices, expected_values):
         "choiceinput_0_numtolerance_input_0",
         "choiceinput_1_numtolerance_input_0"
     ]
-    for this_choice in all_choices:
+    for this_choice in all_inputs:
         element = world.css_find(inputfield(course, problem_type, choice=this_choice))
 
         if this_choice in choices:

--- a/lms/templates/courseware/xqa_interface.html
+++ b/lms/templates/courseware/xqa_interface.html
@@ -5,26 +5,26 @@
 <script type="text/javascript">
 
 function setup_debug(element_id, edit_link, staff_context){
-    var staffDebugTrigger = $('#' + element_id + '_trig'),
-        xqaLogTrigger = $('#' + element_id + '_xqa_log'),
-        historyTrigger = $("#" + element_id + "_history_trig"),
-        debugModalSelector = '#' + element_id + '_debug',
-        historyModalSelector = '#' + element_id + '_history',
-        xqaModalSelector = '#' + element_id + '_xqa-modal',
+    var staffDebugTrigger = $('#trig_' + element_id),
+        xqaLogTrigger = $('#xqa_log_' + element_id),
+        historyTrigger = $("#history_trig_" + element_id),
+        debugModalSelector = '#debug_' + element_id,
+        historyModalSelector = '#history_' + element_id,
+        xqaModalSelector = '#xqa-modal_' + element_id,
         leanOverlaySelector = $('#lean_overlay');
 
     staffDebugTrigger.leanModal();
     xqaLogTrigger.leanModal();
-    $('#' + element_id + '_xqa_form').submit(function () {sendlog(element_id, edit_link, staff_context);});
+    $('#xqa_form_' + element_id).submit(function () {sendlog(element_id, edit_link, staff_context);});
 
     historyTrigger.leanModal();
 
     $('#' + element_id + '_history_form').submit(
         function () {
-            var username = $("#" + element_id + "_history_student_username").val();
-            var location = $("#" + element_id + "_history_location").val();
+            var username = $("#history_student_username_" + element_id).val();
+            var location = $("#history_location_" + element_id).val();
 
-            $("#" + element_id + "_history_text").load('/courses/' + "${unicode(course.id) | u}" +
+            $("#history_text_" + element_id).load('/courses/' + "${unicode(course.id) | u}" +
                 "/submission_history/" + username + "/" + location);
             return false;
         }
@@ -66,8 +66,8 @@ function sendlog(element_id, edit_link, staff_context){
             'return' : 'query',
             format : 'html',
             email : staff_context.user.email,
-            tag:$('#' + element_id + '_xqa_tag').val(),
-            entry: $('#' + element_id + '_xqa_entry').val()
+            tag:$('#xqa_tag_' + element_id).val(),
+            entry: $('#xqa_entry_' + element_id).val()
         };
 
     $.ajax({
@@ -81,7 +81,7 @@ function sendlog(element_id, edit_link, staff_context){
             xhr.setRequestHeader ("Authorization", "Basic eHFhOmFnYXJ3YWw="); },
         timeout : 1000,
         success: function(result) {
-                $('#' + element_id + '_xqa_log_data').html(result);
+                $('#xqa_log_data_' + element_id).html(result);
         },
         error: function() {
             alert('Error: cannot connect to XQA server. Check the value of the XQA_SERVER setting.');
@@ -108,7 +108,7 @@ function getlog(element_id, staff_context){
         dataType: 'jsonp',
         timeout : 1000,
         success: function(result) {
-            $('#' + element_id + '_xqa_log_data').html(result);
+            $('#xqa_log_data_' + element_id).html(result);
         },
         error: function() {
             alert('Error: cannot connect to XQA server. Check the value of the XQA_SERVER setting.');

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -5,11 +5,11 @@ from openedx.core.djangolib.markup import HTML
 %>
 
 <%namespace name='static' file='static_content.html'/>
-<h3 class="hd hd-3 problem-header" id="${ short_id }-problem-title" aria-describedby="${ id }-problem-progress" tabindex="-1">
+<h3 class="hd hd-3 problem-header" id="problem-title-${ short_id }" aria-describedby="problem-progress-${ id }" tabindex="-1">
   ${ problem['name'] }
 </h3>
 
-<div class="problem-progress" id="${ id }-problem-progress"></div>
+<div class="problem-progress" id="problem-progress-${ id }"></div>
 
 <div class="problem">
   ${ HTML(problem['html']) }
@@ -59,7 +59,7 @@ from openedx.core.djangolib.markup import HTML
       % endif
       % if answer_available:
       <span class="problem-action-button-wrapper">
-          <button type="button" class="show problem-action-btn btn-default btn-small" aria-describedby="${ short_id }-problem-title"><span class="icon fa fa-info-circle" aria-hidden="true"></span><span class="show-label">${_('Show Answer')}</span></button>
+          <button type="button" class="show problem-action-btn btn-default btn-small" aria-describedby="problem-title-${ short_id }"><span class="icon fa fa-info-circle" aria-hidden="true"></span><span class="show-label">${_('Show Answer')}</span></button>
       </span>
       % endif
     </div>

--- a/lms/templates/problem_ajax.html
+++ b/lms/templates/problem_ajax.html
@@ -1,5 +1,5 @@
 <div id="problem_${element_id}" class="problems-wrapper" role="group"
-     aria-labelledby="${element_id}-problem-title"
+     aria-labelledby="problem-title-${element_id}"
      data-problem-id="${id}" data-url="${ajax_url}"
      data-problem-score="${current_score}"
      data-problem-total-possible="${total_possible}"

--- a/lms/templates/problem_notifications.html
+++ b/lms/templates/problem_notifications.html
@@ -6,7 +6,7 @@
       ${'' if not is_hidden else 'is-hidden' }"
      tabindex="-1">
     <span class="icon fa ${notification_icon}" aria-hidden="true"></span>
-    <span class="notification-message" aria-describedby="${ short_id }-problem-title">${notification_message}
+    <span class="notification-message" aria-describedby="problem-title-${ short_id }">${notification_message}
     </span>
     <div class="notification-btn-wrapper">
         % if notification_name is 'hint':

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -11,49 +11,49 @@ ${block_content}
   <div>
       <a href="${edit_link}">Edit</a>
       % if xqa_key:
-          / <a href="#${element_id}_xqa-modal" onclick="javascript:getlog('${element_id}', {
+          / <a href="#xqa-modal_${element_id}" onclick="javascript:getlog('${element_id}', {
           'location': '${location | h}',
           'xqa_key': '${xqa_key | h}',
           'category': '${category | h}',
           'user': '${user | h}'
-       })" id="${element_id}_xqa_log">QA</a>
+       })" id="xqa_log_${element_id}">QA</a>
       % endif
   </div>
 %  endif
 %  if not disable_staff_debug_info:
 <div class="wrap-instructor-info">
-  <a class="instructor-info-action" href="#${element_id}_debug" id="${element_id}_trig">${_("Staff Debug Info")}</a>
+  <a class="instructor-info-action" href="#debug_${element_id}" id="trig_${element_id}">${_("Staff Debug Info")}</a>
 
   %  if settings.FEATURES.get('ENABLE_STUDENT_HISTORY_VIEW') and \
     location.category == 'problem':
-    <a class="instructor-info-action" href="#${element_id}_history" id="${element_id}_history_trig">${_("Submission history")}</a>
+    <a class="instructor-info-action" href="#history_${element_id}" id="history_trig_${element_id}">${_("Submission history")}</a>
   %  endif
 </div>
 %  endif
 
-<div aria-hidden="true" role="dialog" tabindex="-1" id="${element_id}_xqa-modal" class="modal xqa-modal">
+<div aria-hidden="true" role="dialog" tabindex="-1" id="xqa-modal_${element_id}" class="modal xqa-modal">
   <div class="inner-wrapper">
     <header>
       <h2>${_("{platform_name} Content Quality Assessment").format(platform_name=settings.PLATFORM_NAME)}</h2>
     </header>
 
-    <form id="${element_id}_xqa_form" class="xqa_form">
-      <label for="${element_id}_xqa_entry">${_("Comment")}</label>
-      <input tabindex="0" id="${element_id}_xqa_entry" type="text" placeholder="${_('comment')}">
-      <label for="${element_id}_xqa_tag">${_("Tag")}</label>
+    <form id="xqa_form_${element_id}" class="xqa_form">
+      <label for="xqa_entry_${element_id}">${_("Comment")}</label>
+      <input tabindex="0" id="xqa_entry_${element_id}" type="text" placeholder="${_('comment')}">
+      <label for="xqa_tag_${element_id}">${_("Tag")}</label>
       <span style="color:black;vertical-align: -10pt">${_('Optional tag (eg "done" or "broken"):') + '&nbsp; '}      </span>
-      <input id="${element_id}_xqa_tag" type="text" placeholder="${_('tag')}" style="width:80px;display:inline">
+      <input id="xqa_tag_${element_id}" type="text" placeholder="${_('tag')}" style="width:80px;display:inline">
       <div class="submit">
         <button name="submit" type="submit">${_('Add comment')}</button>
       </div>
       <hr>
-      <div id="${element_id}_xqa_log_data"></div>
+      <div id="xqa_log_data_${element_id}"></div>
     </form>
 
   </div>
 </div>
 
-<div aria-hidden="true" role="dialog" tabindex="-1" class="modal staff-modal" id="${element_id}_debug" >
+<div aria-hidden="true" role="dialog" tabindex="-1" class="modal staff-modal" id="debug_${element_id}">
   <div class="inner-wrapper">
     <header>
       <h2>${_('Staff Debug')}</h2>
@@ -110,26 +110,26 @@ ${block_content}
   </div>
 </div>
 
-<div aria-hidden="true" role="dialog" tabindex="-1" class="modal history-modal" id="${element_id}_history">
+<div aria-hidden="true" role="dialog" tabindex="-1" class="modal history-modal" id="history_${element_id}">
   <div class="inner-wrapper">
     <header>
       <h2>${_("Submission History Viewer")}</h2>
     </header>
-    <form id="${element_id}_history_form">
-      <label for="${element_id}_history_student_username">${_("User:")}</label>
-      <input tabindex="0" id="${element_id}_history_student_username" type="text" placeholder=""/>
-      <input type="hidden" id="${element_id}_history_location" value="${location | h}"/>
+    <form id="history_form_${element_id}">
+      <label for="history_student_username_${element_id}">${_("User:")}</label>
+      <input tabindex="0" id="history_student_username_${element_id}" type="text" placeholder=""/>
+      <input type="hidden" id="history_location_${element_id}" value="${location | h}"/>
       <div class="submit">
         <button name="submit" type="submit">${_("View History")}</button>
       </div>
     </form>
 
-    <div id="${element_id}_history_text" class="staff_info" style="display:block">
+    <div id="history_text_${element_id}" class="staff_info" style="display:block">
     </div>
   </div>
 </div>
 
-<div id="${element_id}_setup"></div>
+<div id="setup_${element_id}"></div>
 
 <script type="text/javascript">
 // assumes courseware.html's loaded this method.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "webpack-bundle-tracker": "^0.2.0"
   },
   "devDependencies": {
-    "edx-custom-a11y-rules": "0.1.3",
+    "edx-custom-a11y-rules": "1.0.0",
     "eslint-config-edx": "^2.0.1",
     "eslint-config-edx-es5": "^2.0.0",
     "jasmine-core": "^2.4.1",

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -214,4 +214,4 @@ web-fragments==0.2.2
 xblock==0.5.0
 
 # Third Party XBlocks
-edx-sga==0.6.2
+edx-sga==0.6.3


### PR DESCRIPTION
Replaces all ids (and labels, hrefs, javascript, etc that reference them) that may begin with a numeric character. Although it's technically valid HTML5, many browsers don't support it, including phantomjs and Firefox. When these browsers throw, our custom accessibility checks cannot run against the affected elements, which opens us up to quality failures as documented in [TE-1919](https://openedx.atlassian.net/browse/TE-1919).

To remedy this, I've:
- Fixed all the numeric ids throughout edx-platform (this PR)
- [Fixed the numeric ids in edx-sga](https://github.com/mitodl/edx-sga/pull/163)
- Added [an additional rule](https://github.com/edx/edx-custom-a11y-rules/pull/8) to our custom checks to prevent it from happening again.