### PR TITLE
eslint config edx v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "edx-custom-a11y-rules": "0.1.3",
-    "eslint-config-edx": "^2.0.1",
+    "eslint-config-edx": "^3.0.0",
     "eslint-config-edx-es5": "^2.0.0",
     "eslint-import-resolver-webpack": "^0.8.1",
     "jasmine-core": "^2.6.4",


### PR DESCRIPTION
Updates our eslint-config-edx dependency to 3.0.0, which includes support for jsx linting.