### PR TITLE
allow sending emails to course modes even if they've expired (EDUCATO…

### DIFF
--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -217,7 +217,7 @@ class CourseModeTarget(Target):
         if mode_slug is None:
             raise ValueError("Cannot create a CourseModeTarget without specifying a mode_slug.")
         try:
-            validate_course_mode(unicode(course_id), mode_slug)
+            validate_course_mode(unicode(course_id), mode_slug, include_expired=True)
         except CourseModeNotFoundError:
             raise ValueError(
                 "Track {track} does not exist in course {course_id}".format(


### PR DESCRIPTION
…R-364)

## [EDUCATOR-364](https://openedx.atlassian.net/browse/EDUCATOR-364)

### Description

Sending emails to the verified track failed if it was past the upgrade deadline

### How to Test?

1. Create a course, then a course mode for that course with a verified track
2. Set the course mode upgrade deadline in the past
3. Try to send an email to people in the verified track


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @Rabia23 
- [ ] Code review: @efischer19 
