### PR TITLE
Update CMS jquery config to remove script evaluation from ajax call

### DIFF
--- a/cms/static/cms/js/main.js
+++ b/cms/static/cms/js/main.js
@@ -27,7 +27,10 @@
                 headers: {
                     'X-CSRFToken': $.cookie('csrftoken')
                 },
-                dataType: 'json'
+                dataType: 'json',
+                content: {
+                    script: false
+                }
             });
             $(document).ajaxError(function(event, jqXHR, ajaxSettings) {
                 var msg, contentType,


### PR DESCRIPTION
[LEARNER-490](https://openedx.atlassian.net/browse/LEARNER-490)

This change will make sure CMS do not auto evaluate script content from AJAX call

@andy-armstrong @dianakhuang Please help review

See changes on the sandbox at 
https://studio.schenedx.sandbox.edx.org/