### PR TITLE
Revert "Upgrade django-ratelimit-backend to 1.1.1"

### DIFF
--- a/common/djangoapps/course_modes/admin.py
+++ b/common/djangoapps/course_modes/admin.py
@@ -4,10 +4,9 @@ Django admin page for course modes
 from django.conf import settings
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.admin import widgets
+from django.contrib import admin
 
 from pytz import timezone, UTC
-from ratelimitbackend import admin
 
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
@@ -55,7 +54,7 @@ class CourseModeForm(forms.ModelForm):
             "OPTIONAL: After this date/time, users will no longer be able to submit photos for verification.  "
             "This appies ONLY to modes that require verification."
         ),
-        widget=widgets.AdminSplitDateTime,
+        widget=admin.widgets.AdminSplitDateTime,
     )
 
     def __init__(self, *args, **kwargs):

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -1,7 +1,6 @@
 """ Django admin pages for student app """
 from config_models.admin import ConfigurationModelAdmin
 from django import forms
-from django.contrib.admin.sites import NotRegistered
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.utils.translation import ugettext_lazy as _
@@ -114,6 +113,7 @@ class CourseAccessRoleForm(forms.ModelForm):
             self.fields['email'].initial = self.instance.user.email
 
 
+@admin.register(CourseAccessRole)
 class CourseAccessRoleAdmin(admin.ModelAdmin):
     """Admin panel for the Course Access Role. """
     form = CourseAccessRoleForm
@@ -138,6 +138,7 @@ class CourseAccessRoleAdmin(admin.ModelAdmin):
         super(CourseAccessRoleAdmin, self).save_model(request, obj, form, change)
 
 
+@admin.register(LinkedInAddToProfileConfiguration)
 class LinkedInAddToProfileConfigurationAdmin(admin.ModelAdmin):
     """Admin interface for the LinkedIn Add to Profile configuration. """
 
@@ -148,6 +149,7 @@ class LinkedInAddToProfileConfigurationAdmin(admin.ModelAdmin):
     exclude = ('dashboard_tracking_code',)
 
 
+@admin.register(CourseEnrollment)
 class CourseEnrollmentAdmin(admin.ModelAdmin):
     """ Admin interface for the CourseEnrollment model. """
     list_display = ('id', 'course_id', 'mode', 'user', 'is_active',)
@@ -183,6 +185,7 @@ class UserAdmin(BaseUserAdmin):
         return django_readonly + ('username',)
 
 
+@admin.register(UserAttribute)
 class UserAttributeAdmin(admin.ModelAdmin):
     """ Admin interface for the UserAttribute model. """
     list_display = ('user', 'name', 'value',)
@@ -198,18 +201,10 @@ admin.site.register(UserTestGroup)
 admin.site.register(CourseEnrollmentAllowed)
 admin.site.register(Registration)
 admin.site.register(PendingNameChange)
-admin.site.register(CourseAccessRole, CourseAccessRoleAdmin)
-admin.site.register(CourseEnrollment, CourseEnrollmentAdmin)
 admin.site.register(DashboardConfiguration, ConfigurationModelAdmin)
-admin.site.register(LinkedInAddToProfileConfiguration, LinkedInAddToProfileConfigurationAdmin)
 admin.site.register(LogoutViewConfiguration, ConfigurationModelAdmin)
 admin.site.register(RegistrationCookieConfiguration, ConfigurationModelAdmin)
-admin.site.register(UserAttribute, UserAttributeAdmin)
+
 
 # We must first un-register the User model since it may also be registered by the auth app.
-try:
-    admin.site.unregister(User)
-except NotRegistered:
-    pass
-
 admin.site.register(User, UserAdmin)

--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -4,7 +4,7 @@ Admin site configuration for third party authentication
 """
 from config_models.admin import ConfigurationModelAdmin, KeyedConfigurationModelAdmin
 from django import forms
-from ratelimitbackend import admin
+from django.contrib import admin
 
 from third_party_auth.provider import Registry
 

--- a/lms/djangoapps/experiments/admin.py
+++ b/lms/djangoapps/experiments/admin.py
@@ -1,8 +1,9 @@
-from ratelimitbackend import admin
+from django.contrib import admin
 
 from .models import ExperimentData
 
 
+@admin.register(ExperimentData)
 class ExperimentDataAdmin(admin.ModelAdmin):
     list_display = ('user', 'experiment_id', 'key',)
     list_filter = ('experiment_id',)
@@ -10,6 +11,3 @@ class ExperimentDataAdmin(admin.ModelAdmin):
     raw_id_fields = ('user',)
     readonly_fields = ('created', 'modified',)
     search_fields = ('experiment_id', 'user', 'key',)
-
-
-admin.site.register(ExperimentData, ExperimentDataAdmin)

--- a/lms/djangoapps/verify_student/admin.py
+++ b/lms/djangoapps/verify_student/admin.py
@@ -9,6 +9,7 @@ from ratelimitbackend import admin
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 
 
+@admin.register(SoftwareSecurePhotoVerification)
 class SoftwareSecurePhotoVerificationAdmin(admin.ModelAdmin):
     """
     Admin for the SoftwareSecurePhotoVerification table.
@@ -16,6 +17,3 @@ class SoftwareSecurePhotoVerificationAdmin(admin.ModelAdmin):
     list_display = ('id', 'user', 'status', 'receipt_id', 'submitted_at', 'updated_at',)
     raw_id_fields = ('user', 'reviewing_user', 'copy_id_photo_from',)
     search_fields = ('receipt_id', 'user__username',)
-
-
-admin.site.register(SoftwareSecurePhotoVerification, SoftwareSecurePhotoVerificationAdmin)

--- a/openedx/core/djangoapps/api_admin/admin.py
+++ b/openedx/core/djangoapps/api_admin/admin.py
@@ -1,12 +1,13 @@
 """Admin views for API managment."""
 from config_models.admin import ConfigurationModelAdmin
-from ratelimitbackend import admin
+from django.contrib import admin
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangoapps.api_admin.models import ApiAccessConfig, ApiAccessRequest
 
 
+@admin.register(ApiAccessRequest)
 class ApiAccessRequestAdmin(admin.ModelAdmin):
     """Admin for API access requests."""
     list_display = ('user', 'status', 'website')
@@ -38,4 +39,3 @@ class ApiAccessRequestAdmin(admin.ModelAdmin):
         )
 
 admin.site.register(ApiAccessConfig, ConfigurationModelAdmin)
-admin.site.register(ApiAccessRequest, ApiAccessRequestAdmin)

--- a/openedx/core/djangoapps/verified_track_content/admin.py
+++ b/openedx/core/djangoapps/verified_track_content/admin.py
@@ -2,15 +2,13 @@
 Django admin page for verified track configuration
 """
 
-from ratelimitbackend import admin
+from django.contrib import admin
 
 from openedx.core.djangoapps.verified_track_content.forms import VerifiedTrackCourseForm
 from openedx.core.djangoapps.verified_track_content.models import VerifiedTrackCohortedCourse
 
 
+@admin.register(VerifiedTrackCohortedCourse)
 class VerifiedTrackCohortedCourseAdmin(admin.ModelAdmin):
     """Admin for enabling verified track cohorting. """
     form = VerifiedTrackCourseForm
-
-
-admin.site.register(VerifiedTrackCohortedCourse, VerifiedTrackCohortedCourseAdmin)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -111,7 +111,7 @@ stevedore==1.10.0
 sure==1.2.3
 sympy==0.7.1
 xmltodict==0.4.1
-django-ratelimit-backend==1.1.1
+django-ratelimit-backend==1.0
 unicodecsv==0.9.4
 django-require==1.0.11
 django-webpack-loader==0.4.1


### PR DESCRIPTION
Reverts edx/edx-platform#15469 due to issues with external models that use the admin.register decorator not showing up in the django admin.