### PR TITLE
WIP: Fix javascript-concat-html linting issues

### DIFF
--- a/cms/static/js/certificates/views/signatory_editor.js
+++ b/cms/static/js/certificates/views/signatory_editor.js
@@ -1,21 +1,28 @@
 // Backbone Application View: Signatory Editor
 
 define([
-    'jquery',
-    'underscore',
-    'backbone',
+    'jquery', 'underscore', 'backbone',
     'gettext',
     'js/utils/templates',
     'common/js/components/utils/view_utils',
+    'edx-ui-toolkit/js/utils/string-utils',
     'common/js/components/views/feedback_prompt',
     'common/js/components/views/feedback_notification',
     'js/models/uploads',
     'js/views/uploads',
     'text!templates/signatory-editor.underscore'
-],
-function($, _, Backbone, gettext,
-          TemplateUtils, ViewUtils, PromptView, NotificationView, FileUploadModel, FileUploadDialog,
-          signatoryEditorTemplate) {
+], function(
+    $, _, Backbone,
+    gettext,
+    TemplateUtils,
+    ViewUtils,
+    StringUtils,
+    PromptView,
+    NotificationView,
+    FileUploadModel,
+    FileUploadDialog,
+    signatoryEditorTemplate
+) {
     'use strict';
     var SignatoryEditorView = Backbone.View.extend({
         tagName: 'div',
@@ -198,7 +205,11 @@ function($, _, Backbone, gettext,
                 if (!$(selector).hasClass('error')) {
                     var errorMessage = this.model.validationError[modelAttribute];
                     $(selector).addClass('error');
-                    $(selector).append("<span class='message-error'>" + errorMessage + '</span>');
+                    $(selector).append(
+                        StringUtils.interpolate('<span class="message-error">{errorMessage}</span>', {
+                            errorMessage: errorMessage
+                        })
+                    );
                 }
             }
             else {

--- a/cms/static/js/factories/login.js
+++ b/cms/static/js/factories/login.js
@@ -1,4 +1,14 @@
-define(['jquery.cookie', 'utility', 'common/js/components/utils/view_utils'], function(cookie, utility, ViewUtils) {
+define([
+    'jquery.cookie',
+    'utility',
+    'common/js/components/utils/view_utils',
+    'edx-ui-toolkit/js/utils/string-utils'
+], function(
+    cookie,
+    utility,
+    ViewUtils,
+    StringUtils
+) {
     'use strict';
     return function(homepageURL) {
         function postJSON(url, data, callback) {
@@ -38,9 +48,11 @@ define(['jquery.cookie', 'utility', 'common/js/components/utils/view_utils'], fu
                     }
                 } else if ($('#login_error').length === 0) {
                     $('#login_form').prepend(
-                        '<div id="login_error" class="message message-status error">' +
-                        json.value +
-                        '</span></div>'
+                        StringUtils.interpolate(
+                            '<div id="login_error" class="message message-status error">{value}</div>', {
+                                value: json.value
+                            }
+                        )
                     );
                     $('#login_error').addClass('is-shown');
                     deferred.resolve();

--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -1,190 +1,206 @@
-define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/views/utils/create_course_utils',
-    'js/views/utils/create_library_utils', 'common/js/components/utils/view_utils'],
-    function(domReady, $, _, CancelOnEscape, CreateCourseUtilsFactory, CreateLibraryUtilsFactory, ViewUtils) {
-        'use strict';
-        var CreateCourseUtils = new CreateCourseUtilsFactory({
-            name: '.new-course-name',
-            org: '.new-course-org',
-            number: '.new-course-number',
-            run: '.new-course-run',
-            save: '.new-course-save',
-            errorWrapper: '.create-course .wrap-error',
-            errorMessage: '#course_creation_error',
-            tipError: '.create-course span.tip-error',
-            error: '.create-course .error',
-            allowUnicode: '.allow-unicode-course-id'
-        }, {
-            shown: 'is-shown',
-            showing: 'is-showing',
-            hiding: 'is-hiding',
-            disabled: 'is-disabled',
-            error: 'error'
-        });
-
-        var CreateLibraryUtils = new CreateLibraryUtilsFactory({
-            name: '.new-library-name',
-            org: '.new-library-org',
-            number: '.new-library-number',
-            save: '.new-library-save',
-            errorWrapper: '.create-library .wrap-error',
-            errorMessage: '#library_creation_error',
-            tipError: '.create-library  span.tip-error',
-            error: '.create-library .error',
-            allowUnicode: '.allow-unicode-library-id'
-        }, {
-            shown: 'is-shown',
-            showing: 'is-showing',
-            hiding: 'is-hiding',
-            disabled: 'is-disabled',
-            error: 'error'
-        });
-
-        var saveNewCourse = function(e) {
-            e.preventDefault();
-
-            if (CreateCourseUtils.hasInvalidRequiredFields()) {
-                return;
-            }
-
-            var $newCourseForm = $(this).closest('#create-course-form');
-            var display_name = $newCourseForm.find('.new-course-name').val();
-            var org = $newCourseForm.find('.new-course-org').val();
-            var number = $newCourseForm.find('.new-course-number').val();
-            var run = $newCourseForm.find('.new-course-run').val();
-
-            var course_info = {
-                org: org,
-                number: number,
-                display_name: display_name,
-                run: run
-            };
-
-            analytics.track('Created a Course', course_info);
-            CreateCourseUtils.create(course_info, function(errorMessage) {
-                $('.create-course .wrap-error').addClass('is-shown');
-                $('#course_creation_error').html('<p>' + errorMessage + '</p>');
-                $('.new-course-save').addClass('is-disabled').attr('aria-disabled', true);
-            });
-        };
-
-        var rtlTextDirection = function() {
-            var Selectors = {
-                new_course_run: '#new-course-run'
-            };
-
-            if ($('body').hasClass('rtl')) {
-                $(Selectors.new_course_run).addClass('course-run-text-direction placeholder-text-direction');
-                $(Selectors.new_course_run).on('input', function() {
-                    if (this.value === '') {
-                        $(Selectors.new_course_run).addClass('placeholder-text-direction');
-                    } else {
-                        $(Selectors.new_course_run).removeClass('placeholder-text-direction');
-                    }
-                });
-            }
-        };
-
-        var makeCancelHandler = function(addType) {
-            return function(e) {
-                e.preventDefault();
-                $('.new-' + addType + '-button').removeClass('is-disabled').attr('aria-disabled', false);
-                $('.wrapper-create-' + addType).removeClass('is-shown');
-                // Clear out existing fields and errors
-                $('#create-' + addType + '-form input[type=text]').val('');
-                $('#' + addType + '_creation_error').html('');
-                $('.create-' + addType + ' .wrap-error').removeClass('is-shown');
-                $('.new-' + addType + '-save').off('click');
-            };
-        };
-
-        var addNewCourse = function(e) {
-            var $newCourse,
-                $cancelButton,
-                $courseName;
-            e.preventDefault();
-            $('.new-course-button').addClass('is-disabled').attr('aria-disabled', true);
-            $('.new-course-save').addClass('is-disabled').attr('aria-disabled', true);
-            $newCourse = $('.wrapper-create-course').addClass('is-shown');
-            $cancelButton = $newCourse.find('.new-course-cancel');
-            $courseName = $('.new-course-name');
-            $courseName.focus().select();
-            $('.new-course-save').on('click', saveNewCourse);
-            $cancelButton.bind('click', makeCancelHandler('course'));
-            CancelOnEscape($cancelButton);
-            CreateCourseUtils.setupOrgAutocomplete();
-            CreateCourseUtils.configureHandlers();
-            rtlTextDirection();
-        };
-
-        var saveNewLibrary = function(e) {
-            e.preventDefault();
-
-            if (CreateLibraryUtils.hasInvalidRequiredFields()) {
-                return;
-            }
-
-            var $newLibraryForm = $(this).closest('#create-library-form');
-            var display_name = $newLibraryForm.find('.new-library-name').val();
-            var org = $newLibraryForm.find('.new-library-org').val();
-            var number = $newLibraryForm.find('.new-library-number').val();
-
-            var lib_info = {
-                org: org,
-                number: number,
-                display_name: display_name
-            };
-
-            analytics.track('Created a Library', lib_info);
-            CreateLibraryUtils.create(lib_info, function(errorMessage) {
-                $('.create-library .wrap-error').addClass('is-shown');
-                $('#library_creation_error').html('<p>' + errorMessage + '</p>');
-                $('.new-library-save').addClass('is-disabled').attr('aria-disabled', true);
-            });
-        };
-
-        var addNewLibrary = function(e) {
-            e.preventDefault();
-            $('.new-library-button').addClass('is-disabled').attr('aria-disabled', true);
-            $('.new-library-save').addClass('is-disabled').attr('aria-disabled', true);
-            var $newLibrary = $('.wrapper-create-library').addClass('is-shown');
-            var $cancelButton = $newLibrary.find('.new-library-cancel');
-            var $libraryName = $('.new-library-name');
-            $libraryName.focus().select();
-            $('.new-library-save').on('click', saveNewLibrary);
-            $cancelButton.bind('click', makeCancelHandler('library'));
-            CancelOnEscape($cancelButton);
-
-            CreateLibraryUtils.configureHandlers();
-        };
-
-        var showTab = function(tab) {
-            return function(e) {
-                e.preventDefault();
-                $('.courses-tab').toggleClass('active', tab === 'courses');
-                $('.libraries-tab').toggleClass('active', tab === 'libraries');
-
-            // Also toggle this course-related notice shown below the course tab, if it is present:
-                $('.wrapper-creationrights').toggleClass('is-hidden', tab !== 'courses');
-            };
-        };
-
-        var onReady = function() {
-            $('.new-course-button').bind('click', addNewCourse);
-            $('.new-library-button').bind('click', addNewLibrary);
-
-            $('.dismiss-button').bind('click', ViewUtils.deleteNotificationHandler(function() {
-                ViewUtils.reload();
-            }));
-
-            $('.action-reload').bind('click', ViewUtils.reload);
-
-            $('#course-index-tabs .courses-tab').bind('click', showTab('courses'));
-            $('#course-index-tabs .libraries-tab').bind('click', showTab('libraries'));
-        };
-
-        domReady(onReady);
-
-        return {
-            onReady: onReady
-        };
+define([
+    'domReady', 'jquery', 'underscore',
+    'js/utils/cancel_on_escape',
+    'js/views/utils/create_course_utils',
+    'js/views/utils/create_library_utils',
+    'common/js/components/utils/view_utils',
+    'edx-ui-toolkit/js/utils/string-utils'
+], function(
+        domReady, $, _,
+        CancelOnEscape,
+        CreateCourseUtilsFactory,
+        CreateLibraryUtilsFactory,
+        ViewUtils,
+        StringUtils
+) {
+    'use strict';
+    var CreateCourseUtils = new CreateCourseUtilsFactory({
+        name: '.new-course-name',
+        org: '.new-course-org',
+        number: '.new-course-number',
+        run: '.new-course-run',
+        save: '.new-course-save',
+        errorWrapper: '.create-course .wrap-error',
+        errorMessage: '#course_creation_error',
+        tipError: '.create-course span.tip-error',
+        error: '.create-course .error',
+        allowUnicode: '.allow-unicode-course-id'
+    }, {
+        shown: 'is-shown',
+        showing: 'is-showing',
+        hiding: 'is-hiding',
+        disabled: 'is-disabled',
+        error: 'error'
     });
+
+    var CreateLibraryUtils = new CreateLibraryUtilsFactory({
+        name: '.new-library-name',
+        org: '.new-library-org',
+        number: '.new-library-number',
+        save: '.new-library-save',
+        errorWrapper: '.create-library .wrap-error',
+        errorMessage: '#library_creation_error',
+        tipError: '.create-library  span.tip-error',
+        error: '.create-library .error',
+        allowUnicode: '.allow-unicode-library-id'
+    }, {
+        shown: 'is-shown',
+        showing: 'is-showing',
+        hiding: 'is-hiding',
+        disabled: 'is-disabled',
+        error: 'error'
+    });
+
+    var saveNewCourse = function(e) {
+        e.preventDefault();
+
+        if (CreateCourseUtils.hasInvalidRequiredFields()) {
+            return;
+        }
+
+        var $newCourseForm = $(this).closest('#create-course-form');
+        var display_name = $newCourseForm.find('.new-course-name').val();
+        var org = $newCourseForm.find('.new-course-org').val();
+        var number = $newCourseForm.find('.new-course-number').val();
+        var run = $newCourseForm.find('.new-course-run').val();
+
+        var course_info = {
+            org: org,
+            number: number,
+            display_name: display_name,
+            run: run
+        };
+
+        analytics.track('Created a Course', course_info);
+        CreateCourseUtils.create(course_info, function(errorMessage) {
+            $('.create-course .wrap-error').addClass('is-shown');
+            $('#course_creation_error').html(
+                StringUtils.interpolate('<p>{errorMessage}</p>', {errorMessage: errorMessage})
+            );
+            $('.new-course-save').addClass('is-disabled').attr('aria-disabled', true);
+        });
+    };
+
+    var rtlTextDirection = function() {
+        var Selectors = {
+            new_course_run: '#new-course-run'
+        };
+
+        if ($('body').hasClass('rtl')) {
+            $(Selectors.new_course_run).addClass('course-run-text-direction placeholder-text-direction');
+            $(Selectors.new_course_run).on('input', function() {
+                if (this.value === '') {
+                    $(Selectors.new_course_run).addClass('placeholder-text-direction');
+                } else {
+                    $(Selectors.new_course_run).removeClass('placeholder-text-direction');
+                }
+            });
+        }
+    };
+
+    var makeCancelHandler = function(addType) {
+        return function(e) {
+            e.preventDefault();
+            $('.new-' + addType + '-button').removeClass('is-disabled').attr('aria-disabled', false);
+            $('.wrapper-create-' + addType).removeClass('is-shown');
+            // Clear out existing fields and errors
+            $('#create-' + addType + '-form input[type=text]').val('');
+            $('#' + addType + '_creation_error').html('');
+            $('.create-' + addType + ' .wrap-error').removeClass('is-shown');
+            $('.new-' + addType + '-save').off('click');
+        };
+    };
+
+    var addNewCourse = function(e) {
+        var $newCourse,
+            $cancelButton,
+            $courseName;
+        e.preventDefault();
+        $('.new-course-button').addClass('is-disabled').attr('aria-disabled', true);
+        $('.new-course-save').addClass('is-disabled').attr('aria-disabled', true);
+        $newCourse = $('.wrapper-create-course').addClass('is-shown');
+        $cancelButton = $newCourse.find('.new-course-cancel');
+        $courseName = $('.new-course-name');
+        $courseName.focus().select();
+        $('.new-course-save').on('click', saveNewCourse);
+        $cancelButton.bind('click', makeCancelHandler('course'));
+        CancelOnEscape($cancelButton);
+        CreateCourseUtils.setupOrgAutocomplete();
+        CreateCourseUtils.configureHandlers();
+        rtlTextDirection();
+    };
+
+    var saveNewLibrary = function(e) {
+        e.preventDefault();
+
+        if (CreateLibraryUtils.hasInvalidRequiredFields()) {
+            return;
+        }
+
+        var $newLibraryForm = $(this).closest('#create-library-form');
+        var display_name = $newLibraryForm.find('.new-library-name').val();
+        var org = $newLibraryForm.find('.new-library-org').val();
+        var number = $newLibraryForm.find('.new-library-number').val();
+
+        var lib_info = {
+            org: org,
+            number: number,
+            display_name: display_name
+        };
+
+        analytics.track('Created a Library', lib_info);
+        CreateLibraryUtils.create(lib_info, function(errorMessage) {
+            $('.create-library .wrap-error').addClass('is-shown');
+            $('#library_creation_error').html(
+                StringUtils.interpolate('<p>{errorMessage}</p>', {errorMessage: errorMessage})
+            );
+            $('.new-library-save').addClass('is-disabled').attr('aria-disabled', true);
+        });
+    };
+
+    var addNewLibrary = function(e) {
+        e.preventDefault();
+        $('.new-library-button').addClass('is-disabled').attr('aria-disabled', true);
+        $('.new-library-save').addClass('is-disabled').attr('aria-disabled', true);
+        var $newLibrary = $('.wrapper-create-library').addClass('is-shown');
+        var $cancelButton = $newLibrary.find('.new-library-cancel');
+        var $libraryName = $('.new-library-name');
+        $libraryName.focus().select();
+        $('.new-library-save').on('click', saveNewLibrary);
+        $cancelButton.bind('click', makeCancelHandler('library'));
+        CancelOnEscape($cancelButton);
+
+        CreateLibraryUtils.configureHandlers();
+    };
+
+    var showTab = function(tab) {
+        return function(e) {
+            e.preventDefault();
+            $('.courses-tab').toggleClass('active', tab === 'courses');
+            $('.libraries-tab').toggleClass('active', tab === 'libraries');
+
+        // Also toggle this course-related notice shown below the course tab, if it is present:
+            $('.wrapper-creationrights').toggleClass('is-hidden', tab !== 'courses');
+        };
+    };
+
+    var onReady = function() {
+        $('.new-course-button').bind('click', addNewCourse);
+        $('.new-library-button').bind('click', addNewLibrary);
+
+        $('.dismiss-button').bind('click', ViewUtils.deleteNotificationHandler(function() {
+            ViewUtils.reload();
+        }));
+
+        $('.action-reload').bind('click', ViewUtils.reload);
+
+        $('#course-index-tabs .courses-tab').bind('click', showTab('courses'));
+        $('#course-index-tabs .libraries-tab').bind('click', showTab('libraries'));
+    };
+
+    domReady(onReady);
+
+    return {
+        onReady: onReady
+    };
+});

--- a/cms/static/js/maintenance/force_publish_course.js
+++ b/cms/static/js/maintenance/force_publish_course.js
@@ -1,12 +1,11 @@
-define([ // jshint ignore:line
+define([
     'jquery',
     'underscore',
     'gettext',
     'common/js/components/utils/view_utils',
     'edx-ui-toolkit/js/utils/string-utils',
     'edx-ui-toolkit/js/utils/html-utils'
-],
-function($, _, gettext, ViewUtils, StringUtils, HtmlUtils) {
+], function($, _, gettext, ViewUtils, StringUtils, HtmlUtils) {
     'use strict';
     return function(maintenanceViewURL) {
         var showError;
@@ -22,7 +21,9 @@ function($, _, gettext, ViewUtils, StringUtils, HtmlUtils) {
         showError = function(containerElSelector, error) {
             var errorWrapperElSelector, errorHtml;
             errorWrapperElSelector = containerElSelector + ' .wrapper-error';
-            errorHtml = '<div class="error" aria-live="polite" id="course-id-error">' + error + '</div>';
+            errorHtml = StringUtils.interpolate(
+                '<div class="error" aria-live="polite" id="course-id-error">{error}</div>', {error: error}
+            );
             HtmlUtils.setHtml($(errorWrapperElSelector), HtmlUtils.HTML(errorHtml));
             $(errorWrapperElSelector).css('display', 'inline-block');
             $(errorWrapperElSelector).fadeOut(5000);

--- a/cms/static/js/views/container.js
+++ b/cms/static/js/views/container.js
@@ -1,143 +1,163 @@
-define(['jquery', 'underscore', 'js/views/xblock', 'js/utils/module', 'gettext', 'common/js/components/views/feedback_notification',
-    'jquery.ui'], // The container view uses sortable, which is provided by jquery.ui.
-    function($, _, XBlockView, ModuleUtils, gettext, NotificationView) {
-        var studioXBlockWrapperClass = '.studio-xblock-wrapper';
+// The container view uses sortable, which is provided by jquery.ui.
 
-        var ContainerView = XBlockView.extend({
-            // Store the request token of the first xblock on the page (which we know was rendered by Studio when
-            // the page was generated). Use that request token to filter out user-defined HTML in any
-            // child xblocks within the page.
-            requestToken: '',
+define([
+    'jquery',
+    'underscore',
+    'gettext',
+    'js/views/xblock',
+    'js/utils/module',
+    'common/js/components/views/feedback_notification',
+    'edx-ui-toolkit/js/utils/string-utils',
+    'jquery.ui',
+], function(
+        $, _, gettext,
+        XBlockView,
+        ModuleUtils,
+        NotificationView,
+        StringUtils
+) {
+    var studioXBlockWrapperClass = '.studio-xblock-wrapper';
 
-            new_child_view: 'reorderable_container_child_preview',
+    var ContainerView = XBlockView.extend({
+        // Store the request token of the first xblock on the page (which we know was rendered by Studio when
+        // the page was generated). Use that request token to filter out user-defined HTML in any
+        // child xblocks within the page.
+        requestToken: '',
 
-            xblockReady: function() {
-                XBlockView.prototype.xblockReady.call(this);
-                var reorderableClass, reorderableContainer,
-                    newParent, oldParent, self = this;
+        new_child_view: 'reorderable_container_child_preview',
 
-                this.requestToken = this.$('div.xblock').first().data('request-token');
-                reorderableClass = this.makeRequestSpecificSelector('.reorderable-container');
+        xblockReady: function() {
+            XBlockView.prototype.xblockReady.call(this);
+            var reorderableClass, reorderableContainer,
+                newParent, oldParent, self = this;
 
-                reorderableContainer = this.$(reorderableClass);
-                reorderableContainer.sortable({
-                    handle: '.drag-handle',
+            this.requestToken = this.$('div.xblock').first().data('request-token');
+            reorderableClass = this.makeRequestSpecificSelector('.reorderable-container');
 
-                    start: function(event, ui) {
-                        // Necessary because of an open bug in JQuery sortable.
-                        // http://bugs.jqueryui.com/ticket/4990
-                        reorderableContainer.sortable('refreshPositions');
-                    },
+            reorderableContainer = this.$(reorderableClass);
+            reorderableContainer.sortable({
+                handle: '.drag-handle',
 
-                    stop: function(event, ui) {
-                        var saving, hideSaving, removeFromParent;
+                start: function(event, ui) {
+                    // Necessary because of an open bug in JQuery sortable.
+                    // http://bugs.jqueryui.com/ticket/4990
+                    reorderableContainer.sortable('refreshPositions');
+                },
 
-                        if (_.isUndefined(oldParent)) {
-                            // If no actual change occurred,
-                            // oldParent will never have been set.
-                            return;
-                        }
+                stop: function(event, ui) {
+                    var saving, hideSaving, removeFromParent;
 
-                        saving = new NotificationView.Mini({
-                            title: gettext('Saving')
+                    if (_.isUndefined(oldParent)) {
+                        // If no actual change occurred,
+                        // oldParent will never have been set.
+                        return;
+                    }
+
+                    saving = new NotificationView.Mini({
+                        title: gettext('Saving')
+                    });
+                    saving.show();
+
+                    hideSaving = function() {
+                        saving.hide();
+                    };
+
+                    // If moving from one container to another,
+                    // add to new container before deleting from old to
+                    // avoid creating an orphan if the addition fails.
+                    if (newParent) {
+                        removeFromParent = oldParent;
+                        self.updateChildren(newParent, function() {
+                            self.updateChildren(removeFromParent, hideSaving);
                         });
-                        saving.show();
-
-                        hideSaving = function() {
-                            saving.hide();
-                        };
-
-                        // If moving from one container to another,
-                        // add to new container before deleting from old to
-                        // avoid creating an orphan if the addition fails.
-                        if (newParent) {
-                            removeFromParent = oldParent;
-                            self.updateChildren(newParent, function() {
-                                self.updateChildren(removeFromParent, hideSaving);
-                            });
-                        } else {
-                            // No new parent, only reordering within same container.
-                            self.updateChildren(oldParent, hideSaving);
-                        }
-
-                        oldParent = undefined;
-                        newParent = undefined;
-                    },
-                    update: function(event, ui) {
-                        // When dragging from one ol to another, this method
-                        // will be called twice (once for each list). ui.sender will
-                        // be null if the change is related to the list the element
-                        // was originally in (the case of a move within the same container
-                        // or the deletion from a container when moving to a new container).
-                        var parent = $(event.target).closest(studioXBlockWrapperClass);
-                        if (ui.sender) {
-                            // Move to a new container (the addition part).
-                            newParent = parent;
-                        } else {
-                            // Reorder inside a container, or deletion when moving to new container.
-                            oldParent = parent;
-                        }
-                    },
-                    helper: 'original',
-                    opacity: '0.5',
-                    placeholder: 'component-placeholder',
-                    forcePlaceholderSize: true,
-                    axis: 'y',
-                    items: '> .is-draggable',
-                    connectWith: reorderableClass,
-                    tolerance: 'pointer'
-
-                });
-            },
-
-            updateChildren: function(targetParent, successCallback) {
-                var children, childLocators, xblockInfo = this.model;
-
-                // Find descendants with class "studio-xblock-wrapper" whose parent === targetParent.
-                // This is necessary to filter our grandchildren, great-grandchildren, etc.
-                children = targetParent.find(studioXBlockWrapperClass).filter(function() {
-                    var parent = $(this).parent().closest(studioXBlockWrapperClass);
-                    return parent.data('locator') === targetParent.data('locator');
-                });
-
-                childLocators = _.map(
-                    children,
-                    function(child) {
-                        return $(child).data('locator');
+                    } else {
+                        // No new parent, only reordering within same container.
+                        self.updateChildren(oldParent, hideSaving);
                     }
-                );
-                $.ajax({
-                    url: ModuleUtils.getUpdateUrl(targetParent.data('locator')),
-                    type: 'PUT',
-                    dataType: 'json',
-                    contentType: 'application/json',
-                    data: JSON.stringify({
-                        children: childLocators
-                    }),
-                    success: function() {
-                        // change data-parent on the element moved.
-                        if (successCallback) {
-                            successCallback();
-                        }
-                        // Update publish and last modified information from the server.
-                        xblockInfo.fetch();
+
+                    oldParent = undefined;
+                    newParent = undefined;
+                },
+                update: function(event, ui) {
+                    // When dragging from one ol to another, this method
+                    // will be called twice (once for each list). ui.sender will
+                    // be null if the change is related to the list the element
+                    // was originally in (the case of a move within the same container
+                    // or the deletion from a container when moving to a new container).
+                    var parent = $(event.target).closest(studioXBlockWrapperClass);
+                    if (ui.sender) {
+                        // Move to a new container (the addition part).
+                        newParent = parent;
+                    } else {
+                        // Reorder inside a container, or deletion when moving to new container.
+                        oldParent = parent;
                     }
-                });
-            },
+                },
+                helper: 'original',
+                opacity: '0.5',
+                placeholder: 'component-placeholder',
+                forcePlaceholderSize: true,
+                axis: 'y',
+                items: '> .is-draggable',
+                connectWith: reorderableClass,
+                tolerance: 'pointer'
 
-            acknowledgeXBlockDeletion: function(locator) {
-                this.notifyRuntime('deleted-child', locator);
-            },
+            });
+        },
 
-            refresh: function() {
-                var sortableInitializedClass = this.makeRequestSpecificSelector('.reorderable-container.ui-sortable');
-                this.$(sortableInitializedClass).sortable('refresh');
-            },
+        updateChildren: function(targetParent, successCallback) {
+            var children, childLocators, xblockInfo = this.model;
 
-            makeRequestSpecificSelector: function(selector) {
-                return 'div.xblock[data-request-token="' + this.requestToken + '"] > ' + selector;
-            }
-        });
+            // Find descendants with class "studio-xblock-wrapper" whose parent === targetParent.
+            // This is necessary to filter our grandchildren, great-grandchildren, etc.
+            children = targetParent.find(studioXBlockWrapperClass).filter(function() {
+                var parent = $(this).parent().closest(studioXBlockWrapperClass);
+                return parent.data('locator') === targetParent.data('locator');
+            });
 
-        return ContainerView;
-    }); // end define();
+            childLocators = _.map(
+                children,
+                function(child) {
+                    return $(child).data('locator');
+                }
+            );
+            $.ajax({
+                url: ModuleUtils.getUpdateUrl(targetParent.data('locator')),
+                type: 'PUT',
+                dataType: 'json',
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    children: childLocators
+                }),
+                success: function() {
+                    // change data-parent on the element moved.
+                    if (successCallback) {
+                        successCallback();
+                    }
+                    // Update publish and last modified information from the server.
+                    xblockInfo.fetch();
+                }
+            });
+        },
+
+        acknowledgeXBlockDeletion: function(locator) {
+            this.notifyRuntime('deleted-child', locator);
+        },
+
+        refresh: function() {
+            var sortableInitializedClass = this.makeRequestSpecificSelector('.reorderable-container.ui-sortable');
+            this.$(sortableInitializedClass).sortable('refresh');
+        },
+
+        makeRequestSpecificSelector: function(selector) {
+            return StringUtils.interpolate(
+                'div.xblock[data-request-token="{requestToken}"] > {selector}', {
+                    requestToken: this.requestToken,
+                    selector: selector
+                }
+            );
+        }
+    });
+
+    return ContainerView;
+}); // end define();

--- a/cms/static/js/views/course_rerun.js
+++ b/cms/static/js/views/course_rerun.js
@@ -1,87 +1,97 @@
-define(['domReady', 'jquery', 'underscore', 'js/views/utils/create_course_utils', 'common/js/components/utils/view_utils'],
-    function(domReady, $, _, CreateCourseUtilsFactory, ViewUtils) {
-        var CreateCourseUtils = new CreateCourseUtilsFactory({
-            name: '.rerun-course-name',
-            org: '.rerun-course-org',
-            number: '.rerun-course-number',
-            run: '.rerun-course-run',
-            save: '.rerun-course-save',
-            errorWrapper: '.wrapper-error',
-            errorMessage: '#course_rerun_error',
-            tipError: 'span.tip-error',
-            error: '.error',
-            allowUnicode: '.allow-unicode-course-id'
-        }, {
-            shown: 'is-shown',
-            showing: 'is-showing',
-            hiding: 'is-hidden',
-            disabled: 'is-disabled',
-            error: 'error'
+define([
+    'domReady', 'jquery', 'underscore',
+    'js/views/utils/create_course_utils',
+    'common/js/components/utils/view_utils',
+    'edx-ui-toolkit/js/utils/string-utils'
+], function(
+    domReady, $, _,
+    CreateCourseUtilsFactory,
+    ViewUtils,
+    StringUtils
+) {
+    var CreateCourseUtils = new CreateCourseUtilsFactory({
+        name: '.rerun-course-name',
+        org: '.rerun-course-org',
+        number: '.rerun-course-number',
+        run: '.rerun-course-run',
+        save: '.rerun-course-save',
+        errorWrapper: '.wrapper-error',
+        errorMessage: '#course_rerun_error',
+        tipError: 'span.tip-error',
+        error: '.error',
+        allowUnicode: '.allow-unicode-course-id'
+    }, {
+        shown: 'is-shown',
+        showing: 'is-showing',
+        hiding: 'is-hidden',
+        disabled: 'is-disabled',
+        error: 'error'
+    });
+
+    var saveRerunCourse = function(e) {
+        e.preventDefault();
+
+        if (CreateCourseUtils.hasInvalidRequiredFields()) {
+            return;
+        }
+
+        var $newCourseForm = $(this).closest('#rerun-course-form');
+        var display_name = $newCourseForm.find('.rerun-course-name').val();
+        var org = $newCourseForm.find('.rerun-course-org').val();
+        var number = $newCourseForm.find('.rerun-course-number').val();
+        var run = $newCourseForm.find('.rerun-course-run').val();
+
+        course_info = {
+            source_course_key: source_course_key,
+            org: org,
+            number: number,
+            display_name: display_name,
+            run: run
+        };
+
+        analytics.track('Reran a Course', course_info);
+        CreateCourseUtils.create(course_info, function(errorMessage) {
+            $('.wrapper-error').addClass('is-shown').removeClass('is-hidden');
+            $('#course_rerun_error').html(StringUtils.interpolate('<p>{error}</p>', {error: errorMessage}));
+            $('.rerun-course-save').addClass('is-disabled').attr('aria-disabled', true).removeClass('is-processing').html(gettext('Create Re-run'));
+            $('.action-cancel').removeClass('is-hidden');
         });
 
-        var saveRerunCourse = function(e) {
-            e.preventDefault();
+        // Go into creating re-run state
+        $('.rerun-course-save').addClass('is-disabled').attr('aria-disabled', true).addClass('is-processing').html(
+           StringUtils.interpolate('<span class="icon fa fa-refresh fa-spin" aria-hidden="true"></span>{text}',
+               {text: gettext('Processing Re-run Request')}
+        ));
+        $('.action-cancel').addClass('is-hidden');
+    };
 
-            if (CreateCourseUtils.hasInvalidRequiredFields()) {
-                return;
-            }
+    var cancelRerunCourse = function(e) {
+        e.preventDefault();
+        // Clear out existing fields and errors
+        $('.rerun-course-run').val('');
+        $('#course_rerun_error').html('');
+        $('wrapper-error').removeClass('is-shown').addClass('is-hidden');
+        $('.rerun-course-save').off('click');
+        ViewUtils.redirect('/course/');
+    };
 
-            var $newCourseForm = $(this).closest('#rerun-course-form');
-            var display_name = $newCourseForm.find('.rerun-course-name').val();
-            var org = $newCourseForm.find('.rerun-course-org').val();
-            var number = $newCourseForm.find('.rerun-course-number').val();
-            var run = $newCourseForm.find('.rerun-course-run').val();
+    var onReady = function() {
+        var $cancelButton = $('.rerun-course-cancel');
+        var $courseRun = $('.rerun-course-run');
+        $courseRun.focus().select();
+        $('.rerun-course-save').on('click', saveRerunCourse);
+        $cancelButton.bind('click', cancelRerunCourse);
+        $('.cancel-button').bind('click', cancelRerunCourse);
 
-            course_info = {
-                source_course_key: source_course_key,
-                org: org,
-                number: number,
-                display_name: display_name,
-                run: run
-            };
+        CreateCourseUtils.configureHandlers();
+    };
 
-            analytics.track('Reran a Course', course_info);
-            CreateCourseUtils.create(course_info, function(errorMessage) {
-                $('.wrapper-error').addClass('is-shown').removeClass('is-hidden');
-                $('#course_rerun_error').html('<p>' + errorMessage + '</p>');
-                $('.rerun-course-save').addClass('is-disabled').attr('aria-disabled', true).removeClass('is-processing').html(gettext('Create Re-run'));
-                $('.action-cancel').removeClass('is-hidden');
-            });
+    domReady(onReady);
 
-            // Go into creating re-run state
-            $('.rerun-course-save').addClass('is-disabled').attr('aria-disabled', true).addClass('is-processing').html(
-               '<span class="icon fa fa-refresh fa-spin" aria-hidden="true"></span>' + gettext('Processing Re-run Request')  // eslint-disable-line max-len
-            );
-            $('.action-cancel').addClass('is-hidden');
-        };
-
-        var cancelRerunCourse = function(e) {
-            e.preventDefault();
-            // Clear out existing fields and errors
-            $('.rerun-course-run').val('');
-            $('#course_rerun_error').html('');
-            $('wrapper-error').removeClass('is-shown').addClass('is-hidden');
-            $('.rerun-course-save').off('click');
-            ViewUtils.redirect('/course/');
-        };
-
-        var onReady = function() {
-            var $cancelButton = $('.rerun-course-cancel');
-            var $courseRun = $('.rerun-course-run');
-            $courseRun.focus().select();
-            $('.rerun-course-save').on('click', saveRerunCourse);
-            $cancelButton.bind('click', cancelRerunCourse);
-            $('.cancel-button').bind('click', cancelRerunCourse);
-
-            CreateCourseUtils.configureHandlers();
-        };
-
-        domReady(onReady);
-
-        // Return these functions so that they can be tested
-        return {
-            saveRerunCourse: saveRerunCourse,
-            cancelRerunCourse: cancelRerunCourse,
-            onReady: onReady
-        };
-    });
+    // Return these functions so that they can be tested
+    return {
+        saveRerunCourse: saveRerunCourse,
+        cancelRerunCourse: cancelRerunCourse,
+        onReady: onReady
+    };
+});

--- a/cms/static/js/views/metadata.js
+++ b/cms/static/js/views/metadata.js
@@ -1,13 +1,28 @@
-define(
-    [
-        'js/views/baseview', 'underscore', 'js/models/metadata', 'js/views/abstract_editor',
-        'js/models/uploads', 'js/views/uploads',
-        'js/models/license', 'js/views/license',
-        'js/views/video/transcripts/metadata_videolist',
-        'js/views/video/translations_editor'
-    ],
-function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
-         LicenseModel, LicenseView, VideoList, VideoTranslations) {
+define([
+    'js/views/baseview',
+    'underscore',
+    'js/models/metadata',
+    'js/views/abstract_editor',
+    'js/models/uploads',
+    'js/views/uploads',
+    'js/models/license',
+    'js/views/license',
+    'js/views/video/transcripts/metadata_videolist',
+    'js/views/video/translations_editor',
+    'edx-ui-toolkit/js/utils/string-utils'
+], function(
+    BaseView,
+    _,
+    MetadataModel,
+    AbstractEditor,
+    FileUpload,
+    UploadDialog,
+    LicenseModel,
+    LicenseView,
+    VideoList,
+    VideoTranslations,
+    StringUtils
+) {
     var Metadata = {};
 
     Metadata.Editor = BaseView.extend({
@@ -286,11 +301,14 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
             list.empty();
             _.each(value, function(ele, index) {
                 var template = _.template(
-                    '<li class="list-settings-item">' +
-                        '<input type="text" class="input" value="<%- ele %>">' +
-                        '<a href="#" class="remove-action remove-setting" data-index="<%- index %>"><span class="icon fa fa-times-circle" aria-hidden="true"></span><span class="sr">' + gettext('Remove') + '</span></a>' +   // eslint-disable-line max-len
+                    '<li class="list-settings-item">'.concat(
+                        '<input type="text" class="input" value="<%- ele %>">'.concat(
+                        '<a href="#" class="remove-action remove-setting" data-index="<%- index %>">'.concat(
+                            '<span class="icon fa fa-times-circle" aria-hidden="true"></span>'.concat(
+                            StringUtils.interpolate('<span class="sr">{text}</span>', {text: gettext('Remove')}).concat(
+                        '</a>'.concat(
                     '</li>'
-                );
+                )))))));
                 list.append($(template({'ele': ele, 'index': index})));
             });
         },
@@ -452,12 +470,15 @@ function(BaseView, _, MetadataModel, AbstractEditor, FileUpload, UploadDialog,
 
             _.each(value, function(value, key) {
                 var template = _.template(
-                    '<li class="list-settings-item">' +
-                        '<input type="text" class="input input-key" value="<%= key %>">' +
-                        '<input type="text" class="input input-value" value="<%= value %>">' +
-                        '<a href="#" class="remove-action remove-setting" data-value="<%= value %>"><span class="icon fa fa-times-circle" aria-hidden="true"></span><span class="sr">Remove</span></a>' +  // eslint-disable-line max-len
+                    '<li class="list-settings-item">'.concat(
+                        '<input type="text" class="input input-key" value="<%= key %>">'.concat(
+                        '<input type="text" class="input input-value" value="<%= value %>">'.concat(
+                        '<a href="#" class="remove-action remove-setting" data-value="<%= value %>">'.concat(
+                            '<span class="icon fa fa-times-circle" aria-hidden="true"></span>'.concat(
+                            '<span class="sr">Remove</span>'.concat(
+                        '</a>'.concat(
                     '</li>'
-                );
+                ))))))));
 
                 frag.appendChild($(template({'key': key, 'value': value}))[0]);
             });

--- a/cms/static/js/views/xblock.js
+++ b/cms/static/js/views/xblock.js
@@ -1,236 +1,251 @@
-define(['jquery', 'underscore', 'common/js/components/utils/view_utils', 'js/views/baseview', 'xblock/runtime.v1'],
-    function($, _, ViewUtils, BaseView, XBlock) {
-        'use strict';
+define([
+    'jquery', 'underscore',
+    'common/js/components/utils/view_utils',
+    'edx-ui-toolkit/js/utils/string-utils',
+    'js/views/baseview',
+    'xblock/runtime.v1'
+], function(
+    $, _,
+    ViewUtils,
+    StringUtils,
+    BaseView,
+    XBlock
+) {
+    'use strict';
 
-        var XBlockView = BaseView.extend({
-            // takes XBlockInfo as a model
+    var XBlockView = BaseView.extend({
+        // takes XBlockInfo as a model
 
-            events: {
-                'click .notification-action-button': 'fireNotificationActionEvent'
-            },
+        events: {
+            'click .notification-action-button': 'fireNotificationActionEvent'
+        },
 
-            initialize: function() {
-                BaseView.prototype.initialize.call(this);
-                this.view = this.options.view;
-            },
+        initialize: function() {
+            BaseView.prototype.initialize.call(this);
+            this.view = this.options.view;
+        },
 
-            render: function(options) {
-                var self = this,
-                    view = this.view,
-                    xblockInfo = this.model,
-                    xblockUrl = xblockInfo.url();
-                return $.ajax({
-                    url: decodeURIComponent(xblockUrl) + '/' + view,
-                    type: 'GET',
-                    cache: false,
-                    headers: {Accept: 'application/json'},
-                    success: function(fragment) {
-                        self.handleXBlockFragment(fragment, options);
-                    }
-                });
-            },
-
-            initRuntimeData: function(xblock, options) {
-                if (options && options.initRuntimeData && xblock && xblock.runtime && !xblock.runtime.page) {
-                    xblock.runtime.page = options.initRuntimeData;
+        render: function(options) {
+            var self = this,
+                view = this.view,
+                xblockInfo = this.model,
+                xblockUrl = xblockInfo.url();
+            return $.ajax({
+                url: decodeURIComponent(xblockUrl) + '/' + view,
+                type: 'GET',
+                cache: false,
+                headers: {Accept: 'application/json'},
+                success: function(fragment) {
+                    self.handleXBlockFragment(fragment, options);
                 }
-                return xblock;
-            },
+            });
+        },
 
-            handleXBlockFragment: function(fragment, options) {
-                var self = this,
-                    wrapper = this.$el,
-                    xblockElement,
-                    successCallback = options ? options.success || options.done : null,
-                    errorCallback = options ? options.error || options.done : null,
-                    xblock,
-                    fragmentsRendered;
+        initRuntimeData: function(xblock, options) {
+            if (options && options.initRuntimeData && xblock && xblock.runtime && !xblock.runtime.page) {
+                xblock.runtime.page = options.initRuntimeData;
+            }
+            return xblock;
+        },
 
-                fragmentsRendered = this.renderXBlockFragment(fragment, wrapper);
-                fragmentsRendered.always(function() {
-                    xblockElement = self.$('.xblock').first();
-                    try {
-                        xblock = XBlock.initializeBlock(xblockElement);
-                        self.xblock = self.initRuntimeData(xblock, options);
-                        self.xblockReady(self.xblock);
-                        self.$('.xblock_asides-v1').each(function() {
-                            if (!$(this).hasClass('xblock-initialized')) {
-                                var aside = XBlock.initializeBlock($(this));
-                                self.initRuntimeData(aside, options);
-                            }
-                        });
-                        if (successCallback) {
-                            successCallback(xblock);
-                        }
-                    } catch (e) {
-                        console.error(e.stack);
-                        // Add 'xblock-initialization-failed' class to every xblock
-                        self.$('.xblock').addClass('xblock-initialization-failed');
+        handleXBlockFragment: function(fragment, options) {
+            var self = this,
+                wrapper = this.$el,
+                xblockElement,
+                successCallback = options ? options.success || options.done : null,
+                errorCallback = options ? options.error || options.done : null,
+                xblock,
+                fragmentsRendered;
 
-                        // If the xblock was rendered but failed then still call xblockReady to allow
-                        // drag-and-drop to be initialized.
-                        if (xblockElement) {
-                            self.xblockReady(null);
-                        }
-                        if (errorCallback) {
-                            errorCallback();
-                        }
-                    }
-                });
-            },
-
-            /**
-             * Sends a notification event to the runtime, if one is available. Note that the runtime
-             * is only available once the xblock has been rendered and successfully initialized.
-             * @param eventName The name of the event to be fired.
-             * @param data The data to be passed to any listener's of the event.
-             */
-            notifyRuntime: function(eventName, data) {
-                var runtime = this.xblock && this.xblock.runtime;
-                if (runtime) {
-                    runtime.notify(eventName, data);
-                } else if (this.xblock) {
-                    var xblock_children = this.xblock.element && $(this.xblock.element).prop('xblock_children');
-                    if (xblock_children) {
-                        $(xblock_children).each(function() {
-                            if (this.runtime) {
-                                this.runtime.notify(eventName, data);
-                            }
-                        });
-                    }
-                }
-            },
-
-            /**
-             * This method is called upon successful rendering of an xblock. Note that the xblock
-             * may have thrown JavaScript errors after rendering in which case the xblock parameter
-             * will be null.
-             */
-            xblockReady: function(xblock) {  // eslint-disable-line no-unused-vars
-                // Do nothing
-            },
-
-            /**
-             * Renders an xblock fragment into the specified element. The fragment has two attributes:
-             *   html: the HTML to be rendered
-             *   resources: any JavaScript or CSS resources that the HTML depends upon
-             * Note that the XBlock is rendered asynchronously, and so a promise is returned that
-             * represents this process.
-             * @param fragment The fragment returned from the xblock_handler
-             * @param element The element into which to render the fragment (defaults to this.$el)
-             * @returns {Promise} A promise representing the rendering process
-             */
-            renderXBlockFragment: function(fragment, element) {
-                var html = fragment.html,
-                    resources = fragment.resources;
-                if (!element) {
-                    element = this.$el;
-                }
-
-                // Render the HTML first as the scripts might depend upon it, and then
-                // asynchronously add the resources to the page. Any errors that are thrown
-                // by included scripts are logged to the console but are then ignored assuming
-                // that at least the rendered HTML will be in place.
+            fragmentsRendered = this.renderXBlockFragment(fragment, wrapper);
+            fragmentsRendered.always(function() {
+                xblockElement = self.$('.xblock').first();
                 try {
-                    this.updateHtml(element, html);
-                    return this.addXBlockFragmentResources(resources);
+                    xblock = XBlock.initializeBlock(xblockElement);
+                    self.xblock = self.initRuntimeData(xblock, options);
+                    self.xblockReady(self.xblock);
+                    self.$('.xblock_asides-v1').each(function() {
+                        if (!$(this).hasClass('xblock-initialized')) {
+                            var aside = XBlock.initializeBlock($(this));
+                            self.initRuntimeData(aside, options);
+                        }
+                    });
+                    if (successCallback) {
+                        successCallback(xblock);
+                    }
                 } catch (e) {
                     console.error(e.stack);
-                    return $.Deferred().resolve();
-                }
-            },
+                    // Add 'xblock-initialization-failed' class to every xblock
+                    self.$('.xblock').addClass('xblock-initialization-failed');
 
-            /**
-             * Updates an element to have the specified HTML. The default method sets the HTML
-             * as child content, but this can be overridden.
-             * @param element The element to be updated
-             * @param html The desired HTML.
-             */
-            updateHtml: function(element, html) {
-                element.html(html);
-            },
-
-            /**
-             * Dynamically loads all of an XBlock's dependent resources. This is an asynchronous
-             * process so a promise is returned.
-             * @param resources The resources to be rendered
-             * @returns {Promise} A promise representing the rendering process
-             */
-            addXBlockFragmentResources: function(resources) {
-                var self = this,
-                    applyResource,
-                    numResources,
-                    deferred;
-                numResources = resources.length;
-                deferred = $.Deferred();
-                applyResource = function(index) {
-                    var hash, resource, value, promise;
-                    if (index >= numResources) {
-                        deferred.resolve();
-                        return;
+                    // If the xblock was rendered but failed then still call xblockReady to allow
+                    // drag-and-drop to be initialized.
+                    if (xblockElement) {
+                        self.xblockReady(null);
                     }
-                    value = resources[index];
-                    hash = value[0];
-                    if (!window.loadedXBlockResources) {
-                        window.loadedXBlockResources = [];
-                    }
-                    if (_.indexOf(window.loadedXBlockResources, hash) < 0) {
-                        resource = value[1];
-                        promise = self.loadResource(resource);
-                        window.loadedXBlockResources.push(hash);
-                        promise.done(function() {
-                            applyResource(index + 1);
-                        }).fail(function() {
-                            deferred.reject();
-                        });
-                    } else {
-                        applyResource(index + 1);
-                    }
-                };
-                applyResource(0);
-                return deferred.promise();
-            },
-
-            /**
-             * Loads the specified resource into the page.
-             * @param resource The resource to be loaded.
-             * @returns {Promise} A promise representing the loading of the resource.
-             */
-            loadResource: function(resource) {
-                var head = $('head'),
-                    mimetype = resource.mimetype,
-                    kind = resource.kind,
-                    placement = resource.placement,
-                    data = resource.data;
-                if (mimetype === 'text/css') {
-                    if (kind === 'text') {
-                        head.append("<style type='text/css'>" + data + '</style>');
-                    } else if (kind === 'url') {
-                        head.append("<link rel='stylesheet' href='" + data + "' type='text/css'>");
-                    }
-                } else if (mimetype === 'application/javascript') {
-                    if (kind === 'text') {
-                        head.append('<script>' + data + '</script>');
-                    } else if (kind === 'url') {
-                        return ViewUtils.loadJavaScript(data);
-                    }
-                } else if (mimetype === 'text/html') {
-                    if (placement === 'head') {
-                        head.append(data);
+                    if (errorCallback) {
+                        errorCallback();
                     }
                 }
-                // Return an already resolved promise for synchronous updates
-                return $.Deferred().resolve().promise();
-            },
+            });
+        },
 
-            fireNotificationActionEvent: function(event) {
-                var eventName = $(event.currentTarget).data('notification-action');
-                if (eventName) {
-                    event.preventDefault();
-                    this.notifyRuntime(eventName, this.model.get('id'));
+        /**
+         * Sends a notification event to the runtime, if one is available. Note that the runtime
+         * is only available once the xblock has been rendered and successfully initialized.
+         * @param eventName The name of the event to be fired.
+         * @param data The data to be passed to any listener's of the event.
+         */
+        notifyRuntime: function(eventName, data) {
+            var runtime = this.xblock && this.xblock.runtime;
+            if (runtime) {
+                runtime.notify(eventName, data);
+            } else if (this.xblock) {
+                var xblock_children = this.xblock.element && $(this.xblock.element).prop('xblock_children');
+                if (xblock_children) {
+                    $(xblock_children).each(function() {
+                        if (this.runtime) {
+                            this.runtime.notify(eventName, data);
+                        }
+                    });
                 }
             }
-        });
+        },
 
-        return XBlockView;
-    }); // end define();
+        /**
+         * This method is called upon successful rendering of an xblock. Note that the xblock
+         * may have thrown JavaScript errors after rendering in which case the xblock parameter
+         * will be null.
+         */
+        xblockReady: function(xblock) {  // eslint-disable-line no-unused-vars
+            // Do nothing
+        },
+
+        /**
+         * Renders an xblock fragment into the specified element. The fragment has two attributes:
+         *   html: the HTML to be rendered
+         *   resources: any JavaScript or CSS resources that the HTML depends upon
+         * Note that the XBlock is rendered asynchronously, and so a promise is returned that
+         * represents this process.
+         * @param fragment The fragment returned from the xblock_handler
+         * @param element The element into which to render the fragment (defaults to this.$el)
+         * @returns {Promise} A promise representing the rendering process
+         */
+        renderXBlockFragment: function(fragment, element) {
+            var html = fragment.html,
+                resources = fragment.resources;
+            if (!element) {
+                element = this.$el;
+            }
+
+            // Render the HTML first as the scripts might depend upon it, and then
+            // asynchronously add the resources to the page. Any errors that are thrown
+            // by included scripts are logged to the console but are then ignored assuming
+            // that at least the rendered HTML will be in place.
+            try {
+                this.updateHtml(element, html);
+                return this.addXBlockFragmentResources(resources);
+            } catch (e) {
+                console.error(e.stack);
+                return $.Deferred().resolve();
+            }
+        },
+
+        /**
+         * Updates an element to have the specified HTML. The default method sets the HTML
+         * as child content, but this can be overridden.
+         * @param element The element to be updated
+         * @param html The desired HTML.
+         */
+        updateHtml: function(element, html) {
+            element.html(html);
+        },
+
+        /**
+         * Dynamically loads all of an XBlock's dependent resources. This is an asynchronous
+         * process so a promise is returned.
+         * @param resources The resources to be rendered
+         * @returns {Promise} A promise representing the rendering process
+         */
+        addXBlockFragmentResources: function(resources) {
+            var self = this,
+                applyResource,
+                numResources,
+                deferred;
+            numResources = resources.length;
+            deferred = $.Deferred();
+            applyResource = function(index) {
+                var hash, resource, value, promise;
+                if (index >= numResources) {
+                    deferred.resolve();
+                    return;
+                }
+                value = resources[index];
+                hash = value[0];
+                if (!window.loadedXBlockResources) {
+                    window.loadedXBlockResources = [];
+                }
+                if (_.indexOf(window.loadedXBlockResources, hash) < 0) {
+                    resource = value[1];
+                    promise = self.loadResource(resource);
+                    window.loadedXBlockResources.push(hash);
+                    promise.done(function() {
+                        applyResource(index + 1);
+                    }).fail(function() {
+                        deferred.reject();
+                    });
+                } else {
+                    applyResource(index + 1);
+                }
+            };
+            applyResource(0);
+            return deferred.promise();
+        },
+
+        /**
+         * Loads the specified resource into the page.
+         * @param resource The resource to be loaded.
+         * @returns {Promise} A promise representing the loading of the resource.
+         */
+        loadResource: function(resource) {
+            var head = $('head'),
+                mimetype = resource.mimetype,
+                kind = resource.kind,
+                placement = resource.placement,
+                data = resource.data;
+            if (mimetype === 'text/css') {
+                if (kind === 'text') {
+                    head.append(StringUtils.interpolate('<style type="text/css">{data}</style>',
+                        {data: data}
+                    ));
+                } else if (kind === 'url') {
+                    head.append(StringUtils.interpolate('<link rel="stylesheet" href="{data}" type="text/css">',
+                        {data: data}
+                    ));
+                }
+            } else if (mimetype === 'application/javascript') {
+                if (kind === 'text') {
+                    head.append(StringUtils.interpolate('<script>{data}</script>', {data: data}));
+                } else if (kind === 'url') {
+                    return ViewUtils.loadJavaScript(data);
+                }
+            } else if (mimetype === 'text/html') {
+                if (placement === 'head') {
+                    head.append(data);
+                }
+            }
+            // Return an already resolved promise for synchronous updates
+            return $.Deferred().resolve().promise();
+        },
+
+        fireNotificationActionEvent: function(event) {
+            var eventName = $(event.currentTarget).data('notification-action');
+            if (eventName) {
+                event.preventDefault();
+                this.notifyRuntime(eventName, this.model.get('id'));
+            }
+        }
+    });
+
+    return XBlockView;
+}); // end define();

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -1,21 +1,19 @@
 (function(define) {
     'use strict';
     define([
-        'jquery',
-        'underscore',
-        'gettext',
+        'jquery', 'underscore', 'gettext',
         'edx-ui-toolkit/js/utils/html-utils',
         'edx-ui-toolkit/js/utils/string-utils',
         'js/student_account/views/FormView',
         'text!templates/student_account/form_success.underscore',
         'text!templates/student_account/form_status.underscore'
     ], function(
-            $, _, gettext,
-            HtmlUtils,
-            StringUtils,
-            FormView,
-            formSuccessTpl,
-            formStatusTpl
+        $, _, gettext,
+        HtmlUtils,
+        StringUtils,
+        FormView,
+        formSuccessTpl,
+        formStatusTpl
     ) {
         return FormView.extend({
             el: '#login-form',


### PR DESCRIPTION
## Problem

According to the [edX Developer Guide's documentation on javascript linting violations](http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/conventions/safe_templates.html#javascript-concat-html), we shouldn't concatenate HTML strings using `+`, but rather find other functionality (as mentioned in the document) which can do it in a cleaner, more reliable fashion.

### Severity

The last time Jenkins ran for me on a PR, I got this as safelint's report:

```
javascript-concat-html:               163 violations
javascript-escape:                    7 violations
javascript-interpolate:               29 violations
javascript-jquery-append:             76 violations
javascript-jquery-html:               192 violations
javascript-jquery-insert-into-target: 23 violations
javascript-jquery-insertion:          19 violations
javascript-jquery-prepend:            7 violations
mako-html-entities:                   0 violations
mako-invalid-html-filter:             11 violations
mako-invalid-js-filter:               195 violations
mako-js-html-string:                  0 violations
mako-js-missing-quotes:               0 violations
mako-missing-default:                 185 violations
mako-multiple-page-tags:              0 violations
mako-unknown-context:                 0 violations
mako-unparseable-expression:          0 violations
mako-unwanted-html-filter:            0 violations
python-close-before-format:           0 violations
python-concat-html:                   25 violations
python-custom-escape:                 13 violations
python-deprecated-display-name:       43 violations
python-interpolate-html:              66 violations
python-parse-error:                   0 violations
python-requires-html-or-text:         0 violations
python-wrap-html:                     239 violations
underscore-not-escaped:               506 violations

1799 violations total
```

There are 163 out of 1799 violations. That's **9% of all safelint violations** coming from ``javascript-concat-html` linting issues. All can be solved by more appropriately performing concatenation on HTML strings.

## Solution

In some cases, we can do something like `string.concat(string2.concat(string3))`. However, the **majority** of cases are due to the developer's attempt at concatenating a variable value with the HTML, like so:

```javascript
var element = '<div>' + value + '</div>';
```

This can be solved by using edx-ui-toolkit's string utilities (`edx-ui-toolkit/js/utils/string-utils`) as such:

```javascript
var element = StringUtils.interpolate('<div>{value}</div>', {
    value: value
});
```

There are many more ways to do this, as the documentation suggests.

## Status

As for now, I haven't been solving the issue as cleanly as I myself would like, but am working on it. I have also changed indentation in some files because I had to add the reference to the edx-ui-toolkit's string utility functions, and decided following the unclean patterns that existed in some files would be better served by simply cleaning them.

**I will leave a comment in each file that contains mostly indentation changes & point out the important part when this is ready for review.**