### PR TITLE
ENT-447 Add flag to third party auth SAML provider to send to the registration page first

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0012_auto_20170626_1135.py
+++ b/common/djangoapps/third_party_auth/migrations/0012_auto_20170626_1135.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0011_auto_20170616_0112'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='send_to_registration_first',
+            field=models.BooleanField(default=False, help_text='If this option is selected, users will be directed to the registration page immediately after authenticating with the third party instead of the login page.'),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='send_to_registration_first',
+            field=models.BooleanField(default=False, help_text='If this option is selected, users will be directed to the registration page immediately after authenticating with the third party instead of the login page.'),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='send_to_registration_first',
+            field=models.BooleanField(default=False, help_text='If this option is selected, users will be directed to the registration page immediately after authenticating with the third party instead of the login page.'),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -176,6 +176,13 @@ class ProviderConfig(ConfigurationModel):
             "Django platform session default length will be used."
         )
     )
+    send_to_registration_first = models.BooleanField(
+        default=False,
+        help_text=_(
+            "If this option is selected, users will be directed to the registration page "
+            "immediately after authenticating with the third party instead of the login page."
+        ),
+    )
     prefix = None  # used for provider_id. Set to a string value in subclass
     backend_name = None  # Set to a field or fixed value in subclass
     accepts_logins = True  # Whether to display a sign-in button when the provider is enabled

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -558,7 +558,8 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
     def should_force_account_creation():
         """ For some third party providers, we auto-create user accounts """
         current_provider = provider.Registry.get_from_pipeline({'backend': current_partial.backend, 'kwargs': kwargs})
-        return current_provider and current_provider.skip_email_verification
+        return (current_provider and
+                (current_provider.skip_email_verification or current_provider.send_to_registration_first))
 
     if not user:
         if auth_entry in [AUTH_ENTRY_LOGIN_API, AUTH_ENTRY_REGISTER_API]:


### PR DESCRIPTION
One of the requirements for the enterprise landing page authentication flow is that users coming in through SSO are sent to the account creation page first instead of the sign in page. This PR introduces a new setting on the Provider model for sending users to the registration page first.

Changes can be found at 
https://brittneyexline.sandbox.edx.org/enterprise/3d3fa892-58e0-435f-b7d2-37a45b3ce18c/course/course-v1:edX+DemoX+Demo_Course/enroll/

1. Log in to the django admin, go to the Pied Piper SAML Provider, and ensure that send_to_registration_first is unchecked, as well as skip_email_verification. Log out of that session.
2. Visit the enrollment page and note that after authentication with the IdP, you land on the sign in page.
3. Go back to django admin, and change the SAML Provider to have send_to_registration_first checked.
4. Visit the enrollment page again, and note that after authentication with the IdP, you land on the registration page.