### PR TITLE
Mako should be able to render even if webpack hasn't run

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -1,5 +1,6 @@
 <%page expression_filter="h"/>
 <%!
+import logging
 from django.contrib.staticfiles.storage import staticfiles_storage
 from pipeline_mako import compressed_css, compressed_js
 from django.utils.translation import get_language_bidi
@@ -18,6 +19,7 @@ from openedx.core.djangoapps.theming.helpers import (
 )
 from certificates.api import get_asset_url_by_slug
 from openedx.core.djangoapps.lang_pref.api import released_languages
+logger = logging.getLogger(__name__)
 %>
 
 <%def name="marketing_link(name)"><%
@@ -92,16 +94,20 @@ source, template_path = Loader(engine).load_template_source(path)
     </%doc>
     <%
         from django.template import Template, Context
-        return Template("""
-            {% load render_bundle from webpack_loader %}
-            {% render_bundle entry %}
-            <script type="text/javascript">
-                {% autoescape off %}{{ body }}{% endautoescape %}
-            </script>
-        """).render(Context({
-            'entry': entry,
-            'body': capture(caller.body)
-        }))
+        try:
+            return Template("""
+                {% load render_bundle from webpack_loader %}
+                {% render_bundle entry %}
+                <script type="text/javascript">
+                    {% autoescape off %}{{ body }}{% endautoescape %}
+                </script>
+            """).render(Context({
+                'entry': entry,
+                'body': capture(caller.body)
+            }))
+        except IOError as e:
+            # Don't break Mako template rendering if the bundle or webpack-stats can't be found, but log it
+            logger.error(e)
     %>
 </%def>
 


### PR DESCRIPTION
Previously, calls to load a webpack bundle in a Mako template would result in an IOError (and a 500) when rendering that view if webpack hadn't been executed first. This was an issue in test suites (like the Python suite, which doesn't generate assets before running) and I think generally a bad practice (Mako should still be allowed to render whatever it can, even if webpack bundling has failed or been skipped).

With these changes the error thrown when the requested webpack bundle or the webpack-stats.json file don't exist on disk is caught and logged.