### PR TITLE
Add locale to JWT payload

### DIFF
--- a/openedx/core/djangoapps/credit/tests/test_api.py
+++ b/openedx/core/djangoapps/credit/tests/test_api.py
@@ -664,7 +664,7 @@ class CreditRequirementApiTests(CreditApiTestBase):
         self.assertFalse(api.is_user_eligible_for_credit(user.username, self.course_key))
 
         # Satisfy the other requirement
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(25):
             api.set_credit_requirement_status(
                 user,
                 self.course_key,

--- a/openedx/core/lib/token_utils.py
+++ b/openedx/core/lib/token_utils.py
@@ -100,7 +100,7 @@ class JwtBuilder(object):
 
         language = None
         try:
-            user_preference = UserPreference.objects.get(user=self.user)
+            user_preference = UserPreference.objects.get(user=self.user, key='pref-lang')
             language = user_preference.get_all_preferences(self.user).get('pref-lang')
         except UserPreference.DoesNotExist:
             log.debug("UserPreference for User: '{}' does not exist.".format(self.user))

--- a/openedx/core/lib/token_utils.py
+++ b/openedx/core/lib/token_utils.py
@@ -100,7 +100,7 @@ class JwtBuilder(object):
 
         language = None
         try:
-            user_preference = UserPreference.objects.get(user=self.user, key='pref-lang')
+            user_preference = self.user.preferences.get(key='pref-lang')
             language = user_preference.get_all_preferences(self.user).get('pref-lang')
         except UserPreference.DoesNotExist:
             log.debug("UserPreference for User: '{}' does not exist.".format(self.user))


### PR DESCRIPTION
Add locale to the JWT payload. Precursor to sharing locale between different services such as credentials and ecommerce. 