### PR TITLE
Implement course home redirect if user cannot enroll

### DIFF
--- a/common/test/acceptance/tests/lms/test_progress_page.py
+++ b/common/test/acceptance/tests/lms/test_progress_page.py
@@ -326,6 +326,9 @@ class SubsectionGradingPolicyTest(ProgressPageBaseTest):
             self._answer_problem_correctly()
             self.progress_page.visit()
 
+            # Verify the basic a11y of the progress page
+            self.progress_page.a11y_audit.check_for_accessibility_errors()
+
             # Verify that y-Axis labels are aria-hidden
             self.assertEqual(['100%', 'true'], self.progress_page.y_tick_label(0))
             self.assertEqual(['0%', 'true'], self.progress_page.y_tick_label(1))

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -131,6 +131,19 @@ def check_course_access(course, user, action, check_if_enrolled=False):
             raise CourseAccessRedirect(reverse('about_course', args=[unicode(course.id)]))
 
 
+def can_self_enroll_in_course(course_key):
+    """
+    Returns True if the user can enroll themselves in a course.
+
+    Note: an example of a course that a user cannot enroll in directly
+    is a CCX course. For such courses, a user can only be enrolled by
+    a CCX coach.
+    """
+    if hasattr(course_key, 'ccx'):
+        return False
+    return True
+
+
 def find_file(filesystem, dirs, filename):
     """
     Looks for a filename in a list of dirs on a filesystem, in the specified order.

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -46,6 +46,7 @@ from courseware.access import has_access, has_ccx_coach_role
 from courseware.access_response import StartDateError
 from courseware.access_utils import in_preview_mode, is_course_open_for_learner
 from courseware.courses import (
+    can_self_enroll_in_course,
     get_course,
     get_course_by_id,
     get_course_overview_with_access,
@@ -287,10 +288,10 @@ def course_info(request, course_id):
         # if user is not enrolled in a course then app will show enroll/get register link inside course info page.
         user_is_enrolled = CourseEnrollment.is_enrolled(user, course.id)
         show_enroll_banner = request.user.is_authenticated() and not user_is_enrolled
-        if show_enroll_banner and hasattr(course_key, 'ccx'):
-            # if course is CCX and user is not enrolled/registered then do not let him open course direct via link for
-            # self registration. Because only CCX coach can register/enroll a student. If un-enrolled user try
-            # to access CCX redirect him to dashboard.
+
+        # If the user is not enrolled but this is a course that does not support
+        # direct enrollment then redirect them to the dashboard.
+        if not user_is_enrolled and not can_self_enroll_in_course(course_key):
             return redirect(reverse('dashboard'))
 
         # Redirect the user if they are not yet allowed to view this course
@@ -351,6 +352,7 @@ def course_info(request, course_id):
             # TODO: (Experimental Code). See https://openedx.atlassian.net/wiki/display/RET/2.+In-course+Verification+Prompts
             'upgrade_link': check_and_get_upgrade_link(request, user, course.id),
             'upgrade_price': get_cosmetic_verified_display_price(course),
+            'course_tools': course_tools,
             # ENDTODO
         }
 
@@ -681,11 +683,9 @@ def course_about(request, course_id):
     """
     course_key = CourseKey.from_string(course_id)
 
-    if hasattr(course_key, 'ccx'):
-        # if un-enrolled/non-registered user try to access CCX (direct for registration)
-        # then do not show him about page to avoid self registration.
-        # Note: About page will only be shown to user who is not register. So that he can register. But for
-        # CCX only CCX coach can enroll students.
+    # If a user is not able to enroll in a course then redirect
+    # them away from the about page to the dashboard.
+    if not can_self_enroll_in_course(course_key):
         return redirect(reverse('dashboard'))
 
     with modulestore().bulk_operations(course_key):


### PR DESCRIPTION
## [LEARNER-612](https://openedx.atlassian.net/browse/LEARNER-612)

### Description

This is a simple generalization of the CCX logic to work for any course that does not support direct enrollment by a user. It now works on both the course info page and the new unified course home.

### Sandbox
- [ ] _TBD_

### Testing
- [ ] Unit, integration, acceptance tests as appropriate

### Reviewers
FYI: @robrap @HarryRein 
 
### Post-review
- [ ] Rebase and squash commits