### PR TITLE
[ENT-290] Enable switch in Enterprise setup to hide Audit track

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -931,6 +931,13 @@ ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE = ENV_TOKENS.get(
     ENTERPRISE_CUSTOMER_LOGO_IMAGE_SIZE
 )
 
+# Course enrollment modes to be hidden in the Enterprise enrollment page
+# if the "Hide audit track" flag is enabled for an EnterpriseCustomer
+ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES = ENV_TOKENS.get(
+    'ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES',
+    ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES
+)
+
 
 ############## ENTERPRISE SERVICE API CLIENT CONFIGURATION ######################
 # The LMS communicates with the Enterprise service via the EdxRestApiClient class

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3131,6 +3131,7 @@ HELP_TOKENS_BOOKS = {
 
 ENTERPRISE_ENROLLMENT_API_URL = LMS_ROOT_URL + "/api/enrollment/v1/"
 ENTERPRISE_PUBLIC_ENROLLMENT_API_URL = ENTERPRISE_ENROLLMENT_API_URL
+ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES = ['audit', 'honor']
 
 ############## ENTERPRISE SERVICE API CLIENT CONFIGURATION ######################
 # The LMS communicates with the Enterprise service via the EdxRestApiClient class


### PR DESCRIPTION
This PR adds a new setting ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES to be used in edx-enterprise for filtering course modes in the new landing page.

Related edx/edx-enterprise PR: https://github.com/edx/edx-enterprise/pull/104

**JIRA tickets**: [ENT-290](https://openedx.atlassian.net/browse/ENT-290)

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" 

**Reviewers**
- [ ] @haikuginger 
- [ ] edX reviewer[s] TBD