### PR TITLE
fixed CC logo text alternative

### DIFF
--- a/cms/templates/js/license-selector.underscore
+++ b/cms/templates/js/license-selector.underscore
@@ -98,7 +98,7 @@
                     />
             <% } else { %>
 	        <% //<span> must come before <i> icon or else spacing gets messed up %>
-                <span class="sr">gettext("Creative Commons licensed content, with terms as follow:")&nbsp;</span><span aria-hidden="true" class="icon-cc"></span>
+                <span class="sr"><%= gettext("Creative Commons licensed content, with terms as follow:") %>&nbsp;</span><span aria-hidden="true" class="icon-cc"></span>
                 <% _.each(enabled, function(option) { %>
                         <span class="sr"><%- license.options[option.toUpperCase()].name %>&nbsp;</span><span aria-hidden="true" class="icon-cc-<%- option %>"></span>
                 <% }); %>


### PR DESCRIPTION
Fixed the text alternative for the CC logo to make sure that Python evaluated the alternative text.

https://openedx.atlassian.net/browse/AC-631 