### PR TITLE
EDUCATOR-146 Move button will not be shown on Pages page.

### DIFF
--- a/cms/static/sass/views/_static-pages.scss
+++ b/cms/static/sass/views/_static-pages.scss
@@ -281,7 +281,7 @@
           vertical-align: bottom;
         }
 
-        &.action-duplicate {
+        &.action-duplicate, &.action-move {
           display: none;
         }
       }


### PR DESCRIPTION
## [Move button is not showing on studio Pages page-EDUCATOR-146](https://openedx.atlassian.net/browse/EDUCATOR-146)

Related PR : [https://github.com/edx/edx-platform/pull/2276](https://github.com/edx/edx-platform/pull/2276)

### How to Test?

**Stage** 
1. Go to https://studio.stage.edx.org/tabs/course-v1:edx+aishaq+1T2017 
2. Click Add a new page button.
3. You will see the move button 


**Sandbox**
https://studio-move-button.sandbox.edx.org/

**Screenshots**

**Before Fix**
<img width="956" alt="screen shot 2017-05-03 at 4 59 38 pm" src="https://cloud.githubusercontent.com/assets/7627421/25659656/33f0a9f6-3022-11e7-967c-1b75da6c8ccf.png">

**After Fix**
<img width="948" alt="screen shot 2017-05-03 at 5 13 25 pm" src="https://cloud.githubusercontent.com/assets/7627421/25660045/f72eab1a-3023-11e7-926c-14bb56574b9d.png">


### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @Qubad786 
-  [x] @asadazam93 
-  [x] @mushtaqak 

FYI: @andy-armstrong 
### Post-review
- [x] Rebase and squash commits


