### PR TITLE
Handle expired enrollments on the program detail page

### DIFF
--- a/lms/static/js/learner_dashboard/models/course_card_model.js
+++ b/lms/static/js/learner_dashboard/models/course_card_model.js
@@ -14,18 +14,18 @@
                 initialize: function(data) {
                     if (data) {
                         this.context = data;
-                        this.setActiveCourseRun(this.getCourseRun(data.course_runs), data.user_preferences);
+                        this.setActiveCourseRun(this.getCourseRun(data), data.user_preferences);
                     }
                 },
 
-                getCourseRun: function(courseRuns) {
-                    var enrolledCourseRun = _.findWhere(courseRuns, {is_enrolled: true}),
+                getCourseRun: function(course) {
+                    var enrolledCourseRun = _.findWhere(course.course_runs, {is_enrolled: true}),
                         openEnrollmentCourseRuns = this.getEnrollableCourseRuns(),
                         desiredCourseRun;
 
-                    // We populate our model by looking at the course runs.
-                    if (enrolledCourseRun) {
-                        // If the learner is already enrolled in a course run, return that one.
+                    // If the learner has an existing, unexpired enrollment,
+                    // use it to populate the model.
+                    if (enrolledCourseRun && !course.expired) {
                         desiredCourseRun = enrolledCourseRun;
                     } else if (openEnrollmentCourseRuns.length > 0) {
                         if (openEnrollmentCourseRuns.length === 1) {
@@ -34,7 +34,7 @@
                             desiredCourseRun = this.getUnselectedCourseRun(openEnrollmentCourseRuns);
                         }
                     } else {
-                        desiredCourseRun = this.getUnselectedCourseRun(courseRuns);
+                        desiredCourseRun = this.getUnselectedCourseRun(course.course_runs);
                     }
 
                     return desiredCourseRun;

--- a/lms/static/js/spec/learner_dashboard/course_card_view_spec.js
+++ b/lms/static/js/spec/learner_dashboard/course_card_view_spec.js
@@ -145,6 +145,26 @@ define([
             expect(view.$('.course-certificate .certificate-status').length).toEqual(0);
         });
 
+        it('should allow enrollment in future runs when the user has an expired enrollment', function() {
+            var newRun = $.extend({}, course.course_runs[0]),
+                newRunKey = 'course-v1:foo+bar+baz',
+                advertisedStart = 'Summer';
+
+            newRun.key = newRunKey;
+            newRun.is_enrolled = false;
+            newRun.advertised_start = advertisedStart;
+            course.course_runs.push(newRun);
+
+            course.expired = true;
+
+            setupView(course, true);
+
+            expect(courseCardModel.get('course_run_key')).toEqual(newRunKey);
+            expect(view.$('.course-details .course-text .run-period').html()).toEqual(
+                advertisedStart + ' - ' + endDate
+            );
+        });
+
         it('should show a message if an there is an upcoming course run', function() {
             course.course_runs[0].is_enrollment_open = false;
 


### PR DESCRIPTION
Learners should be able to enroll in future runs of courses in which they have an expired enrollment. Previously, the course card model populated itself by selecting the first course run in which the user was enrolled. When the user tried to enroll in another run, nothing would happen because they were already enrolled in the run the page was trying to enroll them in.

Instead of blindly choosing the first run in which the user is enrolled, we now fall through to the same behavior we use for courses in which the user is not enrolled when the user has expired enrollments.

LEARNER-933

@edx/learner-growth FYI.