### PR TITLE
Show post visibility warning on new post

### DIFF
--- a/common/static/common/js/discussion/views/discussion_inline_view.js
+++ b/common/static/common/js/discussion/views/discussion_inline_view.js
@@ -126,7 +126,8 @@
                 course_settings: this.courseSettings,
                 topicId: discussionId,
                 startHeader: this.startHeader,
-                is_commentable_divided: response.is_commentable_divided
+                is_commentable_divided: response.is_commentable_divided,
+                user_group_id: response.user_group_id,
             });
 
             this.newPostView.render();

--- a/common/static/common/js/discussion/views/discussion_topic_menu_view.js
+++ b/common/static/common/js/discussion/views/discussion_topic_menu_view.js
@@ -15,6 +15,7 @@
             initialize: function(options) {
                 this.course_settings = options.course_settings;
                 this.currentTopicId = options.topicId;
+                this.group_name = options.group_name;
                 _.bindAll(this,
                     'handleTopicEvent'
                 );

--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -54,7 +54,7 @@
                 _.extend(context, {
                     group_options: this.getGroupOptions(),
                     is_commentable_divided: this.is_commentable_divided,
-                    is_cohorted: this.course_settings.get('is_cohorted'),
+                    is_discussion_division_enabled: this.course_settings.get('is_discussion_division_enabled'),
                     mode: this.mode,
                     startHeader: this.startHeader,
                     form_id: this.mode + (this.topicId ? '-' + this.topicId : '')
@@ -74,7 +74,7 @@
                         group_name: this.getGroupName()
                     });
                     this.topicView.on('thread:topic_change', this.toggleGroupDropDown);
-                    if (this.course_settings.get('is_cohorted')) {
+                    if (this.course_settings.get('is_discussion_division_enabled')) {
                         this.topicView.on('thread:topic_change', this.updateVisibilityMessage);
                     }
                     this.addField(this.topicView.render());
@@ -111,18 +111,18 @@
 
             NewPostView.prototype.getGroupName = function() {
                 var userGroupId;
-                var cohort;
+                var group;
                 var group_name = null;
-                if (this.course_settings.get('is_cohorted')) {
+                if (this.course_settings.get('is_discussion_division_enabled')) {
                     userGroupId = $('#discussion-container').data('user-group-id');
                     if (!userGroupId) {
                         userGroupId = this.user_group_id;
                     }
-                    cohort = this.course_settings.get('cohorts').find(function(cohort) {
-                        return cohort.id == userGroupId;
+                    group = this.course_settings.get('groups').find(function(group) {
+                        return group.id == userGroupId;
                     });
-                    if (cohort) {
-                        group_name = cohort.name;
+                    if (group) {
+                        group_name = group.name;
                     }
                 }
 
@@ -150,11 +150,11 @@
                 }
             };
 
-            NewPostView.prototype.updateVisibilityMessage = function($target, force_cohorted) {
+            NewPostView.prototype.updateVisibilityMessage = function($target, force_divided) {
                 var visEl = $('.group-visibility .field-label-text');
                 var visTemplate = edx.HtmlUtils.template($('#new-post-visibility-template').html());
                 var group_name = null;
-                if (($target && $target.data('cohorted')) || force_cohorted) {
+                if (($target && $target.data('divided')) || force_divided) {
                     group_name = this.group_name;
                 }
 

--- a/common/static/common/templates/discussion/new-post-visibility.underscore
+++ b/common/static/common/templates/discussion/new-post-visibility.underscore
@@ -1,0 +1,11 @@
+<% if (group_name) { %>
+    <%-
+    interpolate(
+        gettext('This post is visible only to %(group_name)s.'),
+        {group_name: group_name},
+        true
+    )
+    %>
+<% } else { %>
+    <%- gettext('This post is visible to everyone.') %>
+<% } %>

--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -29,7 +29,7 @@
             </div>
         </label>
     </div>
-    <% } else if (is_cohorted) { %>
+    <% } else if (is_discussion_division_enabled) { %>
     <div class="post-field group-visibility">
         <label class="field-label">
             <span class="field-label-text"></span>

--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -29,6 +29,12 @@
             </div>
         </label>
     </div>
+    <% } else if (is_cohorted) { %>
+    <div class="post-field group-visibility">
+        <label class="field-label">
+            <span class="field-label-text"></span>
+	</label>
+    </div>
     <% } %>
     <div class="post-field">
         <label class="field-label">

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -222,12 +222,13 @@ def inline_discussion(request, course_key, discussion_id):
     threads = [utils.prepare_content(thread, course_key, is_staff) for thread in threads]
     with newrelic_function_trace("add_courseware_context"):
         add_courseware_context(threads, course, request.user)
+    course_discussion_settings = get_course_discussion_settings(course.id)
 
     return utils.JsonResponse({
         'is_commentable_divided': is_commentable_divided(course_key, discussion_id),
         'discussion_data': threads,
         'user_info': user_info,
-        'user_group_id': get_group_id_for_user(request.user, course.id),
+        'user_group_id': get_group_id_for_user(request.user, course_discussion_settings),
         'annotated_content_info': annotated_content_info,
         'page': query_params['page'],
         'num_pages': query_params['num_pages'],

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -227,6 +227,7 @@ def inline_discussion(request, course_key, discussion_id):
         'is_commentable_divided': is_commentable_divided(course_key, discussion_id),
         'discussion_data': threads,
         'user_info': user_info,
+        'user_group_id': get_group_id_for_user(request.user, course.id),
         'annotated_content_info': annotated_content_info,
         'page': query_params['page'],
         'num_pages': query_params['num_pages'],

--- a/lms/templates/discussion/_underscore_templates.html
+++ b/lms/templates/discussion/_underscore_templates.html
@@ -13,10 +13,29 @@
 
 <%
 template_names = [
-    'thread', 'thread-show', 'thread-edit', 'thread-response', 'thread-response-show', 'thread-response-edit',
-    'response-comment-show', 'response-comment-edit', 'thread-list-item', 'search-alert',
-    'new-post', 'new-post-menu-entry', 'new-post-menu-category', 'new-post-alert', 'topic', 'post-user-display',
-    'inline-discussion', 'pagination', 'profile-thread', 'customwmd-prompt', 'nav-loading', 'thread-type'
+    'thread',
+    'thread-show',
+    'thread-edit',
+    'thread-response',
+    'thread-response-show',
+    'thread-response-edit',
+    'response-comment-show',
+    'response-comment-edit',
+    'thread-list-item',
+    'search-alert',
+    'new-post',
+    'new-post-menu-entry',
+    'new-post-menu-category',
+    'new-post-alert',
+    'new-post-visibility',
+    'topic',
+    'post-user-display',
+    'inline-discussion',
+    'pagination',
+    'profile-thread',
+    'customwmd-prompt',
+    'nav-loading',
+    'thread-type'
 ]
 
 ## same, but without trailing "-template" in script ID - these templates does not contain any free variables


### PR DESCRIPTION

## Description

When creating a new post, show the cohort visibility warning if appropriate.

## Dependencies

- N/A

## JIRA

- N/A

## Sandbox URLs

- [Discussion tab](https://pr15115.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/)
- [Inline discussion](https://pr15115.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/)

## Latest commit

- badd24 *(updated 2017-06-19)*

## Testing instructions

1. Go to the [Discussion tab](https://pr15115.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/) of the demo course, and log in as `staff@example.com`.  The staff user has been pre-assigned to `cohort0`.
2. Click on `Add post`.  Because the course has been cohorted, the staff user has been assigned to `cohort0`, but the "General" topic has not been divided into groups, you should see the following default message: "This post is visible to everyone."
3. Click on `Topic area`, and choose any other topic.  Because all content-specific topics are divided into groups, the message changes to: "This post is visible only to cohort0".
4. Open a unit with an [inline discussion](https://pr15115.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/), and click on `Show discussion`.
5. Click on `Add post`.  Because all content topics are divided, you should see the following message: "This post is visible only to cohort0."
6. Go to the [Instructor Dashboard](https://pr15115.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-discussions_management) and click on the Discussion management tab.  Select `Not divided`.
7. Go back to the [course discussion tab](https://pr15115.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/), and click on `Add post`.  You should no longer see a post visibility status message.
8. Go back to the unit with an [inline discussion](https://pr15115.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/), show the discussion and click on `add post`.  You should also no longer see a post visibility message.
9. Reenable divided discussions in the instructor dashboard, but disable cohorts entirely for the course, in the [cohort management tab](https://pr15115.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-cohort_management) in the Instructor Dashboard.  Repeat steps 7 and 8 above.  The results should be the same.

## Screenshots

![screenshot1](https://user-images.githubusercontent.com/759355/27291507-cb3ccf2c-54e6-11e7-9061-cf91a95f190a.png)
![screenshot2](https://user-images.githubusercontent.com/759355/27291508-cb444ffe-54e6-11e7-84f0-4d5345ef5cb8.png)
![screenshot3](https://user-images.githubusercontent.com/759355/27291509-cb4f4b5c-54e6-11e7-8f88-777f9d00616d.png)