### PR TITLE
LEARNER-923 Make Pattern Library support tabs transparent

### DIFF
--- a/lms/static/sass/shared-v2/_help-tab.scss
+++ b/lms/static/sass/shared-v2/_help-tab.scss
@@ -12,8 +12,8 @@
         border: 1px solid $lms-border-color;
         border-top-style: none;
         border-radius: 0 0 ($baseline/2) ($baseline/2);
-        background: $white;
-        color: palette(grayscale, base);
+        background: transparentize($white, 0.25);
+        color: transparentize(palette(grayscale, dark), 0.25);
         font-weight: bold;
         text-decoration: none;
         padding: 6px 22px 11px;


### PR DESCRIPTION
Partial fix for a bug with pattern library pages at smaller breakpoints (https://openedx.atlassian.net/browse/LEARNER-923)