### PR TITLE
edx-ora2 1.4.4 release

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -74,7 +74,7 @@ git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@1.4.3#egg=ora2==1.4.3
+git+https://github.com/edx/edx-ora2.git@1.4.4#egg=ora2==1.4.4
 -e git+https://github.com/edx/edx-submissions.git@2.0.0#egg=edx-submissions==2.0.0
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/edx-val.git@0.0.16#egg=edxval==0.0.16


### PR DESCRIPTION
FYI @bdero @gsong @awaisdar001 @staubina - commits are visible at the following link, LMK if anything appears incorrect.
https://github.com/edx/edx-ora2/compare/1.4.3...1.4.4

I plan on merging this tomorrow morning.