### PR TITLE
fix issue where video modal is not closed by clicking outside the video

### DIFF
--- a/lms/static/js/leanModal.js
+++ b/lms/static/js/leanModal.js
@@ -18,6 +18,10 @@
                 closeButton: null,
                 position: 'fixed'
             };
+            var overlay = '<div id="lean_overlay"></div>';
+            if ($('#lean_overlay').length === 0) {
+                $('body').append($(overlay));
+            }
 
             options = $.extend(defaults, options);  // eslint-disable-line no-param-reassign
 


### PR DESCRIPTION
LeanModal.js was missing a few lines, that is required in order to close dialog when clicking outside the modal window.