### PR TITLE
Ability to set HOMEPAGE_COURSE_MAX via SiteConfiguration.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -201,6 +201,11 @@ def index(request, extra_context=None, user=AnonymousUser()):
     # 1) Change False to True
     context['show_homepage_promo_video'] = configuration_helpers.get_value('show_homepage_promo_video', False)
 
+    # Maximum number of courses to display on the homepage.
+    context['homepage_course_max'] = configuration_helpers.get_value(
+        'HOMEPAGE_COURSE_MAX', settings.HOMEPAGE_COURSE_MAX
+    )
+
     # 2) Add your video's YouTube ID (11 chars, eg "123456789xX"), or specify via site configuration
     # Note: This value should be moved into a configuration setting and plumbed-through to the
     # context via the site configuration workflow, versus living here

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -1,9 +1,12 @@
 """
-Tests related to the Site COnfiguration feature
+Tests related to the Site Configuration feature
 """
+from bs4 import BeautifulSoup
+from contextlib import contextmanager
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
+from mock import patch
 from nose.plugins.attrib import attr
 
 from course_modes.models import CourseMode
@@ -128,6 +131,72 @@ class TestSites(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
         # assert that footer template has been properly overriden on homepage
         self.assertNotContains(resp, 'This is a Test Site footer')
+
+    @override_settings(SITE_NAME=settings.MICROSITE_TEST_HOSTNAME)
+    def test_site_homepage_course_max(self):
+        """
+        Verify that the number of courses displayed on the homepage honors
+        the HOMEPAGE_COURSE_MAX setting.
+        """
+        @contextmanager
+        def homepage_course_max_site_config(limit):
+            """Temporarily set the microsite HOMEPAGE_COURSE_MAX setting to desired value."""
+            with patch.dict(settings.MICROSITE_CONFIGURATION, {
+                'test_site': dict(
+                    settings.MICROSITE_CONFIGURATION['test_site'],
+                    HOMEPAGE_COURSE_MAX=limit,
+                )
+            }):
+                yield
+
+        def assert_displayed_course_count(response, expected_count):
+            """Assert that the number of courses displayed matches the expectation."""
+            soup = BeautifulSoup(response.content, 'html.parser')
+            courses = soup.find_all(class_='course')
+            self.assertEqual(len(courses), expected_count)
+
+        # By default the number of courses on the homepage is not limited.
+        # We should see both courses and no link to all courses.
+        resp = self.client.get('/', HTTP_HOST=settings.MICROSITE_TEST_HOSTNAME)
+        self.assertEqual(resp.status_code, 200)
+        assert_displayed_course_count(resp, 2)
+        self.assertNotContains(resp, 'View all Courses')
+
+        # With the limit set to 5, we should still see both courses and no link to all courses.
+        with homepage_course_max_site_config(5):
+            resp = self.client.get('/', HTTP_HOST=settings.MICROSITE_TEST_HOSTNAME)
+            self.assertEqual(resp.status_code, 200)
+            assert_displayed_course_count(resp, 2)
+            self.assertNotContains(resp, 'View all Courses')
+
+        # With the limit set to 2, we should still see both courses and no link to all courses.
+        with homepage_course_max_site_config(2):
+            resp = self.client.get('/', HTTP_HOST=settings.MICROSITE_TEST_HOSTNAME)
+            self.assertEqual(resp.status_code, 200)
+            assert_displayed_course_count(resp, 2)
+            self.assertNotContains(resp, 'View all Courses')
+
+        # With the limit set to 1, we should only see one course.
+        # We should also see the link to all courses.
+        with homepage_course_max_site_config(1):
+            resp = self.client.get('/', HTTP_HOST=settings.MICROSITE_TEST_HOSTNAME)
+            self.assertEqual(resp.status_code, 200)
+            assert_displayed_course_count(resp, 1)
+            self.assertContains(resp, 'View all Courses')
+
+        # If no site configuration is set, the limit falls back to settings.HOMEPAGE_COURSE_MAX.
+        with override_settings(HOMEPAGE_COURSE_MAX=1):
+            resp = self.client.get('/', HTTP_HOST=settings.MICROSITE_TEST_HOSTNAME)
+            self.assertEqual(resp.status_code, 200)
+            assert_displayed_course_count(resp, 1)
+            self.assertContains(resp, 'View all Courses')
+
+        # Site configuration takes precedence over settings when both are set.
+        with homepage_course_max_site_config(2), override_settings(HOMEPAGE_COURSE_MAX=1):
+            resp = self.client.get('/', HTTP_HOST=settings.MICROSITE_TEST_HOSTNAME)
+            self.assertEqual(resp.status_code, 200)
+            assert_displayed_course_count(resp, 2)
+            self.assertNotContains(resp, 'View all Courses')
 
     @override_settings(SITE_NAME=settings.MICROSITE_TEST_HOSTNAME)
     def test_site_anonymous_copyright_content(self):

--- a/lms/templates/courses_list.html
+++ b/lms/templates/courses_list.html
@@ -9,7 +9,7 @@
       <section class="courses">
         <ul class="courses-listing">
           ## limiting the course number by using HOMEPAGE_COURSE_MAX as the maximum number of courses
-          %for course in courses[:settings.HOMEPAGE_COURSE_MAX]:
+          %for course in courses[:homepage_course_max]:
           <li class="courses-listing-item">
               <%include file="course.html" args="course=course" />
           </li>
@@ -17,7 +17,7 @@
         </ul>
       </section>
     ## in case there are courses that are not shown on the homepage, a 'View all Courses' link should appear
-      % if settings.HOMEPAGE_COURSE_MAX and len(courses) > settings.HOMEPAGE_COURSE_MAX:
+      % if homepage_course_max and len(courses) > homepage_course_max:
       <div class="courses-more">
         <a class="courses-more-cta" href="${marketing_link('COURSES')}"> ${_("View all Courses")} </a>
       </div>


### PR DESCRIPTION
This patch makes it possible to set `HOMEPAGE_COURSE_MAX` via `SiteConfiguration` in the django admin. The setting controls the number of courses displayed on the homepage.

**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1817

**Dependencies**: None

**Sandbox URL**: 
- LMS: https://pr15476.sandbox.opencraft.hosting/
- Studio: https://studio-pr15476.sandbox.opencraft.hosting/

The sandbox is set up with 4 courses and `HOMEPAGE_COURSE_MAX` is set to 2 in site configurations.

**Partner information**: 3rd party-hosted open edX instance

**Merge deadline**: None

**Testing instructions**:

1. Create and publish several courses in the Studio, so that they are visible on the LMS homepage.
1. By default there is no limit to the number of courses displayed on the homepage, so you should see all of the courses you added.
1. Go to the Site Configurations section of the django admin (/admin/site_configuration/siteconfiguration/).
1. Set up your Site/Site configuration and add `"HOMEPAGE_COURSE_MAX": 2` (or any other number you want to test).
1. Observe that the LMS homepage now only lists the number of pages you set in the configuration, and it shows a "View all Courses" link, which takes you to a page that lists all courses.

**Note: the homepage is cached and you may have to wait up to three minutes for the cache to update. If you don't want to wait, you can `rm -r /tmp/mako_*` and/or `sudo service memcached restart` before you see the changes. You may even have to restart edxapp (`/edx/bin/supervisor restart edxapp:*`).**

**Reviewers**
- [x] @pomegranited 
- [ ] edX reviewer[s] TBD