### PR TITLE
Christina/ed 427 again

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -280,7 +280,7 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
         is_reorderable = _is_xblock_reorderable(xblock, context)
         selected_groups_label = get_visibility_partition_info(xblock)['selected_groups_label']
         if selected_groups_label:
-            selected_groups_label = _('Visible to: {list_of_groups}').format(list_of_groups=selected_groups_label)
+            selected_groups_label = _('Access restricted to: {list_of_groups}').format(list_of_groups=selected_groups_label)
         template_context = {
             'xblock_context': context,
             'xblock': xblock,

--- a/cms/lib/xblock/test/test_authoring_mixin.py
+++ b/cms/lib/xblock/test/test_authoring_mixin.py
@@ -18,9 +18,9 @@ class AuthoringMixinTestCase(ModuleStoreTestCase):
     Tests the studio authoring XBlock mixin.
     """
     GROUP_NO_LONGER_EXISTS = "This group no longer exists"
-    NO_CONTENT_OR_ENROLLMENT_GROUPS = "No visibility settings are defined for this component"
-    NO_CONTENT_ENROLLMENT_TRACK_ENABLED = "specific groups of learners based either on their enrollment track, or by content groups that you create"
-    NO_CONTENT_ENROLLMENT_TRACK_DISABLED = "specific groups of learners based on content groups that you create"
+    NO_CONTENT_OR_ENROLLMENT_GROUPS = "Access to this component is not restricted"
+    NO_CONTENT_ENROLLMENT_TRACK_ENABLED = "You can restrict access to this component to learners in specific enrollment tracks or content groups"
+    NO_CONTENT_ENROLLMENT_TRACK_DISABLED = "You can restrict access to this component to learners in specific content groups"
     CONTENT_GROUPS_TITLE = "Content Groups"
     ENROLLMENT_GROUPS_TITLE = "Enrollment Track Groups"
     STAFF_LOCKED = 'The unit that contains this component is hidden from learners'

--- a/cms/static/js/spec/views/group_configuration_spec.js
+++ b/cms/static/js/spec/views/group_configuration_spec.js
@@ -901,7 +901,7 @@ define([
 
         it('should show empty usage appropriately', function() {
             this.view.$('.show-groups').click();
-            assertShowEmptyUsages(this.view, "Use this group to control a component's visibility in the ");
+            assertShowEmptyUsages(this.view, 'use this group to control access to a component');
         });
 
         it('should hide empty usage appropriately', function() {
@@ -915,7 +915,7 @@ define([
 
             assertShowNonEmptyUsages(
                 this.view,
-                'This group controls visibility of:',
+                'This group controls access to:',
                 'Cannot delete when in use by a unit'
             );
         });

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -1603,7 +1603,7 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/j
                     var messages = getUnitStatus({has_partition_group_components: true});
                     expect(messages.length).toBe(1);
                     expect(messages).toContainText(
-                        'Some content in this unit is visible only to specific groups of learners'
+                        'Access to some content in this unit is restricted to specific groups of learners'
                     );
                 });
 

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -184,7 +184,7 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/pages/base_page
                 this.editXBlock(event, {
                     view: 'visibility_view',
                     // Translators: "title" is the name of the current component being edited.
-                    titleFormat: gettext('Editing visibility for: %(title)s'),
+                    titleFormat: gettext('Editing access for: %(title)s'),
                     viewSpecificClasses: '',
                     modalSize: 'med'
                 });

--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -248,15 +248,6 @@
         }
       }
     }
-
-    // CASE: xblock has specific visibility based on content groups set
-    &.has-group-visibility-set {
-
-      .action-visibility .visibility-button.visibility-button { // needed to cascade in front of overscoped header-actions CSS rule
-        color: $color-visibility-set;
-      }
-    }
-
   }
 
   // +Messaging - Xblocks

--- a/cms/static/sass/partials/_variables.scss
+++ b/cms/static/sass/partials/_variables.scss
@@ -216,7 +216,6 @@ $color-warning: $orange-l2 !default;
 $color-error: $red-l2 !default;
 $color-staff-only: $black !default;
 $color-gated: $black !default;
-$color-visibility-set: $black !default;
 
 $color-heading-base: $gray-d2 !default;
 $color-copy-base: $gray-l1 !default;

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -84,7 +84,7 @@ from openedx.core.djangolib.markup import HTML, Text
           <div class="enrollment-track-doc">
             <h3 class="title-3">${_("Enrollment Track Groups")}</h3>
             <p>${_("Enrollment track groups allow you to offer different course content to learners in each enrollment track. Learners enrolled in each enrollment track in your course are automatically included in the corresponding enrollment track group.")}</p>
-            <p>${_("On unit pages in the course outline, you can designate components as visible only to learners in a specific enrollment track.")}</p>
+            <p>${_("On unit pages in the course outline, you can restrict access to components to learners based on their enrollment track.")}</p>
             <p>${_("You cannot edit enrollment track groups, but you can expand each group to view details of the course content that is designated for learners in the group.")}</p>
             <p><a href="${get_online_help_info(enrollment_track_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
           </div>
@@ -94,7 +94,7 @@ from openedx.core.djangolib.markup import HTML, Text
           <div class="content-groups-doc">
               <h3 class="title-3">${_("Content Groups")}</h3>
               <p>${_("If you have cohorts enabled in your course, you can use content groups to create cohort-specific courseware. In other words, you can customize the content that particular cohorts see in your course.")}</p>
-              <p>${_("Each content group that you create can be associated with one or more cohorts. In addition to course content that is intended for all learners, you can designate some content as visible only to specified content groups. Only learners in the cohorts that are associated with the specified content groups see the additional content.")}</p>
+              <p>${_("Each content group that you create can be associated with one or more cohorts. In addition to making course content available to all learners, you can restrict access to some content to learners in specific content groups. Only learners in the cohorts that are associated with the specified content groups see the additional content.")}</p>
               <p>${Text(_("Click {em_start}New content group{em_end} to add a new content group. To edit the name of a content group, hover over its box and click {em_start}Edit{em_end}. You can delete a content group only if it is not in use by a unit. To delete a content group, hover over its box and click the delete icon.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
               <p><a href="${get_online_help_info(content_groups_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
           </div>

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -60,7 +60,7 @@ if (staffOnlyMessage) {
     if (hasPartitionGroups) {
         addStatusMessage(
             'partition-groups',
-            gettext('Some content in this unit is visible only to specific groups of learners')
+            gettext('Access to some content in this unit is restricted to specific groups of learners')
         );
     }
 }

--- a/cms/templates/js/partition-group-details.underscore
+++ b/cms/templates/js/partition-group-details.underscore
@@ -44,7 +44,7 @@
   <div class="collection-references wrapper-group-configuration-usages">
     <% if (!_.isEmpty(usage)) { %>
       <h4 class="intro group-configuration-usage-text">
-        <%- gettext('This group controls visibility of:') %>
+        <%- gettext('This group controls access to:') %>
       </h4>
       <ol class="usage group-configuration-usage">
         <% _.each(usage, function(unit) { %>
@@ -56,7 +56,7 @@
     <% } else { %>
         <p class="group-configuration-usage-text">
             <%= HtmlUtils.interpolateHtml(
-                    gettext("Use this group to control a component's visibility in the {linkStart}Course Outline{linkEnd}."),
+                    gettext("In the {linkStart}Course Outline{linkEnd}, use this group to control access to a component."),
                     {
                         linkStart: HtmlUtils.interpolateHtml(
                             HtmlUtils.HTML('<a href="{courseOutlineUrl}" title="{courseOutlineTitle}">'),

--- a/cms/templates/js/publish-xblock.underscore
+++ b/cms/templates/js/publish-xblock.underscore
@@ -100,7 +100,7 @@ var visibleToStaffOnly = visibilityState === 'staff_only';
             <% if (hasPartitionGroupComponents) { %>
                 <p class="note-visibility">
                     <span class="icon fa fa-eye" aria-hidden="true"></span>
-                    <span class="note-copy"><%- gettext("Some content in this unit is visible only to specific groups of learners.") %></span>
+                    <span class="note-copy"><%- gettext("Access to some content in this unit is restricted to specific groups of learners.") %></span>
                 </p>
             <% } %>
         <ul class="actions-inline">

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -82,9 +82,9 @@ messages = xblock.validate().to_json()
                             </li>
                             % if can_edit_visibility:
                                 <li class="action-item action-visibility">
-                                    <button data-tooltip="${_("Visibility Settings")}" class="btn-default visibility-button action-button">
-                                        <span class="icon fa fa-eye" aria-hidden="true"></span>
-                                        <span class="sr">${_("Visibility")}</span>
+                                    <button data-tooltip="${_("Access Settings")}" class="btn-default visibility-button action-button">
+                                        <span class="icon fa fa-gear" aria-hidden="true"></span>
+                                        <span class="sr">${_("Set Access")}</span>
                                     </button>
                                 </li>
                             % endif

--- a/cms/templates/visibility_editor.html
+++ b/cms/templates/visibility_editor.html
@@ -16,13 +16,13 @@ is_staff_locked = ancestor_has_staff_lock(xblock)
 <div class="modal-section visibility-summary">
     % if len(selectable_partitions) == 0:
         <div class="is-not-configured has-actions">
-            <h3 class="title">${_('No visibility settings')}</h3>
+            <h3 class="title">${_('Access is not restricted')}</h3>
             <div class="copy">
-                <p>${_('No visibility settings are defined for this component, but visibility might be affected by inherited settings.')}</p>
+                <p>${_('Access to this component is not restricted, but visibility might be affected by inherited settings.')}</p>
                 % if settings.FEATURES.get('ENABLE_ENROLLMENT_TRACK_USER_PARTITION'):
-                <p>${_('You can make this component visible only to specific groups of learners based either on their enrollment track, or by content groups that you create.')}</p>
+                <p>${_('You can restrict access to this component to learners in specific enrollment tracks or content groups.')}</p>
                 % else:
-                <p>${_('You can make this component visible only to specific groups of learners based on content groups that you create.')}</p>
+                <p>${_('You can restrict access to this component to learners in specific content groups.')}</p>
                 % endif
             </div>
 
@@ -36,7 +36,7 @@ is_staff_locked = ancestor_has_staff_lock(xblock)
             <p class="copy">
                 ## Translators: Any text between {screen_reader_start} and {screen_reader_end} is only read by screen readers and never shown in the browser.
                 ${Text(_(
-                    "{screen_reader_start}Warning:{screen_reader_end} The unit that contains this component is hidden from learners. The unit setting overrides the component visibility settings defined here."
+                    "{screen_reader_start}Warning:{screen_reader_end} The unit that contains this component is hidden from learners. The unit setting overrides the component access settings defined here."
                     )).format(
                         screen_reader_start=HTML('<span class="sr">'),
                         screen_reader_end=HTML('</span>'),
@@ -52,18 +52,21 @@ is_staff_locked = ancestor_has_staff_lock(xblock)
         <div role="group" aria-labelledby="visibility-title">
         <div class="modal-section visibility-controls">
             <h3 class="modal-section-title visibility-header" id="visibility-title">
+                % if selected_partition_index == -1:
                 <span class="current-visibility-title">
                     <span class="icon fa fa-eye" aria-hidden="true"></span>
-                    <span>${_('Currently visible to:')}</span>
+                    <span>${_('Access is not restricted')}</span>
                 </span>
-                % if selected_partition_index == -1:
-                <span>${_('All Learners and Staff')}</span>
                 % else:
+                <span class="current-visibility-title">
+                    <span class="icon fa fa-eye" aria-hidden="true"></span>
+                    <span>${_('Access is restricted to:')}</span>
+                </span>
                 <span>${selected_groups_label}</span>
                 % endif
             </h3>
             <div class="modal-section-content partition-visibility">
-                <label class="group-select-title">${_('Change visibility to:')}
+                <label class="group-select-title">${_('Restrict access to:')}
                     <select>
                         <option value="-1" selected ="selected">
                             % if selected_partition_index == -1:
@@ -96,7 +99,7 @@ is_staff_locked = ancestor_has_staff_lock(xblock)
                             % if group["deleted"]:
                             <label for="visibility-group-${partition["id"]}-${group["id"]}" class="label">
                                 ${_("Deleted Group")}
-                                <span class="note">${_('This group no longer exists. Choose another group or make this component visible to All Learners and Staff.')}</span>
+                                <span class="note">${_('This group no longer exists. Choose another group or do not restrict access to this component.')}</span>
                             </label>
                             % else:
                             <label for="visibility-group-${partition["id"]}-${group["id"]}" class="label">${group["name"]}</label>

--- a/common/test/acceptance/pages/studio/component_editor.py
+++ b/common/test/acceptance/pages/studio/component_editor.py
@@ -126,7 +126,7 @@ class ComponentVisibilityEditorView(BaseComponentEditorView):
         """
         This returns the message shown at the top of the visibility dialog about the
         current visibility state (at the time that the dialog was opened).
-        For example, "Current visible to: All Learners and Staff".
+        For example, "Access is restricted to: All Learners and Staff".
         """
         return self.q(css=self._bounded_selector('.visibility-header'))[0].text
 

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -322,10 +322,10 @@ class BaseGroupConfigurationsTest(ContainerBase):
     CHOOSE_ONE = "Select a group type"
     CONTENT_GROUP_PARTITION = ComponentVisibilityEditorView.CONTENT_GROUP_PARTITION
     ENROLLMENT_TRACK_PARTITION = ComponentVisibilityEditorView.ENROLLMENT_TRACK_PARTITION
-    MISSING_GROUP_LABEL = 'Deleted Group\nThis group no longer exists. Choose another group or make this component visible to All Learners and Staff.'
+    MISSING_GROUP_LABEL = 'Deleted Group\nThis group no longer exists. Choose another group or do not restrict access to this component.'
     VALIDATION_ERROR_LABEL = 'This component has validation issues.'
-    VALIDATION_ERROR_MESSAGE = "Error:\nThis component's visibility settings refer to deleted or invalid groups."
-    GROUP_VISIBILITY_MESSAGE = 'Some content in this unit is visible only to specific groups of learners.'
+    VALIDATION_ERROR_MESSAGE = "Error:\nThis component's access settings refer to deleted or invalid groups."
+    GROUP_VISIBILITY_MESSAGE = 'Access to some content in this unit is restricted to specific groups of learners.'
 
     def setUp(self):
         super(BaseGroupConfigurationsTest, self).setUp()
@@ -377,10 +377,13 @@ class BaseGroupConfigurationsTest(ContainerBase):
         """
         Check that the current visibility is displayed at the top of the dialog.
         """
-        self.assertEqual(
-            "Currently visible to: {groups}".format(groups=expected_current_groups),
-            visibility_editor.current_groups_message
-        )
+        if expected_current_groups == self.ALL_LEARNERS_AND_STAFF:
+            self.assertEqual("Access is not restricted", visibility_editor.current_groups_message)
+        else:
+            self.assertEqual(
+                "Access is restricted to: {groups}".format(groups=expected_current_groups),
+                visibility_editor.current_groups_message
+            )
 
     def verify_selected_partition_scheme(self, visibility_editor, expected_scheme):
         """
@@ -651,7 +654,7 @@ class EnrollmentTrackVisibilityModalTest(BaseGroupConfigurationsTest):
         if not expected_groups:
             self.assertIsNone(component.get_partition_group_message)
         else:
-            self.assertEqual("Visible to: " + expected_groups, component.get_partition_group_message)
+            self.assertEqual("Access restricted to: " + expected_groups, component.get_partition_group_message)
 
     def test_setting_enrollment_tracks(self):
         """

--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -15,8 +15,8 @@ from xmodule.partitions.partitions import NoSuchUserPartitionError, NoSuchUserPa
 # more information can be found here: https://openedx.atlassian.net/browse/PLAT-902
 _ = lambda text: text
 
-INVALID_USER_PARTITION_VALIDATION = _(u"This component's visibility settings refer to deleted or invalid group configurations.")
-INVALID_USER_PARTITION_GROUP_VALIDATION = _(u"This component's visibility settings refer to deleted or invalid groups.")
+INVALID_USER_PARTITION_VALIDATION = _(u"This component's access settings refer to deleted or invalid group configurations.")
+INVALID_USER_PARTITION_GROUP_VALIDATION = _(u"This component's access settings refer to deleted or invalid groups.")
 
 
 class GroupAccessDict(Dict):


### PR DESCRIPTION
## [EDUCATOR-427](https://openedx.atlassian.net/browse/EDUCATOR-427)

### Description

Changes "visibility" language around Content Groups and Enrollment Tracks to "access".

### Sandbox
- [x] https://studio-ed427.sandbox.edx.org/course/course-v1:edX+DemoX+Demo_Course

### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] safecommit violation code review process

Front-end changes:
- [x] i18n
- [x] Accessibility (Check for a11y violations, ensure keyboard accessible, screen reader testing as appropriate)
- [x] RTL

### Reviewers
- [x] Assign reviewers to your PR based on the changes it contains (Dev, Doc, UX, Accessibility, Product, DevOps)

List optional/FYI reviewers here: @sstack22 @roderickmorales @catong (I'd love Carol's thumbs-up on this PR, but she's on vacation this week)
 
### Post-review
- [ ] Rebase and squash commits
