### PR TITLE
update fail old task command to fail in progress as well as queueing …

### DIFF
--- a/lms/djangoapps/instructor_task/management/commands/tests/test_fail_old_tasks.py
+++ b/lms/djangoapps/instructor_task/management/commands/tests/test_fail_old_tasks.py
@@ -5,7 +5,7 @@ from celery.states import FAILURE
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from lms.djangoapps.instructor_task.models import InstructorTask, QUEUING
+from lms.djangoapps.instructor_task.models import InstructorTask, PROGRESS, QUEUING
 from lms.djangoapps.instructor_task.tests.factories import InstructorTaskFactory
 from lms.djangoapps.instructor_task.tests.test_base import InstructorTaskTestCase
 
@@ -13,7 +13,7 @@ from lms.djangoapps.instructor_task.tests.test_base import InstructorTaskTestCas
 @ddt.ddt
 class TestFailOldQueueingTasksCommand(InstructorTaskTestCase):
     """
-    Tests for the `fail_old_queueing_tasks` management command
+    Tests for the `fail_old_tasks` management command
     """
 
     def setUp(self):
@@ -25,8 +25,8 @@ class TestFailOldQueueingTasksCommand(InstructorTaskTestCase):
             task_key='',
             task_id=1,
         )
-        type_1_non_queueing = InstructorTaskFactory.create(
-            task_state='NOT QUEUEING',
+        type_1_progress = InstructorTaskFactory.create(
+            task_state=PROGRESS,
             task_type="type_1",
             task_key='',
             task_id=2,
@@ -38,7 +38,7 @@ class TestFailOldQueueingTasksCommand(InstructorTaskTestCase):
             task_key='',
             task_id=3,
         )
-        self.tasks = [type_1_queueing, type_1_non_queueing, type_2_queueing]
+        self.tasks = [type_1_queueing, type_1_progress, type_2_queueing]
 
     def update_task_created(self, created_date):
         """
@@ -54,9 +54,9 @@ class TestFailOldQueueingTasksCommand(InstructorTaskTestCase):
         in `setUp`.
         """
         type_1_queueing = InstructorTask.objects.get(task_id=1)
-        type_1_non_queueing = InstructorTask.objects.get(task_id=2)
+        type_1_progress = InstructorTask.objects.get(task_id=2)
         type_2_queueing = InstructorTask.objects.get(task_id=3)
-        return type_1_queueing, type_1_non_queueing, type_2_queueing
+        return type_1_queueing, type_1_progress, type_2_queueing
 
     @ddt.data(
         ('2015-05-05', '2015-05-07', '2015-05-06'),
@@ -70,16 +70,17 @@ class TestFailOldQueueingTasksCommand(InstructorTaskTestCase):
         """
         self.update_task_created(created)
         call_command(
-            'fail_old_queueing_tasks',
+            'fail_old_tasks',
+            QUEUING,
             dry_run=True,
             before=before,
             after=after,
         )
 
-        type_1_queueing, type_1_non_queueing, type_2_queueing = self.get_tasks()
+        type_1_queueing, type_1_progress, type_2_queueing = self.get_tasks()
         self.assertEqual(type_1_queueing.task_state, QUEUING)
         self.assertEqual(type_2_queueing.task_state, QUEUING)
-        self.assertEqual(type_1_non_queueing.task_state, 'NOT QUEUEING')
+        self.assertEqual(type_1_progress.task_state, PROGRESS)
 
     @ddt.data(
         ('2015-05-05', '2015-05-07', '2015-05-06', FAILURE),
@@ -91,16 +92,40 @@ class TestFailOldQueueingTasksCommand(InstructorTaskTestCase):
         """
         Test that tasks created outside the window of dates don't get changed,
         while tasks created in the window do get changed.
-        Verifies that non-queueing tasks never get changed.
+        Verifies that tasks in other states never get changed.
         """
         self.update_task_created(created)
 
-        call_command('fail_old_queueing_tasks', before=before, after=after)
+        call_command('fail_old_tasks', QUEUING, before=before, after=after)
 
-        type_1_queueing, type_1_non_queueing, type_2_queueing = self.get_tasks()
+        type_1_queueing, type_1_progress, type_2_queueing = self.get_tasks()
         self.assertEqual(type_1_queueing.task_state, expected_state)
         self.assertEqual(type_2_queueing.task_state, expected_state)
-        self.assertEqual(type_1_non_queueing.task_state, 'NOT QUEUEING')
+        self.assertEqual(type_1_progress.task_state, PROGRESS)
+
+    @ddt.data(
+        (PROGRESS, QUEUING, FAILURE),
+        (QUEUING, FAILURE, PROGRESS)
+    )
+    @ddt.unpack
+    def test_filter_by_task_state(
+        self, task_type, expected_queueing_state, expected_progress_state
+    ):
+        """
+        Test that only tasks with specified states are failed.
+        """
+        self.update_task_created('2015-05-06')
+        call_command(
+            'fail_old_tasks',
+            task_type,
+            before='2015-05-07',
+            after='2015-05-05',
+        )
+        type_1_queueing, type_1_progress, type_2_queueing = self.get_tasks()
+
+        self.assertEqual(type_1_queueing.task_state, expected_queueing_state)
+        self.assertEqual(type_2_queueing.task_state, expected_queueing_state)
+        self.assertEqual(type_1_progress.task_state, expected_progress_state)
 
     def test_filter_by_task_type(self):
         """
@@ -109,16 +134,17 @@ class TestFailOldQueueingTasksCommand(InstructorTaskTestCase):
         """
         self.update_task_created('2015-05-06')
         call_command(
-            'fail_old_queueing_tasks',
+            'fail_old_tasks',
+            QUEUING,
             before='2015-05-07',
             after='2015-05-05',
             task_type="type_1",
         )
-        type_1_queueing, type_1_non_queueing, type_2_queueing = self.get_tasks()
+        type_1_queueing, type_1_progress, type_2_queueing = self.get_tasks()
         self.assertEqual(type_1_queueing.task_state, FAILURE)
         # the other type of task shouldn't be updated
         self.assertEqual(type_2_queueing.task_state, QUEUING)
-        self.assertEqual(type_1_non_queueing.task_state, 'NOT QUEUEING')
+        self.assertEqual(type_1_progress.task_state, PROGRESS)
 
     @ddt.data(
         ('2015-05-05', None),
@@ -131,4 +157,16 @@ class TestFailOldQueueingTasksCommand(InstructorTaskTestCase):
         dates.
         """
         with self.assertRaises(CommandError):
-            call_command('fail_old_queueing_tasks', before=before, after=after)
+            call_command('fail_old_tasks', QUEUING, before=before, after=after)
+
+    @ddt.data(
+        QUEUING + "not a real value",
+        PROGRESS + "also not real",
+    )
+    def test_task_type_error(self, task_type):
+        """
+        Test that the command will throw an error if called with a value
+         that's neither 'QUEUING' nor 'PROGRESS'
+        """
+        with self.assertRaises(CommandError):
+            call_command('fail_old_tasks', task_type, before='2015-05-15', after='2015-05-05')


### PR DESCRIPTION
…tasks

@cahrens and @jibsheet , this is a more generalized version of https://github.com/edx/edx-platform/pull/15141, since, because of [EDUCATOR-416](https://openedx.atlassian.net/browse/EDUCATOR-416), we'll also have to run this for old tasks in progress.