### PR TITLE
Disable view of Git Import when user is professor of course but not s…

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -104,7 +104,7 @@ from openedx.core.djangolib.markup import HTML, Text
     </li>
   </ul>
 
-  %if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD', ''):
+  %if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD', '') and user.is_staff:
       <p>
         ## Translators: git is a version-control system; see http://git-scm.com/about
         ${Text(_("View detailed Git import logs for this course {link_start}by clicking here{link_end}.")).format(


### PR DESCRIPTION
…taff user

Reason: Before this fix, if the user is not staff (user.is_staff=0) and ENABLE_SYSADMIN_DASHBOARD=True
happens that the user can access the Git Import in Sysadmin dashboard and get to see the links in the menu
of the sysadmin dashboard (Users, Courses, Staffing and enrollment). When this user clicks on one of
these links, it gets an error from the server.

Steps to reproduce:
- ENABLE_SYSADMIN_DASHBOARD=True in lms.env.json
- Restart edxapp:lms
- Login with a regular user (is_staff=0, is_supersuser=0)
- Create a course in studio or be staff of a given course
- Access the course in LMS and go to the Instructor tab.
- Go to Course Info
- Look for "View detailed Git import logs for this course by clicking here."  and click on the "clicking here text"
- This user will access the SYSADMIN DASHBOARD on the Git import menu
- The user will see the other menu links: Users, Courses, Staffing and enrollment
- Click on any of those, the user will see an error page