### PR TITLE
ENT-447 Add ability to hide auth warnings for enterprise context.

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -220,6 +220,7 @@ def update_context_for_enterprise(request, context):
         )
         context.update(sidebar_context)
         context['enable_enterprise_sidebar'] = True
+        context['data']['hide_auth_warnings'] = True
     else:
         context['enable_enterprise_sidebar'] = False
 

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -74,6 +74,7 @@
                     this.supportURL = options.support_link;
                     this.passwordResetSupportUrl = options.password_reset_support_link;
                     this.createAccountOption = options.account_creation_allowed;
+                    this.hideAuthWarnings = options.hide_auth_warnings || false;
 
                 // The login view listens for 'sync' events from the reset model
                     this.resetModel = new PasswordResetModel({}, {
@@ -131,7 +132,8 @@
                             platformName: this.platformName,
                             supportURL: this.supportURL,
                             passwordResetSupportUrl: this.passwordResetSupportUrl,
-                            createAccountOption: this.createAccountOption
+                            createAccountOption: this.createAccountOption,
+                            hideAuthWarnings: this.hideAuthWarnings
                         });
 
                     // Listen for 'password-help' event to toggle sub-views
@@ -167,7 +169,8 @@
                             fields: data.fields,
                             model: model,
                             thirdPartyAuth: this.thirdPartyAuth,
-                            platformName: this.platformName
+                            platformName: this.platformName,
+                            hideAuthWarnings: this.hideAuthWarnings
                         });
 
                     // Listen for 'auth-complete' event so we can enroll/redirect the user appropriately.

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -48,6 +48,7 @@
                 this.passwordResetSupportUrl = data.passwordResetSupportUrl;
                 this.createAccountOption = data.createAccountOption;
                 this.accountActivationMessages = data.accountActivationMessages;
+                this.hideAuthWarnings = data.hideAuthWarnings;
 
                 this.listenTo(this.model, 'sync', this.saveSuccess);
                 this.listenTo(this.resetModel, 'sync', this.resetEmail);
@@ -193,8 +194,10 @@
                 if (error.status === 403 &&
                  error.responseText === 'third-party-auth' &&
                  this.currentProvider) {
-                    this.clearFormErrors();
-                    this.renderAuthWarning();
+                    if (!this.hideAuthWarnings) {
+                        this.clearFormErrors();
+                        this.renderAuthWarning();
+                    }
                 } else {
                     this.renderErrors(this.defaultFormErrorsTitle, this.errors);
                 }

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -37,6 +37,7 @@
                     this.errorMessage = data.thirdPartyAuth.errorMessage || '';
                     this.platformName = data.platformName;
                     this.autoSubmit = data.thirdPartyAuth.autoSubmitRegForm;
+                    this.hideAuthWarnings = data.hideAuthWarnings;
 
                     this.listenTo(this.model, 'sync', this.saveSuccess);
                 },
@@ -63,7 +64,7 @@
                     // Must be called after postRender, since postRender sets up $formFeedback.
                     if (this.errorMessage) {
                         this.renderErrors(formErrorsTitle, [this.errorMessage]);
-                    } else if (this.currentProvider) {
+                    } else if (this.currentProvider && !this.hideAuthWarnings) {
                         this.renderAuthWarning();
                     }
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.1.1
-edx-enterprise==0.36.3
+edx-enterprise==0.36.5
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.4


### PR DESCRIPTION
When a user comes in through an sso provider and arrives at the login
or registration page, there is a warning message that comes up to indicate
that the user has to take an action to sign in and register and thus
link their sso account to their edx account. However, it is confusing,
particularly for the enterpise context. This diff disables these messages
from being rendered if these pages are being shown in an enterprise context.

Sandbox link: https://brittneyexline.sandbox.edx.org/enterprise/3d3fa892-58e0-435f-b7d2-37a45b3ce18c/course/course-v1:edX+DemoX+Demo_Course/enroll/
