### PR TITLE
PLAT-1610 Fix social auth config error in Docker bok-choy tests

### DIFF
--- a/lms/envs/bok_choy_docker.env.json
+++ b/lms/envs/bok_choy_docker.env.json
@@ -142,9 +142,9 @@
     "SYSLOG_SERVER": "",
     "TECH_SUPPORT_EMAIL": "technical@example.com",
     "THIRD_PARTY_AUTH_BACKENDS": [
-        "social.backends.google.GoogleOAuth2",
-        "social.backends.linkedin.LinkedinOAuth2",
-        "social.backends.facebook.FacebookOAuth2",
+        "social_core.backends.google.GoogleOAuth2",
+        "social_core.backends.linkedin.LinkedinOAuth2",
+        "social_core.backends.facebook.FacebookOAuth2",
         "third_party_auth.dummy.DummyBackend",
         "third_party_auth.saml.SAMLAuthBackend"
     ],


### PR DESCRIPTION
Support for bok-choy testing in Docker devstack and an upgrade of python-social-auth landed around the same time, resulting in one of the new settings files for the former missing a fix needed for the latter.