### PR TITLE
EDUCATOR-3 Check for course before using it.

### DIFF
--- a/cms/djangoapps/contentstore/proctoring.py
+++ b/cms/djangoapps/contentstore/proctoring.py
@@ -7,7 +7,7 @@ import logging
 from django.conf import settings
 
 from xmodule.modulestore.django import modulestore
-
+from xmodule.modulestore.exceptions import ItemNotFoundError
 from contentstore.views.helpers import is_item_in_course_tree
 
 from edx_proctoring.api import (
@@ -40,6 +40,9 @@ def register_special_exams(course_key):
         return
 
     course = modulestore().get_course(course_key)
+    if course is None:
+        raise ItemNotFoundError("Course {} does not exist", unicode(course_key))
+
     if not course.enable_proctored_exams and not course.enable_timed_exams:
         # likewise if course does not have these features turned on
         # then quickly exit

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -14,10 +14,11 @@ if active_page is None and active_page_context is not UNDEFINED:
     # If active_page is not passed in as an argument, it may be in the context as active_page_context
     active_page = active_page_context
 
-include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and (course.enable_proctored_exams or course.enable_timed_exams)
+if course is not None:
+    include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and (course.enable_proctored_exams or course.enable_timed_exams)
 %>
 
-% if include_special_exams:
+% if include_special_exams is not UNDEFINED and include_special_exams:
     <%static:js group='proctoring'/>
     % for template_name in ["proctored-exam-status"]:
         <script type="text/template" id="${template_name}-tpl">

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -45,7 +45,7 @@ from openedx.features.course_experience import UNIFIED_COURSE_VIEW_FLAG
     % endfor
 % endif
 
-% if include_special_exams:
+% if include_special_exams is not UNDEFINED and include_special_exams:
   % for template_name in ["proctored-exam-status"]:
     <script type="text/template" id="${template_name}-tpl">
         <%static:include path="courseware/${template_name}.underscore" />


### PR DESCRIPTION
## ['NoneType' object has no attribute 'enable_proctored_exams'. EDUCATOR-3](https://openedx.atlassian.net/browse/EDUCATOR-3)

### Description
I have added the extra check on course before using it.

### Test:
Unfortunately, I have tried to reproduce it but I am unable.
I have checked defensively that `course is None ` on different places.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @Qubad786 
- [x] @Rabia23 

FYI: @adampalay 

### Post-review
- [x] Rebase and squash commits