### PR TITLE
Further simplification of code.

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -2,61 +2,61 @@
 Instructor Dashboard Views
 """
 
-import logging
 import datetime
-from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey
+import logging
 import uuid
-import pytz
 
-from django.contrib.auth.decorators import login_required
-from django.views.decorators.http import require_POST
-from django.utils.translation import ugettext as _, ugettext_noop
-from django.views.decorators.csrf import ensure_csrf_cookie
-from django.views.decorators.cache import cache_control
-from edxmako.shortcuts import render_to_response
-from django.core.urlresolvers import reverse
-from django.utils.html import escape
-from django.http import Http404, HttpResponseServerError
-from django.conf import settings
-from util.json_request import JsonResponse
 from mock import patch
 
-from openedx.core.lib.xblock_utils import wrap_xblock
+import pytz
+from bulk_email.models import BulkEmailFlag
+from certificates import api as certs_api
+from certificates.models import (
+    CertificateGenerationConfiguration,
+    CertificateGenerationHistory,
+    CertificateInvalidation,
+    CertificateStatuses,
+    CertificateWhitelist,
+    GeneratedCertificate
+)
+from class_dashboard.dashboard_data import get_array_section_has_problem, get_section_display_name
+from course_modes.models import CourseMode, CourseModesArchive
+from courseware.access import has_access
+from courseware.courses import get_course_by_id, get_studio_url
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse
+from django.http import Http404, HttpResponseServerError
+from django.utils.html import escape
+from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_noop
+from django.views.decorators.cache import cache_control
+from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.http import require_POST
+from django_comment_client.utils import available_division_schemes, has_forum_access
+from django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, CourseDiscussionSettings
+from edxmako.shortcuts import render_to_response
+from lms.djangoapps.courseware.module_render import get_module_by_usage_id
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.verified_track_content.models import VerifiedTrackCohortedCourse
+from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.url_utils import quote_slashes
+from openedx.core.lib.xblock_utils import wrap_xblock
+from shoppingcart.models import Coupon, CourseRegCodeItem, PaidCourseRegistration
+from student.models import CourseEnrollment
+from student.roles import CourseFinanceAdminRole, CourseSalesAdminRole
+from util.json_request import JsonResponse
+from xblock.field_data import DictFieldData
+from xblock.fields import ScopeIds
 from xmodule.html_module import HtmlDescriptor
 from xmodule.modulestore.django import modulestore
 from xmodule.tabs import CourseTab
-from xblock.field_data import DictFieldData
-from xblock.fields import ScopeIds
-from courseware.access import has_access
-from courseware.courses import get_course_by_id, get_studio_url
-from django_comment_client.utils import has_forum_access, available_division_schemes, enrollment_track_group_count
-from django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, CourseDiscussionSettings
-from openedx.core.djangoapps.course_groups.cohorts import get_course_cohorts, is_course_cohorted, DEFAULT_COHORT_NAME
-from student.models import CourseEnrollment
-from shoppingcart.models import Coupon, PaidCourseRegistration, CourseRegCodeItem
-from course_modes.models import CourseMode, CourseModesArchive
-from student.roles import CourseFinanceAdminRole, CourseSalesAdminRole
-from lms.djangoapps.courseware.module_render import get_module_by_usage_id
-from certificates.models import (
-    CertificateGenerationConfiguration,
-    CertificateWhitelist,
-    GeneratedCertificate,
-    CertificateStatuses,
-    CertificateGenerationHistory,
-    CertificateInvalidation,
-)
-from certificates import api as certs_api
-from bulk_email.models import BulkEmailFlag
 
-from class_dashboard.dashboard_data import get_section_display_name, get_array_section_has_problem
 from .tools import get_units_with_due_date, title_or_url
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.verified_track_content.models import VerifiedTrackCohortedCourse
-
-from openedx.core.djangolib.markup import HTML, Text
 
 log = logging.getLogger(__name__)
 
@@ -530,7 +530,6 @@ def _section_discussions_management(course, access):
         'section_display_name': _('Discussions'),
         'is_hidden': (not is_course_cohorted(course_key) and
                       CourseDiscussionSettings.ENROLLMENT_TRACK not in enrollment_track_schemes),
-        'enrollment_track_count': enrollment_track_group_count(course_key),
         'discussion_topics_url': reverse('discussion_topics', kwargs={'course_key_string': unicode(course_key)}),
         'course_discussion_settings': reverse(
             'course_discussions_settings',

--- a/lms/static/js/discussions_management/views/discussions.js
+++ b/lms/static/js/discussions_management/views/discussions.js
@@ -88,9 +88,10 @@
                 },
 
                 cohortStateUpdate: function(state) {
-                    if ($('.discussions-management').data('enrollment-track-count') <= 1) {
+                    if (!this.isSchemeAvailable(ENROLLMENT_TRACK)) {
                         this.showDiscussionManagement(state.is_cohorted);
-                    } if (this.getSelectedScheme() !== COHORT) {
+                    }
+                    if (this.getSelectedScheme() !== COHORT) {
                         this.showCohortSchemeControl(state.is_cohorted);
                     }
                 },
@@ -114,6 +115,8 @@
                         $('.division-scheme-item.cohort').removeClass(HIDDEN_CLASS);
                         if (this.isSchemeAvailable(ENROLLMENT_TRACK)) {
                             $('.division-scheme-item').removeClass(TWO_COLUMN_CLASS).addClass(THREE_COLUMN_CLASS);
+                        } else {
+                            $('.division-scheme-item').removeClass(THREE_COLUMN_CLASS).addClass(TWO_COLUMN_CLASS);
                         }
                     }
                 },

--- a/lms/templates/instructor/instructor_dashboard_2/discussions_management.html
+++ b/lms/templates/instructor/instructor_dashboard_2/discussions_management.html
@@ -12,7 +12,6 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
 <div class="discussions-management"
      data-discussion-topics-url="${section_data['discussion_topics_url']}"
      data-course-discussion-settings-url="${section_data['course_discussion_settings']}"
-     data-enrollment-track-count="${section_data['enrollment_track_count']}"
 >
 </div>
 


### PR DESCRIPTION
@staubina Here is some more simplification around the logic of whether or not the enrollment track scheme is available.

However, I'm still seeing a bug in the following case, and I believe it is because the radio button elements are not yet available at the time the event is handled (I was able to confirm this once in the debugger):

1) No enrollment track scheme present (single enrollment mode)
2) Cohorts initially disabled.
3) Go from courseware to instructor dashboard (no discussion management tab visible).
4) Enable cohorts
5) Click on newly visible discussion management tab.
6) The only radio button present is the "not divided" radio button.

When I was able to hit this in the debugger, $('.division-scheme-item.cohort') and $('.division-scheme-item') (as called in showCohortSchemeControl) returned an empty list.

FYI @jlajoie 