### PR TITLE
Add lti consumer xblock modules to LTI REST endpoints

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1253,6 +1253,7 @@ def get_course_lti_endpoints(request, course_id):
     anonymous_user = AnonymousUser()
     anonymous_user.known = False  # make these "noauth" requests like module_render.handle_xblock_callback_noauth
     lti_descriptors = modulestore().get_items(course.id, qualifiers={'category': 'lti'})
+    lti_descriptors.extend(modulestore().get_items(course.id, qualifiers={'category': 'lti_consumer'}))
 
     lti_noauth_modules = [
         get_module_for_descriptor(


### PR DESCRIPTION
This allows LTI consumer xblock modules being hocked into get_course_lti_endpoints for
discovering LTI result/outcome endpoints.

This was originally part of https://openedx.atlassian.net/browse/OSPR-1490