### PR TITLE
More specific grade_course logging

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -191,7 +191,11 @@ class CourseGradeReport(object):
         batched_rows = self._batched_rows(context)
 
         context.update_status(u'Compiling grades')
-        success_rows, error_rows = self._compile(context, batched_rows)
+        try:
+            success_rows, error_rows = self._compile(context, batched_rows)
+        except Exception:  # pylint:disable=broad-except
+            TASK_LOG.exception('Something failed in compilation')
+            return context.update_status('Failed grades')
 
         context.update_status(u'Uploading grades')
         self._upload(context, success_headers, success_rows, error_headers, error_rows)


### PR DESCRIPTION
@edx/devops This is a repeatable common point of failure for `grade_course` tasks ([JIRA comment](https://openedx.atlassian.net/browse/EDUCATOR-416?focusedCommentId=262622&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-262622), [splunk search](https://splunk.edx.org/en-US/app/search/search?sid=1496331373.1208759)). Cool if I add this logging as well before today's release gets cut?

I'll update https://github.com/edx/edx-platform/pull/15228 to include a revert of this change