### PR TITLE
Refactor CMS Signal Handling

### DIFF
--- a/cms/djangoapps/contentstore/apps.py
+++ b/cms/djangoapps/contentstore/apps.py
@@ -1,0 +1,22 @@
+"""
+Contentstore Application Configuration
+
+Above-modulestore level signal handlers are connected here.
+"""
+
+from django.apps import AppConfig
+
+
+class ContentstoreConfig(AppConfig):
+    """
+    Application Configuration for Grades.
+    """
+    name = u'contentstore'
+
+    def ready(self):
+        """
+        Connect handlers to signals.
+        """
+        # Can't import models at module level in AppConfigs, and models get
+        # included from the signal handlers
+        from .signals import handlers  # pylint: disable=unused-variable

--- a/cms/djangoapps/contentstore/signals/signals.py
+++ b/cms/djangoapps/contentstore/signals/signals.py
@@ -1,0 +1,14 @@
+"""
+Contentstore signals
+"""
+from django.dispatch import Signal
+
+# Signal that indicates that a course grading policy has been updated.
+# This signal is generated when a grading policy change occurs within
+# modulestore for either course or subsection changes.
+GRADING_POLICY_CHANGED = Signal(
+    providing_args=[
+        'user_id',  # Integer User ID
+        'course_id',  # Unicode string representing the course
+    ]
+)

--- a/cms/djangoapps/contentstore/startup.py
+++ b/cms/djangoapps/contentstore/startup.py
@@ -1,2 +1,0 @@
-""" will register signal handlers, moved out of __init__.py to ensure correct loading order post Django 1.7 """
-from . import signals           # pylint: disable=unused-import

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -44,7 +44,7 @@ from contentstore.courseware_index import (
     SearchIndexingError,
     CourseAboutSearchIndexer,
 )
-from contentstore.signals import listen_for_course_publish, listen_for_library_update
+from contentstore.signals.handlers import listen_for_course_publish, listen_for_library_update
 from contentstore.utils import reverse_course_url, reverse_usage_url
 from contentstore.tests.utils import CourseTestCase
 

--- a/cms/djangoapps/contentstore/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/tests/test_gating.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the gating feature in Studio
 """
-from contentstore.signals import handle_item_deleted
+from contentstore.signals.handlers import handle_item_deleted
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import patch
 from openedx.core.lib.gating import api as gating_api
@@ -42,16 +42,16 @@ class TestHandleItemDeleted(ModuleStoreTestCase, MilestonesTestCaseMixin):
         gating_api.add_prerequisite(self.course.id, self.open_seq.location)
         gating_api.set_required_content(self.course.id, self.gated_seq.location, self.open_seq.location, 100)
 
-    @patch('contentstore.signals.gating_api.set_required_content')
-    @patch('contentstore.signals.gating_api.remove_prerequisite')
+    @patch('contentstore.signals.handlers.gating_api.set_required_content')
+    @patch('contentstore.signals.handlers.gating_api.remove_prerequisite')
     def test_chapter_deleted(self, mock_remove_prereq, mock_set_required):
         """ Test gating milestone data is cleanup up when course content item is deleted """
         handle_item_deleted(usage_key=self.chapter.location, user_id=0)
         mock_remove_prereq.assert_called_with(self.open_seq.location)
         mock_set_required.assert_called_with(self.open_seq.location.course_key, self.open_seq.location, None, None)
 
-    @patch('contentstore.signals.gating_api.set_required_content')
-    @patch('contentstore.signals.gating_api.remove_prerequisite')
+    @patch('contentstore.signals.handlers.gating_api.set_required_content')
+    @patch('contentstore.signals.handlers.gating_api.remove_prerequisite')
     def test_sequential_deleted(self, mock_remove_prereq, mock_set_required):
         """ Test gating milestone data is cleanup up when course content item is deleted """
         handle_item_deleted(usage_key=self.open_seq.location, user_id=0)

--- a/cms/djangoapps/contentstore/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/tests/test_proctoring.py
@@ -9,7 +9,7 @@ from pytz import UTC
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
-from contentstore.signals import listen_for_course_publish
+from contentstore.signals.handlers import listen_for_course_publish
 
 from edx_proctoring.api import (
     get_all_exams_for_course,

--- a/cms/djangoapps/contentstore/views/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/views/tests/test_gating.py
@@ -128,8 +128,8 @@ class TestSubsectionGating(CourseTestCase):
         self.assertEqual(resp['prereq_min_score'], 100)
         self.assertEqual(resp['visibility_state'], VisibilityState.gated)
 
-    @patch('contentstore.signals.gating_api.set_required_content')
-    @patch('contentstore.signals.gating_api.remove_prerequisite')
+    @patch('contentstore.signals.handlers.gating_api.set_required_content')
+    @patch('contentstore.signals.handlers.gating_api.remove_prerequisite')
     def test_delete_item_signal_handler_called(self, mock_remove_prereq, mock_set_required):
         seq3 = ItemFactory.create(
             parent_location=self.chapter.location,

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -868,7 +868,8 @@ INSTALLED_APPS = (
     'django_nose',
 
     # For CMS
-    'contentstore',
+    'contentstore.apps.ContentstoreConfig',
+
     'openedx.core.djangoapps.contentserver',
     'course_creators',
     'openedx.core.djangoapps.external_auth',


### PR DESCRIPTION
## [WIP]

## [EDUCATOR-389](https://openedx.atlassian.net/browse/EDUCATOR-389)

### Description
This refactors the signal handling for the CMS to bring it in line with best practices for > Django 1.7

As we have recently added a higher-than-modulestore level signal, this makes sense to do at this time.

### Testing
- [ ] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @sanfordstudent 
- [x] Code review: @iloveagent57 

FYI: @edx/educator-neem, @jmbowman 

### Post-review
- [ ] Rebase and squash commits



