### PR TITLE
Devstack default `ENABLE_CREATOR_GROUP` setting

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -119,6 +119,9 @@ SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
 ########################## Certificates Web/HTML View #######################
 FEATURES['CERTIFICATES_HTML_VIEW'] = True
 
+########################## AUTHOR PERMISSION #######################
+FEATURES['ENABLE_CREATOR_GROUP'] = False
+
 ################################# DJANGO-REQUIRE ###############################
 
 # Whether to run django-require in debug mode.


### PR DESCRIPTION
Per discussion with @nedbat, we decided the best default behavior for devstack is to default `ENABLE_CREATOR_GROUP` feature to false.