### PR TITLE
ENT-405: Hide the audit option from track selection for certain enterprise scenarios

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -122,6 +122,9 @@ class CourseMode(models.Model):
     DEFAULT_MODE = Mode(AUDIT, _('Audit'), 0, '', 'usd', None, None, None, None)
     DEFAULT_MODE_SLUG = AUDIT
 
+    # Modes utilized for audit/free enrollments
+    AUDIT_MODES = [AUDIT, HONOR]
+
     # Modes that allow a student to pursue a verified certificate
     VERIFIED_MODES = [VERIFIED, PROFESSIONAL]
 

--- a/openedx/features/enterprise_support/tests/mixins/enterprise.py
+++ b/openedx/features/enterprise_support/tests/mixins/enterprise.py
@@ -62,7 +62,8 @@ class EnterpriseServiceMockMixin(object):
             catalog_id=1,
             entitlement_id=1,
             learner_id=1,
-            enterprise_customer_uuid='cf246b88-d5f6-4908-a522-fc307e0b0c59'
+            enterprise_customer_uuid='cf246b88-d5f6-4908-a522-fc307e0b0c59',
+            enable_audit_enrollment=False,
     ):
         """
         Helper function to register enterprise learner API endpoint.
@@ -85,6 +86,7 @@ class EnterpriseServiceMockMixin(object):
                         },
                         'enable_data_sharing_consent': True,
                         'enforce_data_sharing_consent': 'at_login',
+                        'enable_audit_enrollment': enable_audit_enrollment,
                         'enterprise_customer_users': [
                             1
                         ],


### PR DESCRIPTION
Builds on top of https://github.com/edx/edx-enterprise/pull/104.  Suppresses the Audit option on the LMS track selection page when the learner meets the following critieria:

1) The learner is linked to an enterprise customer
2) The course in question is found in the enterprise customer's catalog
3) The enterprise customer profile has been configured to hide the audit track.

Note:  Will add test coverage after ENT-290 merges