### PR TITLE
WIP: move discussion view methods out of course_groups

### DIFF
--- a/common/djangoapps/django_comment_common/tests.py
+++ b/common/djangoapps/django_comment_common/tests.py
@@ -120,7 +120,7 @@ class CourseDiscussionSettingsTest(ModuleStoreTestCase):
     def test_invalid_data_types(self):
         exception_msg_template = "Incorrect field type for `{}`. Type must be `{}`"
         fields = [
-            {'name': 'division_scheme', 'type': str},
+            {'name': 'division_scheme', 'type': basestring},
             {'name': 'always_divide_inline_discussions', 'type': bool},
             {'name': 'divided_discussions', 'type': list}
         ]

--- a/common/djangoapps/django_comment_common/utils.py
+++ b/common/djangoapps/django_comment_common/utils.py
@@ -124,7 +124,7 @@ def set_course_discussion_settings(course_key, **kwargs):
     Returns:
         A CourseDiscussionSettings object.
     """
-    fields = {'division_scheme': unicode, 'always_divide_inline_discussions': bool, 'divided_discussions': list}
+    fields = {'division_scheme': basestring, 'always_divide_inline_discussions': bool, 'divided_discussions': list}
     course_discussion_settings = get_course_discussion_settings(course_key)
     for field, field_type in fields.items():
         if field in kwargs:

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -24,6 +24,9 @@ try:
 except ImportError:
     newrelic = None  # pylint: disable=invalid-name
 
+from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.http import require_http_methods
+
 from rest_framework import status
 
 from web_fragments.fragment import Fragment
@@ -36,8 +39,9 @@ from courseware.access import has_access
 from student.models import CourseEnrollment
 from xmodule.modulestore.django import modulestore
 
-from django_comment_common.utils import ThreadContext, get_course_discussion_settings
+from django_comment_common.utils import ThreadContext, get_course_discussion_settings, set_course_discussion_settings
 
+from django_comment_client.constants import TYPE_ENTRY
 from django_comment_client.permissions import has_permission, get_team
 from django_comment_client.utils import (
     merge_dict,
@@ -57,6 +61,8 @@ import lms.lib.comment_client as cc
 from opaque_keys.edx.keys import CourseKey
 
 from contextlib import contextmanager
+from util.json_request import expect_json, JsonResponse
+
 
 THREADS_PER_PAGE = 20
 INLINE_THREADS_PER_PAGE = 20
@@ -684,3 +690,167 @@ class DiscussionBoardFragmentView(EdxFragmentView):
             return self.get_css_dependencies('style-discussion-main-rtl')
         else:
             return self.get_css_dependencies('style-discussion-main')
+
+
+@expect_json
+@login_required
+def discussion_topics(request, course_key_string):
+    """
+    The handler for divided discussion categories requests.
+    This will raise 404 if user is not staff.
+
+    Returns the JSON representation of discussion topics w.r.t categories for the course.
+
+    Example:
+        >>> example = {
+        >>>               "course_wide_discussions": {
+        >>>                   "entries": {
+        >>>                       "General": {
+        >>>                           "sort_key": "General",
+        >>>                           "is_divided": True,
+        >>>                           "id": "i4x-edx-eiorguegnru-course-foobarbaz"
+        >>>                       }
+        >>>                   }
+        >>>                   "children": ["General", "entry"]
+        >>>               },
+        >>>               "inline_discussions" : {
+        >>>                   "subcategories": {
+        >>>                       "Getting Started": {
+        >>>                           "subcategories": {},
+        >>>                           "children": [
+        >>>                               ["Working with Videos", "entry"],
+        >>>                               ["Videos on edX", "entry"]
+        >>>                           ],
+        >>>                           "entries": {
+        >>>                               "Working with Videos": {
+        >>>                                   "sort_key": None,
+        >>>                                   "is_divided": False,
+        >>>                                   "id": "d9f970a42067413cbb633f81cfb12604"
+        >>>                               },
+        >>>                               "Videos on edX": {
+        >>>                                   "sort_key": None,
+        >>>                                   "is_divided": False,
+        >>>                                   "id": "98d8feb5971041a085512ae22b398613"
+        >>>                               }
+        >>>                           }
+        >>>                       },
+        >>>                       "children": ["Getting Started", "subcategory"]
+        >>>                   },
+        >>>               }
+        >>>          }
+    """
+    course_key = CourseKey.from_string(course_key_string)
+    course = get_course_with_access(request.user, 'staff', course_key)
+
+    discussion_topics = {}
+    discussion_category_map = utils.get_discussion_category_map(
+        course, request.user, divided_only_if_explicit=True, exclude_unstarted=False
+    )
+
+    # We extract the data for the course wide discussions from the category map.
+    course_wide_entries = discussion_category_map.pop('entries')
+
+    course_wide_children = []
+    inline_children = []
+
+    for name, c_type in discussion_category_map['children']:
+        if name in course_wide_entries and c_type == TYPE_ENTRY:
+            course_wide_children.append([name, c_type])
+        else:
+            inline_children.append([name, c_type])
+
+    discussion_topics['course_wide_discussions'] = {
+        'entries': course_wide_entries,
+        'children': course_wide_children
+    }
+
+    discussion_category_map['children'] = inline_children
+    discussion_topics['inline_discussions'] = discussion_category_map
+
+    return JsonResponse(discussion_topics)
+
+
+@require_http_methods(("GET", "PATCH"))
+@ensure_csrf_cookie
+@expect_json
+@login_required
+def course_discussions_settings_handler(request, course_key_string):
+    """
+    The restful handler for divided discussion setting requests. Requires JSON.
+    This will raise 404 if user is not staff.
+    GET
+        Returns the JSON representation of divided discussion settings for the course.
+    PATCH
+        Updates the divided discussion settings for the course. Returns the JSON representation of updated settings.
+    """
+    course_key = CourseKey.from_string(course_key_string)
+    course = get_course_with_access(request.user, 'staff', course_key)
+    discussion_settings = get_course_discussion_settings(course_key)
+
+    if request.method == 'PATCH':
+        divided_course_wide_discussions, divided_inline_discussions = get_divided_discussions(
+            course, discussion_settings
+        )
+
+        settings_to_change = {}
+
+        if 'divided_course_wide_discussions' in request.json or 'divided_inline_discussions' in request.json:
+            divided_course_wide_discussions = request.json.get(
+                'divided_course_wide_discussions', divided_course_wide_discussions
+            )
+            divided_inline_discussions = request.json.get(
+                'divided_inline_discussions', divided_inline_discussions
+            )
+            settings_to_change['divided_discussions'] = divided_course_wide_discussions + divided_inline_discussions
+
+        if 'always_divide_inline_discussions' in request.json:
+            settings_to_change['always_divide_inline_discussions'] = request.json.get(
+                'always_divide_inline_discussions'
+            )
+        if 'division_scheme' in request.json:
+            settings_to_change['division_scheme'] = request.json.get(
+                'division_scheme'
+            )
+
+        if not settings_to_change:
+            return JsonResponse({"error": unicode("Bad Request")}, 400)
+
+        try:
+            if settings_to_change:
+                discussion_settings = set_course_discussion_settings(course_key, **settings_to_change)
+
+        except ValueError as err:
+            # Note: error message not translated because it is not exposed to the user (UI prevents this state).
+            return JsonResponse({"error": unicode(err)}, 400)
+
+    divided_course_wide_discussions, divided_inline_discussions = get_divided_discussions(
+        course, discussion_settings
+    )
+
+    return JsonResponse({
+        'id': discussion_settings.id,
+        'divided_inline_discussions': divided_inline_discussions,
+        'divided_course_wide_discussions': divided_course_wide_discussions,
+        'always_divide_inline_discussions': discussion_settings.always_divide_inline_discussions,
+        'division_scheme': discussion_settings.division_scheme
+    })
+
+
+
+def get_divided_discussions(course, discussion_settings):
+    """
+    Returns the course-wide and inline divided discussion ids separately.
+    """
+    divided_course_wide_discussions = []
+    divided_inline_discussions = []
+
+    course_wide_discussions = [topic['id'] for __, topic in course.discussion_topics.items()]
+    all_discussions = utils.get_discussion_categories_ids(course, None, include_all=True)
+
+    for divided_discussion_id in discussion_settings.divided_discussions:
+        if divided_discussion_id in course_wide_discussions:
+            divided_course_wide_discussions.append(divided_discussion_id)
+        elif divided_discussion_id in all_discussions:
+            divided_inline_discussions.append(divided_discussion_id)
+
+    return divided_course_wide_discussions, divided_inline_discussions

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -14,6 +14,7 @@ from edxmako import add_lookup
 
 from django_comment_client.tests.factories import RoleFactory
 from django_comment_client.tests.unicode import UnicodeTestMixin
+from django_comment_client.tests.utils import topic_name_to_id, config_course_discussions
 from django_comment_client.constants import TYPE_ENTRY, TYPE_SUBCATEGORY
 import django_comment_client.utils as utils
 from lms.lib.comment_client.utils import perform_request, CommentClientMaintenanceError
@@ -26,7 +27,7 @@ from courseware.tests.factories import InstructorFactory
 from courseware.tabs import get_course_tab_list
 from openedx.core.djangoapps.course_groups import cohorts
 from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted
-from openedx.core.djangoapps.course_groups.tests.helpers import config_course_cohorts, config_course_discussions, topic_name_to_id, CohortFactory
+from openedx.core.djangoapps.course_groups.tests.helpers import config_course_cohorts, CohortFactory
 from student.tests.factories import UserFactory, AdminFactory, CourseEnrollmentFactory
 from openedx.core.djangoapps.content.course_structures.models import CourseStructure
 from openedx.core.djangoapps.util.testing import ContentGroupTestCase

--- a/lms/djangoapps/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/django_comment_client/tests/utils.py
@@ -5,9 +5,11 @@ from mock import patch
 
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from django_comment_common.models import Role, ForumsConfig
-from django_comment_common.utils import seed_permissions_roles
+from django_comment_common.utils import seed_permissions_roles, set_course_discussion_settings, CourseDiscussionSettings
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
@@ -63,3 +65,58 @@ class CohortedTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCa
             course_id=self.course.id,
             users=[self.moderator]
         )
+
+
+# pylint: disable=dangerous-default-value
+def config_course_discussions(
+        course,
+        discussion_topics={},
+        divided_discussions=[],
+        always_divide_inline_discussions=False
+):
+        """
+        Set discussions and configure divided discussions for a course.
+
+        Arguments:
+            course: CourseDescriptor
+            discussion_topics (Dict): Discussion topic names. Picks ids and
+                sort_keys automatically.
+            divided_discussions: Discussion topics to divide. Converts the
+                list to use the same ids as discussion topic names.
+            always_divide_inline_discussions (bool): Whether inline discussions
+                should be divided by default.
+
+        Returns:
+            Nothing -- modifies course in place.
+        """
+
+        def to_id(name):
+            """Convert name to id."""
+            return topic_name_to_id(course, name)
+
+        set_course_discussion_settings(
+            course.id,
+            divided_discussions=[to_id(name) for name in divided_discussions],
+            always_divide_inline_discussions=always_divide_inline_discussions,
+            division_scheme=CourseDiscussionSettings.COHORT,
+        )
+
+        course.discussion_topics = dict((name, {"sort_key": "A", "id": to_id(name)})
+                                        for name in discussion_topics)
+        try:
+            # Not implemented for XMLModulestore, which is used by test_cohorts.
+            modulestore().update_item(course, ModuleStoreEnum.UserID.test)
+        except NotImplementedError:
+            pass
+
+
+def topic_name_to_id(course, name):
+    """
+    Given a discussion topic name, return an id for that name (includes
+    course and url_name).
+    """
+    return "{course}_{run}_{name}".format(
+        course=course.location.course,
+        run=course.url_name,
+        name=name
+    )

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -509,7 +509,7 @@ urlpatterns += (
         r'^courses/{}/discussions/settings$'.format(
             settings.COURSE_KEY_PATTERN,
         ),
-        'openedx.core.djangoapps.course_groups.views.course_discussions_settings_handler',
+        'lms.djangoapps.discussion.views.course_discussions_settings_handler',
         name='course_discussions_settings',
     ),
 
@@ -560,7 +560,7 @@ urlpatterns += (
         r'^courses/{}/discussion/topics$'.format(
             settings.COURSE_KEY_PATTERN,
         ),
-        'openedx.core.djangoapps.course_groups.views.discussion_topics',
+        'lms.djangoapps.discussion.views.discussion_topics',
         name='discussion_topics',
     ),
     url(

--- a/openedx/core/djangoapps/course_groups/tests/helpers.py
+++ b/openedx/core/djangoapps/course_groups/tests/helpers.py
@@ -63,18 +63,6 @@ class CourseCohortSettingsFactory(DjangoModelFactory):
     always_cohort_inline_discussions = False
 
 
-def topic_name_to_id(course, name):
-    """
-    Given a discussion topic name, return an id for that name (includes
-    course and url_name).
-    """
-    return "{course}_{run}_{name}".format(
-        course=course.location.course,
-        run=course.url_name,
-        name=name
-    )
-
-
 def config_course_cohorts_legacy(
         course,
         discussions,
@@ -133,49 +121,6 @@ def config_course_cohorts_legacy(
         modulestore().update_item(course, ModuleStoreEnum.UserID.test)
     except NotImplementedError:
         pass
-
-
-# pylint: disable=dangerous-default-value
-def config_course_discussions(
-        course,
-        discussion_topics={},
-        divided_discussions=[],
-        always_divide_inline_discussions=False
-):
-        """
-        Set discussions and configure divided discussions for a course.
-
-        Arguments:
-            course: CourseDescriptor
-            discussion_topics (Dict): Discussion topic names. Picks ids and
-                sort_keys automatically.
-            divided_discussions: Discussion topics to divide. Converts the
-                list to use the same ids as discussion topic names.
-            always_divide_inline_discussions (bool): Whether inline discussions
-                should be divided by default.
-
-        Returns:
-            Nothing -- modifies course in place.
-        """
-
-        def to_id(name):
-            """Convert name to id."""
-            return topic_name_to_id(course, name)
-
-        set_course_discussion_settings(
-            course.id,
-            divided_discussions=[to_id(name) for name in divided_discussions],
-            always_divide_inline_discussions=always_divide_inline_discussions,
-            division_scheme=CourseDiscussionSettings.COHORT,
-        )
-
-        course.discussion_topics = dict((name, {"sort_key": "A", "id": to_id(name)})
-                                        for name in discussion_topics)
-        try:
-            # Not implemented for XMLModulestore, which is used by test_cohorts.
-            modulestore().update_item(course, ModuleStoreEnum.UserID.test)
-        except NotImplementedError:
-            pass
 
 
 # pylint: disable=dangerous-default-value

--- a/openedx/core/djangoapps/course_groups/tests/test_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_views.py
@@ -6,7 +6,6 @@ Tests for course group views
 import json
 
 from collections import namedtuple
-from datetime import datetime
 from nose.plugins.attrib import attr
 
 from django.contrib.auth.models import User
@@ -18,24 +17,21 @@ from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from xmodule.modulestore.tests.factories import ItemFactory
-from lms.djangoapps.django_comment_client.constants import TYPE_ENTRY, TYPE_SUBCATEGORY
-from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
 from ..models import CourseUserGroup, CourseCohort
 from ..views import (
-    course_cohort_settings_handler, course_discussions_settings_handler,
+    course_cohort_settings_handler,
     cohort_handler, users_in_cohort,
     add_users_to_cohort, remove_user_from_cohort,
-    link_cohort_to_partition_group, discussion_topics
+    link_cohort_to_partition_group,
 )
 from ..cohorts import (
     get_cohort, get_cohort_by_name, get_cohort_by_id,
     DEFAULT_COHORT_NAME, get_group_info_for_cohort
 )
 from .helpers import (
-    config_course_cohorts, config_course_discussions, config_course_cohorts_legacy, CohortFactory, CourseCohortFactory, topic_name_to_id
+    config_course_cohorts, config_course_cohorts_legacy, CohortFactory, CourseCohortFactory
 )
 
 
@@ -101,40 +97,6 @@ class CohortViewsTestCase(ModuleStoreTestCase):
         view_args.insert(0, request)
         self.assertRaises(Http404, view, *view_args)
 
-    def create_divided_discussions(self):
-        """
-        Set up a divided discussion in the system, complete with all the fixings
-        """
-        divided_inline_discussions = ['Topic A']
-        divided_course_wide_discussions = ["Topic B"]
-        divided_discussions = divided_inline_discussions + divided_course_wide_discussions
-
-        # inline discussion
-        ItemFactory.create(
-            parent_location=self.course.location,
-            category="discussion",
-            discussion_id=topic_name_to_id(self.course, "Topic A"),
-            discussion_category="Chapter",
-            discussion_target="Discussion",
-            start=datetime.now()
-        )
-        # course-wide discussion
-        discussion_topics = {
-            "Topic B": {"id": "Topic B"},
-        }
-
-        config_course_cohorts(
-            self.course,
-            is_cohorted=True,
-        )
-
-        config_course_discussions(
-            self.course,
-            discussion_topics=discussion_topics,
-            divided_discussions=divided_discussions
-        )
-        return divided_inline_discussions, divided_course_wide_discussions
-
     def get_handler(self, course, cohort=None, expected_response_code=200, handler=cohort_handler):
         """
         Call a GET on `handler` for a given `course` and return its response as a dict.
@@ -181,129 +143,6 @@ class CohortViewsTestCase(ModuleStoreTestCase):
             response = handler(request, unicode(course.id))
         self.assertEqual(response.status_code, expected_response_code)
         return json.loads(response.content)
-
-
-@attr(shard=2)
-class CourseDiscussionsHandlerTestCase(CohortViewsTestCase):
-    """
-    Tests the course_discussion_settings_handler
-    """
-    def get_expected_response(self):
-        """
-        Returns the static response dict.
-        """
-        return {
-            u'always_divide_inline_discussions': False,
-            u'divided_inline_discussions': [],
-            u'divided_course_wide_discussions': [],
-            u'id': 1
-        }
-
-    def test_non_staff(self):
-        """
-        Verify that we cannot access course_discussions_settings_handler if we're a non-staff user.
-        """
-        self._verify_non_staff_cannot_access(course_discussions_settings_handler, "GET", [unicode(self.course.id)])
-        self._verify_non_staff_cannot_access(course_discussions_settings_handler, "PATCH", [unicode(self.course.id)])
-
-    def test_update_always_divide_inline_discussion_settings(self):
-        """
-        Verify that course_discussions_settings_handler is working for always_divide_inline_discussions via HTTP PATCH.
-        """
-        config_course_cohorts(self.course, is_cohorted=True)
-
-        response = self.get_handler(self.course, handler=course_discussions_settings_handler)
-
-        expected_response = self.get_expected_response()
-
-        self.assertEqual(response, expected_response)
-
-        expected_response['always_divide_inline_discussions'] = True
-        response = self.patch_handler(self.course, data=expected_response, handler=course_discussions_settings_handler)
-
-        self.assertEqual(response, expected_response)
-
-    def test_update_course_wide_discussion_settings(self):
-        """
-        Verify that course_discussions_settings_handler is working for divided_course_wide_discussions via HTTP PATCH.
-        """
-        # course-wide discussion
-        discussion_topics = {
-            "Topic B": {"id": "Topic B"},
-        }
-
-        config_course_cohorts(self.course, is_cohorted=True)
-        config_course_discussions(self.course, discussion_topics=discussion_topics)
-
-        response = self.get_handler(self.course, handler=course_discussions_settings_handler)
-
-        expected_response = self.get_expected_response()
-        self.assertEqual(response, expected_response)
-
-        expected_response['divided_course_wide_discussions'] = [topic_name_to_id(self.course, "Topic B")]
-        response = self.patch_handler(self.course, data=expected_response, handler=course_discussions_settings_handler)
-
-        self.assertEqual(response, expected_response)
-
-    def test_update_inline_discussion_settings(self):
-        """
-        Verify that course_discussions_settings_handler is working for divided_inline_discussions via HTTP PATCH.
-        """
-        config_course_cohorts(self.course, is_cohorted=True)
-
-        response = self.get_handler(self.course, handler=course_discussions_settings_handler)
-
-        expected_response = self.get_expected_response()
-        self.assertEqual(response, expected_response)
-
-        now = datetime.now()
-        # inline discussion
-        ItemFactory.create(
-            parent_location=self.course.location,
-            category="discussion",
-            discussion_id="Topic_A",
-            discussion_category="Chapter",
-            discussion_target="Discussion",
-            start=now
-        )
-
-        expected_response['divided_inline_discussions'] = ["Topic_A"]
-        response = self.patch_handler(self.course, data=expected_response, handler=course_discussions_settings_handler)
-
-        self.assertEqual(response, expected_response)
-
-    def test_get_settings(self):
-        """
-        Verify that course_discussions_settings_handler is working for HTTP GET.
-        """
-        divided_inline_discussions, divided_course_wide_discussions = self.create_divided_discussions()
-
-        response = self.get_handler(self.course, handler=course_discussions_settings_handler)
-        expected_response = self.get_expected_response()
-
-        expected_response['divided_inline_discussions'] = [topic_name_to_id(self.course, name)
-                                                           for name in divided_inline_discussions]
-        expected_response['divided_course_wide_discussions'] = [topic_name_to_id(self.course, name)
-                                                                for name in divided_course_wide_discussions]
-
-        self.assertEqual(response, expected_response)
-
-    def test_update_settings_with_invalid_field_data_type(self):
-        """
-        Verify that course_discussions_settings_handler return HTTP 400 if field data type is incorrect.
-        """
-        config_course_cohorts(self.course, is_cohorted=True)
-
-        response = self.patch_handler(
-            self.course,
-            data={'always_divide_inline_discussions': ''},
-            expected_response_code=400,
-            handler=course_discussions_settings_handler
-        )
-        self.assertEqual(
-            "Incorrect field type for `{}`. Type must be `{}`".format('always_divide_inline_discussions', bool.__name__),
-            response.get("error")
-        )
 
 
 @attr(shard=2)
@@ -1270,60 +1109,3 @@ class RemoveUserFromCohortTestCase(CohortViewsTestCase):
         cohort = CohortFactory(course_id=self.course.id, users=[user])
         response_dict = self.request_remove_user_from_cohort(user.username, cohort)
         self.verify_removed_user_from_cohort(user.username, response_dict, cohort)
-
-
-@attr(shard=2)
-@skip_unless_lms
-class CourseDividedDiscussionTopicsTestCase(CohortViewsTestCase):
-    """
-    Tests the `divide_discussion_topics` view.
-    """
-
-    def test_non_staff(self):
-        """
-        Verify that we cannot access divide_discussion_topics if we're a non-staff user.
-        """
-        self._verify_non_staff_cannot_access(discussion_topics, "GET", [unicode(self.course.id)])
-
-    def test_get_discussion_topics(self):
-        """
-        Verify that divide_discussion_topics is working for HTTP GET.
-        """
-        # create inline & course-wide discussion to verify the different map.
-        self.create_divided_discussions()
-
-        response = self.get_handler(self.course, handler=discussion_topics)
-        start_date = response['inline_discussions']['subcategories']['Chapter']['start_date']
-        expected_response = {
-            "course_wide_discussions": {
-                'children': [['Topic B', TYPE_ENTRY]],
-                'entries': {
-                    'Topic B': {
-                        'sort_key': 'A',
-                        'is_divided': True,
-                        'id': topic_name_to_id(self.course, "Topic B"),
-                        'start_date': response['course_wide_discussions']['entries']['Topic B']['start_date']
-                    }
-                }
-            },
-            "inline_discussions": {
-                'subcategories': {
-                    'Chapter': {
-                        'subcategories': {},
-                        'children': [['Discussion', TYPE_ENTRY]],
-                        'entries': {
-                            'Discussion': {
-                                'sort_key': None,
-                                'is_divided': True,
-                                'id': topic_name_to_id(self.course, "Topic A"),
-                                'start_date': start_date
-                            }
-                        },
-                        'sort_key': 'Chapter',
-                        'start_date': start_date
-                    }
-                },
-                'children': [['Chapter', TYPE_SUBCATEGORY]]
-            }
-        }
-        self.assertEqual(response, expected_response)

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -4,6 +4,8 @@ Views related to course groups functionality.
 
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST
+from django_comment_common.models import CourseDiscussionSettings
+from django_comment_common.utils import set_course_discussion_settings
 from django.contrib.auth.models import User
 from django.core.paginator import Paginator, EmptyPage
 from django.core.urlresolvers import reverse
@@ -19,15 +21,12 @@ import re
 
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
+
 from courseware.courses import get_course_with_access
 from edxmako.shortcuts import render_to_response
 
 from . import cohorts
 
-from django_comment_common.models import CourseDiscussionSettings
-from django_comment_common.utils import get_course_discussion_settings, set_course_discussion_settings
-from lms.djangoapps.django_comment_client.utils import get_discussion_category_map, get_discussion_categories_ids
-from lms.djangoapps.django_comment_client.constants import TYPE_ENTRY
 from .models import CourseUserGroup, CourseUserGroupPartitionGroup, CohortMembership
 
 log = logging.getLogger(__name__)
@@ -77,23 +76,6 @@ def _get_course_cohort_settings_representation(cohort_id, is_cohorted):
     }
 
 
-def _get_course_discussion_settings_representation(course, course_discussion_settings):
-    """
-    Returns a JSON representation of a course discussion settings.
-    """
-    divided_course_wide_discussions, divided_inline_discussions = get_divided_discussions(
-        course, course_discussion_settings
-    )
-
-    return {
-        'id': course_discussion_settings.id,
-        'divided_inline_discussions': divided_inline_discussions,
-        'divided_course_wide_discussions': divided_course_wide_discussions,
-        'always_divide_inline_discussions': course_discussion_settings.always_divide_inline_discussions,
-        'division_scheme': course_discussion_settings.division_scheme
-    }
-
-
 def _get_cohort_representation(cohort, course):
     """
     Returns a JSON representation of a cohort.
@@ -109,84 +91,6 @@ def _get_cohort_representation(cohort, course):
         'user_partition_id': partition_id,
         'group_id': group_id,
     }
-
-
-def get_divided_discussions(course, discussion_settings):
-    """
-    Returns the course-wide and inline divided discussion ids separately.
-    """
-    divided_course_wide_discussions = []
-    divided_inline_discussions = []
-
-    course_wide_discussions = [topic['id'] for __, topic in course.discussion_topics.items()]
-    all_discussions = get_discussion_categories_ids(course, None, include_all=True)
-
-    for divided_discussion_id in discussion_settings.divided_discussions:
-        if divided_discussion_id in course_wide_discussions:
-            divided_course_wide_discussions.append(divided_discussion_id)
-        elif divided_discussion_id in all_discussions:
-            divided_inline_discussions.append(divided_discussion_id)
-
-    return divided_course_wide_discussions, divided_inline_discussions
-
-
-@require_http_methods(("GET", "PATCH"))
-@ensure_csrf_cookie
-@expect_json
-@login_required
-def course_discussions_settings_handler(request, course_key_string):
-    """
-    The restful handler for divided discussion setting requests. Requires JSON.
-    This will raise 404 if user is not staff.
-    GET
-        Returns the JSON representation of divided discussion settings for the course.
-    PATCH
-        Updates the divided discussion settings for the course. Returns the JSON representation of updated settings.
-    """
-    course_key = CourseKey.from_string(course_key_string)
-    course = get_course_with_access(request.user, 'staff', course_key)
-    discussion_settings = get_course_discussion_settings(course_key)
-
-    if request.method == 'PATCH':
-        divided_course_wide_discussions, divided_inline_discussions = get_divided_discussions(
-            course, discussion_settings
-        )
-
-        settings_to_change = {}
-
-        if 'divided_course_wide_discussions' in request.json or 'divided_inline_discussions' in request.json:
-            divided_course_wide_discussions = request.json.get(
-                'divided_course_wide_discussions', divided_course_wide_discussions
-            )
-            divided_inline_discussions = request.json.get(
-                'divided_inline_discussions', divided_inline_discussions
-            )
-            settings_to_change['divided_discussions'] = divided_course_wide_discussions + divided_inline_discussions
-
-        if 'always_divide_inline_discussions' in request.json:
-            settings_to_change['always_divide_inline_discussions'] = request.json.get(
-                'always_divide_inline_discussions'
-            )
-        if 'division_scheme' in request.json:
-            settings_to_change['division_scheme'] = request.json.get(
-                'division_scheme'
-            )
-
-        if not settings_to_change:
-            return JsonResponse({"error": unicode("Bad Request")}, 400)
-
-        try:
-            if settings_to_change:
-                discussion_settings = set_course_discussion_settings(course_key, **settings_to_change)
-
-        except ValueError as err:
-            # Note: error message not translated because it is not exposed to the user (UI prevents this state).
-            return JsonResponse({"error": unicode(err)}, 400)
-
-    return JsonResponse(_get_course_discussion_settings_representation(
-        course,
-        discussion_settings
-    ))
 
 
 @require_http_methods(("GET", "PATCH"))
@@ -213,6 +117,8 @@ def course_cohort_settings_handler(request, course_key_string):
         is_cohorted = request.json.get('is_cohorted')
         try:
             cohorts.set_course_cohorted(course_key, is_cohorted)
+            # TODO: this is the logic that we will want to change (only change division scheme
+            # if cohorts were disabled and current scheme is CourseDiscussionSettings.COHORT)
             scheme = CourseDiscussionSettings.COHORT if is_cohorted else CourseDiscussionSettings.NONE
             scheme_settings = {'division_scheme': scheme}
             set_course_discussion_settings(course_key, **scheme_settings)
@@ -472,81 +378,3 @@ def debug_cohort_mgmt(request, course_key_string):
         kwargs={'course_key': course_key.to_deprecated_string()}
     )}
     return render_to_response('/course_groups/debug.html', context)
-
-
-@expect_json
-@login_required
-def discussion_topics(request, course_key_string):
-    """
-    The handler for divided discussion categories requests.
-    This will raise 404 if user is not staff.
-
-    Returns the JSON representation of discussion topics w.r.t categories for the course.
-
-    Example:
-        >>> example = {
-        >>>               "course_wide_discussions": {
-        >>>                   "entries": {
-        >>>                       "General": {
-        >>>                           "sort_key": "General",
-        >>>                           "is_divided": True,
-        >>>                           "id": "i4x-edx-eiorguegnru-course-foobarbaz"
-        >>>                       }
-        >>>                   }
-        >>>                   "children": ["General", "entry"]
-        >>>               },
-        >>>               "inline_discussions" : {
-        >>>                   "subcategories": {
-        >>>                       "Getting Started": {
-        >>>                           "subcategories": {},
-        >>>                           "children": [
-        >>>                               ["Working with Videos", "entry"],
-        >>>                               ["Videos on edX", "entry"]
-        >>>                           ],
-        >>>                           "entries": {
-        >>>                               "Working with Videos": {
-        >>>                                   "sort_key": None,
-        >>>                                   "is_divided": False,
-        >>>                                   "id": "d9f970a42067413cbb633f81cfb12604"
-        >>>                               },
-        >>>                               "Videos on edX": {
-        >>>                                   "sort_key": None,
-        >>>                                   "is_divided": False,
-        >>>                                   "id": "98d8feb5971041a085512ae22b398613"
-        >>>                               }
-        >>>                           }
-        >>>                       },
-        >>>                       "children": ["Getting Started", "subcategory"]
-        >>>                   },
-        >>>               }
-        >>>          }
-    """
-    course_key = CourseKey.from_string(course_key_string)
-    course = get_course_with_access(request.user, 'staff', course_key)
-
-    discussion_topics = {}
-    discussion_category_map = get_discussion_category_map(
-        course, request.user, divided_only_if_explicit=True, exclude_unstarted=False
-    )
-
-    # We extract the data for the course wide discussions from the category map.
-    course_wide_entries = discussion_category_map.pop('entries')
-
-    course_wide_children = []
-    inline_children = []
-
-    for name, c_type in discussion_category_map['children']:
-        if name in course_wide_entries and c_type == TYPE_ENTRY:
-            course_wide_children.append([name, c_type])
-        else:
-            inline_children.append([name, c_type])
-
-    discussion_topics['course_wide_discussions'] = {
-        'entries': course_wide_entries,
-        'children': course_wide_children
-    }
-
-    discussion_category_map['children'] = inline_children
-    discussion_topics['inline_discussions'] = discussion_category_map
-
-    return JsonResponse(discussion_topics)


### PR DESCRIPTION
Moves discussion-related view methods (discussion_topics and course_discussions_settings_handler) out of openedx/course/djangoapps/course_groups/views.py and into lms/djangoapps/discussion/views.py.

This was a straightforward moving of code and tests, except for the places where I added comments.

I didn't assign the new test classes to a shard because existing tests in lms/djangoapps/discussion/tests/test_views.py have no shard assignment (meaning that they go to the default shard).

JS unit test failure is also on parent branch (probably a bad merge), and quality issues are all in JS code from the parent branch.

@jlajoie Please review

FYI @staubina 