### PR TITLE
EDUCATOR-199 Fix ICRV broken courses

### DIFF
--- a/openedx/core/djangoapps/user_api/partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/partition_schemes.py
@@ -17,11 +17,26 @@ class NotImplementedPartitionScheme(object):
     """
 
     @classmethod
-    def get_group_for_user(cls, course_key, user, user_partition, assign=True, track_function=None):
+    def get_group_for_user(cls, course_key, user, user_partition, assign=True, track_function=None):  # pylint: disable=unused-argument
         """
-        Dummy method, will fail hard if anyone tries to use this scheme.
+        Returning None is equivalent to saying "This user is not in any groups
+        using this partition scheme", be sure the scheme you're removing is
+        compatible with that assumption.
         """
-        raise NotImplementedError()
+        return None
+
+
+class ReturnGroup1PartitionScheme(object):
+    """
+    This scheme is needed to allow verification partitions to be killed, see EDUCATOR-199
+    """
+    @classmethod
+    def get_group_for_user(cls, course_key, user, user_partition, assign=True, track_function=None):  # pylint: disable=unused-argument
+        """
+        The previous "allow" definition for verification was defined as 1, so return that.
+        Details at https://github.com/edx/edx-platform/pull/14913/files#diff-feff1466ec4d1b8c38894310d8342a80
+        """
+        return user_partition.get_group(1)
 
 
 class RandomUserPartitionScheme(object):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "openedx.user_partition_scheme": [
             "random = openedx.core.djangoapps.user_api.partition_schemes:RandomUserPartitionScheme",
             "cohort = openedx.core.djangoapps.course_groups.partition_scheme:CohortPartitionScheme",
-            "verification = openedx.core.djangoapps.user_api.partition_schemes:NotImplementedPartitionScheme",
+            "verification = openedx.core.djangoapps.user_api.partition_schemes:ReturnGroup1PartitionScheme",
             "enrollment_track = openedx.core.djangoapps.verified_track_content.partition_scheme:EnrollmentTrackPartitionScheme",
         ],
         "openedx.block_structure_transformer": [


### PR DESCRIPTION
@sstack22 I need some product guidance here - with the removal of ICRV blocks, should we default to allowing anyone to access the content, or denying everyone? I went with "allow" based on [this comment](https://github.com/edx/edx-platform/pull/14913/files#diff-feff1466ec4d1b8c38894310d8342a80L59) from now-dead code.

@cahrens, does this seem sane to you? From my splunk searches, I believe this is only called from https://github.com/edx/edx-platform/blob/master/lms/djangoapps/course_blocks/transformers/user_partitions.py#L240 and https://github.com/edx/edx-platform/blob/master/lms/djangoapps/courseware/access.py#L518. It seems like a return value of `None` would lead to denying access, while this value allows it.