### PR TITLE
Remove django-mako requirement

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -22,7 +22,6 @@ django-countries==4.0
 django-extensions==1.5.9
 django-filter==0.11.0
 django-ipware==1.1.0
-django-mako==0.1.5pre
 django-model-utils==2.3.1
 django-mptt==0.7.4
 django-oauth-plus==2.2.8


### PR DESCRIPTION
It looks like it is just plain not being used which makes me suspicious, but it seems that all of the functionality has been subsumed into and replaced by edxmako.