### PR TITLE
bump up the courseoverview version

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -44,7 +44,7 @@ class CourseOverview(TimeStampedModel):
         app_label = 'course_overviews'
 
     # IMPORTANT: Bump this whenever you modify this model and/or add a migration.
-    VERSION = 4
+    VERSION = 5
 
     # Cache entry versioning.
     version = IntegerField()


### PR DESCRIPTION
The purpose of this PR is to bump the course-overview version to backfill the course-overview objects which were stale due to this issue. https://openedx.atlassian.net/browse/EDUCATOR-218