### PR TITLE
EDUCATOR-341: Truncate title in thread created event to 1000 chars

### DIFF
--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -1427,6 +1427,45 @@ class CreateThreadTest(
         SharedModuleStoreTestCase,
         MockSignalHandlerMixin
 ):
+    LONG_TITLE = (
+        'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. '
+        'Aenean commodo ligula eget dolor. Aenean massa. Cum sociis '
+        'natoque penatibus et magnis dis parturient montes, nascetur '
+        'ridiculus mus. Donec quam felis, ultricies nec, '
+        'pellentesque eu, pretium quis, sem. Nulla consequat massa '
+        'quis enim. Donec pede justo, fringilla vel, aliquet nec, '
+        'vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet '
+        'a, venenatis vitae, justo. Nullam dictum felis eu pede '
+        'mollis pretium. Integer tincidunt. Cras dapibus. Vivamus '
+        'elementum semper nisi. Aenean vulputate eleifend tellus. '
+        'Aenean leo ligula, porttitor eu, consequat vitae, eleifend '
+        'ac, enim. Aliquam lorem ante, dapibus in, viverra quis, '
+        'feugiat a, tellus. Phasellus viverra nulla ut metus varius '
+        'laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies '
+        'nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam '
+        'eget dui. Etiam rhoncus. Maecenas tempus, tellus eget '
+        'condimentum rhoncus, sem quam semper libero, sit amet '
+        'adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, '
+        'luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et '
+        'ante tincidunt tempus. Donec vitae sapien ut libero '
+        'venenatis faucibus. Nullam quis ante. Etiam sit amet orci '
+        'eget eros faucibus tincidunt. Duis leo. Sed fringilla '
+        'mauris sit amet nibh. Donec sodales sagittis magna. Sed '
+        'consequat, leo eget bibendum sodales, augue velit cursus '
+        'nunc, quis gravida magna mi a libero. Fusce vulputate '
+        'eleifend sapien. Vestibulum purus quam, scelerisque ut, '
+        'mollis sed, nonummy id, metus. Nullam accumsan lorem in '
+        'dui. Cras ultricies mi eu turpis hendrerit fringilla. '
+        'Vestibulum ante ipsum primis in faucibus orci luctus et '
+        'ultrices posuere cubilia Curae; In ac dui quis mi '
+        'consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu '
+        'tortor, suscipit eget, imperdiet nec, imperdiet iaculis, '
+        'ipsum. Sed aliquam ultrices mauris. Integer ante arcu, '
+        'accumsan a, consectetuer eget, posuere ut, mauris. Praesent '
+        'adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc '
+        'nonummy metus.'
+    )
+
     """Tests for create_thread"""
     @classmethod
     def setUpClass(cls):
@@ -1489,6 +1528,42 @@ class CreateThreadTest(
                 "group_id": None,
                 "thread_type": "discussion",
                 "title": "Test Title",
+                "title_truncated": False,
+                "anonymous": False,
+                "anonymous_to_peers": False,
+                "options": {"followed": False},
+                "id": "test_id",
+                "truncated": False,
+                "body": "Test body",
+                "url": "",
+                "user_forums_roles": [FORUM_ROLE_STUDENT],
+                "user_course_roles": [],
+            }
+        )
+
+    @mock.patch("eventtracking.tracker.emit")
+    def test_title_truncation(self, mock_emit):
+        data = self.minimal_data.copy()
+        data['title'] = self.LONG_TITLE
+
+        cs_thread = make_minimal_cs_thread({
+            "id": "test_id",
+            "username": self.user.username,
+            "read": True,
+        })
+        self.register_post_thread_response(cs_thread)
+        with self.assert_signal_sent(api, 'thread_created', sender=None, user=self.user, exclude_args=('post',)):
+            actual = create_thread(self.request, data)
+        event_name, event_data = mock_emit.call_args[0]
+        self.assertEqual(event_name, "edx.forum.thread.created")
+        self.assertEqual(
+            event_data,
+            {
+                "commentable_id": "test_topic",
+                "group_id": None,
+                "thread_type": "discussion",
+                "title": self.LONG_TITLE[:1000],
+                "title_truncated": True,
                 "anonymous": False,
                 "anonymous_to_peers": False,
                 "options": {"followed": False},

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -50,6 +50,7 @@ from util.file import store_uploaded_file
 log = logging.getLogger(__name__)
 
 TRACKING_MAX_FORUM_BODY = 2000
+TRACKING_MAX_FORUM_TITLE = 1000
 _EVENT_NAME_TEMPLATE = 'edx.forum.{obj_type}.{action_name}'
 
 
@@ -94,6 +95,11 @@ def track_created_event(request, event_name, course, obj, data):
     track_forum_event(request, event_name, course, obj, data)
 
 
+def add_truncated_title_to_event_data(event_data, full_title):
+    event_data['title_truncated'] = (len(full_title) > TRACKING_MAX_FORUM_TITLE)
+    event_data['title'] = full_title[:TRACKING_MAX_FORUM_TITLE]
+
+
 def track_thread_created_event(request, course, thread, followed):
     """
     Send analytics event for a newly created thread.
@@ -103,7 +109,6 @@ def track_thread_created_event(request, course, thread, followed):
         'commentable_id': thread.commentable_id,
         'group_id': thread.get("group_id"),
         'thread_type': thread.thread_type,
-        'title': thread.title,
         'anonymous': thread.anonymous,
         'anonymous_to_peers': thread.anonymous_to_peers,
         'options': {'followed': followed},
@@ -112,6 +117,7 @@ def track_thread_created_event(request, course, thread, followed):
         # However, the view does not contain that data, and including it will
         # likely require changes elsewhere.
     }
+    add_truncated_title_to_event_data(event_data, thread.title)
     track_created_event(request, event_name, course, thread, event_data)
 
 


### PR DESCRIPTION
The ticket [EDUCATOR-341](https://openedx.atlassian.net/browse/EDUCATOR-341), which is being implemented in #15237, introduces a new event: `edx.forum.thread.viewed`. One field in that event is the thread's `title`. Thread titles have no limit to their length; however, tracking events are not logged if their length is longer than 50,000 characters (see [this](https://github.com/edx/event-tracking/blob/master/eventtracking/backends/logger.py#L41) and [this](https://github.com/edx/edx-platform/blob/master/lms/envs/common.py#L651)). So, it was decided that thread titles should be truncated to 1,000 characters in `edx.forum.thread.viewed`. The reasoning behind the decision can be viewed [here](https://openedx.atlassian.net/wiki/pages/resumedraft.action?draftId=159276399&draftShareId=cb93b857-deb9-49e2-9253-8061bfe19ab8&) in the "Design Concerns" section.

For the sake of consistency, this PR first changes the `edx.forum.thread.created` event to truncate its `title` field as well.

@edx/educator-dahlia 