### PR TITLE
Mirror the devstack prereqs in CircleCI and paver install_prereqs.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,8 @@ dependencies:
     - pip install  --exists-action w pbr==0.9.0
     - pip install --exists-action w -r requirements/edx/base.txt
     - pip install --exists-action w -r requirements/edx/paver.txt
+    - pip install --exists-action w -r requirements/edx/development.txt
+    - pip install --exists-action w -r requirements/edx/testing.txt
     - if [ -e requirements/edx/post.txt ]; then pip install --exists-action w -r requirements/edx/post.txt ; fi
 
     - pip install coveralls==1.0

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,6 @@ dependencies:
     - pip install  --exists-action w pbr==0.9.0
     - pip install --exists-action w -r requirements/edx/base.txt
     - pip install --exists-action w -r requirements/edx/paver.txt
-    - pip install --exists-action w -r requirements/edx/development.txt
     - pip install --exists-action w -r requirements/edx/testing.txt
     - if [ -e requirements/edx/post.txt ]; then pip install --exists-action w -r requirements/edx/post.txt ; fi
 

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -28,6 +28,8 @@ PYTHON_REQ_FILES = [
     'requirements/edx/local.txt',
     'requirements/edx/base.txt',
     'requirements/edx/paver.txt',
+    'requirements/edx/development.txt',
+    'requirements/edx/testing.txt',
     'requirements/edx/post.txt',
 ]
 


### PR DESCRIPTION
As an extension of the work here:
https://github.com/edx/configuration/pull/3891
I've created this PR which changes both `paver install_prereqs` and the CircleCI environment-building YML to include both the development.txt and testing.txt requirements.

However, I'm not certain this change is correct. The change assumes that both these environments apply to development/testing environments only. Is that true?

Also, a possible problem I can see emerging from this change and the removal of dev/test requirements from the production edxapp build is that an incorrect removal could pass all tests - and then fail to run in the production environment due to a missing import.

I've opened this PR as a conversation starter - even though the PR above has already been merged.