### PR TITLE
EDUCATOR-793: converts TypeError,NotFoundError logging to debug only

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -239,7 +239,7 @@ class VideoStudentViewHandlers(object):
             try:
                 transcript = self.translation(request.GET.get('videoId', None), transcripts)
             except (TypeError, NotFoundError) as ex:
-                log.info(ex.message)
+                log.debug(ex.message)
                 # Try to return static URL redirection as last resort
                 # if no translation is required
                 return self.get_static_transcript(request, transcripts)


### PR DESCRIPTION
## [EDUCATOR-793](https://openedx.atlassian.net/browse/EDUCATOR-793)

### Description

Swaps the log statement to be debug instead of info to reduce the amount of logging in Splunk.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @jibsheet 

FYI: @muzaffaryousaf @e0d @scottrish 