### PR TITLE
Bump version of xblock-poll that resolves EDUCATOR-273

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -91,5 +91,5 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.1.4#egg=lti_consumer-xbloc
 git+https://github.com/edx/edx-proctoring.git@0.18.1#egg=edx-proctoring==0.18.1
 
 # Third Party XBlocks
-git+https://github.com/open-craft/xblock-poll@v1.2.6#egg=xblock-poll==1.2.6
+git+https://github.com/open-craft/xblock-poll@v1.2.7#egg=xblock-poll==1.2.7
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.18#egg=xblock-drag-and-drop-v2==2.0.18


### PR DESCRIPTION
This commit helps resolve the noise caused in error log because of multiple ajax calls being made as a result of multiple clicks on Submit button in poll. xblock-poll repo has been updated to mitigate the issue. Summary of the change is as follows.

**Summary:**  If submit button is clicked multiple times, multiple ajax requests are sent. To avoid this, we disable the submit button as soon as the submit button is clicked and enable it again at the end of the ajax call depending on the response from backend. This commit addresses EDUCATOR-273 issued in
openedx JIRA.

**Before:** ![before gif](https://raw.githubusercontent.com/ravi-ojha/ravi-ojha.github.io/master/assets/educator_273.gif)
See that? It creates noise in error log because of multiple ajax calls resulting in 500.


**After:** ![after gif](https://raw.githubusercontent.com/ravi-ojha/ravi-ojha.github.io/master/assets/educator_273_fix.gif)
Voila! Just one request.

