### PR TITLE
Only show 'Resume Course' button for enrolled users

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -289,7 +289,8 @@ def course_info(request, course_id):
         masquerade, user = setup_masquerade(request, course_key, staff_access, reset_masquerade_data=True)
 
         # if user is not enrolled in a course then app will show enroll/get register link inside course info page.
-        show_enroll_banner = request.user.is_authenticated() and not CourseEnrollment.is_enrolled(user, course.id)
+        user_is_enrolled = CourseEnrollment.is_enrolled(user, course.id)
+        show_enroll_banner = request.user.is_authenticated() and not user_is_enrolled
         if show_enroll_banner and hasattr(course_key, 'ccx'):
             # if course is CCX and user is not enrolled/registered then do not let him open course direct via link for
             # self registration. Because only CCX coach can register/enroll a student. If un-enrolled user try
@@ -334,6 +335,7 @@ def course_info(request, course_id):
             'supports_preview_menu': True,
             'studio_url': get_studio_url(course, 'course_info'),
             'show_enroll_banner': show_enroll_banner,
+            'user_is_enrolled': user_is_enrolled,
             'dates_fragment': dates_fragment,
             'url_to_enroll': url_to_enroll,
             # TODO: (Experimental Code). See https://openedx.atlassian.net/wiki/display/RET/2.+In-course+Verification+Prompts
@@ -343,9 +345,9 @@ def course_info(request, course_id):
         }
 
         # Get the URL of the user's last position in order to display the 'where you were last' message
-        context['last_accessed_courseware_url'] = None
+        context['resume_course_url'] = None
         if SelfPacedConfiguration.current().enable_course_home_improvements:
-            context['last_accessed_courseware_url'] = get_last_accessed_courseware(course, request, user)
+            context['resume_course_url'] = get_last_accessed_courseware(course, request, user)
 
         if not is_course_open_for_learner(user, course):
             # Disable student view button if user is staff and

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -28,7 +28,7 @@ from openedx.core.djangolib.markup import HTML, Text
       <h2 class="title">${_("You are not enrolled yet")}</h2>
       <div class="copy">
         <p class='enroll-message'>
-          ${Text(_("You are not currently enrolled in this course. {link_start}Sign up now!{link_end}")).format(
+          ${Text(_("You are not currently enrolled in this course. {link_start}Enroll now!{link_end}")).format(
                 link_start=HTML("<a href={}>").format(url_to_enroll),
                 link_end=HTML("</a>")
           )}
@@ -69,9 +69,9 @@ from openedx.core.djangolib.markup import HTML, Text
               <div class="page-subtitle">${course.display_name_with_default}</div>
             </h2>
         </div>
-        % if last_accessed_courseware_url:
+        % if resume_course_url and user_is_enrolled:
           <div class="page-header-secondary">
-              <a href="${last_accessed_courseware_url}" class="last-accessed-link">${_("Resume Course")}</a>
+              <a href="${resume_course_url}" class="last-accessed-link">${_("Resume Course")}</a>
           </div>
         % endif
       </div>


### PR DESCRIPTION
## [LEARNER-198](https://openedx.atlassian.net/browse/LEARNER-198)

### Description
The 'Resume Course' button was appearing for users that were not logged in, as well as users that were logged in but not enrolled in the course. This small fix assures that only enrolled users can view the button.

### Sandbox
- [x] https://pr198.sandbox.edx.org (specific course link [here](https://pr198.sandbox.edx.org/courses/course-v1:DemoX+PERF101+course/info)).

### Testing
- [x] Go to a courses' info page before logging in and assure you can not see the button. Then log in and go back to the page (assuring that you are not enrolled) and confirm the button is not there. Finally, go to the info page for a course that you are enrolled in and confirm it still exists.

### Reviewers
- [x] Assign reviewers to your PR based on the changes it contains (Dev, Doc, UX, Accessibility, Product, DevOps)

List optional/FYI reviewers here:
 
### Post-review
- [x] Rebase and squash commits