### PR TITLE
[ENT-386] Styling Issues on new registration page

### DIFF
--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -62,7 +62,7 @@
         margin: 0;
         letter-spacing: normal;
         font-family: $sans-serif;
-        color: $gray-d4;
+        color: $uxpl-gray-dark;
     }
 
     a, label {
@@ -354,7 +354,7 @@
             }
 
             &.error {
-                border-color: tint($red,50%);
+                border-color: $error-color;
             }
         }
 
@@ -373,11 +373,15 @@
             &:active, &:focus {
                 outline: auto;
             }
+
+            &.error {
+                outline-color: $error-color;
+            }
         }
 
         .tip, .label-optional {
             @extend %t-copy-sub1;
-            color: $gray-d2;
+            color: $uxpl-gray-base;
         }
         .tip {
             display: block;


### PR DESCRIPTION
This PR fixes the style issues reported in the ENT ticket.

**JIRA tickets**: [ENT-386](https://openedx.atlassian.net/browse/ENT-386)

**Dependencies**: None

**Screenshots**:
![captura de pantalla de 2017-05-24 02-12-37](https://cloud.githubusercontent.com/assets/560781/26393264/8b6c8cfe-4026-11e7-8401-bf79a43fc1f3.png)

**Sandbox URL**: https://pr15177.sandbox.opencraft.hosting/register

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: None

**Testing instructions**:

1. Use the sandbox or set up a devstack using this branch (and the settings below)
2. Go to the Register form
3. Verify that the font color of the 'tip' messages like "This name will be used on any certificates that you earn." is `#414141`
4. Verify that the font color of the "Create an Account Using" and "or create a new one here" strings is `#111111`
5. Submit an empty form to raise errors in the required fields and verify that:
    a) the font color of their labels is `#b20610`
    b) the border color of their input fields is `#cb0712`
    c) the outline color of the Gender dropwdown is `#cb0712`

**Reviewers**
- [x] @mtyaka 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_REGISTRATION_EXTRA_FIELDS:
  level_of_education: "optional"
  gender: "required"
  year_of_birth: "optional"
  mailing_address: "optional"
  goals: "optional"
  honor_code: "required"
  city: "hidden"
  country: "hidden"
```