### PR TITLE
Mark test as flaky, and remove flaky from a fixed test.

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -140,7 +140,6 @@ class LoginFromCombinedPageTest(UniqueCourseTest):
         self.login_page.visit().toggle_form()
         self.assertEqual(self.login_page.current_form, "register")
 
-    @flaky  # ECOM-1165
     def test_password_reset_success(self):
         # Create a user account
         email, password = self._create_unique_user()  # pylint: disable=unused-variable
@@ -565,6 +564,7 @@ class CourseWikiTest(UniqueCourseTest):
         self.course_wiki_edit_page.wait_for_page()
 
     @attr(shard=1)
+    @flaky  # EDUCATOR-511
     def test_edit_course_wiki(self):
         """
         Wiki page by default is editable for students.


### PR DESCRIPTION
[EDUCATOR-511](https://openedx.atlassian.net/browse/EDUCATOR-511)

Add a flaky decorator for test_edit_course_wiki per EDUCATOR-511.

And while I was in this file, I noticed a different test point had a flaky decorator, and according to https://openedx.atlassian.net/browse/ECOM-1165 it should have been removed a couple of years ago. So I'll go ahead and attempt to remove it.