### PR TITLE
Remove skip from test where failure cannot be reproduced

### DIFF
--- a/common/test/acceptance/pages/lms/course_wiki.py
+++ b/common/test/acceptance/pages/lms/course_wiki.py
@@ -3,7 +3,7 @@ Wiki tab on courses
 """
 
 from common.test.acceptance.pages.lms.course_page import CoursePage
-from common.test.acceptance.pages.studio.utils import type_in_codemirror
+from common.test.acceptance.pages.studio.utils import type_in_codemirror, get_codemirror_value
 
 
 class CourseWikiPage(CoursePage):
@@ -90,6 +90,13 @@ class CourseWikiEditPage(CourseWikiSubviewPage):
         with new content
         """
         type_in_codemirror(self, 0, content)
+
+    def get_wiki_editor_content(self):
+        """
+        Returns the content currently in the wiki editor.
+        """
+
+        return get_codemirror_value(self, 0)
 
     def save_wiki_content(self):
         """

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -563,7 +563,6 @@ class CourseWikiTest(UniqueCourseTest):
         self.course_wiki_edit_page.wait_for_page()
 
     @attr(shard=1)
-    @skip  # EDUCATOR-511
     def test_edit_course_wiki(self):
         """
         Wiki page by default is editable for students.
@@ -576,6 +575,7 @@ class CourseWikiTest(UniqueCourseTest):
         content = "hello"
         self._open_editor()
         self.course_wiki_edit_page.replace_wiki_content(content)
+        self.assertEqual(content, self.course_wiki_edit_page.get_wiki_editor_content())
         self.course_wiki_edit_page.save_wiki_content()
         actual_content = unicode(self.course_wiki_page.q(css='.wiki-article p').text[0])
         self.assertEqual(content, actual_content)


### PR DESCRIPTION
[EDUCATOR-511](https://openedx.atlassian.net/browse/EDUCATOR-511)

When this test failed previously, an edit had been saved, but it didn't contain the new text. It was as if the text was not actually typed into the editor.

I wanted to verify this was the issue so I added this assert. But then the test passed the next 120 times I ran it in Jenkins. So perhaps checking the text changed the timing? Or perhaps the test will still fail in the future, and then I might get more information.

FYI @jzoldak 