### PR TITLE
Add GUID to memory middleware logs.

### DIFF
--- a/openedx/core/djangoapps/monitoring_utils/middleware.py
+++ b/openedx/core/djangoapps/monitoring_utils/middleware.py
@@ -19,6 +19,7 @@ except ImportError:
 
 import psutil
 import request_cache
+from uuid import uuid4
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 
 
@@ -83,9 +84,11 @@ class MonitoringMemoryMiddleware(object):
     Middleware for monitoring memory usage.
     """
     memory_data_key = u'memory_data'
+    guid_key = u'guid_key'
 
     def process_request(self, request):
         if self._is_enabled():
+            self._cache[self.guid_key] = unicode(uuid4())
             log_prefix = self._log_prefix(u"Before", request)
             self._cache[self.memory_data_key] = self._memory_data(log_prefix)
 
@@ -109,7 +112,7 @@ class MonitoringMemoryMiddleware(object):
         """
         Returns a formatted prefix for logging for the given request.
         """
-        return u"{} request '{} {}'".format(prefix, request.method, request.path)
+        return u"{} request '{} {} {}'".format(prefix, request.method, request.path, self._cache[self.guid_key])
 
     def _memory_data(self, log_prefix):
         """

--- a/openedx/core/djangoapps/monitoring_utils/middleware.py
+++ b/openedx/core/djangoapps/monitoring_utils/middleware.py
@@ -10,17 +10,19 @@ request handlers which do not record custom metrics.
 
 """
 import logging
+from uuid import uuid4
+
+import psutil
+
+import request_cache
+from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+
 log = logging.getLogger(__name__)
 try:
     import newrelic.agent
 except ImportError:
     log.warning("Unable to load NewRelic agent module")
     newrelic = None  # pylint: disable=invalid-name
-
-import psutil
-import request_cache
-from uuid import uuid4
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 
 
 REQUEST_CACHE_KEY = 'monitoring_custom_metrics'


### PR DESCRIPTION
This is how the output looks:

Jun  8 15:34:06 vagrant [service_variant=cms][openedx.core.djangoapps.monitoring_utils.middleware][env:sandbox] INFO [vagrant  4493] [middleware.py:132] - **Before request 'GET /home/ afe50b74-56c5-4356-8cf9-0478f1422e69'** Machine memory usage: vmem(total=4143771648L, available=3028561920L, percent=26.9, used=3960020992L, free=183750656L, active=1288716288, inactive=2484830208, buffers=67235840L, cached=2777575424); Process memory usage: {'memory_percent': 5.799362040521399, 'memory_info': meminfo(rss=240312320, vms=1506349056), 'ext_memory_info': meminfo(rss=240312320, vms=1506349056, shared=27533312, text=3055616, lib=0, data=1068982272, dirty=0), 'cpu_percent': 0.0}

Jun  8 15:34:14 vagrant [service_variant=cms][openedx.core.djangoapps.monitoring_utils.middleware][env:sandbox] INFO [vagrant  4493] [middleware.py:132] - **After request 'GET /home/ afe50b74-56c5-4356-8cf9-0478f1422e69'** Machine memory usage: vmem(total=4143771648L, available=3023093760L, percent=27.0, used=3967614976L, free=176156672L, active=1298526208, inactive=2482675712, buffers=67244032L, cached=2779693056); Process memory usage: {'memory_percent': 5.868752736830348, 'memory_info': meminfo(rss=243187712, vms=1507659776), 'ext_memory_info': meminfo(rss=243187712, vms=1507659776, shared=27533312, text=3055616, lib=0, data=1070292992, dirty=0), 'cpu_percent': 0.0}

Jun  8 15:34:14 vagrant [service_variant=cms][openedx.core.djangoapps.monitoring_utils.middleware][env:sandbox] INFO [vagrant  4493] [middleware.py:162] - **Diff request 'GET /home/ afe50b74-56c5-4356-8cf9-0478f1422e69'** Diff Vmem used: 7593984, Diff percent memory: 0.0693906963089, Diff rss: 2875392, Diff vms: 1310720
