### PR TITLE
bump enterprise version from 0.33.13 to 0.33.15

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.33.13
+edx-enterprise==0.33.15
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.4


### PR DESCRIPTION
ENT-330
@saleem-latif @asadiqbal08 @douglashall @brittneyexline 

Related PRs:
* [Add externally managed consent option for data sharing](https://github.com/edx/edx-enterprise/pull/98)
* [Additional minor UI updates for enterprise landing page](https://github.com/edx/edx-enterprise/pull/102)

Here is the commits list from version 0.33.13 to 0.33.15: https://github.com/edx/edx-enterprise/compare/04c531c...823ec33