### PR TITLE
Exclude UTM parameters from marketing URLs when caching programs

### DIFF
--- a/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
+++ b/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
         for uuid in uuids:
             try:
                 logger.info('Requesting details for program {uuid}.'.format(uuid=uuid))
-                program = client.programs(uuid).get()
+                program = client.programs(uuid).get(exclude_utm=1)
 
                 cache_key = PROGRAM_CACHE_KEY_TPL.format(uuid=uuid)
                 programs[cache_key] = program

--- a/openedx/core/djangoapps/catalog/management/commands/tests/test_cache_programs.py
+++ b/openedx/core/djangoapps/catalog/management/commands/tests/test_cache_programs.py
@@ -46,10 +46,18 @@ class TestCachePrograms(CatalogIntegrationMixin, CacheIsolationTestCase):
         )
 
     def mock_detail(self, uuid, program):
+        def detail_callback(request, uri, headers):
+            expected = {
+                'exclude_utm': ['1'],
+            }
+            self.assertEqual(request.querystring, expected)
+
+            return (200, headers, json.dumps(program))
+
         httpretty.register_uri(
             httpretty.GET,
             self.detail_tpl.format(uuid=uuid),
-            body=json.dumps(program),
+            body=detail_callback,
             content_type='application/json'
         )
 


### PR DESCRIPTION
LEARNER-382

@edx/learner-growth FYI.