### PR TITLE
[ENT-457] Fix failing course_mode tests

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -141,7 +141,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         for mode in ('audit', 'honor', 'verified'):
             CourseModeFactory.create(mode_slug=mode, course_id=self.course.id)
 
-        catalog_integration = self.create_catalog_integration()
+        catalog_integration = self.create_catalog_integration(internal_api_url=settings.COURSE_CATALOG_API_URL)
         UserFactory(username=catalog_integration.service_username)
 
         self.mock_course_discovery_api_for_catalog_contains(
@@ -254,7 +254,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         for mode in ('audit', 'honor', 'verified'):
             CourseModeFactory.create(mode_slug=mode, course_id=self.course.id)
 
-        catalog_integration = self.create_catalog_integration()
+        catalog_integration = self.create_catalog_integration(internal_api_url=settings.COURSE_CATALOG_API_URL)
         UserFactory(username=catalog_integration.service_username)
 
         courses_in_catalog = [str(self.course.id)] if course_in_catalog else []


### PR DESCRIPTION
Currently, calling [`self.create_catalog_integration()`](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/catalog/tests/mixins.py#L10) creates an integration record pointing to a hard-coded URL. However, calling [`self.mock_course_discovery_api_for_catalog_contains()`](https://github.com/edx/edx-platform/blob/master/common/djangoapps/util/tests/mixins/discovery.py#L15-L17) mocks a URL based on settings. If there is a mismatch between settings and the hardcoded URL (as there is by default), the HTTPretty mock will not go into effect.

Fixes a testing bug introduced in #15400.

FYI @itsjeyd @brittneyexline @mattdrayer @douglashall @jzoldak 