### PR TITLE
Login Required Site Middleware

### DIFF
--- a/openedx/core/djangoapps/site_configuration/middleware.py
+++ b/openedx/core/djangoapps/site_configuration/middleware.py
@@ -4,6 +4,9 @@ This file contains Django middleware related to the site_configuration app.
 
 from django.conf import settings
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from django.contrib.auth.decorators import login_required
+from django.conf import settings
+from re import compile
 
 
 class SessionCookieDomainOverrideMiddleware(object):
@@ -53,3 +56,54 @@ class SessionCookieDomainOverrideMiddleware(object):
             response.set_cookie = _set_cookie_wrapper
 
         return response
+
+class LoginRequiredMiddleware:
+    """
+    Middleware that requires a user to be authenticated to view any page other
+    than LOGIN_URL. Exemptions to this requirement can optionally be specified
+    in settings via a list of regular expressions in LOGIN_EXEMPT_URLS (which
+    you can copy from any urls.py).
+    """
+
+    def __init__(self):
+        self.LOGIN_URL = settings.LOGIN_URL or '/login/'
+
+        # Needed for user to be able to login at all
+        self.DEFAULT_LOGIN_EXEMPT_URLS = [
+            r'^user_api/v1/account/.*$',
+            r'^auth/.*$',
+            r'^register.*$',
+            r'^create_account.*$',
+            r'^admin.*$'
+        ]
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+
+        '''
+        If the site is configured to restrict not logged in users to the LOGIN_EXEMPT_URLS
+        from accessing pages, wrap the next view with the django login_required middleware
+        '''
+
+        if request.user.is_authenticated():
+            return None
+
+        RESTRICT_SITE_TO_LOGGED_IN_USERS = configuration_helpers.get_value(
+            'RESTRICT_SITE_TO_LOGGED_IN_USERS',
+            settings.FEATURES.get('RESTRICT_SITE_TO_LOGGED_IN_USERS', False)
+        )
+
+        if RESTRICT_SITE_TO_LOGGED_IN_USERS:
+            LOGIN_EXEMPT_URLS = configuration_helpers.get_value(
+                'LOGIN_EXEMPT_URLS',
+                settings.FEATURES.get('LOGIN_EXEMPT_URLS', None)
+            )
+
+            EXEMPT_URLS = [compile(self.LOGIN_URL.lstrip('/'))]
+
+            if LOGIN_EXEMPT_URLS:
+                if type(LOGIN_EXEMPT_URLS) is str or type(LOGIN_EXEMPT_URLS) is unicode:
+                    LOGIN_EXEMPT_URLS = [LOGIN_EXEMPT_URLS]
+                EXEMPT_URLS += [compile(expr) for expr in LOGIN_EXEMPT_URLS + self.DEFAULT_LOGIN_EXEMPT_URLS]
+            path = request.path_info.lstrip('/')
+            if not any(m.match(path) for m in EXEMPT_URLS):
+                return login_required(view_func)(request, view_args, view_kwargs)

--- a/openedx/core/djangoapps/site_configuration/tests/test_middleware.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_middleware.py
@@ -127,3 +127,53 @@ class SessionCookieDomainSiteConfigurationOverrideTests(TestCase):
         """
         response = self.client.get('/', HTTP_HOST=self.site.domain)
         self.assertIn(self.site.domain, str(response.cookies['sessionid']))
+
+
+class LoginRequiredMiddlewareTests(TestCase):
+
+    def setUp(self):
+        super(LoginRequiredMiddlewareTests, self).setUp()
+
+        self.user = UserFactory.create()
+        self.user.set_password('password')
+        self.user.save()
+        self.open_site = SiteFactory.create(
+            domain='testserver.fake.open',
+            name='testserver.fake.open'
+        )
+        self.open_site_configuration = SiteConfigurationFactory.create(
+            site=self.open_site,
+            values={}
+        )
+
+        self.restricted_site = SiteFactory.create(
+            domain='testserver.fake.restricted',
+            name='testserver.fake.restricted'
+        )
+        self.restricted_site_configuration = SiteConfigurationFactory.create(
+            site=self.restricted_site,
+            values={
+                "RESTRICT_SITE_TO_LOGGED_IN_USERS": True,
+                "LOGIN_EXEMPT_URLS": r'^about'
+            }
+        )
+        self.client = Client()
+
+    def test_anonymous_user_can_access_open_site(self):
+        response = self.client.get('/courses', HTTP_HOST=self.open_site.domain)
+        self.assertEqual(response.status_code, 200, 'Response: ' + str(response.status_code) + ' ' + str(response))
+
+    def test_anonymous_user_cannot_access_restricted_site(self):
+        response = self.client.get('/courses', HTTP_HOST=self.restricted_site.domain)
+        self.assertEqual(response.status_code, 302)
+
+    def test_logged_in_user_can_access_both_sites(self):
+        self.client.login(username=self.user.username, password="password")
+        o_response = self.client.get('/courses', HTTP_HOST=self.open_site.domain)
+        r_response = self.client.get('/courses', HTTP_HOST=self.restricted_site.domain)
+        self.assertEqual(o_response.status_code, 200)
+        self.assertEqual(r_response.status_code, 200)
+
+    def test_anonymous_user_can_access_login_exempt_urls_for_restricted_site(self):
+        response = self.client.get('/about', HTTP_HOST=self.restricted_site.domain)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## What does this PR do?

Provides configurable middleware to restrict site pages to logged in users.
This middleware wraps requests in all urls not explicitly disabled in site configuration/settings.FEATURES in the login_required django decorator

## Why do we need this

At Microsoft we have separated our instance into two django sites (more coming). We want to restrict the content on our employee site while still allowing the courses to be free while keeping our public site open to the public. This middleware allows individual django sites to apply this middleware.

### Sandbox environment

* Restricted Site: http://kabirfs.southcentralus.cloudapp.azure.com
* Open Site: http://openedx.kabirfs.southcentralus.cloudapp.azure.com 

### JIRA Ticket

https://openedx.atlassian.net/browse/OPEN-2008 

### Conversation started

https://openedx.slack.com/archives/C02SNA1U4/p1494273435062603
