### PR TITLE
Re-create image set for course overview.

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -220,6 +220,8 @@ class CourseOverview(TimeStampedModel):
                         course_overview.save()
                         # Remove and recreate all the course tabs
                         CourseOverviewTab.objects.filter(course_overview=course_overview).delete()
+                        # Remove and recreate course images
+                        CourseOverviewImageSet.objects.filter(course_overview=course_overview).delete()
                         CourseOverviewTab.objects.bulk_create([
                             CourseOverviewTab(tab_id=tab.tab_id, course_overview=course_overview)
                             for tab in course.tabs


### PR DESCRIPTION
[EDUCATOR-218](https://openedx.atlassian.net/browse/EDUCATOR-218)

For some reason a unicode `course_key` was being passed to  [`get_prep_value`](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/xmodule_django/models.py#L134) only when we were updating course overview during `image_set.save()` – [source](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/content/course_overviews/models.py#L776) and this was causing the `AssertionError` in the atomic block which resulted in rolling back of course overview – [splunk](https://splunk.edx.org/en-US/app/search/search?earliest=-7d%40h&latest=now&q=search%20index%3Dprod-edx%20%22Response%20was%3A%20course-v1%3AMITProfessionalX%2BCSx%2B2017_T1%20is%20not%20an%20instance%20of%20%3Cclass%20%27opaque_keys.edx.keys.CourseKey%27%3E%22&display.page.search.mode=smart&dispatch.sample_ratio=1&sid=1493983004.294920).

Complete traceback:
```
May  5 07:14:36 ip-10-3-10-188 [service_variant=cms][openedx.core.djangoapps.content.course_overviews.models][env:stage-edx-edxapp] ERROR [ip-10-3-10-188  3334] [models.py:242] - CourseOverview for course course-v1:ArbiSoftDemo+108+2016-17 failed!
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py", line 227, in load_from_module_store
    CourseOverviewImageSet.create_or_update(course_overview, course)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py", line 776, in create_or_update
    image_set.save()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 734, in save
    force_update=force_update, update_fields=update_fields)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 762, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 827, in _save_table
    forced_update)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 877, in _do_update
    return filtered._update(values) > 0
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 580, in _update
    return query.get_compiler(self.db).execute_sql(CURSOR)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 1062, in execute_sql
    cursor = super(SQLUpdateCompiler, self).execute_sql(result_type)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 829, in execute_sql
    sql, params = self.as_sql()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 1030, in as_sql
    val = field.get_db_prep_save(val, connection=self.connection)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/related.py", line 1958, in get_db_prep_save
    return self.related_field.get_db_prep_save(value, connection=connection)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 710, in get_db_prep_save
    prepared=False)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 702, in get_db_prep_value
    value = self.get_prep_value(value)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xmodule_django/models.py", line 134, in get_prep_value
    assert isinstance(value, self.KEY_CLASS), "%s is not an instance of %s" % (value, self.KEY_CLASS)
AssertionError: course-v1:ArbiSoftDemo+108+2016-17 is not an instance of <class 'opaque_keys.edx.keys.CourseKey'>
```

To be on safest side and keeping in mind that this would effect a lot of courses, we have decided to stick to "repopulate" the `CourseOverviewImageSet`. 
