### PR TITLE
WIP: Fix underscore-not-escaped linting issues

### DIFF
--- a/cms/static/js/models/settings/course_grader.js
+++ b/cms/static/js/models/settings/course_grader.js
@@ -66,7 +66,7 @@ define(['backbone', 'underscore', 'gettext'], function(Backbone, _, gettext) {
             }
             if (_.has(attrs, 'min_count') && _.has(attrs, 'drop_count') && !_.has(errors, 'min_count') && !_.has(errors, 'drop_count') && attrs.drop_count > attrs.min_count) {
                 var template = _.template(
-                gettext('Cannot drop more <%= types %> assignments than are assigned.')
+                gettext('Cannot drop more <%- types %> assignments than are assigned.')
             );
                 errors.drop_count = template({types: attrs.type});
             }

--- a/cms/static/js/models/uploads.js
+++ b/cms/static/js/models/uploads.js
@@ -14,7 +14,7 @@ define(['backbone', 'underscore', 'gettext'], function(Backbone, _, gettext) {
         validate: function(attrs, options) {
             if (attrs.selectedFile && !this.checkTypeValidity(attrs.selectedFile)) {
                 return {
-                    message: _.template(gettext('Only <%= fileTypes %> files can be uploaded. Please select a file ending in <%= fileExtensions %> to upload.'))(  // eslint-disable-line max-len
+                    message: _.template(gettext('Only <%- fileTypes %> files can be uploaded. Please select a file ending in <%- fileExtensions %> to upload.'))(  // eslint-disable-line max-len
                     this.formatValidTypes()
                 ),
                     attributes: {selectedFile: true}
@@ -62,7 +62,7 @@ define(['backbone', 'underscore', 'gettext'], function(Backbone, _, gettext) {
             }
             var or = gettext('or');
             var formatTypes = function(types) {
-                return _.template('<%= initial %> <%= or %> <%= last %>')({
+                return _.template('<%- initial %> <%- or %> <%- last %>')({
                     initial: _.initial(types).join(', '),
                     or: or,
                     last: _.last(types)

--- a/cms/static/js/spec/views/paged_container_spec.js
+++ b/cms/static/js/spec/views/paged_container_spec.js
@@ -4,10 +4,10 @@ define(['jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpe
     function($, _, AjaxHelpers, URI, XBlockInfo, PagedContainer, PagingHeader, PagingFooter, XBlockView) {
         var htmlResponseTpl = _.template('' +
             '<div class="xblock-container-paging-parameters" ' +
-                'data-start="<%= start %>" ' +
-                'data-displayed="<%= displayed %>" ' +
-                'data-total="<%= total %>" ' +
-                'data-previews="<%= previews %>"></div>'
+                'data-start="<%- start %>" ' +
+                'data-displayed="<%- displayed %>" ' +
+                'data-total="<%- total %>" ' +
+                'data-previews="<%- previews %>"></div>'
         );
 
         function getResponseHtml(override_options) {

--- a/cms/static/js/views/edit_chapter.js
+++ b/cms/static/js/views/edit_chapter.js
@@ -59,7 +59,7 @@ define(['underscore', 'jquery', 'gettext', 'edx-ui-toolkit/js/utils/html-utils',
                     asset_path: this.$('input.chapter-asset-path').val()
                 });
                 var msg = new FileUploadModel({
-                    title: _.template(gettext('Upload a new PDF to “<%= name %>”'))(
+                    title: _.template(gettext('Upload a new PDF to “<%- name %>”'))(
                         {name: course.escape('name')}),
                     message: gettext('Please select a PDF file to upload.'),
                     mimeTypes: ['application/pdf']

--- a/cms/static/js/views/metadata.js
+++ b/cms/static/js/views/metadata.js
@@ -453,9 +453,9 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             _.each(value, function(value, key) {
                 var template = _.template(
                     '<li class="list-settings-item">' +
-                        '<input type="text" class="input input-key" value="<%= key %>">' +
-                        '<input type="text" class="input input-value" value="<%= value %>">' +
-                        '<a href="#" class="remove-action remove-setting" data-value="<%= value %>"><span class="icon fa fa-times-circle" aria-hidden="true"></span><span class="sr">Remove</span></a>' +  // eslint-disable-line max-len
+                        '<input type="text" class="input input-key" value="<%- key %>">' +
+                        '<input type="text" class="input input-value" value="<%- value %>">' +
+                        '<a href="#" class="remove-action remove-setting" data-value="<%- value %>"><span class="icon fa fa-times-circle" aria-hidden="true"></span><span class="sr">Remove</span></a>' +  // eslint-disable-line max-len
                     '</li>'
                 );
 

--- a/cms/static/js/views/show_textbook.js
+++ b/cms/static/js/views/show_textbook.js
@@ -29,7 +29,7 @@ define(['js/views/baseview', 'underscore', 'gettext', 'common/js/components/view
                     if (e && e.preventDefault) { e.preventDefault(); }
                     var textbook = this.model;
                     new PromptView.Warning({
-                        title: _.template(gettext('Delete “<%= name %>”?'))(
+                        title: _.template(gettext('Delete “<%- name %>”?'))(
                     {name: textbook.get('name')}
                 ),
                         message: gettext("Deleting a textbook cannot be undone and once deleted any reference to it in your courseware's navigation will also be removed."),

--- a/cms/static/js/views/utils/create_course_utils.js
+++ b/cms/static/js/views/utils/create_course_utils.js
@@ -5,7 +5,7 @@ define(['jquery', 'gettext', 'common/js/components/utils/view_utils', 'js/views/
     function($, gettext, ViewUtils, CreateUtilsFactory) {
         'use strict';
         return function(selectors, classes) {
-            var keyLengthViolationMessage = gettext('The combined length of the organization, course number, and course run fields cannot be more than <%=limit%> characters.');
+            var keyLengthViolationMessage = gettext('The combined length of the organization, course number, and course run fields cannot be more than <%-limit%> characters.');
             var keyFieldSelectors = [selectors.org, selectors.number, selectors.run];
             var nonEmptyCheckFieldSelectors = [selectors.name, selectors.org, selectors.number, selectors.run];
 

--- a/cms/static/js/views/utils/create_library_utils.js
+++ b/cms/static/js/views/utils/create_library_utils.js
@@ -5,7 +5,7 @@ define(['jquery', 'gettext', 'common/js/components/utils/view_utils', 'js/views/
     function($, gettext, ViewUtils, CreateUtilsFactory) {
         'use strict';
         return function(selectors, classes) {
-            var keyLengthViolationMessage = gettext('The combined length of the organization and library code fields cannot be more than <%=limit%> characters.');
+            var keyLengthViolationMessage = gettext('The combined length of the organization and library code fields cannot be more than <%-limit%> characters.');
             var keyFieldSelectors = [selectors.org, selectors.number];
             var nonEmptyCheckFieldSelectors = [selectors.name, selectors.org, selectors.number];
 

--- a/cms/templates/js/active-video-upload-list.underscore
+++ b/cms/templates/js/active-video-upload-list.underscore
@@ -5,6 +5,6 @@
     <input type="file" class="sr js-file-input" name="file" multiple>
 </form>
 <section class="active-video-upload-container">
-    <h3 class="sr"><%= gettext("Active Uploads") %></h3>
+    <h3 class="sr"><%- gettext("Active Uploads") %></h3>
     <ul class="active-video-upload-list"></ul>
 </section>

--- a/cms/templates/js/active-video-upload.underscore
+++ b/cms/templates/js/active-video-upload.underscore
@@ -1,5 +1,5 @@
 <h4 class="video-detail-name"><%- fileName %></h4>
-<progress class="video-detail-progress" value="<%= progress %>"></progress>
+<progress class="video-detail-progress" value="<%- progress %>"></progress>
 <div class="video-upload-status">
     <span class="icon alert-icon fa fa-warning upload-failure" aria-hidden="true"></span>
     <span class="video-detail-status"><%- gettext(status) %></span>

--- a/cms/templates/js/add-xblock-component-button.underscore
+++ b/cms/templates/js/add-xblock-component-button.underscore
@@ -1,9 +1,9 @@
 <% if (type === 'advanced' || templates.length > 1) { %>
-<button type="button" class="multiple-templates add-xblock-component-button" data-type="<%= type %>">
+<button type="button" class="multiple-templates add-xblock-component-button" data-type="<%- type %>">
 <% } else { %>
-<button type="button" class="single-template add-xblock-component-button" data-type="<%= type %>" data-category="<%= templates[0].category %>">
+<button type="button" class="single-template add-xblock-component-button" data-type="<%- type %>" data-category="<%- templates[0].category %>">
 <% } %>
-  <span class="large-template-icon large-<%= type %>-icon"></span>
-  <span class="sr"> <%= gettext("Add Component:") %></span>
-  <span class="name"><%= display_name %></span>
+  <span class="large-template-icon large-<%- type %>-icon"></span>
+  <span class="sr"> <%- gettext("Add Component:") %></span>
+  <span class="name"><%- display_name %></span>
 </button>

--- a/cms/templates/js/add-xblock-component.underscore
+++ b/cms/templates/js/add-xblock-component.underscore
@@ -1,5 +1,5 @@
 <div class="new-component">
-    <h5><%= gettext("Add New Component") %></h5>
+    <h5><%- gettext("Add New Component") %></h5>
     <ul class="new-component-type">
     </ul>
 </div>

--- a/cms/templates/js/advanced_entry.underscore
+++ b/cms/templates/js/advanced_entry.underscore
@@ -1,14 +1,14 @@
-<li class="field-group course-advanced-policy-list-item <%= deprecated ? 'is-deprecated' : '' %>">
-	<div class="field is-not-editable text key" id="<%= key %>">
-		<h3 class="title" id="<%= keyUniqueId %>"><%= display_name %></h3>
+<li class="field-group course-advanced-policy-list-item <%- deprecated ? 'is-deprecated' : '' %>">
+	<div class="field is-not-editable text key" id="<%- key %>">
+		<h3 class="title" id="<%- keyUniqueId %>"><%- display_name %></h3>
   </div>
 
   <div class="field text value">
-    <label class="sr" for="<%= valueUniqueId %>"><%= display_name %></label>
-    <textarea class="json text" id="<%= valueUniqueId %>"><%= value %></textarea>
-    <span class="tip tip-stacked"><%= help %></span>
+    <label class="sr" for="<%- valueUniqueId %>"><%- display_name %></label>
+    <textarea class="json text" id="<%- valueUniqueId %>"><%- value %></textarea>
+    <span class="tip tip-stacked"><%- help %></span>
   </div>
   <% if (deprecated) { %>
-      <span class="status"><%= gettext("Deprecated") %></span>
+      <span class="status"><%- gettext("Deprecated") %></span>
   <% } %>
 </li>

--- a/cms/templates/js/asset-upload-modal.underscore
+++ b/cms/templates/js/asset-upload-modal.underscore
@@ -1,7 +1,7 @@
 <div class="upload-modal modal" style="display: none;">
-    <a href="#" class="close-button"><span class="icon fa fa-times-circle" aria-hidden="true"></span> <span class="sr"><%= gettext('close') %></span></a>
+    <a href="#" class="close-button"><span class="icon fa fa-times-circle" aria-hidden="true"></span> <span class="sr"><%- gettext('close') %></span></a>
     <div class="modal-body">
-        <h1 class="title"><%= gettext("Upload New File") %></h1>
+        <h1 class="title"><%- gettext("Upload New File") %></h1>
         <p class="file-name">
         <div class="progress-bar">
             <div class="progress-fill"></div>
@@ -12,7 +12,7 @@
         </div>
         <form class="file-chooser" action="asset-url"
               method="post" enctype="multipart/form-data">
-            <a href="#" class="choose-file-button"><%= gettext("Choose File") %></a>
+            <a href="#" class="choose-file-button"><%- gettext("Choose File") %></a>
             <input type="file" class="file-input" name="file">
         </form>
     </div>

--- a/cms/templates/js/certificate-web-preview.underscore
+++ b/cms/templates/js/certificate-web-preview.underscore
@@ -1,17 +1,17 @@
-<label for="course-modes"><%= gettext("Choose mode") %></label>
+<label for="course-modes"><%- gettext("Choose mode") %></label>
 <select id="course-modes">
 <% _.each(course_modes, function(course_mode) { %>
-     <option value= "<%= course_mode %>"><%= course_mode %></option>
+     <option value= "<%- course_mode %>"><%- course_mode %></option>
 <% }); %>
 </select>
-<a href=<%= certificate_web_view_url %> class="button preview-certificate-link" target="_blank">
-    <%= gettext("Preview Certificate") %>
+<a href=<%- certificate_web_view_url %> class="button preview-certificate-link" target="_blank">
+    <%- gettext("Preview Certificate") %>
 </a>
 <button class="button activate-cert">
     <span>
     <% if(!is_active) { %>
-        <%= gettext("Activate") %></span>
+        <%- gettext("Activate") %></span>
     <% } else { %>
-        <%= gettext("Deactivate") %></span>
+        <%- gettext("Deactivate") %></span>
     <% } %>
 </button>

--- a/cms/templates/js/course-outline-modal.underscore
+++ b/cms/templates/js/course-outline-modal.underscore
@@ -1,4 +1,4 @@
-<div class="xblock-editor" data-locator="<%= xblockInfo.get('id') %>" data-course-key="<%= xblockInfo.get('courseKey') %>">
+<div class="xblock-editor" data-locator="<%- xblockInfo.get('id') %>" data-course-key="<%- xblockInfo.get('courseKey') %>">
     <div class="message modal-introduction">
         <p><%- introductionMessage %></p>
     </div>

--- a/cms/templates/js/course_grade_policy.underscore
+++ b/cms/templates/js/course_grade_policy.underscore
@@ -1,35 +1,35 @@
 <li class="field-group course-grading-assignment-list-item">
   <div class="field text" id="field-course-grading-assignment-name">
-  	<label for="course-grading-assignment-name"><%= gettext("Assignment Type Name") %></label>
-  	<input type="text" class="long" id="course-grading-assignment-name" value="<%= model.get('type') %>" />
-  	<span class="tip tip-stacked"><%= gettext("The general category for this type of assignment, for example, Homework or Midterm Exam. This name is visible to learners.") %></span>
+  	<label for="course-grading-assignment-name"><%- gettext("Assignment Type Name") %></label>
+  	<input type="text" class="long" id="course-grading-assignment-name" value="<%- model.get('type') %>" />
+  	<span class="tip tip-stacked"><%- gettext("The general category for this type of assignment, for example, Homework or Midterm Exam. This name is visible to learners.") %></span>
   </div>
 
   <div class="field text" id="field-course-grading-assignment-shortname">
-    <label for="course-grading-assignment-shortname"><%= gettext("Abbreviation") %></label>
-    <input type="text" class="short" id="course-grading-assignment-shortname" value="<%= model.get('short_label') %>" />
-    <span class="tip tip-stacked"><%= gettext("This short name for the assignment type (for example, HW or Midterm) appears next to assignments on a learner's Progress page.") %></span>
+    <label for="course-grading-assignment-shortname"><%- gettext("Abbreviation") %></label>
+    <input type="text" class="short" id="course-grading-assignment-shortname" value="<%- model.get('short_label') %>" />
+    <span class="tip tip-stacked"><%- gettext("This short name for the assignment type (for example, HW or Midterm) appears next to assignments on a learner's Progress page.") %></span>
   </div>
 
   <div class="field text" id="field-course-grading-assignment-gradeweight">
-    <label for="course-grading-assignment-gradeweight"><%= gettext("Weight of Total Grade") %></label>
-    <input type="text" class="short" id="course-grading-assignment-gradeweight" value = "<%= model.get('weight') %>" />
-    <span class="tip tip-stacked"><%= gettext("The weight of all assignments of this type as a percentage of the total grade, for example, 40. Do not include the percent symbol.") %></span>
+    <label for="course-grading-assignment-gradeweight"><%- gettext("Weight of Total Grade") %></label>
+    <input type="text" class="short" id="course-grading-assignment-gradeweight" value = "<%- model.get('weight') %>" />
+    <span class="tip tip-stacked"><%- gettext("The weight of all assignments of this type as a percentage of the total grade, for example, 40. Do not include the percent symbol.") %></span>
   </div>
 
   <div class="field text" id="field-course-grading-assignment-totalassignments">
-    <label for="course-grading-assignment-totalassignments"><%= gettext("Total Number") %></label>
-    <input type="text" class="short" id="course-grading-assignment-totalassignments" value = "<%= model.get('min_count') %>" />
-    <span class="tip tip-stacked"><%= gettext("The number of subsections in the course that contain problems of this assignment type.") %></span>
+    <label for="course-grading-assignment-totalassignments"><%- gettext("Total Number") %></label>
+    <input type="text" class="short" id="course-grading-assignment-totalassignments" value = "<%- model.get('min_count') %>" />
+    <span class="tip tip-stacked"><%- gettext("The number of subsections in the course that contain problems of this assignment type.") %></span>
   </div>
 
   <div class="field text" id="field-course-grading-assignment-droppable">
-    <label for="course-grading-assignment-droppable"><%= gettext("Number of Droppable") %></label>
-    <input type="text" class="short" id="course-grading-assignment-droppable" value = "<%= model.get('drop_count') %>" />
-    <span class="tip tip-stacked"><%= gettext("The number of assignments of this type that will be dropped. The lowest scoring assignments are dropped first.") %></span>
+    <label for="course-grading-assignment-droppable"><%- gettext("Number of Droppable") %></label>
+    <input type="text" class="short" id="course-grading-assignment-droppable" value = "<%- model.get('drop_count') %>" />
+    <span class="tip tip-stacked"><%- gettext("The number of assignments of this type that will be dropped. The lowest scoring assignments are dropped first.") %></span>
   </div>
 
   <div class="actions">
-  	<a href="#" class="button delete-button standard remove-item remove-grading-data"><span class="delete-icon"></span><%= gettext("Delete") %></a>
+  	<a href="#" class="button delete-button standard remove-item remove-grading-data"><span class="delete-icon"></span><%- gettext("Delete") %></a>
   </div>
 </li>

--- a/cms/templates/js/course_info_handouts.underscore
+++ b/cms/templates/js/course_info_handouts.underscore
@@ -1,22 +1,22 @@
-<a href="#" class="edit-button"><span class="edit-icon"></span><%= gettext("Edit") %></a>
+<a href="#" class="edit-button"><span class="edit-icon"></span><%- gettext("Edit") %></a>
 
-<h2 class="title"><%= gettext("Course Handouts") %></h2>
+<h2 class="title"><%- gettext("Course Handouts") %></h2>
 <%if (model.get('data') != null) { %>
   <div class="handouts-content">
 
   </div>
 <% } else {%>
-  <p><%= gettext("You have no handouts defined") %></p>
+  <p><%- gettext("You have no handouts defined") %></p>
 <% } %>
 <form class="edit-handouts-form" style="display: block;">
   <div class="message message-status error" name="handout_html_error" id="handout_error">
-    <%= gettext("There is invalid code in your content. Please check to make sure it is valid HTML.") %>
+    <%- gettext("There is invalid code in your content. Please check to make sure it is valid HTML.") %>
   </div>
   <div class="row">
     <textarea class="handouts-content-editor text-editor"></textarea>
   </div>
   <div class="row">
-    <a href="#" class="save-button"><%= gettext("Save") %></a>
-    <a href="#" class="cancel-button"><%= gettext("Cancel") %></a>
+    <a href="#" class="save-button"><%- gettext("Save") %></a>
+    <a href="#" class="cancel-button"><%- gettext("Cancel") %></a>
   </div>
 </form>

--- a/cms/templates/js/course_info_update.underscore
+++ b/cms/templates/js/course_info_update.underscore
@@ -2,34 +2,34 @@
 	<!-- FIXME what style should we use for initially hidden? --> <!-- TODO decide whether this should use codemirror -->
 	<form class="new-update-form">
 		<div class="row">
-			<label for="update-date-<%= updateModel.cid %>" class="inline-label"><%= gettext('Date') %>:</label>
+			<label for="update-date-<%- updateModel.cid %>" class="inline-label"><%- gettext('Date') %>:</label>
 			<!-- TODO replace w/ date widget and actual date (problem is that persisted version is "Month day" not an actual date obj -->
-			<input id="update-date-<%= updateModel.cid %>" type="text" class="date" value="<%= updateModel.get('date') %>">
+			<input id="update-date-<%- updateModel.cid %>" type="text" class="date" value="<%- updateModel.get('date') %>">
 		</div>
 		<div class="row">
-			<textarea class="new-update-content text-editor"><%= updateModel.get('content') %></textarea>
+			<textarea class="new-update-content text-editor"><%- updateModel.get('content') %></textarea>
 		</div>
         <%if (push_notification_enabled) { %>
     		<div class="row new-update-push-notification">
-                <input id="update-notification-checkbox-<%= updateModel.cid %>" type="checkbox" class="toggle-checkbox" data-tooltip="<%= gettext('Send push notification to mobile apps') %>" checked />
-                <label for="update-notification-checkbox-<%= updateModel.cid %>" class="inline-label"><%= gettext('Send notification to mobile apps') %></label>
+                <input id="update-notification-checkbox-<%- updateModel.cid %>" type="checkbox" class="toggle-checkbox" data-tooltip="<%- gettext('Send push notification to mobile apps') %>" checked />
+                <label for="update-notification-checkbox-<%- updateModel.cid %>" class="inline-label"><%- gettext('Send notification to mobile apps') %></label>
             </div>
         <% } %>
 		<div class="row">
 			<!-- cid rather than id b/c new ones have cid's not id's -->
-            <button class="save-button" name="<%= updateModel.cid %>"><%= gettext('Post') %></button>
-            <button class="cancel-button" name="<%= updateModel.cid %>"><%= gettext('Cancel') %></button>
+            <button class="save-button" name="<%- updateModel.cid %>"><%- gettext('Post') %></button>
+            <button class="cancel-button" name="<%- updateModel.cid %>"><%- gettext('Cancel') %></button>
 		</div>
 	</form>
 	<div class="post-preview">
 		<div class="post-actions">
-            <button class="edit-button" name="<%= updateModel.cid %>"><span class="edit-icon"></span><%= gettext('Edit') %></button>
-            <button class="delete-button" name="<%= updateModel.cid %>"><span class="delete-icon"></span><%= gettext('Delete') %></button>
+            <button class="edit-button" name="<%- updateModel.cid %>"><span class="edit-icon"></span><%- gettext('Edit') %></button>
+            <button class="delete-button" name="<%- updateModel.cid %>"><span class="delete-icon"></span><%- gettext('Delete') %></button>
 		</div>
 		<h2>
-			<span class="calendar-icon"></span><span class="date-display"><%=
+			<span class="calendar-icon"></span><span class="date-display"><%-
 				updateModel.get('date') %></span>
 		</h2>
-		<div class="update-contents"><%= updateModel.get('content') %></div>
+		<div class="update-contents"><%- updateModel.get('content') %></div>
 	</div>
 </li>

--- a/cms/templates/js/due-date-editor.underscore
+++ b/cms/templates/js/due-date-editor.underscore
@@ -1,12 +1,12 @@
 <ul class="list-fields list-input datepair date-setter">
     <li class="field field-text field-due-date">
-        <label for="due_date"><%= gettext('Due Date:') %></label>
+        <label for="due_date"><%- gettext('Due Date:') %></label>
         <input type="text" id="due_date" name="due_date" value=""
             placeholder="MM/DD/YYYY" class="due-date date input input-text" autocomplete="off"/>
     </li>
 
     <li class="field field-text field-due-time">
-        <label for="due_time"><%= gettext('Due Time in UTC:') %></label>
+        <label for="due_time"><%- gettext('Due Time in UTC:') %></label>
         <input type="text" id="due_time" name="due_time" value=""
             placeholder="HH:MM" class="due-time time input input-text" autocomplete="off" />
     </li>
@@ -14,9 +14,9 @@
 
 <ul class="list-actions">
     <li class="action-item">
-        <a href="#" data-tooltip="<%= gettext('Clear Grading Due Date') %>" class="clear-date action-button action-clear">
+        <a href="#" data-tooltip="<%- gettext('Clear Grading Due Date') %>" class="clear-date action-button action-clear">
             <span class="icon fa fa-undo" aria-hidden="true"></span>
-            <span class="sr"><%= gettext('Clear Grading Due Date') %></span>
+            <span class="sr"><%- gettext('Clear Grading Due Date') %></span>
         </a>
     </li>
 </ul>

--- a/cms/templates/js/edit-xblock-modal.underscore
+++ b/cms/templates/js/edit-xblock-modal.underscore
@@ -1,1 +1,1 @@
-<div class="xblock-editor" data-locator="<%= xblockInfo.get('id') %>" data-course-key="<%= xblockInfo.get('courseKey') %>"></div>
+<div class="xblock-editor" data-locator="<%- xblockInfo.get('id') %>" data-course-key="<%- xblockInfo.get('courseKey') %>"></div>

--- a/cms/templates/js/editor-mode-button.underscore
+++ b/cms/templates/js/editor-mode-button.underscore
@@ -1,3 +1,3 @@
-<li class="action-item" data-mode="<%= mode %>">
-    <a href="#" class="<%= mode %>-button"><%= displayName %></a>
+<li class="action-item" data-mode="<%- mode %>">
+    <a href="#" class="<%- mode %>-button"><%- displayName %></a>
 </li>

--- a/cms/templates/js/grading-editor.underscore
+++ b/cms/templates/js/grading-editor.underscore
@@ -1,12 +1,12 @@
-<h3 class="modal-section-title"><%= gettext('Grading') %></h3>
+<h3 class="modal-section-title"><%- gettext('Grading') %></h3>
 <div class="modal-section-content grading-type">
     <ul class="list-fields list-input">
         <li class="field field-grading-type field-select">
-            <label for="grading_type" class="label"><%= gettext('Grade as:') %></label>
+            <label for="grading_type" class="label"><%- gettext('Grade as:') %></label>
             <select class="input" id="grading_type">
-                <option value="notgraded"><%= gettext('Not Graded') %></option>
+                <option value="notgraded"><%- gettext('Not Graded') %></option>
                 <% _.each(graderTypes, function(grader) { %>
-                  <option value="<%= grader %>"><%= grader %></option>
+                  <option value="<%- grader %>"><%- grader %></option>
                 <% }); %>
             </select>
         </li>

--- a/cms/templates/js/group-configuration-details.underscore
+++ b/cms/templates/js/group-configuration-details.underscore
@@ -31,9 +31,9 @@
 
     <% if(showGroups) { %>
       <% allocation = Math.floor(100 / groups.length) %>
-      <ol class="collection-items groups groups-<%= index %>">
+      <ol class="collection-items groups groups-<%- index %>">
         <% groups.each(function(group, groupIndex) { %>
-          <li class="item group group-<%= groupIndex %>">
+          <li class="item group group-<%- groupIndex %>">
             <span class="name group-name"><%- group.get('name') %></span>
             <span class="meta group-allocation"><%- allocation %>%</span>
           </li>

--- a/cms/templates/js/license-selector.underscore
+++ b/cms/templates/js/license-selector.underscore
@@ -1,6 +1,6 @@
 <div class="wrapper-license">
     <h3 class="label setting-label">
-        <%= gettext("License Type") %>
+        <%- gettext("License Type") %>
     </h3>
     <ul class="license-types">
         <% var link_start_tpl = '<a href="{url}" target="_blank">'; %>
@@ -15,7 +15,7 @@
                 <p class="tip">
                     <% if(license.url) { %>
                         <a href="<%- license.url %>" target="_blank">
-                            <%= gettext("Learn more about {license_name}")
+                            <%- gettext("Learn more about {license_name}")
                                         .replace("{license_name}", license.name)
                             %>
                         </a>
@@ -71,15 +71,15 @@
 <% if (showPreview) { %>
     <div class="wrapper-license-preview">
         <h4 class="label setting-label">
-            <%= gettext("License Display") %>
+            <%- gettext("License Display") %>
         </h4>
         <p class="tip">
-            <%= gettext("The following message will be displayed at the bottom of the courseware pages within your course:") %>
+            <%- gettext("The following message will be displayed at the bottom of the courseware pages within your course:") %>
         </p>
         <div class="license-preview">
         <% // keep this synchronized with the contents of common/templates/license.html %>
         <% if (model.type === "all-rights-reserved") { %>
-            © <span class="license-text"><%= gettext("All Rights Reserved") %></span>
+            © <span class="license-text"><%- gettext("All Rights Reserved") %></span>
         <% } else if (model.type === "creative-commons") {
              var possible = ["by", "nc", "nd", "sa"];
              var enabled = _.filter(possible, function(option) {
@@ -98,16 +98,16 @@
                     />
             <% } else { %>
 	        <% //<span> must come before <i> icon or else spacing gets messed up %>
-                <span class="sr"><%= gettext("Creative Commons licensed content, with terms as follow:") %>&nbsp;</span><span aria-hidden="true" class="icon-cc"></span>
+                <span class="sr"><%- gettext("Creative Commons licensed content, with terms as follow:") %>&nbsp;</span><span aria-hidden="true" class="icon-cc"></span>
                 <% _.each(enabled, function(option) { %>
                         <span class="sr"><%- license.options[option.toUpperCase()].name %>&nbsp;</span><span aria-hidden="true" class="icon-cc-<%- option %>"></span>
                 <% }); %>
-                <span class="license-text"><%= gettext("Some Rights Reserved") %></span>
+                <span class="license-text"><%- gettext("Some Rights Reserved") %></span>
             <% } %>
         <% } else { %>
-            <%= typeof licenseString == "string" ? licenseString : "" %>
+            <%- typeof licenseString == "string" ? licenseString : "" %>
             <% // Default to ARR license %>
-            © <span class="license-text"><%= gettext("All Rights Reserved") %></span>
+            © <span class="license-text"><%- gettext("All Rights Reserved") %></span>
         <% } %>
         </a>
     </div>

--- a/cms/templates/js/maintenance/force-published-course-response.underscore
+++ b/cms/templates/js/maintenance/force-published-course-response.underscore
@@ -3,7 +3,7 @@
         <%- gettext('You have done a dry run of force publishing the course. Nothing has changed. Had you run it, the following course versions would have been change.') %>
     </div>
     <div class="main-output">
-        <%= StringUtils.interpolate(
+        <%- StringUtils.interpolate(
             gettext('The published branch version, {published}, was reset to the draft branch version, {draft}.'),
             {
                 published: current_versions['published-branch'],

--- a/cms/templates/js/metadata-dict-entry.underscore
+++ b/cms/templates/js/metadata-dict-entry.underscore
@@ -1,14 +1,14 @@
 <div class="wrapper-comp-setting metadata-dict">
-  <label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name')%></label>
-  <div id="<%= uniqueId %>" class="wrapper-dict-settings">
+  <label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name')%></label>
+  <div id="<%- uniqueId %>" class="wrapper-dict-settings">
     <ol class="list-settings"></ol>
     <a href="#" class="create-action create-setting">
-      <span class="icon fa fa-plus" aria-hidden="true"></span><%= gettext("Add") %> <span class="sr"><%= model.get('display_name')%></span>
+      <span class="icon fa fa-plus" aria-hidden="true"></span><%- gettext("Add") %> <span class="sr"><%- model.get('display_name')%></span>
     </a>
   </div>
-  <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
+  <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%- gettext("Clear") %>" data-tooltip="<%- gettext("Clear") %>">
     <span class="icon fa fa-undo" aria-hidden="true"></span>
-    <span class="sr">"<%= gettext("Clear Value") %>"</span>
+    <span class="sr">"<%- gettext("Clear Value") %>"</span>
   </button>
 </div>
-<span class="tip setting-help"><%= model.get('help') %></span>
+<span class="tip setting-help"><%- model.get('help') %></span>

--- a/cms/templates/js/metadata-file-uploader-entry.underscore
+++ b/cms/templates/js/metadata-file-uploader-entry.underscore
@@ -1,9 +1,9 @@
 <div class="wrapper-comp-setting file-uploader">
-  <label class="label setting-label"><%= model.get('display_name') %></label>
-  <input type="hidden" id="<%= uniqueId %>" class="input setting-input" value="<%= model.get("value") %>">
+  <label class="label setting-label"><%- model.get('display_name') %></label>
+  <input type="hidden" id="<%- uniqueId %>" class="input setting-input" value="<%- model.get("value") %>">
   <div class="wrapper-uploader-actions"></div>
-  <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
-        <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"<%= gettext("Clear Value") %>"</span>
+  <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%- gettext("Clear") %>" data-tooltip="<%- gettext("Clear") %>">
+        <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"<%- gettext("Clear Value") %>"</span>
     </button>
 </div>
-<span class="tip setting-help"><%= model.get('help') %></span>
+<span class="tip setting-help"><%- model.get('help') %></span>

--- a/cms/templates/js/metadata-file-uploader-item.underscore
+++ b/cms/templates/js/metadata-file-uploader-item.underscore
@@ -1,3 +1,3 @@
-<a href="#" class="upload-action upload-setting"><%= model.get('value') ? gettext('Replace') : gettext('Upload') %>
-</a><% if (model.get('value')) { %><a href="<%= model.get("value") %>" target="_blank" class="download-action download-setting"><%= gettext("Download") %>
+<a href="#" class="upload-action upload-setting"><%- model.get('value') ? gettext('Replace') : gettext('Upload') %>
+</a><% if (model.get('value')) { %><a href="<%- model.get("value") %>" target="_blank" class="download-action download-setting"><%- gettext("Download") %>
 </a><% } %>

--- a/cms/templates/js/metadata-list-entry.underscore
+++ b/cms/templates/js/metadata-list-entry.underscore
@@ -1,17 +1,17 @@
 <div class="wrapper-comp-setting metadata-list-enum">
-  <label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name')%></label>
-  <div id="<%= uniqueId %>" class="wrapper-list-settings">
+  <label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name')%></label>
+  <div id="<%- uniqueId %>" class="wrapper-list-settings">
     <ol class="list-settings">
 
     </ol>
 
     <a href="#" class="create-action create-setting">
-      <span class="icon fa fa-plus" aria-hidden="true"></span><%= gettext("Add") %> <span class="sr"><%= model.get('display_name')%></span>
+      <span class="icon fa fa-plus" aria-hidden="true"></span><%- gettext("Add") %> <span class="sr"><%- model.get('display_name')%></span>
     </a>
   </div>
-  <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
+  <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%- gettext("Clear") %>" data-tooltip="<%- gettext("Clear") %>">
     <span class="icon fa fa-undo" aria-hidden="true"></span>
-    <span class="sr">"<%= gettext("Clear Value") %>"</span>
+    <span class="sr">"<%- gettext("Clear Value") %>"</span>
   </button>
 </div>
-<span class="tip setting-help"><%= model.get('help') %></span>
+<span class="tip setting-help"><%- model.get('help') %></span>

--- a/cms/templates/js/metadata-number-entry.underscore
+++ b/cms/templates/js/metadata-number-entry.underscore
@@ -1,8 +1,8 @@
 <div class="wrapper-comp-setting">
-	<label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
-	<input class="input setting-input setting-input-number" type="number" id="<%= uniqueId %>" value='<%= model.get("value") %>'/>
-    <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
-        <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"<%= gettext("Clear Value") %>"</span>
+	<label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name') %></label>
+	<input class="input setting-input setting-input-number" type="number" id="<%- uniqueId %>" value='<%- model.get("value") %>'/>
+    <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%- gettext("Clear") %>" data-tooltip="<%- gettext("Clear") %>">
+        <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"<%- gettext("Clear Value") %>"</span>
     </button>
 </div>
-<span class="tip setting-help"><%= model.get('help') %></span>
+<span class="tip setting-help"><%- model.get('help') %></span>

--- a/cms/templates/js/metadata-option-entry.underscore
+++ b/cms/templates/js/metadata-option-entry.underscore
@@ -1,16 +1,16 @@
 <div class="wrapper-comp-setting">
-    <label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
-    <select class="input setting-input" id="<%= uniqueId %>" name="<%= model.get('display_name') %>">
+    <label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name') %></label>
+    <select class="input setting-input" id="<%- uniqueId %>" name="<%- model.get('display_name') %>">
         <% _.each(model.get('options'), function(option) { %>
             <% if (option.display_name !== undefined) { %>
-                <option value="<%= option['display_name'] %>"><%= option['display_name'] %></option>
+                <option value="<%- option['display_name'] %>"><%- option['display_name'] %></option>
             <% } else { %>
-                <option value="<%= option %>"><%= option %></option>
+                <option value="<%- option %>"><%- option %></option>
             <% } %>
         <% }) %>
     </select>
-    <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
-        <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"<%= gettext("Clear Value") %>"</span>
+    <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%- gettext("Clear") %>" data-tooltip="<%- gettext("Clear") %>">
+        <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"<%- gettext("Clear Value") %>"</span>
     </button>
 </div>
-<span class="tip setting-help"><%= model.get('help') %></span>
+<span class="tip setting-help"><%- model.get('help') %></span>

--- a/cms/templates/js/metadata-string-entry.underscore
+++ b/cms/templates/js/metadata-string-entry.underscore
@@ -1,8 +1,8 @@
 <div class="wrapper-comp-setting">
-	<label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
-	<input class="input setting-input" type="text" id="<%= uniqueId %>" value='<%= model.get("value") %>'/>
-	<button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
-        <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"<%= gettext("Clear Value") %>"</span>
+	<label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name') %></label>
+	<input class="input setting-input" type="text" id="<%- uniqueId %>" value='<%- model.get("value") %>'/>
+	<button class="action setting-clear inactive" type="button" name="setting-clear" value="<%- gettext("Clear") %>" data-tooltip="<%- gettext("Clear") %>">
+        <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"<%- gettext("Clear Value") %>"</span>
     </button>
 </div>
-<span class="tip setting-help"><%= model.get('help') %></span>
+<span class="tip setting-help"><%- model.get('help') %></span>

--- a/cms/templates/js/mock/mock-xmodule-editor.underscore
+++ b/cms/templates/js/mock/mock-xmodule-editor.underscore
@@ -16,13 +16,13 @@
 
         <script id="metadata-string-entry" type="text/template">
             <div class="wrapper-comp-setting">
-                \t<label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
-                \t<input class="input setting-input" type="text" id="<%= uniqueId %>" value='<%= model.get("value") %>'/>
+                \t<label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name') %></label>
+                \t<input class="input setting-input" type="text" id="<%- uniqueId %>" value='<%- model.get("value") %>'/>
                 \t<button class="action setting-clear inactive" type="button" name="setting-clear" value="Clear" data-tooltip="Clear">
                 <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"Clear Value"</span>
                 </button>
             </div>
-            <span class="tip setting-help"><%= model.get('help') %></span>
+            <span class="tip setting-help"><%- model.get('help') %></span>
 
         </script>
 

--- a/cms/templates/js/mock/mock-xmodule-settings-only-editor.underscore
+++ b/cms/templates/js/mock/mock-xmodule-settings-only-editor.underscore
@@ -12,13 +12,13 @@
 
         <script id="metadata-string-entry" type="text/template">
             <div class="wrapper-comp-setting">
-                \t<label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
-                \t<input class="input setting-input" type="text" id="<%= uniqueId %>" value='<%= model.get("value") %>'/>
+                \t<label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name') %></label>
+                \t<input class="input setting-input" type="text" id="<%- uniqueId %>" value='<%- model.get("value") %>'/>
                 \t<button class="action setting-clear inactive" type="button" name="setting-clear" value="Clear" data-tooltip="Clear">
                 <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"Clear Value"</span>
                 </button>
             </div>
-            <span class="tip setting-help"><%= model.get('help') %></span>
+            <span class="tip setting-help"><%- model.get('help') %></span>
 
         </script>
 

--- a/cms/templates/js/publish-editor.underscore
+++ b/cms/templates/js/publish-editor.underscore
@@ -6,13 +6,13 @@
             <% _.each(xblockInfo.get('child_info').children, function(subsection) { %>
               <% if (subsection.isPublishable())  { %>
                 <li class="outline-item outline-subsection">
-                    <h4 class="subsection-title item-title"><%= subsection.get('display_name') %></h4>
+                    <h4 class="subsection-title item-title"><%- subsection.get('display_name') %></h4>
                     <div class="subsection-content">
                         <ol class="list-units">
                           <% _.each(subsection.get('child_info').children, function(unit) { %>
                             <% if (unit.isPublishable())  { %>
                               <li class="outline-item outline-unit">
-                                  <span class="unit-title item-title"><%= unit.get('display_name') %></span>
+                                  <span class="unit-title item-title"><%- unit.get('display_name') %></span>
                               </li>
                             <% } %>
                           <% }); %>
@@ -27,7 +27,7 @@
             <% _.each(xblockInfo.get('child_info').children, function(unit) { %>
               <% if (unit.isPublishable())  { %>
                 <li class="outline-item outline-unit">
-                    <span class="unit-title item-title"><%= unit.get('display_name') %></span>
+                    <span class="unit-title item-title"><%- unit.get('display_name') %></span>
                 </li>
               <% } %>
             <% }); %>

--- a/cms/templates/js/publish-history.underscore
+++ b/cms/templates/js/publish-history.underscore
@@ -12,5 +12,5 @@ if (published_on && published_by) {
 %>
 
 <div class="wrapper-last-publish">
-    <p class="copy"><%= copy %></p>
+    <p class="copy"><%- copy %></p>
 </div>

--- a/cms/templates/js/section-name-edit.underscore
+++ b/cms/templates/js/section-name-edit.underscore
@@ -1,5 +1,5 @@
 <form class="section-name-edit">
-    <input type="text" value="<%= name %>" autocomplete="off"/>
-    <input type="submit" class="save-button" value="<%= gettext("Save") %>" />
-    <input type="button" class="cancel-button" value="<%= gettext("Cancel") %>" />
+    <input type="text" value="<%- name %>" autocomplete="off"/>
+    <input type="submit" class="save-button" value="<%- gettext("Save") %>" />
+    <input type="button" class="cancel-button" value="<%- gettext("Cancel") %>" />
 </form>

--- a/cms/templates/js/signatory-actions.underscore
+++ b/cms/templates/js/signatory-actions.underscore
@@ -1,6 +1,6 @@
 <div class="collection-edit">
     <div class="actions custom-signatory-action">
-            <button class="signatory-panel-save action action-primary" type="submit"><%= gettext("Save") %></button>
-            <button class="signatory-panel-close action action-secondary action-cancel"><%= gettext("Cancel") %></button>
+            <button class="signatory-panel-save action action-primary" type="submit"><%- gettext("Save") %></button>
+            <button class="signatory-panel-close action action-secondary action-cancel"><%- gettext("Cancel") %></button>
     </div>
 </div>

--- a/cms/templates/js/team-member.underscore
+++ b/cms/templates/js/team-member.underscore
@@ -1,11 +1,11 @@
-<li class="user-item" data-email="<%= user.email %>">
+<li class="user-item" data-email="<%- user.email %>">
     <span class="wrapper-ui-badge">
-    <span class="flag flag-role flag-role-<%= user.role %> is-hanging">
-      <span class="label sr"><%= gettext("Current Role:") %></span>
+    <span class="flag flag-role flag-role-<%- user.role %> is-hanging">
+      <span class="label sr"><%- gettext("Current Role:") %></span>
       <span class="value">
-        <%= roles[user.role] %>
+        <%- roles[user.role] %>
         <% if (is_current_user) { %>
-            <span class="msg-you"><%= gettext("You!") %></span>
+            <span class="msg-you"><%- gettext("You!") %></span>
         <% } %>
       </span>
     </span>
@@ -13,11 +13,11 @@
 
     <div class="item-metadata">
     <h3 class="user-name">
-      <span class="user-username"><%= user.username %></span>
+      <span class="user-username"><%- user.username %></span>
       <span class="user-email">
-        <a class="action action-email" href="mailto:<%= user.email %>"
-                title="<%= viewHelpers.format(gettext("send an email message to {email}"), {email: user.email})%>">
-            <%= user.email %>
+        <a class="action action-email" href="mailto:<%- user.email %>"
+                title="<%- viewHelpers.format(gettext("send an email message to {email}"), {email: user.email})%>">
+            <%- user.email %>
         </a>
       </span>
     </h3>
@@ -29,19 +29,19 @@
         <% for (var i=0; i < actions.length; i++) { %>
             <% var action = actions[i]; %>
                 <% if (action.notoggle) { %>
-                    <span class="admin-role notoggleforyou"><%= gettext("Promote another member to Admin to remove your admin rights") %></span>
+                    <span class="admin-role notoggleforyou"><%- gettext("Promote another member to Admin to remove your admin rights") %></span>
                 <% } else { %>
-                    <a href="#" class="make-<%= action.to_role %> admin-role <%= action.direction %>-admin-role">
+                    <a href="#" class="make-<%- action.to_role %> admin-role <%- action.direction %>-admin-role">
                         <% var template = (action.direction === 'add') ? gettext("Add {role} Access") : gettext("Remove {role} Access"); %>
-                        <%= viewHelpers.format(template, {role: action.label}) %></span>
+                        <%- viewHelpers.format(template, {role: action.label}) %></span>
                     </a>
                 <% } %>
         <% } %>
         </li>
-        <li class="action action-delete <%=!allow_delete ? "is-disabled" : "" %> aria-disabled="<%=!allow_delete%>">
-            <a href="#" class="delete remove-user action-icon" data-id="<%= user.email %>">
+        <li class="action action-delete <%-!allow_delete ? "is-disabled" : "" %> aria-disabled="<%-!allow_delete%>">
+            <a href="#" class="delete remove-user action-icon" data-id="<%- user.email %>">
                 <span class="icon fa fa-trash-o" aria-hidden="true"></span>
-                <span class="sr"><%= viewHelpers.format(gettext("Delete the user, {username}"), {username:user.username}) %></span>
+                <span class="sr"><%- viewHelpers.format(gettext("Delete the user, {username}"), {username:user.username}) %></span>
             </a>
         </li>
     </ul>

--- a/cms/templates/js/unit-outline.underscore
+++ b/cms/templates/js/unit-outline.underscore
@@ -1,23 +1,23 @@
 <% if (parentInfo) { %>
-    <li class="outline-item outline-<%= xblockType %> <%= visibilityClass %> <%= xblockInfo.get('id') === currentUnitId ? 'is-current' : '' %>"
-        data-parent="<%= parentInfo.get('id') %>" data-locator="<%= xblockInfo.get('id') %>">
-        <div class="<%= xblockType %>-header">
-            <h3 class="<%= xblockType %>-header-details">
-                <span class="<%= xblockType %>-title item-title">
-                    <a href="<%= xblockInfo.get('studio_url') %>"><%- xblockInfo.get('display_name') %></a>
+    <li class="outline-item outline-<%- xblockType %> <%- visibilityClass %> <%- xblockInfo.get('id') === currentUnitId ? 'is-current' : '' %>"
+        data-parent="<%- parentInfo.get('id') %>" data-locator="<%- xblockInfo.get('id') %>">
+        <div class="<%- xblockType %>-header">
+            <h3 class="<%- xblockType %>-header-details">
+                <span class="<%- xblockType %>-title item-title">
+                    <a href="<%- xblockInfo.get('studio_url') %>"><%- xblockInfo.get('display_name') %></a>
                 </span>
             </h3>
         </div>
 <% } %>
 
-        <div class="<%= xblockType %>-content outline-content">
-            <ol class="<%= typeListClass %>">
+        <div class="<%- xblockType %>-content outline-content">
+            <ol class="<%- typeListClass %>">
             </ol>
             <% if (childType) { %>
-                <div class="add-<%= childType %> add-item">
-                    <a href="#" class="button button-new" data-category="<%= childCategory %>"
-                       data-parent="<%= xblockInfo.get('id') %>" data-default-name="<%= defaultNewChildName %>">
-                        <span class="icon fa fa-plus" aria-hidden="true"></span><%= addChildLabel %>
+                <div class="add-<%- childType %> add-item">
+                    <a href="#" class="button button-new" data-category="<%- childCategory %>"
+                       data-parent="<%- xblockInfo.get('id') %>" data-default-name="<%- defaultNewChildName %>">
+                        <span class="icon fa fa-plus" aria-hidden="true"></span><%- addChildLabel %>
                     </a>
                 </div>
             <% } %>

--- a/cms/templates/js/validation-error-modal.underscore
+++ b/cms/templates/js/validation-error-modal.underscore
@@ -1,7 +1,7 @@
 <div class = "validation-error-modal-content">
     <div class "error-header">
         <p>
-        <%= _.template(
+        <%- _.template(
             ngettext(
                 "There was {strong_start}{num_errors} validation error{strong_end} while trying to save the course settings in the database.",
                 "There were {strong_start}{num_errors} validation errors{strong_end} while trying to save the course settings in the database.",
@@ -13,7 +13,7 @@
                 num_errors: num_errors,
                 strong_end: '</strong>'
             })%>
-        <%= gettext("Please check the following validation feedbacks and reflect them in your course settings:")%></p>
+        <%- gettext("Please check the following validation feedbacks and reflect them in your course settings:")%></p>
     </div>
 
     <hr>
@@ -24,9 +24,9 @@
             <li class = "error-item">
                 <span class='error-item-title'>
                     <span class="icon fa fa-warning" aria-hidden="true"></span>
-                    <strong><%= value.model.display_name %></strong>:
+                    <strong><%- value.model.display_name %></strong>:
                 </span>
-                <textarea class = "error-item-message" disabled='disabled'><%=value.message%></textarea>
+                <textarea class = "error-item-message" disabled='disabled'><%- value.message %></textarea>
             </li>
 
         <% }); %>

--- a/cms/templates/js/verification-access-editor.underscore
+++ b/cms/templates/js/verification-access-editor.underscore
@@ -1,6 +1,6 @@
 <form>
   <div role="group" aria-labelledby="verification-checkpoint-title">
-    <h3 id="verification-checkpoint-title" class="modal-section-title"><%= gettext('Verification Checkpoint') %></h3>
+    <h3 id="verification-checkpoint-title" class="modal-section-title"><%- gettext('Verification Checkpoint') %></h3>
     <div class="modal-section-content verification-access">
       <div class="list-fields list-input">
         <div class="field field-checkbox checkbox-cosmetic">
@@ -20,7 +20,7 @@
           </label>
 
           <label class="sr" for="verification-partition-select">
-            <%= gettext('Verification checkpoint to be completed') %>
+            <%- gettext('Verification checkpoint to be completed') %>
           </label>
 
           <select id="verification-partition-select">
@@ -35,7 +35,7 @@
           </select>
 
           <div id="verification-help-text" class="note">
-            <%= gettext("Learners who require verification must pass the selected checkpoint to see the content in this unit. Learners who do not require verification see this content by default.") %>
+            <%- gettext("Learners who require verification must pass the selected checkpoint to see the content in this unit. Learners who do not require verification see this content by default.") %>
           </div>
         </div>
       </div>

--- a/cms/templates/js/video/metadata-translations-entry.underscore
+++ b/cms/templates/js/video/metadata-translations-entry.underscore
@@ -1,14 +1,14 @@
 <div class="wrapper-comp-setting metadata-video-translations">
-  <label class="label setting-label"><%= model.get('display_name')%></label>
+  <label class="label setting-label"><%- model.get('display_name')%></label>
   <div class="wrapper-translations-settings">
     <ol class="list-settings"></ol>
     <a href="#" class="create-action create-setting">
-      <span class="icon fa fa-plus" aria-hidden="true"></span><%= gettext("Add") %> <span class="sr"><%= model.get('display_name')%></span>
+      <span class="icon fa fa-plus" aria-hidden="true"></span><%- gettext("Add") %> <span class="sr"><%- model.get('display_name')%></span>
     </a>
   </div>
-  <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%= gettext("Clear") %>" data-tooltip="<%= gettext("Clear") %>">
+  <button class="action setting-clear inactive" type="button" name="setting-clear" value="<%- gettext("Clear") %>" data-tooltip="<%- gettext("Clear") %>">
     <span class="icon fa fa-undo" aria-hidden="true"></span>
-    <span class="sr">"<%= gettext("Clear Value") %>"</span>
+    <span class="sr">"<%- gettext("Clear Value") %>"</span>
   </button>
 </div>
-<span class="tip setting-help"><%= model.get('help') %></span>
+<span class="tip setting-help"><%- model.get('help') %></span>

--- a/cms/templates/js/video/metadata-translations-item.underscore
+++ b/cms/templates/js/video/metadata-translations-item.underscore
@@ -1,11 +1,11 @@
 <li class="list-settings-item">
-  <a href="#" class="remove-action remove-setting" data-lang="<%= lang %>" data-value="<%= value %>"><span class="icon fa fa-times-circle" aria-hidden="true"></span><span class="sr"><%= gettext("Remove") %></span></a>
-  <input type="hidden" class="input" value="<%= value %>">
+  <a href="#" class="remove-action remove-setting" data-lang="<%- lang %>" data-value="<%- value %>"><span class="icon fa fa-times-circle" aria-hidden="true"></span><span class="sr"><%- gettext("Remove") %></span></a>
+  <input type="hidden" class="input" value="<%- value %>">
   <div class="list-settings-buttons"><% if (lang) {
-    %><a href="#" class="upload-action upload-setting" data-lang="<%= lang %>" data-value="<%= value %>"><%= value ? gettext("Replace") : gettext("Upload") %>
+    %><a href="#" class="upload-action upload-setting" data-lang="<%- lang %>" data-value="<%- value %>"><%- value ? gettext("Replace") : gettext("Upload") %>
     </a><%
      } %><% if (value) {
-     %><a href="<%= url %>?filename=<%= value %>" class="download-action download-setting"><%= gettext("Download") %>
+     %><a href="<%- url %>?filename=<%- value %>" class="download-action download-setting"><%- gettext("Download") %>
     </a><%
      }
    %><div>

--- a/cms/templates/js/video/transcripts/file-upload.underscore
+++ b/cms/templates/js/video/transcripts/file-upload.underscore
@@ -4,7 +4,7 @@
 <form class="file-chooser" action="/transcripts/upload"
                           method="post" enctype="multipart/form-data">
   <input type="file" class="file-input" name="transcript-file"
-    accept="<%= _.map(ext, function(val){ return '.' + val; }).join(', ') %>">
-  <input type="hidden" name="locator" value="<%= component_locator %>">
-  <input type="hidden" name="video_list" value='<%= JSON.stringify(video_list) %>'>
+    accept="<%- _.map(ext, function(val){ return '.' + val; }).join(', ') %>">
+  <input type="hidden" name="locator" value="<%- component_locator %>">
+  <input type="hidden" name="video_list" value='<%- JSON.stringify(video_list) %>'>
 </form>

--- a/cms/templates/js/video/transcripts/messages/transcripts-choose.underscore
+++ b/cms/templates/js/video/transcripts/messages/transcripts-choose.underscore
@@ -1,17 +1,17 @@
 <div class="transcripts-message-status status-error">
     <span class="icon fa fa-remove" aria-hidden="true"></span>
-    <%= gettext("Timed Transcript Conflict") %>
+    <%- gettext("Timed Transcript Conflict") %>
 </div>
 
 <p class="transcripts-message">
-    <%= gettext("The timed transcript for the first video file does not appear to be the same as the timed transcript for the second video file.") %>
+    <%- gettext("The timed transcript for the first video file does not appear to be the same as the timed transcript for the second video file.") %>
     <strong>
-        <%= gettext("Which timed transcript would you like to use?") %>
+        <%- gettext("Which timed transcript would you like to use?") %>
     </strong>
 </p>
 
 <p class="transcripts-error-message is-invisible">
-    <%= gettext("Error.") %>
+    <%- gettext("Error.") %>
 </p>
 
 <div class="wrapper-transcripts-buttons">
@@ -28,12 +28,12 @@
             class="action setting-choose"
             type="button"
             name="setting-choose"
-            data-video-id="<%= value %>"
-            value="<%= message %>"
-            data-tooltip="<%= message %>"
+            data-video-id="<%- value %>"
+            value="<%- message %>"
+            data-tooltip="<%- message %>"
         >
             <span>
-                <%= message %>
+                <%- message %>
             </span>
         </button>
     <% }) %>

--- a/cms/templates/js/video/transcripts/messages/transcripts-found.underscore
+++ b/cms/templates/js/video/transcripts/messages/transcripts-found.underscore
@@ -1,16 +1,16 @@
-<div class="transcripts-message-status"><span class="icon fa fa-check" aria-hidden="true"></span><%= gettext("Timed Transcript Found") %></div>
+<div class="transcripts-message-status"><span class="icon fa fa-check" aria-hidden="true"></span><%- gettext("Timed Transcript Found") %></div>
 <p class="transcripts-message">
-<%= gettext("EdX has a timed transcript for this video. If you want to edit this transcript, you can download, edit, and re-upload the existing transcript. If you want to replace this transcript, upload a new .srt transcript file.") %>
+<%- gettext("EdX has a timed transcript for this video. If you want to edit this transcript, you can download, edit, and re-upload the existing transcript. If you want to replace this transcript, upload a new .srt transcript file.") %>
 </p>
 <div class="transcripts-file-uploader"></div>
 <p class="transcripts-error-message is-invisible">
-<%= gettext("Error.") %>
+<%- gettext("Error.") %>
 </p>
 <div class="wrapper-transcripts-buttons">
-    <button class="action setting-upload" type="button" name="setting-upload" value="<%= gettext("Upload New Transcript") %>" data-tooltip="<%= gettext("Upload New .srt Transcript") %>">
-        <span><%= gettext("Upload New Transcript") %></span>
+    <button class="action setting-upload" type="button" name="setting-upload" value="<%- gettext("Upload New Transcript") %>" data-tooltip="<%- gettext("Upload New .srt Transcript") %>">
+        <span><%- gettext("Upload New Transcript") %></span>
     </button>
-    <a class="action setting-download" href="/transcripts/download?locator=<%= component_locator %>&subs_id=<%= subs_id %>" data-tooltip="<%= gettext("Download Transcript for Editing") %>">
-        <span><%= gettext("Download Transcript for Editing") %></span>
+    <a class="action setting-download" href="/transcripts/download?locator=<%- component_locator %>&subs_id=<%- subs_id %>" data-tooltip="<%- gettext("Download Transcript for Editing") %>">
+        <span><%- gettext("Download Transcript for Editing") %></span>
     </a>
 </div>

--- a/cms/templates/js/video/transcripts/messages/transcripts-import.underscore
+++ b/cms/templates/js/video/transcripts/messages/transcripts-import.underscore
@@ -1,16 +1,16 @@
-<div class="transcripts-message-status status-error"><span class="icon fa fa-remove" aria-hidden="true"></span><%= gettext("No EdX Timed Transcript") %></div>
+<div class="transcripts-message-status status-error"><span class="icon fa fa-remove" aria-hidden="true"></span><%- gettext("No EdX Timed Transcript") %></div>
 <p class="transcripts-message">
-<%= gettext("EdX doesn't have a timed transcript for this video in Studio, but we found a transcript on YouTube. You can import the YouTube transcript or upload your own .srt transcript file.") %>
+<%- gettext("EdX doesn't have a timed transcript for this video in Studio, but we found a transcript on YouTube. You can import the YouTube transcript or upload your own .srt transcript file.") %>
 </p>
 <div class="transcripts-file-uploader"></div>
 <p class="transcripts-error-message is-invisible">
-<%= gettext("Error.") %>
+<%- gettext("Error.") %>
 </p>
 <div class="wrapper-transcripts-buttons">
-    <button class="action setting-import" type="button" name="setting-import" value="<%= gettext("Import YouTube Transcript") %>" data-tooltip="<%= gettext("Import YouTube Transcript") %>">
-        <span><%= gettext("Import YouTube Transcript") %></span>
+    <button class="action setting-import" type="button" name="setting-import" value="<%- gettext("Import YouTube Transcript") %>" data-tooltip="<%- gettext("Import YouTube Transcript") %>">
+        <span><%- gettext("Import YouTube Transcript") %></span>
     </button>
-    <button class="action setting-upload" type="button" name="setting-upload" value="<%= gettext("Upload New Transcript") %>" data-tooltip="<%= gettext("Upload New .srt Transcript") %>">
-        <span><%= gettext("Upload New Transcript") %></span>
+    <button class="action setting-upload" type="button" name="setting-upload" value="<%- gettext("Upload New Transcript") %>" data-tooltip="<%- gettext("Upload New .srt Transcript") %>">
+        <span><%- gettext("Upload New Transcript") %></span>
     </button>
 </div>

--- a/cms/templates/js/video/transcripts/messages/transcripts-not-found.underscore
+++ b/cms/templates/js/video/transcripts/messages/transcripts-not-found.underscore
@@ -1,16 +1,16 @@
-<div class="transcripts-message-status status-error"><span class="icon fa fa-remove" aria-hidden="true"></span><%= gettext("No Timed Transcript") %></div>
+<div class="transcripts-message-status status-error"><span class="icon fa fa-remove" aria-hidden="true"></span><%- gettext("No Timed Transcript") %></div>
 <p class="transcripts-message">
-<%= gettext("EdX doesn\'t have a timed transcript for this video. Please upload an .srt file.") %>
+<%- gettext("EdX doesn\'t have a timed transcript for this video. Please upload an .srt file.") %>
 </p>
 <div class="transcripts-file-uploader"></div>
 <p class="transcripts-error-message is-invisible">
-<%= gettext("Error.") %>
+<%- gettext("Error.") %>
 </p>
 <div class="wrapper-transcripts-buttons">
-    <button class="action setting-upload" type="button" name="setting-upload" value="<%= gettext("Upload New Transcript") %>" data-tooltip="<%= gettext("Upload New Transcript") %>">
-        <%= gettext("Upload New Transcript") %>
+    <button class="action setting-upload" type="button" name="setting-upload" value="<%- gettext("Upload New Transcript") %>" data-tooltip="<%- gettext("Upload New Transcript") %>">
+        <%- gettext("Upload New Transcript") %>
     </button>
-    <a class="action setting-download is-disabled" aria-disabled="true" href="javascropt: void(0);" data-tooltip="<%= gettext("Download Transcript for Editing") %>">
-        <%= gettext("Download Transcript for Editing") %>
+    <a class="action setting-download is-disabled" aria-disabled="true" href="javascropt: void(0);" data-tooltip="<%- gettext("Download Transcript for Editing") %>">
+        <%- gettext("Download Transcript for Editing") %>
     </a>
 </div>

--- a/cms/templates/js/video/transcripts/messages/transcripts-replace.underscore
+++ b/cms/templates/js/video/transcripts/messages/transcripts-replace.underscore
@@ -1,17 +1,17 @@
 <div class="transcripts-message-status status-error">
     <span class="icon fa fa-remove" aria-hidden="true"></span>
-    <%= gettext("Timed Transcript Conflict") %>
+    <%- gettext("Timed Transcript Conflict") %>
 </div>
 
 <p class="transcripts-message">
-    <%= gettext("The timed transcript for this video on edX is out of date, but YouTube has a current timed transcript for this video.") %>
+    <%- gettext("The timed transcript for this video on edX is out of date, but YouTube has a current timed transcript for this video.") %>
     <strong>
-        <%= gettext("Do you want to replace the edX transcript with the YouTube transcript?") %>
+        <%- gettext("Do you want to replace the edX transcript with the YouTube transcript?") %>
     </strong>
 </p>
 
 <p class="transcripts-error-message is-invisible">
-    <%= gettext("Error.") %>
+    <%- gettext("Error.") %>
 </p>
 
 <div class="wrapper-transcripts-buttons">
@@ -19,11 +19,11 @@
         class="action setting-replace"
         type="button"
         name="setting-replace"
-        value="<%= gettext("Yes, replace the edX transcript with the YouTube transcript") %>"
-        data-tooltip="<%= gettext("Yes, replace the edX transcript with the YouTube transcript") %>"
+        value="<%- gettext("Yes, replace the edX transcript with the YouTube transcript") %>"
+        data-tooltip="<%- gettext("Yes, replace the edX transcript with the YouTube transcript") %>"
     >
         <span>
-            <%= gettext("Yes, replace the edX transcript with the YouTube transcript") %>
+            <%- gettext("Yes, replace the edX transcript with the YouTube transcript") %>
         </span>
     </button>
 </div>

--- a/cms/templates/js/video/transcripts/messages/transcripts-uploaded.underscore
+++ b/cms/templates/js/video/transcripts/messages/transcripts-uploaded.underscore
@@ -1,16 +1,16 @@
-<div class="transcripts-message-status"><span class="icon fa fa-check" aria-hidden="true"></span><%= gettext("Timed Transcript Uploaded Successfully") %></div>
+<div class="transcripts-message-status"><span class="icon fa fa-check" aria-hidden="true"></span><%- gettext("Timed Transcript Uploaded Successfully") %></div>
 <p class="transcripts-message">
-<%= gettext("EdX has a timed transcript for this video. If you want to replace this transcript, upload a new .srt transcript file. If you want to edit this transcript, you can download, edit, and re-upload the existing transcript.") %>
+<%- gettext("EdX has a timed transcript for this video. If you want to replace this transcript, upload a new .srt transcript file. If you want to edit this transcript, you can download, edit, and re-upload the existing transcript.") %>
 </p>
 <div class="transcripts-file-uploader"></div>
 <p class="transcripts-error-message is-invisible">
-<%= gettext("Error.") %>
+<%- gettext("Error.") %>
 </p>
 <div class="wrapper-transcripts-buttons">
-    <button class="action setting-upload" type="button" name="setting-upload" value="<%= gettext("Upload New Transcript") %>" data-tooltip="<%= gettext("Upload New Transcript") %>">
-        <span><%= gettext("Upload New Transcript") %></span>
+    <button class="action setting-upload" type="button" name="setting-upload" value="<%- gettext("Upload New Transcript") %>" data-tooltip="<%- gettext("Upload New Transcript") %>">
+        <span><%- gettext("Upload New Transcript") %></span>
     </button>
-    <a class="action setting-download" href="/transcripts/download?locator=<%= component_locator %>&subs_id=<%= subs_id %>" data-tooltip="<%= gettext("Download Transcript for Editing") %>">
-        <span><%= gettext("Download Transcript for Editing") %></span>
+    <a class="action setting-download" href="/transcripts/download?locator=<%- component_locator %>&subs_id=<%- subs_id %>" data-tooltip="<%- gettext("Download Transcript for Editing") %>">
+        <span><%- gettext("Download Transcript for Editing") %></span>
     </a>
 </div>

--- a/cms/templates/js/video/transcripts/messages/transcripts-use-existing.underscore
+++ b/cms/templates/js/video/transcripts/messages/transcripts-use-existing.underscore
@@ -1,16 +1,16 @@
 <div class="transcripts-message-status status-error">
     <span class="icon fa fa-remove" aria-hidden="true"></span>
-    <%= gettext("Confirm Timed Transcript") %>
+    <%- gettext("Confirm Timed Transcript") %>
 </div>
 
 <p class="transcripts-message">
-    <%= gettext("You changed a video URL, but did not change the timed transcript file. Do you want to use the current timed transcript or upload a new .srt transcript file?") %>
+    <%- gettext("You changed a video URL, but did not change the timed transcript file. Do you want to use the current timed transcript or upload a new .srt transcript file?") %>
 </p>
 
 <div class="transcripts-file-uploader"></div>
 
 <p class="transcripts-error-message is-invisible">
-    <%= gettext("Error.") %>
+    <%- gettext("Error.") %>
 </p>
 
 <div class="wrapper-transcripts-buttons">
@@ -18,22 +18,22 @@
         class="action setting-use-existing"
         type="button"
         name="setting-use-existing"
-        value="<%= gettext("Use Current Transcript") %>"
-        data-tooltip="<%= gettext("Use Current Transcript") %>"
+        value="<%- gettext("Use Current Transcript") %>"
+        data-tooltip="<%- gettext("Use Current Transcript") %>"
     >
         <span>
-            <%= gettext("Use Current Transcript") %>
+            <%- gettext("Use Current Transcript") %>
         </span>
     </button>
     <button
         class="action setting-upload"
         type="button"
         name="setting-upload"
-        value="<%= gettext("Upload New Transcript") %>"
-        data-tooltip="<%= gettext("Upload New Transcript") %>"
+        value="<%- gettext("Upload New Transcript") %>"
+        data-tooltip="<%- gettext("Upload New Transcript") %>"
     >
         <span>
-            <%= gettext("Upload New Transcript") %>
+            <%- gettext("Upload New Transcript") %>
         </span>
     </button>
 </div>

--- a/cms/templates/js/video/transcripts/metadata-videolist-entry.underscore
+++ b/cms/templates/js/video/transcripts/metadata-videolist-entry.underscore
@@ -1,20 +1,20 @@
 <div class="wrapper-comp-setting metadata-videolist-enum">
-  <label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name')%></label>
+  <label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name')%></label>
   <div class="wrapper-videolist-settings">
-    <div class="wrapper-videolist-url videolist-settings-item"><input type="text" id="<%= uniqueId %>"  class="input videolist-url" value="<%= model.get('value')[0] %>"></div>
-    <div class="tip videolist-url-tip setting-help"><%= model.get('help') %></div>
+    <div class="wrapper-videolist-url videolist-settings-item"><input type="text" id="<%- uniqueId %>"  class="input videolist-url" value="<%- model.get('value')[0] %>"></div>
+    <div class="tip videolist-url-tip setting-help"><%- model.get('help') %></div>
     <div class="wrapper-videolist-urls">
       <a href="#" class="collapse-action collapse-setting">
-        <span class="icon fa fa-plus" aria-hidden="true"></span><%= gettext("Add URLs for additional versions") %> <span class="sr"><%= model.get('display_name')%></span>
+        <span class="icon fa fa-plus" aria-hidden="true"></span><%- gettext("Add URLs for additional versions") %> <span class="sr"><%- model.get('display_name')%></span>
       </a>
       <div class="videolist-extra-videos">
-        <span class="tip videolist-extra-videos-tip setting-help"><%= gettext("To be sure all students can access the video, we recommend providing both an .mp4 and a .webm version of your video. Click below to add a URL for another version. These URLs cannot be YouTube URLs. The first listed video that's compatible with the student's computer will play.") %></span>
+        <span class="tip videolist-extra-videos-tip setting-help"><%- gettext("To be sure all students can access the video, we recommend providing both an .mp4 and a .webm version of your video. Click below to add a URL for another version. These URLs cannot be YouTube URLs. The first listed video that's compatible with the student's computer will play.") %></span>
         <ol class="videolist-settings">
             <li class="videolist-settings-item">
-              <input type="text" class="input" value="<%= model.get('value')[1] %>">
+              <input type="text" class="input" value="<%- model.get('value')[1] %>">
             </li>
             <li class="videolist-settings-item">
-              <input type="text" class="input" value="<%= model.get('value')[2] %>">
+              <input type="text" class="input" value="<%- model.get('value')[2] %>">
             </li>
         </ol>
       </div>
@@ -22,6 +22,6 @@
   </div>
 </div>
 <div class="transcripts-status is-invisible">
-    <label class="label setting-label transcripts-label"><%= gettext("Default Timed Transcript") %></label>
+    <label class="label setting-label transcripts-label"><%- gettext("Default Timed Transcript") %></label>
     <div class="wrapper-transcripts-message"></div>
 </div>

--- a/cms/templates/js/xblock-outline.underscore
+++ b/cms/templates/js/xblock-outline.underscore
@@ -1,12 +1,12 @@
 <% if (parentInfo) { %>
-<li class="outline-item outline-item-<%= xblockType %> <%= includesChildren ? 'is-collapsible' : '' %> is-draggable <%= isCollapsed ? 'is-collapsed' : '' %>"
-    data-parent="<%= parentInfo.get('id') %>" data-locator="<%= xblockInfo.get('id') %>">
+<li class="outline-item outline-item-<%- xblockType %> <%- includesChildren ? 'is-collapsible' : '' %> is-draggable <%- isCollapsed ? 'is-collapsed' : '' %>"
+    data-parent="<%- parentInfo.get('id') %>" data-locator="<%- xblockInfo.get('id') %>">
     <span class="draggable-drop-indicator draggable-drop-indicator-before"><span class="icon fa fa-caret-right" aria-hidden="true"></span></span>
 
     <div class="wrapper-xblock-header">
         <div class="wrapper-xblock-header-primary">
             <% if (includesChildren) { %>
-                <h3 class="xblock-title expand-collapse <%= isCollapsed ? 'expand' : 'collapse' %>"
+                <h3 class="xblock-title expand-collapse <%- isCollapsed ? 'expand' : 'collapse' %>"
                     title="<%= interpolate(
                           gettext('Collapse/Expand this %(xblock_type)s'), { xblock_type: xblockTypeDisplayName }, true
                     ) %>"
@@ -17,7 +17,7 @@
             <% } %>
 
                 <% if (xblockInfo.get('studio_url') && xblockInfo.get('category') !== 'chapter') { %>
-                    <a href="<%= xblockInfo.get('studio_url') %>"><%- xblockInfo.get('display_name') %></a>
+                    <a href="<%- xblockInfo.get('studio_url') %>"><%- xblockInfo.get('display_name') %></a>
                 <% } else { %>
                     <span class="wrapper-xblock-field is-editable" data-field="display_name">
                         <span class="xblock-field-value"><%- xblockInfo.get('display_name') %></span>
@@ -28,9 +28,9 @@
             <div class="item-actions">
                 <ul class="actions-list">
                     <li class="action-item action-delete">
-                        <a href="#" data-tooltip="<%= gettext('Delete') %>" class="delete-button action-button">
+                        <a href="#" data-tooltip="<%- gettext('Delete') %>" class="delete-button action-button">
                             <span class="icon fa fa-remove" aria-hidden="true"></span>
-                            <span class="sr"><%= gettext('Delete') %></span>
+                            <span class="sr"><%- gettext('Delete') %></span>
                         </a>
                     </li>
                 </ul>
@@ -40,7 +40,7 @@
             <% if (xblockInfo.get('release_date')) { %>
                 <div class="meta-info">
                     <span class="icon fa fa-clock-o" aria-hidden="true"></span>
-                    <%= gettext('Released:') %> <%= xblockInfo.get('release_date') %>
+                    <%- gettext('Released:') %> <%- xblockInfo.get('release_date') %>
                 </div>
             <% } %>
 
@@ -54,30 +54,30 @@
 <% } %>
     <% if (!parentInfo && xblockInfo.get('child_info') && xblockInfo.get('child_info').children.length === 0) { %>
         <div class="no-content add-xblock-component">
-            <p><%= gettext("You haven't added any content to this course yet.") %>
-                <a href="#" class="button button-new" data-category="<%= childCategory %>"
-                   data-parent="<%= xblockInfo.get('id') %>" data-default-name="<%= defaultNewChildName %>"
+            <p><%- gettext("You haven't added any content to this course yet.") %>
+                <a href="#" class="button button-new" data-category="<%- childCategory %>"
+                   data-parent="<%- xblockInfo.get('id') %>" data-default-name="<%- defaultNewChildName %>"
                    title="<%= interpolate(
                          gettext('Click to add a new %(xblock_type)s'), { xblock_type: defaultNewChildName }, true
                    ) %>"
                 >
-                    <span class="icon fa fa-plus" aria-hidden="true"></span><%= addChildLabel %>
+                    <span class="icon fa fa-plus" aria-hidden="true"></span><%- addChildLabel %>
                 </a>
             </p>
         </div>
     <% } else { %>
-        <ol class="sortable-list sortable-<%= xblockType %>-list">
+        <ol class="sortable-list sortable-<%- xblockType %>-list">
         </ol>
 
         <% if (childType) { %>
             <div class="add-xblock-component">
-                <a href="#" class="button button-new" data-category="<%= childCategory %>"
-                   data-parent="<%= xblockInfo.get('id') %>" data-default-name="<%= defaultNewChildName %>"
+                <a href="#" class="button button-new" data-category="<%- childCategory %>"
+                   data-parent="<%- xblockInfo.get('id') %>" data-default-name="<%- defaultNewChildName %>"
                    title="<%= interpolate(
                          gettext('Click to add a new %(xblock_type)s'), { xblock_type: defaultNewChildName }, true
                    ) %>"
                 >
-                    <span class="icon fa fa-plus" aria-hidden="true"></span><%= addChildLabel %>
+                    <span class="icon fa fa-plus" aria-hidden="true"></span><%- addChildLabel %>
                 </a>
             </div>
         <% } %>

--- a/cms/templates/js/xblock-string-field-editor.underscore
+++ b/cms/templates/js/xblock-string-field-editor.underscore
@@ -8,9 +8,9 @@
   <form>
     <% var formLabel = gettext("Edit %(display_name)s (required)"); %>
     <label><span class="sr"><%= interpolate(formLabel, {display_name: fieldDisplayName}, true) %></span>
-      <input type="text" value="<%= value %>" class="xblock-field-input incontext-editor-input" data-metadata-name="<%= fieldName %>" title="<%= gettext('Edit the name') %>">
+      <input type="text" value="<%- value %>" class="xblock-field-input incontext-editor-input" data-metadata-name="<%- fieldName %>" title="<%- gettext('Edit the name') %>">
     </label>
-    <button class="sr action action-primary" name="submit" type="submit"><%= gettext("Save") %></button>
-    <button class="sr action action-secondary" name="cancel" type="button"><%= gettext("Cancel") %></button>
+    <button class="sr action action-primary" name="submit" type="submit"><%- gettext("Save") %></button>
+    <button class="sr action action-secondary" name="cancel" type="button"><%- gettext("Cancel") %></button>
   </form>
 </div>

--- a/cms/templates/js/xblock-validation-messages.underscore
+++ b/cms/templates/js/xblock-validation-messages.underscore
@@ -3,7 +3,7 @@ var summaryMessage = validation.get("summary");
 var aggregateMessageType = summaryMessage.type;
 var aggregateValidationClass = aggregateMessageType === "error"? "has-errors" : "has-warnings";
 %>
-    <div class="xblock-message validation <%= aggregateValidationClass %> <%= additionalClasses %>">
+    <div class="xblock-message validation <%- aggregateValidationClass %> <%- additionalClasses %>">
         <p class="<%- aggregateMessageType %>"><span class="icon fa <%- getIcon(aggregateMessageType) %>" aria-hidden="true"></span>
         <%- summaryMessage.text %>
         <% if (summaryMessage.action_class) { %>
@@ -25,7 +25,7 @@ var aggregateValidationClass = aggregateMessageType === "error"? "has-errors" : 
                 var messageType = message.type
                 var messageTypeDisplayName = getDisplayName(messageType)
                 %>
-                <li class="xblock-message-item <%= messageType %>">
+                <li class="xblock-message-item <%- messageType %>">
                     <span class="message-text">
                         <% if (messageTypeDisplayName) { %>
                             <span class="sr"><%- messageTypeDisplayName %>:</span>

--- a/common/lib/xmodule/xmodule/js/fixtures/imageinput.underscore
+++ b/common/lib/xmodule/xmodule/js/fixtures/imageinput.underscore
@@ -2,24 +2,24 @@
 <!-- ${width}  = 300   -->
 <!-- ${height} = 400   -->
 
-<div class="imageinput capa_inputtype" id="inputtype_<%=id%>">
+<div class="imageinput capa_inputtype" id="inputtype_<%-id%>">
     <input
         type="hidden"
         class="imageinput"
         src=""
-        name="input_<%=id%>"
-        id="input_<%=id%>"
+        name="input_<%-id%>"
+        id="input_<%-id%>"
         value=""
     />
 
     <div style="position:relative;">
         <div
-            id="imageinput_<%=id%>"
-            style="width: <%=width%>px; height: <%=height%>px; position: relative; left: 0; top: 0; visibility: hidden;"
+            id="imageinput_<%-id%>"
+            style="width: <%-width%>px; height: <%-height%>px; position: relative; left: 0; top: 0; visibility: hidden;"
         >
             <!-- image will go here -->
         </div>
-        <div id="answer_<%=id%>" data-width="100" data-height="100"></div>
+        <div id="answer_<%-id%>" data-width="100" data-height="100"></div>
     </div>
 
 
@@ -27,8 +27,8 @@
         <span
             class="unanswered"
             style="display: inline-block;"
-            id="status_<%=id%>"
-            aria-describedby="input_<%=id%>"
+            id="status_<%-id%>"
+            aria-describedby="input_<%-id%>"
         >
             <span class="sr">Status: unanswered</span>
         </span>

--- a/common/lib/xmodule/xmodule/js/fixtures/tabs-edit.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/tabs-edit.html
@@ -1,5 +1,5 @@
 <div class="wrapper wrapper-modal-window wrapper-modal-window-mock">
-    <div class="modal-window confirm modal-editor modal-lg modal-type-<%= xblockInfo.get('category') %>">
+    <div class="modal-window confirm modal-editor modal-lg modal-type-<%- xblockInfo.get('category') %>">
         <div class="edit-xblock-modal" action="#">
             <div class="modal-header">
                 <h2 class="title modal-window-title">Mock Modal Title</h2>

--- a/common/lib/xmodule/xmodule/js/src/video/09_poster.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_poster.js
@@ -23,8 +23,8 @@
         VideoPoster.moduleName = 'Poster';
         VideoPoster.prototype = {
             template: _.template([
-                '<div class="video-pre-roll is-<%= type %> poster" ',
-                'style="background-image: url(<%= url %>)">',
+                '<div class="video-pre-roll is-<%- type %> poster" ',
+                'style="background-image: url(<%- url %>)">',
                 '<button class="btn-play btn-pre-roll">',
                 '<img src="/static/images/play.png" alt="">',
                 '<span class="sr">', gettext('Play video'), '</span>',

--- a/common/static/common/js/utils/edx.utils.validate.js
+++ b/common/static/common/js/utils/edx.utils.validate.js
@@ -21,7 +21,7 @@
                 var _fn = {
                     validate: {
 
-                        template: _.template('<li><%= content %></li>'),
+                        template: _.template('<li><%- content %></li>'),
 
                         msg: {
                             email: gettext("The email address you've provided isn't formatted correctly."),

--- a/common/static/common/templates/components/paginated-view.underscore
+++ b/common/static/common/templates/components/paginated-view.underscore
@@ -1,4 +1,4 @@
-<div class="sr-is-focusable sr-<%= type %>-view" tabindex="-1"></div>
-<div class="<%= type %>-paging-header"></div>
-<ul class="<%= type %>-list cards-list"></ul>
-<div class="<%= type %>-paging-footer"></div>
+<div class="sr-is-focusable sr-<%- type %>-view" tabindex="-1"></div>
+<div class="<%- type %>-paging-header"></div>
+<ul class="<%- type %>-list cards-list"></ul>
+<div class="<%- type %>-paging-footer"></div>

--- a/common/static/common/templates/components/paging-footer.underscore
+++ b/common/static/common/templates/components/paging-footer.underscore
@@ -1,5 +1,5 @@
-<nav class="pagination pagination-full bottom" aria-label="<%= paginationLabel %>">
-    <div class="nav-item previous"><button class="nav-link previous-page-link"><span class="icon fa fa-angle-left" aria-hidden="true"></span> <span class="nav-label"><%= gettext("Previous") %></span></button></div>
+<nav class="pagination pagination-full bottom" aria-label="<%- paginationLabel %>">
+    <div class="nav-item previous"><button class="nav-link previous-page-link"><span class="icon fa fa-angle-left" aria-hidden="true"></span> <span class="nav-label"><%- gettext("Previous") %></span></button></div>
     <div class="nav-item page">
         <div class="pagination-form">
             <label class="page-number-label" for="page-number-input"><%= interpolate(
@@ -8,13 +8,13 @@
                     true
                 )%></label>
             <input id="page-number-input" class="page-number-input" name="page-number" type="text" size="4" autocomplete="off" aria-describedby="page-number-input-helper"/>
-            <span class="sr field-helper" id="page-number-input-helper"><%= gettext("Enter the page number you'd like to quickly navigate to.") %></span>
+            <span class="sr field-helper" id="page-number-input-helper"><%- gettext("Enter the page number you'd like to quickly navigate to.") %></span>
         </div>
 
-        <span class="current-page"><%= current_page %></span>
+        <span class="current-page"><%- current_page %></span>
         <span class="sr">&nbsp;out of&nbsp;</span>
         <span class="page-divider" aria-hidden="true">/</span>
-        <span class="total-pages"><%= total_pages %></span>
+        <span class="total-pages"><%- total_pages %></span>
     </div>
-    <div class="nav-item next"><button class="nav-link next-page-link"><span class="nav-label"><%= gettext("Next") %></span> <span class="icon fa fa-angle-right" aria-hidden="true"></span></button></div>
+    <div class="nav-item next"><button class="nav-link next-page-link"><span class="nav-label"><%- gettext("Next") %></span> <span class="icon fa fa-angle-right" aria-hidden="true"></span></button></div>
 </nav>

--- a/common/static/common/templates/components/progress_circle_view.underscore
+++ b/common/static/common/templates/components/progress_circle_view.underscore
@@ -4,7 +4,7 @@
 <div class="progress-circle-wrapper">
     <svg class="progress-circle" viewBox="0 0 44 44" aria-hidden="true">
         <circle class="js-circle bg" r="<%- radius %>" cx="<%- x %>" cy="<%- y %>" stroke-width="<%- strokeWidth %>" fill="none"></circle>
-        <%= circleSegments %>
+        <%- circleSegments %>
     </svg>
     <div class="progress-label">
         <div class="numbers">

--- a/common/static/common/templates/components/system-feedback.underscore
+++ b/common/static/common/templates/components/system-feedback.underscore
@@ -1,22 +1,22 @@
-<div class="wrapper wrapper-<%= type %> wrapper-<%= type %>-<%= intent %>
+<div class="wrapper wrapper-<%- type %> wrapper-<%- type %>-<%- intent %>
             <% if(obj.shown) { %>is-shown<% } else { %>is-hiding<% } %>
-            <% if(_.contains(['help', 'mini'], intent)) { %>wrapper-<%= type %>-status<% } %>"
-     id="<%= type %>-<%= intent %>"
+            <% if(_.contains(['help', 'mini'], intent)) { %>wrapper-<%- type %>-status<% } %>"
+     id="<%- type %>-<%- intent %>"
      aria-hidden="<% if(obj.shown) { %>false<% } else { %>true<% } %>"
-     aria-labelledby="<%= type %>-<%= intent %>-title"
+     aria-labelledby="<%- type %>-<%- intent %>-title"
      tabindex="-1"
-     <% if (obj.message) { %>aria-describedby="<%= type %>-<%= intent %>-description" <% } %>
+     <% if (obj.message) { %>aria-describedby="<%- type %>-<%- intent %>-description" <% } %>
      <% if (obj.actions) { %>role="dialog"<% } %>
   >
-  <div class="<%= type %> <%= intent %> <% if(obj.actions) { %>has-actions<% } %>">
+  <div class="<%- type %> <%- intent %> <% if(obj.actions) { %>has-actions<% } %>">
     <% if(obj.icon) { %>
       <% var iconClass = {"warning": "warning", "confirmation": "check", "error": "warning", "announcement": "bullhorn", "step-required": "exclamation-circle", "help": "question", "mini": "cog"} %>
-      <span class="feedback-symbol fa fa-<%= iconClass[intent] %>" aria-hidden="true"></span>
+      <span class="feedback-symbol fa fa-<%- iconClass[intent] %>" aria-hidden="true"></span>
     <% } %>
 
     <div class="copy">
-      <h2 class="title title-3" id="<%= type %>-<%= intent %>-title"><%- title %></h2>
-      <% if(obj.message) { %><p class="message" id="<%= type %>-<%= intent %>-description"><%- message %></p><% } %>
+      <h2 class="title title-3" id="<%- type %>-<%- intent %>-title"><%- title %></h2>
+      <% if(obj.message) { %><p class="message" id="<%- type %>-<%- intent %>-description"><%- message %></p><% } %>
     </div>
 
     <% if(obj.actions) { %>
@@ -24,13 +24,13 @@
       <ul>
         <% if(actions.primary) { %>
         <li class="nav-item">
-          <button class="action-primary <%= actions.primary.class %>"><%- actions.primary.text %></button>
+          <button class="action-primary <%- actions.primary.class %>"><%- actions.primary.text %></button>
         </li>
         <% } %>
         <% if(actions.secondary) {
              _.each(actions.secondary, function(secondary) { %>
         <li class="nav-item">
-          <button class="action-secondary <%= secondary.class %>"><%- secondary.text %></button>
+          <button class="action-secondary <%- secondary.class %>"><%- secondary.text %></button>
         </li>
         <%   });
            } %>
@@ -39,9 +39,9 @@
     <% } %>
 
     <% if(obj.closeIcon) { %>
-    <a href="#" rel="view" class="action action-close action-<%= type %>-close">
+    <a href="#" rel="view" class="action action-close action-<%- type %>-close">
       <span class="icon fa fa-times-circle" aria-hidden="true"></span>
-      <span class="label">close <%= type %></span>
+      <span class="label">close <%- type %></span>
     </a>
     <% } %>
   </div>

--- a/common/static/common/templates/components/tabpanel.underscore
+++ b/common/static/common/templates/components/tabpanel.underscore
@@ -1,1 +1,1 @@
-<div role="tabpanel" class="tabpanel is-hidden" id="<%= tabId %>" aria-labelledby="tab-<%= index %>" aria-hidden="true" tabindex="0"></div>
+<div role="tabpanel" class="tabpanel is-hidden" id="<%- tabId %>" aria-labelledby="tab-<%- index %>" aria-hidden="true" tabindex="0"></div>

--- a/common/static/common/templates/discussion/pagination.underscore
+++ b/common/static/common/templates/discussion/pagination.underscore
@@ -1,31 +1,31 @@
 <nav class="discussion-paginator">
     <ol>
         <% if (previous) { %>
-            <li class="previous-page"><a class="discussion-pagination" href="<%= previous.url %>" data-page-number="<%= previous.number %>">&lt; <%- gettext("Previous") %></a></li>
+            <li class="previous-page"><a class="discussion-pagination" href="<%- previous.url %>" data-page-number="<%- previous.number %>">&lt; <%- gettext("Previous") %></a></li>
         <% } %>
         <% if (first) { %>
-            <li class="first-page"><a class="discussion-pagination" href="<%= first.url %>" data-page-number="1">1</a></li>
+            <li class="first-page"><a class="discussion-pagination" href="<%- first.url %>" data-page-number="1">1</a></li>
         <% } %>
         <% if (leftdots) { %>
             <li class="previous-ellipses"><%- gettext("…") %></li>
         <% } %>
 
         <% _.each(lowPages, function(page) { %>
-            <li class="lower-page"><a class="discussion-pagination" href="<%= page.url %>" data-page-number="<%= page.number %>"><%= page.number %></a></li>
+            <li class="lower-page"><a class="discussion-pagination" href="<%- page.url %>" data-page-number="<%- page.number %>"><%- page.number %></a></li>
         <% }); %>
-        <li class="current-page"><span><%= page %></span></li>
+        <li class="current-page"><span><%- page %></span></li>
         <% _.each(highPages, function(page) { %>
-            <li class="higher-page"><a class="discussion-pagination" href="<%= page.url %>" data-page-number="<%= page.number %>"><%= page.number %></a></li>
+            <li class="higher-page"><a class="discussion-pagination" href="<%- page.url %>" data-page-number="<%- page.number %>"><%- page.number %></a></li>
         <% }); %>
 
         <% if (rightdots) { %>
             <li class="next-ellipses"><%- gettext("…") %></li>
         <% } %>
         <% if (last) { %>
-            <li class="last-page"><a class="discussion-pagination" href="<%= last.url %>" data-page-number="<%= last.number %>"><%= last.number %></a></li>
+            <li class="last-page"><a class="discussion-pagination" href="<%- last.url %>" data-page-number="<%- last.number %>"><%- last.number %></a></li>
         <% } %>
         <% if (next) { %>
-            <li class="next-page"><a class="discussion-pagination" href="<%= next.url %>" data-page-number="<%= next.number %>"><%- gettext("Next") %> &gt;</a></li>
+            <li class="next-page"><a class="discussion-pagination" href="<%- next.url %>" data-page-number="<%- next.number %>"><%- gettext("Next") %> &gt;</a></li>
         <% } %>
     </ol>
 </nav>

--- a/common/static/common/templates/discussion/profile-thread.underscore
+++ b/common/static/common/templates/discussion/profile-thread.underscore
@@ -15,7 +15,7 @@
                 </span>
             </p>
         </header>
-        <div class="post-body"><%= abbreviatedBody %></div>
+        <div class="post-body"><%- abbreviatedBody %></div>
     </div>
     <div class="post-tools">
         <a href="<%- permalink %>"><%- gettext("View discussion") %></a>

--- a/common/static/common/templates/discussion/response-comment-show.underscore
+++ b/common/static/common/templates/discussion/response-comment-show.underscore
@@ -1,6 +1,6 @@
 <div class="discussion-comment" id="comment_<%- id %>">
   <div class="response-body"><%- body %></div>
-  <%=
+  <%-
       _.template(
           $('#forum-actions').html())(
           {

--- a/common/static/common/templates/discussion/thread-list-item.underscore
+++ b/common/static/common/templates/discussion/thread-list-item.underscore
@@ -17,8 +17,8 @@
           sr_text = gettext("unanswered question");
       }
       %>
-      <span class="sr"><%= sr_text %></span>
-      <span class="icon fa <%= icon_class %>" aria-hidden="true"></span>
+      <span class="sr"><%- sr_text %></span>
+      <span class="icon fa <%- icon_class %>" aria-hidden="true"></span>
     </div><div class="forum-nav-thread-wrapper-1">
       <span class="forum-nav-thread-title"><%- title %></span>
       <% if (showThreadPreview){ %>

--- a/common/static/common/templates/discussion/thread-response-show.underscore
+++ b/common/static/common/templates/discussion/thread-response-show.underscore
@@ -1,8 +1,8 @@
 <header class="response-header">
   <div class="response-header-content">
-    <%= author_display %>
+    <%- author_display %>
     <p class="posted-details">
-        <span class="timeago" title="<%= created_at %>"><%= created_at %></span>
+        <span class="timeago" title="<%- created_at %>"><%- created_at %></span>
         <% if (obj.endorsement && obj.endorsed) { %>
             -
             <%
@@ -44,7 +44,7 @@
       </div>
       </div>
       <div class="response-header-actions">
-        <%=
+        <%-
             _.template(
                 $('#forum-actions').html())(
                 {

--- a/common/static/common/templates/discussion/thread-show.underscore
+++ b/common/static/common/templates/discussion/thread-show.underscore
@@ -2,7 +2,7 @@
     <header class="post-header">
         <% if (!readOnly) { %>
             <div class="post-header-actions">
-                <%=
+                <%-
                 _.template(
                     $('#forum-actions').html())(
                     {

--- a/common/static/common/templates/discussion/thread-type.underscore
+++ b/common/static/common/templates/discussion/thread-type.underscore
@@ -10,16 +10,16 @@
         <div class="field-label">
             <fieldset class="field-input">
                 <legend class="sr"><%- gettext("Post type") %></legend>
-                <label for="<%= form_id %>-post-type-question" class="post-type-label">
-                    <input aria-describedby="field_help_post_type" type="radio" name="<%= form_id %>-post-type" class="field-input input-radio" id="<%= form_id %>-post-type-question" value="question">
+                <label for="<%- form_id %>-post-type-question" class="post-type-label">
+                    <input aria-describedby="field_help_post_type" type="radio" name="<%- form_id %>-post-type" class="field-input input-radio" id="<%- form_id %>-post-type-question" value="question">
                     <span class="field-input-label">
                         <span class="icon fa fa-question" aria-hidden="true"></span>
                         <% // Translators: This is a forum post type %>
                         <%- gettext("Question") %>
                     </span>
                 </label>
-                <label for="<%= form_id %>-post-type-discussion" class="post-type-label">
-                    <input aria-describedby="field_help_post_type" type="radio" name="<%= form_id %>-post-type" class="field-input input-radio" id="<%= form_id %>-post-type-discussion" value="discussion" checked>
+                <label for="<%- form_id %>-post-type-discussion" class="post-type-label">
+                    <input aria-describedby="field_help_post_type" type="radio" name="<%- form_id %>-post-type" class="field-input input-radio" id="<%- form_id %>-post-type-discussion" value="discussion" checked>
                     <span class="field-input-label">
                         <span class="icon fa fa-comments" aria-hidden="true"></span>
                         <% // Translators: This is a forum post type %>

--- a/common/static/common/templates/image-modal.underscore
+++ b/common/static/common/templates/image-modal.underscore
@@ -1,6 +1,6 @@
 <div class="wrapper-modal wrapper-modal-image">
   <section class="image-link">
-    <%= smallHTML%>
+    <%- smallHTML%>
     <a href="#" class="modal-ui-icon action-fullscreen" role="button">
       <span class="label">
         <span class="icon fa fa-arrows-alt fa-large" aria-hidden="true"></span> <%- gettext("Fullscreen") %>
@@ -11,7 +11,7 @@
   <section class="image-modal">
     <section class="image-content">
       <div class="image-wrapper">
-        <img alt="<%= largeALT %>, <%- gettext('Large') %>" src="<%= largeSRC %>" />
+        <img alt="<%- largeALT %>, <%- gettext('Large') %>" src="<%- largeSRC %>" />
       </div>
 
       <a href="#" class="modal-ui-icon action-close" role="button">

--- a/lms/djangoapps/support/static/support/templates/enrollment.underscore
+++ b/lms/djangoapps/support/static/support/templates/enrollment.underscore
@@ -46,8 +46,8 @@
         <td>
           <button
               class="change-enrollment-btn"
-              data-modes="<%= _.pluck(enrollment.get('course_modes'), 'slug')%>"
-              data-course_id="<%= enrollment.get('course_id') %>"
+              data-modes="<%- _.pluck(enrollment.get('course_modes'), 'slug')%>"
+              data-course_id="<%- enrollment.get('course_id') %>"
           >
             <%- gettext('Change Enrollment') %>
           </button>

--- a/lms/djangoapps/teams/static/teams/templates/date.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/date.underscore
@@ -1,1 +1,1 @@
-<abbr title="<%= date %>"></abbr>
+<abbr title="<%- date %>"></abbr>

--- a/lms/djangoapps/teams/static/teams/templates/edit-team-member.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/edit-team-member.underscore
@@ -1,16 +1,16 @@
 <li class="team-member">
-    <a class="member-profile" href="<%= memberProfileUrl %>">
-        <img class="image-url" src="<%= imageUrl %>" alt="<%= username %>'s profile page" />
+    <a class="member-profile" href="<%- memberProfileUrl %>">
+        <img class="image-url" src="<%- imageUrl %>" alt="<%- username %>'s profile page" />
     </a>
     <div class="member-info-container">
-    	<span class="primary"><%= username %></span>
+    	<span class="primary"><%- username %></span>
     	<div class="secondary">
-    		<span id="date-joined"><%= dateJoined %></span>
+    		<span id="date-joined"><%- dateJoined %></span>
     		<span> | </span>
-    		<span id="last-active"><%= lastActive %></span>
+    		<span id="last-active"><%- lastActive %></span>
     	</div>
     </div>
-    <button class="action-remove-member" data-username="<%= username %>">
-        <%- gettext("Remove") %><span class="sr">&nbsp;<%= username %></span>
+    <button class="action-remove-member" data-username="<%- username %>">
+        <%- gettext("Remove") %><span class="sr">&nbsp;<%- username %></span>
     </button>
 </li>

--- a/lms/djangoapps/teams/static/teams/templates/team-actions.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/team-actions.underscore
@@ -1,4 +1,4 @@
 <div class="team-actions">
   <h3 class="title"><%- gettext("Are you having trouble finding a team to join?") %></h3>
-  <p class="copy"><%= message %></p>
+  <p class="copy"><%- message %></p>
 </div>

--- a/lms/djangoapps/teams/static/teams/templates/team-member.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/team-member.underscore
@@ -1,8 +1,8 @@
 <li>
   <span class="team-member">
-    <a class="member-profile" href="<%= memberProfileUrl %>">
-      <p class="tooltip-custom"><%= username %></p>
-      <img class="image-url" src="<%= imageUrl %>" alt="profile page" />
+    <a class="member-profile" href="<%- memberProfileUrl %>">
+      <p class="tooltip-custom"><%- username %></p>
+      <img class="image-url" src="<%- imageUrl %>" alt="profile page" />
     </a>
   </span>
 </li>

--- a/lms/djangoapps/teams/static/teams/templates/team-membership-details.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/team-membership-details.underscore
@@ -1,4 +1,4 @@
-<span class="member-count"><%= membership_message %></span>
+<span class="member-count"><%- membership_message %></span>
 <ul class="list-member-thumbs">
     <% _.each(memberships, function (membership) { %>
         <li class="item-member-thumb"><img alt="<%- membership.user.username %>" src="<%- membership.user.profile_image.image_url_small %>"></img></li>

--- a/lms/static/js/certificates/views/certificate_invalidation_view.js
+++ b/lms/static/js/certificates/views/certificate_invalidation_view.js
@@ -46,7 +46,7 @@
                     );
 
                     if (this.collection.findWhere({user: user})) {
-                        message = gettext('Certificate of <%= user %> has already been invalidated. Please check your spelling and retry.');  // eslint-disable-line max-len
+                        message = gettext('Certificate of <%- user %> has already been invalidated. Please check your spelling and retry.');  // eslint-disable-line max-len
                         this.escapeAndShowMessage(_.template(message)({user: user}));
                     }
                     else if (certificate_invalidation.isValid()) {
@@ -56,7 +56,7 @@
 
                             success: function(model) {
                                 self.collection.add(model);
-                                message = gettext('Certificate has been successfully invalidated for <%= user %>.');
+                                message = gettext('Certificate has been successfully invalidated for <%- user %>.');
                                 self.escapeAndShowMessage(_.template(message)({user: user}));
                             },
 

--- a/lms/static/js/certificates/views/certificate_whitelist_editor.js
+++ b/lms/static/js/certificates/views/certificate_whitelist_editor.js
@@ -58,13 +58,13 @@
                     var message = '';
 
                     if (this.collection.findWhere(model)) {
-                        message = gettext('<%= user %> already in exception list.');
+                        message = gettext('<%- user %> already in exception list.');
                         this.escapeAndShowMessage(
                             _.template(message)({user: (user_name || user_email)})
                         );
                     }
                     else if (certificate_exception.isValid()) {
-                        message = gettext('<%= user %> has been successfully added to the exception list. Click Generate Exception Certificate below to send the certificate.');  // eslint-disable-line max-len
+                        message = gettext('<%- user %> has been successfully added to the exception list. Click Generate Exception Certificate below to send the certificate.');  // eslint-disable-line max-len
                         certificate_exception.save(
                             null,
                             {

--- a/lms/static/js/instructor_dashboard/student_admin.js
+++ b/lms/static/js/instructor_dashboard/student_admin.js
@@ -113,7 +113,7 @@
                     delete_module: false
                 };
                 successMessage = gettext("Success! Problem attempts reset for problem '<%- problem_id %>' and student '<%- student_id %>'.");  // eslint-disable-line max-len
-                errorMessage = gettext("Error resetting problem attempts for problem '<%= problem_id %>' and student '<%- student_id %>'. Make sure that the problem and student identifiers are complete and correct.");  // eslint-disable-line max-len
+                errorMessage = gettext("Error resetting problem attempts for problem '<%- problem_id %>' and student '<%- student_id %>'. Make sure that the problem and student identifiers are complete and correct.");  // eslint-disable-line max-len
                 fullSuccessMessage = _.template(successMessage)({
                     problem_id: problemToReset,
                     student_id: uniqStudentIdentifier

--- a/lms/templates/commerce/provider.underscore
+++ b/lms/templates/commerce/provider.underscore
@@ -12,7 +12,7 @@
         ) %>
   </div>
   <div class="provider-instructions">
-    <%= fulfillment_instructions %>
+    <%- fulfillment_instructions %>
   </div>
 </div>
 

--- a/lms/templates/components/card/card.underscore
+++ b/lms/templates/components/card/card.underscore
@@ -6,7 +6,7 @@
         <% } %>
         <h3 class="card-title"
             <% if (!_.isUndefined(srInfo)) { %>
-                aria-describedby="<%= srInfo.id %>"
+                aria-describedby="<%- srInfo.id %>"
             <% } %>
             ><%- title %>
         </h3>
@@ -17,7 +17,7 @@
     <div class="card-meta">
     </div>
     <div class="card-actions">
-        <a class="action <%= action_class %>" href="<%= action_url %>"><%= action_content %></a>
+        <a class="action <%- action_class %>" href="<%- action_url %>"><%- action_content %></a>
     </div>
 </div>
 <% } else { %>
@@ -28,14 +28,14 @@
         <% } %>
         <h3 class="card-title"
             <% if (!_.isUndefined(srInfo)) { %>
-                aria-describedby="<%= srInfo.id %>"
+                aria-describedby="<%- srInfo.id %>"
             <% } %>
             ><%- title %>
         </h3>
         <p class="card-description"><%- description %></p>
     </div>
     <div class="card-actions">
-        <a class="action <%= action_class %>" href="<%= action_url %>"><%= action_content %></a>
+        <a class="action <%- action_class %>" href="<%- action_url %>"><%- action_content %></a>
     </div>
 </div>
 <div class="wrapper-card-meta">

--- a/lms/templates/components/header/header.underscore
+++ b/lms/templates/components/header/header.underscore
@@ -4,7 +4,7 @@
         <% if (breadcrumbs !== null && breadcrumbs.length > 0) { %>
             <nav class="breadcrumbs" aria-label="<%- nav_aria_label %>">
             <% _.each(breadcrumbs, function (breadcrumb) { %>
-                <a class="nav-item" href="<%= breadcrumb.url %>"><%- breadcrumb.title %></a>
+                <a class="nav-item" href="<%- breadcrumb.url %>"><%- breadcrumb.title %></a>
                 <span class="icon fa-angle-right" aria-hidden="true"></span>
             <% }) %>
             </nav>

--- a/lms/templates/edxnotes/note-item.underscore
+++ b/lms/templates/edxnotes/note-item.underscore
@@ -32,7 +32,7 @@
     <div class="wrapper-reference-content">
         <p class="reference-title"><%- gettext("Noted in:") %></p>
         <% if (unit.url) { %>
-          <a class="reference-meta reference-unit-link" href="<%= unit.url %>#<%= id %>"><%- unit.display_name %></a>
+          <a class="reference-meta reference-unit-link" href="<%- unit.url %>#<%- id %>"><%- unit.display_name %></a>
         <% } else { %>
           <span class="reference-meta"><%- unit.display_name %></span>
         <% } %>

--- a/lms/templates/edxnotes/tab-item.underscore
+++ b/lms/templates/edxnotes/tab-item.underscore
@@ -1,7 +1,7 @@
 <% var hasIcon = icon ? 1 : 0; %>
 
 <a class="tab-label <% if (hasIcon) { print('has-icon') } %>" href="#">
-  <% if (hasIcon) { %><span class="icon <%= icon %>" aria-hidden="true"></span> <% } %><%- gettext(name) %>
+  <% if (hasIcon) { %><span class="icon <%- icon %>" aria-hidden="true"></span> <% } %><%- gettext(name) %>
 </a>
 
 <% if (is_closable) { %>

--- a/lms/templates/fields/field_image.underscore
+++ b/lms/templates/fields/field_image.underscore
@@ -1,17 +1,17 @@
 <div class="image-wrapper">
-    <img class="image-frame" src="<%- imageUrl %>"  alt="<%=imageAltText%>"/>
+    <img class="image-frame" src="<%- imageUrl %>"  alt="<%- imageAltText %>"/>
     <div class="u-field-actions">
         <label class="u-field-upload-button">
-            <span class="upload-button-icon" aria-hidden="true"><%= uploadButtonIcon %></span>
-            <span class="upload-button-title" aria-live="polite"><%= uploadButtonTitle %></span>
-            <input class="upload-button-input" type="file" name="<%= inputName %>"/>
+            <span class="upload-button-icon" aria-hidden="true"><%- uploadButtonIcon %></span>
+            <span class="upload-button-title" aria-live="polite"><%- uploadButtonTitle %></span>
+            <input class="upload-button-input" type="file" name="<%- inputName %>"/>
        	</label>
-       	<button class="upload-submit" type="button" hidden="true"><%= uploadButtonTitle %></button>
+       	<button class="upload-submit" type="button" hidden="true"><%- uploadButtonTitle %></button>
         
         <button class="u-field-remove-button" type="button">
-            <span class="remove-button-icon" aria-hidden="true"><%= removeButtonIcon %></span>
-            <span class="remove-button-title" aria-live="polite"><%= removeButtonTitle %></span>
-            <span class="sr"><%= screenReaderTitle %></span>
+            <span class="remove-button-icon" aria-hidden="true"><%- removeButtonIcon %></span>
+            <span class="remove-button-title" aria-live="polite"><%- removeButtonTitle %></span>
+            <span class="sr"><%- screenReaderTitle %></span>
         </button>
     </div>
 </div>

--- a/lms/templates/fields/message_banner.underscore
+++ b/lms/templates/fields/message_banner.underscore
@@ -1,4 +1,4 @@
-<div class="wrapper-msg urgency-<%= urgency %> <%= type %>">
+<div class="wrapper-msg urgency-<%- urgency %> <%- type %>">
     <div class="msg">
         <div class="msg-content">
             <div class="copy">

--- a/lms/templates/financial-assistance/financial_assessment_form.underscore
+++ b/lms/templates/financial-assistance/financial_assessment_form.underscore
@@ -34,7 +34,7 @@
 		</div>
 	</div>
 
-	<%= fields %>
+	<%- fields %>
 
 	<div class="cta-wrapper clearfix">
 		<a href="<%- student_faq_url %>" class="nav-link"><%- interpolate_text(

--- a/lms/templates/instructor/instructor_dashboard_2/enrollment-code-lookup-links.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/enrollment-code-lookup-links.underscore
@@ -12,7 +12,7 @@
             <td> <%- is_registration_code_valid %> </td>
             <td>
                 <% _.each(actions, function(action){ %>
-                    <a class="registration_code_action_link" data-registration-code="<%= action.registration_code %>" data-action-type="<%= action.action_type %>" href="#" data-endpoint="<%= action.action_url %>">
+                    <a class="registration_code_action_link" data-registration-code="<%- action.registration_code %>" data-action-type="<%- action.action_type %>" href="#" data-endpoint="<%- action.action_url %>">
                         <%- action.action_name %>
                     </a>
                 <% }); %>

--- a/lms/templates/learner_dashboard/program_header_view.underscore
+++ b/lms/templates/learner_dashboard/program_header_view.underscore
@@ -1,7 +1,7 @@
 <div class="program-details-header">
     <div class="meta-info grid-container">
         <% if (logo) { %>
-            <span aria-label="<%- gettext(programData.type) %>" class="<%- programData.type.toLowerCase() %> program-details-icon"><%= logo %></span>
+            <span aria-label="<%- gettext(programData.type) %>" class="<%- programData.type.toLowerCase() %> program-details-icon"><%- logo %></span>
         <% } %>
         <h2 class="hd-1 program-title"><%- programData.title %></h2>
     </div>

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -1,9 +1,9 @@
-<div class="form-field <%=type%>-<%= name %>">
+<div class="form-field <%-type%>-<%- name %>">
     <% if ( type !== 'checkbox' ) { %>
-        <label for="<%= form %>-<%= name %>">
-            <span class="label-text"><%= label %></span>
-            <% if ( required && requiredStr && (type !== 'hidden') ) { %><span class="label-required"><%= requiredStr %></span><% } %>
-            <% if ( !required && optionalStr && (type !== 'hidden') ) { %><span class="label-optional"><%= optionalStr %></span><% } %>
+        <label for="<%- form %>-<%- name %>">
+            <span class="label-text"><%- label %></span>
+            <% if ( required && requiredStr && (type !== 'hidden') ) { %><span class="label-required"><%- requiredStr %></span><% } %>
+            <% if ( !required && optionalStr && (type !== 'hidden') ) { %><span class="label-optional"><%- optionalStr %></span><% } %>
         </label>
         <% if (supplementalLink && supplementalText) { %>
             <div class="supplemental-link">
@@ -13,45 +13,45 @@
     <% } %>
 
     <% if ( type === 'select' ) { %>
-        <select id="<%= form %>-<%= name %>"
-            name="<%= name %>"
+        <select id="<%- form %>-<%- name %>"
+            name="<%- name %>"
             class="input-inline"
             <% if ( instructions ) { %>
-            aria-describedby="<%= form %>-<%= name %>-desc"
+            aria-describedby="<%- form %>-<%- name %>-desc"
             <% } %>
             <% if ( typeof errorMessages !== 'undefined' ) {
                 _.each(errorMessages, function( msg, type ) {%>
-                    data-errormsg-<%= type %>="<%= msg %>"
+                    data-errormsg-<%- type %>="<%- msg %>"
             <%  });
             } %>
             <% if ( required ) { %> aria-required="true" required<% } %>>
         <% _.each(options, function(el) { %>
-            <option value="<%= el.value%>"<% if ( el.default ) { %> data-isdefault="true" selected<% } %>><%= el.name %></option>
+            <option value="<%- el.value%>"<% if ( el.default ) { %> data-isdefault="true" selected<% } %>><%- el.name %></option>
         <% }); %>
         </select>
-        <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
+        <% if ( instructions ) { %> <span class="tip tip-input" id="<%- form %>-<%- name %>-desc"><%- instructions %></span><% } %>
         <% if (supplementalLink && supplementalText) { %>
             <div class="supplemental-link">
                 <a href="<%- supplementalLink %>" target="_blank"><%- supplementalText %></a>
             </div>
         <% } %>
     <% } else if ( type === 'textarea' ) { %>
-        <textarea id="<%= form %>-<%= name %>"
-            type="<%= type %>"
-            name="<%= name %>"
+        <textarea id="<%- form %>-<%- name %>"
+            type="<%- type %>"
+            name="<%- name %>"
             class="input-block"
             <% if ( instructions ) { %>
-            aria-describedby="<%= form %>-<%= name %>-desc"
+            aria-describedby="<%- form %>-<%- name %>-desc"
             <% } %>
-            <% if ( restrictions.min_length ) { %> minlength="<%= restrictions.min_length %>"<% } %>
-            <% if ( restrictions.max_length ) { %> maxlength="<%= restrictions.max_length %>"<% } %>
+            <% if ( restrictions.min_length ) { %> minlength="<%- restrictions.min_length %>"<% } %>
+            <% if ( restrictions.max_length ) { %> maxlength="<%- restrictions.max_length %>"<% } %>
             <% if ( typeof errorMessages !== 'undefined' ) {
                 _.each(errorMessages, function( msg, type ) {%>
-                    data-errormsg-<%= type %>="<%= msg %>"
+                    data-errormsg-<%- type %>="<%- msg %>"
             <%  });
             } %>
             <% if ( required ) { %> aria-required="true" required<% } %> ></textarea>
-            <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
+            <% if ( instructions ) { %> <span class="tip tip-input" id="<%- form %>-<%- name %>-desc"><%- instructions %></span><% } %>
             <% if (supplementalLink && supplementalText) { %>
                 <div class="supplemental-link">
                     <a href="<%- supplementalLink %>" target="_blank"><%- supplementalText %></a>
@@ -65,30 +65,30 @@
                 </div>
             <% } %>
         <% } %>
-        <input id="<%= form %>-<%= name %>"
-           type="<%= type %>"
-           name="<%= name %>"
+        <input id="<%- form %>-<%- name %>"
+           type="<%- type %>"
+           name="<%- name %>"
            class="input-block <% if ( type === 'checkbox' ) { %>checkbox<% } %>"
-            <% if ( instructions ) { %> aria-describedby="<%= form %>-<%= name %>-desc" <% } %>
-            <% if ( restrictions.min_length ) { %> minlength="<%= restrictions.min_length %>"<% } %>
-            <% if ( restrictions.max_length ) { %> maxlength="<%= restrictions.max_length %>"<% } %>
+            <% if ( instructions ) { %> aria-describedby="<%- form %>-<%- name %>-desc" <% } %>
+            <% if ( restrictions.min_length ) { %> minlength="<%- restrictions.min_length %>"<% } %>
+            <% if ( restrictions.max_length ) { %> maxlength="<%- restrictions.max_length %>"<% } %>
             <% if ( required ) { %> required<% } %>
             <% if ( typeof errorMessages !== 'undefined' ) {
                 _.each(errorMessages, function( msg, type ) {%>
-                    data-errormsg-<%= type %>="<%= msg %>"
+                    data-errormsg-<%- type %>="<%- msg %>"
             <%  });
             } %>
-            <% if ( placeholder ) { %> placeholder="<%= placeholder %>"<% } %>
+            <% if ( placeholder ) { %> placeholder="<%- placeholder %>"<% } %>
             value="<%- defaultValue %>"
         />
         <% if ( type === 'checkbox' ) { %>
-            <label for="<%= form %>-<%= name %>">
-                <span class="label-text"><%= label %></span>
-                <% if ( required && requiredStr ) { %><span class="label-required"><%= requiredStr %></span><% } %>
-                <% if ( !required && optionalStr ) { %><span class="label-optional"><%= optionalStr %></span><% } %>
+            <label for="<%- form %>-<%- name %>">
+                <span class="label-text"><%- label %></span>
+                <% if ( required && requiredStr ) { %><span class="label-required"><%- requiredStr %></span><% } %>
+                <% if ( !required && optionalStr ) { %><span class="label-optional"><%- optionalStr %></span><% } %>
             </label>
         <% } %>
-        <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
+        <% if ( instructions ) { %> <span class="tip tip-input" id="<%- form %>-<%- name %>-desc"><%- instructions %></span><% } %>
     <% } %>
 
     <% if( form === 'login' && name === 'password' ) { %>

--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -21,7 +21,7 @@
         <%- gettext("If you do not yet have an account, use the button below to register.") %>
     </p>
 
-    <%= context.fields %>
+    <%- context.fields %>
 
     <button type="submit" class="action action-primary action-update js-login login-button"><%- gettext("Sign in") %></button>
 

--- a/lms/templates/student_account/password_reset.underscore
+++ b/lms/templates/student_account/password_reset.underscore
@@ -7,7 +7,7 @@
 
     <p class="action-label"><%- gettext("Please enter your email address below and we will send you instructions for setting a new password.") %></p>
 
-    <%= fields %>
+    <%- fields %>
 
     <button type="submit" class="action action-primary action-update js-reset"><%- gettext("Reset my password") %></button>
 </form>

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -47,7 +47,7 @@
         <% } %>
     <% } %>
 
-    <%= context.fields %>
+    <%- context.fields %>
 
     <button type="submit" class="action action-primary action-update js-register register-button"><%- gettext("Create account") %></button>
 </form>

--- a/lms/templates/student_profile/badge_list.underscore
+++ b/lms/templates/student_profile/badge_list.underscore
@@ -1,4 +1,4 @@
-<div class="sr-is-focusable sr-<%= type %>-view" tabindex="-1"></div>
-<div class="<%= type %>-paging-header"></div>
-<div class="<%= type %>-list cards-list"></div>
-<div class="<%= type %>-paging-footer"></div>
+<div class="sr-is-focusable sr-<%- type %>-view" tabindex="-1"></div>
+<div class="<%- type %>-paging-header"></div>
+<div class="<%- type %>-list cards-list"></div>
+<div class="<%- type %>-paging-footer"></div>

--- a/lms/templates/student_profile/badge_placeholder.underscore
+++ b/lms/templates/student_profile/badge_placeholder.underscore
@@ -5,6 +5,6 @@
   <div class="badge-details">
     <div class="badge-name"><%- gettext("What's Your Next Accomplishment?") %></div>
     <p class="badge-description"><%- gettext('Start working toward your next learning goal.') %></p>
-    <a class="find-course" href="<%= find_courses_url %>"><span class="find-button-container"><%- gettext('Find a course') %></span></a>
+    <a class="find-course" href="<%- find_courses_url %>"><span class="find-button-container"><%- gettext('Find a course') %></span></a>
   </div>
 </div>


### PR DESCRIPTION
## Problem

According to the [edX Developer Guide's documentation on underscore linting violations](http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/conventions/safe_templates.html#underscore-not-escaped), we should be using the format

```
<%- expression %>
```

in favor of

```
<%= expression %>
```

except in cases where we already are escaping HTML through using functions like those mentioned in the document.

### Severity

The last time Jenkins ran for me on a PR that had already corrected a large underscore file's linting issues, I got this as safelint's report:

```
javascript-concat-html:               163 violations
javascript-escape:                    7 violations
javascript-interpolate:               29 violations
javascript-jquery-append:             76 violations
javascript-jquery-html:               192 violations
javascript-jquery-insert-into-target: 23 violations
javascript-jquery-insertion:          19 violations
javascript-jquery-prepend:            7 violations
mako-html-entities:                   0 violations
mako-invalid-html-filter:             11 violations
mako-invalid-js-filter:               195 violations
mako-js-html-string:                  0 violations
mako-js-missing-quotes:               0 violations
mako-missing-default:                 185 violations
mako-multiple-page-tags:              0 violations
mako-unknown-context:                 0 violations
mako-unparseable-expression:          0 violations
mako-unwanted-html-filter:            0 violations
python-close-before-format:           0 violations
python-concat-html:                   25 violations
python-custom-escape:                 13 violations
python-deprecated-display-name:       43 violations
python-interpolate-html:              66 violations
python-parse-error:                   0 violations
python-requires-html-or-text:         0 violations
python-wrap-html:                     239 violations
underscore-not-escaped:               506 violations

1799 violations total
```

Even after fixing a big violator, there are 506 out of 1799 violations. That's **28% of all safelint violations** coming from `underscore-not-escaped` issues.

## Solution

We simply replace all occurrences of `<%= expression %>` with `<%- expression %>` where a function that escapes HTML isn't already being used (in that case, we can leave it as it is).

I might have missed a spot or two, but will figure it out on the next Jenkins run.