### PR TITLE
Override video url with edx val encodings

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -701,10 +701,32 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
             'default_value': [get_youtube_link(youtube_id_1_0['default_value'])]
         })
 
-        youtube_id_1_0_value = get_youtube_link(youtube_id_1_0['value'])
+        source_url = self.create_youtube_url(youtube_id_1_0['value'])
 
-        if youtube_id_1_0_value:
-            video_url['value'].insert(0, youtube_id_1_0_value)
+        # First try a lookup in VAL. If any video encoding is found given the video id then
+        # override the source_url with it.
+        if self.edx_video_id and edxval_api:
+
+            val_profiles = ['youtube', 'desktop_webm', 'desktop_mp4']
+            if HLSPlaybackEnabledFlag.feature_enabled(self.runtime.course_id.for_branch(None)):
+                val_profiles.append('hls')
+
+            # Get video encodings for val profiles.
+            val_video_encodings = edxval_api.get_urls_for_profiles(self.edx_video_id, val_profiles)
+
+            # If multiple encodings are there in val, the priority will be: youtube > hls > mp4 and webm.
+            if val_video_encodings.get('youtube'):
+                source_url = self.create_youtube_url(val_video_encodings['youtube'])
+            elif val_video_encodings.get('hls'):
+                source_url = val_video_encodings['hls']
+            elif val_video_encodings.get('desktop_mp4'):
+                source_url = val_video_encodings['desktop_mp4']
+            elif val_video_encodings.get('desktop_webm'):
+                source_url = val_video_encodings['desktop_webm']
+
+        # Only add if html5 sources do not already contain source_url.
+        if source_url and source_url not in video_url['value']:
+            video_url['value'].insert(0, source_url)
 
         metadata = {
             'display_name': display_name,


### PR DESCRIPTION
[EDUCATOR-323](https://openedx.atlassian.net/browse/EDUCATOR-323)

Video url does not show any URL in `video_url` field from basic tab when `edx-val` returns non-youtube encodings. Consequently, neither YT nor HLS/HTML5 sources could be set on video and transcripts won't be uploaded. In our current transcripts design, transcripts get generated for sources set on video xmodule – i.e. YT/HTML5/HLS, and if no source is set on the video, transcripts will certainly be uploaded for no source. With this PR, non-youtube val encodings will also be set on video xmodule (as `html5_sources`) and subs will be generated for them when we'll upload transcript.

Sandbox – [studio-non-youtube-val-encodings.sandbox.edx.org](https://studio-non-youtube-val-encodings.sandbox.edx.org/course/course-v1:UET+CS111+2017_CS)