### PR TITLE
Don't allow any user to create courses by default (backport to Ficus)

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -130,8 +130,8 @@ FEATURES = {
     'AUTOPLAY_VIDEOS': False,
 
     # If set to True, new Studio users won't be able to author courses unless
-    # edX has explicitly added them to the course creator group.
-    'ENABLE_CREATOR_GROUP': False,
+    # an Open edX admin has added them to the course creator group.
+    'ENABLE_CREATOR_GROUP': True,
 
     # whether to use password policy enforcement or not
     'ENFORCE_PASSWORD_POLICY': False,

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -121,6 +121,9 @@ SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
 ########################## Certificates Web/HTML View #######################
 FEATURES['CERTIFICATES_HTML_VIEW'] = True
 
+########################## AUTHOR PERMISSION #######################
+FEATURES['ENABLE_CREATOR_GROUP'] = False
+
 ################################# DJANGO-REQUIRE ###############################
 
 # Whether to run django-require in debug mode.

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -319,6 +319,9 @@ FEATURES['ENABLE_LIBRARY_INDEX'] = True
 SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
 
 
+########################## AUTHOR PERMISSION #######################
+FEATURES['ENABLE_CREATOR_GROUP'] = False
+
 # teams feature
 FEATURES['ENABLE_TEAMS'] = True
 


### PR DESCRIPTION
In f095c5fec6507ba38552b0e02530e8ce981ffcbe it was decided to enable
anyone to make courses in Studio by default in order to make things
easier in dev environments. This was before the code was open source.
This default is likely in effect for many Open edX instances, but almost
no one would want this setting outside of development.