### PR TITLE
LEARNER-868: Default unified_course_view on in devstack.

### DIFF
--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -237,8 +237,6 @@ from django.db.utils import ProgrammingError
 from waffle.models import Flag
 try:
     flag, created = Flag.objects.get_or_create(name='unified_course_view')
-    flag.everyone = True
-    flag.save
     WAFFLE_OVERRIDE = True
 except ProgrammingError:
     # during initial reset_db, the table for the flag doesn't yet exist.

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -261,6 +261,18 @@ JWT_AUTH.update({
     'JWT_AUDIENCE': 'lms-key',
 })
 
+# TODO: TNL-6546: Remove this waffle and flag code.
+from django.db.utils import ProgrammingError
+from waffle.models import Flag
+try:
+    flag, created = Flag.objects.get_or_create(name='unified_course_view')
+    flag.everyone = True
+    flag.save()
+    WAFFLE_OVERRIDE = True
+except ProgrammingError:
+    # during initial reset_db, the table for the flag doesn't yet exist.
+    pass
+
 #####################################################################
 # See if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):


### PR DESCRIPTION
## [LEARNER-868](https://openedx.atlassian.net/browse/LEARNER-868)

### Description

This PR turns on unified_course_view by default in devstacks.  It would not affect sandboxes or aws.

### Testing
- [ ] Unit, integration, acceptance tests as appropriate

### Post-review
- [ ] Rebase and squash commits