### PR TITLE
EDUCATOR-514 | Hide the certificate_available_date field until release

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -5,6 +5,8 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 from xblock.fields import Scope
 
+from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+
 from xblock_django.models import XBlockStudioConfigurationFlag
 from xmodule.modulestore.django import modulestore
 
@@ -100,6 +102,13 @@ class CourseMetadata(object):
         # display the "Allow Unsupported XBlocks" setting.
         if not XBlockStudioConfigurationFlag.is_enabled():
             filtered_list.append('allow_unsupported_xblocks')
+
+        # TODO: https://openedx.atlassian.net/browse/EDUCATOR-736
+        # Before we roll out the auto-certs feature, move this to a good, shared
+        # place such that we're not repeating code found in LMS.
+        switches = WaffleSwitchNamespace(name=u'certificates', log_prefix=u'Certificates: ')
+        if not switches.is_enabled(u'instructor_paced_only'):
+            filtered_list.append('certificate_available_date')
 
         return filtered_list
 


### PR DESCRIPTION
We added a course module field `certificate_available_date` prematurely.  It doesn't seem to actually be visible from studio on prod or on my devstack, so maybe we didn't do it quite right to begin with.  Anyway, this change adds that field to the list of advanced settings to hide unless the certificates waffle switch is enabled.

Reviews:
- [x] @nasthagiri 

FYI Reviewers:
@edx/educator-neem 