### PR TITLE
ENT-329: Success Message for Account Activation for logged out users.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -90,7 +90,7 @@ from openedx.core.djangoapps.external_auth.login_and_register import (
     register as external_auth_register
 )
 from openedx.core.djangoapps import monitoring_utils
-from openedx.core.djangolib.markup import HTML, Text
+from openedx.core.djangolib.markup import HTML
 
 import track.views
 
@@ -2302,7 +2302,7 @@ def activate_account(request, key):
     except (Registration.DoesNotExist, Registration.MultipleObjectsReturned):
         messages.error(
             request,
-            Text(_(
+            HTML(_(
                 '{html_start}Your account could not be activated{html_end}'
                 'Something went wrong, please <a href="{support_url}">contact support</a> to resolve this issue.'
             )).format(
@@ -2310,7 +2310,7 @@ def activate_account(request, key):
                 html_start=HTML('<p class="message-title">'),
                 html_end=HTML('</p>'),
             ),
-            extra_tags='account-activation icon'
+            extra_tags='account-activation aa-icon'
         )
     else:
         if not registration.user.is_active:
@@ -2318,20 +2318,20 @@ def activate_account(request, key):
             # Add account activation success message for display later
             messages.success(
                 request,
-                Text(_('{html_start}Success{html_end} You have activated your account.')).format(
+                HTML(_('{html_start}Success{html_end} You have activated your account.')).format(
                     html_start=HTML('<p class="message-title">'),
                     html_end=HTML('</p>'),
                 ),
-                extra_tags='account-activation icon',
+                extra_tags='account-activation aa-icon',
             )
         else:
             messages.info(
                 request,
-                Text(_('{html_start}This account has already been activated.{html_end}')).format(
+                HTML(_('{html_start}This account has already been activated.{html_end}')).format(
                     html_start=HTML('<p class="message-title">'),
                     html_end=HTML('</p>'),
                 ),
-                extra_tags='account-activation icon',
+                extra_tags='account-activation aa-icon',
             )
 
         # Enroll student in any pending courses he/she may have if auto_enroll flag is set

--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -353,7 +353,7 @@ class CombinedLoginAndRegisterPage(PageObject):
         """Wait for a status message to be visible following third_party registration, then return it."""
         def _check_func():
             """Return third party auth status notice message."""
-            selector = '.js-auth-warning p'
+            selector = '.js-auth-warning div'
             msg_element = self.q(css=selector)
             if msg_element.visible:
                 return (True, msg_element.text[0])

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -117,6 +117,13 @@ def login_and_registration_form(request, initial_mode="login"):
     if ext_auth_response is not None:
         return ext_auth_response
 
+    # Account activation message
+    account_activation_messages = [
+        {
+            'message': message.message, 'tags': message.tags
+        } for message in messages.get_messages(request) if 'account-activation' in message.tags
+    ]
+
     # Otherwise, render the combined login/registration page
     context = {
         'data': {
@@ -126,6 +133,7 @@ def login_and_registration_form(request, initial_mode="login"):
             'third_party_auth_hint': third_party_auth_hint or '',
             'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
             'support_link': configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK),
+            'account_activation_messages': account_activation_messages,
 
             # Include form descriptions retrieved from the user API.
             # We could have the JS client make these requests directly,

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -52,6 +52,9 @@
 
                     this.thirdPartyAuthHint = options.third_party_auth_hint || null;
 
+                    // Account activation messages
+                    this.accountActivationMessages = options.account_activation_messages || [];
+
                     if (options.login_redirect_url) {
                     // Ensure that the next URL is internal for security reasons
                         if (! window.isExternal(options.login_redirect_url)) {
@@ -82,6 +85,10 @@
                 // Once the third party error message has been shown once,
                 // there is no need to show it again, if the user changes mode:
                     this.thirdPartyAuth.errorMessage = null;
+
+                    // Once the account activation messages have been shown once,
+                    // there is no need to show it again, if the user changes mode:
+                    this.accountActivationMessages = [];
                 },
 
                 render: function() {
@@ -119,6 +126,7 @@
                             model: model,
                             resetModel: this.resetModel,
                             thirdPartyAuth: this.thirdPartyAuth,
+                            accountActivationMessages: this.accountActivationMessages,
                             platformName: this.platformName,
                             supportURL: this.supportURL,
                             createAccountOption: this.createAccountOption

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -39,6 +39,7 @@
                     this.resetModel = data.resetModel;
                     this.supportURL = data.supportURL;
                     this.createAccountOption = data.createAccountOption;
+                    this.accountActivationMessages = data.accountActivationMessages;
 
                     this.listenTo(this.model, 'sync', this.saveSuccess);
                     this.listenTo(this.resetModel, 'sync', this.resetEmail);
@@ -85,6 +86,20 @@
                          */
                         this.model.save();
                     }
+
+                    // Display account activation success or error messages.
+                    this.renderAccountActivationMessages();
+                },
+
+                renderAccountActivationMessages: function() {
+                    _.each(this.accountActivationMessages, this.renderAccountActivationMessage, this);
+                },
+
+                renderAccountActivationMessage: function(message) {
+                    this.renderFormFeedback(this.formStatusTpl, {
+                        jsHook: message.tags,
+                        message: HtmlUtils.HTML(message.message)
+                    });
                 },
 
                 forgotPassword: function(event) {

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -1453,7 +1453,7 @@ a.fade-cover{
       margin-bottom: 0;
     }
 
-    &.icon .message-copy:before {
+    &.aa-icon .message-copy:before {
       position: absolute;
       left: -1em;
       content: "\f05a";  // fa-info-circle
@@ -1468,7 +1468,7 @@ a.fade-cover{
     background-color: $palette-success-back;
     border: $palette-success-border 1px solid;
 
-    &.icon .message-copy:before {
+    &.aa-icon .message-copy:before {
       position: absolute;
       left: -1em;
       content: "\f00c";  // fa-check
@@ -1483,7 +1483,7 @@ a.fade-cover{
     background-color: $palette-error-back;
     border: $palette-error-border 1px solid;
 
-    &.icon .message-copy:before {
+    &.aa-icon .message-copy:before {
       position: absolute;
       left: -1em;
       content: "\f06a";  // fa-exclamation-circle

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -560,6 +560,30 @@
                 margin: 0 0 ($baseline/4) $baseline;
             }
         }
+
+        &.account-activation {
+            .message-copy {
+                padding: 0 1em !important;
+            }
+
+            &.info {
+                background-color: $palette-info-back;
+                border: $palette-info-border 1px solid;
+                color: $palette-info-text;
+            }
+
+            &.success {
+                background-color: $palette-success-back;
+                border: $palette-success-border 1px solid;
+                color: $palette-success-text;
+           }
+
+            &.error {
+                background-color: $palette-error-back;
+                border: $palette-error-border 1px solid;
+                color: $palette-error-text 1px solid;
+            }
+        }
     }
 
     .submission-error, .system-error {

--- a/lms/templates/student_account/form_status.underscore
+++ b/lms/templates/student_account/form_status.underscore
@@ -1,6 +1,6 @@
 <div class="<%- jsHook %> status">
-    <p class="message-copy">
-        <%- message %>
+    <div class="message-copy">
+        <%= HtmlUtils.ensureHtml(message) %>
     </p>
 </div>
 


### PR DESCRIPTION
@brittneyexline , @douglashall , @asadiqbal08 , @zubair-arbi 

This PR contains updates for account activation messages for logged out users.

__Jira Ticket__: [ENT-329](https://openedx.atlassian.net/browse/ENT-329)

__Description:__
If a learner does not have an activated account, and is signed out. When the learner clicks the link to activate their account from their email, the system changes their account flag to active. The learner still needs to sign in. This story is to redirect the learner from that Successful Activation page with the giant green fake not-a-button, to the actual sign in page with an Account Activation success message displaying.

__Acceptance Criteria__
1. When a signed-out learner clicks the account activation link from their email, the system will activate their account and display the Sign In page
2. On the sign in page, display the account activation success message 