### PR TITLE
Use standard 'url' templatetag - deprecated/removed from future.

### DIFF
--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 {% load sekizai_tags i18n configuration theme_pipeline optional_include staticfiles %}
-{% load url from future %}
 <html lang="{{LANGUAGE_CODE}}">
 <head>
   <meta charset="UTF-8">

--- a/lms/templates/registration/password_reset_email.html
+++ b/lms/templates/registration/password_reset_email.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load url from future %}{% autoescape off %}
+{% load i18n %}{% autoescape off %}
 {% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new password:" %}

--- a/lms/templates/wiki/article.html
+++ b/lms/templates/wiki/article.html
@@ -1,6 +1,5 @@
 {% extends "wiki/base.html" %}
 {% load wiki_tags i18n %}
-{% load url from future %}
 
 {% block pagetitle %}{{ article.current_revision.title }}{% endblock %}
 

--- a/lms/templates/wiki/base.html
+++ b/lms/templates/wiki/base.html
@@ -1,6 +1,6 @@
 {% extends "main_django.html" %}
 {% with online_help_token="wiki" %}
-{% load theme_pipeline %}{% load sekizai_tags i18n configuration %}{% load url from future %}{% load staticfiles %}
+{% load theme_pipeline %}{% load sekizai_tags i18n configuration %}{% load staticfiles %}
 
 {% block title %}
   {% block pagetitle %}{% endblock %} | {% trans "Wiki" %} | {% platform_name %}

--- a/lms/templates/wiki/create.html
+++ b/lms/templates/wiki/create.html
@@ -1,6 +1,5 @@
 {% extends "wiki/base.html" %}
 {% load wiki_tags i18n sekizai_tags %}
-{% load url from future %}
 
 {% block pagetitle %}{% trans "Add new article" %}{% endblock %}
 

--- a/lms/templates/wiki/delete.html
+++ b/lms/templates/wiki/delete.html
@@ -1,6 +1,5 @@
 {% extends "wiki/base.html" %}
 {% load wiki_tags i18n sekizai_tags %}
-{% load url from future %}
 
 {% block pagetitle %}{% trans "Delete article" %}{% endblock %}
 

--- a/lms/templates/wiki/edit.html
+++ b/lms/templates/wiki/edit.html
@@ -1,6 +1,5 @@
 {% extends "wiki/article.html" %}
 {% load wiki_tags i18n sekizai_tags %}
-{% load url from future %}
 
 {% block pagetitle %}{% trans "Edit" %}: {{ article.current_revision.title }}{% endblock %}
 

--- a/lms/templates/wiki/history.html
+++ b/lms/templates/wiki/history.html
@@ -1,6 +1,5 @@
 {% extends "wiki/article.html" %}
 {% load wiki_tags i18n sekizai_tags %}
-{% load url from future %}
 
 {% block pagetitle %}{% trans "History" %}: {{ article.current_revision.title }}{% endblock %}
 

--- a/lms/templates/wiki/includes/anonymous_blocked.html
+++ b/lms/templates/wiki/includes/anonymous_blocked.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load url from future %}
 <em>
 {% url 'wiki:signup' as signup_url %}
 {% url 'wiki:login' as login_url %}

--- a/lms/templates/wiki/plugins/attachments/index.html
+++ b/lms/templates/wiki/plugins/attachments/index.html
@@ -1,6 +1,5 @@
 {% extends "wiki/article.html" %}
 {% load wiki_tags i18n humanize %}
-{% load url from future %}
 
 {% block pagetitle %}{% trans "Attachments" %}: {{ article.current_revision.title }}{% endblock %}
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-1562

From the [Django 1.9 Release Notes](https://docs.djangoproject.com/en/1.11/releases/1.9/):
"ssi and url template tags are removed from the future template tag library."
The tags are now in the built-in default template tag library:
https://docs.djangoproject.com/en/1.9/ref/templates/builtins/#url