### PR TITLE
400 for non-rescorable blocks

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -101,6 +101,11 @@ class InstructorDashboardPage(CoursePage):
         ecommerce_section.wait_for_page()
         return ecommerce_section
 
+    def is_rescore_unsupported_message_visible(self):
+        return u'This component cannot be rescored.' in unicode(
+            self.q(css='.request-response-error').html
+        )
+
     @staticmethod
     def get_asset_path(file_name):
         """

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2118,18 +2118,24 @@ def rescore_problem(request, course_id):
 
     if student:
         response_payload['student'] = student_identifier
-        lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student(
-            request,
-            module_state_key,
-            student,
-            only_if_higher,
-        )
+        try:
+            lms.djangoapps.instructor_task.api.submit_rescore_problem_for_student(
+                request,
+                module_state_key,
+                student,
+                only_if_higher,
+            )
+        except NotImplementedError as exc:
+            return HttpResponseBadRequest(exc.message)
     elif all_students:
-        lms.djangoapps.instructor_task.api.submit_rescore_problem_for_all_students(
-            request,
-            module_state_key,
-            only_if_higher,
-        )
+        try:
+            lms.djangoapps.instructor_task.api.submit_rescore_problem_for_all_students(
+                request,
+                module_state_key,
+                only_if_higher,
+            )
+        except NotImplementedError as exc:
+            return HttpResponseBadRequest(exc.message)
     else:
         return HttpResponseBadRequest()
 

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -255,10 +255,14 @@ def check_arguments_for_rescoring(usage_key):
     in).  An ItemNotFoundException is raised if the corresponding module
     descriptor doesn't exist.  NotImplementedError is raised if the
     corresponding module doesn't support rescoring calls.
+
+    Note: the string returned here is surfaced as the error
+    message on the instructor dashboard when a rescore is
+    submitted for a non-rescorable block.
     """
     descriptor = modulestore().get_item(usage_key)
     if not _supports_rescore(descriptor):
-        msg = "Specified module does not support rescoring."
+        msg = _("This component cannot be rescored.")
         raise NotImplementedError(msg)
 
 

--- a/lms/static/js/instructor_dashboard/student_admin.js
+++ b/lms/static/js/instructor_dashboard/student_admin.js
@@ -436,7 +436,7 @@
         }
 
         StudentAdmin.prototype.rescore_problem_single = function(onlyIfHigher) {
-            var errorMessage, fullErrorMessage, fullSuccessMessage,
+            var defaultErrorMessage, fullDefaultErrorMessage, fullSuccessMessage,
                 problemToReset, sendData, successMessage, uniqStudentIdentifier,
                 that = this;
             uniqStudentIdentifier = this.$field_student_select_grade.val();
@@ -461,8 +461,8 @@
                 student_id: uniqStudentIdentifier,
                 problem_id: problemToReset
             });
-            errorMessage = gettext("Error starting a task to rescore problem '<%- problem_id %>' for student '<%- student_id %>'. Make sure that the the problem and student identifiers are complete and correct.");  // eslint-disable-line max-len
-            fullErrorMessage = _.template(errorMessage)({
+            defaultErrorMessage = gettext("Error starting a task to rescore problem '<%- problem_id %>' for student '<%- student_id %>'. Make sure that the the problem and student identifiers are complete and correct.");  // eslint-disable-line max-len
+            fullDefaultErrorMessage = _.template(defaultErrorMessage)({
                 student_id: uniqStudentIdentifier,
                 problem_id: problemToReset
             });
@@ -474,8 +474,11 @@
                 success: this.clear_errors_then(function() {
                     return alert(fullSuccessMessage);  // eslint-disable-line no-alert
                 }),
-                error: statusAjaxError(function() {
-                    return that.$request_err_grade.text(fullErrorMessage);
+                error: statusAjaxError(function(response) {
+                    if (response.responseText) {
+                        return that.$request_err_grade.text(response.responseText);
+                    }
+                    return that.$request_err_grade.text(fullDefaultErrorMessage);
                 })
             });
         };
@@ -518,8 +521,9 @@
         };
 
         StudentAdmin.prototype.rescore_problem_all = function(onlyIfHigher) {
-            var confirmMessage, errorMessage, fullConfirmMessage,
-                fullErrorMessage, fullSuccessMessage, problemToReset, sendData, successMessage,
+            var confirmMessage, defaultErrorMessage, fullConfirmMessage,
+                fullDefaultErrorMessage, fullSuccessMessage, problemToReset,
+                sendData, successMessage,
                 that = this;
             problemToReset = this.$field_problem_select_all.val();
             if (!problemToReset) {
@@ -541,8 +545,8 @@
                 fullSuccessMessage = _.template(successMessage)({
                     problem_id: problemToReset
                 });
-                errorMessage = gettext("Error starting a task to rescore problem '<%- problem_id %>'. Make sure that the problem identifier is complete and correct.");  // eslint-disable-line max-len
-                fullErrorMessage = _.template(errorMessage)({
+                defaultErrorMessage = gettext("Error starting a task to rescore problem '<%- problem_id %>'. Make sure that the problem identifier is complete and correct.");  // eslint-disable-line max-len
+                fullDefaultErrorMessage = _.template(defaultErrorMessage)({
                     problem_id: problemToReset
                 });
                 return $.ajax({
@@ -553,8 +557,11 @@
                     success: this.clear_errors_then(function() {
                         return alert(fullSuccessMessage);  // eslint-disable-line no-alert
                     }),
-                    error: statusAjaxError(function() {
-                        return that.$request_response_error_all.text(fullErrorMessage);
+                    error: statusAjaxError(function(response) {
+                        if (response.responseText) {
+                            return that.$request_response_error_all.text(response.responseText);
+                        }
+                        return that.$request_response_error_all.text(fullDefaultErrorMessage);
                     })
                 });
             } else {


### PR DESCRIPTION
This PR returns a 400 instead of a 500 when course staff try to rescore a block that does not support rescoring, and should silence [the related intermittent error we see in New Relic](https://rpm.newrelic.com/accounts/88178/applications/3343327/traced_errors/6a4f519d-3021-11e7-8968-0242ac11000f_0_4723). The frontend will now display a separate message when the user tries to rescore a non-rescorable block.

Reviewer: @yro 
Doc review: @srpearce 
FYI: @edx/educator-neem