### PR TITLE
Customized OAuth application model

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -59,7 +59,7 @@ from lms.envs.common import (
     # The following setting is included as it is used to check whether to
     # display credit eligibility table on the CMS or not.
     ENABLE_CREDIT_ELIGIBILITY, YOUTUBE_API_KEY,
-    COURSE_MODE_DEFAULTS, DEFAULT_COURSE_ABOUT_IMAGE_URL,
+    COURSE_MODE_DEFAULTS, DEFAULT_COURSE_ABOUT_IMAGE_URL, OAUTH2_PROVIDER_APPLICATION_MODEL,
 
     # User-uploaded content
     MEDIA_ROOT,
@@ -1046,6 +1046,7 @@ INSTALLED_APPS = [
 
     # django-oauth-toolkit
     'oauth2_provider',
+    'openedx.core.djangoapps.oauth_dispatch',
 
     # These are apps that aren't strictly needed by Studio, but are imported by
     # other apps that are.  Django 1.8 wants to have imported models supported
@@ -1390,13 +1391,6 @@ HELP_TOKENS_INI_FILE = REPO_ROOT / "cms" / "envs" / "help_tokens.ini"
 HELP_TOKENS_LANGUAGE_CODE = lambda settings: settings.LANGUAGE_CODE
 HELP_TOKENS_VERSION = lambda settings: doc_version()
 derived('HELP_TOKENS_LANGUAGE_CODE', 'HELP_TOKENS_VERSION')
-
-# This is required for the migrations in oauth_dispatch.models
-# otherwise it fails saying this attribute is not present in Settings
-# Although Studio does not exable OAuth2 Provider capability, the new approach
-# to generating test databases will discover and try to create all tables
-# and this setting needs to be present
-OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 
 # Used with Email sending
 RETRY_ACTIVATION_EMAIL_MAX_ATTEMPTS = 5

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 from freezegun import freeze_time
-from oauth2_provider import models as dot_models
+from oauth2_provider.models import get_application_model, AccessToken
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -59,14 +59,14 @@ class CertificatesRestApiTest(SharedModuleStoreTestCase, APITestCase):
 
         # create a configuration for django-oauth-toolkit (DOT)
         dot_app_user = UserFactory.create(password=USER_PASSWORD)
-        dot_app = dot_models.Application.objects.create(
+        dot_app = get_application_model().objects.create(
             name='test app',
             user=dot_app_user,
             client_type='confidential',
             authorization_grant_type='authorization-code',
             redirect_uris='http://localhost:8079/complete/edxorg/'
         )
-        self.dot_access_token = dot_models.AccessToken.objects.create(
+        self.dot_access_token = AccessToken.objects.create(
             user=self.student,
             application=dot_app,
             expires=datetime.utcnow() + timedelta(weeks=1),

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -528,9 +528,9 @@ OAUTH2_PROVIDER = {
         'profile': 'Read your user profile',
     },
 }
-# This is required for the migrations in oauth_dispatch.models
-# otherwise it fails saying this attribute is not present in Settings
-OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
+
+OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth_dispatch.Application'
+
 
 ################################## TEMPLATE CONFIGURATION #####################################
 # Mako templating
@@ -2116,7 +2116,7 @@ INSTALLED_APPS = [
 
     # django-oauth-toolkit
     'oauth2_provider',
-    'openedx.core.djangoapps.oauth_dispatch.apps.OAuthDispatchAppConfig',
+    'openedx.core.djangoapps.oauth_dispatch',
 
     'third_party_auth',
 

--- a/openedx/core/djangoapps/auth_exchange/forms.py
+++ b/openedx/core/djangoapps/auth_exchange/forms.py
@@ -5,7 +5,7 @@ import provider.constants
 from django.contrib.auth.models import User
 from django.forms import CharField
 from edx_oauth2_provider.constants import SCOPE_NAMES
-from oauth2_provider.models import Application
+from oauth2_provider.models import get_application_model
 from provider.forms import OAuthForm, OAuthValidationError
 from provider.oauth2.forms import ScopeChoiceField, ScopeMixin
 from provider.oauth2.models import Client
@@ -14,6 +14,8 @@ from social_core.backends import oauth as social_oauth
 from social_core.exceptions import AuthException
 
 from third_party_auth import pipeline
+
+Application = get_application_model()
 
 
 class AccessTokenExchangeForm(ScopeMixin, OAuthForm):

--- a/openedx/core/djangoapps/oauth_dispatch/__init__.py
+++ b/openedx/core/djangoapps/oauth_dispatch/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'openedx.core.djangoapps.oauth_dispatch.apps.OAuthDispatchAppConfig'

--- a/openedx/core/djangoapps/oauth_dispatch/adapters/dop.py
+++ b/openedx/core/djangoapps/oauth_dispatch/adapters/dop.py
@@ -2,8 +2,8 @@
 Adapter to isolate django-oauth2-provider dependencies
 """
 
-from provider.oauth2 import models
 from provider import constants, scope
+from provider.oauth2 import models
 
 
 class DOPAdapter(object):

--- a/openedx/core/djangoapps/oauth_dispatch/adapters/dot.py
+++ b/openedx/core/djangoapps/oauth_dispatch/adapters/dot.py
@@ -2,7 +2,7 @@
 Adapter to isolate django-oauth-toolkit dependencies
 """
 
-from oauth2_provider import models
+from oauth2_provider.models import get_application_model, AbstractApplication, AccessToken
 
 
 class DOTAdapter(object):
@@ -10,6 +10,7 @@ class DOTAdapter(object):
     Standard interface for working with django-oauth-toolkit
     """
 
+    Application = get_application_model()
     backend = object()
 
     def create_confidential_client(self,
@@ -17,15 +18,15 @@ class DOTAdapter(object):
                                    user,
                                    redirect_uri,
                                    client_id=None,
-                                   authorization_grant_type=models.Application.GRANT_AUTHORIZATION_CODE):
+                                   authorization_grant_type=AbstractApplication.GRANT_AUTHORIZATION_CODE):
         """
         Create an oauth client application that is confidential.
         """
-        return models.Application.objects.create(
+        return get_application_model().objects.create(
             name=name,
             user=user,
             client_id=client_id,
-            client_type=models.Application.CLIENT_CONFIDENTIAL,
+            client_type=AbstractApplication.CLIENT_CONFIDENTIAL,
             authorization_grant_type=authorization_grant_type,
             redirect_uris=redirect_uri,
         )
@@ -34,12 +35,14 @@ class DOTAdapter(object):
         """
         Create an oauth client application that is public.
         """
-        return models.Application.objects.create(
+        Application = get_application_model()
+
+        return Application.objects.create(
             name=name,
             user=user,
             client_id=client_id,
-            client_type=models.Application.CLIENT_PUBLIC,
-            authorization_grant_type=models.Application.GRANT_PASSWORD,
+            client_type=Application.CLIENT_PUBLIC,
+            authorization_grant_type=Application.GRANT_PASSWORD,
             redirect_uris=redirect_uri,
         )
 
@@ -49,7 +52,7 @@ class DOTAdapter(object):
 
         Wraps django's queryset.get() method.
         """
-        return models.Application.objects.get(**filters)
+        return get_application_model().objects.get(**filters)
 
     def get_client_for_token(self, token):
         """
@@ -61,7 +64,7 @@ class DOTAdapter(object):
         """
         Given a token string, return the matching AccessToken object.
         """
-        return models.AccessToken.objects.get(token=token_string)
+        return AccessToken.objects.get(token=token_string)
 
     def normalize_scopes(self, scopes):
         """

--- a/openedx/core/djangoapps/oauth_dispatch/admin.py
+++ b/openedx/core/djangoapps/oauth_dispatch/admin.py
@@ -1,9 +1,6 @@
-"""
-Override admin configuration for django-oauth-toolkit
-"""
-
-from django.contrib.admin import ModelAdmin, site
-from oauth2_provider import models
+from django.contrib import admin
+from oauth2_provider.admin import ApplicationAdmin
+from oauth2_provider.models import AccessToken, get_application_model, Grant, RefreshToken
 
 from .models import RestrictedApplication
 
@@ -18,68 +15,46 @@ def reregister(model_class):
         class ModelClassAdmin(ModelAdmin):
             pass
     """
+
     def decorator(cls):
-        """
-        The actual decorator that does the work.
-        """
-        site.unregister(model_class)
-        site.register(model_class, cls)
+        admin.site.unregister(model_class)
+        admin.site.register(model_class, cls)
         return cls
 
     return decorator
 
 
-@reregister(models.AccessToken)
-class DOTAccessTokenAdmin(ModelAdmin):
-    """
-    Custom AccessToken Admin
-    """
-    date_hierarchy = u'expires'
-    list_display = [u'token', u'user', u'application', u'expires']
-    list_filter = [u'application']
-    raw_id_fields = [u'user']
-    search_fields = [u'token', u'user__username']
+@reregister(AccessToken)
+class DOTAccessTokenAdmin(admin.ModelAdmin):
+    date_hierarchy = 'expires'
+    list_display = ('token', 'user', 'application', 'expires')
+    list_filter = ('application',)
+    raw_id_fields = ('user',)
+    search_fields = ('token', 'user__username')
 
 
-@reregister(models.RefreshToken)
-class DOTRefreshTokenAdmin(ModelAdmin):
-    """
-    Custom AccessToken Admin
-    """
-    list_display = [u'token', u'user', u'application', u'access_token']
-    list_filter = [u'application']
-    raw_id_fields = [u'user', u'access_token']
-    search_fields = [u'token', u'user__username', u'access_token__token']
+@reregister(RefreshToken)
+class DOTRefreshTokenAdmin(admin.ModelAdmin):
+    list_display = ('token', 'user', 'application', 'access_token')
+    list_filter = ('application',)
+    raw_id_fields = ('user', 'access_token')
+    search_fields = ('token', 'user__username', 'access_token__token')
 
 
-@reregister(models.Application)
-class DOTApplicationAdmin(ModelAdmin):
-    """
-    Custom Application Admin
-    """
-    list_display = [u'name', u'user', u'client_type', u'authorization_grant_type', u'client_id']
-    list_filter = [u'client_type', u'authorization_grant_type']
-    raw_id_fields = [u'user']
-    search_fields = [u'name', u'user__username', u'client_id']
+@reregister(get_application_model())
+class DOTApplicationAdmin(ApplicationAdmin):
+    search_fields = ('name', 'user__username', 'client_id')
 
 
-@reregister(models.Grant)
-class DOTGrantAdmin(ModelAdmin):
-    """
-    Custom Grant Admin
-    """
-    date_hierarchy = u'expires'
-    list_display = [u'code', u'user', u'application', u'expires']
-    list_filter = [u'application']
-    raw_id_fields = [u'user']
-    search_fields = [u'code', u'user__username']
+@reregister(Grant)
+class DOTGrantAdmin(admin.ModelAdmin):
+    date_hierarchy = 'expires'
+    list_display = ('code', 'user', 'application', 'expires')
+    list_filter = ('application',)
+    raw_id_fields = ('user',)
+    search_fields = ('code', 'user__username')
 
 
-class RestrictedApplicationAdmin(ModelAdmin):
-    """
-    ModelAdmin for the Restricted Application
-    """
-    list_display = [u'application']
-
-
-site.register(RestrictedApplication, RestrictedApplicationAdmin)
+@admin.register(RestrictedApplication)
+class RestrictedApplicationAdmin(admin.ModelAdmin):
+    list_display = ('application',)

--- a/openedx/core/djangoapps/oauth_dispatch/apps.py
+++ b/openedx/core/djangoapps/oauth_dispatch/apps.py
@@ -1,14 +1,8 @@
-"""
-Configure OAuthDispatch App
-"""
-
 from __future__ import absolute_import
 
 from django.apps import AppConfig
 
 
 class OAuthDispatchAppConfig(AppConfig):
-    """
-    OAuthDispatch Configuration
-    """
-    name = u'openedx.core.djangoapps.oauth_dispatch'
+    name = 'openedx.core.djangoapps.oauth_dispatch'
+    verbose_name = 'OAuth Dispatch'

--- a/openedx/core/djangoapps/oauth_dispatch/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/oauth_dispatch/migrations/0001_initial.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
 from django.conf import settings
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/oauth_dispatch/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/oauth_dispatch/migrations/0001_initial.py
@@ -6,11 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
-    dependencies = [
-        migrations.swappable_dependency(settings.OAUTH2_PROVIDER_APPLICATION_MODEL),
-    ]
-
     operations = [
         migrations.CreateModel(
             name='RestrictedApplication',

--- a/openedx/core/djangoapps/oauth_dispatch/migrations/0002_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/migrations/0002_application.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+
+import oauth2_provider.generators
+import oauth2_provider.validators
+from django.conf import settings
+from django.db import connection, migrations, models
+
+log = logging.getLogger(__name__)
+
+
+class FakeForwardCreateModel(migrations.CreateModel):
+    """
+    Migration class that only executes forwards if the table does not exist.
+
+    This migration will only be executed for new installations. The table will already exist for installations setup
+    prior to this migration being merged. We use the existence of the table to determine if a prior migration applied.
+    """
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            # We only migrate if the table does not exist
+            table_name = model._meta.db_table
+            if table_name in connection.introspection.table_names():
+                log.warning(
+                    'The database table (%s) for the model %s.%s already exists. No changes have been made to the '
+                    'table as this behavior is expected for older installations. This is message is just an FYI that '
+                    'this migration has essentially been faked.',
+                    table_name, app_label, self.name)
+            else:
+                schema_editor.create_model(model)
+
+
+class Migration(migrations.Migration):
+    run_before = [
+        ('oauth2_provider', '0001_initial'),
+    ]
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('oauth_dispatch', '0001_initial'),
+    ]
+
+    operations = [
+        FakeForwardCreateModel(
+            name='Application',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('client_id', models.CharField(default=oauth2_provider.generators.generate_client_id, unique=True, max_length=100, db_index=True)),
+                ('redirect_uris', models.TextField(help_text='Allowed URIs list, space separated', blank=True, validators=[oauth2_provider.validators.validate_uris])),
+                ('client_type', models.CharField(max_length=32, choices=[('confidential', 'Confidential'), ('public', 'Public')])),
+                ('authorization_grant_type', models.CharField(max_length=32, choices=[('authorization-code', 'Authorization code'), ('implicit', 'Implicit'), ('password', 'Resource owner password-based'), ('client-credentials', 'Client credentials')])),
+                ('client_secret', models.CharField(default=oauth2_provider.generators.generate_client_secret, max_length=255, db_index=True, blank=True)),
+                ('name', models.CharField(max_length=255, blank=True)),
+                ('skip_authorization', models.BooleanField(default=False)),
+                ('user', models.ForeignKey(related_name='oauth_dispatch_application', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+            options={
+                'db_table': 'oauth2_provider_application',
+            },
+        ),
+    ]

--- a/openedx/core/djangoapps/oauth_dispatch/models.py
+++ b/openedx/core/djangoapps/oauth_dispatch/models.py
@@ -1,14 +1,35 @@
-"""
-Specialized models for oauth_dispatch djangoapp
-"""
-
 from datetime import datetime
 
+from django.conf import settings
 from django.db import models
-from oauth2_provider.settings import oauth2_settings
+# from django.utils.translation import ugettext_lazy as _
+from oauth2_provider.models import AbstractApplication
 from pytz import utc
 
 
+class Application(AbstractApplication):
+    """ OAuth application model.
+
+    Allows for declared authorization grant type in addition to the client credentials grant.
+    """
+
+    class Meta(object):
+        # NOTE: We use this table name to avoid issues with migrating existing data
+        # and updating foreign keys for existing installations.
+        db_table = 'oauth2_provider_application'
+
+    # TODO Phase 2: Use this instead of RestrictedApplication
+    # restricted = models.BooleanField(
+    #     default=False,
+    #     help_text=_('Restricted clients receive expired access tokens. '
+    #                 'They are intended to provide identity information to third-parties.')
+    # )
+
+    def allows_grant_type(self, *grant_types):
+        return bool({self.authorization_grant_type, self.GRANT_CLIENT_CREDENTIALS}.intersection(set(grant_types)))
+
+
+# TODO Phase 3: Delete this model
 class RestrictedApplication(models.Model):
     """
     This model lists which django-oauth-toolkit Applications are considered 'restricted'
@@ -18,7 +39,7 @@ class RestrictedApplication(models.Model):
     so that they cannot be used to call into APIs.
     """
 
-    application = models.ForeignKey(oauth2_settings.APPLICATION_MODEL, null=False)
+    application = models.ForeignKey(settings.OAUTH2_PROVIDER_APPLICATION_MODEL, null=False)
 
     def __unicode__(self):
         """

--- a/openedx/core/djangoapps/oauth_dispatch/tests/factories.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/factories.py
@@ -3,11 +3,10 @@
 from datetime import datetime, timedelta
 
 import factory
+import pytz
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
-import pytz
-
-from oauth2_provider.models import Application, AccessToken, RefreshToken
+from oauth2_provider.models import AccessToken, Application, RefreshToken
 
 from student.tests.factories import UserFactory
 

--- a/openedx/core/djangoapps/oauth_dispatch/tests/factories.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/factories.py
@@ -6,20 +6,19 @@ import factory
 import pytz
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
-from oauth2_provider.models import AccessToken, Application, RefreshToken
+from oauth2_provider.models import AbstractApplication, AccessToken, RefreshToken, get_application_model
 
+from openedx.core.djangoapps.oauth_dispatch.models import Application
 from student.tests.factories import UserFactory
 
 
 class ApplicationFactory(DjangoModelFactory):
     class Meta(object):
-        model = Application
+        model = get_application_model()
 
     user = factory.SubFactory(UserFactory)
-    client_id = factory.Sequence(u'client_{0}'.format)
-    client_secret = 'some_secret'
-    client_type = 'confidential'
-    authorization_grant_type = 'Client credentials'
+    client_type = AbstractApplication.CLIENT_CONFIDENTIAL
+    authorization_grant_type = AbstractApplication.GRANT_AUTHORIZATION_CODE
 
 
 class AccessTokenFactory(DjangoModelFactory):

--- a/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
@@ -2,9 +2,8 @@
 OAuth Dispatch test mixins
 """
 
-from django.conf import settings
-
 import jwt
+from django.conf import settings
 from jwt.exceptions import ExpiredSignatureError
 
 from student.models import UserProfile, anonymous_id_for_user

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
@@ -10,11 +10,12 @@ from django.test import TestCase
 from edx_oauth2_provider.tests.factories import ClientFactory
 from oauth2_provider.models import Application
 from provider.oauth2.models import AccessToken
+
 from student.tests.factories import UserFactory
 
 from . import mixins
-from .constants import DUMMY_REDIRECT_URL
 from ..adapters import DOTAdapter
+from .constants import DUMMY_REDIRECT_URL
 
 
 @unittest.skipUnless(settings.FEATURES.get("ENABLE_OAUTH2_PROVIDER"), "OAuth2 not enabled")

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
@@ -8,14 +8,15 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from edx_oauth2_provider.tests.factories import ClientFactory
-from oauth2_provider.models import Application
+from oauth2_provider.models import get_application_model
 from provider.oauth2.models import AccessToken
 
 from student.tests.factories import UserFactory
-
 from . import mixins
-from ..adapters import DOTAdapter
 from .constants import DUMMY_REDIRECT_URL
+from ..adapters import DOTAdapter
+
+Application = get_application_model()
 
 
 @unittest.skipUnless(settings.FEATURES.get("ENABLE_OAUTH2_PROVIDER"), "OAuth2 not enabled")

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dop_adapter.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dop_adapter.py
@@ -7,8 +7,8 @@ from datetime import timedelta
 import ddt
 from django.test import TestCase
 from django.utils.timezone import now
-from provider.oauth2 import models
 from provider import constants
+from provider.oauth2 import models
 
 from student.tests.factories import UserFactory
 

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_adapter.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_adapter.py
@@ -2,6 +2,7 @@
 Tests for DOT Adapter
 """
 
+import unittest
 from datetime import timedelta
 
 import ddt
@@ -9,13 +10,12 @@ from django.conf import settings
 from django.test import TestCase
 from django.utils.timezone import now
 from oauth2_provider import models
-import unittest
 
 from student.tests.factories import UserFactory
 
 from ..adapters import DOTAdapter
-from .constants import DUMMY_REDIRECT_URL, DUMMY_REDIRECT_URL2
 from ..models import RestrictedApplication
+from .constants import DUMMY_REDIRECT_URL, DUMMY_REDIRECT_URL2
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_adapter.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_adapter.py
@@ -12,10 +12,11 @@ from django.utils.timezone import now
 from oauth2_provider import models
 
 from student.tests.factories import UserFactory
-
+from .constants import DUMMY_REDIRECT_URL, DUMMY_REDIRECT_URL2
 from ..adapters import DOTAdapter
 from ..models import RestrictedApplication
-from .constants import DUMMY_REDIRECT_URL, DUMMY_REDIRECT_URL2
+
+Application = models.get_application_model()
 
 
 @ddt.ddt
@@ -59,13 +60,13 @@ class DOTAdapterTestCase(TestCase):
         ))
 
     @ddt.data(
-        ('confidential', models.Application.CLIENT_CONFIDENTIAL),
-        ('public', models.Application.CLIENT_PUBLIC),
+        ('confidential', Application.CLIENT_CONFIDENTIAL),
+        ('public', Application.CLIENT_PUBLIC),
     )
     @ddt.unpack
     def test_create_client(self, client_name, client_type):
         client = getattr(self, '{}_client'.format(client_name))
-        self.assertIsInstance(client, models.Application)
+        self.assertIsInstance(client, models.get_application_model())
         self.assertEqual(client.client_id, '{}-client-id'.format(client_name))
         self.assertEqual(client.client_type, client_type)
 
@@ -76,13 +77,13 @@ class DOTAdapterTestCase(TestCase):
         """
         client = self.adapter.get_client(
             redirect_uris=DUMMY_REDIRECT_URL,
-            client_type=models.Application.CLIENT_CONFIDENTIAL
+            client_type=Application.CLIENT_CONFIDENTIAL
         )
-        self.assertIsInstance(client, models.Application)
-        self.assertEqual(client.client_type, models.Application.CLIENT_CONFIDENTIAL)
+        self.assertIsInstance(client, models.get_application_model())
+        self.assertEqual(client.client_type, Application.CLIENT_CONFIDENTIAL)
 
     def test_get_client_not_found(self):
-        with self.assertRaises(models.Application.DoesNotExist):
+        with self.assertRaises(Application.DoesNotExist):
             self.adapter.get_client(client_id='not-found')
 
     def test_get_client_for_token(self):

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -5,7 +5,8 @@ Test of custom django-oauth-toolkit behavior
 # pylint: disable=protected-access
 
 from django.contrib.auth.models import User
-from django.test import TestCase, RequestFactory
+from django.test import RequestFactory, TestCase
+
 from ..dot_overrides import EdxOAuth2Validator
 
 

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_factories.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_factories.py
@@ -1,9 +1,10 @@
 # pylint: disable=missing-docstring
 
+import unittest
+
 from django.conf import settings
 from django.test import TestCase
-from oauth2_provider.models import Application, AccessToken, RefreshToken
-import unittest
+from oauth2_provider.models import AccessToken, Application, RefreshToken
 
 from openedx.core.djangoapps.oauth_dispatch.tests import factories
 from student.tests.factories import UserFactory

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_factories.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_factories.py
@@ -4,10 +4,12 @@ import unittest
 
 from django.conf import settings
 from django.test import TestCase
-from oauth2_provider.models import AccessToken, Application, RefreshToken
+from oauth2_provider.models import AccessToken, RefreshToken, get_application_model
 
 from openedx.core.djangoapps.oauth_dispatch.tests import factories
 from student.tests.factories import UserFactory
+
+Application = get_application_model()
 
 
 @unittest.skipUnless(settings.FEATURES.get("ENABLE_OAUTH2_PROVIDER"), "OAuth2 not enabled")

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_models.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_models.py
@@ -1,0 +1,19 @@
+import ddt
+from django.test import TestCase
+
+from openedx.core.djangoapps.oauth_dispatch.models import Application
+from openedx.core.djangoapps.oauth_dispatch.tests.factories import ApplicationFactory
+
+
+@ddt.ddt
+class ApplicationTests(TestCase):
+    @ddt.data(
+        Application.GRANT_AUTHORIZATION_CODE,
+        Application.GRANT_IMPLICIT,
+        Application.GRANT_PASSWORD,
+        Application.GRANT_CLIENT_CREDENTIALS,
+    )
+    def test_allows_grant_type(self, authorization_grant_type):
+        """ The method should always allow the client credentials grant. """
+        application = ApplicationFactory(authorization_grant_type=authorization_grant_type)
+        self.assertTrue(application.allows_grant_type(Application.GRANT_CLIENT_CREDENTIALS))

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -16,10 +16,10 @@ from provider import constants
 
 from student.tests.factories import UserFactory
 from third_party_auth.tests.utils import ThirdPartyOAuthTestMixin, ThirdPartyOAuthTestMixinGoogle
+
 from . import mixins
+from .. import adapters, models
 from .constants import DUMMY_REDIRECT_URL
-from .. import adapters
-from .. import models
 
 # NOTE (CCB): We use this feature flag in a roundabout way to determine if the oauth_dispatch app is installed
 # in the current service--LMS or Studio. Normally we would check if settings.ROOT_URLCONF == 'lms.urls'; however,

--- a/openedx/core/djangoapps/oauth_dispatch/views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/views.py
@@ -15,12 +15,11 @@ from django.http import JsonResponse
 from django.views.generic import View
 from edx_oauth2_provider import views as dop_views  # django-oauth2-provider views
 from jwkest.jwk import RSAKey
-from oauth2_provider import models as dot_models  # django-oauth-toolkit
-from oauth2_provider import views as dot_views
+from oauth2_provider import views as dot_views  # django-oauth-toolkit
+from oauth2_provider.models import get_application_model
 
 from openedx.core.djangoapps.auth_exchange import views as auth_exchange_views
 from openedx.core.lib.token_utils import JwtBuilder
-
 from . import adapters
 
 
@@ -39,7 +38,7 @@ class _DispatchingView(View):
         """
         Returns the appropriate adapter based on the OAuth client linked to the request.
         """
-        if dot_models.Application.objects.filter(client_id=self._get_client_id(request)).exists():
+        if get_application_model().objects.filter(client_id=self._get_client_id(request)).exists():
             return self.dot_adapter
         else:
             return self.dop_adapter


### PR DESCRIPTION
This model allows Django OAuth Toolkit applications to use the client credentials grant type in addition to the grant type stored on the instance.

LEARNER-726