### PR TITLE
Limit courses and libraries returned for global staff.

### DIFF
--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -625,6 +625,18 @@
 
   }
 
+  .optimization-form {
+    margin-bottom: $baseline;
+
+    label {
+      font-size: 1.4rem;
+    }
+
+    .form-actions {
+      margin-top: ($baseline/2);
+    }
+  }
+
   // ====================
 
   // ELEM: new user form

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -183,6 +183,30 @@ from openedx.core.djangolib.markup import HTML, Text
       </div>
       % endif
 
+      %if optimization_enabled:
+      <div class="optimization-form">
+        <h2 class="title title-3">${_("Organization and Library Settings")}</h2>
+        <form class="form" action="/home/" method="GET">
+          <fieldset class="form-group">
+            <div class="field">
+              <label class="field-label">${_("Show all courses in organization:")}
+                <input class="field-input input-text" type="text" name="org"
+                       placeholder="${_('For example, MITx')}"/>
+              </label>
+            </div>
+            <div class="field">
+              <label class="field-label">${_("Show content libraries")}
+                <input class="field-input input-text" type="checkbox" value="true" name="libraries"/>
+              </label>
+            </div>
+          </fieldset>
+          <div class="form-actions">
+              <button class="btn-brand btn-base" type="submit">${_("Submit")}</button>
+          </div>
+        </form>
+      </div>
+      %endif
+
       <!-- STATE: processing courses -->
       %if allow_course_reruns and rerun_creator_status and len(in_process_course_actions) > 0:
       <div class="courses courses-processing">
@@ -296,7 +320,7 @@ from openedx.core.djangolib.markup import HTML, Text
       </ul>
       % endif
 
-      %if len(courses) > 0:
+      %if len(courses) > 0 or optimization_enabled:
       <div class="courses courses-tab active">
         <ul class="list-courses">
           %for course_info in sorted(courses, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):


### PR DESCRIPTION
## [EDUCATOR-563](https://openedx.atlassian.net/browse/EDUCATOR-563)

### Description

This PR limits the courses and content libraries shown to global staff, if the associated waffle switch is enabled (it will be enabled for edx.org, not for edge).

### Sandbox
- [x] https://studio-ed563.sandbox.edx.org/home/
The user "staff" is global staff, so logging in with that account shows the change.
The user "honor" is course staff on all courses/content libraries, so logging in with that account shows the full courses and content libraries available.

### Testing
- [ ] NO TESTING ADDED-- this is an experiment that will only be enabled for edx.org global staff.

Front-end changes:
- [x] i18n
- [x] Accessibility (Check for a11y violations, ensure keyboard accessible, screen reader testing as appropriate)
- [x] RTL

### Reviewers
- [x] Assign reviewers to your PR based on the changes it contains (Dev, Doc, UX, Accessibility, Product, DevOps)

List optional/FYI reviewers here: FYI @nasthagiri @scottrish @jibsheet 
 
### Post-review
- [x] Rebase and squash commits