### PR TITLE
EDUCATOR-394 disable self-generated certificates when course is reset to instructor-paced

### DIFF
--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -1,17 +1,18 @@
-""" Unit tests for enabling self-generated certificates by default
-for self-paced courses.
+"""
+Unit tests for enabling self-generated certificates for self-paced courses
+and disabling for instructor-paced courses.
 """
 from certificates import api as certs_api
 from certificates.models import CertificateGenerationConfiguration
-from certificates.signals import _listen_for_course_publish
+from certificates.signals import _listen_for_course_pacing_changed
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
 class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):
-    """ Tests for enabling self-generated certificates by default
-    for self-paced courses.
+    """
+    Tests for enabling/disabling self-generated certificates according to course-pacing.
     """
 
     def setUp(self):
@@ -21,11 +22,21 @@ class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):
         # Enable the feature
         CertificateGenerationConfiguration.objects.create(enabled=True)
 
-    def test_cert_generation_enabled_for_self_paced(self):
-        """ Verify the signal enable the self-generated certificates by default for
-        self-paced courses.
+    def test_cert_generation_flag_on_pacing_toggle(self):
         """
+        Verify that signal enables or disables self-generated certificates
+        according to course-pacing.
+        """
+        #self-generation of cert disables by default
         self.assertFalse(certs_api.cert_generation_enabled(self.course.id))
 
-        _listen_for_course_publish('store', self.course.id)
+        _listen_for_course_pacing_changed('store', self.course.id, self.course.self_paced)
+        #verify that self-generation of cert is enabled for self-paced course
         self.assertTrue(certs_api.cert_generation_enabled(self.course.id))
+
+        self.course.self_paced = False
+        self.store.update_item(self.course, self.user.id)
+
+        _listen_for_course_pacing_changed('store', self.course.id, self.course.self_paced)
+        # verify that self-generation of cert is disabled for instructor-paced course
+        self.assertFalse(certs_api.cert_generation_enabled(self.course.id))

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -5,12 +5,15 @@ import re
 import logging
 
 from django.conf import settings
+from django.dispatch import Signal
 
 from xmodule.fields import Date
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.lib.courses import course_image_url
 from xmodule.modulestore.django import modulestore
+
+COURSE_PACING_CHANGE = Signal(providing_args=["course_key", "course_self_paced"])
 
 
 # This list represents the attribute keys for a course's 'about' info.
@@ -188,6 +191,7 @@ class CourseDetails(object):
         descriptor = module_store.get_course(course_key)
 
         dirty = False
+        is_pacing_changed = False
 
         # In the descriptor's setter, the date is converted to JSON
         # using Date's to_json method. Calling to_json on something that
@@ -271,9 +275,14 @@ class CourseDetails(object):
                 and jsondict['self_paced'] != descriptor.self_paced):
             descriptor.self_paced = jsondict['self_paced']
             dirty = True
+            is_pacing_changed = True
 
         if dirty:
             module_store.update_item(descriptor, user.id)
+
+        # fires a signal indicating that the course pacing has changed
+        if is_pacing_changed:
+            COURSE_PACING_CHANGE.send(sender=None, course_key=course_key, course_self_paced=descriptor.self_paced)
 
         # NOTE: below auto writes to the db w/o verifying that any of
         # the fields actually changed to make faster, could compare


### PR DESCRIPTION
code has already been reviewed by the reviewers in the following PR:
edx/edx-platform/pull/15163
We need to make new branch because the original branch has a lot of commits and we are unable to rebase it where it should have been rebased to have one.