### PR TITLE
WIP: adds in course discussion settings model and refactors method names

### DIFF
--- a/common/djangoapps/django_comment_common/migrations/0005_coursediscussionsettings.py
+++ b/common/djangoapps/django_comment_common/migrations/0005_coursediscussionsettings.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(help_text=b'Which course are these settings associated with?', unique=True, max_length=255, db_index=True)),
                 ('always_divide_inline_discussions', models.BooleanField(default=False)),
-                ('_divided_discussions', models.TextField(null=True, db_column=b'cohorted_discussions', blank=True)),
+                ('_divided_discussions', models.TextField(null=True, db_column=b'divided_discussions', blank=True)),
                 ('division_scheme', models.CharField(default=None, max_length=20, choices=[(None, b'None'), (b'cohort', b'Cohort'), (b'enrollment_track', b'Enrollment Track')])),
             ],
         ),

--- a/common/djangoapps/django_comment_common/migrations/0005_coursediscussionsettings.py
+++ b/common/djangoapps/django_comment_common/migrations/0005_coursediscussionsettings.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import openedx.core.djangoapps.xmodule_django.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_comment_common', '0004_auto_20161117_1209'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CourseDiscussionSettings',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(help_text=b'Which course are these settings associated with?', unique=True, max_length=255, db_index=True)),
+                ('always_divide_inline_discussions', models.BooleanField(default=False)),
+                ('_divided_discussions', models.TextField(null=True, db_column=b'cohorted_discussions', blank=True)),
+                ('division_scheme', models.CharField(default=None, max_length=20, choices=[(None, b'None'), (b'cohort', b'Cohort'), (b'enrollment_track', b'Enrollment Track')])),
+            ],
+        ),
+    ]

--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from django.conf import settings
@@ -164,3 +165,29 @@ class ForumsConfig(ConfigurationModel):
     def __unicode__(self):
         """Simple representation so the admin screen looks less ugly."""
         return u"ForumsConfig: timeout={}".format(self.connection_timeout)
+
+
+class CourseDiscussionSettings(models.Model):
+    course_id = CourseKeyField(
+        unique=True,
+        max_length=255,
+        db_index=True,
+        help_text="Which course are these settings associated with?",
+    )
+    always_divide_inline_discussions = models.BooleanField(default=False)
+    _divided_discussions = models.TextField(db_column='cohorted_discussions', null=True, blank=True)  # JSON list
+
+    COHORT = 'cohort'
+    ENROLLMENT_TRACK = 'enrollment_track'
+    ASSIGNMENT_TYPE_CHOICES = ((None, 'None'), (COHORT, 'Cohort'), (ENROLLMENT_TRACK, 'Enrollment Track'))
+    division_scheme = models.CharField(max_length=20, choices=ASSIGNMENT_TYPE_CHOICES, default=None)
+
+    @property
+    def divided_discussions(self):
+        """Jsonify the cohorted_discussions"""
+        return json.loads(self._divided_discussions)
+
+    @divided_discussions.setter
+    def divided_discussions(self, value):
+        """Un-Jsonify the cohorted_discussions"""
+        self._divided_discussions = json.dumps(value)

--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -175,7 +175,7 @@ class CourseDiscussionSettings(models.Model):
         help_text="Which course are these settings associated with?",
     )
     always_divide_inline_discussions = models.BooleanField(default=False)
-    _divided_discussions = models.TextField(db_column='cohorted_discussions', null=True, blank=True)  # JSON list
+    _divided_discussions = models.TextField(db_column='divided_discussions', null=True, blank=True)  # JSON list
 
     COHORT = 'cohort'
     ENROLLMENT_TRACK = 'enrollment_track'
@@ -184,10 +184,10 @@ class CourseDiscussionSettings(models.Model):
 
     @property
     def divided_discussions(self):
-        """Jsonify the cohorted_discussions"""
+        """Jsonify the divided_discussions"""
         return json.loads(self._divided_discussions)
 
     @divided_discussions.setter
     def divided_discussions(self, value):
-        """Un-Jsonify the cohorted_discussions"""
+        """Un-Jsonify the divided_discussions"""
         self._divided_discussions = json.dumps(value)

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -25,7 +25,7 @@ from courseware import courses
 from courseware.access import has_access
 from openedx.core.djangoapps.content.course_structures.models import CourseStructure
 from openedx.core.djangoapps.course_groups.cohorts import (
-    get_course_cohort_settings, get_cohort_by_id, get_cohort_id, is_course_cohorted
+    get_course_settings, get_cohort_by_id, get_cohort_id, is_course_cohorted
 )
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
 from request_cache.middleware import request_cached
@@ -310,7 +310,7 @@ def get_discussion_category_map(course, user, divided_only_if_explicit=False, ex
 
     xblocks = get_accessible_discussion_xblocks(course, user)
 
-    course_cohort_settings = get_course_cohort_settings(course.id)
+    course_cohort_settings, course_discussion_settings = get_course_settings(course.id)
 
     for xblock in xblocks:
         discussion_id = xblock.discussion_id
@@ -800,7 +800,7 @@ def is_commentable_divided(course_key, commentable_id):
         Http404 if the course doesn't exist.
     """
     course = courses.get_course_by_id(course_key)
-    course_cohort_settings = get_course_cohort_settings(course_key)
+    course_cohort_settings, course_discussion_settings = get_course_settings(course_key)
 
     if not course_cohort_settings.is_cohorted or get_team(commentable_id):
         # this is the easy case :)
@@ -812,7 +812,7 @@ def is_commentable_divided(course_key, commentable_id):
         # top level discussions have to be manually configured as cohorted
         # (default is not).
         # Same thing for inline discussions if the default is explicitly set to False in settings
-        ans = commentable_id in course_cohort_settings.cohorted_discussions
+        ans = commentable_id in course_discussion_settings.cohorted_discussions
     else:
         # inline discussions are cohorted by default
         ans = True

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -13,6 +13,7 @@ from django.http import Http404
 from django.utils.translation import ugettext as _
 
 from courseware import courses
+from django_comment_common.models import CourseDiscussionSettings
 from eventtracking import tracker
 from request_cache.middleware import RequestCache, request_cached
 from student.models import get_user_by_username_or_email
@@ -118,7 +119,8 @@ def is_course_cohorted(course_key):
     Raises:
        Http404 if the course doesn't exist.
     """
-    return get_course_cohort_settings(course_key).is_cohorted
+    course_cohort_settings, course_discussion_settings = get_course_settings(course_key)
+    return course_cohort_settings.is_cohorted
 
 
 def get_cohort_id(user, course_key, use_cached=False):
@@ -130,18 +132,19 @@ def get_cohort_id(user, course_key, use_cached=False):
     return None if cohort is None else cohort.id
 
 
-def get_cohorted_commentables(course_key):
+def get_divided_commentables(course_key):
     """
     Given a course_key return a set of strings representing cohorted commentables.
     """
 
-    course_cohort_settings = get_course_cohort_settings(course_key)
+    course_cohort_settings, course_discussion_settings = get_course_settings(course_key)
 
+    # We may need to check the division_scheme for the discussion_settings in the future
     if not course_cohort_settings.is_cohorted:
         # this is the easy case :)
         ans = set()
     else:
-        ans = set(course_cohort_settings.cohorted_discussions)
+        ans = set(course_discussion_settings.cohorted_discussions)
 
     return ans
 
@@ -176,7 +179,7 @@ def get_cohort(user, course_key, assign=True, use_cached=False):
 
     # First check whether the course is cohorted (users shouldn't be in a cohort
     # in non-cohorted courses, but settings can change after course starts)
-    course_cohort_settings = get_course_cohort_settings(course_key)
+    course_cohort_settings, course_discussion_settings = course_cohort_settings(course_key)
     if not course_cohort_settings.is_cohorted:
         return request_cache.data.setdefault(cache_key, None)
 
@@ -261,6 +264,22 @@ def migrate_cohort_settings(course):
             CourseCohort.create(cohort_name=group_name, course_id=course.id, assignment_type=CourseCohort.RANDOM)
 
     return cohort_settings
+
+
+def migrate_discussion_settings(course_cohorts_settings):
+    """
+    Migrate all of the divided discussion settings from CourseCohortSettings to CourseDiscussionSettings
+    """
+    discussion_settings, created = CourseDiscussionSettings.objects.get_or_create(
+        course_id=course_cohorts_settings.course_id,
+        defaults={
+            'always_divide_inline_discussions': course_cohorts_settings.always_cohort_inline_discussions,
+            'divided_discussions': course_cohorts_settings.cohorted_discussions,
+            'division_scheme': CourseDiscussionSettings.COHORT
+        }
+    )
+
+    return discussion_settings
 
 
 def get_course_cohorts(course, assignment_type=None):
@@ -470,7 +489,7 @@ def is_last_random_cohort(user_group):
     return len(random_cohorts) == 1 and random_cohorts[0].name == user_group.name
 
 
-def set_course_cohort_settings(course_key, **kwargs):
+def set_course_settings(course_key, **kwargs):
     """
     Set cohort settings for a course.
 
@@ -481,24 +500,30 @@ def set_course_cohort_settings(course_key, **kwargs):
         cohorted_discussions (list): List of discussion ids.
 
     Returns:
-        A CourseCohortSettings object.
+        A CourseCohortSettings and CourseDiscussionSettings object.
 
     Raises:
         Http404 if course_key is invalid.
     """
     fields = {'is_cohorted': bool, 'always_cohort_inline_discussions': bool, 'cohorted_discussions': list}
-    course_cohort_settings = get_course_cohort_settings(course_key)
+    course_cohort_settings, course_discussion_settings = get_course_settings(course_key)
     for field, field_type in fields.items():
         if field in kwargs:
             if not isinstance(kwargs[field], field_type):
                 raise ValueError("Incorrect field type for `{}`. Type must be `{}`".format(field, field_type.__name__))
-            setattr(course_cohort_settings, field, kwargs[field])
-    course_cohort_settings.save()
-    return course_cohort_settings
+            if field == 'is_cohorted':
+                setattr(course_cohort_settings, field, kwargs[field])
+                course_cohort_settings.save()
+            elif field == 'always_cohort_inline_discussions':
+                setattr(course_discussion_settings, 'always_divide_inline_discussions', kwargs[field])
+            elif field == 'cohorted_discussions':
+                setattr(course_discussion_settings, 'divided_discussions', kwargs[field])
+    course_discussion_settings.save()
+    return course_cohort_settings, course_discussion_settings
 
 
 @request_cached
-def get_course_cohort_settings(course_key):
+def get_course_settings(course_key):
     """
     Return cohort settings for a course.
 
@@ -516,4 +541,9 @@ def get_course_cohort_settings(course_key):
     except CourseCohortsSettings.DoesNotExist:
         course = courses.get_course_by_id(course_key)
         course_cohort_settings = migrate_cohort_settings(course)
-    return course_cohort_settings
+    try:
+        course_discussion_settings = CourseDiscussionSettings.objects.get(course_id=course_key)
+    except CourseDiscussionSettings.DoesNotExist:
+        course_discussion_settings = migrate_discussion_settings(course_cohort_settings)
+
+    return course_cohort_settings, course_discussion_settings

--- a/openedx/core/djangoapps/course_groups/tests/helpers.py
+++ b/openedx/core/djangoapps/course_groups/tests/helpers.py
@@ -10,7 +10,7 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import ModuleStoreEnum
 
-from ..cohorts import set_course_cohort_settings
+from ..cohorts import set_course_settings
 from ..models import CourseUserGroup, CourseCohort, CourseCohortsSettings, CohortMembership
 
 
@@ -165,7 +165,7 @@ def config_course_cohorts(
         """Convert name to id."""
         return topic_name_to_id(course, name)
 
-    set_course_cohort_settings(
+    set_course_settings(
         course.id,
         is_cohorted=is_cohorted,
         cohorted_discussions=[to_id(name) for name in cohorted_discussions],

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -475,17 +475,17 @@ class TestCohorts(ModuleStoreTestCase):
             {cohort1.id: cohort1.name, cohort2.id: cohort2.name}
         )
 
-    def test_get_cohorted_commentables(self):
+    def test_get_divided_commentables(self):
         """
-        Make sure cohorts.get_cohorted_commentables() correctly returns a list of strings representing cohorted
-        commentables.  Also verify that we can't get the cohorted commentables from a course which does not exist.
+        Make sure cohorts.get_divided_commentables() correctly returns a list of strings representing divided
+        commentables.  Also verify that we can't get the divided commentables from a course which does not exist.
         """
         course = modulestore().get_course(self.toy_course_key)
 
-        self.assertEqual(cohorts.get_cohorted_commentables(course.id), set())
+        self.assertEqual(cohorts.get_divided_commentables(course.id), set())
 
         config_course_cohorts(course, is_cohorted=True)
-        self.assertEqual(cohorts.get_cohorted_commentables(course.id), set())
+        self.assertEqual(cohorts.get_divided_commentables(course.id), set())
 
         config_course_cohorts(
             course,
@@ -494,7 +494,7 @@ class TestCohorts(ModuleStoreTestCase):
             cohorted_discussions=["Feedback"]
         )
         self.assertItemsEqual(
-            cohorts.get_cohorted_commentables(course.id),
+            cohorts.get_divided_commentables(course.id),
             set([topic_name_to_id(course, "Feedback")])
         )
 
@@ -505,12 +505,12 @@ class TestCohorts(ModuleStoreTestCase):
             cohorted_discussions=["General", "Feedback"]
         )
         self.assertItemsEqual(
-            cohorts.get_cohorted_commentables(course.id),
+            cohorts.get_divided_commentables(course.id),
             set([topic_name_to_id(course, "General"), topic_name_to_id(course, "Feedback")])
         )
         self.assertRaises(
             Http404,
-            lambda: cohorts.get_cohorted_commentables(SlashSeparatedCourseKey("course", "does_not", "exist"))
+            lambda: cohorts.get_divided_commentables(SlashSeparatedCourseKey("course", "does_not", "exist"))
         )
 
     def test_get_cohort_by_name(self):
@@ -672,12 +672,12 @@ class TestCohorts(ModuleStoreTestCase):
         # Note that the following get() will fail with MultipleObjectsReturned if race condition is not handled.
         self.assertEqual(first_cohort.users.get(), course_user)
 
-    def test_get_course_cohort_settings(self):
+    def test_get_course_settings(self):
         """
-        Test that cohorts.get_course_cohort_settings is working as expected.
+        Test that cohorts.course_cohort_settings is working as expected.
         """
         course = modulestore().get_course(self.toy_course_key)
-        course_cohort_settings = cohorts.get_course_cohort_settings(course.id)
+        course_cohort_settings = cohorts.course_cohort_settings(course.id)
 
         self.assertFalse(course_cohort_settings.is_cohorted)
         self.assertEqual(course_cohort_settings.cohorted_discussions, [])
@@ -685,19 +685,19 @@ class TestCohorts(ModuleStoreTestCase):
 
     def test_update_course_cohort_settings(self):
         """
-        Test that cohorts.set_course_cohort_settings is working as expected.
+        Test that cohorts.set_course_settings is working as expected.
         """
         course = modulestore().get_course(self.toy_course_key)
         CourseCohortSettingsFactory(course_id=course.id)
 
-        cohorts.set_course_cohort_settings(
+        cohorts.set_course_settings(
             course.id,
             is_cohorted=False,
             cohorted_discussions=['topic a id', 'topic b id'],
             always_cohort_inline_discussions=True
         )
 
-        course_cohort_settings = cohorts.get_course_cohort_settings(course.id)
+        course_cohort_settings, course_discussion_settings = cohorts.course_cohort_settings(course.id)
 
         self.assertFalse(course_cohort_settings.is_cohorted)
         self.assertEqual(course_cohort_settings.cohorted_discussions, ['topic a id', 'topic b id'])
@@ -705,7 +705,7 @@ class TestCohorts(ModuleStoreTestCase):
 
     def test_update_course_cohort_settings_with_invalid_data_type(self):
         """
-        Test that cohorts.set_course_cohort_settings raises exception if fields have incorrect data type.
+        Test that cohorts.set_course_settings raises exception if fields have incorrect data type.
         """
         course = modulestore().get_course(self.toy_course_key)
         CourseCohortSettingsFactory(course_id=course.id)
@@ -719,7 +719,7 @@ class TestCohorts(ModuleStoreTestCase):
 
         for field in fields:
             with self.assertRaises(ValueError) as value_error:
-                cohorts.set_course_cohort_settings(course.id, **{field['name']: ''})
+                cohorts.set_course_settings(course.id, **{field['name']: ''})
 
             self.assertEqual(
                 value_error.exception.message,

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -64,12 +64,12 @@ def unlink_cohort_partition_group(cohort):
 
 
 # pylint: disable=invalid-name
-def _get_course_cohort_settings_representation(course, course_cohort_settings):
+def _get_course_settings_representation(course, course_cohort_settings, course_discussion_settings):
     """
     Returns a JSON representation of a course cohort settings.
     """
-    cohorted_course_wide_discussions, cohorted_inline_discussions = get_cohorted_discussions(
-        course, course_cohort_settings
+    cohorted_course_wide_discussions, cohorted_inline_discussions = get_divided_discussions(
+        course, course_cohort_settings, course_discussion_settings
     )
 
     return {
@@ -98,23 +98,23 @@ def _get_cohort_representation(cohort, course):
     }
 
 
-def get_cohorted_discussions(course, course_settings):
+def get_divided_discussions(course, course_settings, discussion_settings):
     """
-    Returns the course-wide and inline cohorted discussion ids separately.
+    Returns the course-wide and inline divided discussion ids separately.
     """
-    cohorted_course_wide_discussions = []
-    cohorted_inline_discussions = []
+    divided_course_wide_discussions = []
+    divided_inline_discussions = []
 
     course_wide_discussions = [topic['id'] for __, topic in course.discussion_topics.items()]
     all_discussions = get_discussion_categories_ids(course, None, include_all=True)
 
-    for cohorted_discussion_id in course_settings.cohorted_discussions:
-        if cohorted_discussion_id in course_wide_discussions:
-            cohorted_course_wide_discussions.append(cohorted_discussion_id)
-        elif cohorted_discussion_id in all_discussions:
-            cohorted_inline_discussions.append(cohorted_discussion_id)
+    for divided_discussion_id in discussion_settings.divided_discussions:
+        if divided_discussion_id in course_wide_discussions:
+            divided_course_wide_discussions.append(divided_discussion_id)
+        elif divided_discussion_id in all_discussions:
+            divided_inline_discussions.append(divided_discussion_id)
 
-    return cohorted_course_wide_discussions, cohorted_inline_discussions
+    return divided_course_wide_discussions, divided_inline_discussions
 
 
 @require_http_methods(("GET", "PATCH"))
@@ -132,11 +132,11 @@ def course_cohort_settings_handler(request, course_key_string):
     """
     course_key = CourseKey.from_string(course_key_string)
     course = get_course_with_access(request.user, 'staff', course_key)
-    cohort_settings = cohorts.get_course_cohort_settings(course_key)
+    cohort_settings, discussion_settings = cohorts.get_course_settings(course_key)
 
     if request.method == 'PATCH':
-        cohorted_course_wide_discussions, cohorted_inline_discussions = get_cohorted_discussions(
-            course, cohort_settings
+        cohorted_course_wide_discussions, cohorted_inline_discussions = get_divided_discussions(
+            course, cohort_settings, discussion_settings
         )
 
         settings_to_change = {}
@@ -162,14 +162,14 @@ def course_cohort_settings_handler(request, course_key_string):
             return JsonResponse({"error": unicode("Bad Request")}, 400)
 
         try:
-            cohort_settings = cohorts.set_course_cohort_settings(
+            cohort_settings, discussion_settings = cohorts.set_course_settings(
                 course_key, **settings_to_change
             )
         except ValueError as err:
             # Note: error message not translated because it is not exposed to the user (UI prevents this state).
             return JsonResponse({"error": unicode(err)}, 400)
 
-    return JsonResponse(_get_course_cohort_settings_representation(course, cohort_settings))
+    return JsonResponse(_get_course_settings_representation(course, cohort_settings, discussion_settings))
 
 
 @require_http_methods(("GET", "PUT", "POST", "PATCH"))

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -77,7 +77,7 @@ def _get_course_settings_representation(course, course_cohort_settings, course_d
         'is_cohorted': course_cohort_settings.is_cohorted,
         'cohorted_inline_discussions': cohorted_inline_discussions,
         'cohorted_course_wide_discussions': cohorted_course_wide_discussions,
-        'always_cohort_inline_discussions': course_cohort_settings.always_cohort_inline_discussions,
+        'always_cohort_inline_discussions': course_discussion_settings.always_divide_inline_discussions,
     }
 
 

--- a/openedx/core/djangoapps/verified_track_content/tests/test_models.py
+++ b/openedx/core/djangoapps/verified_track_content/tests/test_models.py
@@ -18,7 +18,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from ..models import VerifiedTrackCohortedCourse, DEFAULT_VERIFIED_COHORT_NAME
 from ..tasks import sync_cohort_with_mode
 from openedx.core.djangoapps.course_groups.cohorts import (
-    set_course_cohort_settings, add_cohort, CourseCohort, DEFAULT_COHORT_NAME
+    set_course_settings, add_cohort, CourseCohort, DEFAULT_COHORT_NAME
 )
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
@@ -88,7 +88,7 @@ class TestMoveToVerified(SharedModuleStoreTestCase):
 
     def _enable_cohorting(self):
         """ Turn on cohorting in the course. """
-        set_course_cohort_settings(self.course.id, is_cohorted=True)
+        set_course_settings(self.course.id, is_cohorted=True)
 
     def _create_verified_cohort(self, name=DEFAULT_VERIFIED_COHORT_NAME):
         """ Create a verified cohort. """


### PR DESCRIPTION
## [EDUCATOR-12](https://openedx.atlassian.net/browse/EDUCATOR-12)

@staubina @cahrens 

Hey guys, I currently have this to where the model, CourseDiscussionSettings in common/django_comment_common updates appropriately. There are many methods that have been refactored to use 'discussion' instead of 'cohort'. 

The method `_get_course_cohort_settings_representation` receives cohorted_inline_discussions set appropriately, but does not set the UI accordingly, ex. a returned object from _get_course_settings_representation contains 
```
["b11488e3580241f08146cbcfca693d06", "d7b66e45154b4af18f33213337685e91", "9ad16580878f49d1bf20ce1bc533d16e"]
``` 
but the UI is not reflective of this, in the sense that these checkboxes are not selected.