### PR TITLE
Override video xmodule's youtube id with the id coming from val YT profile

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -506,6 +506,16 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
 
         if metadata_was_changed_by_user:
             self.edx_video_id = self.edx_video_id.strip()
+
+            # We want to override `youtube_id_1_0` with val youtube profile in the first place when someone adds/edits
+            # an `edx_video_id` or its underlying YT val profile. Without this, override will only happen when a user
+            # saves the video second time. This is because of the syncing of basic and advanced video settings which
+            # also syncs val youtube id from basic tab's `Video Url` to advanced tab's `Youtube ID`.
+            if self.edx_video_id and edxval_api:
+                val_youtube_id = edxval_api.get_url_for_profile(self.edx_video_id, 'youtube')
+                if val_youtube_id and self.youtube_id_1_0 != val_youtube_id:
+                    self.youtube_id_1_0 = val_youtube_id
+
             manage_video_subtitles_save(
                 self,
                 user,

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1197,6 +1197,24 @@ class TestEditorSavedMethod(BaseTestXmodule):
         item.editor_saved(self.user, old_metadata, None)
         self.assertEqual(item.edx_video_id, stripped_video_id)
 
+    @ddt.data(TEST_DATA_MONGO_MODULESTORE, TEST_DATA_SPLIT_MODULESTORE)
+    @patch('xmodule.video_module.video_module.edxval_api.get_url_for_profile', Mock(return_value='test_yt_id'))
+    def test_editor_saved_with_yt_val_profile(self, default_store):
+        """
+        Verify editor saved overrides `youtube_id_1_0` when a youtube val profile is there
+        for a given `edx_video_id`.
+        """
+        self.MODULESTORE = default_store
+        self.initialize_module(metadata=self.metadata)
+        item = self.store.get_item(self.item_descriptor.location)
+        self.assertEqual(item.youtube_id_1_0, '3_yD_cEKoCk')
+
+        # Now, modify `edx_video_id` and save should override `youtube_id_1_0`.
+        old_metadata = own_metadata(item)
+        item.edx_video_id = unicode(uuid4())
+        item.editor_saved(self.user, old_metadata, None)
+        self.assertEqual(item.youtube_id_1_0, 'test_yt_id')
+
 
 @ddt.ddt
 class TestVideoDescriptorStudentViewJson(TestCase):


### PR DESCRIPTION
[EDUCATOR-793](https://openedx.atlassian.net/browse/EDUCATOR-793)

With this PR `youtube_id_1_0`  will be overridden with val youtube profile when someone edits `edx_video_id` and save the changes –` i.e.` only if the given `edx_video_id` has YT profile. This is needed for [this](https://github.com/edx/edx-platform/blob/5160909d3b084266c50b992f26220324d00438a9/common/lib/xmodule/xmodule/video_module/video_handlers.py#L123-L123) validation to work correctly. 

Sandbox – https://studio-yt-id-does-not-exists.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@6b97cdefe3ba4b618b794be6f5804192?action=new