### PR TITLE
Keep button shape for long strings

### DIFF
--- a/cms/static/sass/elements/_system-help.scss
+++ b/cms/static/sass/elements/_system-help.scss
@@ -245,6 +245,7 @@
 
   // learn more (aka external help button)
   .external-help-button {
+    display: inline-block;
     @extend %ui-btn-flat-outline;
     @extend %sizing;
   }


### PR DESCRIPTION
The external help button is showed deformed when the contained string is long enough to more than a line.  It is separated in various lines and not as a block button. I saw that bug when my platform was in spanish. 
![image](https://user-images.githubusercontent.com/26482547/27692124-36751b08-5ce6-11e7-8114-d24ff6305fc6.png)

This button appears in the info at right side in some views in cms like when you saw a created library.
![image](https://user-images.githubusercontent.com/26482547/27691954-cc4b88b6-5ce5-11e7-81cc-e8ffce3f7c09.png)

With the attribute "display: inline-block;". It only changes the way to show the string so the button didn't change in english version. If you use "display: block;" the button changes for short strings too.
![image](https://user-images.githubusercontent.com/26482547/27692247-7e5ac13e-5ce6-11e7-9666-aa1ba72bbafd.png)

To replicate:
- Access to the platform.
- Change default language to spanish.
- Restart services.
- Go to cms. And create a new library or select one already created.
- Look the button in the right side column.
 