### PR TITLE
Revert "EDUCATOR-394 Disable self generation certificates when course is reset to instructor-paced."

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -1,27 +1,29 @@
-"""
-Signal handler for enabling/disabling self-generated certificates based on the course-pacing.
+""" Signal handler for enabling self-generated certificates by default
+for self-paced courses.
 """
 from celery.task import task
-from django.dispatch import receiver
+from django.dispatch.dispatcher import receiver
 from opaque_keys.edx.keys import CourseKey
 
 from certificates.models import CertificateGenerationCourseSetting
-from openedx.core.djangoapps.models.course_details import COURSE_PACING_CHANGE
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from xmodule.modulestore.django import SignalHandler
 
 
-@receiver(COURSE_PACING_CHANGE, dispatch_uid="course_pacing_changed")
-def _listen_for_course_pacing_changed(sender, course_key, course_self_paced, **kwargs):  # pylint: disable=unused-argument
+@receiver(SignalHandler.course_published)
+def _listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable=unused-argument
+    """ Catches the signal that a course has been published in Studio and
+    enable the self-generated certificates by default for self-paced
+    courses.
     """
-    Catches the signal that course pacing has changed and enable/disable
-    the self-generated certificates according to course-pacing.
-    """
-    toggle_self_generated_certs.delay(unicode(course_key), course_self_paced)
+    enable_self_generated_certs.delay(unicode(course_key))
 
 
 @task()
-def toggle_self_generated_certs(course_key, course_self_paced):
-    """
-    Enable or disable self-generated certificates for a course according to pacing.
-    """
+def enable_self_generated_certs(course_key):
+    """Enable the self-generated certificates by default for self-paced courses."""
     course_key = CourseKey.from_string(course_key)
-    CertificateGenerationCourseSetting.set_enabled_for_course(course_key, course_self_paced)
+    course = CourseOverview.get_from_id(course_key)
+    is_enabled_for_course = CertificateGenerationCourseSetting.is_enabled_for_course(course_key)
+    if course.self_paced and not is_enabled_for_course:
+        CertificateGenerationCourseSetting.set_enabled_for_course(course_key, True)

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -1,18 +1,17 @@
-"""
-Unit tests for enabling self-generated certificates for self-paced courses
-and disabling for instructor-paced courses.
+""" Unit tests for enabling self-generated certificates by default
+for self-paced courses.
 """
 from certificates import api as certs_api
 from certificates.models import CertificateGenerationConfiguration
-from certificates.signals import _listen_for_course_pacing_changed
+from certificates.signals import _listen_for_course_publish
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
 class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):
-    """
-    Tests for enabling/disabling self-generated certificates according to course-pacing.
+    """ Tests for enabling self-generated certificates by default
+    for self-paced courses.
     """
 
     def setUp(self):
@@ -22,21 +21,11 @@ class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):
         # Enable the feature
         CertificateGenerationConfiguration.objects.create(enabled=True)
 
-    def test_cert_generation_flag_on_pacing_toggle(self):
+    def test_cert_generation_enabled_for_self_paced(self):
+        """ Verify the signal enable the self-generated certificates by default for
+        self-paced courses.
         """
-        Verify that signal enables or disables self-generated certificates
-        according to course-pacing.
-        """
-        #self-generation of cert disables by default
         self.assertFalse(certs_api.cert_generation_enabled(self.course.id))
 
-        _listen_for_course_pacing_changed('store', self.course.id, self.course.self_paced)
-        #verify that self-generation of cert is enabled for self-paced course
+        _listen_for_course_publish('store', self.course.id)
         self.assertTrue(certs_api.cert_generation_enabled(self.course.id))
-
-        self.course.self_paced = False
-        self.store.update_item(self.course, self.user.id)
-
-        _listen_for_course_pacing_changed('store', self.course.id, self.course.self_paced)
-        # verify that self-generation of cert is disabled for instructor-paced course
-        self.assertFalse(certs_api.cert_generation_enabled(self.course.id))

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -5,15 +5,12 @@ import re
 import logging
 
 from django.conf import settings
-from django.dispatch import Signal
 
 from xmodule.fields import Date
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.lib.courses import course_image_url
 from xmodule.modulestore.django import modulestore
-
-COURSE_PACING_CHANGE = Signal(providing_args=["course_key", "course_self_paced"])
 
 
 # This list represents the attribute keys for a course's 'about' info.
@@ -191,7 +188,6 @@ class CourseDetails(object):
         descriptor = module_store.get_course(course_key)
 
         dirty = False
-        is_pacing_changed = False
 
         # In the descriptor's setter, the date is converted to JSON
         # using Date's to_json method. Calling to_json on something that
@@ -275,14 +271,9 @@ class CourseDetails(object):
                 and jsondict['self_paced'] != descriptor.self_paced):
             descriptor.self_paced = jsondict['self_paced']
             dirty = True
-            is_pacing_changed = True
 
         if dirty:
             module_store.update_item(descriptor, user.id)
-
-        # fires a signal indicating that the course pacing has changed
-        if is_pacing_changed:
-            COURSE_PACING_CHANGE.send(sender=None, course_key=course_key, course_self_paced=descriptor.self_paced)
 
         # NOTE: below auto writes to the db w/o verifying that any of
         # the fields actually changed to make faster, could compare


### PR DESCRIPTION
Reverts edx/edx-platform#15163

We need to revert it because the original branch was merged with a lot of commits where it should have been rebased to have one.