### PR TITLE
PLAT-1229 Support for JS tests in Docker devstack

### DIFF
--- a/common/static/common/js/karma.common.conf.js
+++ b/common/static/common/js/karma.common.conf.js
@@ -34,6 +34,7 @@
 //
 
 /* eslint-env node */
+/* globals process */
 
 'use strict';
 
@@ -255,6 +256,11 @@ function getBaseConfig(config, useRequireJs) {
         });
     };
 
+    var hostname = 'localhost';
+    if (process.env.hasOwnProperty('BOK_CHOY_HOSTNAME')) {
+        hostname = process.env.BOK_CHOY_HOSTNAME;
+    }
+
     initFrameworks.$inject = ['config.files'];
 
     var customPlugin = {
@@ -278,6 +284,7 @@ function getBaseConfig(config, useRequireJs) {
             'karma-chrome-launcher',
             'karma-firefox-launcher',
             'karma-spec-reporter',
+            'karma-webdriver-launcher',
             'karma-webpack',
             'karma-sourcemap-loader',
             customPlugin
@@ -303,7 +310,8 @@ function getBaseConfig(config, useRequireJs) {
         junitReporter: junitSettings(config),
 
 
-        // web server port
+        // web server hostname and port
+        hostname: hostname,
         port: 9876,
 
 
@@ -332,6 +340,14 @@ function getBaseConfig(config, useRequireJs) {
                 prefs: {
                     'app.update.auto': false,
                     'app.update.enabled': false
+                }
+            },
+            FirefoxDocker: {
+                base: 'WebDriver',
+                browserName: 'firefox',
+                config: {
+                    hostname: 'edx.devstack.firefox',
+                    port: 4444
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "karma-requirejs": "^0.2.6",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "^0.0.20",
+    "karma-webdriver-launcher": "^1.0.5",
     "karma-webpack": "^2.0.3",
     "pa11y": "4.0.1",
     "pa11y-reporter-json-oldnode": "1.0.0",

--- a/pavelib/paver_tests/test_js_test.py
+++ b/pavelib/paver_tests/test_js_test.py
@@ -27,7 +27,8 @@ class TestPaverJavaScriptTestTasks(PaverTestCase):
         u"--single-run={single_run} "
         u"--capture-timeout=60000 "
         u"--junitreportpath="
-        u"{platform_root}/reports/javascript/javascript_xunit-{suite}.xml"
+        u"{platform_root}/reports/javascript/javascript_xunit-{suite}.xml "
+        u"--browsers={browser}"
     )
     EXPECTED_COVERAGE_OPTIONS = (
         u' --coverage --coveragereportpath={platform_root}/reports/javascript/coverage-{suite}.xml'
@@ -130,6 +131,7 @@ class TestPaverJavaScriptTestTasks(PaverTestCase):
                     single_run='false' if dev_mode else 'true',
                     suite=suite,
                     platform_root=self.platform_root,
+                    browser=Env.KARMA_BROWSER,
                 ),
             )
             if is_coverage:

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -138,6 +138,9 @@ class Env(object):
     # Test Ids Directory
     TEST_DIR = REPO_ROOT / ".testids"
 
+    # Configured browser to use for the js test suites
+    KARMA_BROWSER = 'FirefoxDocker' if USING_DOCKER else 'FirefoxNoUpdates'
+
     # Files used to run each of the js test suites
     # TODO:  Store this as a dict. Order seems to matter for some
     # reason. See issue TE-415.

--- a/pavelib/utils/test/suites/js_suite.py
+++ b/pavelib/utils/test/suites/js_suite.py
@@ -83,6 +83,7 @@ class JsTestSubSuite(TestSuite):
             "--single-run={}".format('false' if self.mode == 'dev' else 'true'),
             "--capture-timeout=60000",
             "--junitreportpath={}".format(self.xunit_report),
+            "--browsers={}".format(Env.KARMA_BROWSER),
         ]
 
         if self.port:


### PR DESCRIPTION
Added support for running the karma JavaScript tests in Docker devstack:

* Install karma-webdriver-launcher to support running the tests via Selenium
* Configure a remote web driver to use the same standalone Selenium Docker container that we use for bok-choy tests
* Auto-detect when to use Selenium vs. a local Firefox process
* Specify the hostname to use in the browser, since it differs between the lms container, studio container, and Vagrant or Jenkins

Some video-related tests aren't passing under Docker devstack yet, I haven't drilled into the reason why.  Most of them seem to be functions which are unexpectedly getting "html5" as an argument instead of "hls", it may just be a browser configuration issue.