### PR TITLE
Enqueue Generate Certs Task on Passing Grade

### DIFF
--- a/openedx/core/djangoapps/signals/signals.py
+++ b/openedx/core/djangoapps/signals/signals.py
@@ -11,3 +11,11 @@ COURSE_GRADE_CHANGED = Signal(providing_args=["user", "course_grade", "course_ke
 # TODO: runtime coupling between apps will be reduced if this event is changed to carry a username
 # rather than a User object; however, this will require changes to the milestones and badges APIs
 COURSE_CERT_AWARDED = Signal(providing_args=["user", "course_key", "mode", "status"])
+
+# Signal that indicates that a user has passed a course.
+COURSE_GRADE_NOW_PASSED = Signal(
+    providing_args=[
+        'user',  # user object
+        'course_key',  # course.id
+    ]
+)


### PR DESCRIPTION
## [EDUCATOR-520](https://openedx.atlassian.net/browse/EDUCATOR-520)

### Description
Enqueue certificates task on learner receipt of passing grade.

### Testing
- [x] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @iloveagent57 

FYI: @edx/educator-neem, @rlucioni 

### Post-review
- [x] Rebase and squash commits

