### PR TITLE
Update Studio help tokens following doc reorg for Publisher

### DIFF
--- a/cms/envs/help_tokens.ini
+++ b/cms/envs/help_tokens.ini
@@ -1,5 +1,5 @@
 # below are the sub-paths to the documentation for the various pages
-# NOTE: If any of these page settings change, then their corresponding test should be updated
+# NOTE: If any of these page settings change, their corresponding test must be updated
 #       in edx-platform/common/test/acceptance/tests/studio/test_studio.help.py
 [pages]
 default = course_author:index.html
@@ -12,12 +12,12 @@ updates = course_author:course_assets/handouts_updates.html
 pages = course_author:course_assets/pages.html
 files = course_author:course_assets/course_files.html
 textbooks = course_author:course_assets/textbooks.html
-schedule = course_author:set_up_course/setting_up_student_view.html
+schedule = course_author:set_up_course/studio_add_course_information/index.html
 grading = course_author:grading/index.html
-team_course = course_author:set_up_course/course_staffing.html#add-course-team-members
+team_course = course_author:set_up_course/studio_add_course_information/studio_course_staffing.html
 team_library = course_author:course_components/libraries.html#give-other-users-access-to-your-library
 advanced = course_author:index.html
-checklist = course_author:set_up_course/creating_new_course.html
+checklist = course_author:set_up_course/index.html
 import_library = course_author:course_components/libraries.html#import-a-library
 import_course = course_author:releasing_course/export_import_course.html#import-a-course
 export_library = course_author:course_components/libraries.html#export-a-library
@@ -31,7 +31,7 @@ enrollment_tracks = course_author:course_features/cohorts/cohorted_courseware.ht
 group_configurations = course_author:course_features/content_experiments/content_experiments_configure.html#set-up-group-configurations-in-edx-studio
 container = course_author:developing_course/course_components.html#components-that-contain-other-components
 video = course_author:video/video_uploads.html
-certificates = course_author:set_up_course/creating_course_certificates.html
+certificates = course_author:set_up_course/studio_add_course_information/studio_creating_certificates.html
 
 # below are the language directory names for the different locales
 [locales]

--- a/common/test/acceptance/tests/studio/test_studio_help.py
+++ b/common/test/acceptance/tests/studio/test_studio_help.py
@@ -809,7 +809,7 @@ class SettingsHelpTest(StudioCourseTest):
         Then Help link should open.
         And help url should be correct
         """
-        expected_url = _get_expected_documentation_url('/set_up_course/setting_up_student_view.html')
+        expected_url = _get_expected_documentation_url('/set_up_course/studio_add_course_information/index.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
@@ -882,7 +882,7 @@ class CourseTeamSettingsHelpTest(StudioCourseTest):
         Then Help link should open.
         And help url should be correct
         """
-        expected_url = _get_expected_documentation_url('/set_up_course/course_staffing.html#add-course-team-members')
+        expected_url = _get_expected_documentation_url('/set_up_course/studio_add_course_information/studio_course_staffing.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
@@ -1012,7 +1012,7 @@ class CertificatePageHelpTest(StudioCourseTest):
         Then Help link should open.
         And help url should be correct
         """
-        expected_url = _get_expected_documentation_url('/set_up_course/creating_course_certificates.html')
+        expected_url = _get_expected_documentation_url('/set_up_course/studio_add_course_information/studio_creating_certificates.html')
 
         # Assert that help link is correct.
         assert_nav_help_link(
@@ -1031,7 +1031,7 @@ class CertificatePageHelpTest(StudioCourseTest):
         Then Help link should open.
         And help url should be correct
         """
-        expected_url = _get_expected_documentation_url('/set_up_course/creating_course_certificates.html')
+        expected_url = _get_expected_documentation_url('/set_up_course/studio_add_course_information/studio_creating_certificates.html')
 
         # Assert that help link is correct.
         assert_side_bar_help_link(

--- a/common/test/acceptance/tests/studio/test_studio_help.py
+++ b/common/test/acceptance/tests/studio/test_studio_help.py
@@ -799,7 +799,6 @@ class SettingsHelpTest(StudioCourseTest):
 
         self.settings_page.visit()
 
-    @skip("Fix studio help links in DOC-3686")
     def test_settings_page_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Settings page.
@@ -872,7 +871,6 @@ class CourseTeamSettingsHelpTest(StudioCourseTest):
 
         self.course_team_settings_page.visit()
 
-    @skip("Fix studio help links in DOC-3686")
     def test_course_course_team_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Course Team settings page
@@ -1002,7 +1000,6 @@ class CertificatePageHelpTest(StudioCourseTest):
 
         self.certificates_page.visit()
 
-    @skip("Fix studio help links in DOC-3686")
     def test_certificate_page_nav_help(self):
         """
         Scenario: Help link in navigation bar is working on Certificate settings page
@@ -1021,7 +1018,6 @@ class CertificatePageHelpTest(StudioCourseTest):
             href=expected_url,
         )
 
-    @skip("Fix studio help links in DOC-3686")
     def test_certificate_page_side_bar_help(self):
         """
         Scenario: Help link in side bar is working Certificate settings page


### PR DESCRIPTION
To create Publisher docs, I had to do some restructuring in [Building and Running an edX Course](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/index.html). This broke a few of the Help links from Studio to the docs. This PR fixes the links. 

Reviewers:
[ ] @edx/doc 
[ ] @awaisdar001 