### PR TITLE
Correct activation email support link defaults in views.py

### DIFF
--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -33,8 +33,8 @@ class TestActivateAccount(TestCase):
 
         self.platform_name = configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
         self.activation_email_support_link = configuration_helpers.get_value(
-            'ACTIVATION_EMAIL_SUPPORT_LINK', settings.SUPPORT_SITE_LINK  # Intentional default.
-        )
+            'ACTIVATION_EMAIL_SUPPORT_LINK', settings.ACTIVATION_EMAIL_SUPPORT_LINK
+        ) or settings.SUPPORT_SITE_LINK
 
     def login(self):
         """

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -652,8 +652,8 @@ def dashboard(request):
         settings.FEATURES.get('DISPLAY_COURSE_MODES_ON_DASHBOARD', True)
     )
     activation_email_support_link = configuration_helpers.get_value(
-        'ACTIVATION_EMAIL_SUPPORT_LINK', settings.SUPPORT_SITE_LINK
-    )
+        'ACTIVATION_EMAIL_SUPPORT_LINK', settings.ACTIVATION_EMAIL_SUPPORT_LINK
+    ) or settings.SUPPORT_SITE_LINK
 
     # Let's filter out any courses in an "org" that has been declared to be
     # in a configuration


### PR DESCRIPTION
As per the discussion in https://github.com/edx/edx-platform/pull/15196 at https://github.com/edx/edx-platform/pull/15196#discussion_r120017453 , it looks like setting the default here like this is actually incorrect. This PR should fix that.