### PR TITLE
ENT-480: Turn on Password field for Enterprise Account Creation

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -86,7 +86,7 @@ from openedx.core.djangoapps.theming import helpers as theming_helpers
 from openedx.core.djangoapps.user_api.preferences import api as preferences_api
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_experience import course_home_url_name
-from openedx.features.enterprise_support.api import get_dashboard_consent_notification
+from openedx.features.enterprise_support.api import get_dashboard_consent_notification, enterprise_customer_for_request
 from shoppingcart.api import order_history
 from shoppingcart.models import CourseRegistrationCode, DonationConfiguration
 from student.cookies import delete_logged_in_cookies, set_logged_in_cookies, set_user_info_cookie
@@ -1809,7 +1809,10 @@ def create_account_with_params(request, params):
     is_third_party_auth_enabled = third_party_auth.is_enabled()
 
     if is_third_party_auth_enabled and (pipeline.running(request) or third_party_auth_credentials_in_api):
-        params["password"] = pipeline.make_random_password()
+
+        # For enterprise account creation we are taking user password even for SSO
+        if not enterprise_customer_for_request(request):
+            params["password"] = pipeline.make_random_password()
 
     # in case user is registering via third party (Google, Facebook) and pipeline has expired, show appropriate
     # error message

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1043,6 +1043,23 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 }
             )
 
+    def test_enterprise_overrides(self):
+        """
+        Verify that enterprise overrides are applied on logistration pages
+        for enterprise SSO.
+        """
+        with simulate_running_pipeline(
+            'openedx.core.djangoapps.user_api.views.third_party_auth.pipeline', 'google-oauth2',
+            email='bob@example.com',
+            fullname='Bob',
+            username='Bob123',
+            country='pk'
+        ):
+            with mock.patch(
+                'openedx.features.enterprise_support.api.enterprise_customer_for_request', return_value=True,
+            ):
+                self._assert_password_field_visible({})
+
     def test_register_form_level_of_education(self):
         self._assert_reg_field(
             {"level_of_education": "optional"},
@@ -1957,6 +1974,28 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
             "name": "password",
             "type": "hidden",
             "required": False
+        })
+
+    def _assert_password_field_visible(self, field_settings):
+        """
+        Assert that given field settings have a password field and the
+        password field is visible, required and have expected attributes.
+        """
+        self._assert_reg_field(field_settings, {
+            'name': 'password',
+            'defaultValue': '',
+            'type': 'password',
+            'required': True,
+            'label': 'Password',
+            'placeholder': '',
+            'instructions': '',
+            'restrictions': {
+                'min_length': PASSWORD_MIN_LENGTH,
+                'max_length': PASSWORD_MAX_LENGTH
+            },
+            'errorMessages': {},
+            'supplementalText': '',
+            'supplementalLink': '',
         })
 
     def _assert_social_auth_provider_present(self, field_settings, backend):


### PR DESCRIPTION
Hi @douglashall , @brittneyexline , @zubair-arbi 

Please take a look at this PR, I have added password field for enterprise account creation.

**Jira Ticket:** [ENT-480](https://openedx.atlassian.net/browse/ENT-480)

**Description:**
Password field needs to be showing on the Enterprise Account Creation page. It is displayed in sandbox but not in stage.

**Sandbox:** https://enterprise.sandbox.edx.org has this PR deployed.

**Testing Instructions:**

1. Make sure user is logged out of the sandbox.
2. Go to registration page at https://enterprise.sandbox.edx.org/register
3. Click on "testshib" and login with a user that is not already attached with any edX user, You can detach an edX account from IdP account 
    1. Go to user's account settings page https://enterprise.sandbox.edx.org/account/settings
    2. Click on "Linked accounts"
    3. Click "Unlink This Account" at the bottom of the IdP that you wan to unlink.
4. After that you will be redirected to edX's registration page, Make sure that password field is displayed there. Make sure that you can later login with the new email and password at edX without having to go through SSO flow.