### PR TITLE
EDUCATOR-294 – Fix studio header menu

### DIFF
--- a/cms/static/sass/elements/_header.scss
+++ b/cms/static/sass/elements/_header.scss
@@ -272,11 +272,11 @@
   .wrapper-header {
 
     .wrapper-l {
-      width: flex-grid(8,12);
+      width: flex-grid(9,12);
     }
 
     .wrapper-r {
-      width: flex-grid(4,12);
+      width: flex-grid(3,12);
     }
 
     .branding {


### PR DESCRIPTION
[EDUCATOR-294](https://openedx.atlassian.net/browse/EDUCATOR-294)
[Sandbox](https://studio-cms-header-menu.sandbox.edx.org/course/course-v1:edX+Test101+course)

This PR fixes menu header for `('es-419', 'Spanish')`.

**BEFORE**
<img width="1264" alt="screen shot 2017-06-09 at 4 06 18 pm" src="https://user-images.githubusercontent.com/7848408/26973007-baeccde0-4d2d-11e7-9543-b3a8d7eee6be.png">

**AFTER**
<img width="1274" alt="screen shot 2017-06-09 at 4 06 40 pm" src="https://user-images.githubusercontent.com/7848408/26973013-cb31ca02-4d2d-11e7-9556-a729b02793b6.png">


@mushtaqak @roderickmorales may I please get your review on this?

Thanks.
