### PR TITLE
Upgrade django-config-models to 0.1.8

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -17,7 +17,7 @@ defusedxml==0.4.1
 django-babel-underscore==0.5.1
 markey==0.8  # From django-babel-underscore
 django-celery==3.2.1
-django-config-models==0.1.3
+django-config-models==0.1.8
 django-countries==4.0
 django-extensions==1.5.9
 django-filter==0.11.0


### PR DESCRIPTION
- Work is to support the Django 1.11 upgrade task PLAT-1441