### PR TITLE
Remove paramiko requirement

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -77,7 +77,6 @@ MySQL-python==1.2.5
 networkx==1.7
 nose-xunitmp==0.3.2
 oauthlib==1.0.3
-paramiko==1.9.0
 path.py==8.2.1
 piexif==1.0.2
 Pillow==3.4


### PR DESCRIPTION
This was used for a management command for pearson that is no longer in the platform