### PR TITLE
Add flag to configure whether "Notify users by email" is checked by default.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -388,6 +388,10 @@ FEATURES = {
 
     # Allow users to change their email address.
     'ALLOW_EMAIL_ADDRESS_CHANGE': True,
+
+    # Whether to check the "Notify users by email" checkbox in the batch enrollment form
+    # in the instructor dashboard.
+    'BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT': True,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -64,7 +64,8 @@ from django.utils.translation import ugettext as _
     </div>
     <div class="enroll-option">
         <label class="has-hint">
-            <input type="checkbox" name="email-students" id="email-students" value="Notify-students-by-email" checked="yes" aria-describedby="heading-batch-enrollment">
+          <input type="checkbox" name="email-students" id="email-students" value="Notify-students-by-email" aria-describedby="heading-batch-enrollment"
+                 ${'checked="yes"' if settings.FEATURES.get('BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT') else ''}>
             <span class="label-text">${_("Notify users by email")}</span>
             <div class="hint email-students-hint">
                 <span class="hint-caret"></span>


### PR DESCRIPTION
The batch enrollment form in the instructor dashboard has a feature to notify users, which is enabled by default:

![image](https://user-images.githubusercontent.com/249196/27481330-50cdfe58-581c-11e7-822b-672efd329a1c.png)

One of our customers never wants to send these emails, but accidentally did so a few times since they forgot to uncheck the checkbox.  This PR makes the default state of that checkbox configurable.

**JIRA tickets**: [OSPR-1798](https://openedx.atlassian.net/browse/OSPR-1798)

**Discussions**: None

**Dependencies**: None

**Screenshots**: See above

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

On the devstack, add the `BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT` feature flag to the `FEATURES` dictionary in `lms.env.json`:

    ...
    "FEATURES": {
        "BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT": false,
        ...

Log in as the staff user, navigate to the "Membership" tab in the instructor dashboard on some course and notice that the status of the "Notify users by email" checkbox matches the setting.

**Author notes and concerns**:

I'm not sure whether this should be implemented using a configuration model.

**Reviewers**
- [ ] @itsjeyd 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT: false
```