### PR TITLE
EDUCATOR-278 Remove flaky decorator from test_can_reset_attempts.

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -407,7 +407,6 @@ class ProctoredExamsTest(BaseInstructorDashboardTest):
         # Then, the added record should be visible
         self.assertTrue(allowance_section.is_allowance_record_visible)
 
-    @flaky  # TNL-5832
     def test_can_reset_attempts(self):
         """
         Make sure that Exam attempts are visible and can be reset.


### PR DESCRIPTION
## [Remove Flaky decorator EDUCATOR-278](https://openedx.atlassian.net/browse/EDUCATOR-278)

### Reviewers
- [x] @noraiz-anwar   
- [x] @adampalay 

FYI: @efischer19 

### Post-review
- [x] Rebase and squash commits
