### PR TITLE
DOC-3411 Update lms_config.ini: instructor dashboard Help landing page

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_help.py
+++ b/common/test/acceptance/tests/lms/test_lms_help.py
@@ -107,6 +107,6 @@ class InstructorDashboardHelp(BaseInstructorDashboardTest):
         When I click "Help"
         Then I see help about the instructor dashboard in a new tab
         """
-        href = url_for_help('learner', '/SFD_instructor_dash_help.html')
+        href = url_for_help('course_author', '/CA_instructor_dash_help.html')
         self.instructor_dashboard_page.click_help()
         assert_opened_help_link_is_correct(self, href)

--- a/docs/lms_config.ini
+++ b/docs/lms_config.ini
@@ -3,7 +3,7 @@
 #       in edx-platform/common/test/acceptance/tests/lms/test_lms_help.py
 [pages]
 default = learner:index.html
-instructor = learner:SFD_instructor_dash_help.html
+instructor = course_author:CA_instructor_dash_help.html
 course = learner:index.html
 profile = learner:SFD_dashboard_profile_SectionHead.html
 dashboard = learner:SFD_dashboard_profile_SectionHead.html


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DOC-3411

This PR updates the lms_config.ini so that the Help target for the LMS instructor dashboard is a page in the "Building and Running" guide rather than the Learner's Guide.

This change is a step towards a future state where we might have individual Help context for each tab in the instructor dashboard. Currently there is a single Help token to represent all the tabs in the instructor dashboard, hence the need for a single landing page.

The landing page can be viewed at: http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/CA_instructor_dash_help.html and
http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/CA_instructor_dash_help.html

Reviewers:
- [x] Doc: @edx/doc
- [x] Dev: @nedbat 