### PR TITLE
Avoid passing a generator expression to cache.get_many()

### DIFF
--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -53,7 +53,7 @@ def get_programs(uuid=None):
         if not uuids:
             logger.warning('Program UUIDs are not cached.')
 
-        programs = cache.get_many(PROGRAM_CACHE_KEY_TPL.format(uuid=uuid) for uuid in uuids)
+        programs = cache.get_many([PROGRAM_CACHE_KEY_TPL.format(uuid=uuid) for uuid in uuids])
         programs = list(programs.values())
 
         missing_uuids = set(uuids) - set(program['uuid'] for program in programs)


### PR DESCRIPTION
Generator expressions passed to the memcached backend's implementation of get_many() are exhausted prematurely. This results in KeyErrors when the backend tries to map keys returned by memcached back to keys passed by application code.

See https://github.com/django/django/blob/stable/1.8.x/django/core/cache/backends/memcached.py/#L99.

LEARNER-382

This particular issue only manifests itself when using the memcached backend. The generator expression works when using the [locmem](https://github.com/django/django/blob/stable/1.8.x/django/core/cache/backends/base.py#L135) backend, which doesn't attempt to iterate over it twice. Given that this code is unit tested and that my earlier builds passed without catching this, the only reasonable conclusion to draw is that we're using the locmem backend when running tests on Jenkins.

@edx/learner @edx/testeng be advised.