### PR TITLE
Cookie consent page loaded from navigation template instead of footer…

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -140,6 +140,3 @@
     <link rel="stylesheet" type="text/css" href="${url}"></link>
   % endfor
 % endif
-% if settings.FEATURES.get('ENABLE_COOKIE_CONSENT', False):
-  <%include file="widgets/cookie-consent.html" />
-% endif

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -115,3 +115,6 @@ site_status_msg = get_site_status_msg(course_id)
 % endif
 
 <%include file="../help_modal.html"/>
+% if settings.FEATURES.get('ENABLE_COOKIE_CONSENT', False):
+  <%include file="../widgets/cookie-consent.html" />
+% endif


### PR DESCRIPTION
… template.

Following the commit ae9c68691255f1461da0b9d49c548905112cee98, we can see the cookie consent template was loaded from footer template.
The login and registration templates do not load footer, so the cookie consent template is not being loader either.
With this fix, the cookie consent template is being loaded from navigation template, so it is shown in login and registration pages as well.