### PR TITLE
EDUCATOR-546

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/delete_course.py
+++ b/cms/djangoapps/contentstore/management/commands/delete_course.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand, CommandError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from contentstore.utils import delete_course_and_groups
+from contentstore.utils import delete_course
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 
@@ -21,11 +21,35 @@ from .prompt import query_yes_no
 class Command(BaseCommand):
     """
     Delete a MongoDB backed course
+    Example usage:
+        $ ./manage.py cms delete_course 'course-v1:edX+DemoX+Demo_Course' --settings=devstack
+        $ ./manage.py cms delete_course 'course-v1:edX+DemoX+Demo_Course' --keep-instructors --settings=devstack
+
+    Note:
+        keep-instructors option is added in effort to delete duplicate courses safely.
+        There happens to be courses with difference of casing in ids, for example
+        course-v1:DartmouthX+DART.ENGL.01.X+2016_T1 is a duplicate of course-v1:DartmouthX+DART.ENGL.01.x+2016_T1
+        (Note the differene in 'x' of course number). These two are independent courses in MongoDB.
+        Current MYSQL setup is case-insensitive which essentially means there are not
+        seperate entries (in all course related mysql tables, but here we are concerned about accesses)
+        for duplicate courses.
+        This option will make us able to delete course (duplicate one) from
+        mongo while perserving course's related access data in mysql.
     """
     help = '''Delete a MongoDB backed course'''
 
     def add_arguments(self, parser):
+        """
+        Add arguments to the command parser.
+        """
         parser.add_argument('course_key', help="ID of the course to delete.")
+
+        parser.add_argument(
+            '--keep-instructors',
+            action='store_true',
+            default=False,
+            help='Do not remove permissions of users and groups for course',
+        )
 
     def handle(self, *args, **options):
         try:
@@ -39,5 +63,5 @@ class Command(BaseCommand):
         print 'Going to delete the %s course from DB....' % options['course_key']
         if query_yes_no("Deleting course {0}. Confirm?".format(course_key), default="no"):
             if query_yes_no("Are you sure. This action cannot be undone!", default="no"):
-                delete_course_and_groups(course_key, ModuleStoreEnum.UserID.mgmt_command)
+                delete_course(course_key, ModuleStoreEnum.UserID.mgmt_command, options['keep_instructors'])
                 print "Deleted course {}".format(course_key)

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -15,7 +15,7 @@ from opaque_keys.edx.locations import CourseLocator
 
 from common.test.utils import XssTestMixin
 from contentstore.tests.utils import AjaxEnabledTestClient
-from contentstore.utils import delete_course_and_groups
+from contentstore.utils import delete_course
 from contentstore.views.course import (
     AccessListFallback,
     _accessible_courses_iter,
@@ -298,7 +298,7 @@ class TestCourseListing(ModuleStoreTestCase, XssTestMixin):
         self.assertEqual(courses_list, courses_list_by_groups)
 
         # now delete this course and re-add user to instructor group of this course
-        delete_course_and_groups(course_key, self.user.id)
+        delete_course(course_key, self.user.id)
 
         CourseInstructorRole(course_key).add_users(self.user)
 

--- a/cms/djangoapps/contentstore/tests/test_users_default_role.py
+++ b/cms/djangoapps/contentstore/tests/test_users_default_role.py
@@ -3,7 +3,7 @@ Unit tests for checking default forum role "Student" of a user when he creates a
 after deleting it creates same course again
 """
 from contentstore.tests.utils import AjaxEnabledTestClient
-from contentstore.utils import delete_course_and_groups, reverse_url
+from contentstore.utils import delete_course, reverse_url
 from courseware.tests.factories import UserFactory
 from student.models import CourseEnrollment
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -60,7 +60,7 @@ class TestUsersDefaultRole(ModuleStoreTestCase):
         # check that user has his default "Student" forum role for this course
         self.assertTrue(self.user.roles.filter(name="Student", course_id=self.course_key))
 
-        delete_course_and_groups(self.course_key, self.user.id)
+        delete_course(self.course_key, self.user.id)
 
         # check that user's enrollment for this course is not deleted
         self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course_key))
@@ -78,7 +78,7 @@ class TestUsersDefaultRole(ModuleStoreTestCase):
         self.assertTrue(self.user.roles.filter(name="Student", course_id=self.course_key))
 
         # delete this course and recreate this course with same user
-        delete_course_and_groups(self.course_key, self.user.id)
+        delete_course(self.course_key, self.user.id)
         resp = self._create_course_with_given_location(self.course_key)
         self.assertEqual(resp.status_code, 200)
 
@@ -96,7 +96,7 @@ class TestUsersDefaultRole(ModuleStoreTestCase):
         # check that user has enrollment and his default "Student" forum role for this course
         self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course_key))
         # delete this course and recreate this course with same user
-        delete_course_and_groups(self.course_key, self.user.id)
+        delete_course(self.course_key, self.user.id)
 
         # now create same course with different name case ('uppercase')
         new_course_key = self.course_key.replace(course=self.course_key.course.upper())

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -61,22 +61,38 @@ def remove_all_instructors(course_key):
     instructor_role.remove_users(*instructor_role.users_with_role())
 
 
-def delete_course_and_groups(course_key, user_id):
+def delete_course(course_key, user_id, keep_instructors=False):
     """
-    This deletes the courseware associated with a course_key as well as cleaning update_item
-    the various user table stuff (groups, permissions, etc.)
+    Delete course from module store and if specified remove user and
+    groups permissions from course.
+    """
+    _delete_course_from_modulestore(course_key, user_id)
+
+    if not keep_instructors:
+        _remove_instructors(course_key)
+
+
+def _delete_course_from_modulestore(course_key, user_id):
+    """
+    Delete course from MongoDB. Deleting course will fire a signal which will result into
+    deletion of the courseware associated with a course_key.
     """
     module_store = modulestore()
 
     with module_store.bulk_operations(course_key):
         module_store.delete_course(course_key, user_id)
 
-        print 'removing User permissions from course....'
-        # in the django layer, we need to remove all the user permissions groups associated with this course
-        try:
-            remove_all_instructors(course_key)
-        except Exception as err:
-            log.error("Error in deleting course groups for {0}: {1}".format(course_key, err))
+
+def _remove_instructors(course_key):
+    """
+    In the django layer, remove all the user/groups permissions associated with this course
+    """
+    print 'removing User permissions from course....'
+
+    try:
+        remove_all_instructors(course_key)
+    except Exception as err:
+        log.error("Error in deleting course groups for {0}: {1}".format(course_key, err))
 
 
 def get_lms_link_for_item(location, preview=False):


### PR DESCRIPTION
## [EDUCATOR-546](https://openedx.atlassian.net/browse/EDUCATOR-546)

### Description
delete_course management command deletes course as well as remove all instructors from course. We need a solution where we can specify wether to delete instructors from course or not.
It is needed because there are some duplicate courses with one difference in the case of letters in course id.
For example course-v1:DartmouthX+DART.ENGL.01.X+2016_T1 is a duplicate of course-v1:DartmouthX+DART.ENGL.01.x+2016_T1. This makes a situation where there are two independent courses in modulestore, but as current setup of mysql is case-insensitive, related mysql data is same for both courses.
So, deleting either course with delete_course command will remove associated access roles of this course.
In this PR an option --keep-instructors is added, when this option will be given a course will be deleted from modulestore without removing accesses. This way we will be able to delete duplicate course from modulestore, while keeping required mysql data unchanged. 

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @Rabia23 
- [x] Code review: @awaisdar001 
- [x] Code review: @attiyaIshaque 

FYI: @adampalay 

### Post-review
- [x] Rebase and squash commits