### PR TITLE
Updated programs detail page to always call Credentials API

### DIFF
--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -752,12 +752,18 @@ class TestGetCertificates(TestCase):
 
     def test_course_run_certificates_missing(self, mock_get_credentials):
         """
-        Verify an empty list is returned when course run certificates are missing,
-        and that no attempt is made to retrieve program certificates.
+        Verify program certificates are retrieved even if the learner has not earned any course certificates.
         """
+        expected = [{
+            'type': 'program',
+            'title': self.program['title'],
+            'url': self.program_certificate_url,
+        }]
+        mock_get_credentials.return_value = [{'certificate_url': self.program_certificate_url}]
+
         certificates = get_certificates(self.user, self.program)
-        self.assertEqual(certificates, [])
-        self.assertFalse(mock_get_credentials.called)
+        self.assertTrue(mock_get_credentials.called)
+        self.assertEqual(certificates, expected)
 
     def test_program_certificate_missing(self, mock_get_credentials):
         """

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -464,18 +464,13 @@ def get_certificates(user, extended_program):
                 # We only want one certificate per course to be returned.
                 break
 
-    # A user can only have earned a program certificate if they've earned certificates
-    # in associated course runs. If they haven't earned any course run certificates,
-    # they can't have earned a program certificate, and we can save a network call
-    # to the credentials service.
-    if certificates:
-        program_credentials = get_credentials(user, program_uuid=extended_program['uuid'])
-        if program_credentials:
-            certificates.append({
-                'type': 'program',
-                'title': extended_program['title'],
-                'url': program_credentials[0]['certificate_url'],
-            })
+    program_credentials = get_credentials(user, program_uuid=extended_program['uuid'])
+    if program_credentials:
+        certificates.append({
+            'type': 'program',
+            'title': extended_program['title'],
+            'url': program_credentials[0]['certificate_url'],
+        })
 
     return certificates
 


### PR DESCRIPTION
The programs detail page now always makes a call to the Credentials API to check for program credentials, regardless of whether the user has earned a course certificate. The course certificate constraint adds an additional burden to testing in exchange for slightly decreased load on the API. The cost outweighs the benefit given the limited traffic to this page.

LEARNER-1103