### PR TITLE
update edx-search to version 1.0.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -57,7 +57,7 @@ edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.4
 edx-rest-api-client==1.7.1
-edx-search==0.1.2
+edx-search==1.0.1
 facebook-sdk==0.4.0
 feedparser==5.1.3
 firebase-token-generator==1.3.2


### PR DESCRIPTION
edx-search has a tagged 1.0.1 release, which has not been released to platform yet. We're now ready to release that version to platform as part of the edx-search elasticsearch upgrade. The edx-search version is currently at 0.1.2, which requires a version of elasticsearch <1.0.0, which is 0.4.5. 0.4.5 is incompatible with the version of elasticsearch we want to be running as part of the elasticsearch upgrade (1.5).

Tagging @dianakhuang @cpennington @feanil  so you are aware.
