### PR TITLE
Implementing connection timeout for sailthru api call.

### DIFF
--- a/lms/djangoapps/email_marketing/migrations/0005_emailmarketingconfiguration_user_registration_cookie_timeout_delay.py
+++ b/lms/djangoapps/email_marketing/migrations/0005_emailmarketingconfiguration_user_registration_cookie_timeout_delay.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('email_marketing', '0004_emailmarketingconfiguration_welcome_email_send_delay'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='emailmarketingconfiguration',
+            name='user_registration_cookie_timeout_delay',
+            field=models.FloatField(default=1.5, help_text='The number of seconds to delay/timeout wait to get cookie values from sailthru.'),
+        ),
+    ]

--- a/lms/djangoapps/email_marketing/models.py
+++ b/lms/djangoapps/email_marketing/models.py
@@ -136,6 +136,14 @@ class EmailMarketingConfiguration(ConfigurationModel):
         )
     )
 
+    # The number of seconds to delay/timeout wait to get cookie values from sailthru.
+    user_registration_cookie_timeout_delay = models.fields.FloatField(
+        default=1.5,
+        help_text=_(
+            "The number of seconds to delay/timeout wait to get cookie values from sailthru."
+        )
+    )
+
     def __unicode__(self):
         return u"Email marketing configuration: New user list %s, Activation template: %s" % \
                (self.sailthru_new_user_list, self.sailthru_activation_template)


### PR DESCRIPTION
LEARNER-1186

WIP - Implements timeout for Sailthru api call. It enables sailthru api calls to exits early, removing the latency that could be faced by caller process.