### PR TITLE
Add invitation_only field to course serializer

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -73,6 +73,7 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     pacing = serializers.CharField()
     mobile_available = serializers.BooleanField()
     hidden = serializers.SerializerMethodField()
+    invitation_only = serializers.BooleanField()
 
     # 'course_id' is a deprecated field, please use 'id' instead.
     course_id = serializers.CharField(source='id', read_only=True)

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -72,6 +72,7 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
             'pacing': 'instructor',
             'mobile_available': False,
             'hidden': False,
+            'invitation_only': False,
 
             # 'course_id' is a deprecated field, please use 'id' instead.
             'course_id': u'edX/toy/2012_Fall',


### PR DESCRIPTION
### Description

[OSPR-1780](https://openedx.atlassian.net/browse/OSPR-1780)

This PR adds the ```invitation_only``` field to the ```course_serializer```.

### Notes

Other PRs that depend on this one:
- [Add invitation only button to course detail view (iOS)](https://github.com/edx/edx-app-ios/pull/945)
- [Add invitation only button to course detail view (Android)](https://github.com/edx/edx-app-android/pull/956)

### Reviewers
- [x] Code review: @bradenmacdonald 

cc @marcotuts @gsong 
