### PR TITLE
EDUCATOR-283 Old mathjax not load in preview box.

### DIFF
--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -202,7 +202,7 @@
                 var $general;
                 this.$('.forum-new-post-form')[0].reset();
                 DiscussionUtil.clearFormErrors(this.$('.post-errors'));
-                this.$('.wmd-preview p').html('');
+                this.$('.wmd-preview').html('');
                 if (this.isTabMode()) {
                     $general = this.$('.post-topic option:contains(General)');
                     this.topicView.setTopic($general || this.$('button.topic-title').first());

--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -718,12 +718,12 @@ class DiscussionTabHomePage(CoursePage, DiscussionPageMixin):
         """
         self.q(css=".wmd-input").fill(new_body)
 
-    def get_new_post_preview_value(self):
+    def get_new_post_preview_value(self, selector=".wmd-preview > *"):
         """
         Get the rendered preview of the contents of the Discussions new post editor
         Waits for content to appear, as the preview is triggered on debounced/delayed onchange
         """
-        self.wait_for_element_visibility(".wmd-preview > *", "WMD preview pane has contents", timeout=10)
+        self.wait_for_element_visibility(selector, "WMD preview pane has contents", timeout=10)
         return self.q(css=".wmd-preview").html[0]
 
     def get_new_post_preview_text(self):

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -11,7 +11,7 @@ from pytz import UTC
 from flaky import flaky
 
 from common.test.acceptance.tests.discussion.helpers import BaseDiscussionTestCase
-from common.test.acceptance.tests.helpers import UniqueCourseTest
+from common.test.acceptance.tests.helpers import UniqueCourseTest, get_modal_alert
 from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
 from common.test.acceptance.pages.lms.courseware import CoursewarePage
 from common.test.acceptance.pages.lms.discussion import (
@@ -996,6 +996,27 @@ class DiscussionEditorPreviewTest(UniqueCourseTest):
         )
 
         self.assertEqual(self.page.get_new_post_preview_text(), 'Text line 1\nText line 2')
+
+    def test_mathjax_not_rendered_after_post_cancel(self):
+        """
+        Tests that mathjax is not rendered when we cancel the post
+
+        When user types the mathjax expression into discussion editor, it will appear in te preview
+        box, and when user cancel it and again click the "Add new post" button, mathjax will not
+        appear in the preview box
+        """
+        self.page.set_new_post_editor_value(
+            '\\begin{equation}'
+            '\\tau_g(\omega) = - \\frac{d}{d\omega}\phi(\omega) \hspace{2em} (1) '
+            '\\end{equation}'
+        )
+        self.assertIsNotNone(self.page.get_new_post_preview_text())
+        self.page.click_element(".cancel")
+        alert = get_modal_alert(self.browser)
+        alert.accept()
+        self.assertIsNotNone(self.page.new_post_button)
+        self.page.click_new_post_button()
+        self.assertEqual(self.page.get_new_post_preview_value('.wmd-preview'), "")
 
 
 @attr(shard=2)


### PR DESCRIPTION
## [Discussion preview shows old MathJax content. EDUCATOR-283](https://openedx.atlassian.net/browse/EDUCATOR-283)

### Description
This PR fixes that Old mathjax is not shown in the discussion preview while creating the new post and cancel the existing post.

### How to Test?

_**_MathJax :_**_ 

```
Specifically, the group delay $\tau_g(\omega)$ of a system with frequency response $H(e^{j\omega})$ and impulse response $h[n]$ is computed according to 
\begin{equation}
\tau_g(\omega) = - \frac{d}{d\omega}\phi(\omega) \hspace{2em} (1)
\end{equation}

```

**Stage** 
Go to discussion: https://courses.stage.edx.org/courses/course-v1:edx+aishaq+1T2017/discussion/forum/

_**First Scenario**_

1. Create a new post with MathJax content (see above MathJax). 
2. Note that the content shows in Preview before you save the new post. 
3. Save the Post.
4. Click "Add a Post" to create another post. 
5. The "Preview" region is incorrectly pre-populated with Old MathJax. 

_**Second Scenario**_

1. Create a new post with MathJax content (see above MathJax). 
2. Note that the content shows in Preview before you save the new post. 
3. Cancel the Post.
4. Click "Add a Post" to create another post. 
5. The "Preview" region is incorrectly pre-populated with Old MathJax. 

**Sandbox**
https://preview-283.sandbox.edx.org/


### Tests
 - [x] Acceptance Test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @noraiz-anwar 
- [x] @Ayub-Khan 

FYI: @adampalay 

### Post-review
- [x] Rebase and squash commits
