### PR TITLE
TNL-6832 | Grade reports should include unenrolled learners

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -929,12 +929,18 @@ class CourseEnrollmentManager(models.Manager):
 
         return is_course_full
 
-    def users_enrolled_in(self, course_id):
-        """Return a queryset of User for every user enrolled in the course."""
-        return User.objects.filter(
-            courseenrollment__course_id=course_id,
-            courseenrollment__is_active=True
-        )
+    def users_enrolled_in(self, course_id, include_inactive=False):
+        """
+        Return a queryset of User for every user enrolled in the course.  If
+        `include_inactive` is True, returns both active and inactive enrollees
+        for the course. Otherwise returns actively enrolled users only.
+        """
+        filter_kwargs = {
+            'courseenrollment__course_id': course_id,
+        }
+        if not include_inactive:
+            filter_kwargs['courseenrollment__is_active'] = True
+        return User.objects.filter(**filter_kwargs)
 
     def enrollment_counts(self, course_id):
         """

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -21,6 +21,7 @@ class CourseEnrollmentTests(SharedModuleStoreTestCase):
     def setUp(self):
         super(CourseEnrollmentTests, self).setUp()
         self.user = UserFactory.create()
+        self.user_2 = UserFactory.create()
 
     def test_enrollment_status_hash_cache_key(self):
         username = 'test-user'
@@ -82,3 +83,23 @@ class CourseEnrollmentTests(SharedModuleStoreTestCase):
         # Modifying enrollments should delete the cached value.
         CourseEnrollmentFactory.create(user=self.user)
         self.assertIsNone(cache.get(CourseEnrollment.enrollment_status_hash_cache_key(self.user)))
+
+    def test_users_enrolled_in_active_only(self):
+        """CourseEnrollment.users_enrolled_in should return only Users with active enrollments when
+        `include_inactive` has its default value (False)."""
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id, is_active=True)
+        CourseEnrollmentFactory.create(user=self.user_2, course_id=self.course.id, is_active=False)
+
+        active_enrolled_users = list(CourseEnrollment.objects.users_enrolled_in(self.course.id))
+        self.assertEqual([self.user], active_enrolled_users)
+
+    def test_users_enrolled_in_all(self):
+        """CourseEnrollment.users_enrolled_in should return active and inactive users when
+        `include_inactive` is True."""
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id, is_active=True)
+        CourseEnrollmentFactory.create(user=self.user_2, course_id=self.course.id, is_active=False)
+
+        all_enrolled_users = list(
+            CourseEnrollment.objects.users_enrolled_in(self.course.id, include_inactive=True)
+        )
+        self.assertListEqual([self.user, self.user_2], all_enrolled_users)

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -272,7 +272,8 @@ class CourseGradeReport(object):
         def grouper(iterable, chunk_size=self.USER_BATCH_SIZE, fillvalue=None):
             args = [iter(iterable)] * chunk_size
             return izip_longest(*args, fillvalue=fillvalue)
-        users = CourseEnrollment.objects.users_enrolled_in(context.course_id)
+
+        users = CourseEnrollment.objects.users_enrolled_in(context.course_id, include_inactive=True)
         users = users.select_related('profile__allow_certificate')
         return grouper(users)
 
@@ -412,7 +413,7 @@ class ProblemGradeReport(object):
         start_time = time()
         start_date = datetime.now(UTC)
         status_interval = 100
-        enrolled_students = CourseEnrollment.objects.users_enrolled_in(course_id)
+        enrolled_students = CourseEnrollment.objects.users_enrolled_in(course_id, include_inactive=True)
         task_progress = TaskProgress(action_name, enrolled_students.count(), start_time)
 
         # This struct encapsulates both the display names of each static item in the

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -162,21 +162,21 @@ class InstructorTaskCourseTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase)
             self.login(user_email, "test")
             self.current_user = username
 
-    def _create_user(self, username, email=None, is_staff=False, mode='honor'):
+    def _create_user(self, username, email=None, is_staff=False, mode='honor', enrollment_active=True):
         """Creates a user and enrolls them in the test course."""
         if email is None:
             email = InstructorTaskCourseTestCase.get_user_email(username)
         thisuser = UserFactory.create(username=username, email=email, is_staff=is_staff)
-        CourseEnrollmentFactory.create(user=thisuser, course_id=self.course.id, mode=mode)
+        CourseEnrollmentFactory.create(user=thisuser, course_id=self.course.id, mode=mode, is_active=enrollment_active)
         return thisuser
 
     def create_instructor(self, username, email=None):
         """Creates an instructor for the test course."""
         return self._create_user(username, email, is_staff=True)
 
-    def create_student(self, username, email=None, mode='honor'):
+    def create_student(self, username, email=None, mode='honor', enrollment_active=True):
         """Creates a student for the test course."""
-        return self._create_user(username, email, is_staff=False, mode=mode)
+        return self._create_user(username, email, is_staff=False, mode=mode, enrollment_active=enrollment_active)
 
     @staticmethod
     def get_task_status(task_id):


### PR DESCRIPTION
...in addition to currently enrolled learners.  I tried to make sure that this wouldn't change the behavior of anything else that depends on `users_enrolled_in` by defaulting the `is_active` parameter to True.