### PR TITLE
mattdrayer/ENT-484: Ensure Audit enrollment when only option

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -363,6 +363,31 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
 
         self.assertRedirects(response, redirect_url)
 
+    def test_choose_mode_audit_enroll_on_get(self):
+        """
+        Confirms that the learner will be enrolled in Audit track if it is the only possible option
+        """
+        # Create the course mode
+        audit_mode = 'audit'
+        CourseModeFactory.create(mode_slug=audit_mode, course_id=self.course.id, min_price=0)
+
+        # Assert learner is not enrolled in Audit track pre-POST
+        mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
+        self.assertIsNone(mode)
+        self.assertIsNone(is_active)
+
+        # Choose the audit mode (POST request)
+        choose_track_url = reverse('course_modes_choose', args=[unicode(self.course.id)])
+        response = self.client.get(choose_track_url)
+
+        # Assert learner is enrolled in Audit track and sent to the dashboard
+        mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
+        self.assertEquals(mode, audit_mode)
+        self.assertTrue(is_active)
+
+        redirect_url = reverse('dashboard')
+        self.assertRedirects(response, redirect_url)
+
     def test_choose_mode_audit_enroll_on_post(self):
         audit_mode = 'audit'
         # Create the course modes

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -107,6 +107,16 @@ class ChooseModeView(View):
         # If there isn't a verified mode available, then there's nothing
         # to do on this page.  Send the user to the dashboard.
         if not CourseMode.has_verified_mode(modes):
+            # If the learner has arrived at this screen via the traditional enrollment workflow,
+            # then they should already be enrolled in an audit mode for the course, assuming one has
+            # been configured.  However, alternative enrollment workflows have been introduced into the
+            # system, such as third-party discovery.  These workflows result in learners arriving
+            # directly at this screen, and they will not necessarily be pre-enrolled in the audit mode.
+            # In this particular case, Audit is the ONLY option available, and thus we need to ensure
+            # that the learner is truly enrolled before we redirect them away to the dashboard.
+            if len(modes) == 1 and modes.get(CourseMode.AUDIT):
+                CourseEnrollment.enroll(request.user, course_key, CourseMode.AUDIT)
+
             return redirect(reverse('dashboard'))
 
         # If a user has already paid, redirect them to the dashboard.


### PR DESCRIPTION
Addresses the scenario where the track selection page is accessed directly by a learner who is not already enrolled in a course run, and the Audit track is the only available option for the run.  

Existing behavior would redirect the learner away from the track selection screen under the assumption that they were pre-enrolled in the Audit track.

New behavior checks to see if Audit is the only available option and if so, ensures that an enrollment record is written before sending the learner to the dashboard.