### PR TITLE
Assign users to cohorts before registration

### DIFF
--- a/common/test/acceptance/tests/discussion/test_cohort_management.py
+++ b/common/test/acceptance/tests/discussion/test_cohort_management.py
@@ -149,8 +149,8 @@ class CohortConfigurationTest(EventsTestMixin, UniqueCourseTest, CohortTestMixin
         confirmation_messages = self.cohort_management_page.get_cohort_confirmation_messages()
         self.assertEqual(
             [
-                "2 students have been added to this cohort",
-                "1 student was removed from " + self.manual_cohort_name
+                "2 learners have been added to this cohort.",
+                "1 learner was moved from " + self.manual_cohort_name
             ],
             confirmation_messages
         )
@@ -217,16 +217,16 @@ class CohortConfigurationTest(EventsTestMixin, UniqueCourseTest, CohortTestMixin
 
         self.assertEqual(
             [
-                "0 students have been added to this cohort",
-                "1 student was already in the cohort"
+                "0 learners have been added to this cohort.",
+                "1 learner was already in the cohort"
             ],
             self.cohort_management_page.get_cohort_confirmation_messages()
         )
 
         self.assertEqual(
             [
-                "There was an error when trying to add students:",
-                "Unknown user: unknown_user"
+                "There was an error when trying to add learners:",
+                "Unknown username: unknown_user"
             ],
             self.cohort_management_page.get_cohort_error_messages()
         )

--- a/lms/djangoapps/instructor_task/tasks_helper/misc.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/misc.py
@@ -10,6 +10,7 @@ from time import time
 
 import unicodecsv
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.core.files.storage import DefaultStorage
 from openassessment.data import OraAggregateData
 from pytz import UTC
@@ -137,9 +138,9 @@ def cohort_students_and_upload(_xmodule_instance_args, _entry_id, course_id, tas
 
     # cohorts_status is a mapping from cohort_name to metadata about
     # that cohort.  The metadata will include information about users
-    # successfully added to the cohort, users not found, and a cached
-    # reference to the corresponding cohort object to prevent
-    # redundant cohort queries.
+    # successfully added to the cohort, users not found, Preassigned
+    # users, and a cached reference to the corresponding cohort object
+    # to prevent redundant cohort queries.
     cohorts_status = {}
 
     with DefaultStorage().open(task_input['file_name']) as f:
@@ -152,8 +153,10 @@ def cohort_students_and_upload(_xmodule_instance_args, _entry_id, course_id, tas
             if not cohorts_status.get(cohort_name):
                 cohorts_status[cohort_name] = {
                     'Cohort Name': cohort_name,
-                    'Students Added': 0,
-                    'Students Not Found': set()
+                    'Learners Added': 0,
+                    'Learners Not Found': set(),
+                    'Invalid Email Addresses': set(),
+                    'Preassigned Learners': set()
                 }
                 try:
                     cohorts_status[cohort_name]['cohort'] = CourseUserGroup.objects.get(
@@ -170,11 +173,25 @@ def cohort_students_and_upload(_xmodule_instance_args, _entry_id, course_id, tas
                 continue
 
             try:
-                add_user_to_cohort(cohorts_status[cohort_name]['cohort'], username_or_email)
-                cohorts_status[cohort_name]['Students Added'] += 1
-                task_progress.succeeded += 1
+                # If add_user_to_cohort successfully adds a user, a user object is returned.
+                # If a user is preassigned to a cohort, no user object is returned (we already have the email address).
+                (user, previous_cohort, preassigned) = add_user_to_cohort(cohorts_status[cohort_name]['cohort'], username_or_email)
+                if preassigned:
+                    cohorts_status[cohort_name]['Preassigned Learners'].add(username_or_email)
+                    task_progress.preassigned += 1
+                else:
+                    cohorts_status[cohort_name]['Learners Added'] += 1
+                    task_progress.succeeded += 1
             except User.DoesNotExist:
-                cohorts_status[cohort_name]['Students Not Found'].add(username_or_email)
+                # Raised when a user with the username could not be found, and the email is not valid
+                cohorts_status[cohort_name]['Learners Not Found'].add(username_or_email)
+                task_progress.failed += 1
+            except ValidationError:
+                # Raised when a user with the username could not be found, and the email is not valid,
+                # but the entered string contains an "@"
+                # Since there is no way to know if the entered string is an invalid username or an invalid email,
+                # assume that a string with the "@" symbol in it is an attempt at entering an email
+                cohorts_status[cohort_name]['Invalid Email Addresses'].add(username_or_email)
                 task_progress.failed += 1
             except ValueError:
                 # Raised when the user is already in the given cohort
@@ -186,10 +203,12 @@ def cohort_students_and_upload(_xmodule_instance_args, _entry_id, course_id, tas
     task_progress.update_task_state(extra_meta=current_step)
 
     # Filter the output of `add_users_to_cohorts` in order to upload the result.
-    output_header = ['Cohort Name', 'Exists', 'Students Added', 'Students Not Found']
+    output_header = ['Cohort Name', 'Exists', 'Learners Added', 'Learners Not Found', 'Invalid Email Addresses', 'Preassigned Learners']
     output_rows = [
         [
-            ','.join(status_dict.get(column_name, '')) if column_name == 'Students Not Found'
+            ','.join(status_dict.get(column_name, '')) if (column_name == 'Learners Not Found'
+                                                           or column_name == 'Invalid Email Addresses'
+                                                           or column_name == 'Preassigned Learners')
             else status_dict[column_name]
             for column_name in output_header
         ]

--- a/lms/djangoapps/instructor_task/tasks_helper/runner.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/runner.py
@@ -26,6 +26,7 @@ class TaskProgress(object):
         self.succeeded = 0
         self.skipped = 0
         self.failed = 0
+        self.preassigned = 0
 
     def update_task_state(self, extra_meta=None):
         """
@@ -47,6 +48,7 @@ class TaskProgress(object):
             'skipped': self.skipped,
             'failed': self.failed,
             'total': self.total,
+            'preassigned': self.preassigned,
             'duration_ms': int((time() - self.start_time) * 1000),
         }
         if extra_meta is not None:

--- a/lms/templates/instructor/instructor_dashboard_2/cohort-editor.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort-editor.underscore
@@ -2,26 +2,27 @@
     <header class="cohort-management-group-header"></header>
 
     <ul class="wrapper-tabs">
-        <li class="tab tab-manage_students is-selected" data-tab="manage_students"><button type="button" class="toggle-button"><span class="sr"><%- gettext('Selected tab') %> </span><%- gettext("Manage Students") %></button></li>
+        <li class="tab tab-manage_students is-selected" data-tab="manage_students"><button type="button" class="toggle-button"><span class="sr"><%- gettext('Selected tab') %> </span><%- gettext("Manage Learners") %></button></li>
         <li class="tab tab-settings" data-tab="settings"><button type="button" class="toggle-button"><%- gettext("Settings") %></button></li>
     </ul>
 
     <div class="cohort-management-group-add tab-content tab-content-manage_students" tabindex="-1">
         <form action="" method="post" id="cohort-management-group-add-form" class="cohort-management-group-add-form">
 
-            <h4 class="hd hd-3 form-title"><%- gettext('Add students to this cohort') %></h4>
+            <h4 class="hd hd-3 form-title"><%- gettext('Add learners to this cohort') %></h4>
 
             <div class="form-introduction">
-                <p><%- gettext('Note: Students can be in only one cohort. Adding students to this group overrides any previous group assignment.') %></p>
+                <p><%- gettext('Note: Learners can be in only one cohort. Adding learners to this group overrides any previous group assignment.') %></p>
             </div>
 
             <div class="cohort-confirmations" aria-live="polite" tabindex="-1"></div>
+            <div class="cohort-preassigned" aria-live="polite" tabindex="-1"></div>
             <div class="cohort-errors" aria-live="polite" tabindex="-1"></div>
 
             <div class="form-fields">
                 <div class="field field-textarea is-required">
                     <label for="cohort-management-group-add-students" class="label">
-                        <%- gettext('Enter email addresses and/or usernames, separated by new lines or commas, for the students you want to add. *') %>
+                        <%- gettext('Enter email addresses and/or usernames, separated by new lines or commas, for the learners you want to add. *') %>
                         <span class="sr"><%- gettext('(Required Field)') %></span>
                     </label>
                     <textarea name="cohort-management-group-add-students" id="cohort-management-group-add-students"
@@ -35,7 +36,7 @@
 
             <div class="form-actions">
                 <button class="form-submit button action-primary action-view">
-                    <span class="button-icon icon fa fa-plus" aria-hidden="true"></span> <%- gettext('Add Students') %>
+                    <span class="button-icon icon fa fa-plus" aria-hidden="true"></span> <%- gettext('Add Learners') %>
                 </button>
             </div>
         </form>

--- a/lms/templates/instructor/instructor_dashboard_2/cohorts.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohorts.underscore
@@ -34,14 +34,14 @@
         <hr class="divider divider-lv1" />
 
         <!-- Uploading a CSV file of cohort assignments. -->
-        <button class="toggle-cohort-management-secondary" data-href="#cohort-management-file-upload"><%- gettext('Assign students to cohorts by uploading a CSV file') %></button>
+        <button class="toggle-cohort-management-secondary" data-href="#cohort-management-file-upload"><%- gettext('Assign learners to cohorts by uploading a CSV file') %></button>
         <div class="cohort-management-file-upload csv-upload hidden" id="cohort-management-file-upload" tabindex="-1"></div>
 
         <div class="cohort-management-supplemental">
             <p class="">
                 <span class="icon fa fa-info-circle" aria-hidden="true"></span>
                 <%= HtmlUtils.interpolateHtml(
-                    gettext('To review student cohort assignments or see the results of uploading a CSV file, download course profile information or cohort results on the {link_start}Data Download{link_end} page.'),
+                    gettext('To review learner cohort assignments or see the results of uploading a CSV file, download course profile information or cohort results on the {link_start}Data Download{link_end} page.'),
                     {
                         link_start: HtmlUtils.HTML('<button type="button" class="btn-link link-cross-reference" data-section="data_download">'),
                         link_end: HtmlUtils.HTML('</button>')

--- a/openedx/core/djangoapps/course_groups/migrations/0003_auto_20170609_1455.py
+++ b/openedx/core/djangoapps/course_groups/migrations/0003_auto_20170609_1455.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import openedx.core.djangoapps.xmodule_django.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_groups', '0002_change_inline_default_cohort_value'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UnregisteredLearnerCohortAssignments',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('email', models.CharField(db_index=True, max_length=255, blank=True)),
+                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255)),
+                ('course_user_group', models.ForeignKey(to='course_groups.CourseUserGroup')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='unregisteredlearnercohortassignments',
+            unique_together=set([('course_id', 'email')]),
+        ),
+    ]

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -10,7 +10,6 @@ from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
-
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from util.db import outer_atomic
 
@@ -236,3 +235,13 @@ class CourseCohort(models.Model):
         )
 
         return course_cohort
+
+
+class UnregisteredLearnerCohortAssignments(models.Model):
+
+    class Meta(object):
+        unique_together = (('course_id', 'email'), )
+
+    course_user_group = models.ForeignKey(CourseUserGroup)
+    email = models.CharField(blank=True, max_length=255, db_index=True)
+    course_id = CourseKeyField(max_length=255)


### PR DESCRIPTION
## [EDUCATOR-549](https://openedx.atlassian.net/browse/EDUCATOR-549)

### Description

Allow assignment of email addresses to cohorts even if the email addresses aren't associated to an account.
Added, in the notification that alerts you about successfully/unsuccessfully adding users to a cohort, a line about preregistering users. 
Also re-wrote the error message "User could not be found" that would come up if a user wasn't found or an invalid email address was entered - changed to "Email address is invalid" if username/email entered contains an @ symbol and "User could not be found" if it doesn't. 
Some more docs changes ("student" changed to "learner", since preregistered emails are not yet students enrolled in the course)
Added/updated tests.

### Sandbox
- [x] ssemenova.sandbox.edx.org

### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] Database migrations are backwards-compatible

Front-end changes:
- [x] i18n
(I am unsure if I need to run something to generate new i18n files because I changed some of the notification messages?)

### Reviewers
- [x] @cahrens 
- [x] @staubina 
- [ ] @catong
 
### Post-review
- [ ] Rebase and squash commits
