### PR TITLE
Use a stable ordering for shuffled tasks.

### DIFF
--- a/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
@@ -27,6 +27,14 @@ def _sorted_by_batch(calls):
     return sorted(calls, key=lambda x: (x[1]['kwargs']['course_key'], x[1]['kwargs']['offset']))
 
 
+class Any(object):
+    """
+    Dummy object that compares equal to all other objects.
+    """
+    def __eq__(self, other):
+        return True
+
+
 @ddt.ddt
 class TestComputeGrades(SharedModuleStoreTestCase):
     """
@@ -100,7 +108,8 @@ class TestComputeGrades(SharedModuleStoreTestCase):
             'course_key': course_key,
             'batch_size': 2,
             'offset': offset,
-            'estimate_first_attempted': estimate_first_attempted
+            'estimate_first_attempted': estimate_first_attempted,
+            'seq_id': Any(),
         }
         self.assertEqual(
             _sorted_by_batch(mock_task.apply_async.call_args_list),
@@ -136,7 +145,8 @@ class TestComputeGrades(SharedModuleStoreTestCase):
                         'course_key': self.course_keys[1],
                         'batch_size': 2,
                         'offset': 0,
-                        'estimate_first_attempted': True
+                        'estimate_first_attempted': True,
+                        'seq_id': Any(),
                     },
                 },),
                 ({
@@ -144,7 +154,8 @@ class TestComputeGrades(SharedModuleStoreTestCase):
                         'course_key': self.course_keys[1],
                         'batch_size': 2,
                         'offset': 2,
-                        'estimate_first_attempted': True
+                        'estimate_first_attempted': True,
+                        'seq_id': Any(),
                     },
                 },),
             ],

--- a/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import ddt
 from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
-from mock import patch
+from mock import ANY, patch
 import six
 
 from student.models import CourseEnrollment
@@ -25,14 +25,6 @@ def _sorted_by_batch(calls):
     Return the list of calls sorted by course_key and batch.
     """
     return sorted(calls, key=lambda x: (x[1]['kwargs']['course_key'], x[1]['kwargs']['offset']))
-
-
-class Any(object):
-    """
-    Dummy object that compares equal to all other objects.
-    """
-    def __eq__(self, other):
-        return True
 
 
 @ddt.ddt
@@ -109,7 +101,7 @@ class TestComputeGrades(SharedModuleStoreTestCase):
             'batch_size': 2,
             'offset': offset,
             'estimate_first_attempted': estimate_first_attempted,
-            'seq_id': Any(),
+            'seq_id': ANY,
         }
         self.assertEqual(
             _sorted_by_batch(mock_task.apply_async.call_args_list),
@@ -146,7 +138,7 @@ class TestComputeGrades(SharedModuleStoreTestCase):
                         'batch_size': 2,
                         'offset': 0,
                         'estimate_first_attempted': True,
-                        'seq_id': Any(),
+                        'seq_id': ANY,
                     },
                 },),
                 ({
@@ -155,7 +147,7 @@ class TestComputeGrades(SharedModuleStoreTestCase):
                         'batch_size': 2,
                         'offset': 2,
                         'estimate_first_attempted': True,
-                        'seq_id': Any(),
+                        'seq_id': ANY,
                     },
                 },),
             ],


### PR DESCRIPTION
Currently, when we restart compute-grades tasks, we have to start over from scratch.  This is a step toward being able to pick up where we left off.  Shuffling is now done by a stable order (md5 of the arguments passed), and each task reports an incrementing sequence ID, which we should be able to use to pick up where we left off.  

## TBD (in another PR):
* Add a way to tell the management command to skip N tasks.
* Automate tracking of sequence IDs.  Currently, we'll just have to look for them in splunk, and guess how far back from the latest completed we should go to catch all uncompleted tasks.

## Reviewers:

- [ ] @jibsheet 
- [x] @iloveagent57 

FYI: @edx/educator-neem 