### PR TITLE
EDUCATOR-217-364 add logs in bulk email

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2523,6 +2523,7 @@ def send_email(request, course_id):
     course_id = CourseKey.from_string(course_id)
 
     if not BulkEmailFlag.feature_enabled(course_id):
+        log.warning(u'Email is not enabled for course %s', course_id)
         return HttpResponseForbidden("Email is not enabled for this course.")
 
     targets = json.loads(request.POST.get("send_to"))
@@ -2564,6 +2565,8 @@ def send_email(request, course_id):
             from_addr=from_addr
         )
     except ValueError as err:
+        log.exception(u'Cannot create course email for course %s requested by user %s for targets %s',
+                      course_id, request.user, targets)
         return HttpResponseBadRequest(repr(err))
 
     # Submit the task, so that the correct InstructorTask object gets created (for monitoring purposes)


### PR DESCRIPTION
# [Unable to send bulk email to verified learners in some courses - EDUCATOR-364](https://openedx.atlassian.net/browse/EDUCATOR-364)

### Description

In some courses, course teams are unable to send bulk email to verified track learners. We are showing a generic error message to the user **Error sending email** in [JS](https://github.com/edx/edx-platform/blob/master/lms/static/js/instructor_dashboard/send_email.js#L122-L122). From the views, we are returning **HttpResponseBadRequest** and **HttpResponseForbidden** [here](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/instructor/views/api.py#L2513-L2576) in a case of exception but we don't have any information to track the issue. We have added logs which will help investigate the issue.

### How to Test?

**Stage** 
Not Applicable.

**Screenshots**
Not Applicable.


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @awaisdar001 
- [x] Code review: @attiyaIshaque   

### Post-review
- [x] Rebase and squash commits