### PR TITLE
ENT-367: Remove enterprise cookie when it is not needed any further.

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -150,7 +150,15 @@ def login_and_registration_form(request, initial_mode="login"):
 
     context = update_context_for_enterprise(request, context)
 
-    return render_to_response('student_account/login_and_register.html', context)
+    response = render_to_response('student_account/login_and_register.html', context)
+
+    # Remove enterprise cookie so that subsequent requests show default login page.
+    response.delete_cookie(
+        configuration_helpers.get_value("ENTERPRISE_CUSTOMER_COOKIE_NAME", settings.ENTERPRISE_CUSTOMER_COOKIE_NAME),
+        domain=configuration_helpers.get_value("BASE_COOKIE_DOMAIN", settings.BASE_COOKIE_DOMAIN),
+    )
+
+    return response
 
 
 @require_http_methods(['POST'])

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -953,7 +953,6 @@ ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES = ENV_TOKENS.get(
     ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES
 )
 
-
 ############## ENTERPRISE SERVICE API CLIENT CONFIGURATION ######################
 # The LMS communicates with the Enterprise service via the EdxRestApiClient class
 # The below environmental settings are utilized by the LMS when interacting with
@@ -991,6 +990,10 @@ ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS = set(
         'ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS',
         ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS
     )
+)
+BASE_COOKIE_DOMAIN = ENV_TOKENS.get(
+    'BASE_COOKIE_DOMAIN',
+    BASE_COOKIE_DOMAIN
 )
 
 ############## CATALOG/DISCOVERY SERVICE API CLIENT CONFIGURATION ######################

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3177,6 +3177,7 @@ ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS = {
     'mailing_address',
 }
 ENTERPRISE_CUSTOMER_COOKIE_NAME = 'enterprise_customer_uuid'
+BASE_COOKIE_DOMAIN = 'localhost'
 
 ############## Settings for Course Enrollment Modes ######################
 COURSE_ENROLLMENT_MODES = {


### PR DESCRIPTION
Hi @douglashall , @brittneyexline , @zubair-arbi , @asadiqbal08 

Please take a look at this, This PR adds the functionality to support the following use case.

1. Visit offers page using enterprise coupon URL.
2. Select course.
3. Verify you are redirected to logistration page with enterprise side bar displayed.
4. Create an account.
5. Log out.
6. In the same browser window, visit /login or /register.
7. Verify the enterprise sidebar is not displayed.
