### PR TITLE
TestWelcomeMessageView shouldn't care about test order

### DIFF
--- a/openedx/features/course_experience/tests/views/test_welcome_message.py
+++ b/openedx/features/course_experience/tests/views/test_welcome_message.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from .test_course_updates import create_course_update, remove_course_updates
@@ -27,32 +27,24 @@ def welcome_message_url(course):
     )
 
 
-class TestWelcomeMessageView(SharedModuleStoreTestCase):
+class TestWelcomeMessageView(ModuleStoreTestCase):
     """
     Tests for the course welcome message fragment view.
     """
-    @classmethod
-    def setUpClass(cls):
-        """Set up the simplest course possible."""
-        # setUpClassAndTestData() already calls setUpClass on SharedModuleStoreTestCase
-        # pylint: disable=super-method-not-called
-        with super(TestWelcomeMessageView, cls).setUpClassAndTestData():
-            with cls.store.default_store(ModuleStoreEnum.Type.split):
-                cls.course = CourseFactory.create()
-                with cls.store.bulk_operations(cls.course.id):
-                    # Create a basic course structure
-                    chapter = ItemFactory.create(category='chapter', parent_location=cls.course.location)
-                    section = ItemFactory.create(category='sequential', parent_location=chapter.location)
-                    ItemFactory.create(category='vertical', parent_location=section.location)
-
-    @classmethod
-    def setUpTestData(cls):
-        """Set up and enroll our fake user in the course."""
-        cls.user = UserFactory(password=TEST_PASSWORD)
-        CourseEnrollment.enroll(cls.user, cls.course.id)
-
     def setUp(self):
+        """Set up the simplest course possible, then set up and enroll our fake user in the course."""
         super(TestWelcomeMessageView, self).setUp()
+        with self.store.default_store(ModuleStoreEnum.Type.split):
+            self.course = CourseFactory.create()
+            with self.store.bulk_operations(self.course.id):
+                # Create a basic course structure
+                chapter = ItemFactory.create(category='chapter', parent_location=self.course.location)
+                section = ItemFactory.create(category='sequential', parent_location=chapter.location)
+                ItemFactory.create(category='vertical', parent_location=section.location)
+
+        self.user = UserFactory(password=TEST_PASSWORD)
+        CourseEnrollment.enroll(self.user, self.course.id)
+
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
 
     def tearDown(self):


### PR DESCRIPTION
Was running into an issue when running `paver test_system`, which calls tests with the `--with-randomly` flag and therefore shuffles test ordering, that caused runs of this test class to fail due to changed state in one of the tests.  This change:
* has the test class inherit from `ModuleStoreTestCase`
* Moves all of the setup to `setUp()` and out of `setUpClass()`

Reviewers:
- [x] @ormsbee (thanks for pointing out the fix, BTW!)

FYI Reviewers:
@edx/educator-all 