### PR TITLE
Separate Archived courses into a separate list in Studio

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -518,11 +518,13 @@ def course_listing(request):
             u'can_edit': has_studio_write_access(request.user, library.location.library_key),
         }
 
-    courses_iter = _remove_in_process_courses(courses_iter, in_process_course_actions)
+    split_archived = settings.FEATURES.get(u'ENABLE_SEPARATE_ARCHIVED_COURSES', False)
+    active_courses, archived_courses = _process_courses_list(courses_iter, in_process_course_actions, split_archived)
     in_process_course_actions = [format_in_process_course_view(uca) for uca in in_process_course_actions]
 
     return render_to_response(u'index.html', {
-        u'courses': list(courses_iter),
+        u'courses': active_courses,
+        u'archived_courses': archived_courses,
         u'in_process_course_actions': in_process_course_actions,
         u'libraries_enabled': LIBRARIES_ENABLED,
         u'libraries': [format_library_for_view(lib) for lib in libraries],
@@ -639,7 +641,6 @@ def get_courses_accessible_to_user(request, org=None):
             the courses returned. A value of None will have no effect (all courses
             returned), an empty string will result in no courses, and otherwise only courses with the
             specified org will be returned. The default value is None.
-
     """
     if GlobalStaff().has_user(request.user):
         # user has global access so no need to get courses from django groups
@@ -654,10 +655,15 @@ def get_courses_accessible_to_user(request, org=None):
     return courses, in_process_course_actions
 
 
-def _remove_in_process_courses(courses_iter, in_process_course_actions):
+def _process_courses_list(courses_iter, in_process_course_actions, split_archived=False):
     """
-    removes any in-process courses in courses list. in-process actually refers to courses
-    that are in the process of being generated for re-run
+    Iterates over the list of courses to be displayed to the user, and:
+
+    * Removes any in-process courses from the courses list. "In-process" refers to courses
+      that are in the process of being generated for re-run.
+    * If split_archived=True, removes any archived courses and returns them in a separate list.
+      Archived courses have has_ended() == True.
+    * Formats the returned courses (in both lists) to prepare them for rendering to the view.
     """
     def format_course_for_view(course):
         """
@@ -675,11 +681,20 @@ def _remove_in_process_courses(courses_iter, in_process_course_actions):
         }
 
     in_process_action_course_keys = {uca.course_key for uca in in_process_course_actions}
-    return (
-        format_course_for_view(course)
-        for course in courses_iter
-        if not isinstance(course, ErrorDescriptor) and (course.id not in in_process_action_course_keys)
-    )
+    active_courses = []
+    archived_courses = []
+
+    for course in courses_iter:
+        if isinstance(course, ErrorDescriptor) or (course.id in in_process_action_course_keys):
+            continue
+
+        formatted_course = format_course_for_view(course)
+        if split_archived and course.has_ended():
+            archived_courses.append(formatted_course)
+        else:
+            active_courses.append(formatted_course)
+
+    return active_courses, archived_courses
 
 
 def course_outline_initial_state(locator_to_show, course_structure):
@@ -1035,7 +1050,7 @@ def settings_handler(request, course_key_string):
                 # exclude current course from the list of available courses
                 courses = (course for course in courses if course.id != course_key)
                 if courses:
-                    courses = _remove_in_process_courses(courses, in_process_course_actions)
+                    courses, __ = _process_courses_list(courses, in_process_course_actions)
                 settings_context.update({'possible_pre_requisite_courses': list(courses)})
 
             if credit_eligibility_enabled:

--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -161,6 +161,7 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
             return function(e) {
                 e.preventDefault();
                 $('.courses-tab').toggleClass('active', tab === 'courses');
+                $('.archived-courses-tab').toggleClass('active', tab === 'archived-courses');
                 $('.libraries-tab').toggleClass('active', tab === 'libraries');
 
             // Also toggle this course-related notice shown below the course tab, if it is present:
@@ -179,6 +180,7 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
             $('.action-reload').bind('click', ViewUtils.reload);
 
             $('#course-index-tabs .courses-tab').bind('click', showTab('courses'));
+            $('#course-index-tabs .archived-courses-tab').bind('click', showTab('archived-courses'));
             $('#course-index-tabs .libraries-tab').bind('click', showTab('libraries'));
         };
 

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -318,7 +318,7 @@
   }
 
   // ELEM: course listings
-  .courses-tab, .libraries-tab {
+  .courses-tab, .archived-courses-tab, .libraries-tab {
     display: none;
 
     &.active {
@@ -326,7 +326,7 @@
     }
   }
 
-  .courses, .libraries {
+  .courses, .libraries, .archived-courses {
     .title {
       @extend %t-title6;
       margin-bottom: $baseline;
@@ -342,7 +342,7 @@
       padding-bottom: ($baseline/2);
       color: $gray-l2;
     }
-	}
+  }
 
   .list-courses {
     border-radius: 3px;

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -308,10 +308,15 @@ from openedx.core.djangolib.markup import HTML, Text
       </div>
       %endif
 
-      % if libraries_enabled:
+      % if libraries_enabled or archived_courses:
       <ul id="course-index-tabs">
         <li class="courses-tab active"><a>${_("Courses")}</a></li>
+        % if archived_courses:
+        <li class="archived-courses-tab"><a>${_("Archived Courses")}</a></li>
+        % endif
+        % if libraries_enabled:
         <li class="libraries-tab"><a>${_("Libraries")}</a></li>
+        % endif
       </ul>
       % endif
 
@@ -466,6 +471,44 @@ from openedx.core.djangolib.markup import HTML, Text
         </div>
       </div>
       % endif
+
+      %if archived_courses:
+      <div class="archived-courses archived-courses-tab">
+        <ul class="list-courses">
+          %for course_info in sorted(archived_courses, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):
+          <li class="course-item" data-course-key="${course_info['course_key']}">
+            <a class="course-link" href="${course_info['url']}">
+              <h3 class="course-title">${course_info['display_name']}</h3>
+
+              <div class="course-metadata">
+                <span class="course-org metadata-item">
+                  <span class="label">${_("Organization:")}</span> <span class="value">${course_info['org']}</span>
+                </span>
+                <span class="course-num metadata-item">
+                  <span class="label">${_("Course Number:")}</span>
+                  <span class="value">${course_info['number']}</span>
+                </span>
+                <span class="course-run metadata-item">
+                  <span class="label">${_("Course Run:")}</span> <span class="value">${course_info['run']}</span>
+                </span>
+              </div>
+            </a>
+
+            <ul  class="item-actions course-actions">
+              % if allow_course_reruns and rerun_creator_status and course_creator_status=='granted':
+              <li class="action action-rerun">
+                <a href="${course_info['rerun_link']}" class="button rerun-button">${_("Re-run Course")}</a>
+              </li>
+              % endif
+              <li class="action action-view">
+                <a href="${course_info['lms_link']}" rel="external" class="button view-button">${_("View Live")}</a>
+              </li>
+            </ul>
+          </li>
+          %endfor
+        </ul>
+      </div>
+      %endif
 
       %if len(libraries) > 0:
       <div class="libraries libraries-tab">

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -5,6 +5,7 @@ import json
 import logging
 from cStringIO import StringIO
 from datetime import datetime, timedelta
+import dateutil.parser
 
 import requests
 from lazy import lazy
@@ -1393,9 +1394,10 @@ class CourseSummary(object):
     A lightweight course summary class, which constructs split/mongo course summary without loading
     the course. It is used at cms for listing courses to global staff user.
     """
-    course_info_fields = ['display_name', 'display_coursenumber', 'display_organization']
+    course_info_fields = ['display_name', 'display_coursenumber', 'display_organization', 'end']
 
-    def __init__(self, course_locator, display_name=u"Empty", display_coursenumber=None, display_organization=None):
+    def __init__(self, course_locator, display_name=u"Empty", display_coursenumber=None, display_organization=None,
+                 end=None):
         """
         Initialize and construct course summary
 
@@ -1412,6 +1414,8 @@ class CourseSummary(object):
 
         display_organization (unicode|None): Course organization that is specified & appears in the courseware
 
+        end (unicode|None): Course end date.  Must contain timezone.
+
         """
         self.display_coursenumber = display_coursenumber
         self.display_organization = display_organization
@@ -1419,6 +1423,9 @@ class CourseSummary(object):
 
         self.id = course_locator  # pylint: disable=invalid-name
         self.location = course_locator.make_usage_key('course', 'course')
+        self.end = end
+        if end is not None and not isinstance(end, datetime):
+            self.end = dateutil.parser.parse(end)
 
     @property
     def display_org_with_default(self):
@@ -1439,3 +1446,9 @@ class CourseSummary(object):
         if self.display_coursenumber:
             return self.display_coursenumber
         return self.location.course
+
+    def has_ended(self):
+        """
+        Returns whether the course has ended.
+        """
+        return course_metadata_utils.has_course_ended(self.end)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_semantics.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_semantics.py
@@ -211,7 +211,7 @@ class DirectOnlyCategorySemantics(PureModulestoreTestCase):
         """
         def verify_course_summery_fields(course_summary):
             """ Verify that every `course_summary` object has all the required fields """
-            expected_fields = CourseSummary.course_info_fields + ['id', 'location']
+            expected_fields = CourseSummary.course_info_fields + ['id', 'location', 'has_ended']
             return all([hasattr(course_summary, field) for field in expected_fields])
 
         self.assertTrue(all(verify_course_summery_fields(course_summary) for course_summary in course_summaries))


### PR DESCRIPTION
Adds a feature flag which, when enabled, splits the Courses listed on the Studio Home page into two lists:
* Courses - "active" courses with no end date, or whose end date has not passed yet.
* Archived Courses - courses whose end date has passed.

**JIRA tickets**: [OSPR-1803](https://openedx.atlassian.net/browse/OSPR-1803)

**Discussions**: [`edx-code` group post](https://groups.google.com/forum/#!msg/edx-code/Oao9f_Atd_8/S5JxMUObAwAJ)

**Screenshots**:

![active courses](https://user-images.githubusercontent.com/7556571/27680252-44f137e8-5cfa-11e7-8fb4-c3cb55038934.png)
![archived courses](https://user-images.githubusercontent.com/7556571/27680256-472ab750-5cfa-11e7-8856-ea55aa73b03f.png)

**Sandbox URL**:

Sandbox has `FEATURES['ENABLE_SEPARATE_ARCHIVED_COURSES']` enabled.

LMS: https://pr15431.sandbox.opencraft.hosting/
Studio: https://studio-pr15431.sandbox.opencraft.hosting/

**Partner information**: 3rd party-hosted open edX instance

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: None

**Testing instructions**:

With `FEATURES['ENABLE_SEPARATE_ARCHIVED_COURSES']` enabled:
1. Load the Studio home page.  Notice that there is no Archived Courses tab shown.
1. Create two courses in Studio:
    * Active Course - with no end date set, or with an end date set in the future.
    * Archived Course - with an end date set in the past.
1. Refresh the Studio home page.  Notice that:
    * The Active Course appears under the main Courses tab.
    * The Archived Course appears under the Archived Courses tab.

With `FEATURES['ENABLE_SEPARATE_ARCHIVED_COURSES']` disabled or removed:
1. Load the Studio home page.  Notice that:
* There is no Archived Courses tab shown.
* The new courses appear under the main Courses tab

**Author notes and concerns**:

1. The original aim of this feature was to avoid loading the archived courses during the initial request, and instead provide them via a separate, asynchronous request.
   However, since the mongo offers no clear way to filter out archived courses from the modulestore queries, it made more sense to just return the archived courses synchronously with the active courses, since they're all being fetched anyway.
   See the tests added which verify that enabling the feature does not add any new database queries.

**Reviewers**
- [x] @smarnach 
- [x] @cahrens 

CC @gsong 

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_SEPARATE_ARCHIVED_COURSES: true
```