### PR TITLE
Sstudent/course policy event

### DIFF
--- a/cms/djangoapps/models/settings/course_grading.py
+++ b/cms/djangoapps/models/settings/course_grading.py
@@ -1,7 +1,14 @@
+from base64 import b64encode
 from datetime import timedelta
+from hashlib import sha1
+import json
 
 from contentstore.signals.signals import GRADING_POLICY_CHANGED
+from eventtracking import tracker
+from track.event_transaction_utils import create_new_event_transaction_id, set_event_transaction_type
 from xmodule.modulestore.django import modulestore
+
+GRADING_POLICY_CHANGED_EVENT_TYPE = 'edx.grades.grading_policy_changed'
 
 
 class CourseGradingModel(object):
@@ -66,8 +73,7 @@ class CourseGradingModel(object):
         CourseGradingModel.update_grace_period_from_json(course_key, jsondict['grace_period'], user)
 
         CourseGradingModel.update_minimum_grade_credit_from_json(course_key, jsondict['minimum_grade_credit'], user)
-
-        GRADING_POLICY_CHANGED.send(sender=CourseGradingModel, user_id=user.id, course_id=course_key)
+        _grading_event_and_signal(course_key, user.id)
 
         return CourseGradingModel.fetch(course_key)
 
@@ -89,8 +95,7 @@ class CourseGradingModel(object):
             descriptor.raw_grader.append(grader)
 
         modulestore().update_item(descriptor, user.id)
-
-        GRADING_POLICY_CHANGED.send(sender=CourseGradingModel, user_id=user.id, course_id=course_key)
+        _grading_event_and_signal(course_key, user.id)
 
         return CourseGradingModel.jsonize_grader(index, descriptor.raw_grader[index])
 
@@ -104,7 +109,7 @@ class CourseGradingModel(object):
         descriptor.grade_cutoffs = cutoffs
 
         modulestore().update_item(descriptor, user.id)
-
+        _grading_event_and_signal(course_key, user.id)
         return cutoffs
 
     @staticmethod
@@ -160,8 +165,7 @@ class CourseGradingModel(object):
             descriptor.raw_grader = descriptor.raw_grader
 
         modulestore().update_item(descriptor, user.id)
-
-        GRADING_POLICY_CHANGED.send(sender=CourseGradingModel, user_id=user.id, course_id=course_key)
+        _grading_event_and_signal(course_key, user.id)
 
     @staticmethod
     def delete_grace_period(course_key, user):
@@ -192,13 +196,7 @@ class CourseGradingModel(object):
             del descriptor.graded
 
         modulestore().update_item(descriptor, user.id)
-
-        GRADING_POLICY_CHANGED.send(
-            sender=CourseGradingModel,
-            user_id=user.id,
-            course_id=descriptor.location.course_key
-        )
-
+        _grading_event_and_signal(descriptor.location.course_key, user.id)
         return {'graderType': grader_type}
 
     @staticmethod
@@ -253,3 +251,27 @@ class CourseGradingModel(object):
             "short_label": grader.get('short_label', ""),
             "weight": grader.get('weight', 0) * 100,
         }
+
+
+def _grading_event_and_signal(course_key, user_id):
+    name = GRADING_POLICY_CHANGED_EVENT_TYPE
+    course = modulestore().get_course(course_key)
+
+    data = {
+        "course_id": unicode(course_key),
+        "user_id": unicode(user_id),
+        "grading_policy_hash": unicode(hash_grading_policy(course.grading_policy)),
+        "event_transaction_id": unicode(create_new_event_transaction_id()),
+        "event_transaction_type": GRADING_POLICY_CHANGED_EVENT_TYPE,
+    }
+    tracker.emit(name, data)
+    GRADING_POLICY_CHANGED.send(sender=CourseGradingModel, user_id=user_id, course_id=course_key)
+
+
+def hash_grading_policy(grading_policy):
+    ordered_policy = json.dumps(
+        grading_policy,
+        separators=(',', ':'),  # Remove spaces from separators for more compact representation
+        sort_keys=True,
+    )
+    return b64encode(sha1(ordered_policy).digest())

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -91,6 +91,12 @@ def compute_grades_for_course_v2(self, **kwargs):
         waffle switch.  If false or not provided, use the global value of
         the ESTIMATE_FIRST_ATTEMPTED waffle switch.
     """
+    if 'event_transaction_id' in kwargs:
+        set_event_transaction_id(kwargs['event_transaction_id'])
+
+    if 'event_transaction_type' in kwargs:
+        set_event_transaction_type(kwargs['event_transaction_type'])
+
     course_key = kwargs.pop('course_key')
     offset = kwargs.pop('offset')
     batch_size = kwargs.pop('batch_size')


### PR DESCRIPTION
## [EDUCATOR-392](https://openedx.atlassian.net/browse/EDUCATOR-392)

### Description

Adds eventing for grading policy changes that trigger recalculation of course grades.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @yro or @iloveagent57 

FYI: @edx/educator-neem 

FYI: @stroilova 

- [ ] Rebase and squash commits