### PR TITLE
Added unicode to CourseUserGroup

### DIFF
--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -61,6 +61,9 @@ class CourseUserGroup(models.Model):
             name=name
         )
 
+    def __unicode__(self):
+        return self.name
+
 
 class CohortMembership(models.Model):
     """Used internally to enforce our particular definition of uniqueness"""


### PR DESCRIPTION
This to make it readable in Admin Panel for models that using this field as a foreign key, and for the forms as well.  