### PR TITLE
Fix EDUCATOR-269: Don't show "Issue Open Badges" if the feature is disabled

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -98,6 +98,11 @@ class CourseMetadata(object):
             filtered_list.append('enable_ccx')
             filtered_list.append('ccx_connector')
 
+        # Do not show "Issue Open Badges" in Studio Advanced Settings
+        # if the feature is disabled.
+        if not settings.FEATURES.get('ENABLE_OPENBADGES'):
+            filtered_list.append('issue_badges')
+
         # If the XBlockStudioConfiguration table is not being used, there is no need to
         # display the "Allow Unsupported XBlocks" setting.
         if not XBlockStudioConfigurationFlag.is_enabled():

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -98,6 +98,9 @@ FEATURES['ENABLE_VIDEO_BUMPER'] = True  # Enable video bumper in Studio settings
 
 FEATURES['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = True
 
+# Enable support for OpenBadges accomplishments
+FEATURES['ENABLE_OPENBADGES'] = True
+
 # Enable partner support link in Studio footer
 PARTNER_SUPPORT_EMAIL = 'partner-support@example.com'
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -218,6 +218,9 @@ FEATURES = {
     # Show video bumper in Studio
     'ENABLE_VIDEO_BUMPER': False,
 
+    # Show issue open badges in Studio
+    'ENABLE_OPENBADGES': False,
+
     # How many seconds to show the bumper again, default is 7 days:
     'SHOW_BUMPER_PERIODICITY': 7 * 24 * 3600,
 


### PR DESCRIPTION
**Summary:** We show "Issue Open Badges" setting in Studio -> Course -> Settings -> Advanced Settings, even if the flag `ENABLE_OPENBADGES` is set to `False`. With this commit, it will only show up in Advanced Settings if `ENABLE_OPENBADGES` is set to `True`. This commit fixes bug EDUCATOR-269.