### PR TITLE
Added course level lang attribute for LMS WIP

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -282,6 +282,7 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
         selected_groups_label = get_visibility_partition_info(xblock)['selected_groups_label']
         if selected_groups_label:
             selected_groups_label = _('Access restricted to: {list_of_groups}').format(list_of_groups=selected_groups_label)
+        course = modulestore().get_course(xblock.location.course_key)
         template_context = {
             'xblock_context': context,
             'xblock': xblock,
@@ -293,8 +294,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'can_edit_visibility': context.get('can_edit_visibility', True),
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
-            'can_move': context.get('can_move', True)
+            'can_move': context.get('can_move', True),
+            'language': getattr(course, 'language', None)
         }
+
         html = render_to_string('studio_xblock_wrapper.html', template_context)
         frag = wrap_fragment(frag, html)
     return frag

--- a/cms/templates/course_info.html
+++ b/cms/templates/course_info.html
@@ -62,7 +62,11 @@ from openedx.core.djangolib.js_utils import (
 
   <div class="main-wrapper">
     <div class="inner-wrapper">
-      <div class="course-info-wrapper">
+      <div class="course-info-wrapper"
+        % if getattr(context_course, 'language'):
+          lang="${context_course.language}"
+        % endif
+      >
         <div class="main-column window">
           <article class="course-updates" id="course-update-view">
             <ol class="update-list" id="course-update-list"></ol>

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -175,8 +175,11 @@ from openedx.core.djangolib.markup import HTML, Text
                     </div>
                % endif
             </div>
-
-            <div class="wrapper-dnd">
+            <div class="wrapper-dnd"
+              % if getattr(context_course, 'language'):
+                lang="${context_course.language}"
+              % endif
+            >
                 <%
                 course_locator = context_course.location
                 %>

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -158,7 +158,11 @@ messages = xblock.validate().to_json()
 
 % if show_preview:
     % if is_root or not xblock_url:
-        <article class="xblock-render">
+        % if not is_root and language:
+            <article class="xblock-render" lang="${language}">
+        % else:
+            <article class="xblock-render">
+        % endif
         ${content | n, decode.utf8}
         </article>
     % else:

--- a/lms/djangoapps/discussion/templates/discussion/discussion_board_fragment.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_board_fragment.html
@@ -41,7 +41,11 @@ from openedx.core.djangolib.markup import HTML
             <div class="forum-search"></div>
         </div>
     </header>
-    <div class="page-content">
+    <div class="page-content"
+      % if getattr(course, 'language'):
+        lang="${course.language}"
+      % endif
+    >
         <div class="discussion-body layout layout-1t2t">
             <aside class="forum-nav layout-col layout-col-a" role="complementary" aria-label="${_("Discussion thread list")}">
                 <%include file="_filter_dropdown.html" />

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -111,7 +111,11 @@ ${HTML(fragment.foot_html())}
   <%include file="/courseware/course_navigation.html" args="active_page='courseware'" />
 % endif
 
-<div class="container">
+<div class="container"
+  % if getattr(course, 'language'):
+    lang="${course.language}"
+  % endif
+  >
   <div class="course-wrapper" role="presentation">
 
 % if disable_accordion is UNDEFINED or not disable_accordion:

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -58,7 +58,11 @@ from openedx.core.djangolib.markup import HTML, Text
 <%block name="bodyclass">view-in-course view-course-info ${course.css_class or ''}</%block>
 
 <main id="main" aria-label="Content" tabindex="-1">
-    <div class="container">
+    <div class="container"
+    % if getattr(course, 'language'):
+      lang="${course.language}"
+    % endif
+    >
       <div class="home">
         <div class="page-header-main">
             <h2 class="hd hd-2 page-title">${_("Welcome to {org}'s {course_name}!").format(org=course.display_org_with_default, course_name=course.display_number_with_default)}

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -42,7 +42,11 @@ from django.utils.http import urlquote_plus
 <main id="main" aria-label="Content" tabindex="-1">
     <div class="container">
         <div class="profile-wrapper">
-            <section class="course-info" id="course-info-progress">
+            <section class="course-info" id="course-info-progress"
+              % if getattr(course, 'language'):
+                lang="${course.language}"
+              % endif
+              >
                 % if staff_access and studio_url is not None:
                 <div class="wrap-instructor-info">
                     <a class="instructor-info-action studio-view" href="${studio_url}">${_("View Grading in studio")}</a>

--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -25,6 +25,11 @@ ${HTML(fragment.foot_html())}
 <%include file="/courseware/course_navigation.html" args="active_page=active_page" />
 
 <main id="main" aria-label="Content" tabindex="-1">
+    <section class="container"
+    % if getattr(course, 'language'):
+      lang=${course.language}
+    % endif
+    >
     <section class="container">
       <div class="static_tab_wrapper">
         ${HTML(fragment.body_html())}

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -54,7 +54,11 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
   % else:
     <% mode_class = '' %>
   % endif
-<div class="course-container">
+      <div class="course-container"
+        % if getattr(course_overview, 'language'):
+          lang="${course_overview.language}"
+        % endif
+      >
 <article class="course${mode_class}">
   <% course_target = reverse(course_home_url_name(course_overview.id), args=[unicode(course_overview.id)]) %>
   <section class="details" aria-labelledby="details-heading-${course_overview.number}">

--- a/lms/templates/wiki/base.html
+++ b/lms/templates/wiki/base.html
@@ -59,7 +59,11 @@
 <div class="container">
   <div class="wiki-wrapper">
     <main id="main" aria-label="Content" tabindex="-1">
-      <section class="wiki {{ selected_tab }}" id="wiki-content">
+          <section class="wiki {{ selected_tab }}" id="wiki-content"
+            {% if request.course.language %}
+              lang="{{ request.course.language }}"
+            {% endif %}
+          >
         {% block wiki_body %}
 
           {% block wiki_breadcrumbs %}{% endblock %}

--- a/openedx/core/djangoapps/content/course_overviews/migrations/0013_courseoverview_language.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0013_courseoverview_language.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_overviews', '0012_courseoverview_eligible_for_financial_aid'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseoverview',
+            name='language',
+            field=models.TextField(null=True),
+        ),
+    ]

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -101,6 +101,8 @@ class CourseOverview(TimeStampedModel):
     marketing_url = TextField(null=True)
     eligible_for_financial_aid = BooleanField(default=True)
 
+    language = TextField(null=True)
+
     @classmethod
     def _create_or_update(cls, course):
         """
@@ -189,6 +191,8 @@ class CourseOverview(TimeStampedModel):
         course_overview.effort = CourseDetails.fetch_about_attribute(course.id, 'effort')
         course_overview.course_video_url = CourseDetails.fetch_video_url(course.id)
         course_overview.self_paced = course.self_paced
+
+        course_overview.language = course.language
 
         return course_overview
 


### PR DESCRIPTION
When building a course, there is the option to set the language for the course. If the language is set, the lang attribute is added to the HTML of the course in both LMS and Studio. If there is no language set, the lang attribute is not added. Adds a column to course_overviews to store the course language.

https://openedx.atlassian.net/browse/AC-685 
https://sarahkf.sandbox.edx.org