### PR TITLE
Fix sysadmin csv download as unicode

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -2,7 +2,7 @@
 This module creates a sysadmin dashboard for managing and viewing
 courses.
 """
-import csv
+import unicodecsv as csv
 import json
 import logging
 import os


### PR DESCRIPTION
# Scenario:
## LMS - SysAdmin

When trying to download CSV file with Staff and Superuser users, server respond with 500 code when there is some user with fullname with special characters as á, é, í,...

`
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/dashboard/sysadmin.py", line 101, in csv_data
    writer.writerow(row)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf1' in position 18: ordinal not in range(128)
`
# Ways to reproduce the bug before solved

* Go to `/sysadmin/staffing`
* Click on `Download staff and instructor list (csv file)`


# Fix

Use `unicodecsv` instead of `csv` library
