### PR TITLE
ENT-361: Allow hiding of IDP selection page during SSO

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0010_add_skip_hinted_login_dialog_field.py
+++ b/common/djangoapps/third_party_auth/migrations/0010_add_skip_hinted_login_dialog_field.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0009_auto_20170415_1144'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='skip_hinted_login_dialog',
+            field=models.BooleanField(default=False, help_text='If this option is enabled, users that visit a "TPA hinted" URL for this provider (e.g. a URL ending with `?tpa_hint=[provider_name]`) will be forwarded directly to the login URL of the provider instead of being first prompted with a login dialog.'),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='skip_hinted_login_dialog',
+            field=models.BooleanField(default=False, help_text='If this option is enabled, users that visit a "TPA hinted" URL for this provider (e.g. a URL ending with `?tpa_hint=[provider_name]`) will be forwarded directly to the login URL of the provider instead of being first prompted with a login dialog.'),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='skip_hinted_login_dialog',
+            field=models.BooleanField(default=False, help_text='If this option is enabled, users that visit a "TPA hinted" URL for this provider (e.g. a URL ending with `?tpa_hint=[provider_name]`) will be forwarded directly to the login URL of the provider instead of being first prompted with a login dialog.'),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -117,6 +117,14 @@ class ProviderConfig(ConfigurationModel):
             'The Site that this provider configuration belongs to.'
         ),
     )
+    skip_hinted_login_dialog = models.BooleanField(
+        default=False,
+        help_text=_(
+            "If this option is enabled, users that visit a \"TPA hinted\" URL for this provider "
+            "(e.g. a URL ending with `?tpa_hint=[provider_name]`) will be forwarded directly to "
+            "the login URL of the provider instead of being first prompted with a login dialog."
+        ),
+    )
     skip_registration_form = models.BooleanField(
         default=False,
         help_text=_(

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -290,7 +290,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         super(StudentAccountLoginAndRegistrationTest, self).setUp()
 
         # Several third party auth providers are created for these tests:
-        self.configure_google_provider(enabled=True, visible=True)
+        self.google_provider = self.configure_google_provider(enabled=True, visible=True)
         self.configure_facebook_provider(enabled=True, visible=True)
         self.configure_dummy_provider(
             visible=True,
@@ -442,6 +442,18 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         params = [("next", "/courses/something/?tpa_hint={0}".format(tpa_hint))]
         response = self.client.get(reverse('signin_user'), params, HTTP_ACCEPT="text/html")
         self.assertNotIn(response.content, tpa_hint)
+
+    def test_hinted_login_dialog_disabled(self):
+        """Test that the dialog doesn't show up for hinted logins when disabled. """
+        self.google_provider.skip_hinted_login_dialog = True
+        self.google_provider.save()
+        params = [("next", "/courses/something/?tpa_hint=oa2-google-oauth2")]
+        response = self.client.get(reverse('signin_user'), params, HTTP_ACCEPT="text/html")
+        self.assertRedirects(
+            response,
+            'auth/login/google-oauth2/?auth_entry=login&next=%2Fcourses%2Fsomething%2F%3Ftpa_hint%3Doa2-google-oauth2',
+            target_status_code=302
+        )
 
     @override_settings(SITE_NAME=settings.MICROSITE_TEST_HOSTNAME)
     def test_microsite_uses_old_login_page(self):

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -83,7 +83,14 @@ def login_and_registration_form(request, initial_mode="login"):
         try:
             next_args = urlparse.parse_qs(urlparse.urlparse(redirect_to).query)
             provider_id = next_args['tpa_hint'][0]
-            if third_party_auth.provider.Registry.get(provider_id=provider_id):
+            tpa_hint_provider = third_party_auth.provider.Registry.get(provider_id=provider_id)
+            if tpa_hint_provider:
+                if tpa_hint_provider.skip_hinted_login_dialog:
+                    # Forward the user directly to the provider's login URL when the provider is configured
+                    # to skip the dialog.
+                    return redirect(
+                        pipeline.get_login_url(provider_id, pipeline.AUTH_ENTRY_LOGIN, redirect_url=redirect_to)
+                    )
                 third_party_auth_hint = provider_id
                 initial_mode = "hinted_login"
         except (KeyError, ValueError, IndexError):


### PR DESCRIPTION
This PR introduces a per-IDP setting that allows for making TPA-hinted URLs (URLs with the `tpa_hint` parameter) forward users directly to the IDP login URL rather than prompt the user with a dialog.

**JIRA tickets**: Implements [ENT-361](https://openedx.atlassian.net/browse/ENT-361).

**Discussions**: There was a short discussion on the [ticket](https://openedx.atlassian.net/browse/ENT-361) which recommended leveraging the existing `tpa_hint` param in order to fulfill this requirement.

**Dependencies**: None

**Sandbox URL**: https://pr15022.sandbox.opencraft.hosting/

**Merge deadline**: The end of the current Enterprise sprint is Friday (2017/5/5)

**Testing instructions**:

No Enterprise or Ecommerce setup steps are necessary for testing this PR.

1. Setup a devstack and checkout this branch (`git checkout bdero/ent-361`)
1. Set the `ENABLE_THIRD_PARTY_AUTH` feature flag to `true` in */edx/app/edxapp/lms.env.json*
1. Login as the `staff@example.com` user and [add a new `OAuth2ProviderConfig`](http://localhost:8000/admin/third_party_auth/oauth2providerconfig/add/):
   1. Check "Enabled"
   1. For "Name" fill in `dummy`
   1. **Make sure "Skip hinted login dialog" is unchecked!**
   1. For the "Backend name" dropdown select `dummy`
   1. For the "Provider slug" enter `dummy`
   1. Click "Save"
1. Navigate to any courseware page, copy its URL, and append **`?tpa_hint=oa2-dummy`** to the end of it; for example:
   ```
   http://localhost:8000/courses/course-v1:asdf+asdf+asdf/courseware/8b555b84247742ba8c13e9816fbf7eb5/c6eeb4189f2a49edbda6861cb078235b/?tpa_hint=oa2-dummy
   ```
1. [Sign out](http://localhost:8000/logout) of the LMS
1. Navigate to the URL you produced in **step 4**; you should be prompted with the "hinted" login form: 
   ![test_provider login](https://i.imgur.com/PDBCBBo.png)
1. Login to the LMS again and navigate to the [`OAuth2ProviderConfig` admin panel](http://localhost:8000/admin/third_party_auth/oauth2providerconfig/)
1. Click "Update" next to the "dummy" provider config to reconfigure it:
   1. **Check the "Skip hinted login dialog" checkbox**
   1. Click "Save"
1. [Sign out](http://localhost:8000/logout) of the LMS
1. Navigate to the URL you produced in **step 4** again; you should be immediately logged in (without seeing the dialog shown in **step 6**) and land on courseware page

**Reviewers**
- [ ] @haikuginger  
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
  ENABLE_THIRD_PARTY_AUTH: true
```