### PR TITLE
[ENT-381] Conform to WCAG 2 AA contrast minimums for Google OAuth.

### DIFF
--- a/lms/static/sass/multicourse/_account.scss
+++ b/lms/static/sass/multicourse/_account.scss
@@ -534,7 +534,7 @@
       }
 
       &.button-oa2-google-oauth2:hover, &.button-oa2-google-oauth2:focus {
-        background-color: #dd4b39;
+        background-color: $google-red;
         border: 1px solid #A5382B;
       }
 
@@ -543,7 +543,7 @@
       }
 
       &.button-oa2-facebook:hover, &.button-oa2-facebook:focus {
-        background-color: #3b5998;
+        background-color: $facebook-blue;
         border: 1px solid #263A62;
       }
 
@@ -552,7 +552,7 @@
       }
 
       &.button-oa2-linkedin-oauth2:hover , &.button-oa2-linkedin-oauth2:focus {
-        background-color: #0077b5;
+        background-color: $linkedin-blue;
         border: 1px solid #06527D;
       }
 

--- a/lms/static/sass/partials/base/_variables.scss
+++ b/lms/static/sass/partials/base/_variables.scss
@@ -200,7 +200,7 @@ $ui-notification-height: ($baseline*10);
 $twitter-blue: #55ACEE;
 $facebook-blue: #3B5998;
 $linkedin-blue: #0077B5;
-$google-red: #DD4B39;
+$google-red: #D73924;
 $microsoft-blue: #00BCF2;
 
 // shadows


### PR DESCRIPTION
As the title says -- colors don't conform to the WCAG 2 AA contrast minimums for Google OAuth so they're requested to be changed from [#DD4B39](http://www.color-hex.com/color/dd4b39) to [#D73924](http://www.color-hex.com/color/d73924).

**JIRA tickets**: Implements [ENT-381](https://openedx.atlassian.net/browse/ENT-381).

**Screenshots**: Please see the difference between [#DD4B39](http://www.color-hex.com/color/dd4b39) and [#D73924](http://www.color-hex.com/color/d73924)

**Sandbox**: https://pr15160.sandbox.opencraft.hosting/

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: Not urgent.

**Screenshots**:

*NOTE*: The screenshots lost a little quality through processing/uploading, so color-picking them won't give back the exact colors as used in this PR. But you can still compare them to see that a change occurs, and the actual change is as you can see in the PR. The background of the "G" is the same color that shows when you hover over them.

Old
![](http://i.imgur.com/KYsYIqJ.jpg)

New
![](http://i.imgur.com/bj1U4mh.jpg)

**Testing instructions**:

1. Start up this branch on a fresh devstack, and setup Google+ OAuth2 backend.
2. See that the color is changed using a color picker.

**Reviewers**
- [ ] @bradenmacdonald 
- [ ] edX reviewer[s] TBD