### PR TITLE
Allow lower- and mixed-case country default values on registration form

### DIFF
--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -935,7 +935,15 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
             }
         )
 
-    def test_register_form_third_party_auth_running_google(self):
+    @ddt.data(
+        ('pk', 'PK'),
+        ('Pk', 'PK'),
+        ('pK', 'PK'),
+        ('PK', 'PK'),
+        ('us', 'US'),
+    )
+    @ddt.unpack
+    def test_register_form_third_party_auth_running_google(self, input_country_code, expected_country_code):
         no_extra_fields_setting = {}
         country_options = (
             [
@@ -948,7 +956,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 {
                     "value": country_code,
                     "name": unicode(country_name),
-                    "default": True if country_code == "PK" else False
+                    "default": True if country_code == expected_country_code else False
                 }
                 for country_code, country_name in SORTED_COUNTRIES
             ]
@@ -960,7 +968,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
             email="bob@example.com",
             fullname="Bob",
             username="Bob123",
-            country="PK"
+            country=input_country_code
         ):
             self._assert_password_field_hidden(no_extra_fields_setting)
             self._assert_social_auth_provider_present(no_extra_fields_setting, provider)
@@ -1025,7 +1033,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 {
                     u"label": u"Country",
                     u"name": u"country",
-                    u"defaultValue": u"PK",
+                    u"defaultValue": expected_country_code,
                     u"type": u"select",
                     u"required": True,
                     u"options": country_options,

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -787,6 +787,14 @@ class RegistrationView(APIView):
         country_label = _(u"Country")
         error_msg = _(u"Please select your Country.")
 
+        # If we set a country code, make sure it's uppercase for the sake of the form.
+        default_country = form_desc._field_overrides.get('country', {}).get('defaultValue')
+        if default_country:
+            form_desc.override_field_properties(
+                'country',
+                default=default_country.upper()
+            )
+
         form_desc.add_field(
             "country",
             label=country_label,


### PR DESCRIPTION
Some SSO providers may provide a country code in lower- or mixed-case formats. Since our registration form only accepts upper-case format, this pull request updates those received default values to be upper-case for proper matching.

**JIRA tickets**: Fixes bug in [ENT-423](https://openedx.atlassian.net/browse/ENT-423)

**Dependencies**: None

**Screenshots**: N/A

**Partner information**: (if applicable - see below)

**Merge deadline**: ASAP

**Testing instructions**:

1. Add an `import pdb; pdb.set_trace()` statement at line 789 in `openedx/core/djangoapps/user_api/views.py`.
2. Browse to the registration page.
3. In the console, simulate an SSO pipeline inserting a lower-case country code by doing the following:
    ```python
    (pdb) form_desc._field_overrides['country']['defaultValue'] = 'pk'
    (pdb) c
    ```
4. Verify that on the registration page, the Country field is automatically filled out as "Pakistan", the country code for which is `PK`.
5. You can perform additional validation by, with the existing edx-platform code, performing the same operations, and verifying that the default country remains blank, since there's no country with the lowercase code `pk`.


**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```