### PR TITLE
Fix [EDUCATOR-338]: Errors: "'float' object is not callable"

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -34,4 +34,4 @@ ubcpi-xblock==0.6.2
 
 # Vector Drawing and ActiveTable XBlocks (Davidson)
 -e git+https://github.com/open-craft/xblock-vectordraw.git@v0.2.1#egg=xblock-vectordraw==0.2.1
--e git+https://github.com/open-craft/xblock-activetable.git@1786a2c8fc06ca3ecfac1972464048982bd486ff#egg=xblock-activetable
+-e git+https://github.com/open-craft/xblock-activetable.git@e933d41bb86a8d50fb878787ca680165a092a6d5#egg=xblock-activetable


### PR DESCRIPTION
See [EDUCATOR-338](https://openedx.atlassian.net/browse/EDUCATOR-338).

**JIRA tickets**: [EDUCATOR-338](https://openedx.atlassian.net/browse/EDUCATOR-338)

**Discussions**: We have a `max_score` defined under ActiveTable as a Float XBlock field, but a *method* `max_score` exists elsewhere that was getting conflicts with it.

**Dependencies**: None

**Deployment targets**: edge.edx.org

**Merge deadline**: Does not affect many courses, so not that tight.

**Testing instructions**:

* See the XBlock's [original PR](https://github.com/open-craft/xblock-activetable/pull/2) and, in particular, a [test to make sure nothing else broke](https://github.com/open-craft/xblock-activetable/pull/2#issuecomment-301975669).

**Reviewers**
- [x] @smarnach 
- [x] edX reviewer[s] TBD