### PR TITLE
PLAT-1323 Remove older, slower code path for course export

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -559,20 +559,6 @@ class ExportTestCase(CourseTestCase):
         resp = self.client.get(output_url)
         self._verify_export_succeeded(resp)
 
-    def test_export_targz(self):
-        """
-        Get tar.gz file, using HTTP_ACCEPT.
-        """
-        resp = self.client.get(self.url, HTTP_ACCEPT='application/x-tgz')
-        self._verify_export_succeeded(resp)
-
-    def test_export_targz_urlparam(self):
-        """
-        Get tar.gz file, using URL parameter.
-        """
-        resp = self.client.get(self.url + '?_accept=application/x-tgz')
-        self._verify_export_succeeded(resp)
-
     def _verify_export_succeeded(self, resp):
         """ Export success helper method. """
         self.assertEquals(resp.status_code, 200)


### PR DESCRIPTION
When I added support for asynchronous course import and export, I left in a code path for backwards-compatible synchronous exports.  I did this for the benefit of pages which were loaded just before the upgrade and for any automation that partners may have hacked together based on the old behavior, but in practice this has been hit so rarely that it's only serving to confuse the DevOps and Performance teams when a request performs terribly by following this path.

This change just eliminates the option of doing a full course export in the course of a single GET request by passing "application/x-tgz" in the HTTP_ACCEPT header.  The UI no longer utilizes this at all, so it shouldn't really impact normal site operations.