### PR TITLE
Prevent footer loaded via branding API from loading unused CSS

### DIFF
--- a/themes/edx.org/lms/templates/footer.html
+++ b/themes/edx.org/lms/templates/footer.html
@@ -94,23 +94,20 @@
       </div>
     </div>
 </footer>
+
 % if include_dependencies:
   <%static:js group='base_vendor'/>
   <%static:css group='style-vendor'/>
   <%include file="widgets/segment-io.html" />
   <%include file="widgets/segment-io-footer.html" />
 % endif
+
 % if bidi == 'rtl':
 <%static:css group='style-lms-footer-edx-rtl'/>
 % else:
 <%static:css group='style-lms-footer-edx'/>
 % endif
 
-% if footer_css_urls:
-  % for url in footer_css_urls:
-    <link rel="stylesheet" type="text/css" href="${url}"></link>
-  % endfor
-% endif
 % if footer_js_url:
   <script type="text/javascript" src="${footer_js_url}"></script>
 % endif


### PR DESCRIPTION
Footer HTML requested from the branding API was including two CSS files, lms-footer.css and lms-footer-edx.css. edx.org pages only require lms-footer-edx.css to render the footer. The template code being removed here appears to have been accidentally left in place during a theming change: https://github.com/edx/edx-platform/commit/c0648ab1642dfaece6f42fba9ce129e695b67b8c\#diff-439477a9ba29f7c208e25b0a535cdabeR80.

ECOM-3655

@edx/learner-growth FYI.