### PR TITLE
Quiet factory loggers so they don't overload jenkins resources

### DIFF
--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -71,6 +71,7 @@ import logging
 LOG_OVERRIDES = [
     ('track.middleware', logging.CRITICAL),
     ('edx.discussion', logging.CRITICAL),
+    ('factory.generate', logging.WARNING),
 ]
 for log_name, log_level in LOG_OVERRIDES:
     logging.getLogger(log_name).setLevel(log_level)

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -117,6 +117,7 @@ LOG_OVERRIDES = [
     ('edxmako.shortcuts', logging.ERROR),
     ('dd.dogapi', logging.ERROR),
     ('edx.discussion', logging.CRITICAL),
+    ('factory.generate', logging.WARNING),
 ]
 for log_name, log_level in LOG_OVERRIDES:
     logging.getLogger(log_name).setLevel(log_level)


### PR DESCRIPTION
On failure Jenkins workers will sometimes give this error:
```
IOError: [Errno 11] Resource temporarily unavailable
```
due to the volume of messages that are logged to the console.