### PR TITLE
Allow displaying videos without transcripts

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -247,6 +247,11 @@ FEATURES = {
     # Show the language selector in the header
     'SHOW_HEADER_LANGUAGE_SELECTOR': False,
 
+    # At edX it's safe to assume that English transcripts are always available
+    # This is not the case for all installations.
+    # The default value in {lms,cms}/envs/common.py and xmodule/tests/test_video.py should be consistent.
+    'FALLBACK_TO_ENGLISH_TRANSCRIPTS': True,
+
     # Set this to False to facilitate cleaning up invalid xml from your modulestore.
     'ENABLE_XBLOCK_XML_VALIDATION': True,
 

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -2,6 +2,7 @@
 Utility functions for transcripts.
 ++++++++++++++++++++++++++++++++++
 """
+from django.conf import settings
 import os
 import copy
 import json
@@ -556,7 +557,7 @@ class VideoTranscriptsMixin(object):
     This is necessary for both VideoModule and VideoDescriptor.
     """
 
-    def available_translations(self, transcripts, verify_assets=True):
+    def available_translations(self, transcripts, verify_assets=None):
         """Return a list of language codes for which we have transcripts.
 
         Args:
@@ -566,13 +567,16 @@ class VideoTranscriptsMixin(object):
                 we might do this is to avoid slamming contentstore() with queries
                 when trying to make a listing of videos and their languages.
 
-                Defaults to True.
+                Defaults to `not FALLBACK_TO_ENGLISH_TRANSCRIPTS`.
 
             transcripts (dict): A dict with all transcripts and a sub.
 
                 Defaults to False
         """
         translations = []
+        if verify_assets is None:
+            verify_assets = not settings.FEATURES.get('FALLBACK_TO_ENGLISH_TRANSCRIPTS')
+
         sub, other_langs = transcripts["sub"], transcripts["transcripts"]
 
         # If we're not verifying the assets, we just trust our field values

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -276,7 +276,7 @@ class VideoStudentViewHandlers(object):
 
         elif dispatch.startswith('available_translations'):
 
-            available_translations = self.available_translations(transcripts)
+            available_translations = self.available_translations(transcripts, verify_assets=True)
             if available_translations:
                 response = Response(json.dumps(available_translations))
                 response.content_type = 'application/json'

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -991,7 +991,7 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
         transcripts_info = self.get_transcripts_info()
         transcripts = {
             lang: self.runtime.handler_url(self, 'transcript', 'download', query="lang=" + lang, thirdparty=True)
-            for lang in self.available_translations(transcripts_info, verify_assets=False)
+            for lang in self.available_translations(transcripts_info)
         }
 
         return {

--- a/lms/djangoapps/mobile_api/video_outlines/serializers.py
+++ b/lms/djangoapps/mobile_api/video_outlines/serializers.py
@@ -209,7 +209,7 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
 
     # Transcripts...
     transcripts_info = video_descriptor.get_transcripts_info()
-    transcript_langs = video_descriptor.available_translations(transcripts_info, verify_assets=False)
+    transcript_langs = video_descriptor.available_translations(transcripts_info)
 
     transcripts = {
         lang: reverse(

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -346,6 +346,11 @@ FEATURES = {
     # Show the language selector in the header
     'SHOW_HEADER_LANGUAGE_SELECTOR': False,
 
+    # At edX it's safe to assume that English transcripts are always available
+    # This is not the case for all installations.
+    # The default value in {lms,cms}/envs/common.py and xmodule/tests/test_video.py should be consistent.
+    'FALLBACK_TO_ENGLISH_TRANSCRIPTS': True,
+
     # Show the language selector in the footer
     'SHOW_FOOTER_LANGUAGE_SELECTOR': False,
 


### PR DESCRIPTION
## Description
This is a bug for mobile we got it reported and fixed earlier in our fork by @ahmedaljazzar:
 - https://github.com/Edraak/edx-platform/pull/279
 - https://github.com/Edraak/edx-platform/issues/290

## Background
As far as I know, at edX every video has to have transcripts. So it's safe to assume that English transcripts is always a working fallback. The accessibility is something that is well invested in the US and the English language in general, especially with the aid of YouTube's free transcripters and the large community of volunteers.

However, in our case @Edraak it's a different story. We can't always afford having transcripts for our videos. So, that's a broken assumption. Therefore this PR is created with backward compatibility in mind.

## TODO
 - [x] Figure out how to properly make an `xmodule` test work with `FEATURES`?
 - [x] Unit tests and quality checks
 - [x] Get engineering/product feedback from @edX
 - [x] Get additional review from @ahmedaljazzar 
 - [x] Should `'en'` be changed to `settings.LANGUAGE_CODE` instead? (looks like it!)
 - [x] Manual testing with mobile app
   (or the API directly `/api/mobile/v0.5/video_outlines/courses/course-v1:Edraak+JAZ101+2017`)

## Sandbox
- [x] https://default-english-transcripts.sandbox.edx.org/

## Bug
Video player: Caption icon should not be displayed for the video doesn't have a transcript.

### Before
Notice that the "English" transcript option is there, but the video has no transcripts at all:
<img width="250" src="https://user-images.githubusercontent.com/645156/27902004-bfb38944-623c-11e7-828a-c1a89fc1684f.png" />


### After
Notice the "English" options is no longer showing:
<img width="250" src="https://user-images.githubusercontent.com/645156/27902016-c8994ddc-623c-11e7-8398-543ba49dfd82.png" />
