### PR TITLE
LEARNER-1279: Revert: Course jump tos should go to the main course home page.

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -1439,8 +1439,6 @@ class DefaultStatesContentTest(CourseOutlineTest):
 
     __test__ = True
 
-    # TODO: TNL-6546: Removing unified_course_view_flag
-    # This test will need to be rewritten to point to the new course home page.
     def test_view_live(self):
         """
         Scenario: View Live version from course outline

--- a/lms/djangoapps/courseware/url_helpers.py
+++ b/lms/djangoapps/courseware/url_helpers.py
@@ -9,15 +9,12 @@ from xmodule.modulestore.search import path_to_location, navigation_index
 from xmodule.modulestore.django import modulestore
 
 
-# TODO: TNL-6547: Remove unified_course_view parameter
-def get_redirect_url(course_key, usage_key, unified_course_view=False):
+def get_redirect_url(course_key, usage_key):
     """ Returns the redirect url back to courseware
 
     Args:
         course_id(str): Course Id string
         location(str): The location id of course component
-        unified_course_view (bool): temporary parameter while this feature is behind a waffle flag.
-            Is the unified_course_view waffle flag on?
 
     Raises:
         ItemNotFoundError if no data at the location or NoPathToItem if location not in any class
@@ -25,8 +22,6 @@ def get_redirect_url(course_key, usage_key, unified_course_view=False):
     Returns:
         Redirect url string
     """
-    if usage_key.block_type == 'course' and unified_course_view:
-        return reverse('openedx.course_experience.course_home', args=[unicode(course_key)])
 
     (
         course_key, chapter, section, vertical_unused,

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -207,7 +207,7 @@ def jump_to_id(request, course_id, module_id):
 
 
 @ensure_csrf_cookie
-def jump_to(request, course_id, location):
+def jump_to(_request, course_id, location):
     """
     Show the page that contains a specific location.
 
@@ -222,8 +222,7 @@ def jump_to(request, course_id, location):
     except InvalidKeyError:
         raise Http404(u"Invalid course_key or usage_key")
     try:
-        unified_course_view = waffle.flag_is_active(request, UNIFIED_COURSE_VIEW_FLAG)
-        redirect_url = get_redirect_url(course_key, usage_key, unified_course_view=unified_course_view)
+        redirect_url = get_redirect_url(course_key, usage_key)
     except ItemNotFoundError:
         raise Http404(u"No data at this location: {0}".format(usage_key))
     except NoPathToItem:


### PR DESCRIPTION
## [LEARNER-1279](https://openedx.atlassian.net/browse/LEARNER-1279)

### Description

This is an attempt at fixing the "Start Course" button, by rolling back the change used for the Studio course-level preview links:
Revert commit: c14f0b14eabb34fc7423db08e78a21fe54168c53

There may need to be an additional follow-up for how to handle those links if it is important to link to the outline.

### Sandbox
- [x] [https://robrap.sandbox.edx.org](https://robrap.sandbox.edx.org)

### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] Analytics
- [x] Performance
- [x] Database migrations are backwards-compatible

Front-end changes:
- [x] i18n
- [x] Accessibility (Check for a11y violations, ensure keyboard accessible, screen reader testing as appropriate)
- [x] RTL

### Reviewers
- [X] Assign reviewers to your PR based on the changes it contains (Dev, Doc, UX, Accessibility, Product, DevOps)

### Post-review
- [ ] Rebase and squash commits