### PR TITLE
Bump up the NewRelic plugin version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -133,7 +133,7 @@ watchdog==0.8.3
 
 # Metrics gathering and monitoring
 dogapi==1.2.1
-newrelic==2.78.0.57
+newrelic==2.86.3.70
 
 # Used for documentation gathering
 sphinx==1.1.3


### PR DESCRIPTION
Most bugfixes are python3 or Tornado specific, but several relate to Django 1.10 and they improved transaction traces since we last updated.

https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-286370