### PR TITLE
Bbaker/educator 344

### DIFF
--- a/common/lib/xmodule/xmodule/partitions/partitions_service.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions_service.py
@@ -87,9 +87,8 @@ class PartitionService(object):
     with a given course.
     """
 
-    def __init__(self, course_id, track_function=None, cache=None):
+    def __init__(self, course_id, cache=None):
         self._course_id = course_id
-        self._track_function = track_function
         self._cache = cache
 
     def get_course(self):
@@ -165,7 +164,7 @@ class PartitionService(object):
         the partition's scheme.
         """
         return user_partition.scheme.get_group_for_user(
-            self._course_id, user, user_partition, assign=assign, track_function=self._track_function
+            self._course_id, user, user_partition, assign=assign,
         )
 
 

--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -96,7 +96,7 @@ class MockUserPartitionScheme(object):
         self.name = name
         self.current_group = current_group
 
-    def get_group_for_user(self, course_id, user, user_partition, assign=True, track_function=None):  # pylint: disable=unused-argument
+    def get_group_for_user(self, course_id, user, user_partition, assign=True):  # pylint: disable=unused-argument
         """
         Returns the current group if set, else the first group from the specified user partition.
         """
@@ -446,7 +446,6 @@ class PartitionServiceBaseClass(PartitionTestCase):
         return MockPartitionService(
             self.course,
             course_id=self.course.id,
-            track_function=Mock(),
             cache=cache
         )
 

--- a/common/lib/xmodule/xmodule/tests/test_split_test_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_split_test_module.py
@@ -96,7 +96,6 @@ class SplitTestModuleTest(XModuleXmlImportTest, PartitionTestCase):
         partitions_service = MockPartitionService(
             self.course,
             course_id=self.course.id,
-            track_function=Mock(name='track_function'),
         )
         self.module_system._services['partitions'] = partitions_service  # pylint: disable=protected-access
 

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -31,7 +31,7 @@ class MemoryUserPartitionScheme(object):
         """
         self.current_group.setdefault(user.id, {})[user_partition.id] = group
 
-    def get_group_for_user(self, course_id, user, user_partition, track_function=None):  # pylint: disable=unused-argument
+    def get_group_for_user(self, course_id, user, user_partition):  # pylint: disable=unused-argument
         """
         Fetch the group to which this user is linked in this partition, or None.
         """

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -604,7 +604,7 @@ class TestGradeReportConditionalContent(TestReportMixin, TestConditionalContent,
             group_config_hdr_tpl = 'Experiment Group ({})'
             return {
                 group_config_hdr_tpl.format(self.partition.name): self.partition.scheme.get_group_for_user(
-                    self.course.id, user, self.partition, track_function=None
+                    self.course.id, user, self.partition
                 ).name
             }
 

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -140,7 +140,6 @@ class LmsModuleSystem(ModuleSystem):  # pylint: disable=abstract-method
         services['library_tools'] = LibraryToolsService(modulestore())
         services['partitions'] = PartitionService(
             course_id=kwargs.get('course_id'),
-            track_function=kwargs.get('track_function', None),
             cache=request_cache_dict
         )
         store = modulestore()

--- a/openedx/core/djangoapps/course_groups/partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/partition_scheme.py
@@ -25,7 +25,7 @@ class CohortPartitionScheme(object):
 
     # pylint: disable=unused-argument
     @classmethod
-    def get_group_for_user(cls, course_key, user, user_partition, track_function=None, use_cached=True):
+    def get_group_for_user(cls, course_key, user, user_partition, use_cached=True):
         """
         Returns the Group from the specified user partition to which the user
         is assigned, via their cohort membership and any mappings from cohorts

--- a/openedx/core/djangoapps/user_api/partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/partition_schemes.py
@@ -19,7 +19,7 @@ class NotImplementedPartitionScheme(object):
     """
 
     @classmethod
-    def get_group_for_user(cls, course_key, user, user_partition, assign=True, track_function=None):  # pylint: disable=unused-argument
+    def get_group_for_user(cls, course_key, user, user_partition, assign=True):  # pylint: disable=unused-argument
         """
         Returning None is equivalent to saying "This user is not in any groups
         using this partition scheme", be sure the scheme you're removing is
@@ -33,7 +33,7 @@ class ReturnGroup1PartitionScheme(object):
     This scheme is needed to allow verification partitions to be killed, see EDUCATOR-199
     """
     @classmethod
-    def get_group_for_user(cls, course_key, user, user_partition, assign=True, track_function=None):  # pylint: disable=unused-argument
+    def get_group_for_user(cls, course_key, user, user_partition, assign=True):  # pylint: disable=unused-argument
         """
         The previous "allow" definition for verification was defined as 1, so return that.
         Details at https://github.com/edx/edx-platform/pull/14913/files#diff-feff1466ec4d1b8c38894310d8342a80
@@ -48,7 +48,7 @@ class RandomUserPartitionScheme(object):
     RANDOM = random.Random()
 
     @classmethod
-    def get_group_for_user(cls, course_key, user, user_partition, assign=True, track_function=None):
+    def get_group_for_user(cls, course_key, user, user_partition, assign=True):
         """
         Returns the group from the specified user position to which the user is assigned.
         If the user has not yet been assigned, a group will be randomly chosen for them if assign flag is True.
@@ -85,25 +85,24 @@ class RandomUserPartitionScheme(object):
             # persist the value as a course tag
             course_tag_api.set_course_tag(user, course_key, partition_key, group.id)
 
-            if track_function:
-                # emit event for analytics
-                # FYI - context is always user ID that is logged in, NOT the user id that is
-                # being operated on. If instructor can move user explicitly, then we should
-                # put in event_info the user id that is being operated on.
-                event_name = 'xmodule.partitions.assigned_user_to_partition'
-                event_info = {
-                    'group_id': group.id,
-                    'group_name': group.name,
-                    'partition_id': user_partition.id,
-                    'partition_name': user_partition.name
-                }
-                # pylint: disable=fixme
-                # TODO: Use the XBlock publish api instead
-                with tracker.get_tracker().context(event_name, {}):
-                    tracker.emit(
-                        event_name,
-                        event_info,
-                    )
+            # emit event for analytics
+            # FYI - context is always user ID that is logged in, NOT the user id that is
+            # being operated on. If instructor can move user explicitly, then we should
+            # put in event_info the user id that is being operated on.
+            event_name = 'xmodule.partitions.assigned_user_to_partition'
+            event_info = {
+                'group_id': group.id,
+                'group_name': group.name,
+                'partition_id': user_partition.id,
+                'partition_name': user_partition.name
+            }
+            # pylint: disable=fixme
+            # TODO: Use the XBlock publish api instead
+            with tracker.get_tracker().context(event_name, {}):
+                tracker.emit(
+                    event_name,
+                    event_info,
+                )
 
         return group
 

--- a/openedx/core/djangoapps/user_api/partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/partition_schemes.py
@@ -5,6 +5,8 @@ import logging
 import random
 import course_tag.api as course_tag_api
 
+from eventtracking import tracker
+
 from xmodule.partitions.partitions import UserPartitionError, NoSuchUserPartitionGroupError
 
 log = logging.getLogger(__name__)
@@ -88,6 +90,7 @@ class RandomUserPartitionScheme(object):
                 # FYI - context is always user ID that is logged in, NOT the user id that is
                 # being operated on. If instructor can move user explicitly, then we should
                 # put in event_info the user id that is being operated on.
+                event_name = 'xmodule.partitions.assigned_user_to_partition'
                 event_info = {
                     'group_id': group.id,
                     'group_name': group.name,
@@ -96,7 +99,11 @@ class RandomUserPartitionScheme(object):
                 }
                 # pylint: disable=fixme
                 # TODO: Use the XBlock publish api instead
-                track_function('xmodule.partitions.assigned_user_to_partition', event_info)
+                with tracker.get_tracker().context(event_name, {}):
+                    tracker.emit(
+                        event_name,
+                        event_info,
+                    )
 
         return group
 


### PR DESCRIPTION
## [EDUCATOR-344](https://openedx.atlassian.net/browse/EDUCATOR-344)

### Description

Fixes the eventing for assigning users to an experiment by removing the call to track_function and instead using tracker.emit as done in lms/djangoapps/grades/models.py.  

### Sandbox
https://pr15290.sandbox.edx.org/

### Testing
Testing done by creating a course and unit with a content group experiment, then viewing the course and checking that both the log in edx/var/log/tracking and the database table user_api_usercoursetag show the proper events and entries.