### PR TITLE
Repair export_all_courses script

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export_all_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/export_all_courses.py
@@ -13,14 +13,14 @@ class Command(BaseCommand):
     """
     help = 'Export all courses from mongo to the specified data directory and list the courses which failed to export'
 
+    def add_arguments(self, parser):
+        parser.add_argument('output_path')
+
     def handle(self, *args, **options):
         """
         Execute the command
         """
-        if len(args) != 1:
-            raise CommandError("export requires one argument: <output path>")
-
-        output_path = args[0]
+        output_path = options['output_path']
         courses, failed_export_courses = export_courses_to_output_path(output_path)
 
         print "=" * 80


### PR DESCRIPTION
When running python `/edx/app/edxapp/edx-platform/manage.py cms --settings=aws export_all_courses /edx/app/courses/export/`, one would receive an error:

```
manage.py export_all_courses: error: unrecognized arguments: /edx/app/courses/export/
```

To solve this, I changed the script to use argparse instead of manually
using args[0]. Now `export_all_courses --help` will also show that it as
output_path as a positional argument.