### PR TITLE
ED-367 log in production

### DIFF
--- a/common/djangoapps/request_cache/__init__.py
+++ b/common/djangoapps/request_cache/__init__.py
@@ -68,16 +68,11 @@ def get_request_or_stub():
     request that can be used to build an absolute URI.
 
     This is useful in cases where we need to pass in a request object
-    but don't have an active request (for example, in test cases).
+    but don't have an active request (for example, in tests, celery tasks, and XBlocks).
     """
     request = crum.get_current_request()
 
     if request is None:
-        log.warning(
-            "Could not retrieve the current request. "
-            "A stub request will be created instead using settings.SITE_NAME. "
-            "This should be used *only* in test cases, never in production!"
-        )
 
         # The settings SITE_NAME may contain a port number, so we need to
         # parse the full URL.

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -29,6 +29,15 @@ class UserPreference(models.Model):
     class Meta(object):
         unique_together = ("user", "key")
 
+    @staticmethod
+    def get_all_preferences(user):
+        """
+        Gets all preferences for a given user
+
+        Returns: Set of (preference type, value) pairs for each of the user's preferences
+        """
+        return dict([(pref.key, pref.value) for pref in user.preferences.all()])
+
     @classmethod
     def get_value(cls, user, preference_key, default=None):
         """Gets the user preference value for a given key.

--- a/openedx/core/djangoapps/user_api/preferences/api.py
+++ b/openedx/core/djangoapps/user_api/preferences/api.py
@@ -72,18 +72,7 @@ def get_user_preferences(requesting_user, username=None):
          UserAPIInternalError: the operation failed due to an unexpected error.
     """
     existing_user = _get_authorized_user(requesting_user, username, allow_staff=True)
-
-    # Django Rest Framework V3 uses the current request to version
-    # hyperlinked URLS, so we need to retrieve the request and pass
-    # it in the serializer's context (otherwise we get an AssertionError).
-    # We're retrieving the request from the cache rather than passing it in
-    # as an argument because this is an implementation detail of how we're
-    # serializing data, which we want to encapsulate in the API call.
-    context = {
-        "request": get_request_or_stub()
-    }
-    user_serializer = UserSerializer(existing_user, context=context)
-    return user_serializer.data["preferences"]
+    return UserPreference.get_all_preferences(existing_user)
 
 
 @intercept_errors(UserAPIInternalError, ignore_errors=[UserAPIRequestError])

--- a/openedx/core/djangoapps/user_api/serializers.py
+++ b/openedx/core/djangoapps/user_api/serializers.py
@@ -28,7 +28,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         """
         Returns the set of preferences as a dict for the specified user
         """
-        return dict([(pref.key, pref.value) for pref in user.preferences.all()])
+        return UserPreference.get_all_preferences(user)
 
     class Meta(object):
         model = User


### PR DESCRIPTION
## [EDUCATOR-367](https://openedx.atlassian.net/browse/EDUCATOR-367)

### Description

Deleted the warning that was causing the log to show up in production.
In the discussion about the bug, @andy-armstrong mentioned that the log in production is probably being logged because get_user_preferences is being called by an [XBlock](https://github.com/edx/edx-platform/blob/master/common/djangoapps/xblock_django/user_service.py#L76) which doesn't have access to the request. Since calls to get_user_preferences don't need the serialized data, and just return a list of user preferences, I re-wrote get_user_preferences to use a new method called get_all_preferences, that gets a user's preferences without needing the serializer.

### Testing
- [ ] Unit, integration, acceptance tests as appropriate

### Reviewers
- [ ] @cahrens 
- [ ] @staubina 
- [ ] @andy-armstrong 
 
### Post-review
- [ ] Rebase and squash commits