### PR TITLE
Re-introduce "Fix valid signature" from OSPR-1539

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -887,8 +887,10 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
             "Content-Type": "application/json",
             "Date": formatdate(timeval=None, localtime=False, usegmt=True)
         }
+
+        body_for_signature = {"EdX-ID": str(self.receipt_id)}
         _message, _sig, authorization = generate_signed_message(
-            "POST", headers, body, access_key, secret_key
+            "POST", headers, body_for_signature, access_key, secret_key
         )
         headers['Authorization'] = authorization
 

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1104,13 +1104,15 @@ def results_callback(request):
 
     headers = {
         "Authorization": request.META.get("HTTP_AUTHORIZATION", ""),
+        "Content-Type": "application/json",
         "Date": request.META.get("HTTP_DATE", "")
     }
 
+    body_for_signature = {"EdX-ID": body_dict.get("EdX-ID")}
     has_valid_signature(
         "POST",
         headers,
-        body_dict,
+        body_for_signature,
         settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_ACCESS_KEY"],
         settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_SECRET_KEY"]
     )


### PR DESCRIPTION
This reverts commit 4ce1222e998abc8d6d4664ad78f4653af6ce5934.

Because we reverted this change for LEARNER-1464, I would like to introduce this change back.
I will be talking with Software Secure on this signature change and only will merge after we developed a plan to integrate this change with SoftwareSecure.