### PR TITLE
Route SAML entityID URL to SP metadata view

### DIFF
--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -212,7 +212,7 @@ class SAMLTestCase(TestCase):
             kwargs['private_key'] = self._get_private_key()
         if 'public_key' not in kwargs:
             kwargs['public_key'] = self._get_public_key()
-        kwargs.setdefault('entity_id', "https://saml.example.none")
+        kwargs.setdefault('entity_id', "https://saml.example.none/saml")
         super(SAMLTestCase, self).enable_saml(**kwargs)
 
     @mock.patch('third_party_auth.saml.log')

--- a/common/djangoapps/third_party_auth/urls.py
+++ b/common/djangoapps/third_party_auth/urls.py
@@ -11,4 +11,5 @@ urlpatterns = patterns(
     url(r'^auth/saml/metadata.xml', saml_metadata_view),
     url(r'^auth/login/(?P<backend>lti)/$', lti_login_and_complete_view),
     url(r'^auth/', include('social.apps.django_app.urls', namespace='social')),
+    url(r'^saml', saml_metadata_view),
 )


### PR DESCRIPTION
This PR links the SAML Service Provider `entityID` metadata value (`https://host/saml`) to the `saml_metadata_view`, which previously was only accessible at `/auth/saml/metadata.xml`

See http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf, section 4.1 (1226) for more information.