### PR TITLE
Updated Enrollment API to always store enrollment attributes

### DIFF
--- a/common/djangoapps/enrollment/api.py
+++ b/common/djangoapps/enrollment/api.py
@@ -142,7 +142,7 @@ def get_enrollment(user_id, course_id):
     return _data_api().get_course_enrollment(user_id, course_id)
 
 
-def add_enrollment(user_id, course_id, mode=None, is_active=True):
+def add_enrollment(user_id, course_id, mode=None, is_active=True, enrollment_attributes=None):
     """Enrolls a user in a course.
 
     Enrolls a user in a course. If the mode is not specified, this will default to `CourseMode.DEFAULT_MODE_SLUG`.
@@ -150,12 +150,11 @@ def add_enrollment(user_id, course_id, mode=None, is_active=True):
     Arguments:
         user_id (str): The user to enroll.
         course_id (str): The course to enroll the user in.
-
-    Keyword Arguments:
         mode (str): Optional argument for the type of enrollment to create. Ex. 'audit', 'honor', 'verified',
             'professional'. If not specified, this defaults to the default course mode.
         is_active (boolean): Optional argument for making the new enrollment inactive. If not specified, is_active
             defaults to True.
+        enrollment_attributes (list): Attributes to be set the enrollment.
 
     Returns:
         A serializable dictionary of the new course enrollment.
@@ -194,7 +193,12 @@ def add_enrollment(user_id, course_id, mode=None, is_active=True):
     if mode is None:
         mode = _default_course_mode(course_id)
     validate_course_mode(course_id, mode, is_active=is_active)
-    return _data_api().create_course_enrollment(user_id, course_id, mode, is_active)
+    enrollment = _data_api().create_course_enrollment(user_id, course_id, mode, is_active)
+
+    if enrollment_attributes is not None:
+        set_enrollment_attributes(user_id, course_id, enrollment_attributes)
+
+    return enrollment
 
 
 def update_enrollment(user_id, course_id, mode=None, is_active=None, enrollment_attributes=None, include_expired=False):

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -641,7 +641,13 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                 )
             else:
                 # Will reactivate inactive enrollments.
-                response = api.add_enrollment(username, unicode(course_id), mode=mode, is_active=is_active)
+                response = api.add_enrollment(
+                    username,
+                    unicode(course_id),
+                    mode=mode,
+                    is_active=is_active,
+                    enrollment_attributes=enrollment_attributes
+                )
 
             email_opt_in = request.data.get('email_opt_in', None)
             if email_opt_in is not None:


### PR DESCRIPTION
Enrollment attributes are now always stored, regardless of whether an enrollment is being created or updated. This will ensure that learners who purchase paid modes, without first enrolling in a non-paid mode, can request refunds if they choose to un-enroll from a course run within the refund window.

LEARNER-1282