### PR TITLE
[ENT-378] Remove code for custom header logo

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -34,10 +34,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.theming.helpers import is_request_in_themed_site
 from openedx.core.djangoapps.user_api.accounts.api import request_password_change
 from openedx.core.djangoapps.user_api.errors import UserNotFound
-from openedx.features.enterprise_support.api import (
-    enterprise_customer_for_request,
-    set_enterprise_branding_filter_param
-)
+from openedx.features.enterprise_support.api import enterprise_customer_for_request
 from openedx.core.lib.time_zone_utils import TIME_ZONE_CHOICES
 from openedx.core.lib.edx_api_utils import get_edx_api_data
 from student.models import UserProfile
@@ -98,8 +95,6 @@ def login_and_registration_form(request, initial_mode="login"):
                 initial_mode = "hinted_login"
         except (KeyError, ValueError, IndexError):
             pass
-
-    set_enterprise_branding_filter_param(request=request, provider_id=third_party_auth_hint)
 
     # If this is a themed site, revert to the old login/registration pages.
     # We need to do this for now to support existing themes.

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -31,10 +31,6 @@
       display: block;
     }
 
-    img.ec-logo-size {
-      width: 84px;
-      height: 56px;
-    }
   }
 
   nav {

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -13,7 +13,6 @@ from openedx.core.djangolib.markup import HTML, Text
 from branding import api as branding_api
 # app that handles site status messages
 from status.status import get_site_status_msg
-from openedx.features.enterprise_support.api import get_enterprise_customer_logo_url
 from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>
 
@@ -53,14 +52,7 @@ site_status_msg = get_site_status_msg(course_id)
         <div class="logo">
           <a href="${marketing_link('ROOT')}">
             <%block name="navigation_logo">
-            <%
-            logo_url = get_enterprise_customer_logo_url(request)
-            logo_size = 'ec-logo-size'
-            if logo_url is None:
-                logo_url = branding_api.get_logo_url(is_secure)
-                logo_size = ''
-            %>
-                <img class="${logo_size}" src="${logo_url}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
+            <img src="${branding_api.get_logo_url(is_secure)}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
             </%block>
           </a>
         </div>

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -33,7 +33,6 @@ except ImportError:
 
 
 CONSENT_FAILED_PARAMETER = 'consent_failed'
-ENTERPRISE_CUSTOMER_BRANDING_OVERRIDE_DETAILS = 'enterprise_customer_branding_override_details'
 LOGGER = logging.getLogger("edx.enterprise_helpers")
 
 
@@ -325,63 +324,6 @@ def insert_enterprise_pipeline_elements(pipeline):
 
     for index, element in enumerate(additional_elements):
         pipeline.insert(insert_point + index, element)
-
-
-def get_enterprise_customer_logo_url(request):
-    """
-    Client API operation adapter/wrapper.
-    """
-
-    if not enterprise_enabled():
-        return None
-
-    parameter = get_enterprise_branding_filter_param(request)
-    if not parameter:
-        return None
-
-    provider_id = parameter.get('provider_id', None)
-    ec_uuid = parameter.get('ec_uuid', None)
-
-    if provider_id:
-        branding_info = enterprise_utils.get_enterprise_branding_info_by_provider_id(identity_provider_id=provider_id)
-    elif ec_uuid:
-        branding_info = enterprise_utils.get_enterprise_branding_info_by_ec_uuid(ec_uuid=ec_uuid)
-
-    logo_url = None
-    if branding_info and branding_info.logo:
-        logo_url = branding_info.logo.url
-
-    return logo_url
-
-
-def set_enterprise_branding_filter_param(request, provider_id):
-    """
-    Setting 'ENTERPRISE_CUSTOMER_BRANDING_OVERRIDE_DETAILS' in session. 'ENTERPRISE_CUSTOMER_BRANDING_OVERRIDE_DETAILS'
-    either be provider_id or ec_uuid. e.g. {provider_id: 'xyz'} or {ec_src: enterprise_customer_uuid}
-    """
-    ec_uuid = request.GET.get('ec_src', None)
-    if provider_id:
-        LOGGER.info(
-            "Session key 'ENTERPRISE_CUSTOMER_BRANDING_OVERRIDE_DETAILS' has been set with provider_id '%s'",
-            provider_id
-        )
-        request.session[ENTERPRISE_CUSTOMER_BRANDING_OVERRIDE_DETAILS] = {'provider_id': provider_id}
-
-    elif ec_uuid:
-        # we are assuming that none sso based enterprise will return Enterprise Customer uuid as 'ec_src' in query
-        # param e.g. edx.org/foo/bar?ec_src=6185ed46-68a4-45d6-8367-96c0bf70d1a6
-        LOGGER.info(
-            "Session key 'ENTERPRISE_CUSTOMER_BRANDING_OVERRIDE_DETAILS' has been set with ec_uuid '%s'", ec_uuid
-        )
-        request.session[ENTERPRISE_CUSTOMER_BRANDING_OVERRIDE_DETAILS] = {'ec_uuid': ec_uuid}
-
-
-def get_enterprise_branding_filter_param(request):
-    """
-    :return Filter parameter from session for enterprise customer branding information.
-
-    """
-    return request.session.get(ENTERPRISE_CUSTOMER_BRANDING_OVERRIDE_DETAILS, None)
 
 
 def get_cache_key(**kwargs):

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -13,11 +13,8 @@ from openedx.features.enterprise_support.api import (
     enterprise_customer_for_request,
     enterprise_enabled,
     get_dashboard_consent_notification,
-    get_enterprise_branding_filter_param,
     get_enterprise_consent_url,
-    get_enterprise_customer_logo_url,
-    insert_enterprise_pipeline_elements,
-    set_enterprise_branding_filter_param
+    insert_enterprise_pipeline_elements
 )
 
 
@@ -49,74 +46,6 @@ class TestEnterpriseApi(unittest.TestCase):
                                     'enterprise.tpa_pipeline.handle_enterprise_logistration',
                                     'social.pipeline.social_auth.load_extra_data',
                                     'def'])
-
-    def test_set_enterprise_branding_filter_param(self):
-        """
-        Test that the enterprise customer branding parameters are setting correctly.
-        """
-        ec_uuid = '97b4a894-cea9-4103-8f9f-2c5c95a58ba3'
-        provider_id = 'test-provider-idp'
-
-        request = mock.MagicMock(session={}, GET={'ec_src': ec_uuid})
-        set_enterprise_branding_filter_param(request, provider_id=None)
-        self.assertEqual(get_enterprise_branding_filter_param(request), {'ec_uuid': ec_uuid})
-
-        set_enterprise_branding_filter_param(request, provider_id=provider_id)
-        self.assertEqual(get_enterprise_branding_filter_param(request), {'provider_id': provider_id})
-
-    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
-    def test_get_enterprise_customer_logo_url(self):
-        """
-        Test test_get_enterprise_customer_logo_url return the logo url as desired.
-        """
-        ec_uuid = '97b4a894-cea9-4103-8f9f-2c5c95a58ba3'
-        provider_id = 'test-provider-idp'
-        request = mock.MagicMock(session={}, GET={'ec_src': ec_uuid})
-        branding_info = mock.Mock(
-            logo=mock.Mock(
-                url='/test/image.png'
-            )
-        )
-
-        set_enterprise_branding_filter_param(request, provider_id=None)
-        with mock.patch('enterprise.utils.get_enterprise_branding_info_by_ec_uuid', return_value=branding_info):
-            logo_url = get_enterprise_customer_logo_url(request)
-            self.assertEqual(logo_url, '/test/image.png')
-
-        set_enterprise_branding_filter_param(request, provider_id)
-        with mock.patch('enterprise.utils.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
-            logo_url = get_enterprise_customer_logo_url(request)
-            self.assertEqual(logo_url, '/test/image.png')
-
-    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=False)
-    def test_get_enterprise_customer_logo_url_return_none(self):
-        """
-        Test get_enterprise_customer_logo_url return 'None' when enterprise application is not installed.
-        """
-        request = mock.MagicMock(session={})
-        branding_info = mock.Mock()
-
-        set_enterprise_branding_filter_param(request, 'test-idp')
-        with mock.patch('enterprise.utils.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
-            logo_url = get_enterprise_customer_logo_url(request)
-            self.assertEqual(logo_url, None)
-
-    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
-    @mock.patch(
-        'openedx.features.enterprise_support.api.get_enterprise_branding_filter_param',
-        mock.Mock(return_value=None)
-    )
-    def test_get_enterprise_customer_logo_url_return_none_when_param_missing(self):
-        """
-        Test get_enterprise_customer_logo_url return 'None' when filter parameters are missing.
-        """
-        request = mock.MagicMock(session={})
-        branding_info = mock.Mock()
-
-        set_enterprise_branding_filter_param(request, provider_id=None)
-        with mock.patch('enterprise.utils.get_enterprise_branding_info_by_provider_id', return_value=branding_info):
-            logo_url = get_enterprise_customer_logo_url(request)
-            self.assertEqual(logo_url, None)
 
     @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
     @mock.patch('openedx.features.enterprise_support.api.get_enterprise_customer_for_request')


### PR DESCRIPTION
This PR removes the code introduced in [ENT-32](https://openedx.atlassian.net/browse/ENT-32) where the enteprise logo was displayed. The PR associated with that work was https://github.com/edx/edx-platform/pull/14064

**JIRA tickets**: [ENT-378](https://openedx.atlassian.net/browse/ENT-378)

**Dependencies**: None

**Sandbox URL**: https://pr15187.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

1. Set up a devstack using this branch
2. Add an Enterprise Customer with a logo
3. Add a learner to the Enterprise Customer
4. Log in with the learner user
5. Verify that after logging in the image in the navigation area at the top is the platform image

**Reviewers**
- [x] @mtyaka 
- [ ] edX reviewer[s] TBD