### PR TITLE
WL-1086 Center password reset page

### DIFF
--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -81,7 +81,8 @@
     padding-left: ($baseline/2);
     padding-right: ($baseline/2);
     $third-party-button-height: ($baseline*1.75);
-    display: inline-block;
+    display: block;
+    margin:auto;
     max-width: 500px;
 
     .instructions {


### PR DESCRIPTION
The screen the set a new password after a reset is currently misaligned
on prod. It's pushed to the left side due to an inline-block display
property. Changed to block and fixed margins.