### PR TITLE
Fix the activation email support link in the dashboard sidebar

### DIFF
--- a/lms/templates/registration/account_activation_sidebar_notice.html
+++ b/lms/templates/registration/account_activation_sidebar_notice.html
@@ -23,8 +23,9 @@ from openedx.core.djangolib.markup import HTML, Text
           email_start=HTML("<strong>"),
           email_end=HTML("</strong>"),
           email=email,
-          activation_email_support_link=activation_email_support_link,
-          link_start=HTML("<a target='_blank' href='${activation_email_support_link}'>"),
+          link_start=HTML("<a target='_blank' href='{activation_email_support_link}'>").format(
+            activation_email_support_link=activation_email_support_link,
+          ),
           link_end=HTML("</a>"),
         )}
         </p>


### PR DESCRIPTION
The activation email support link HTML is escaped before variable interpolation takes place so the href on the link is incorrect looking something like `https://courses.edx.org/$%7Bactivation_email_support_link%7D`.