### PR TITLE
Add ability to set the Discussion division scheme

### DIFF
--- a/common/djangoapps/django_comment_common/tests.py
+++ b/common/djangoapps/django_comment_common/tests.py
@@ -120,7 +120,7 @@ class CourseDiscussionSettingsTest(ModuleStoreTestCase):
     def test_invalid_data_types(self):
         exception_msg_template = "Incorrect field type for `{}`. Type must be `{}`"
         fields = [
-            {'name': 'division_scheme', 'type': str},
+            {'name': 'division_scheme', 'type': basestring},
             {'name': 'always_divide_inline_discussions', 'type': bool},
             {'name': 'divided_discussions', 'type': list}
         ]

--- a/common/djangoapps/django_comment_common/utils.py
+++ b/common/djangoapps/django_comment_common/utils.py
@@ -124,12 +124,13 @@ def set_course_discussion_settings(course_key, **kwargs):
     Returns:
         A CourseDiscussionSettings object.
     """
-    fields = {'division_scheme': str, 'always_divide_inline_discussions': bool, 'divided_discussions': list}
+    fields = {'division_scheme': basestring, 'always_divide_inline_discussions': bool, 'divided_discussions': list}
     course_discussion_settings = get_course_discussion_settings(course_key)
     for field, field_type in fields.items():
         if field in kwargs:
             if not isinstance(kwargs[field], field_type):
                 raise ValueError("Incorrect field type for `{}`. Type must be `{}`".format(field, field_type.__name__))
             setattr(course_discussion_settings, field, kwargs[field])
-        course_discussion_settings.save()
+
+    course_discussion_settings.save()
     return course_discussion_settings

--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -263,10 +263,6 @@ class CohortManagementSection(PageObject):
     no_content_group_button_css = '.cohort-management-details-association-course input.radio-no'
     select_content_group_button_css = '.cohort-management-details-association-course input.radio-yes'
     assignment_type_buttons_css = '.cohort-management-assignment-type-settings input'
-    discussion_form_selectors = {
-        'course-wide': '.cohort-course-wide-discussions-form',
-        'inline': '.cohort-inline-discussions-form'
-    }
 
     def get_cohort_help_element_and_click_help(self):
         """
@@ -689,8 +685,13 @@ class DiscussionManagementSection(PageObject):
 
     discussion_form_selectors = {
         'course-wide': '.cohort-course-wide-discussions-form',
-        'inline': '.cohort-inline-discussions-form'
+        'inline': '.cohort-inline-discussions-form',
+        'scheme': '.division-scheme-container',
     }
+
+    NOT_DIVIDED_SCHEME = "none"
+    COHORT_SCHEME = "cohort"
+    ENROLLMENT_TRACK_SCHEME = "enrollment_track"
 
     def is_browser_on_page(self):
         return self.q(css=self.discussion_form_selectors['course-wide']).present
@@ -800,6 +801,25 @@ class DiscussionManagementSection(PageObject):
         Returns the status for category checkboxes.
         """
         return self.q(css=self._bounded_selector('.check-discussion-category:checked')).is_present()
+
+    def get_selected_scheme(self):
+        """
+        Returns the ID of the selected discussion division scheme
+        ("NOT_DIVIDED_SCHEME", "COHORT_SCHEME", or "ENROLLMENT_TRACK_SCHEME)".
+        """
+        return self.q(css=self._bounded_selector('.division-scheme:checked')).first.attrs('id')[0]
+
+    def select_division_scheme(self, scheme):
+        """
+        Selects the radio button associated with the specified division scheme.
+        """
+        self.q(css=self._bounded_selector("input#%s" % scheme)).first.click()
+
+    def division_scheme_visible(self, scheme):
+        """
+        Returns whether or not the specified scheme is visible as an option.
+        """
+        return self.q(css=self._bounded_selector("input#%s" % scheme)).visible
 
 
 class MembershipPageAutoEnrollSection(PageObject):

--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -807,19 +807,19 @@ class DiscussionManagementSection(PageObject):
         Returns the ID of the selected discussion division scheme
         ("NOT_DIVIDED_SCHEME", "COHORT_SCHEME", or "ENROLLMENT_TRACK_SCHEME)".
         """
-        return self.q(css=self._bounded_selector('.division-scheme:checked')).first.attrs('id')[0]
+        return self.q(css=self._bounded_selector('.division-scheme:checked')).first.attrs('value')[0]
 
     def select_division_scheme(self, scheme):
         """
         Selects the radio button associated with the specified division scheme.
         """
-        self.q(css=self._bounded_selector("input#%s" % scheme)).first.click()
+        self.q(css=self._bounded_selector("input.%s" % scheme)).first.click()
 
     def division_scheme_visible(self, scheme):
         """
         Returns whether or not the specified scheme is visible as an option.
         """
-        return self.q(css=self._bounded_selector("input#%s" % scheme)).visible
+        return self.q(css=self._bounded_selector("input.%s" % scheme)).visible
 
 
 class MembershipPageAutoEnrollSection(PageObject):

--- a/common/test/acceptance/tests/discussion/helpers.py
+++ b/common/test/acceptance/tests/discussion/helpers.py
@@ -76,22 +76,26 @@ class CohortTestMixin(object):
 
     def enable_cohorting(self, course_fixture):
         """
-        enables cohorts and always_divide_inline_discussions for the current course fixture.
+        Enables cohorting for the specified course fixture.
         """
-        url = LMS_BASE_URL + "/courses/" + course_fixture._course_key + '/cohorts/settings'  # pylint: disable=protected-access
-        discussions_url = LMS_BASE_URL + "/courses/" + course_fixture._course_key + '/discussions/settings'  # pylint: disable=protected-access
-
+        url = LMS_BASE_URL + "/courses/" + course_fixture._course_key + '/cohorts/settings'
         data = json.dumps({'is_cohorted': True})
-        discussions_data = json.dumps({'always_divide_inline_discussions': True})
-
         response = course_fixture.session.patch(url, data=data, headers=course_fixture.headers)
+        self.assertTrue(response.ok, "Failed to enable cohorts")
+
+    def enable_always_divide_inline_discussions(self, course_fixture):
+        """
+        Enables "always_divide_inline_discussions" (but does not enabling cohorting).
+        """
+        discussions_url = LMS_BASE_URL + "/courses/" + course_fixture._course_key + '/discussions/settings'
+        discussions_data = json.dumps({'always_divide_inline_discussions': True})
         course_fixture.session.patch(discussions_url, data=discussions_data, headers=course_fixture.headers)
 
     def disable_cohorting(self, course_fixture):
         """
-        Disables cohorting for the current course fixture.
+        Disables cohorting for the specified course fixture.
         """
-        url = LMS_BASE_URL + "/courses/" + course_fixture._course_key + '/cohorts/settings'  # pylint: disable=protected-access
+        url = LMS_BASE_URL + "/courses/" + course_fixture._course_key + '/cohorts/settings'
         data = json.dumps({'is_cohorted': False})
         response = course_fixture.session.patch(url, data=data, headers=course_fixture.headers)
         self.assertTrue(response.ok, "Failed to disable cohorts")

--- a/common/test/acceptance/tests/discussion/test_cohorts.py
+++ b/common/test/acceptance/tests/discussion/test_cohorts.py
@@ -47,6 +47,7 @@ class CohortedDiscussionTestMixin(BaseDiscussionMixin, CohortTestMixin):
 
         # Enable cohorts and verify that the post shows to cohort only.
         self.enable_cohorting(self.course_fixture)
+        self.enable_always_divide_inline_discussions(self.course_fixture)
         self.refresh_thread_page(self.thread_id)
         self.assertEquals(
             self.thread_page.get_group_visibility_label(),

--- a/common/test/acceptance/tests/discussion/test_discussion_management.py
+++ b/common/test/acceptance/tests/discussion/test_discussion_management.py
@@ -4,25 +4,26 @@ End-to-end tests related to the divided discussion management on the LMS Instruc
 """
 
 from nose.plugins.attrib import attr
-from common.test.acceptance.tests.discussion.helpers import CohortTestMixin
+from common.test.acceptance.tests.discussion.helpers import BaseDiscussionMixin, CohortTestMixin
 from common.test.acceptance.tests.helpers import UniqueCourseTest
 from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage
+from common.test.acceptance.pages.lms.discussion import DiscussionTabSingleThreadPage
 from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage
+from common.test.acceptance.pages.common.utils import add_enrollment_course_modes
 
 import uuid
 
 
-@attr(shard=6)
-class DividedDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
+class BaseDividedDiscussionTest(UniqueCourseTest, CohortTestMixin):
     """
-    Tests for dividing the inline and course-wide discussion topics.
+    Base class for tests related to divided discussions.
     """
     def setUp(self):
         """
         Set up a discussion topic
         """
-        super(DividedDiscussionTopicsTest, self).setUp()
+        super(BaseDividedDiscussionTest, self).setUp()
 
         self.discussion_id = "test_discussion_{}".format(uuid.uuid4().hex)
         self.course_fixture = CourseFixture(**self.course_info).add_children(
@@ -59,24 +60,53 @@ class DividedDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
 
         self.course_wide_key = 'course-wide'
         self.inline_key = 'inline'
+        self.scheme_key = 'scheme'
 
-    def divided_discussion_topics_are_visible(self):
+    def check_discussion_topic_visibility(self, visible=True):
         """
         Assert that discussion topics are visible with appropriate content.
         """
-        self.assertTrue(self.discussion_management_page.discussion_topics_visible())
+        self.assertEqual(visible, self.discussion_management_page.discussion_topics_visible())
 
-        self.assertEqual(
-            "Course-Wide Discussion Topics",
-            self.discussion_management_page.divided_discussion_heading_is_visible(self.course_wide_key)
-        )
-        self.assertTrue(self.discussion_management_page.is_save_button_disabled(self.course_wide_key))
+        if visible:
+            self.assertEqual(
+                "Course-Wide Discussion Topics",
+                self.discussion_management_page.divided_discussion_heading_is_visible(self.course_wide_key)
+            )
+            self.assertTrue(self.discussion_management_page.is_save_button_disabled(self.course_wide_key))
 
-        self.assertEqual(
-            "Content-Specific Discussion Topics",
-            self.discussion_management_page.divided_discussion_heading_is_visible(self.inline_key)
-        )
-        self.assertTrue(self.discussion_management_page.is_save_button_disabled(self.inline_key))
+            self.assertEqual(
+                "Content-Specific Discussion Topics",
+                self.discussion_management_page.divided_discussion_heading_is_visible(self.inline_key)
+            )
+            self.assertTrue(self.discussion_management_page.is_save_button_disabled(self.inline_key))
+
+    def reload_page(self, topics_visible=True):
+        """
+        Refresh the page, then verify if the discussion topics are visible on the discussion
+        management instructor dashboard tab.
+        """
+        self.browser.refresh()
+        self.discussion_management_page.wait_for_page()
+
+        self.instructor_dashboard_page.select_discussion_management()
+        self.discussion_management_page.wait_for_page()
+
+        self.check_discussion_topic_visibility(topics_visible)
+
+    def verify_save_confirmation_message(self, key):
+        """
+        Verify that the save confirmation message for the specified portion of the page is visible.
+        """
+        confirmation_message = self.discussion_management_page.get_divide_discussions_message(key=key)
+        self.assertEqual("Your changes have been saved.", confirmation_message)
+
+
+@attr(shard=6)
+class DividedDiscussionTopicsTest(BaseDividedDiscussionTest):
+    """
+    Tests for dividing the inline and course-wide discussion topics.
+    """
 
     def save_and_verify_discussion_topics(self, key):
         """
@@ -86,23 +116,10 @@ class DividedDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
         self.discussion_management_page.save_discussion_topics(key)
 
         # verifies that changes saved successfully.
-        confirmation_message = self.discussion_management_page.get_divide_discussions_message(key=key)
-        self.assertEqual("Your changes have been saved.", confirmation_message)
+        self.verify_save_confirmation_message(key)
 
         # save button disabled again.
         self.assertTrue(self.discussion_management_page.is_save_button_disabled(key))
-
-    def reload_page(self):
-        """
-        Refresh the page.
-        """
-        self.browser.refresh()
-        self.discussion_management_page.wait_for_page()
-
-        self.instructor_dashboard_page.select_discussion_management()
-        self.discussion_management_page.wait_for_page()
-
-        self.divided_discussion_topics_are_visible()
 
     def verify_discussion_topics_after_reload(self, key, divided_topics):
         """
@@ -124,7 +141,7 @@ class DividedDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
         When I reload the page
         Then I see the discussion topic selected
         """
-        self.divided_discussion_topics_are_visible()
+        self.check_discussion_topic_visibility()
 
         divided_topics_before = self.discussion_management_page.get_divided_topics_count(self.course_wide_key)
         self.discussion_management_page.select_discussion_topic(self.course_wide_key)
@@ -151,7 +168,7 @@ class DividedDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
         And I reload the page
         Then I see the always_divide_inline_topics option enabled
         """
-        self.divided_discussion_topics_are_visible()
+        self.check_discussion_topic_visibility()
 
         # enable always inline discussion topics and save the change
         self.discussion_management_page.select_always_inline_discussion()
@@ -175,7 +192,7 @@ class DividedDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
         And I reload the page
         Then I see the divide_some_inline_topics option enabled
         """
-        self.divided_discussion_topics_are_visible()
+        self.check_discussion_topic_visibility()
         # By default always inline discussion topics is False. Enable it (and reload the page).
         self.assertFalse(self.discussion_management_page.always_inline_discussion_selected())
         self.discussion_management_page.select_always_inline_discussion()
@@ -207,7 +224,7 @@ class DividedDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
         When I reload the page
         Then I see the discussion topic selected
         """
-        self.divided_discussion_topics_are_visible()
+        self.check_discussion_topic_visibility()
 
         divided_topics_before = self.discussion_management_page.get_divided_topics_count(self.inline_key)
         # check the discussion topic.
@@ -234,7 +251,7 @@ class DividedDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
         Then I see enabled saved button
         Then I see parent category to be checked.
         """
-        self.divided_discussion_topics_are_visible()
+        self.check_discussion_topic_visibility()
 
         # category should not be selected.
         self.assertFalse(self.discussion_management_page.is_category_selected())
@@ -255,7 +272,7 @@ class DividedDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
         Then I see enabled saved button
         Then I see parent category to be deselected.
         """
-        self.divided_discussion_topics_are_visible()
+        self.check_discussion_topic_visibility()
 
         # category should not be selected.
         self.assertFalse(self.discussion_management_page.is_category_selected())
@@ -271,3 +288,162 @@ class DividedDiscussionTopicsTest(UniqueCourseTest, CohortTestMixin):
 
         # category should not be selected.
         self.assertFalse(self.discussion_management_page.is_category_selected())
+
+
+@attr(shard=6)
+class DivisionSchemeTest(BaseDividedDiscussionTest, BaseDiscussionMixin):
+    """
+    Tests for changing the division scheme for Discussions.
+    """
+
+    def add_modes_and_view_discussion_mgmt_page(self, modes):
+        """
+        Adds enrollment modes to the course, and then goes to the
+        discussion tab on the instructor dashboard.
+        """
+        add_enrollment_course_modes(self.browser, self.course_id, modes)
+        self.view_discussion_management_page()
+
+    def view_discussion_management_page(self):
+        """
+        Go to the discussion tab on the instructor dashboard.
+        """
+        self.instructor_dashboard_page.visit()
+        self.instructor_dashboard_page.select_discussion_management()
+        self.discussion_management_page.wait_for_page()
+
+    def setup_thread_page(self, thread_id):
+        """
+        This is called by BaseDiscussionMixin.setup_thread.
+        """
+        self.thread_page = DiscussionTabSingleThreadPage(
+            self.browser, self.course_id, self.discussion_id, thread_id
+        )
+        self.thread_page.visit()
+
+    def test_not_divided_hides_discussion_topics(self):
+        """
+        Tests that discussion topics are hidden iff discussion division is disabled.
+        """
+        # Initially "Cohort" is the selected scheme.
+        self.assertTrue(
+            self.discussion_management_page.division_scheme_visible(self.discussion_management_page.COHORT_SCHEME)
+        )
+        self.assertEqual(
+            self.discussion_management_page.COHORT_SCHEME,
+            self.discussion_management_page.get_selected_scheme()
+        )
+        self.check_discussion_topic_visibility(visible=True)
+
+        self.discussion_management_page.select_division_scheme(self.discussion_management_page.NOT_DIVIDED_SCHEME)
+        self.verify_save_confirmation_message(self.scheme_key)
+        self.check_discussion_topic_visibility(visible=False)
+
+        # Reload the page and make sure that the change was persisted
+        self.reload_page(topics_visible=False)
+        self.assertTrue(self.discussion_management_page.division_scheme_visible(
+            self.discussion_management_page.COHORT_SCHEME)
+        )
+        self.assertEqual(
+            self.discussion_management_page.NOT_DIVIDED_SCHEME,
+            self.discussion_management_page.get_selected_scheme()
+        )
+
+        # Select "cohort" again and make sure that the discussion topics appear.
+        self.discussion_management_page.select_division_scheme(self.discussion_management_page.COHORT_SCHEME)
+        self.verify_save_confirmation_message(self.scheme_key)
+        self.check_discussion_topic_visibility(visible=True)
+
+    def test_disabling_cohorts(self):
+        """
+        Test that disabling cohorts hides the cohort division scheme iff it is not the selected scheme
+        (even without reloading the page).
+        """
+        # TODO: will be added as part of AJ's work.
+        pass
+
+    def test_single_enrollment_mode(self):
+        """
+        Test that the enrollment track scheme is not visible if there is a single enrollment mode.
+        """
+        self.add_modes_and_view_discussion_mgmt_page(['audit'])
+        self.assertFalse(
+            self.discussion_management_page.division_scheme_visible(
+                self.discussion_management_page.ENROLLMENT_TRACK_SCHEME
+            )
+        )
+
+    def test_radio_buttons_with_multiple_enrollment_modes(self):
+        """
+        Test that the enrollment track scheme is visible if there are multiple enrollment tracks,
+        and that the selection can be persisted.
+
+        Also verifies that the cohort division scheme is not presented if cohorts are disabled and cohorts
+        are not the selected division scheme.
+        """
+        self.add_modes_and_view_discussion_mgmt_page(['audit', 'verified'])
+        self.assertTrue(
+            self.discussion_management_page.division_scheme_visible(
+                self.discussion_management_page.ENROLLMENT_TRACK_SCHEME
+            )
+        )
+        # And the cohort scheme is initially visible because it is selected (and cohorts are enabled).
+        self.assertTrue(
+            self.discussion_management_page.division_scheme_visible(self.discussion_management_page.COHORT_SCHEME)
+        )
+
+        self.discussion_management_page.select_division_scheme(self.discussion_management_page.ENROLLMENT_TRACK_SCHEME)
+        self.verify_save_confirmation_message(self.scheme_key)
+        self.check_discussion_topic_visibility(visible=True)
+
+        # Also disable cohorts so we can verify that the cohort scheme choice goes away.
+        self.disable_cohorting(self.course_fixture)
+
+        self.reload_page(topics_visible=True)
+        self.assertEqual(
+            self.discussion_management_page.ENROLLMENT_TRACK_SCHEME,
+            self.discussion_management_page.get_selected_scheme()
+        )
+        # Verify that the cohort scheme is no longer visible as cohorts are disabled.
+        self.assertFalse(
+            self.discussion_management_page.division_scheme_visible(self.discussion_management_page.COHORT_SCHEME)
+        )
+
+    def test_enrollment_track_discussion_visibility_label(self):
+        """
+        If enrollment tracks are the division scheme, verifies that discussion visibility labels
+        correctly render.
+
+        Note that there are similar tests for cohorts in test_cohorts.py.
+        """
+        def refresh_thread_page():
+            self.browser.refresh()
+            self.thread_page.wait_for_page()
+
+        # Make moderator for viewing all groups in discussions.
+        AutoAuthPage(self.browser, course_id=self.course_id, roles="Moderator", staff=True).visit()
+
+        self.add_modes_and_view_discussion_mgmt_page(['audit', 'verified'])
+        self.discussion_management_page.select_division_scheme(self.discussion_management_page.ENROLLMENT_TRACK_SCHEME)
+        self.verify_save_confirmation_message(self.scheme_key)
+        # Set "always divide" as the thread we will be creating will be an inline thread,
+        # and this way the thread does not need to be explicitly divided.
+        self.enable_always_divide_inline_discussions(self.course_fixture)
+
+        # Create a thread with group_id corresponding to the Audit enrollment mode.
+        # The Audit group ID is 1, and for the comment service group_id we negate it.
+        self.setup_thread(1, group_id=-1)
+
+        refresh_thread_page()
+        self.assertEquals(
+            self.thread_page.get_group_visibility_label(),
+            "This post is visible only to {}.".format("Audit")
+        )
+
+        # Disable dividing discussions and verify that the post now shows as visible to everyone.
+        self.view_discussion_management_page()
+        self.discussion_management_page.select_division_scheme(self.discussion_management_page.NOT_DIVIDED_SCHEME)
+        self.verify_save_confirmation_message(self.scheme_key)
+
+        self.thread_page.visit()
+        self.assertEquals(self.thread_page.get_group_visibility_label(), "This post is visible to everyone.")

--- a/common/test/acceptance/tests/discussion/test_discussion_management.py
+++ b/common/test/acceptance/tests/discussion/test_discussion_management.py
@@ -99,7 +99,7 @@ class BaseDividedDiscussionTest(UniqueCourseTest, CohortTestMixin):
         Verify that the save confirmation message for the specified portion of the page is visible.
         """
         confirmation_message = self.discussion_management_page.get_divide_discussions_message(key=key)
-        self.assertEqual("Your changes have been saved.", confirmation_message)
+        self.assertIn("Your changes have been saved.", confirmation_message)
 
 
 @attr(shard=6)

--- a/common/test/acceptance/tests/lms/test_lms_cohorted_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_cohorted_courseware_search.py
@@ -7,7 +7,6 @@ import uuid
 
 from nose.plugins.attrib import attr
 
-from common.test.acceptance.fixtures import LMS_BASE_URL
 from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 from common.test.acceptance.pages.common.logout import LogoutPage
 from common.test.acceptance.pages.lms.courseware_search import CoursewareSearchPage
@@ -19,10 +18,11 @@ from common.test.acceptance.pages.studio.overview import CourseOutlinePage as St
 from common.test.acceptance.pages.studio.settings_group_configurations import GroupConfigurationsPage
 from common.test.acceptance.tests.helpers import remove_file
 from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
+from common.test.acceptance.tests.discussion.helpers import CohortTestMixin
 
 
 @attr(shard=1)
-class CoursewareSearchCohortTest(ContainerBase):
+class CoursewareSearchCohortTest(ContainerBase, CohortTestMixin):
     """
     Test courseware search.
     """
@@ -131,15 +131,6 @@ class CoursewareSearchCohortTest(ContainerBase):
                 )
             )
         )
-
-    def enable_cohorting(self, course_fixture):
-        """
-        Enables cohorting for the current course.
-        """
-        url = LMS_BASE_URL + "/courses/" + course_fixture._course_key + '/cohorts/settings'  # pylint: disable=protected-access
-        data = json.dumps({'is_cohorted': True})
-        response = course_fixture.session.patch(url, data=data, headers=course_fixture.headers)
-        self.assertTrue(response.ok, "Failed to enable cohorts")
 
     def create_content_groups(self):
         """

--- a/common/test/acceptance/tests/lms/test_lms_help.py
+++ b/common/test/acceptance/tests/lms/test_lms_help.py
@@ -10,9 +10,10 @@ from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDash
 from common.test.acceptance.tests.helpers import assert_opened_help_link_is_correct, url_for_help
 from common.test.acceptance.tests.lms.test_lms_instructor_dashboard import BaseInstructorDashboardTest
 from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
+from common.test.acceptance.tests.discussion.helpers import CohortTestMixin
 
 
-class TestCohortHelp(ContainerBase):
+class TestCohortHelp(ContainerBase, CohortTestMixin):
     """
     Tests help links in Cohort page
     """
@@ -73,15 +74,6 @@ class TestCohortHelp(ContainerBase):
             '/course_features/cohorts/cohorts_overview.html#all-automated-assignment',
         )
         self.verify_help_link(href)
-
-    def enable_cohorting(self, course_fixture):
-        """
-        Enables cohorting for the current course.
-        """
-        url = LMS_BASE_URL + "/courses/" + course_fixture._course_key + '/cohorts/settings'  # pylint: disable=protected-access
-        data = json.dumps({'is_cohorted': True})
-        response = course_fixture.session.patch(url, data=data, headers=course_fixture.headers)
-        self.assertTrue(response.ok, "Failed to enable cohorts")
 
 
 class InstructorDashboardHelp(BaseInstructorDashboardTest):

--- a/common/test/acceptance/tests/test_cohorted_courseware.py
+++ b/common/test/acceptance/tests/test_cohorted_courseware.py
@@ -7,7 +7,6 @@ import json
 from bok_choy.page_object import XSS_INJECTION
 from nose.plugins.attrib import attr
 
-from common.test.acceptance.fixtures import LMS_BASE_URL
 from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 from common.test.acceptance.pages.common.utils import add_enrollment_course_modes, enroll_user_track
 from common.test.acceptance.pages.lms.auto_auth import AutoAuthPage as LmsAutoAuthPage
@@ -17,6 +16,7 @@ from common.test.acceptance.pages.studio.auto_auth import AutoAuthPage as Studio
 from common.test.acceptance.pages.studio.component_editor import ComponentVisibilityEditorView
 from common.test.acceptance.pages.studio.settings_group_configurations import GroupConfigurationsPage
 from common.test.acceptance.tests.lms.test_lms_user_preview import verify_expected_problem_visibility
+from common.test.acceptance.tests.discussion.helpers import CohortTestMixin
 from studio.base_studio_test import ContainerBase
 
 AUDIT_TRACK = "Audit"
@@ -24,7 +24,7 @@ VERIFIED_TRACK = "Verified"
 
 
 @attr(shard=5)
-class EndToEndCohortedCoursewareTest(ContainerBase):
+class EndToEndCohortedCoursewareTest(ContainerBase, CohortTestMixin):
     """
     End-to-end of cohorted courseware.
     """
@@ -113,15 +113,6 @@ class EndToEndCohortedCoursewareTest(ContainerBase):
                 )
             )
         )
-
-    def enable_cohorting(self, course_fixture):
-        """
-        Enables cohorting for the current course.
-        """
-        url = LMS_BASE_URL + "/courses/" + course_fixture._course_key + '/cohorts/settings'  # pylint: disable=protected-access
-        data = json.dumps({'is_cohorted': True})
-        response = course_fixture.session.patch(url, data=data, headers=course_fixture.headers)
-        self.assertTrue(response.ok, "Failed to enable cohorts")
 
     def create_content_groups(self):
         """

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from datetime import datetime
 import ddt
 from django.core.urlresolvers import reverse
 from django.http import Http404
@@ -9,20 +10,27 @@ from django.test.utils import override_settings
 from django.utils import translation
 from lms.lib.comment_client.utils import CommentClientPaginatedResult
 
+from course_modes.models import CourseMode
+from course_modes.tests.factories import CourseModeFactory
 from django_comment_common.utils import ThreadContext
-from django_comment_common.models import ForumsConfig
+from django_comment_common.models import ForumsConfig, CourseDiscussionSettings
 from django_comment_client.permissions import get_team
+from django_comment_client.tests.utils import config_course_discussions
 from django_comment_client.tests.group_id import (
     GroupIdAssertionMixin,
     CohortedTopicGroupIdTestMixin,
     NonCohortedTopicGroupIdTestMixin,
 )
+from django_comment_client.constants import TYPE_ENTRY, TYPE_SUBCATEGORY
 from django_comment_client.tests.unicode import UnicodeTestMixin
-from django_comment_client.tests.utils import CohortedTestCase, ForumsEnableMixin
+from django_comment_client.tests.utils import CohortedTestCase, ForumsEnableMixin, topic_name_to_id
 from django_comment_client.utils import strip_none
 from lms.djangoapps.discussion import views
+from lms.djangoapps.discussion.views import course_discussions_settings_handler
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from util.testing import UrlResetMixin
+from openedx.core.djangoapps.course_groups.tests.helpers import config_course_cohorts
+from openedx.core.djangoapps.course_groups.tests.test_views import CohortViewsTestCase
 from openedx.core.djangoapps.util.testing import ContentGroupTestCase
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from xmodule.modulestore import ModuleStoreEnum
@@ -1626,3 +1634,252 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ForumsEnableMixin
                         kwargs=dict(course_id=course_id, discussion_id=self.discussion_id, thread_id=thread_id)),
         ):
             self.verify_consent_required(self.client, url)
+
+
+class DividedDiscussionsTestCase(CohortViewsTestCase):
+
+    def create_divided_discussions(self):
+        """
+        Set up a divided discussion in the system, complete with all the fixings
+        """
+        divided_inline_discussions = ['Topic A']
+        divided_course_wide_discussions = ["Topic B"]
+        divided_discussions = divided_inline_discussions + divided_course_wide_discussions
+
+        # inline discussion
+        ItemFactory.create(
+            parent_location=self.course.location,
+            category="discussion",
+            discussion_id=topic_name_to_id(self.course, "Topic A"),
+            discussion_category="Chapter",
+            discussion_target="Discussion",
+            start=datetime.now()
+        )
+        # course-wide discussion
+        discussion_topics = {
+            "Topic B": {"id": "Topic B"},
+        }
+
+        config_course_cohorts(
+            self.course,
+            is_cohorted=True,
+        )
+
+        config_course_discussions(
+            self.course,
+            discussion_topics=discussion_topics,
+            divided_discussions=divided_discussions
+        )
+        return divided_inline_discussions, divided_course_wide_discussions
+
+
+class CourseDiscussionTopicsTestCase(DividedDiscussionsTestCase):
+    """
+    Tests the `divide_discussion_topics` view.
+    """
+
+    def test_non_staff(self):
+        """
+        Verify that we cannot access divide_discussion_topics if we're a non-staff user.
+        """
+        self._verify_non_staff_cannot_access(views.discussion_topics, "GET", [unicode(self.course.id)])
+
+    def test_get_discussion_topics(self):
+        """
+        Verify that discussion_topics is working for HTTP GET.
+        """
+        # create inline & course-wide discussion to verify the different map.
+        self.create_divided_discussions()
+
+        response = self.get_handler(self.course, handler=views.discussion_topics)
+        start_date = response['inline_discussions']['subcategories']['Chapter']['start_date']
+        expected_response = {
+            "course_wide_discussions": {
+                'children': [['Topic B', TYPE_ENTRY]],
+                'entries': {
+                    'Topic B': {
+                        'sort_key': 'A',
+                        'is_divided': True,
+                        'id': topic_name_to_id(self.course, "Topic B"),
+                        'start_date': response['course_wide_discussions']['entries']['Topic B']['start_date']
+                    }
+                }
+            },
+            "inline_discussions": {
+                'subcategories': {
+                    'Chapter': {
+                        'subcategories': {},
+                        'children': [['Discussion', TYPE_ENTRY]],
+                        'entries': {
+                            'Discussion': {
+                                'sort_key': None,
+                                'is_divided': True,
+                                'id': topic_name_to_id(self.course, "Topic A"),
+                                'start_date': start_date
+                            }
+                        },
+                        'sort_key': 'Chapter',
+                        'start_date': start_date
+                    }
+                },
+                'children': [['Chapter', TYPE_SUBCATEGORY]]
+            }
+        }
+        self.assertEqual(response, expected_response)
+
+
+class CourseDiscussionsHandlerTestCase(DividedDiscussionsTestCase):
+    """
+    Tests the course_discussion_settings_handler
+    """
+    def get_expected_response(self):
+        """
+        Returns the static response dict.
+        """
+        return {
+            u'always_divide_inline_discussions': False,
+            u'divided_inline_discussions': [],
+            u'divided_course_wide_discussions': [],
+            u'id': 1,
+            u'division_scheme': u'cohort',
+            u'available_division_schemes': [u'cohort']
+        }
+
+    def test_non_staff(self):
+        """
+        Verify that we cannot access course_discussions_settings_handler if we're a non-staff user.
+        """
+        self._verify_non_staff_cannot_access(
+            course_discussions_settings_handler, "GET", [unicode(self.course.id)]
+        )
+        self._verify_non_staff_cannot_access(
+            course_discussions_settings_handler, "PATCH", [unicode(self.course.id)]
+        )
+
+    def test_update_always_divide_inline_discussion_settings(self):
+        """
+        Verify that course_discussions_settings_handler is working for always_divide_inline_discussions via HTTP PATCH.
+        """
+        config_course_cohorts(self.course, is_cohorted=True)
+
+        response = self.get_handler(self.course, handler=course_discussions_settings_handler)
+
+        expected_response = self.get_expected_response()
+
+        self.assertEqual(response, expected_response)
+
+        expected_response['always_divide_inline_discussions'] = True
+        response = self.patch_handler(
+            self.course, data=expected_response, handler=course_discussions_settings_handler
+        )
+
+        self.assertEqual(response, expected_response)
+
+    def test_update_course_wide_discussion_settings(self):
+        """
+        Verify that course_discussions_settings_handler is working for divided_course_wide_discussions via HTTP PATCH.
+        """
+        # course-wide discussion
+        discussion_topics = {
+            "Topic B": {"id": "Topic B"},
+        }
+
+        config_course_cohorts(self.course, is_cohorted=True)
+        config_course_discussions(self.course, discussion_topics=discussion_topics)
+
+        response = self.get_handler(self.course, handler=views.course_discussions_settings_handler)
+
+        expected_response = self.get_expected_response()
+        self.assertEqual(response, expected_response)
+
+        expected_response['divided_course_wide_discussions'] = [topic_name_to_id(self.course, "Topic B")]
+        response = self.patch_handler(
+            self.course, data=expected_response, handler=views.course_discussions_settings_handler
+        )
+
+        self.assertEqual(response, expected_response)
+
+    def test_update_inline_discussion_settings(self):
+        """
+        Verify that course_discussions_settings_handler is working for divided_inline_discussions via HTTP PATCH.
+        """
+        config_course_cohorts(self.course, is_cohorted=True)
+
+        response = self.get_handler(self.course, handler=views.course_discussions_settings_handler)
+
+        expected_response = self.get_expected_response()
+        self.assertEqual(response, expected_response)
+
+        now = datetime.now()
+        # inline discussion
+        ItemFactory.create(
+            parent_location=self.course.location,
+            category="discussion",
+            discussion_id="Topic_A",
+            discussion_category="Chapter",
+            discussion_target="Discussion",
+            start=now
+        )
+
+        expected_response['divided_inline_discussions'] = ["Topic_A"]
+        response = self.patch_handler(
+            self.course, data=expected_response, handler=views.course_discussions_settings_handler
+        )
+
+        self.assertEqual(response, expected_response)
+
+    def test_get_settings(self):
+        """
+        Verify that course_discussions_settings_handler is working for HTTP GET.
+        """
+        divided_inline_discussions, divided_course_wide_discussions = self.create_divided_discussions()
+
+        response = self.get_handler(self.course, handler=views.course_discussions_settings_handler)
+        expected_response = self.get_expected_response()
+
+        expected_response['divided_inline_discussions'] = [topic_name_to_id(self.course, name)
+                                                           for name in divided_inline_discussions]
+        expected_response['divided_course_wide_discussions'] = [topic_name_to_id(self.course, name)
+                                                                for name in divided_course_wide_discussions]
+
+        self.assertEqual(response, expected_response)
+
+    def test_update_settings_with_invalid_field_data_type(self):
+        """
+        Verify that course_discussions_settings_handler return HTTP 400 if field data type is incorrect.
+        """
+        config_course_cohorts(self.course, is_cohorted=True)
+
+        response = self.patch_handler(
+            self.course,
+            data={'always_divide_inline_discussions': ''},
+            expected_response_code=400,
+            handler=views.course_discussions_settings_handler
+        )
+        self.assertEqual(
+            "Incorrect field type for `{}`. Type must be `{}`".format('always_divide_inline_discussions', bool.__name__),
+            response.get("error")
+        )
+
+    def test_available_schemes(self):
+        # Cohorts disabled, single enrollment mode.
+        config_course_cohorts(self.course, is_cohorted=False)
+        response = self.get_handler(self.course, handler=views.course_discussions_settings_handler)
+        expected_response = self.get_expected_response()
+        expected_response['available_division_schemes'] = []
+        self.assertEqual(response, expected_response)
+
+        # Add 2 enrollment modes
+        CourseModeFactory.create(course_id=self.course.id, mode_slug=CourseMode.AUDIT)
+        CourseModeFactory.create(course_id=self.course.id, mode_slug=CourseMode.VERIFIED)
+        response = self.get_handler(self.course, handler=views.course_discussions_settings_handler)
+        expected_response['available_division_schemes'] = [CourseDiscussionSettings.ENROLLMENT_TRACK]
+        self.assertEqual(response, expected_response)
+
+        # Enable cohorts
+        config_course_cohorts(self.course, is_cohorted=True)
+        response = self.get_handler(self.course, handler=views.course_discussions_settings_handler)
+        expected_response['available_division_schemes'] = [
+            CourseDiscussionSettings.COHORT, CourseDiscussionSettings.ENROLLMENT_TRACK
+        ]
+        self.assertEqual(response, expected_response)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -24,6 +24,9 @@ try:
 except ImportError:
     newrelic = None  # pylint: disable=invalid-name
 
+from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.http import require_http_methods
+
 from rest_framework import status
 
 from web_fragments.fragment import Fragment
@@ -36,10 +39,12 @@ from courseware.access import has_access
 from student.models import CourseEnrollment
 from xmodule.modulestore.django import modulestore
 
-from django_comment_common.utils import ThreadContext, get_course_discussion_settings
+from django_comment_common.utils import ThreadContext, get_course_discussion_settings, set_course_discussion_settings
 
+from django_comment_client.constants import TYPE_ENTRY
 from django_comment_client.permissions import has_permission, get_team
 from django_comment_client.utils import (
+    available_division_schemes,
     merge_dict,
     extract,
     strip_none,
@@ -57,6 +62,8 @@ import lms.lib.comment_client as cc
 from opaque_keys.edx.keys import CourseKey
 
 from contextlib import contextmanager
+from util.json_request import expect_json, JsonResponse
+
 
 THREADS_PER_PAGE = 20
 INLINE_THREADS_PER_PAGE = 20
@@ -684,3 +691,167 @@ class DiscussionBoardFragmentView(EdxFragmentView):
             return self.get_css_dependencies('style-discussion-main-rtl')
         else:
             return self.get_css_dependencies('style-discussion-main')
+
+
+@expect_json
+@login_required
+def discussion_topics(request, course_key_string):
+    """
+    The handler for divided discussion categories requests.
+    This will raise 404 if user is not staff.
+
+    Returns the JSON representation of discussion topics w.r.t categories for the course.
+
+    Example:
+        >>> example = {
+        >>>               "course_wide_discussions": {
+        >>>                   "entries": {
+        >>>                       "General": {
+        >>>                           "sort_key": "General",
+        >>>                           "is_divided": True,
+        >>>                           "id": "i4x-edx-eiorguegnru-course-foobarbaz"
+        >>>                       }
+        >>>                   }
+        >>>                   "children": ["General", "entry"]
+        >>>               },
+        >>>               "inline_discussions" : {
+        >>>                   "subcategories": {
+        >>>                       "Getting Started": {
+        >>>                           "subcategories": {},
+        >>>                           "children": [
+        >>>                               ["Working with Videos", "entry"],
+        >>>                               ["Videos on edX", "entry"]
+        >>>                           ],
+        >>>                           "entries": {
+        >>>                               "Working with Videos": {
+        >>>                                   "sort_key": None,
+        >>>                                   "is_divided": False,
+        >>>                                   "id": "d9f970a42067413cbb633f81cfb12604"
+        >>>                               },
+        >>>                               "Videos on edX": {
+        >>>                                   "sort_key": None,
+        >>>                                   "is_divided": False,
+        >>>                                   "id": "98d8feb5971041a085512ae22b398613"
+        >>>                               }
+        >>>                           }
+        >>>                       },
+        >>>                       "children": ["Getting Started", "subcategory"]
+        >>>                   },
+        >>>               }
+        >>>          }
+    """
+    course_key = CourseKey.from_string(course_key_string)
+    course = get_course_with_access(request.user, 'staff', course_key)
+
+    discussion_topics = {}
+    discussion_category_map = utils.get_discussion_category_map(
+        course, request.user, divided_only_if_explicit=True, exclude_unstarted=False
+    )
+
+    # We extract the data for the course wide discussions from the category map.
+    course_wide_entries = discussion_category_map.pop('entries')
+
+    course_wide_children = []
+    inline_children = []
+
+    for name, c_type in discussion_category_map['children']:
+        if name in course_wide_entries and c_type == TYPE_ENTRY:
+            course_wide_children.append([name, c_type])
+        else:
+            inline_children.append([name, c_type])
+
+    discussion_topics['course_wide_discussions'] = {
+        'entries': course_wide_entries,
+        'children': course_wide_children
+    }
+
+    discussion_category_map['children'] = inline_children
+    discussion_topics['inline_discussions'] = discussion_category_map
+
+    return JsonResponse(discussion_topics)
+
+
+@require_http_methods(("GET", "PATCH"))
+@ensure_csrf_cookie
+@expect_json
+@login_required
+def course_discussions_settings_handler(request, course_key_string):
+    """
+    The restful handler for divided discussion setting requests. Requires JSON.
+    This will raise 404 if user is not staff.
+    GET
+        Returns the JSON representation of divided discussion settings for the course.
+    PATCH
+        Updates the divided discussion settings for the course. Returns the JSON representation of updated settings.
+    """
+    course_key = CourseKey.from_string(course_key_string)
+    course = get_course_with_access(request.user, 'staff', course_key)
+    discussion_settings = get_course_discussion_settings(course_key)
+
+    if request.method == 'PATCH':
+        divided_course_wide_discussions, divided_inline_discussions = get_divided_discussions(
+            course, discussion_settings
+        )
+
+        settings_to_change = {}
+
+        if 'divided_course_wide_discussions' in request.json or 'divided_inline_discussions' in request.json:
+            divided_course_wide_discussions = request.json.get(
+                'divided_course_wide_discussions', divided_course_wide_discussions
+            )
+            divided_inline_discussions = request.json.get(
+                'divided_inline_discussions', divided_inline_discussions
+            )
+            settings_to_change['divided_discussions'] = divided_course_wide_discussions + divided_inline_discussions
+
+        if 'always_divide_inline_discussions' in request.json:
+            settings_to_change['always_divide_inline_discussions'] = request.json.get(
+                'always_divide_inline_discussions'
+            )
+        if 'division_scheme' in request.json:
+            settings_to_change['division_scheme'] = request.json.get(
+                'division_scheme'
+            )
+
+        if not settings_to_change:
+            return JsonResponse({"error": unicode("Bad Request")}, 400)
+
+        try:
+            if settings_to_change:
+                discussion_settings = set_course_discussion_settings(course_key, **settings_to_change)
+
+        except ValueError as err:
+            # Note: error message not translated because it is not exposed to the user (UI prevents this state).
+            return JsonResponse({"error": unicode(err)}, 400)
+
+    divided_course_wide_discussions, divided_inline_discussions = get_divided_discussions(
+        course, discussion_settings
+    )
+
+    return JsonResponse({
+        'id': discussion_settings.id,
+        'divided_inline_discussions': divided_inline_discussions,
+        'divided_course_wide_discussions': divided_course_wide_discussions,
+        'always_divide_inline_discussions': discussion_settings.always_divide_inline_discussions,
+        'division_scheme': discussion_settings.division_scheme,
+        'available_division_schemes': available_division_schemes(course_key)
+    })
+
+
+def get_divided_discussions(course, discussion_settings):
+    """
+    Returns the course-wide and inline divided discussion ids separately.
+    """
+    divided_course_wide_discussions = []
+    divided_inline_discussions = []
+
+    course_wide_discussions = [topic['id'] for __, topic in course.discussion_topics.items()]
+    all_discussions = utils.get_discussion_categories_ids(course, None, include_all=True)
+
+    for divided_discussion_id in discussion_settings.divided_discussions:
+        if divided_discussion_id in course_wide_discussions:
+            divided_course_wide_discussions.append(divided_discussion_id)
+        elif divided_discussion_id in all_discussions:
+            divided_inline_discussions.append(divided_discussion_id)
+
+    return divided_course_wide_discussions, divided_inline_discussions

--- a/lms/djangoapps/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/django_comment_client/tests/utils.py
@@ -5,9 +5,11 @@ from mock import patch
 
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from django_comment_common.models import Role, ForumsConfig
-from django_comment_common.utils import seed_permissions_roles
+from django_comment_common.utils import seed_permissions_roles, set_course_discussion_settings, CourseDiscussionSettings
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
@@ -63,3 +65,58 @@ class CohortedTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCa
             course_id=self.course.id,
             users=[self.moderator]
         )
+
+
+# pylint: disable=dangerous-default-value
+def config_course_discussions(
+        course,
+        discussion_topics={},
+        divided_discussions=[],
+        always_divide_inline_discussions=False
+):
+        """
+        Set discussions and configure divided discussions for a course.
+
+        Arguments:
+            course: CourseDescriptor
+            discussion_topics (Dict): Discussion topic names. Picks ids and
+                sort_keys automatically.
+            divided_discussions: Discussion topics to divide. Converts the
+                list to use the same ids as discussion topic names.
+            always_divide_inline_discussions (bool): Whether inline discussions
+                should be divided by default.
+
+        Returns:
+            Nothing -- modifies course in place.
+        """
+
+        def to_id(name):
+            """Convert name to id."""
+            return topic_name_to_id(course, name)
+
+        set_course_discussion_settings(
+            course.id,
+            divided_discussions=[to_id(name) for name in divided_discussions],
+            always_divide_inline_discussions=always_divide_inline_discussions,
+            division_scheme=CourseDiscussionSettings.COHORT,
+        )
+
+        course.discussion_topics = dict((name, {"sort_key": "A", "id": to_id(name)})
+                                        for name in discussion_topics)
+        try:
+            # Not implemented for XMLModulestore, which is used by test_cohorts.
+            modulestore().update_item(course, ModuleStoreEnum.UserID.test)
+        except NotImplementedError:
+            pass
+
+
+def topic_name_to_id(course, name):
+    """
+    Given a discussion topic name, return an id for that name (includes
+    course and url_name).
+    """
+    return "{course}_{run}_{name}".format(
+        course=course.location.course,
+        run=course.url_name,
+        name=name
+    )

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -860,6 +860,24 @@ def course_discussion_division_enabled(course_discussion_settings):
     return _get_course_division_scheme(course_discussion_settings) != CourseDiscussionSettings.NONE
 
 
+def available_division_schemes(course_key):
+    """
+    Returns a list of possible discussion division schemes for this course.
+    This takes into account if cohorts are enabled and if there are multiple
+    enrollment tracks. If no schemes are available, returns an empty list.
+    Args:
+        course_key: CourseKey
+
+    Returns: list of possible division schemes (for example, CourseDiscussionSettings.COHORT)
+    """
+    available_schemes = []
+    if is_course_cohorted(course_key):
+        available_schemes.append(CourseDiscussionSettings.COHORT)
+    if len(_get_enrollment_track_groups(course_key)) > 1:
+        available_schemes.append(CourseDiscussionSettings.ENROLLMENT_TRACK)
+    return available_schemes
+
+
 def _get_course_division_scheme(course_discussion_settings):
     division_scheme = course_discussion_settings.division_scheme
     if (

--- a/lms/static/js/discussions_management/models/course_discussions_settings.js
+++ b/lms/static/js/discussions_management/models/course_discussions_settings.js
@@ -6,7 +6,8 @@
             defaults: {
                 divided_inline_discussions: [],
                 divided_course_wide_discussions: [],
-                always_divide_inline_discussions: false
+                always_divide_inline_discussions: false,
+                division_scheme: 'none'
             }
         });
         return CourseDiscussionsSettingsModel;

--- a/lms/static/js/discussions_management/views/discussions.js
+++ b/lms/static/js/discussions_management/views/discussions.js
@@ -3,11 +3,24 @@
     define(['jquery', 'underscore', 'backbone', 'gettext',
         'js/discussions_management/views/divided_discussions_inline',
         'js/discussions_management/views/divided_discussions_course_wide',
-        'edx-ui-toolkit/js/utils/html-utils'
+        'edx-ui-toolkit/js/utils/html-utils',
+        'edx-ui-toolkit/js/utils/string-utils',
+        'js/models/notification',
+        'js/views/notification'
     ],
 
-        function($, _, Backbone, gettext, InlineDiscussionsView, CourseWideDiscussionsView, HtmlUtils) {
+        function($, _, Backbone, gettext, InlineDiscussionsView, CourseWideDiscussionsView, HtmlUtils, StringUtils) {
+            /* global NotificationModel, NotificationView */
+
+            var hiddenClass = 'is-hidden';
+            var cohort = 'cohort';
+            var none = 'none';
+            var enrollmentTrack = 'enrollment_track';
+
             var DiscussionsView = Backbone.View.extend({
+                events: {
+                    'click .division-scheme': 'divisionSchemeChanged'
+                },
 
                 initialize: function(options) {
                     this.template = HtmlUtils.template($('#discussions-tpl').text());
@@ -16,16 +29,145 @@
                 },
 
                 render: function() {
-                    HtmlUtils.setHtml(this.$el, this.template({}));
-                    this.showDiscussionTopics();
+                    var numberAvailableSchemes = this.discussionSettings.attributes.available_division_schemes.length;
+                    HtmlUtils.setHtml(this.$el, this.template({
+                        availableSchemes: this.getDivisionSchemeData(this.discussionSettings.attributes.division_scheme), //  eslint-disable-line max-len
+                        layoutClass: numberAvailableSchemes === 1 ? 'two-column-layout' : 'three-column-layout'
+                    }));
+                    this.updateTopicVisibility(this.getSelectedScheme(), this.getTopicNav());
+                    this.renderTopics();
                     return this;
+                },
+
+                getDivisionSchemeData: function(selectedScheme) {
+                    return [
+                        {
+                            key: none,
+                            displayName: gettext('Not divided'),
+                            descriptiveText: gettext('Discussions are unified; all learners interact with posts from other learners, regardless of the group they are in.'), //  eslint-disable-line max-len
+                            selected: selectedScheme === none,
+                            enabled: true // always leave none enabled
+                        },
+                        {
+                            key: enrollmentTrack,
+                            displayName: gettext('Enrollment Tracks'),
+                            descriptiveText: gettext('Use enrollment tracks as the basis for dividing discussions. All learners, regardless of their enrollment track, see the same discussion topics, but within divided topics, only learners who are in the same enrollment track see and respond to each others’ posts.'), //  eslint-disable-line max-len
+                            selected: selectedScheme === enrollmentTrack,
+                            enabled: this.isSchemeAvailable(enrollmentTrack) || selectedScheme === enrollmentTrack
+                        },
+                        {
+                            key: cohort,
+                            displayName: gettext('Cohorts'),
+                            descriptiveText: gettext('Use cohorts as the basis for dividing discussions. All learners, regardless of cohort, see the same discussion topics, but within divided topics, only members of the same cohort see and respond to each others’ posts. '), //  eslint-disable-line max-len
+                            selected: selectedScheme === cohort,
+                            enabled: this.isSchemeAvailable(cohort) || selectedScheme === cohort
+                        }
+
+                    ];
+                },
+
+                isSchemeAvailable: function(scheme) {
+                    return this.discussionSettings.attributes.available_division_schemes.indexOf(scheme) !== -1;
+                },
+
+                showMessage: function(message, type) {
+                    var model = new NotificationModel({type: type || 'confirmation', title: message});
+                    this.removeNotification();
+                    this.notification = new NotificationView({
+                        model: model
+                    });
+                    this.$('.division-scheme-container').prepend(this.notification.$el);
+                    this.notification.render();
+                },
+
+                removeNotification: function() {
+                    if (this.notification) {
+                        this.notification.remove();
+                    }
+                },
+
+                getSelectedScheme: function() {
+                    return this.$('input[name="division-scheme"]:checked').val();
+                },
+
+                getTopicNav: function() {
+                    return this.$('.topic-division-nav');
+                },
+
+                divisionSchemeChanged: function() {
+                    var selectedScheme = this.getSelectedScheme(),
+                        topicNav = this.getTopicNav(),
+                        fieldData = {
+                            division_scheme: selectedScheme
+                        };
+
+                    this.updateTopicVisibility(selectedScheme, topicNav);
+                    this.saveDivisionScheme(topicNav, fieldData, selectedScheme);
+                },
+
+                saveDivisionScheme: function($element, fieldData, selectedScheme) {
+                    var self = this,
+                        discussionSettingsModel = this.discussionSettings,
+                        showErrorMessage,
+                        details = '';
+
+                    this.removeNotification();
+                    showErrorMessage = function(message) {
+                        self.showMessage(message, 'error');
+                    };
+
+                    discussionSettingsModel.save(
+                        fieldData, {patch: true, wait: true}
+                    ).done(function() {
+                        switch (selectedScheme) {
+                        case none:
+                            details = gettext('Discussion topics in the course are not divided.');
+                            break;
+                        case enrollmentTrack:
+                            details = gettext('Any divided discussion topics are divided based on enrollment track.'); //  eslint-disable-line max-len
+                            break;
+                        case cohort:
+                            details = gettext('Any divided discussion topics are divided based on cohort.');
+                            break;
+                        default:
+                            break;
+                        }
+                        self.showMessage(
+                            StringUtils.interpolate(
+                                gettext('Your changes have been saved. {details}'),
+                                {details: details},
+                                true
+                            )
+                        );
+                    }).fail(function(result) {
+                        var errorMessage = null,
+                            jsonResponse;
+                        try {
+                            jsonResponse = JSON.parse(result.responseText);
+                            errorMessage = jsonResponse.error;
+                        } catch (e) {
+                            // Ignore the exception and show the default error message instead.
+                        }
+                        if (!errorMessage) {
+                            errorMessage = gettext('We have encountered an error. Refresh your browser and then try again.'); //  eslint-disable-line max-len
+                        }
+                        showErrorMessage(errorMessage);
+                    });
+                },
+
+                updateTopicVisibility: function(selectedScheme, topicNav) {
+                    if (selectedScheme === none) {
+                        topicNav.addClass(hiddenClass);
+                    } else {
+                        topicNav.removeClass(hiddenClass);
+                    }
                 },
 
                 getSectionCss: function(section) {
                     return ".instructor-nav .nav-item [data-section='" + section + "']";
                 },
 
-                showDiscussionTopics: function() {
+                renderTopics: function() {
                     var dividedDiscussionsElement = this.$('.discussions-nav');
                     if (!this.CourseWideDiscussionsView) {
                         this.CourseWideDiscussionsView = new CourseWideDiscussionsView({

--- a/lms/static/js/spec/groups/views/discussions_spec.js
+++ b/lms/static/js/spec/groups/views/discussions_spec.js
@@ -20,22 +20,26 @@ define(['backbone', 'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers
 
             createMockDiscussionsSettingsJson = function(dividedInlineDiscussions,
                                                          dividedCourseWideDiscussions,
-                                                         alwaysDivideInlineDiscussions) {
+                                                         alwaysDivideInlineDiscussions,
+                                                         availableDivisionSchemes) {
                 return {
                     id: 0,
                     divided_inline_discussions: dividedInlineDiscussions || [],
                     divided_course_wide_discussions: dividedCourseWideDiscussions || [],
-                    always_divide_inline_discussions: alwaysDivideInlineDiscussions || false
+                    always_divide_inline_discussions: alwaysDivideInlineDiscussions || false,
+                    available_division_schemes: availableDivisionSchemes || ['cohort']
                 };
             };
 
             createMockDiscussionsSettings = function(dividedInlineDiscussions,
                                                      dividedCourseWideDiscussions,
-                                                     alwaysDivideInlineDiscussions) {
+                                                     alwaysDivideInlineDiscussions,
+                                                     availableDivisionSchemes) {
                 return new CourseDiscussionsSettingsModel(
                     createMockDiscussionsSettingsJson(dividedInlineDiscussions,
                                                       dividedCourseWideDiscussions,
-                                                      alwaysDivideInlineDiscussions)
+                                                      alwaysDivideInlineDiscussions,
+                                                      availableDivisionSchemes)
                 );
             };
 
@@ -132,14 +136,14 @@ define(['backbone', 'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers
                 expect($courseWideDiscussionsForm.text()).
                     toContain('Course-Wide Discussion Topics');
                 expect($courseWideDiscussionsForm.text()).
-                    toContain('Select the course-wide discussion topics that you want to divide by cohort.');
+                    toContain('Select the course-wide discussion topics that you want to divide.');
 
                 // Should see the inline discussions form and its content
                 expect($inlineDiscussionsForm.length).toBe(1);
                 expect($inlineDiscussionsForm.text()).
                     toContain('Content-Specific Discussion Topics');
                 expect($inlineDiscussionsForm.text()).
-                    toContain('Specify whether content-specific discussion topics are divided by cohort.');
+                    toContain('Specify whether content-specific discussion topics are divided.');
             };
 
             beforeEach(function() {

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1241,6 +1241,36 @@
 // --------------------
 .instructor-dashboard-wrapper-2 section.idash-section#discussions_management {
 
+  .division-scheme-container {
+    // See https://css-tricks.com/snippets/css/a-guide-to-flexbox/
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+
+    .division-scheme {
+      font-size: 18px;
+    }
+
+    .division-scheme-item {
+      padding-left: 1%;
+      padding-right: 1%;
+      float: left;
+    }
+
+    .three-column-layout {
+       max-width: 33%;
+    }
+
+    .two-column-layout {
+       max-width: 50%;
+    }
+
+    .field-message {
+        font-size: 13px;
+    }
+  }
+
+  // cohort management
   .form-submit {
     @include idashbutton($uxpl-blue-base);
     @include font-size(14);

--- a/lms/templates/instructor/instructor_dashboard_2/discussions.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/discussions.underscore
@@ -1,5 +1,26 @@
 <!-- Discussion Topics. -->
 <div class="discussions-nav" id="discussions-management" tabindex="-1">
-    <div class="course-wide-discussions-nav"></div>
-    <div class="inline-discussions-nav"></div>
+    <div class="hd hd-3 subsection-title" id="division-scheme-title"><%- gettext('Specify whether discussion topics are divided') %></div>
+    <div class="division-scheme-container">
+        <div class="division-scheme-items" role="group" aria-labelledby="division-scheme-title">
+            <% for (var i = 0; i < availableSchemes.length; i++) { %>
+                <div class="division-scheme-item <%- layoutClass %> <% if (!availableSchemes[i].enabled) { %>is-hidden<% } %>">
+                    <label class="division-scheme-label">
+                        <input class="division-scheme <%- availableSchemes[i].key %>" type="radio" name="division-scheme"
+                               value="<%- availableSchemes[i].key %>" aria-describedby="<%- availableSchemes[i].key %>-description"
+                        <% if (availableSchemes[i].selected) { %>
+                        checked
+                        <% } %>
+                        >
+                        <%- availableSchemes[i].displayName %>
+                    </label>
+                    <p class='field-message' id="<%- availableSchemes[i].key %>-description"><%- availableSchemes[i].descriptiveText %></p>
+                </div>
+            <% } %>
+        </div>
+    </div>
+    <div class="topic-division-nav">
+        <div class="course-wide-discussions-nav"></div>
+        <div class="inline-discussions-nav"></div>
+    </div>
 </div>

--- a/lms/templates/instructor/instructor_dashboard_2/divided-discussions-course-wide.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/divided-discussions-course-wide.underscore
@@ -1,11 +1,10 @@
-<h3 class="hd hd-3 subsection-title"><%- gettext('Specify whether discussion topics are divided by cohort') %></h3>
 <form action="" method="post" id="cohort-course-wide-discussions-form" class="cohort-course-wide-discussions-form">
     <div class="wrapper discussions-management-supplemental">
         <div class="form-fields">
             <div class="form-field">
                 <div class="course-wide-discussion-topics">
                     <h4 class="hd hd-4 subsection-title"><%- gettext('Course-Wide Discussion Topics') %></h4>
-                    <p><%- gettext('Select the course-wide discussion topics that you want to divide by cohort.') %></p>
+                    <p><%- gettext('Select the course-wide discussion topics that you want to divide.') %></p>
                     <div class="field">
                         <ul class="discussions-wrapper"><%= HtmlUtils.ensureHtml(courseWideTopicsHtml) %></ul>
                     </div>

--- a/lms/templates/instructor/instructor_dashboard_2/divided-discussions-inline.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/divided-discussions-inline.underscore
@@ -6,17 +6,17 @@
             <div class="form-field">
                 <div class="inline-discussion-topics">
                     <h4 class="hd hd-4 subsection-title"><%- gettext('Content-Specific Discussion Topics') %></h4>
-                    <p><%- gettext('Specify whether content-specific discussion topics are divided by cohort.') %></p>
+                    <p><%- gettext('Specify whether content-specific discussion topics are divided.') %></p>
                     <div class="always_divide_inline_discussions">
                         <label>
                             <input type="radio" name="inline" class="check-all-inline-discussions" <%- alwaysDivideInlineDiscussions ? 'checked="checked"' : '' %>/>
-                            <span class="all-inline-discussions"><%- gettext('Always cohort content-specific discussion topics') %></span>
+                            <span class="all-inline-discussions"><%- gettext('Always divide content-specific discussion topics') %></span>
                         </label>
                     </div>
                     <div class="divide_inline_discussions">
                         <label>
                             <input type="radio" name="inline" class="check-cohort-inline-discussions" <%- alwaysDivideInlineDiscussions ? '' : 'checked="checked"' %>/>
-                            <span class="all-inline-discussions"><%- gettext('Cohort selected content-specific discussion topics') %></span>
+                            <span class="all-inline-discussions"><%- gettext('Divide the selected content-specific discussion topics') %></span>
                         </label>
                     </div>
                     <hr class="divider divider-lv1" />

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -509,7 +509,7 @@ urlpatterns += (
         r'^courses/{}/discussions/settings$'.format(
             settings.COURSE_KEY_PATTERN,
         ),
-        'openedx.core.djangoapps.course_groups.views.course_discussions_settings_handler',
+        'lms.djangoapps.discussion.views.course_discussions_settings_handler',
         name='course_discussions_settings',
     ),
 
@@ -560,7 +560,7 @@ urlpatterns += (
         r'^courses/{}/discussion/topics$'.format(
             settings.COURSE_KEY_PATTERN,
         ),
-        'openedx.core.djangoapps.course_groups.views.discussion_topics',
+        'lms.djangoapps.discussion.views.discussion_topics',
         name='discussion_topics',
     ),
     url(

--- a/openedx/core/djangoapps/course_groups/tests/helpers.py
+++ b/openedx/core/djangoapps/course_groups/tests/helpers.py
@@ -63,25 +63,10 @@ class CourseCohortSettingsFactory(DjangoModelFactory):
     always_cohort_inline_discussions = False
 
 
-def topic_name_to_id(course, name):
-    """
-    Given a discussion topic name, return an id for that name (includes
-    course and url_name).
-    """
-    return "{course}_{run}_{name}".format(
-        course=course.location.course,
-        run=course.url_name,
-        name=name
-    )
-
-
 def config_course_cohorts_legacy(
         course,
-        discussions,
         cohorted,
-        cohorted_discussions=None,
-        auto_cohort_groups=None,
-        always_cohort_inline_discussions=None
+        auto_cohort_groups=None
 ):
     """
     Given a course with no discussion set up, add the discussions and set
@@ -93,38 +78,18 @@ def config_course_cohorts_legacy(
 
     Arguments:
         course: CourseDescriptor
-        discussions: list of topic names strings.  Picks ids and sort_keys
-            automatically.
         cohorted: bool.
-        cohorted_discussions: optional list of topic names.  If specified,
-            converts them to use the same ids as topic names.
         auto_cohort_groups: optional list of strings
                   (names of groups to put students into).
 
     Returns:
         Nothing -- modifies course in place.
     """
-    def to_id(name):
-        """
-        Helper method to convert a discussion topic name to a database identifier
-        """
-        return topic_name_to_id(course, name)
-
-    topics = dict((name, {"sort_key": "A",
-                          "id": to_id(name)})
-                  for name in discussions)
-
-    course.discussion_topics = topics
+    course.discussion_topics = {}
 
     config = {"cohorted": cohorted}
-    if cohorted_discussions is not None:
-        config["cohorted_discussions"] = [to_id(name)
-                                          for name in cohorted_discussions]
     if auto_cohort_groups is not None:
         config["auto_cohort_groups"] = auto_cohort_groups
-
-    if always_cohort_inline_discussions is not None:
-        config["always_cohort_inline_discussions"] = always_cohort_inline_discussions
 
     course.cohort_config = config
 
@@ -136,52 +101,10 @@ def config_course_cohorts_legacy(
 
 
 # pylint: disable=dangerous-default-value
-def config_course_discussions(
-        course,
-        discussion_topics={},
-        divided_discussions=[],
-        always_divide_inline_discussions=False
-):
-        """
-        Set discussions and configure divided discussions for a course.
-
-        Arguments:
-            course: CourseDescriptor
-            discussion_topics (Dict): Discussion topic names. Picks ids and
-                sort_keys automatically.
-            divided_discussions: Discussion topics to divide. Converts the
-                list to use the same ids as discussion topic names.
-            always_divide_inline_discussions (bool): Whether inline discussions
-                should be divided by default.
-
-        Returns:
-            Nothing -- modifies course in place.
-        """
-
-        def to_id(name):
-            """Convert name to id."""
-            return topic_name_to_id(course, name)
-
-        set_course_discussion_settings(
-            course.id,
-            divided_discussions=[to_id(name) for name in divided_discussions],
-            always_divide_inline_discussions=always_divide_inline_discussions,
-            division_scheme=CourseDiscussionSettings.COHORT,
-        )
-
-        course.discussion_topics = dict((name, {"sort_key": "A", "id": to_id(name)})
-                                        for name in discussion_topics)
-        try:
-            # Not implemented for XMLModulestore, which is used by test_cohorts.
-            modulestore().update_item(course, ModuleStoreEnum.UserID.test)
-        except NotImplementedError:
-            pass
-
-
-# pylint: disable=dangerous-default-value
 def config_course_cohorts(
         course,
         is_cohorted,
+        discussion_division_scheme=CourseDiscussionSettings.COHORT,
         auto_cohorts=[],
         manual_cohorts=[],
 ):
@@ -191,6 +114,8 @@ def config_course_cohorts(
     Arguments:
         course: CourseDescriptor
         is_cohorted (bool): Is the course cohorted?
+        discussion_division_scheme (String): the division scheme for discussions. Default is
+            CourseDiscussionSettings.COHORT.
         auto_cohorts (list): Names of auto cohorts to create.
         manual_cohorts (list): Names of manual cohorts to create.
 
@@ -201,7 +126,7 @@ def config_course_cohorts(
     set_course_cohorted(course.id, is_cohorted)
     set_course_discussion_settings(
         course.id,
-        division_scheme=CourseDiscussionSettings.COHORT,
+        division_scheme=discussion_division_scheme,
     )
 
     for cohort_name in auto_cohorts:

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -350,7 +350,6 @@ class TestCohorts(ModuleStoreTestCase):
         # This will have no effect on lms side as we are already done with migrations
         config_course_cohorts_legacy(
             course,
-            discussions=[],
             cohorted=True,
             auto_cohort_groups=["OtherGroup"]
         )
@@ -393,7 +392,6 @@ class TestCohorts(ModuleStoreTestCase):
         # This will have no effect on lms side as we are already done with migrations
         config_course_cohorts_legacy(
             course,
-            discussions=[],
             cohorted=True,
             auto_cohort_groups=["AutoGroup"]
         )

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -19,15 +19,12 @@ import re
 
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
+
 from courseware.courses import get_course_with_access
 from edxmako.shortcuts import render_to_response
 
 from . import cohorts
 
-from django_comment_common.models import CourseDiscussionSettings
-from django_comment_common.utils import get_course_discussion_settings, set_course_discussion_settings
-from lms.djangoapps.django_comment_client.utils import get_discussion_category_map, get_discussion_categories_ids
-from lms.djangoapps.django_comment_client.constants import TYPE_ENTRY
 from .models import CourseUserGroup, CourseUserGroupPartitionGroup, CohortMembership
 
 log = logging.getLogger(__name__)
@@ -77,22 +74,6 @@ def _get_course_cohort_settings_representation(cohort_id, is_cohorted):
     }
 
 
-def _get_course_discussion_settings_representation(course, course_discussion_settings):
-    """
-    Returns a JSON representation of a course discussion settings.
-    """
-    divided_course_wide_discussions, divided_inline_discussions = get_divided_discussions(
-        course, course_discussion_settings
-    )
-
-    return {
-        'id': course_discussion_settings.id,
-        'divided_inline_discussions': divided_inline_discussions,
-        'divided_course_wide_discussions': divided_course_wide_discussions,
-        'always_divide_inline_discussions': course_discussion_settings.always_divide_inline_discussions,
-    }
-
-
 def _get_cohort_representation(cohort, course):
     """
     Returns a JSON representation of a cohort.
@@ -110,80 +91,6 @@ def _get_cohort_representation(cohort, course):
     }
 
 
-def get_divided_discussions(course, discussion_settings):
-    """
-    Returns the course-wide and inline divided discussion ids separately.
-    """
-    divided_course_wide_discussions = []
-    divided_inline_discussions = []
-
-    course_wide_discussions = [topic['id'] for __, topic in course.discussion_topics.items()]
-    all_discussions = get_discussion_categories_ids(course, None, include_all=True)
-
-    for divided_discussion_id in discussion_settings.divided_discussions:
-        if divided_discussion_id in course_wide_discussions:
-            divided_course_wide_discussions.append(divided_discussion_id)
-        elif divided_discussion_id in all_discussions:
-            divided_inline_discussions.append(divided_discussion_id)
-
-    return divided_course_wide_discussions, divided_inline_discussions
-
-
-@require_http_methods(("GET", "PATCH"))
-@ensure_csrf_cookie
-@expect_json
-@login_required
-def course_discussions_settings_handler(request, course_key_string):
-    """
-    The restful handler for divided discussion setting requests. Requires JSON.
-    This will raise 404 if user is not staff.
-    GET
-        Returns the JSON representation of divided discussion settings for the course.
-    PATCH
-        Updates the divided discussion settings for the course. Returns the JSON representation of updated settings.
-    """
-    course_key = CourseKey.from_string(course_key_string)
-    course = get_course_with_access(request.user, 'staff', course_key)
-    discussion_settings = get_course_discussion_settings(course_key)
-
-    if request.method == 'PATCH':
-        divided_course_wide_discussions, divided_inline_discussions = get_divided_discussions(
-            course, discussion_settings
-        )
-
-        settings_to_change = {}
-
-        if 'divided_course_wide_discussions' in request.json or 'divided_inline_discussions' in request.json:
-            divided_course_wide_discussions = request.json.get(
-                'divided_course_wide_discussions', divided_course_wide_discussions
-            )
-            divided_inline_discussions = request.json.get(
-                'divided_inline_discussions', divided_inline_discussions
-            )
-            settings_to_change['divided_discussions'] = divided_course_wide_discussions + divided_inline_discussions
-
-        if 'always_divide_inline_discussions' in request.json:
-            settings_to_change['always_divide_inline_discussions'] = request.json.get(
-                'always_divide_inline_discussions'
-            )
-
-        if not settings_to_change:
-            return JsonResponse({"error": unicode("Bad Request")}, 400)
-
-        try:
-            if settings_to_change:
-                discussion_settings = set_course_discussion_settings(course_key, **settings_to_change)
-
-        except ValueError as err:
-            # Note: error message not translated because it is not exposed to the user (UI prevents this state).
-            return JsonResponse({"error": unicode(err)}, 400)
-
-    return JsonResponse(_get_course_discussion_settings_representation(
-        course,
-        discussion_settings
-    ))
-
-
 @require_http_methods(("GET", "PATCH"))
 @ensure_csrf_cookie
 @expect_json
@@ -199,7 +106,7 @@ def course_cohort_settings_handler(request, course_key_string):
     """
     course_key = CourseKey.from_string(course_key_string)
     # Although this course data is not used this method will return 404 is user is not staff
-    course = get_course_with_access(request.user, 'staff', course_key)
+    get_course_with_access(request.user, 'staff', course_key)
 
     if request.method == 'PATCH':
         if 'is_cohorted' not in request.json:
@@ -208,9 +115,6 @@ def course_cohort_settings_handler(request, course_key_string):
         is_cohorted = request.json.get('is_cohorted')
         try:
             cohorts.set_course_cohorted(course_key, is_cohorted)
-            scheme = CourseDiscussionSettings.COHORT if is_cohorted else CourseDiscussionSettings.NONE
-            scheme_settings = {'division_scheme': scheme}
-            set_course_discussion_settings(course_key, **scheme_settings)
         except ValueError as err:
             # Note: error message not translated because it is not exposed to the user (UI prevents this state).
             return JsonResponse({"error": unicode(err)}, 400)
@@ -467,81 +371,3 @@ def debug_cohort_mgmt(request, course_key_string):
         kwargs={'course_key': course_key.to_deprecated_string()}
     )}
     return render_to_response('/course_groups/debug.html', context)
-
-
-@expect_json
-@login_required
-def discussion_topics(request, course_key_string):
-    """
-    The handler for divided discussion categories requests.
-    This will raise 404 if user is not staff.
-
-    Returns the JSON representation of discussion topics w.r.t categories for the course.
-
-    Example:
-        >>> example = {
-        >>>               "course_wide_discussions": {
-        >>>                   "entries": {
-        >>>                       "General": {
-        >>>                           "sort_key": "General",
-        >>>                           "is_divided": True,
-        >>>                           "id": "i4x-edx-eiorguegnru-course-foobarbaz"
-        >>>                       }
-        >>>                   }
-        >>>                   "children": ["General", "entry"]
-        >>>               },
-        >>>               "inline_discussions" : {
-        >>>                   "subcategories": {
-        >>>                       "Getting Started": {
-        >>>                           "subcategories": {},
-        >>>                           "children": [
-        >>>                               ["Working with Videos", "entry"],
-        >>>                               ["Videos on edX", "entry"]
-        >>>                           ],
-        >>>                           "entries": {
-        >>>                               "Working with Videos": {
-        >>>                                   "sort_key": None,
-        >>>                                   "is_divided": False,
-        >>>                                   "id": "d9f970a42067413cbb633f81cfb12604"
-        >>>                               },
-        >>>                               "Videos on edX": {
-        >>>                                   "sort_key": None,
-        >>>                                   "is_divided": False,
-        >>>                                   "id": "98d8feb5971041a085512ae22b398613"
-        >>>                               }
-        >>>                           }
-        >>>                       },
-        >>>                       "children": ["Getting Started", "subcategory"]
-        >>>                   },
-        >>>               }
-        >>>          }
-    """
-    course_key = CourseKey.from_string(course_key_string)
-    course = get_course_with_access(request.user, 'staff', course_key)
-
-    discussion_topics = {}
-    discussion_category_map = get_discussion_category_map(
-        course, request.user, divided_only_if_explicit=True, exclude_unstarted=False
-    )
-
-    # We extract the data for the course wide discussions from the category map.
-    course_wide_entries = discussion_category_map.pop('entries')
-
-    course_wide_children = []
-    inline_children = []
-
-    for name, c_type in discussion_category_map['children']:
-        if name in course_wide_entries and c_type == TYPE_ENTRY:
-            course_wide_children.append([name, c_type])
-        else:
-            inline_children.append([name, c_type])
-
-    discussion_topics['course_wide_discussions'] = {
-        'entries': course_wide_entries,
-        'children': course_wide_children
-    }
-
-    discussion_category_map['children'] = inline_children
-    discussion_topics['inline_discussions'] = discussion_category_map
-
-    return JsonResponse(discussion_topics)


### PR DESCRIPTION
## [EDUCATOR-229](https://openedx.atlassian.net/browse/EDUCATOR-229)

### Description

This adds radio buttons to the top of the instructor dashboard Discussion tab so that the course team can select the division scheme.

If cohorts are enabled, cohorts should be present (on reload of the instructor dashboard-- dynamic hiding of the option based on cohorts enabling/disabling will happen in a future story).

If there are 2 or more enrollment tracks, enrollment tracks should be present.

If cohorts are disabled and <=1 enrollment track (and cohorts are not the selected division scheme), currently the Discussion tab shows with only "Not divided". A future story will hide the Discussion tab in that case.

### Sandbox
- [x] Course with only 1 enrollment track: https://radiobuttons.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-discussions_management

Course with 2 enrollment tracks:
https://radiobuttons.sandbox.edx.org/courses/course-v1:edX+Test101+course/instructor#view-discussions_management

### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] safecommit violation code review process (there are 3 violations, but they are all in untouched files unrelated to these code changes)

Front-end changes:
- [x] i18n
- [ ] Accessibility (Check for a11y violations, ensure keyboard accessible, screen reader testing as appropriate)
- [ ] RTL

### Reviewers
- [ ] Assign reviewers to your PR based on the changes it contains (Dev, Doc, UX, Accessibility, Product, DevOps)

FYI @bbaker6225  
 
### Post-review
- [ ] Rebase and squash commits