### PR TITLE
Support reading of programs exclusively from the cache

### DIFF
--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -2,16 +2,19 @@
 import copy
 import logging
 
+import waffle
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from edx_rest_api_client.client import EdxRestApiClient
 
+from openedx.core.djangoapps.catalog.cache import PROGRAM_CACHE_KEY_TPL, PROGRAM_UUIDS_CACHE_KEY
 from openedx.core.djangoapps.catalog.models import CatalogIntegration
 from openedx.core.lib.edx_api_utils import get_edx_api_data
 from openedx.core.lib.token_utils import JwtBuilder
 
-log = logging.getLogger(__name__)
 
+logger = logging.getLogger(__name__)
 User = get_user_model()  # pylint: disable=invalid-name
 
 
@@ -24,55 +27,74 @@ def create_catalog_api_client(user, catalog_integration):
     return EdxRestApiClient(catalog_integration.internal_api_url, jwt=jwt)
 
 
-def get_programs(uuid=None, types=None):  # pylint: disable=redefined-builtin
-    """Retrieve marketable programs from the catalog service.
+def get_programs(uuid=None):
+    """Read programs from the cache.
+
+    The cache is populated by a management command, cache_programs.
 
     Keyword Arguments:
-        uuid (string): UUID identifying a specific program.
-        types (list of string): List of program type names used to filter programs by type
-                                (e.g., ["MicroMasters"] will only return MicroMasters programs,
-                                ["MicroMasters", "XSeries"] will return MicroMasters and XSeries programs).
+        uuid (string): UUID identifying a specific program to read from the cache.
 
     Returns:
         list of dict, representing programs.
         dict, if a specific program is requested.
     """
-    catalog_integration = CatalogIntegration.current()
-    if catalog_integration.enabled:
-        try:
-            user = User.objects.get(username=catalog_integration.service_username)
-        except User.DoesNotExist:
-            return []
-
-        api = create_catalog_api_client(user, catalog_integration)
-        types_param = ','.join(types) if types else None
-
-        cache_key = '{base}.programs{types}'.format(
-            base=catalog_integration.CACHE_KEY,
-            types='.' + types_param if types_param else ''
-        )
-
-        querystring = {
-            'exclude_utm': 1,
-            'status': ('active', 'retired',),
-        }
+    if waffle.switch_is_active('read_cached_programs'):
+        missing_details_msg_tpl = 'Details for program {uuid} are not cached.'
 
         if uuid:
-            querystring['use_full_course_serializer'] = 1
+            program = cache.get(PROGRAM_CACHE_KEY_TPL.format(uuid=uuid))
+            if not program:
+                logger.warning(missing_details_msg_tpl.format(uuid=uuid))
 
-        if types_param:
-            querystring['types'] = types_param
+            return program
 
-        return get_edx_api_data(
-            catalog_integration,
-            'programs',
-            api=api,
-            resource_id=uuid,
-            cache_key=cache_key if catalog_integration.is_cache_enabled else None,
-            querystring=querystring,
-        )
+        uuids = cache.get(PROGRAM_UUIDS_CACHE_KEY, [])
+        if not uuids:
+            logger.warning('Program UUIDs are not cached.')
+
+        programs = cache.get_many(PROGRAM_CACHE_KEY_TPL.format(uuid=uuid) for uuid in uuids)
+        programs = list(programs.values())
+
+        missing_uuids = set(uuids) - set(program['uuid'] for program in programs)
+        for uuid in missing_uuids:
+            logger.warning(missing_details_msg_tpl.format(uuid=uuid))
+
+        return programs
     else:
-        return []
+        # Old implementation which may request programs in-process. To be removed
+        # as part of LEARNER-382.
+        catalog_integration = CatalogIntegration.current()
+        if catalog_integration.enabled:
+            try:
+                user = User.objects.get(username=catalog_integration.service_username)
+            except User.DoesNotExist:
+                return []
+
+            api = create_catalog_api_client(user, catalog_integration)
+
+            cache_key = '{base}.programs'.format(
+                base=catalog_integration.CACHE_KEY
+            )
+
+            querystring = {
+                'exclude_utm': 1,
+                'status': ('active', 'retired',),
+            }
+
+            if uuid:
+                querystring['use_full_course_serializer'] = 1
+
+            return get_edx_api_data(
+                catalog_integration,
+                'programs',
+                api=api,
+                resource_id=uuid,
+                cache_key=cache_key if catalog_integration.is_cache_enabled else None,
+                querystring=querystring,
+            )
+        else:
+            return []
 
 
 def get_program_types(name=None):
@@ -121,11 +143,19 @@ def get_programs_with_type(types=None):
         list of dict, representing the active programs.
     """
     programs_with_type = []
-    programs = get_programs(types=types)
+    programs = get_programs()
 
     if programs:
         program_types = {program_type['name']: program_type for program_type in get_program_types()}
         for program in programs:
+            # This limited type filtering is sufficient for current needs and
+            # helps us avoid additional complexity when caching program data.
+            # However, if the need for additional filtering of programs should
+            # arise, consider using the cache_programs management command to
+            # cache the filtered lists of UUIDs.
+            if types and program['type'] not in types:
+                continue
+
             # deepcopy the program dict here so we are not adding
             # the type to the cached object
             program_with_type = copy.deepcopy(program)
@@ -148,7 +178,7 @@ def get_course_runs():
         try:
             user = User.objects.get(username=catalog_integration.service_username)
         except User.DoesNotExist:
-            log.error(
+            logger.error(
                 'Catalog service user with username [%s] does not exist. Course runs will not be retrieved.',
                 catalog_integration.service_username,
             )


### PR DESCRIPTION
When enabled, these changes prevent LMS application code from hitting the discovery service in-process to retrieve programs. Instead, program data is pulled from cache entries populated by a management command, cache_programs.

LEARNER-382

@edx/learner FYI.