### PR TITLE
EDUCATOR-544

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -1,53 +1,60 @@
 """Tests for items views."""
 import json
 from datetime import datetime, timedelta
+
 import ddt
-
-from mock import patch, Mock, PropertyMock
-from pytz import UTC
-from pyquery import PyQuery
-from webob import Response
-
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.core.urlresolvers import reverse
-from contentstore.utils import reverse_usage_url, reverse_course_url
-
+from mock import Mock, PropertyMock, patch
 from opaque_keys import InvalidKeyError
-from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
-from contentstore.views.component import (
-    component_handler, get_component_templates
-)
-
-from contentstore.views.item import (
-    create_xblock_info, _get_source_index, _get_module_info, ALWAYS, VisibilityState, _xblock_type_and_display_name,
-    add_container_page_publishing_info
-)
-from contentstore.tests.utils import CourseTestCase
-from student.tests.factories import UserFactory
-from xblock_django.models import XBlockConfiguration, XBlockStudioConfiguration, XBlockStudioConfigurationFlag
-from xmodule.capa_module import CapaDescriptor
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.exceptions import ItemNotFoundError
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, TEST_DATA_SPLIT_MODULESTORE
-from xmodule.modulestore.tests.factories import ItemFactory, LibraryFactory, check_mongo_calls, CourseFactory
-from xmodule.x_module import STUDIO_VIEW, STUDENT_VIEW
-from xmodule.course_module import DEFAULT_START_DATE
+from opaque_keys.edx.keys import CourseKey, UsageKey
+from opaque_keys.edx.locations import Location
+from pyquery import PyQuery
+from pytz import UTC
+from webob import Response
 from xblock.core import XBlockAside
-from xblock.fields import Scope, String, ScopeIds
+from xblock.exceptions import NoSuchHandlerError
+from xblock.fields import Scope, ScopeIds, String
 from xblock.fragment import Fragment
 from xblock.runtime import DictKeyValueStore, KvsFieldData
 from xblock.test.tools import TestRuntime
-from xblock.exceptions import NoSuchHandlerError
-from xblock_django.user_service import DjangoXBlockUserService
-from opaque_keys.edx.keys import UsageKey, CourseKey
-from opaque_keys.edx.locations import Location
-from xmodule.partitions.partitions import (
-    Group, UserPartition, ENROLLMENT_TRACK_PARTITION_ID, MINIMUM_STATIC_PARTITION_ID
+from xblock.validation import ValidationMessage
+
+from contentstore.tests.utils import CourseTestCase
+from contentstore.utils import reverse_course_url, reverse_usage_url
+from contentstore.views.component import component_handler, get_component_templates
+from contentstore.views.item import (
+    ALWAYS,
+    VisibilityState,
+    _get_module_info,
+    _get_source_index,
+    _xblock_type_and_display_name,
+    add_container_page_publishing_info,
+    create_xblock_info
 )
+from lms_xblock.mixin import NONSENSICAL_ACCESS_RESTRICTION
+from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
+from student.tests.factories import UserFactory
+from xblock_django.models import XBlockConfiguration, XBlockStudioConfiguration, XBlockStudioConfigurationFlag
+from xblock_django.user_service import DjangoXBlockUserService
+from xmodule.capa_module import CapaDescriptor
+from xmodule.course_module import DEFAULT_START_DATE
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.exceptions import ItemNotFoundError
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory, check_mongo_calls
+from xmodule.partitions.partitions import (
+    ENROLLMENT_TRACK_PARTITION_ID,
+    MINIMUM_STATIC_PARTITION_ID,
+    Group,
+    UserPartition
+)
+from xmodule.partitions.tests.test_partitions import MockPartitionService
+from xmodule.x_module import STUDENT_VIEW, STUDIO_VIEW
 
 
 class AsideTest(XBlockAside):
@@ -1154,6 +1161,64 @@ class TestMoveItem(ItemTest):
         self.assertEqual(response.status_code, 400)
         response = json.loads(response.content)
         self.assertEqual(response['error'], 'Patch request did not recognise any parameters to handle.')
+
+    def _verify_validation_message(self, message, expected_message, expected_message_type):
+        """
+        Verify that the validation message has the expected validation message and type.
+        """
+        self.assertEqual(message.text, expected_message)
+        self.assertEqual(message.type, expected_message_type)
+
+    def test_move_component_nonsensical_access_restriction_validation(self):
+        """
+        Test that moving a component with non-contradicting access
+        restrictions into a unit that has contradicting access
+        restrictions brings up the nonsensical access validation
+        message and that the message does not show up when moved
+        into a unit where the component's access settings do not
+        contradict the unit's access settings.
+        """
+        group1 = self.course.user_partitions[0].groups[0]
+        group2 = self.course.user_partitions[0].groups[1]
+        vert2 = self.store.get_item(self.vert2_usage_key)
+        html = self.store.get_item(self.html_usage_key)
+
+        # Inject mock partition service as obtaining the course from the draft modulestore
+        # (which is the default for these tests) does not work.
+        partitions_service = MockPartitionService(
+            self.course,
+            course_id=self.course.id,
+        )
+        html.runtime._services['partitions'] = partitions_service
+
+        # Set access settings so html will contradict vert2 when moved into that unit
+        vert2.group_access = {self.course.user_partitions[0].id: [group1.id]}
+        html.group_access = {self.course.user_partitions[0].id: [group2.id]}
+        self.store.update_item(html, self.user.id)
+        self.store.update_item(vert2, self.user.id)
+
+        # Verify that there is no warning when html is in a non contradicting unit
+        validation = html.validate()
+        self.assertEqual(len(validation.messages), 0)
+
+        # Now move it and confirm that the html component has been moved into vertical 2
+        self.assert_move_item(self.html_usage_key, self.vert2_usage_key)
+        html.parent = self.vert2_usage_key
+        self.store.update_item(html, self.user.id)
+        validation = html.validate()
+        self.assertEqual(len(validation.messages), 1)
+        self._verify_validation_message(
+            validation.messages[0],
+            NONSENSICAL_ACCESS_RESTRICTION,
+            ValidationMessage.ERROR,
+        )
+
+        # Move the html component back and confirm that the warning is gone again
+        self.assert_move_item(self.html_usage_key, self.vert_usage_key)
+        html.parent = self.vert_usage_key
+        self.store.update_item(html, self.user.id)
+        validation = html.validate()
+        self.assertEqual(len(validation.messages), 0)
 
     @patch('contentstore.views.item.log')
     def test_move_logging(self, mock_logger):

--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -23,6 +23,7 @@ from courseware.access import has_access
 from courseware.courses import get_current_child
 from edxnotes.exceptions import EdxNotesParseError, EdxNotesServiceUnavailable
 from edxnotes.plugins import EdxNotesTab
+from lms.lib.utils import get_parent_unit
 from openedx.core.lib.token_utils import JwtBuilder
 from student.models import anonymous_id_for_user
 from util.date_utils import get_default_time_display
@@ -118,21 +119,6 @@ def send_request(user, course_id, page, page_size, path="", text=None):
         raise EdxNotesServiceUnavailable(_("EdxNotes Service is unavailable. Please try again in a few minutes."))
 
     return response
-
-
-def get_parent_unit(xblock):
-    """
-    Find vertical that is a unit, not just some container.
-    """
-    while xblock:
-        xblock = xblock.get_parent()
-        if xblock is None:
-            return None
-        parent = xblock.get_parent()
-        if parent is None:
-            return None
-        if parent.category == 'sequential':
-            return xblock
 
 
 def preprocess_collection(user, course, collection):

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -691,21 +691,6 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
             helpers.preprocess_collection(self.user, self.course, initial_collection)
         )
 
-    def test_get_parent_unit(self):
-        """
-        Tests `get_parent_unit` method for the successful result.
-        """
-        parent = helpers.get_parent_unit(self.html_module_1)
-        self.assertEqual(parent.location, self.vertical.location)
-
-        parent = helpers.get_parent_unit(self.child_html_module)
-        self.assertEqual(parent.location, self.vertical_with_container.location)
-
-        self.assertIsNone(helpers.get_parent_unit(None))
-        self.assertIsNone(helpers.get_parent_unit(self.course))
-        self.assertIsNone(helpers.get_parent_unit(self.chapter))
-        self.assertIsNone(helpers.get_parent_unit(self.sequential))
-
     def test_get_module_context_sequential(self):
         """
         Tests `get_module_context` method for the sequential.

--- a/lms/lib/tests/test_utils.py
+++ b/lms/lib/tests/test_utils.py
@@ -1,0 +1,59 @@
+"""
+Tests for the LMS/lib utils
+"""
+from lms.lib import utils
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+
+
+class LmsUtilsTest(ModuleStoreTestCase):
+    """
+    Tests for the LMS utility functions
+    """
+    def setUp(self):
+        """
+        Setup a dummy course content.
+        """
+        super(LmsUtilsTest, self).setUp()
+
+        with self.store.default_store(ModuleStoreEnum.Type.mongo):
+            self.course = CourseFactory.create()
+            self.chapter = ItemFactory.create(category="chapter", parent_location=self.course.location)
+            self.sequential = ItemFactory.create(category="sequential", parent_location=self.chapter.location)
+            self.vertical = ItemFactory.create(category="vertical", parent_location=self.sequential.location)
+            self.html_module_1 = ItemFactory.create(category="html", parent_location=self.vertical.location)
+            self.vertical_with_container = ItemFactory.create(
+                category="vertical", parent_location=self.sequential.location
+            )
+            self.child_container = ItemFactory.create(
+                category="split_test", parent_location=self.vertical_with_container.location)
+            self.child_vertical = ItemFactory.create(category="vertical", parent_location=self.child_container.location)
+            self.child_html_module = ItemFactory.create(category="html", parent_location=self.child_vertical.location)
+
+            # Read again so that children lists are accurate
+            self.course = self.store.get_item(self.course.location)
+            self.chapter = self.store.get_item(self.chapter.location)
+            self.sequential = self.store.get_item(self.sequential.location)
+            self.vertical = self.store.get_item(self.vertical.location)
+
+            self.vertical_with_container = self.store.get_item(self.vertical_with_container.location)
+            self.child_container = self.store.get_item(self.child_container.location)
+            self.child_vertical = self.store.get_item(self.child_vertical.location)
+            self.child_html_module = self.store.get_item(self.child_html_module.location)
+
+    def test_get_parent_unit(self):
+        """
+        Tests `get_parent_unit` method for the successful result.
+        """
+        parent = utils.get_parent_unit(self.html_module_1)
+        self.assertEqual(parent.location, self.vertical.location)
+
+        parent = utils.get_parent_unit(self.child_html_module)
+        self.assertEqual(parent.location, self.vertical_with_container.location)
+
+        self.assertIsNone(utils.get_parent_unit(None))
+        self.assertIsNone(utils.get_parent_unit(self.vertical))
+        self.assertIsNone(utils.get_parent_unit(self.course))
+        self.assertIsNone(utils.get_parent_unit(self.chapter))
+        self.assertIsNone(utils.get_parent_unit(self.sequential))

--- a/lms/lib/utils.py
+++ b/lms/lib/utils.py
@@ -1,0 +1,30 @@
+"""
+Helper methods for the LMS.
+"""
+
+
+def get_parent_unit(xblock):
+    """
+    Finds xblock's parent unit if it exists.
+
+    To find an xblock's parent unit, we traverse up the xblock's
+    family tree until we find an xblock whose parent is a
+    sequential xblock, which guarantees that the xblock is a unit.
+    The `get_parent()` call on both the xblock and the parent block
+    ensure that we don't accidentally return that a unit is its own
+    parent unit.
+
+    Returns:
+        xblock: Returns the parent unit xblock if it exists.
+        If no parent unit exists, returns None
+    """
+    while xblock:
+        parent = xblock.get_parent()
+        if parent is None:
+            return None
+        grandparent = parent.get_parent()
+        if grandparent is None:
+            return None
+        if parent.category == "vertical" and grandparent.category == "sequential":
+            return parent
+        xblock = parent


### PR DESCRIPTION
## [EDUCATOR-544](https://openedx.atlassian.net/browse/EDUCATOR-544)

### Description

Adds a new validation message for the unit page to warn the user when they have set access to a component in such a way that it contradicts the unit access settings.  For example, if unit level access is set to "Verified", and a component within the unit is set to "Audit", that setting does not make sense because the component will not be visible to anybody.

### Sandbox

- [x] Sandbox up at https://studio-nonsensical-unit-access-settings.sandbox.edx.org
         Unit page where component's access settings contradict the unit access settings: https://studio-nonsensical-unit-access-settings.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc

### Testing
- [x] Unit, integration, acceptance tests as appropriate

List optional/FYI reviewers here:
@sstack22 @catong  
 
### Post-review
- [ ] Rebase and squash commits