### PR TITLE
Enable course sidebar for new course home page

### DIFF
--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -2,7 +2,7 @@
 Test cases for tabs.
 """
 
-import waffle
+from waffle.testutils import override_flag
 
 from django.core.urlresolvers import reverse
 from django.http import Http404
@@ -781,10 +781,9 @@ class CourseInfoTabTestCase(TabTestCase):
         tabs = get_course_tab_list(self.request, self.course)
         self.assertEqual(tabs[0].type, 'course_info')
 
-    @patch('waffle.flag_is_active')
-    def test_default_tab_for_new_course_experience(self, patched_flag_is_active):
+    @override_flag(UNIFIED_COURSE_EXPERIENCE_FLAG, active=True)
+    def test_default_tab_for_new_course_experience(self):
         # Verify that the unified course experience hides the course info tab
-        patched_flag_is_active.return_value = True
         tabs = get_course_tab_list(self.request, self.course)
         self.assertEqual(tabs[0].type, 'courseware')
 

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -6,6 +6,7 @@
 from datetime import datetime
 from pytz import timezone, utc
 
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from courseware.courses import get_course_info_section, get_course_date_blocks
@@ -113,6 +114,13 @@ from openedx.core.djangolib.markup import HTML, Text
         </section>
 
         <section aria-label="${_('Handout Navigation')}" class="handouts">
+          <h3 class="hd hd-3 handouts-header">${_("Course Tools")}</h3>
+            <div>
+                <a class="action-show-bookmarks" href="${reverse('openedx.course_bookmarks.home', args=[course.id])}">
+                    <span class="icon fa fa-bookmark" aria-hidden="true"></span>
+                    ${_("Bookmarks")}
+                </a>
+            </div>
 
           % if SelfPacedConfiguration.current().enable_course_home_improvements:
             ${HTML(dates_fragment.body_html())}

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -23,13 +23,9 @@ from openedx.features.course_experience import UNIFIED_COURSE_EXPERIENCE_FLAG
     <header class="page-header has-secondary">
         <div class="page-header-main">
             <nav aria-label="${_('Course Outline')}" class="sr-is-focusable" tabindex="-1">
-                % if waffle.flag_is_active(request, UNIFIED_COURSE_EXPERIENCE_FLAG):
-                    <h2 class="hd hd-3 page-title">
-                        ${_("{course_name}").format(org=course.display_org_with_default, course_name=course.display_name_with_default)}
-                    </h2>
-                % else:
-                    <h2 class="hd hd-2 page-title">${_('Course Outline')}</h2>
-                % endif
+                <h2 class="hd hd-3 page-title">
+                    ${_("{course_name}").format(org=course.display_org_with_default, course_name=course.display_name_with_default)}
+                </h2>
             </nav>
         </div>
         <div class="page-header-secondary">
@@ -49,11 +45,6 @@ from openedx.features.course_experience import UNIFIED_COURSE_EXPERIENCE_FLAG
                 </div>
             % endif
             <div class="form-actions">
-                % if not waffle.flag_is_active(request, UNIFIED_COURSE_EXPERIENCE_FLAG):
-                    <a class="btn action-show-bookmarks" href="${reverse('openedx.course_bookmarks.home', args=[course_key])}">
-                        ${_("Bookmarks")}
-                    </a>
-                % endif
                 % if resume_course_url:
                     <a class="btn btn-brand action-resume-course" href="${resume_course_url}">
                         % if has_visited_course:
@@ -67,43 +58,41 @@ from openedx.features.course_experience import UNIFIED_COURSE_EXPERIENCE_FLAG
         </div>
     </header>
     <div class="page-content">
-        % if waffle.flag_is_active(request, UNIFIED_COURSE_EXPERIENCE_FLAG):
-            <div class="layout layout-1q3q">
-                <main class="layout-col layout-col-b">
-                    ${HTML(outline_fragment.body_html())}
-                </main>
-                <aside class="course-sidebar layout-col layout-col-a">
-                    <div class="section section-tools">
-                        <h3 class="hd-6">${_("Course Tools")}</h3>
-                        <ul class="list-unstyled">
+        <div class="layout layout-1q3q">
+            <main class="layout-col layout-col-b">
+                ${HTML(outline_fragment.body_html())}
+            </main>
+            <aside class="course-sidebar layout-col layout-col-a">
+                <div class="section section-tools">
+                    <h3 class="hd-6">${_("Course Tools")}</h3>
+                    <ul class="list-unstyled">
+                        <li>
+                            <a href="${reverse('openedx.course_bookmarks.home', args=[course_key])}">
+                                <span class="icon fa fa-bookmark" aria-hidden="true"></span>
+                                ${_("Bookmarks")}
+                            </a>
+                        </li>
+                        % if waffle.flag_is_active(request, UNIFIED_COURSE_EXPERIENCE_FLAG):
                             <li>
-                                <a class="action-show-bookmarks" href="${reverse('openedx.course_bookmarks.home', args=[course_key])}">
-                                    <span class="icon fa fa-bookmark" aria-hidden="true"></span>
-                                    ${_("Bookmarks")}
-                                </a>
-                            </li>
-                            <li>
-                                <a class="action-show-bookmarks" href="${reverse('openedx.course_experience.course_updates', args=[course.id])}">
+                                <a href="${reverse('openedx.course_experience.course_updates', args=[course.id])}">
                                     <span class="icon fa fa-newspaper-o" aria-hidden="true"></span>
                                     ${_("Updates")}
                                 </a>
                             </li>
-                        </ul>
+                        % endif
+                    </ul>
+                </div>
+                <div class="section section-dates">
+                    ${HTML(dates_fragment.body_html())}
+                </div>
+                % if handouts_html:
+                    <div class="section section-handouts">
+                        <h3 class="hd-6">${_("Course Handouts")}</h3>
+                        ${HTML(handouts_html)}
                     </div>
-                    <div class="section section-dates">
-                        ${HTML(dates_fragment.body_html())}
-                    </div>
-                    % if handouts_html:
-                        <div class="section section-handouts">
-                            <h3 class="hd-6">${_("Course Handouts")}</h3>
-                            ${HTML(handouts_html)}
-                        </div>
-                    % endif
-                </aside>
-            </div>
-        % else:
-            ${HTML(outline_fragment.body_html())}
-        % endif
+                % endif
+            </aside>
+        </div>
     </div>
 </div>
 </%block>

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -23,9 +23,7 @@ from openedx.features.course_experience import UNIFIED_COURSE_EXPERIENCE_FLAG
     <header class="page-header has-secondary">
         <div class="page-header-main">
             <nav aria-label="${_('Course Outline')}" class="sr-is-focusable" tabindex="-1">
-                <h2 class="hd hd-3 page-title">
-                    ${_("{course_name}").format(org=course.display_org_with_default, course_name=course.display_name_with_default)}
-                </h2>
+                <h2 class="hd hd-3 page-title">${course.display_name_with_default}</h2>
             </nav>
         </div>
         <div class="page-header-secondary">

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -65,7 +65,7 @@ class TestCourseHomePage(SharedModuleStoreTestCase):
         get_course_in_cache(self.course.id)
 
         # Fetch the view and verify the query counts
-        with self.assertNumQueries(37):
+        with self.assertNumQueries(35):
             with check_mongo_calls(3):
                 url = course_home_url(self.course)
                 self.client.get(url)

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -96,14 +96,16 @@ class CourseHomeFragmentView(EdxFragmentView):
         # Render the course dates as a fragment
         dates_fragment = CourseDatesFragmentView().render_to_fragment(request, course_id=course_id, **kwargs)
 
-        # Get the handouts
         # TODO: Use get_course_overview_with_access and blocks api
         course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=True)
+
+        # Get the handouts
         handouts_html = get_course_info_section(request, request.user, course, 'handouts')
 
         # Render the course home fragment
         context = {
             'csrf': csrf(request)['csrf_token'],
+            'course': course,
             'course_key': course_key,
             'course': course,
             'outline_fragment': outline_fragment,


### PR DESCRIPTION
## [LEARNER-764](https://openedx.atlassian.net/browse/LEARNER-764)

### Description

This change updates the new course home page so that the sidebar is shown irrespective of the Waffle flag to enable the unified course/home tab. If the flag is off, the sidebar is shown but without the "Updates" section since that is still available on the "Home" page. If the flag is on, the "Home" page is hidden and the "Updates" section appears on the "Course" page.

Here is the experience that will go live when this is released to prod (with the flag off):

![image](https://cloud.githubusercontent.com/assets/5985072/25722507/7f6e6f38-30e2-11e7-81a8-33208b076cd0.png)


In addition, the "Course Tools" section has been added to the sidebar of the "Home" page for consistency:

![image](https://cloud.githubusercontent.com/assets/5985072/25719320/0f6f0b30-30d7-11e7-96d1-0ef1bb983fee.png)

### Sandbox
- [x] https://andy-armstrong.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/

Staff users have the unified experience enabled, while regular users have it off, so you can see both situations. The latter is what regular users will see when this launches.

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers

FYI: @catong @dianakhuang 

### Post-review
- [ ] Rebase and squash commits