### PR TITLE
ENT-367: Show Enterprise Logistration for coupon users

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3189,6 +3189,7 @@ ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS = {
     'year_of_birth',
     'mailing_address',
 }
+ENTERPRISE_CUSTOMER_COOKIE_NAME = 'enterprise_customer_uuid'
 
 ############## Settings for Course Enrollment Modes ######################
 COURSE_ENROLLMENT_MODES = {

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -248,7 +248,7 @@ def enterprise_customer_for_request(request, tpa_hint=None):
         except EnterpriseCustomer.DoesNotExist:
             pass
 
-    ec_uuid = request.GET.get('enterprise_customer')
+    ec_uuid = request.GET.get('enterprise_customer') or request.COOKIES.get(settings.ENTERPRISE_CUSTOMER_COOKIE_NAME)
     if not ec and ec_uuid:
         try:
             ec = EnterpriseCustomer.objects.get(uuid=ec_uuid)


### PR DESCRIPTION
Hi @douglashall , @zubair-arbi , @asadiqbal08 

Please take a look, This PR adds branding for enterprise learners coming from coupon redemption page.

__Jira Ticket:__ [ENT-367](https://openedx.atlassian.net/browse/ENT-367)

__Description:__
When the user comes into the offers page and is then redirected to login or register, and go through data sharing consent, the user should see the cobranded version of the logistration page and DSC page, then return to the existing flow.
