### PR TITLE
Generalize "cohorts" and remove unused imports.

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -2,8 +2,6 @@
 <%page args="section_data"/>
 <%!
 from django.utils.translation import ugettext as _
-from courseware.courses import get_studio_url
-from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition
 %>
 <script type="text/template" id="member-list-widget-template">
   <div class="member-list-widget">
@@ -224,10 +222,10 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       data-display-name="${_("Discussion Admins")}"
       data-info-text="
         ${_("Discussion Admins can edit or delete any post, clear misuse flags, close "
-         "and re-open threads, endorse responses, and see posts from all cohorts. "
+         "and re-open threads, endorse responses, and see posts from all groups. "
          "Their posts are marked as 'staff'. They can also add and remove the "
-         "discussion moderation roles to manage course team membership. You can "
-         "only give course team roles to enrolled users.")}"
+         "discussion moderation roles to manage course team membership. Only "
+         "enrolled users can be added as Discussion Admins.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="${_("Add Discussion Admin")}"
@@ -240,10 +238,10 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       data-display-name="${_("Discussion Moderators")}"
       data-info-text="
         ${_("Discussion Moderators can edit or delete any post, clear misuse flags, close "
-         "and re-open threads, endorse responses, and see posts from all cohorts. "
+         "and re-open threads, endorse responses, and see posts from all groups. "
          "Their posts are marked as 'staff'. They cannot manage course team membership by "
-         "adding or removing discussion moderation roles. You can only give course team "
-         "roles to enrolled users.")}"
+         "adding or removing discussion moderation roles. Only enrolled users can be "
+         "added as Discussion Moderators.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="${_("Add Moderator")}"
@@ -253,11 +251,11 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       data-rolename="Community TA"
       data-display-name="${_("Discussion Community TAs")}"
       data-info-text="
-        ${_("Community TA's are members of the community whom you deem particularly "
+        ${_("Community TAs are members of the community whom you deem particularly "
         "helpful on the discussion boards. They can edit or delete any post, clear "
         "misuse flags, close and re-open threads, endorse responses, and see posts from "
-        "all cohorts. Their posts are marked as 'Community TA'. You can only give course "
-        "team roles to enrolled users.")}"
+        "all groups. Their posts are marked as 'Community TA'. Only enrolled users can "
+        "be added as Community TAs.")}"
       data-list-endpoint="${ section_data['list_forum_members_url'] }"
       data-modify-endpoint="${ section_data['update_forum_role_membership_url'] }"
       data-add-button-label="${_("Add Community TA")}"


### PR DESCRIPTION
@catong noticed the usage of cohorts, and while changing this file, I discovered that these imports are unused (I was very curious about what was using "get_cohorted_user_partition"!).

Sandbox: https://groups.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-membership