### PR TITLE
Add chromeless class to the wrapper when in chromeless mode.

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -69,7 +69,7 @@ ${HTML(fragment.foot_html())}
 
 </%block>
 
-<div class="course-wrapper">
+<div class="course-wrapper chromeless">
   <section class="course-content" id="course-content">
       <main id="main" tabindex="-1" aria-label="Content">
         ${HTML(fragment.body_html())}


### PR DESCRIPTION
This makes it easier for CSS rules to target chromeless mode. This is useful for xblocks which want to use some CSS tweaks specific to the chromeless view.

**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1813

**Dependencies**: None

**Sandbox URL**: 
- LMS: https://pr15474.sandbox.opencraft.hosting/
- Studio: https://studio-pr15474.sandbox.opencraft.hosting/

**Partner information**: 3rd party-hosted open edX instance

**Merge deadline**: None

**Testing instructions**:

1. Use the Course Blocks API (`/api/courses/v1/blocks/?all_blocks=true&depth=all&course_id=Org/Course/Run`) to find a direct `student_view_url` link to a block (it will start with `/xblock/i4x://...`).
1. Visit the link and verify that `chromeless` class is present on the `courseware-wrapper` div.

Example from the sandbox: https://pr15474.sandbox.opencraft.hosting/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@45d46192272c4f6db6b63586520bbdf4

**Reviewers**
- [x] @bdero
- [ ] edX reviewer[s] TBD