### PR TITLE
Fixing naming issue in edx.org theme.

### DIFF
--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -183,7 +183,7 @@
       }
     }
 
-    .user-dropdown {
+    .user-dropdown, .dropdown {
       font-size: $body-font-size;
       padding: 0 ($baseline/2);
       color: $base-font-color;
@@ -193,7 +193,7 @@
       text-shadow: none;
     }
 
-    .user-dropdown-menu {
+    .user-dropdown-menu, .dropdown-menu {
       background: $white;
       border-radius: 4px;
       box-shadow: 0 2px 2px 0 rgba(0,0,0, 0.3);
@@ -557,7 +557,7 @@
       }
     }
 
-    .dropdown {
+    .user-dropdown, .dropdown {
       font-size: $body-font-size;
       padding: ($baseline/5) ($baseline/2);
       color: $base-font-color;
@@ -567,7 +567,7 @@
       text-shadow: none;
     }
 
-    .dropdown-menu {
+    .user-dropdown-menu, .dropdown-menu {
       background: $border-color-4;
       border-radius: 4px;
       box-shadow: 0 2px 24px 0 rgba(0,0,0, 0.3);


### PR DESCRIPTION
When we created the bootstrap theme we had to fix a styling issue with using a "dropdown" class. When moving it to "user-dropdown" we fixed the standard open-edx theming but forgot to also fix it for the custom edx.org theme. 

I also added back the .dropdown tag as to not mess up the ecommerce team's implementation of dropdown.

Can test by adding back the dropdown and dropdown-menu classes in the chrome debugger.