### PR TITLE
Revert "fix valid signature" from OSPR-1539

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -887,10 +887,8 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
             "Content-Type": "application/json",
             "Date": formatdate(timeval=None, localtime=False, usegmt=True)
         }
-
-        body_for_signature = {"EdX-ID": str(self.receipt_id)}
         _message, _sig, authorization = generate_signed_message(
-            "POST", headers, body_for_signature, access_key, secret_key
+            "POST", headers, body, access_key, secret_key
         )
         headers['Authorization'] = authorization
 

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1104,15 +1104,13 @@ def results_callback(request):
 
     headers = {
         "Authorization": request.META.get("HTTP_AUTHORIZATION", ""),
-        "Content-Type": "application/json",
         "Date": request.META.get("HTTP_DATE", "")
     }
 
-    body_for_signature = {"EdX-ID": body_dict.get("EdX-ID")}
     has_valid_signature(
         "POST",
         headers,
-        body_for_signature,
+        body_dict,
         settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_ACCESS_KEY"],
         settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_SECRET_KEY"]
     )


### PR DESCRIPTION
This reverts commit e58e295ca01b983d6008043ab4faf43486520523.

This is to fix LEARNER-1464

The root cause is, once we change the signature we have with SoftwareSecure, we have to ask SoftwareSecure to change the way they validate our signature as well. Otherwise, SoftwareSecure would think our request has bad signature and won't accept our call. The communication with SoftwareSecure was not done before the OSPR merge. I am reverting the OSPR merge to give ourselves a chance to talk to SoftwareSecure