### PR TITLE
Update version of proctoring.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -88,7 +88,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.3#egg=lti_consumer-xblock==1.1.3
-git+https://github.com/edx/edx-proctoring.git@0.18.0#egg=edx-proctoring==0.18.0
+git+https://github.com/edx/edx-proctoring.git@0.18.1#egg=edx-proctoring==0.18.1
 git+https://github.com/edx/help-tokens.git@v1.0.0#egg=help-tokens==1.0.0
 
 # Third Party XBlocks


### PR DESCRIPTION
EDUCATOR-396

Related to https://github.com/edx/edx-proctoring/pull/350

https://github.com/edx/edx-proctoring/compare/0.18.0...0.18.1

I created a sandbox with these changes, enabled proctoring (with "verified" in verified track), and tried out some of the templates. All seems well. https://ed396.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/2f4aa3578d6b435a971cea9b430a286b/f57073c149a34009beeada368c7fca9d/

@jibsheet FYI that I am updating the version of the proctoring repo. The [edx-proctoring release process](https://openedx.atlassian.net/wiki/display/ENG/edx-proctoring+Release+Process) says someone from devops should review, but I would think a developer review is also acceptable. There are no database migrations.
