### PR TITLE
Remove extra div.

### DIFF
--- a/cms/templates/visibility_editor.html
+++ b/cms/templates/visibility_editor.html
@@ -49,7 +49,6 @@ is_staff_locked = ancestor_has_staff_lock(xblock)
 
 % if len(selectable_partitions) > 0:
     <form class="visibility-controls-form" method="post" action="">
-        <div role="group" aria-labelledby="visibility-title">
         <div class="modal-section visibility-controls">
             <h3 class="modal-section-title visibility-header" id="visibility-title">
                 % if selected_partition_index == -1:


### PR DESCRIPTION
This was probably left over from a previous variation (there was no closing div).

I OK'd with @cptvitamin that there was no use for this div with role group.

Sandbox: https://studio-cahrens.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc

FYI @jlajoie 