### PR TITLE
Remove deprecated django.utils.importlib

### DIFF
--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -3,6 +3,7 @@
 import json
 import unittest
 from datetime import datetime
+from importlib import import_module
 
 import ddt
 import mock
@@ -13,7 +14,6 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase, TransactionTestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
-from django.utils.importlib import import_module
 from mock import patch
 
 import student

--- a/openedx/core/djangoapps/safe_sessions/testing.py
+++ b/openedx/core/djangoapps/safe_sessions/testing.py
@@ -59,7 +59,7 @@ def safe_cookie_test_session_patch():
         """
         from django.apps import apps
         from django.conf import settings
-        from django.utils.importlib import import_module
+        from importlib import import_module
         from .middleware import SafeCookieData, SafeCookieError, SafeSessionMiddleware
 
         if apps.is_installed('django.contrib.sessions'):


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/releases/1.7/#django-utils-dictconfig-django-utils-importlib

Causing this deprecation message:
```
py.warnings: WARNING: /edx/app/edxapp/edx-platform/openedx/core/djangoapps/safe_sessions/testing.py:62: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
  from django.utils.importlib import import_module
```