### PR TITLE
Move matplotlib to post requirements.

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -13,7 +13,6 @@ numpy==1.6.2
 networkx==1.7
 sympy==0.7.1
 pyparsing==2.0.7
-matplotlib==1.3.1
 
 # We forked NLTK just to make it work with setuptools instead of distribute
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6

--- a/requirements/edx-sandbox/post.txt
+++ b/requirements/edx-sandbox/post.txt
@@ -7,3 +7,4 @@
 # Packages to install in the Python sandbox for secured execution.
 scipy==0.14.0
 lxml==3.4.4
+matplotlib==1.3.1


### PR DESCRIPTION
Matplotlib depends on numpy, so we want to ensure the correct version of numpy is already installed when we attempt to install matplotlib.

A new version of numpy (1.13.0rc1) was released yesterday, which is breaking fresh installations on Ubuntu 16.04.

**JIRA Ticket**: [OSPR-1765](https://openedx.atlassian.net/browse/OSPR-1765)

**Discussions**: https://groups.google.com/forum/#!topic/openedx-ops/XB86A6MaCOs

**Dependencies**: None

**Sandbox URLs**:
- LMS: https://pr15101.sandbox.opencraft.hosting/
- Studio: https://studio-pr15101.sandbox.opencraft.hosting/

**Merge deadline**: ASAP, this is breaking new installations.

**Testing instructions**:

1. Try to deploy a new edx-platform instance based on master branch using default vagrant scripts from edx/configuration. Observe that the deployment fails at the "code sandbox | Install base sandbox requirements and create sandbox virtualenv" step.

1. Deploy again, this time use the patch from this PR. Installation should now succeed.

**Author notes and concerns**:

Fresh installations of ficus.3 release are breaking too, so a new ficus.4 release should probably be released with this patch ASAP.

**Reviewers**
- [x] @bradenmacdonald
- [ ] edX reviewer[s]