### PR TITLE
Bulk-reads and Request caching in Course Grade Report

### DIFF
--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -16,7 +16,7 @@ from opaque_keys.edx.locator import CourseLocator
 import pytz
 
 from course_modes.helpers import enrollment_mode_display
-from course_modes.models import CourseMode, Mode
+from course_modes.models import CourseMode, Mode, invalidate_course_mode_cache
 from course_modes.tests.factories import CourseModeFactory
 
 
@@ -30,6 +30,9 @@ class CourseModeModelTest(TestCase):
         super(CourseModeModelTest, self).setUp()
         self.course_key = SlashSeparatedCourseKey('Test', 'TestCourse', 'TestCourseRun')
         CourseMode.objects.all().delete()
+
+    def tearDown(self):
+        invalidate_course_mode_cache(sender=None)
 
     def create_mode(
             self,

--- a/common/djangoapps/request_cache/__init__.py
+++ b/common/djangoapps/request_cache/__init__.py
@@ -41,6 +41,16 @@ def get_cache(name):
     return middleware.RequestCache.get_request_cache(name)
 
 
+def clear_cache(name):
+    """
+    Clears the request cache named ``name``.
+
+    Arguments:
+        name (str): The name of the request cache to clear
+    """
+    return middleware.RequestCache.clear_request_cache(name)
+
+
 def get_request():
     """
     Return the current request.

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -998,7 +998,9 @@ class CourseEnrollment(models.Model):
     history = HistoricalRecords()
 
     # cache key format e.g enrollment.<username>.<course_key>.mode = 'honor'
-    COURSE_ENROLLMENT_CACHE_KEY = u"enrollment.{}.{}.mode"
+    COURSE_ENROLLMENT_CACHE_KEY = u"enrollment.{}.{}.mode"  # TODO Can this be removed?  It doesn't seem to be used.
+
+    MODE_CACHE_NAMESPACE = u'CourseEnrollment.mode_and_active'
 
     class Meta(object):
         unique_together = (('user', 'course_id'),)
@@ -1698,11 +1700,27 @@ class CourseEnrollment(models.Model):
         return enrollment_state
 
     @classmethod
+    def bulk_fetch_enrollment_states(cls, users, course_key):
+        """
+        Bulk pre-fetches the enrollment states for the given users
+        for the given course.
+        """
+        # before populating the cache with another bulk set of data,
+        # remove previously cached entries to keep memory usage low.
+        request_cache.clear_cache(cls.MODE_CACHE_NAMESPACE)
+
+        records = cls.objects.filter(user__in=users, course_id=course_key).select_related('user__id')
+        cache = cls._get_mode_active_request_cache()
+        for record in records:
+            enrollment_state = CourseEnrollmentState(record.mode, record.is_active)
+            cls._update_enrollment(cache, record.user.id, course_key, enrollment_state)
+
+    @classmethod
     def _get_mode_active_request_cache(cls):
         """
         Returns the request-specific cache for CourseEnrollment
         """
-        return request_cache.get_cache('CourseEnrollment.mode_and_active')
+        return request_cache.get_cache(cls.MODE_CACHE_NAMESPACE)
 
     @classmethod
     def _get_enrollment_in_request_cache(cls, user, course_key):
@@ -1718,7 +1736,15 @@ class CourseEnrollment(models.Model):
         Updates the cached value for the user's enrollment in the
         request cache.
         """
-        cls._get_mode_active_request_cache()[(user.id, course_key)] = enrollment_state
+        cls._update_enrollment(cls._get_mode_active_request_cache(), user.id, course_key, enrollment_state)
+
+    @classmethod
+    def _update_enrollment(cls, cache, user_id, course_key, enrollment_state):
+        """
+        Updates the cached value for the user's enrollment in the
+        given cache.
+        """
+        cache[(user_id, course_key)] = enrollment_state
 
 
 @receiver(models.signals.post_save, sender=CourseEnrollment)

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -4,10 +4,12 @@ adding users, removing users, and listing members
 """
 
 from abc import ABCMeta, abstractmethod
+from collections import defaultdict
 
 from django.contrib.auth.models import User
 import logging
 
+from request_cache import get_cache
 from student.models import CourseAccessRole
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
@@ -34,14 +36,38 @@ def register_access_role(cls):
     return cls
 
 
+class BulkRoleCache(object):
+    CACHE_NAMESPACE = u"student.roles.BulkRoleCache"
+    CACHE_KEY = u'roles_by_user'
+
+    @classmethod
+    def prefetch(cls, users):
+        roles_by_user = defaultdict(set)
+        get_cache(cls.CACHE_NAMESPACE)[cls.CACHE_KEY] = roles_by_user
+
+        for role in CourseAccessRole.objects.filter(user__in=users).select_related('user__id'):
+            roles_by_user[role.user.id].add(role)
+
+        users_without_roles = filter(lambda u: u.id not in roles_by_user, users)
+        for user in users_without_roles:
+            roles_by_user[user.id] = set()
+
+    @classmethod
+    def get_user_roles(cls, user):
+        return get_cache(cls.CACHE_NAMESPACE)[cls.CACHE_KEY][user.id]
+
+
 class RoleCache(object):
     """
     A cache of the CourseAccessRoles held by a particular user
     """
     def __init__(self, user):
-        self._roles = set(
-            CourseAccessRole.objects.filter(user=user).all()
-        )
+        try:
+            self._roles = BulkRoleCache.get_user_roles(user)
+        except KeyError:
+            self._roles = set(
+                CourseAccessRole.objects.filter(user=user).all()
+            )
 
     def has_role(self, role, course_id, org):
         """

--- a/lms/djangoapps/certificates/tests/tests.py
+++ b/lms/djangoapps/certificates/tests/tests.py
@@ -54,11 +54,11 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
         Verify that certificate_info_for_user works.
         """
         student = UserFactory()
-        course = CourseFactory.create(org='edx', number='verified', display_name='Verified Course')
+        _ = CourseFactory.create(org='edx', number='verified', display_name='Verified Course')
         student.profile.allow_certificate = allow_certificate
         student.profile.save()
 
-        certificate_info = certificate_info_for_user(student, course.id, grade, whitelisted)
+        certificate_info = certificate_info_for_user(student, grade, whitelisted, user_certificate=None)
         self.assertEqual(certificate_info, output)
 
     @unpack
@@ -81,14 +81,13 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
         student.profile.allow_certificate = allow_certificate
         student.profile.save()
 
-        GeneratedCertificateFactory.create(
+        certificate = GeneratedCertificateFactory.create(
             user=student,
             course_id=course.id,
             status=CertificateStatuses.downloadable,
             mode='honor'
         )
-
-        certificate_info = certificate_info_for_user(student, course.id, grade, whitelisted)
+        certificate_info = certificate_info_for_user(student, grade, whitelisted, certificate)
         self.assertEqual(certificate_info, output)
 
     def test_course_ids_with_certs_for_user(self):

--- a/lms/djangoapps/grades/new/course_grade_factory.py
+++ b/lms/djangoapps/grades/new/course_grade_factory.py
@@ -81,7 +81,6 @@ class CourseGradeFactory(object):
             users,
             course=None,
             collected_block_structure=None,
-            course_structure=None,
             course_key=None,
             force_update=False,
     ):
@@ -99,7 +98,9 @@ class CourseGradeFactory(object):
         #    compute the grade for all students.
         # 2. Optimization: the collected course_structure is not
         #    retrieved from the data store multiple times.
-        course_data = CourseData(None, course, collected_block_structure, course_structure, course_key)
+        course_data = CourseData(
+            user=None, course=course, collected_block_structure=collected_block_structure, course_key=course_key,
+        )
         for user in users:
             with dog_stats_api.timer(
                     'lms.grades.CourseGradeFactory.iter',
@@ -107,7 +108,9 @@ class CourseGradeFactory(object):
             ):
                 try:
                     method = CourseGradeFactory().update if force_update else CourseGradeFactory().create
-                    course_grade = method(user, course, course_data.collected_structure, course_structure, course_key)
+                    course_grade = method(
+                        user, course_data.course, course_data.collected_structure, course_key=course_key,
+                    )
                     yield self.GradeResult(user, course_grade, None)
 
                 except Exception as exc:  # pylint: disable=broad-except

--- a/lms/djangoapps/grades/tests/test_new.py
+++ b/lms/djangoapps/grades/tests/test_new.py
@@ -178,10 +178,10 @@ class TestCourseGradeFactory(GradeTestBase):
             self.assertEqual(course_grade.letter_grade, u'Pass' if expected_pass else None)
             self.assertEqual(course_grade.percent, 0.5)
 
-        with self.assertNumQueries(12), mock_get_score(1, 2):
+        with self.assertNumQueries(11), mock_get_score(1, 2):
             _assert_create(expected_pass=True)
 
-        with self.assertNumQueries(15), mock_get_score(1, 2):
+        with self.assertNumQueries(13), mock_get_score(1, 2):
             grade_factory.update(self.request.user, self.course)
 
         with self.assertNumQueries(1):
@@ -189,7 +189,7 @@ class TestCourseGradeFactory(GradeTestBase):
 
         self._update_grading_policy(passing=0.9)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(6):
             _assert_create(expected_pass=False)
 
     @ddt.data(True, False)

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -409,8 +409,8 @@ class ComputeGradesForCourseTest(HasCourseWithProblemsMixin, ModuleStoreTestCase
 
     @ddt.data(*xrange(1, 12, 3))
     def test_database_calls(self, batch_size):
-        per_user_queries = 17 * min(batch_size, 6)  # No more than 6 due to offset
-        with self.assertNumQueries(5 + per_user_queries):
+        per_user_queries = 15 * min(batch_size, 6)  # No more than 6 due to offset
+        with self.assertNumQueries(6 + per_user_queries):
             with check_mongo_calls(1):
                 compute_grades_for_course_v2.delay(
                     course_key=six.text_type(self.course.id),

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -12,14 +12,19 @@ from time import time
 
 from instructor_analytics.basic import list_problem_responses
 from instructor_analytics.csvs import format_dictlist
-from certificates.models import CertificateWhitelist, certificate_info_for_user
+from certificates.models import CertificateWhitelist, certificate_info_for_user, GeneratedCertificate
 from courseware.courses import get_course_by_id
-from lms.djangoapps.grades.context import grading_context_for_course
+from lms.djangoapps.grades.context import grading_context_for_course, grading_context
 from lms.djangoapps.grades.new.course_grade_factory import CourseGradeFactory
+from lms.djangoapps.grades.models import PersistentCourseGrade
 from lms.djangoapps.teams.models import CourseTeamMembership
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
-from openedx.core.djangoapps.course_groups.cohorts import get_cohort, is_course_cohorted
+from openedx.core.djangoapps.content.block_structure.api import get_course_in_cache
+from openedx.core.djangoapps.course_groups.cohorts import get_cohort, is_course_cohorted, bulk_cache_cohorts
+from openedx.core.djangoapps.user_api.course_tag.api import BulkCourseTags
 from student.models import CourseEnrollment
+from student.roles import BulkRoleCache
+from xmodule.modulestore.django import modulestore
 from xmodule.partitions.partitions_service import PartitionService
 from xmodule.split_test_module import get_split_user_partitions
 
@@ -30,7 +35,7 @@ from .utils import upload_csv_to_report_store
 TASK_LOG = logging.getLogger('edx.celery.task')
 
 
-class CourseGradeReportContext(object):
+class _CourseGradeReportContext(object):
     """
     Internal class that provides a common context to use for a single grade
     report.  When a report is parallelized across multiple processes,
@@ -58,6 +63,10 @@ class CourseGradeReportContext(object):
         return get_course_by_id(self.course_id)
 
     @lazy
+    def course_structure(self):
+        return get_course_in_cache(self.course_id)
+
+    @lazy
     def course_experiments(self):
         return get_split_user_partitions(self.course.user_partitions)
 
@@ -75,9 +84,9 @@ class CourseGradeReportContext(object):
         Returns an OrderedDict that maps an assignment type to a dict of
         subsection-headers and average-header.
         """
-        grading_context = grading_context_for_course(self.course_id)
+        grading_cxt = grading_context(self.course_structure)
         graded_assignments_map = OrderedDict()
-        for assignment_type_name, subsection_infos in grading_context['all_graded_subsections_by_type'].iteritems():
+        for assignment_type_name, subsection_infos in grading_cxt['all_graded_subsections_by_type'].iteritems():
             graded_subsections_map = OrderedDict()
             for subsection_index, subsection_info in enumerate(subsection_infos, start=1):
                 subsection = subsection_info['subsection_block']
@@ -112,17 +121,64 @@ class CourseGradeReportContext(object):
         return self.task_progress.update_task_state(extra_meta={'step': message})
 
 
+class _CertificateBulkContext(object):
+    def __init__(self, context, users):
+        certificate_whitelist = CertificateWhitelist.objects.filter(course_id=context.course_id, whitelist=True)
+        self.whitelisted_user_ids = [entry.user_id for entry in certificate_whitelist]
+        self.certificates_by_user = {
+            certificate.user.id: certificate
+            for certificate in
+            GeneratedCertificate.objects.filter(course_id=context.course_id, user__in=users)
+        }
+
+
+class _TeamBulkContext(object):
+    def __init__(self, context, users):
+        if context.teams_enabled:
+            self.teams_by_user = {
+                membership.user.id: membership.team.name
+                for membership in
+                CourseTeamMembership.objects.filter(team__course_id=context.course_id, user__in=users)
+            }
+        else:
+            self.teams_by_user = {}
+
+
+class _EnrollmentBulkContext(object):
+    def __init__(self, context, users):
+        CourseEnrollment.bulk_fetch_enrollment_states(users, context.course_id)
+        self.verified_users = [
+            verified.user.id for verified in
+            SoftwareSecurePhotoVerification.verified_query().filter(user__in=users).select_related('user__id')
+        ]
+
+
+class _CourseGradeBulkContext(object):
+    def __init__(self, context, users):
+        self.certs = _CertificateBulkContext(context, users)
+        self.teams = _TeamBulkContext(context, users)
+        self.enrollments = _EnrollmentBulkContext(context, users)
+        bulk_cache_cohorts(context.course_id, users)
+        BulkRoleCache.prefetch(users)
+        PersistentCourseGrade.prefetch(context.course_id, users)
+        BulkCourseTags.prefetch(context.course_id, users)
+
+
 class CourseGradeReport(object):
     """
     Class to encapsulate functionality related to generating Grade Reports.
     """
+    # Batch size for chunking the list of enrollees in the course.
+    USER_BATCH_SIZE = 100
+
     @classmethod
     def generate(cls, _xmodule_instance_args, _entry_id, course_id, _task_input, action_name):
         """
         Public method to generate a grade report.
         """
-        context = CourseGradeReportContext(_xmodule_instance_args, _entry_id, course_id, _task_input, action_name)
-        return CourseGradeReport()._generate(context)
+        with modulestore().bulk_operations(course_id):
+            context = _CourseGradeReportContext(_xmodule_instance_args, _entry_id, course_id, _task_input, action_name)
+            return CourseGradeReport()._generate(context)
 
     def _generate(self, context):
         """
@@ -166,6 +222,7 @@ class CourseGradeReport(object):
         A generator of batches of (success_rows, error_rows) for this report.
         """
         for users in self._batch_users(context):
+            users = filter(lambda u: u is not None, users)
             yield self._rows_for_users(context, users)
 
     def _compile(self, context, batched_rows):
@@ -211,10 +268,11 @@ class CourseGradeReport(object):
         """
         Returns a generator of batches of users.
         """
-        def grouper(iterable, chunk_size=1, fillvalue=None):
+        def grouper(iterable, chunk_size=self.USER_BATCH_SIZE, fillvalue=None):
             args = [iter(iterable)] * chunk_size
             return izip_longest(*args, fillvalue=fillvalue)
         users = CourseEnrollment.objects.users_enrolled_in(context.course_id)
+        users = users.select_related('profile__allow_certificate')
         return grouper(users)
 
     def _user_grade_results(self, course_grade, context):
@@ -249,7 +307,7 @@ class CourseGradeReport(object):
         """
         cohort_group_names = []
         if context.cohorts_enabled:
-            group = get_cohort(user, context.course_id, assign=False)
+            group = get_cohort(user, context.course_id, assign=False, use_cached=True)
             cohort_group_names.append(group.name if group else '')
         return cohort_group_names
 
@@ -264,20 +322,13 @@ class CourseGradeReport(object):
             experiment_group_names.append(group.name if group else '')
         return experiment_group_names
 
-    def _user_team_names(self, user, context):
+    def _user_team_names(self, user, bulk_teams):
         """
         Returns a list of names of teams in which the given user belongs.
         """
-        team_names = []
-        if context.teams_enabled:
-            try:
-                membership = CourseTeamMembership.objects.get(user=user, team__course_id=context.course_id)
-                team_names.append(membership.team.name)
-            except CourseTeamMembership.DoesNotExist:
-                team_names.append('')
-        return team_names
+        return [bulk_teams.teams_by_user.get(user.id, '')]
 
-    def _user_verification_mode(self, user, context):
+    def _user_verification_mode(self, user, context, bulk_enrollments):
         """
         Returns a list of enrollment-mode and verification-status for the
         given user.
@@ -286,19 +337,21 @@ class CourseGradeReport(object):
         verification_status = SoftwareSecurePhotoVerification.verification_status_for_user(
             user,
             context.course_id,
-            enrollment_mode
+            enrollment_mode,
+            user_is_verified=user.id in bulk_enrollments.verified_users,
         )
         return [enrollment_mode, verification_status]
 
-    def _user_certificate_info(self, user, context, course_grade, whitelisted_user_ids):
+    def _user_certificate_info(self, user, context, course_grade, bulk_certs):
         """
         Returns the course certification information for the given user.
         """
+        is_whitelisted = user.id in bulk_certs.whitelisted_user_ids
         certificate_info = certificate_info_for_user(
             user,
-            context.course_id,
             course_grade.letter_grade,
-            user.id in whitelisted_user_ids
+            is_whitelisted,
+            bulk_certs.certificates_by_user.get(user.id),
         )
         TASK_LOG.info(
             u'Student certificate eligibility: %s '
@@ -311,7 +364,7 @@ class CourseGradeReport(object):
             course_grade.letter_grade,
             context.course.grade_cutoffs,
             user.profile.allow_certificate,
-            user.id in whitelisted_user_ids,
+            is_whitelisted,
         )
         return certificate_info
 
@@ -319,24 +372,30 @@ class CourseGradeReport(object):
         """
         Returns a list of rows for the given users for this report.
         """
-        certificate_whitelist = CertificateWhitelist.objects.filter(course_id=context.course_id, whitelist=True)
-        whitelisted_user_ids = [entry.user_id for entry in certificate_whitelist]
-        success_rows, error_rows = [], []
-        for user, course_grade, error in CourseGradeFactory().iter(users, course_key=context.course_id):
-            if not course_grade:
-                # An empty gradeset means we failed to grade a student.
-                error_rows.append([user.id, user.username, error.message])
-            else:
-                success_rows.append(
-                    [user.id, user.email, user.username] +
-                    self._user_grade_results(course_grade, context) +
-                    self._user_cohort_group_names(user, context) +
-                    self._user_experiment_group_names(user, context) +
-                    self._user_team_names(user, context) +
-                    self._user_verification_mode(user, context) +
-                    self._user_certificate_info(user, context, course_grade, whitelisted_user_ids)
-                )
-        return success_rows, error_rows
+        with modulestore().bulk_operations(context.course_id):
+            bulk_context = _CourseGradeBulkContext(context, users)
+
+            success_rows, error_rows = [], []
+            for user, course_grade, error in CourseGradeFactory().iter(
+                users,
+                course=context.course,
+                collected_block_structure=context.course_structure,
+                course_key=context.course_id,
+            ):
+                if not course_grade:
+                    # An empty gradeset means we failed to grade a student.
+                    error_rows.append([user.id, user.username, error.message])
+                else:
+                    success_rows.append(
+                        [user.id, user.email, user.username] +
+                        self._user_grade_results(course_grade, context) +
+                        self._user_cohort_group_names(user, context) +
+                        self._user_experiment_group_names(user, context) +
+                        self._user_team_names(user, bulk_context.teams) +
+                        self._user_verification_mode(user, context, bulk_context.enrollments) +
+                        self._user_certificate_info(user, context, course_grade, bulk_context.certs)
+                    )
+            return success_rows, error_rows
 
 
 class ProblemGradeReport(object):

--- a/openedx/core/djangoapps/credit/tests/test_api.py
+++ b/openedx/core/djangoapps/credit/tests/test_api.py
@@ -664,7 +664,7 @@ class CreditRequirementApiTests(CreditApiTestBase):
         self.assertFalse(api.is_user_eligible_for_credit(user.username, self.course_key))
 
         # Satisfy the other requirement
-        with self.assertNumQueries(25):
+        with self.assertNumQueries(24):
             api.set_credit_requirement_status(
                 user,
                 self.course_key,
@@ -718,7 +718,7 @@ class CreditRequirementApiTests(CreditApiTestBase):
         # Delete the eligibility entries and satisfy the user's eligibility
         # requirement again to trigger eligibility notification
         CreditEligibility.objects.all().delete()
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(16):
             api.set_credit_requirement_status(
                 user,
                 self.course_key,

--- a/openedx/core/djangoapps/user_api/partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/partition_schemes.py
@@ -70,7 +70,7 @@ class RandomUserPartitionScheme(object):
                     exc_info=True
                 )
 
-        if group is None and assign:
+        if group is None and assign and not course_tag_api.BulkCourseTags.is_prefetched(course_key):
             if not user_partition.groups:
                 raise UserPartitionError('Cannot assign user to an empty user partition')
 

--- a/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
@@ -26,6 +26,11 @@ class MemoryCourseTagAPI(object):
         """Gets the value of ``key``"""
         self._tags[course_id][key] = value
 
+    class BulkCourseTags(object):
+        @classmethod
+        def is_prefetched(self, course_id):
+            return False
+
 
 class TestRandomUserPartitionScheme(PartitionTestCase):
     """


### PR DESCRIPTION
## [EDUCATOR-249](https://openedx.atlassian.net/browse/EDUCATOR-249)

### Description

This PR changes the Course Grade Report so that SQL and Mongo queries no longer increase linearly with the number of enrollees in the course.  With bulk pre-fetching of user-specific data and smarter caching of course-specific settings, we now have semi-constant number of queries.  It's "semi-constant" since it's dependent on Batch size.

### Sandbox
- [ ] Build a sandbox for your branch and add a link here

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @efischer19 

FYI:  @edx/educator-neem @jibsheet 

### Post-review
- [ ] Rebase and squash commits