### PR TITLE
PLAT-1597 Fix test mongo cleanup hostname in Docker devstack

### DIFF
--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -130,7 +130,7 @@ class Env(object):
     }
 
     # Mongo databases that will be dropped before/after the tests run
-    BOK_CHOY_MONGO_HOST = 'edx.devstack.mongo' if USING_DOCKER else 'localhost'
+    MONGO_HOST = 'edx.devstack.mongo' if USING_DOCKER else 'localhost'
     BOK_CHOY_MONGO_DATABASE = "test"
     BOK_CHOY_CACHE_HOST = 'edx.devstack.memcached' if USING_DOCKER else '0.0.0.0'
     BOK_CHOY_CACHE = memcache.Client(['{}:11211'.format(BOK_CHOY_CACHE_HOST)], debug=0)

--- a/pavelib/utils/test/bokchoy_utils.py
+++ b/pavelib/utils/test/bokchoy_utils.py
@@ -124,7 +124,7 @@ def is_mongo_running():
     """
     # The mongo command will connect to the service,
     # failing with a non-zero exit code if it cannot connect.
-    output = os.popen('mongo --host {} --eval "print(\'running\')"'.format(Env.BOK_CHOY_MONGO_HOST)).read()
+    output = os.popen('mongo --host {} --eval "print(\'running\')"'.format(Env.MONGO_HOST)).read()
     return output and "running" in output
 
 
@@ -157,7 +157,7 @@ def clear_mongo():
     """
     sh(
         "mongo --host {} {} --eval 'db.dropDatabase()' > /dev/null".format(
-            Env.BOK_CHOY_MONGO_HOST,
+            Env.MONGO_HOST,
             Env.BOK_CHOY_MONGO_DATABASE,
         )
     )

--- a/pavelib/utils/test/utils.py
+++ b/pavelib/utils/test/utils.py
@@ -13,7 +13,6 @@ from pavelib.utils.timer import timed
 from bok_choy.browser import browser
 
 MONGO_PORT_NUM = int(os.environ.get('EDXAPP_TEST_MONGO_PORT', '27017'))
-MONGO_HOST = os.environ.get('EDXAPP_TEST_MONGO_HOST', 'localhost')
 MINIMUM_FIREFOX_VERSION = 28.0
 
 __test__ = False  # do not collect
@@ -70,7 +69,7 @@ def clean_mongo():
     Clean mongo test databases
     """
     sh("mongo {host}:{port} {repo_root}/scripts/delete-mongo-test-dbs.js".format(
-        host=MONGO_HOST,
+        host=Env.MONGO_HOST,
         port=MONGO_PORT_NUM,
         repo_root=Env.REPO_ROOT,
     ))


### PR DESCRIPTION
Paver's mongo cleanup task was depending on the correct hostname being set in the environment by the Django settings, but it looks like the value is sometimes fetched before settings are loaded (so it was trying and failing to run cleanup against a localhost mongo).  We were already determining the correct mongo host in the paver env for bok-choy, so this changes the test cleanup to just use that.

This does make it more difficult to set a custom host which isn't localhost or edx.devstack.mongo; if that's a problem, I could add the EDXAPP_TEST_MONGO_HOST and EDXAPP_TEST_MONGO_PORT environment variables explicitly to devstack's docker-compose.yml instead (for both lms and studio).