### PR TITLE
edx.org link for Open edX footer

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -35,7 +35,7 @@ def is_enabled():
 def get_footer(is_secure=True):
     """Retrieve information used to render the footer.
 
-    This will handle both the OpenEdX and EdX.org versions
+    This will handle both the Open edX and edX.org versions
     of the footer.  All user-facing text is internationalized.
 
     Currently, this does NOT support theming.
@@ -101,6 +101,10 @@ def get_footer(is_secure=True):
         "mobile_links": _footer_mobile_links(is_secure),
         "legal_links": _footer_legal_links(),
         "openedx_link": _footer_openedx_link(),
+        "edx_org_link": {
+            "url": "https://www.edx.org/?utm_medium=affiliate_partner&utm_source=opensource-partner&utm_content=open-edx-partner-footer-link&utm_campaign=open-edx-footer",
+            "text": _("Take free online courses at edX.org"),
+        },
     }
 
 
@@ -120,7 +124,7 @@ def _footer_copyright():
 
 
 def _footer_openedx_link():
-    """Return the image link for "powered by OpenEdX".
+    """Return the image link for "Powered by Open edX".
 
     Args:
         is_secure (bool): Whether the request is using TLS.

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -90,6 +90,10 @@ class TestFooter(TestCase):
                 'url': 'http://open.edx.org',
                 'image': 'https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png',
                 'title': 'Powered by Open edX'
-            }
+            },
+            'edx_org_link': {
+                'url': 'https://www.edx.org/?utm_medium=affiliate_partner&utm_source=opensource-partner&utm_content=open-edx-partner-footer-link&utm_campaign=open-edx-footer',
+                'text': 'Take free online courses at edX.org',
+            },
         }
         self.assertEqual(actual_footer, expected_footer)

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -132,11 +132,7 @@
         display: inline-block;
         font-size: em(11);
 
-      }
-
-      .nav-legal-02 a {
-
-        &:before {
+        &:not(:first-child) a:before {
           margin-right: ($baseline/4);
           content: "-";
         }

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -58,6 +58,7 @@
               <a href="${link['url']}">${link['title']}</a>
             </li>
           % endfor
+          <li><a href="${footer['edx_org_link']['url']}">${footer['edx_org_link']['text']}</a></li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
The goal here is to get some SEO, and perhaps some users, from the Open edX sites to edx.org.

The footer now looks like this:
<img width="931" alt="image" src="https://user-images.githubusercontent.com/23789/27297498-0eba930e-54f3-11e7-8c5b-4a7c58fa346a.png">
