### PR TITLE
ENT-385: change error msg for confirm email

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -281,3 +281,4 @@ Brian Mesick <bmesick@edx.org>
 Jeff LaJoie <jlajoie@edx.org>
 Ivan Ivić <iivic@edx.org>
 Brandon Baker <bcbaker@wesleyan.edu>
+Shirley He <she@edx.org>

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1202,7 +1202,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 "required": True,
                 "label": "Confirm Email",
                 "errorMessages": {
-                    "required": "Please confirm your email address.",
+                    "required": "The email addresses do not match.",
                 }
             }
         )

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -428,7 +428,7 @@ class RegistrationView(APIView):
         # Translators: This label appears above a field on the registration form
         # meant to confirm the user's email address.
         email_label = _(u"Confirm Email")
-        error_msg = _(u"Please confirm your email address.")
+        error_msg = _(u"The email addresses do not match.")
 
         form_desc.add_field(
             "confirm_email",


### PR DESCRIPTION
**Background:** For the new registration page, if the confirm email doesn't match the original email, an error message with "Please confirm your email" is given. The error message could be changed to something clearer. 

**Studio Updates:** None.

**LMS Updates:** Changes the original message, "Please confirm your email", to the new message, "The email addresses do not match".

**Testing:** Tested locally - upon entering differing emails in the email and confirm email fields, the error message has now been changed to the updated version. 
