### PR TITLE
Open Response Assessment tab for Instructor Dashboard - bugfix

### DIFF
--- a/lms/static/js/instructor_dashboard/open_response_assessment.js
+++ b/lms/static/js/instructor_dashboard/open_response_assessment.js
@@ -7,11 +7,15 @@
         function OpenResponseAssessmentBlock($section) {
             this.$section = $section;
             this.$section.data('wrapper', this);
+            this.initialized = false;
         }
 
         OpenResponseAssessmentBlock.prototype.onClickTitle = function() {
             var block = this.$section.find('.open-response-assessment');
-            XBlock.initializeBlock($(block).find('.xblock')[0]);
+            if (!this.initialized) {
+                this.initialized = true;
+                XBlock.initializeBlock($(block).find('.xblock')[0]);
+            }
         };
 
         return OpenResponseAssessmentBlock;


### PR DESCRIPTION
It is little bugfix for the Open Response Assessment tab in the Instructor Dashboard (that was created not so long ago: https://github.com/edx/edx-platform/pull/14562)

This fix prevent initialization of the ORA grid more than one time.

@efischer19 could you please take a look