### PR TITLE
mattdrayer/ENT-328: Update account activation message on sign-in form.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -90,7 +90,10 @@ from lms.envs.common import (
     FILE_UPLOAD_STORAGE_PREFIX,
 
     COURSE_ENROLLMENT_MODES,
+
     HELP_TOKENS_BOOKS,
+
+    SUPPORT_SITE_LINK,
 )
 from path import Path as path
 from warnings import simplefilter

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -126,7 +126,7 @@ class LoginTest(CacheIsolationTestCase):
         # Should now be unable to login
         response, mock_audit_log = self._login_response('test@edx.org', 'test_password')
         self._assert_response(response, success=False,
-                              value="Before you sign in, you need to activate your account")
+                              value="In order to sign in, you need to activate your account.")
         self._assert_audit_log(mock_audit_log, 'warning', [u'Login failed', u'Account not active for user'])
 
     @patch.dict("django.conf.settings.FEATURES", {'SQUELCH_PII_IN_LOGS': True})
@@ -138,7 +138,7 @@ class LoginTest(CacheIsolationTestCase):
         # Should now be unable to login
         response, mock_audit_log = self._login_response('test@edx.org', 'test_password')
         self._assert_response(response, success=False,
-                              value="Before you sign in, you need to activate your account")
+                              value="In order to sign in, you need to activate your account.")
         self._assert_audit_log(mock_audit_log, 'warning', [u'Login failed', u'Account not active for user'])
         self._assert_not_in_audit_log(mock_audit_log, 'warning', [u'test'])
 
@@ -408,7 +408,7 @@ class LoginTest(CacheIsolationTestCase):
 
         if value is not None:
             msg = ("'%s' did not contain '%s'" %
-                   (str(response_dict['value']), str(value)))
+                   (unicode(response_dict['value']), unicode(value)))
             self.assertIn(value, response_dict['value'], msg)
 
     def _assert_audit_log(self, mock_audit_log, level, log_strings):

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -365,7 +365,7 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         self.assertEqual(200, response.status_code)  # Yes, it's a 200 even though it's a failure.
         payload = json.loads(response.content)
         self.assertFalse(payload.get('success'))
-        self.assertIn('Before you sign in, you need to activate your account', payload.get('value'))
+        self.assertIn('In order to sign in, you need to activate your account.', payload.get('value'))
 
     def assert_json_failure_response_is_missing_social_auth(self, response):
         """Asserts failure on /login for missing social auth looks right."""


### PR DESCRIPTION
@douglashall @chris-mike here is the update for the account activation alert message that appears on the sign-in page.  Screenshot attached for reference.  If you'd also like to see the branch on a sandbox let me know and I'll set one up.  Also note that @griffresch asked to hide this change behind a feature flag but I've left that out for now because it doesn't seem necessary.

<img width="1333" alt="screen shot 2017-05-02 at 9 28 05 am" src="https://cloud.githubusercontent.com/assets/4520595/25619676/b4489b4a-2f19-11e7-95a6-f2193b47f8e4.png">

