### PR TITLE
Add isort to edx-platform

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+indent='    '
+line_length=120
+multi_line_output=3

--- a/openedx/features/course_bookmarks/urls.py
+++ b/openedx/features/course_bookmarks/urls.py
@@ -4,7 +4,7 @@ Defines URLs for the course experience.
 
 from django.conf.urls import url
 
-from views.course_bookmarks import CourseBookmarksView, CourseBookmarksFragmentView
+from views.course_bookmarks import CourseBookmarksFragmentView, CourseBookmarksView
 
 urlpatterns = [
     url(

--- a/openedx/features/course_experience/urls.py
+++ b/openedx/features/course_experience/urls.py
@@ -4,7 +4,7 @@ Defines URLs for the course experience.
 
 from django.conf.urls import url
 
-from views.course_home import CourseHomeView, CourseHomeFragmentView
+from views.course_home import CourseHomeFragmentView, CourseHomeView
 from views.course_outline import CourseOutlineFragmentView
 from views.course_updates import CourseUpdatesFragmentView, CourseUpdatesView
 from views.welcome_message import WelcomeMessageFragmentView

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -1,9 +1,10 @@
 """
 Common utilities for the course experience, including course outline.
 """
+from opaque_keys.edx.keys import CourseKey
+
 from lms.djangoapps.course_api.blocks.api import get_blocks
 from lms.djangoapps.course_blocks.utils import get_student_module_as_dict
-from opaque_keys.edx.keys import CourseKey
 from openedx.core.lib.cache_utils import memoized
 from xmodule.modulestore.django import modulestore
 

--- a/openedx/features/course_experience/views/course_dates.py
+++ b/openedx/features/course_experience/views/course_dates.py
@@ -4,8 +4,9 @@ Fragment for rendering the course dates sidebar.
 from django.template.loader import render_to_string
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
+
+from courseware.courses import get_course_date_blocks, get_course_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
-from courseware.courses import get_course_with_access, get_course_date_blocks
 
 
 class CourseDatesFragmentView(EdxFragmentView):

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -8,18 +8,18 @@ from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
+from opaque_keys.edx.keys import CourseKey
+from web_fragments.fragment import Fragment
 
 from courseware.courses import get_course_info_section, get_course_with_access
 from lms.djangoapps.courseware.views.views import CourseTabView
-from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from util.views import ensure_valid_course_key
-from web_fragments.fragment import Fragment
 
-from .course_outline import CourseOutlineFragmentView
-from .course_dates import CourseDatesFragmentView
-from .welcome_message import WelcomeMessageFragmentView
 from ..utils import get_course_outline_block_tree
+from .course_dates import CourseDatesFragmentView
+from .course_outline import CourseOutlineFragmentView
+from .welcome_message import WelcomeMessageFragmentView
 
 
 class CourseHomeView(CourseTabView):

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -4,11 +4,11 @@ Views to show a course outline.
 
 from django.core.context_processors import csrf
 from django.template.loader import render_to_string
+from opaque_keys.edx.keys import CourseKey
+from web_fragments.fragment import Fragment
 
 from courseware.courses import get_course_overview_with_access
-from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
-from web_fragments.fragment import Fragment
 
 from ..utils import get_course_outline_block_tree
 

--- a/openedx/features/course_experience/views/course_updates.py
+++ b/openedx/features/course_experience/views/course_updates.py
@@ -8,13 +8,13 @@ from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
+from opaque_keys.edx.keys import CourseKey
+from web_fragments.fragment import Fragment
 
 from courseware.courses import get_course_info_section, get_course_with_access
 from lms.djangoapps.courseware.views.views import CourseTabView
-from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.features.course_experience import default_course_url_name
-from web_fragments.fragment import Fragment
 
 
 class CourseUpdatesView(CourseTabView):

--- a/openedx/features/course_experience/views/welcome_message.py
+++ b/openedx/features/course_experience/views/welcome_message.py
@@ -3,11 +3,11 @@ View logic for handling course welcome messages.
 """
 
 from django.template.loader import render_to_string
+from opaque_keys.edx.keys import CourseKey
+from web_fragments.fragment import Fragment
 
 from courseware.courses import get_course_info_section_module, get_course_with_access
-from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
-from web_fragments.fragment import Fragment
 
 
 class WelcomeMessageFragmentView(EdxFragmentView):

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -1,11 +1,11 @@
 """
 APIs providing support for enterprise functionality.
 """
-from functools import wraps
 import hashlib
 import logging
-import six
+from functools import wraps
 
+import six
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -14,9 +14,15 @@ from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.utils.http import urlencode
 from django.utils.translation import ugettext as _
-from slumber.exceptions import HttpClientError, HttpServerError
-
 from edx_rest_api_client.client import EdxRestApiClient
+from requests.exceptions import ConnectionError, Timeout
+from slumber.exceptions import HttpClientError, HttpServerError, SlumberBaseException
+
+from openedx.core.djangoapps.api_admin.utils import course_discovery_api_client
+from openedx.core.djangoapps.catalog.models import CatalogIntegration
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.lib.token_utils import JwtBuilder
+
 try:
     from enterprise import utils as enterprise_utils
     from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomer
@@ -24,13 +30,6 @@ try:
     from enterprise.utils import consent_necessary_for_course
 except ImportError:
     pass
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from slumber.exceptions import SlumberBaseException
-from requests.exceptions import ConnectionError, Timeout
-from openedx.core.djangoapps.api_admin.utils import course_discovery_api_client
-
-from openedx.core.lib.token_utils import JwtBuilder
-from openedx.core.djangoapps.catalog.models import CatalogIntegration
 
 
 CONSENT_FAILED_PARAMETER = 'consent_failed'

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -5,6 +5,7 @@
 # Python libraries to install directly from github / PyPi
 
 click==3.3
+isort==4.2.5
 
 # Third-party:
 -e git+https://github.com/doctoryes/code_block_timer.git@f3d0629f086bcc649c3c77f4bc5b9c2c8172c3bf#egg=code_block_timer


### PR DESCRIPTION
## [LEARNER-1168](https://openedx.atlassian.net/browse/LEARNER-1168)

### Description

This change adds isort to edx-platform to provide an automated way to keep imports in order. For now this requires that developers manually run isort on their files, or use a plugin in their editor of choice:

https://github.com/timothycrosley/isort/wiki/isort-Plugins

To give a sense for what these changes look like, I've run isort against a number of files that I've been working on recently.

Note: once we are comfortable with this approach, we should add linting to enforce the import order. Here's an example from the course-discovery repo:

https://github.com/edx/course-discovery/blob/master/Makefile#L45
 
### Post-review
- [ ] Rebase and squash commits