### PR TITLE
Revert: Default unified_course_view on in devstack.

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -261,18 +261,6 @@ JWT_AUTH.update({
     'JWT_AUDIENCE': 'lms-key',
 })
 
-# TODO: TNL-6546: Remove this waffle and flag code.
-from django.db.utils import ProgrammingError
-from waffle.models import Flag
-try:
-    flag, created = Flag.objects.get_or_create(name='unified_course_view')
-    flag.everyone = True
-    flag.save()
-    WAFFLE_OVERRIDE = True
-except ProgrammingError:
-    # during initial reset_db, the table for the flag doesn't yet exist.
-    pass
-
 #####################################################################
 # See if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):


### PR DESCRIPTION
This change was breaking Docker Devstack.  It was a known temporary hack that could probably be fixed by re-ordering, but this PR is for a revert.

Maybe this will just be a lesson learned and we'll add this to the document of what one should or should not do while working with waffle flags.

FYI: @andy-armstrong @dianakhuang