### PR TITLE
Upgrade proctoring (supports django 1.11)

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -87,7 +87,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.4#egg=lti_consumer-xblock==1.1.4
-git+https://github.com/edx/edx-proctoring.git@0.18.1#egg=edx-proctoring==0.18.1
+git+https://github.com/edx/edx-proctoring.git@0.18.2#egg=edx-proctoring==0.18.2
 
 # Third Party XBlocks
 git+https://github.com/open-craft/xblock-poll@v1.2.7#egg=xblock-poll==1.2.7


### PR DESCRIPTION
[EDUCATOR-767](https://openedx.atlassian.net/browse/EDUCATOR-767): Upgrade edx-platform to new version of edx-proctoring
* Bump edx-proctoring to use https://github.com/edx/edx-proctoring/releases/tag/0.18.2, which supports django 1.11

@edx/educator-dahlia 