### PR TITLE
Add cryptography package to sandbox environment

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -13,6 +13,7 @@ numpy==1.6.2
 networkx==1.7
 sympy==0.7.1
 pyparsing==2.0.7
+cryptography==1.9
 
 # We forked NLTK just to make it work with setuptools instead of distribute
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
The cryptography package is designed to be the "cryptographic
standard library" for Python developers. (Documents are online
at https://cryptography.io/en/latest/).

The use case for adding this is to bring encrypted claims from
outside edX into a course for assigning a grade using CAPA.
As an example, imagine that users enrolled in a computer security
and penetration testing class on edX are challenged to advance
as many levels as possible in a certain capture-the-flag (CTF)
puzzle hosted on an external app.

The external platform may provide the users an encrypted, tamper-
resistant token allowing them to enter that into an edX CAPA
auto-graded exercise in order for the edX user to claim credit
within the edX course.

For example, the external platform might take some plaintext JSON
like this:

    {'user': 'isaac@example.com', 'score': 30}

And then use the Fernet symmetric encryption to give the user a
token like this:

    gAAAAABZQX8xwdtvpdnTtuXWQUnbTPVA-Gw5dz6-kXFuKi0_2jpqFkSG
    Dhy-BugBx38xhUfbmao9KwIhcxZt0uBAE0WT_uzjagLn7BwRIQP4Ap_B
    r4e797QQllWcaHXVHhskHk6ETohc

Because the external platform and the `loncapa/python` script share
a secret, this token (1) means nothing to the user, (2) can be
decrypted on the edX side and used accordingly, and (3) won't
work if tampered with in between.

There are probably other use cases for using tokens, HMAC, or
encryption with autograded exercises. In any case, the crytography
library is well tested and reliable, so adding it presents little
risk and will probably benefit others.

**NOTE:** the changed file says this:

    # If you open a pull request that adds a new dependency, you should notify:
    #   * @edx/ospr - to check licensing
    #   * @edx/devops - to check system requirements

Not sure how to do that despite searching around so perhaps this is old?