### PR TITLE
Add message on unit container page to show unit level access

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -47,7 +47,7 @@ CONTAINER_TEMPLATES = [
     "add-xblock-component", "add-xblock-component-button", "add-xblock-component-menu",
     "add-xblock-component-support-legend", "add-xblock-component-support-level", "add-xblock-component-menu-problem",
     "xblock-string-field-editor", "publish-xblock", "publish-history",
-    "unit-outline", "container-message", "license-selector",
+    "unit-outline", "container-message", "container-unit-access", "license-selector",
 ]
 
 

--- a/cms/static/js/spec/views/group_configuration_spec.js
+++ b/cms/static/js/spec/views/group_configuration_spec.js
@@ -76,7 +76,7 @@ define([
         expect(view.$('.delete')).toHaveClass('is-disabled');
         expect(view.$(SELECTORS.usageText)).not.toExist();
         expect(view.$(SELECTORS.usageUnit)).not.toExist();
-        expect(view.$(SELECTORS.usageCount)).toContainText('Used in 2 units');
+        expect(view.$(SELECTORS.usageCount)).toContainText('Used in 2 locations');
     };
     var setUsageInfo = function(model) {
         model.set('usage', [

--- a/cms/static/js/spec/views/pages/container_subviews_spec.js
+++ b/cms/static/js/spec/views/pages/container_subviews_spec.js
@@ -108,18 +108,6 @@ define(['jquery', 'underscore', 'underscore.string', 'edx-ui-toolkit/js/utils/sp
                     fetch({published: false});
                     expect(containerPage.$(viewPublishedCss)).toHaveClass(disabledCss);
                 });
-
-                it('updates when has_partition_group_components attribute changes', function() {
-                    renderContainerPage(this, mockContainerXBlockHtml);
-                    fetch({has_partition_group_components: false});
-                    expect(containerPage.$(visibilityNoteCss).length).toBe(0);
-
-                    fetch({has_partition_group_components: true});
-                    expect(containerPage.$(visibilityNoteCss).length).toBe(1);
-
-                    fetch({has_partition_group_components: false});
-                    expect(containerPage.$(visibilityNoteCss).length).toBe(0);
-                });
             });
 
             describe('Publisher', function() {

--- a/cms/static/js/views/group_configuration_details.js
+++ b/cms/static/js/views/group_configuration_details.js
@@ -86,7 +86,7 @@ function(BaseView, _, gettext, str, StringUtils, HtmlUtils) {
                         Translators: 'count' is number of units that the group
                         configuration is used in.
                     */
-                    'Used in {count} unit', 'Used in {count} units',
+                    'Used in {count} location', 'Used in {count} locations',
                     count
                 ),
                     {count: count}

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -687,7 +687,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         getGroupAccessData: function() {
             var userPartitionId = this.getSelectedEnrollmentTrackId(),
                 groupAccess = {};
-            if (userPartitionId !== -1 && !isNaN(userPartitionId)) { // If the selected partition ID is not none
+            if (userPartitionId !== -1 && !isNaN(userPartitionId)) {
                 groupAccess[userPartitionId] = this.getSelectedCheckboxesByDivId(userPartitionId);
                 return groupAccess;
             } else {

--- a/cms/static/js/views/pages/container.js
+++ b/cms/static/js/views/pages/container.js
@@ -56,6 +56,12 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/pages/base_page
                 this.messageView.render();
                 this.isUnitPage = this.options.isUnitPage;
                 if (this.isUnitPage) {
+                    this.unitAccessView = new ContainerSubviews.UnitAccess({
+                        el: this.$('.container-unit-access'),
+                        model: this.model
+                    });
+                    this.unitAccessView.render();
+
                     this.xblockPublisher = new ContainerSubviews.Publisher({
                         el: this.$('#publish-unit'),
                         model: this.model,

--- a/cms/static/js/views/pages/container_subviews.js
+++ b/cms/static/js/views/pages/container_subviews.js
@@ -32,6 +32,30 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
             render: function() {}
         });
 
+        var UnitAccess = ContainerStateListenerView.extend({
+            initialize: function() {
+                ContainerStateListenerView.prototype.initialize.call(this);
+                this.template = this.loadTemplate('container-unit-access');
+            },
+
+            shouldRefresh: function(model) {
+                return ViewUtils.hasChangedAttributes(model, ['has_partition_group_components', 'user_partitions']);
+            },
+
+            render: function() {
+                HtmlUtils.setHtml(
+                    this.$el,
+                    HtmlUtils.HTML(
+                        this.template({
+                            hasPartitionGroupComponents: this.model.get('has_partition_group_components'),
+                            userPartitionInfo: this.model.get('user_partition_info')
+                        })
+                    )
+                );
+                return this;
+            }
+        });
+
         var MessageView = ContainerStateListenerView.extend({
             initialize: function() {
                 ContainerStateListenerView.prototype.initialize.call(this);
@@ -98,7 +122,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
             onSync: function(model) {
                 if (ViewUtils.hasChangedAttributes(model, [
                     'has_changes', 'published', 'edited_on', 'edited_by', 'visibility_state',
-                    'has_explicit_staff_lock', 'has_partition_group_components'
+                    'has_explicit_staff_lock'
                 ])) {
                     this.render();
                 }
@@ -124,7 +148,6 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
                             releaseDateFrom: this.model.get('release_date_from'),
                             hasExplicitStaffLock: this.model.get('has_explicit_staff_lock'),
                             staffLockFrom: this.model.get('staff_lock_from'),
-                            hasPartitionGroupComponents: this.model.get('has_partition_group_components'),
                             course: window.course,
                             HtmlUtils: HtmlUtils
                         })
@@ -270,9 +293,10 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
         });
 
         return {
-            'MessageView': MessageView,
-            'ViewLiveButtonController': ViewLiveButtonController,
-            'Publisher': Publisher,
-            'PublishHistory': PublishHistory
+            MessageView: MessageView,
+            ViewLiveButtonController: ViewLiveButtonController,
+            Publisher: Publisher,
+            PublishHistory: PublishHistory,
+            UnitAccess: UnitAccess
         };
     }); // end define();

--- a/cms/static/js/views/partition_group_details.js
+++ b/cms/static/js/views/partition_group_details.js
@@ -68,10 +68,10 @@ define([
                 /* globals ngettext */
                 return StringUtils.interpolate(ngettext(
                     /*
-                        Translators: 'count' is number of units that the group
+                        Translators: 'count' is number of locations that the group
                         configuration is used in.
                     */
-                    'Used in {count} unit', 'Used in {count} units',
+                    'Used in {count} location', 'Used in {count} locations',
                     count
                 ),
                     {count: count}

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -783,6 +783,46 @@
 
   .edit-unit-access, .edit-staff-lock {
     .modal-section-content {
+    @include font-size(16);
+
+    .group-select-title {
+      font-weight: font-weight(semi-bold);
+      font-size: inherit;
+      margin-bottom: ($baseline/4);
+
+      .user-partition-select {
+        font-size: inherit;
+      }
+    }
+
+    .partition-group-directions {
+      padding-top: ($baseline/2);
+    }
+
+    .label {
+
+      &.deleted {
+        color: $red;
+      }
+
+      font-size: inherit;
+      margin-left: ($baseline/4);
+    }
+
+    .deleted-group-message {
+      display: block;
+      color: $red;
+      @include font-size(14);
+    }
+
+    .field {
+      margin-top: ($baseline/4);
+    }
+  }
+  }
+
+  .edit-unit-access, .edit-staff-lock {
+    .modal-section-content {
       @include font-size(16);
 
       .group-select-title {

--- a/cms/static/sass/views/_container.scss
+++ b/cms/static/sass/views/_container.scss
@@ -55,6 +55,14 @@
             }
           }
         }
+
+        .container-unit-access {
+          @include font-size(14);
+          line-height: 1.5;
+          white-space: normal;
+          color: #707070;
+          font-weight: font-weight(semi-bold);
+        }
       }
 
       &.has-actions {

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -72,6 +72,8 @@ from openedx.core.djangolib.markup import HTML, Text
                  data-field="display_name" data-field-display-name="${_("Display Name")}">
                 <h1 class="page-header-title xblock-field-value incontext-editor-value"><span class="title-value">${xblock.display_name_with_default}</span></h1>
             </div>
+            <div class="container-unit-access">
+            </div>
         </div>
 
         <nav class="nav-actions" aria-label="${_('Page Actions')}">

--- a/cms/templates/js/container-unit-access.underscore
+++ b/cms/templates/js/container-unit-access.underscore
@@ -1,0 +1,15 @@
+<%
+var selectedGroupsLabel = userPartitionInfo['selected_groups_label'];
+var selectedPartitionIndex = userPartitionInfo['selected_partition_index'];
+%>
+<% if (selectedGroupsLabel) { %>
+    <span class="access-message"><%-
+        edx.StringUtils.interpolate(
+                gettext('Access to this unit is restricted to: {selectedGroupsLabel}'),
+                {
+                    selectedGroupsLabel: selectedGroupsLabel
+                }
+        ) %></span>
+<% } else if (hasPartitionGroupComponents) { %>
+    <span class="access-message"><%- gettext('Access to some content in this unit is restricted to specific groups of learners.') %></span>
+<% } %>

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -63,7 +63,7 @@ if (staffOnlyMessage) {
     if (selectedPartitionIndex !== -1 && !isNaN(selectedPartitionIndex) && xblockInfo.isVertical()) {
         messageType = 'partition-groups';
         messageText = edx.StringUtils.interpolate(
-                gettext('Access to this unit is restricted to {selectedGroupsLabel}'),
+                gettext('Access to this unit is restricted to: {selectedGroupsLabel}'),
                 {
                     selectedGroupsLabel: selectedGroupsLabel
                 }

--- a/cms/templates/js/publish-xblock.underscore
+++ b/cms/templates/js/publish-xblock.underscore
@@ -97,12 +97,6 @@ var visibleToStaffOnly = visibilityState === 'staff_only';
         <% } else { %>
             <p class="visbility-copy copy"><%- gettext("Staff and Learners") %></p>
         <% } %>
-            <% if (hasPartitionGroupComponents) { %>
-                <p class="note-visibility">
-                    <span class="icon fa fa-eye" aria-hidden="true"></span>
-                    <span class="note-copy"><%- gettext("Access to some content in this unit is restricted to specific groups of learners.") %></span>
-                </p>
-            <% } %>
         <ul class="actions-inline">
             <li class="action-inline">
                 <a href="" class="action-staff-lock" role="button" aria-pressed="<%- hasExplicitStaffLock %>">

--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -332,6 +332,16 @@ class ContainerPage(PageObject, HelpMixin):
         """
         return self.q(css=".xblock-message.information").first.text[0]
 
+    def get_xblock_access_message(self):
+        """
+        Returns a message detailing the access to the specified unit
+        """
+        access_message = self.q(css=".access-message").first
+        if access_message:
+            return access_message.text[0]
+        else:
+            return ""
+
     def is_inline_editing_display_name(self):
         """
         Return whether this container's display name is in its editable form.

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -16,6 +16,7 @@ from common.test.acceptance.pages.common.utils import add_enrollment_course_mode
 from common.test.acceptance.pages.lms.course_home import CourseHomePage
 from common.test.acceptance.pages.lms.courseware import CoursewarePage
 from common.test.acceptance.pages.lms.progress import ProgressPage
+from common.test.acceptance.pages.lms.staff_view import StaffCoursewarePage
 from common.test.acceptance.pages.studio.overview import ContainerPage, CourseOutlinePage, ExpandCollapseLinkState
 from common.test.acceptance.pages.studio.settings_advanced import AdvancedSettingsPage
 from common.test.acceptance.pages.studio.settings_group_configurations import GroupConfigurationsPage
@@ -589,15 +590,14 @@ class UnitAccessTest(CourseOutlineTest):
         self.assertEqual(course_home_page.outline.num_units, 2)
 
         # Test for a user without additional content available
-        course_home_page.visit()
-        course_home_page.preview.set_staff_view_mode("Learner in Test Group B")
-        course_home_page.resume_course_from_header()
+        staff_page = StaffCoursewarePage(self.browser, self.course_id)
+        staff_page.set_staff_view_mode('Learner in Test Group B')
+        staff_page.wait_for_page()
         self.assertEqual(course_home_page.outline.num_units, 1)
 
         # Test for a user with additional content available
-        course_home_page.visit()
-        course_home_page.preview.set_staff_view_mode("Learner in Test Group A")
-        course_home_page.resume_course_from_header()
+        staff_page.set_staff_view_mode('Learner in Test Group A')
+        staff_page.wait_for_page()
         self.assertEqual(course_home_page.outline.num_units, 2)
 
     def test_restricted_sections_for_enrollment_track_users_in_lms(self):
@@ -628,15 +628,15 @@ class UnitAccessTest(CourseOutlineTest):
         self.assertEqual(course_home_page.outline.num_units, 2)
 
         # Test for a user without additional content available
-        course_home_page.visit()
-        course_home_page.preview.set_staff_view_mode("Learner in Verified")
-        course_home_page.resume_course_from_header()
+        staff_page = StaffCoursewarePage(self.browser, self.course_id)
+        staff_page.set_staff_view_mode('Learner in Verified')
+        staff_page.wait_for_page()
         self.assertEqual(course_home_page.outline.num_units, 1)
 
         # Test for a user with additional content available
-        course_home_page.visit()
-        course_home_page.preview.set_staff_view_mode("Learner in Audit")
-        course_home_page.resume_course_from_header()
+        staff_page = StaffCoursewarePage(self.browser, self.course_id)
+        staff_page.set_staff_view_mode('Learner in Audit')
+        staff_page.wait_for_page()
         self.assertEqual(course_home_page.outline.num_units, 2)
 
 


### PR DESCRIPTION
## [EDUCATOR-543](https://openedx.atlassian.net/browse/EDUCATOR-543)

### Description

Adds message describing the unit level access underneath the title on the Unit container page.   

### Sandbox
- [x] Sandbox up at: https://studio-display-access-unit-page.sandbox.edx.org
         Unit page with unit level restrictions: https://studio-display-access-unit-page.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc
         Unit page with restricted components:  https://studio-display-access-unit-page.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@2a2babe901624a3086bc84c25ca433e9?action=new

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
@cahrens 
@jlajoie 

FYI @sstack22 and @catong 
 
### Post-review
- [x] Rebase and squash commits