### PR TITLE
[ENT-336][ENT-337][ENT-338] Enterprise registration/login form updates

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -951,6 +951,25 @@ ENTERPRISE_API_CACHE_TIMEOUT = ENV_TOKENS.get(
     ENTERPRISE_API_CACHE_TIMEOUT
 )
 
+############## ENTERPRISE SERVICE LMS CONFIGURATION ##################################
+# The LMS has some features embedded that are related to the Enterprise service, but
+# which are not provided by the Enterprise service. These settings override the
+# base values for the parameters as defined in common.py
+
+ENTERPRISE_PLATFORM_WELCOME_TEMPLATE = ENV_TOKENS.get(
+    'ENTERPRISE_PLATFORM_WELCOME_TEMPLATE',
+    ENTERPRISE_PLATFORM_WELCOME_TEMPLATE
+)
+ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE = ENV_TOKENS.get(
+    'ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE',
+    ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE
+)
+ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS = set(
+    ENV_TOKENS.get(
+        'ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS',
+        ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS
+    )
+)
 
 ############## CATALOG/DISCOVERY SERVICE API CLIENT CONFIGURATION ######################
 # The LMS communicates with the Catalog service via the EdxRestApiClient class

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3142,6 +3142,26 @@ ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
 ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
 ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE = 512   # Enterprise logo image size limit in KB's
 
+############## ENTERPRISE SERVICE LMS CONFIGURATION ##################################
+# The LMS has some features embedded that are related to the Enterprise service, but
+# which are not provided by the Enterprise service. These settings provide base values
+# for those features.
+
+ENTERPRISE_PLATFORM_WELCOME_TEMPLATE = _(u'Welcome to {platform_name}.')
+ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE = _(
+    u'{start_bold}{enterprise_name}{end_bold} has partnered with {start_bold}'
+    '{platform_name}{end_bold} to offer you high-quality learning opportunities '
+    'from the world\'s best universities.'
+)
+ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS = {
+    'age',
+    'level_of_education',
+    'gender',
+    'goals',
+    'year_of_birth',
+    'mailing_address',
+}
+
 ############## Settings for Course Enrollment Modes ######################
 COURSE_ENROLLMENT_MODES = {
     "audit": 1,

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -3,16 +3,50 @@
 @import '../base/grid-settings';
 @import "neat/neat"; // lib - Neat
 
-.login-register {
+@media (min-width: 768px) {
+    .enterprise-content {
+        width: 20%;
+        float: left;
+        height: 100%;
+        padding-left: $baseline;
+        padding-right: $baseline;
+    }
+
+    .login-register.border-left {
+        border-left: 1px solid #d9d9d9;
+        padding-left: ($baseline*1.5);
+        padding-right: $baseline;
+    }
+}
+
+@media (max-width: 767px) {
+    .enterprise-content {
+        margin: auto auto;
+        display: block;
+        padding-left: ($baseline/2);
+        padding-right: ($baseline/2);
+
+        img.enterprise-logo {
+            display: none;
+        }
+    }
+}
+
+.window-wrap {
+    background: $white;
+}
+
+.login-register-content {
     @include box-sizing(border-box);
     @include outer-container;
-    $grid-columns: 12;
-    background: $white;
-    min-height: 100%;
     width: 100%;
-    padding-left: ($baseline/2);
-    padding-right: ($baseline/2);
-    $third-party-button-height: ($baseline*1.75);
+    justify-content: center;
+    margin-top: $baseline;
+    background: $white;
+    display: flex;
+    flex-wrap: wrap;
+    -webkit-flex-wrap: wrap;
+    -moz-flex-wrap: wrap;
 
     h2 {
         @extend %t-title4;
@@ -34,6 +68,21 @@
     a, label {
         @extend %expand-clickable-area;
     }
+
+    a {
+        text-decoration: underline;
+    }
+}
+
+.login-register {
+    $grid-columns: 12;
+    background: $white;
+    min-height: 100%;
+    padding-left: ($baseline/2);
+    padding-right: ($baseline/2);
+    $third-party-button-height: ($baseline*1.75);
+    display: inline-block;
+    max-width: 500px;
 
     .instructions {
         @extend %t-copy-base;
@@ -586,4 +635,27 @@
 
 .supplemental-link {
     margin: 1rem 0;
+}
+
+.enterprise-content {
+    display: inline-block;
+    text-align: left;
+    vertical-align: top;
+    max-width: 500px;
+
+    .centered-div {
+        margin: 0 auto;
+        margin-right: 0px;
+        float: right;
+    }
+
+    img {
+        height: 100px;
+    }
+
+    h2 {
+        font-size: 16px;
+        line-height: 1.5;
+        color: $gray-d2;
+    }
 }

--- a/lms/templates/student_account/enterprise_sidebar.html
+++ b/lms/templates/student_account/enterprise_sidebar.html
@@ -1,0 +1,13 @@
+<div id="enterprise-content-container" class="enterprise-content">
+    <div class="centered-div">
+        % if enterprise_logo_url:
+            <img src="${enterprise_logo_url}" alt="${enterprise_name}" class="enterprise-logo">
+        % endif
+        <h2>
+            ${enterprise_branded_welcome_string}
+        </h2>
+        <h2>
+            ${platform_welcome_string}
+        </h2>
+    </div>
+</div>

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -29,11 +29,22 @@
         <script type="text/template" id="${template_name}-tpl">
             <%static:include path="student_account/${template_name}.underscore" />
         </script>
-% endfor
+    % endfor
 </%block>
-
 <div class="section-bkg-wrapper">
     <main id="main" aria-label="Content" tabindex="-1">
-        <div id="login-and-registration-container" class="login-register" />
+        <div id="content-container" class="login-register-content">
+            % if enable_enterprise_sidebar:
+                <%include file="enterprise_sidebar.html" />
+                <%
+                    border_class = 'border-left'
+                %>
+            % else:
+                <%
+                    border_class = ''
+                %>
+            % endif
+            <div id="login-and-registration-container" class="login-register ${border_class}"></div>
+        </div>
     </main>
 </div>

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -10,6 +10,7 @@ from django.test.utils import override_settings
 
 from openedx.features.enterprise_support.api import (
     enterprise_enabled,
+    enterprise_customer_for_request,
     insert_enterprise_pipeline_elements,
     data_sharing_consent_required,
     set_enterprise_branding_filter_param,
@@ -116,6 +117,48 @@ class TestEnterpriseApi(unittest.TestCase):
         with mock.patch('enterprise.utils.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
             logo_url = get_enterprise_customer_logo_url(request)
             self.assertEqual(logo_url, None)
+
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
+    @mock.patch('openedx.features.enterprise_support.api.get_enterprise_customer_for_request')
+    @mock.patch('openedx.features.enterprise_support.api.EnterpriseCustomer')
+    def test_enterprise_customer_for_request(self, ec_class_mock, get_ec_pipeline_mock):
+        """
+        Test that the correct EnterpriseCustomer, if any, is returned.
+        """
+        def get_ec_mock(**kwargs):
+            by_provider_id_kw = 'enterprise_customer_identity_provider__provider_id'
+            provider_id = kwargs.get(by_provider_id_kw, '')
+            uuid = kwargs.get('uuid', '')
+            if uuid == 'real-uuid' or provider_id == 'real-provider-id':
+                return 'this-is-actually-an-enterprise-customer'
+            elif uuid == 'not-a-uuid':
+                raise ValueError
+            else:
+                raise Exception
+
+        ec_class_mock.DoesNotExist = Exception
+        ec_class_mock.objects.get.side_effect = get_ec_mock
+
+        get_ec_pipeline_mock.return_value = None
+
+        request = mock.MagicMock()
+        request.GET.get.return_value = 'real-uuid'
+        self.assertEqual(enterprise_customer_for_request(request), 'this-is-actually-an-enterprise-customer')
+        request.GET.get.return_value = 'not-a-uuid'
+        self.assertEqual(enterprise_customer_for_request(request), None)
+        request.GET.get.return_value = 'fake-uuid'
+        self.assertEqual(enterprise_customer_for_request(request), None)
+        request.GET.get.return_value = None
+        self.assertEqual(
+            enterprise_customer_for_request(request, tpa_hint='real-provider-id'),
+            'this-is-actually-an-enterprise-customer'
+        )
+        self.assertEqual(enterprise_customer_for_request(request, tpa_hint='fake-provider-id'), None)
+        self.assertEqual(enterprise_customer_for_request(request, tpa_hint=None), None)
+
+        get_ec_pipeline_mock.return_value = 'also-a-real-enterprise'
+
+        self.assertEqual(enterprise_customer_for_request(request), 'also-a-real-enterprise')
 
     def check_data_sharing_consent(self, consent_required=False, consent_url=None):
         """


### PR DESCRIPTION
This pull request is based on #14985, and adds several items:

- Enterprise sidebar during Enterprise-linked logistration flows, defined as follows:
    - `tpa_hint` URL parameter pointing to an SSO provider linked to an Enterprise Customer
    - `enterprise_customer` URL parameter with the UUID of an Enterprise Customer
    - Active third-party auth pipeline using an SSO provider linked to an Enterprise Customer
- Hides third-party auth providers during Enterprise-linked logistration flows
- Makes the form slightly more narrow
- Removes irrelevant/non-required fields from the Enterprise registration form

**JIRA tickets**: Implements [ENT-336](https://openedx.atlassian.net/browse/ENT-336), [ENT-337](https://openedx.atlassian.net/browse/ENT-337), and [ENT-338](https://openedx.atlassian.net/browse/ENT-338).

**Dependencies**: #14985 

**Screenshots**:

<img width="1245" alt="screen shot 2017-05-09 at 8 43 49 am" src="https://cloud.githubusercontent.com/assets/7773758/25851420/b1dcef12-3493-11e7-9517-e65a25032a7b.png">

<img width="1239" alt="screen shot 2017-05-09 at 8 44 00 am" src="https://cloud.githubusercontent.com/assets/7773758/25851421/b1e15b6a-3493-11e7-8746-3988e39b53c2.png">


**Sandbox URLs (64e5c03)**:

- https://pr15025.sandbox.opencraft.hosting/login?enterprise_customer=83f24af0-7077-489a-8a17-8ca4eafec6bb

- https://pr15025.sandbox.opencraft.hosting/register?enterprise_customer=83f24af0-7077-489a-8a17-8ca4eafec6bb 

**Merge deadline**: May 8 2017

**Testing instructions**:

1. Create an Enterprise Customer and upload a logo
2. Add at least one SSO provider, enable it, and make it visible. Link it to your Enterprise Customer.
3. In an incognito window, browse to `http://your-instance-domain/register?enterprise_customer=your-enterprise-customer-uuid`.
    - Verify the presence of the Enterprise Customer's logo
    - Verify that SSO provider buttons are not present
    - Verify that if you resize the window down to be very narrow, the Enterprise Customer logo moves to be on top of the registration form.
    - Verify that the some forms shown on the standard registration page are not visible on the Enterprise registration page.


**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```