### PR TITLE
send small bulk emails out on the default queue

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -265,9 +265,9 @@ BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS = ENV_TOKENS.get(
 # We have to reset the value here, since we have changed the value of the queue name.
 BULK_EMAIL_ROUTING_KEY = ENV_TOKENS.get('BULK_EMAIL_ROUTING_KEY', HIGH_PRIORITY_QUEUE)
 
-# We can run smaller jobs on the low priority queue. See note above for why
+# We can run smaller jobs on the default priority queue. See note above for why
 # we have to reset the value here.
-BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = ENV_TOKENS.get('BULK_EMAIL_ROUTING_KEY_SMALL_JOBS', LOW_PRIORITY_QUEUE)
+BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = ENV_TOKENS.get('BULK_EMAIL_ROUTING_KEY_SMALL_JOBS', DEFAULT_PRIORITY_QUEUE)
 
 # Queue to use for updating persistent grades
 RECALCULATE_GRADES_ROUTING_KEY = ENV_TOKENS.get('RECALCULATE_GRADES_ROUTING_KEY', LOW_PRIORITY_QUEUE)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1883,7 +1883,7 @@ BULK_EMAIL_ROUTING_KEY = HIGH_PRIORITY_QUEUE
 
 # We also define a queue for smaller jobs so that large courses don't block
 # smaller emails (see BULK_EMAIL_JOB_SIZE_THRESHOLD setting)
-BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = LOW_PRIORITY_QUEUE
+BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = DEFAULT_PRIORITY_QUEUE
 
 # For emails with fewer than these number of recipients, send them through
 # a different queue to avoid large courses blocking emails that are meant to be

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -221,9 +221,9 @@ if 'loc_cache' not in CACHES:
 # We have to reset the value here, since we have changed the value of the queue name.
 BULK_EMAIL_ROUTING_KEY = HIGH_PRIORITY_QUEUE
 
-# We can run smaller jobs on the low priority queue. See note above for why
+# We can run smaller jobs on the default priority queue. See note above for why
 # we have to reset the value here.
-BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = LOW_PRIORITY_QUEUE
+BULK_EMAIL_ROUTING_KEY_SMALL_JOBS = DEFAULT_PRIORITY_QUEUE
 
 LANGUAGE_DICT = dict(LANGUAGES)
 


### PR DESCRIPTION
As far as I can tell, right now only the job to send small bulk emails and the job to dump courses to coursegraph are using the low priority queue. Since dumping every course to coursegraph will load the queue up with thousands of tasks, my worry is that, on the few occasions when we do do that, those small email jobs will be stuck behind the coursegraph jobs.

Instead, I think we should move the small bulk email jobs to the default queue, so that we don't have to worry about what happens to them when we dump every course to coursegraph.

Reviewers:
- [ ] @fredsmith 
- [ ] @jibsheet 

@efischer19 , FYI