### PR TITLE
Show post visibility warning on new post

### DIFF
--- a/common/static/common/js/discussion/views/discussion_inline_view.js
+++ b/common/static/common/js/discussion/views/discussion_inline_view.js
@@ -126,7 +126,8 @@
                 course_settings: this.courseSettings,
                 topicId: discussionId,
                 startHeader: this.startHeader,
-                is_commentable_divided: response.is_commentable_divided
+                is_commentable_divided: response.is_commentable_divided,
+                user_group_id: response.user_group_id,
             });
 
             this.newPostView.render();

--- a/common/static/common/js/discussion/views/discussion_inline_view.js
+++ b/common/static/common/js/discussion/views/discussion_inline_view.js
@@ -127,7 +127,7 @@
                 topicId: discussionId,
                 startHeader: this.startHeader,
                 is_commentable_divided: response.is_commentable_divided,
-                user_group_id: response.user_group_id,
+                user_group_id: response.user_group_id
             });
 
             this.newPostView.render();

--- a/common/static/common/js/discussion/views/discussion_topic_menu_view.js
+++ b/common/static/common/js/discussion/views/discussion_topic_menu_view.js
@@ -15,6 +15,7 @@
             initialize: function(options) {
                 this.course_settings = options.course_settings;
                 this.currentTopicId = options.topicId;
+                this.group_name = options.group_name;
                 _.bindAll(this,
                     'handleTopicEvent'
                 );

--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -42,6 +42,7 @@
                 }
                 this.course_settings = options.course_settings;
                 this.is_commentable_divided = options.is_commentable_divided;
+                this.user_group_id = options.user_group_id;
                 this.topicId = options.topicId;
                 this.discussionBoardView = options.discussionBoardView;
             };
@@ -53,6 +54,7 @@
                 _.extend(context, {
                     group_options: this.getGroupOptions(),
                     is_commentable_divided: this.is_commentable_divided,
+                    is_discussion_division_enabled: this.course_settings.get('is_discussion_division_enabled'),
                     mode: this.mode,
                     startHeader: this.startHeader,
                     form_id: this.mode + (this.topicId ? '-' + this.topicId : '')
@@ -68,10 +70,17 @@
                 if (this.isTabMode()) {
                     this.topicView = new DiscussionTopicMenuView({
                         topicId: this.topicId,
-                        course_settings: this.course_settings
+                        course_settings: this.course_settings,
+                        group_name: this.getGroupName()
                     });
-                    this.topicView.on('thread:topic_change', this.toggleGroupDropdown);
+                    this.topicView.on('thread:topic_change', this.toggleGroupDropDown);
+                    if (this.course_settings.get('is_discussion_division_enabled')) {
+                        this.topicView.on('thread:topic_change', this.updateVisibilityMessage);
+                    }
                     this.addField(this.topicView.render());
+                } else {
+                    this.group_name = this.getGroupName();
+                    this.updateVisibilityMessage(null, this.is_commentable_divided);
                 }
                 return DiscussionUtil.makeWmdEditor(this.$el, $.proxy(this.$, this), 'js-post-body');
             };
@@ -100,6 +109,26 @@
                 }
             };
 
+            NewPostView.prototype.getGroupName = function() {
+                var userGroupId;
+                var group;
+                var group_name = null;
+                if (this.course_settings.get('is_discussion_division_enabled')) {
+                    userGroupId = $('#discussion-container').data('user-group-id');
+                    if (!userGroupId) {
+                        userGroupId = this.user_group_id;
+                    }
+                    group = this.course_settings.get('groups').find(function(group) {
+                        return group.id == userGroupId;
+                    });
+                    if (group) {
+                        group_name = group.name;
+                    }
+                }
+
+                return group_name;
+            };
+
             NewPostView.prototype.events = {
                 'keypress .forum-new-post-form input:not(.wmd-input)': function(event) {
                     return DiscussionUtil.ignoreEnterKey(event);
@@ -119,6 +148,17 @@
                     $('.js-group-select').val('').prop('disabled', true);
                     return $('.group-selector-wrapper').addClass('disabled');
                 }
+            };
+
+            NewPostView.prototype.updateVisibilityMessage = function($target, force_divided) {
+                var visEl = $('.group-visibility .field-label-text');
+                var visTemplate = edx.HtmlUtils.template($('#new-post-visibility-template').html());
+                var group_name = null;
+                if (($target && $target.data('divided')) || force_divided) {
+                    group_name = this.group_name;
+                }
+
+                edx.HtmlUtils.setHtml(visEl, visTemplate({group_name: group_name}));
             };
 
             NewPostView.prototype.postOptionChange = function(event) {

--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -151,7 +151,7 @@
             };
 
             NewPostView.prototype.updateVisibilityMessage = function($target, forceDivided) {
-                var $visEl = $('.group-visibility .field-label-text');
+                var $visEl = $('#wrapper-visibility-message');
                 var visTemplate = edx.HtmlUtils.template($('#new-post-visibility-template').html());
                 var groupName = null;
                 if (($target && $target.data('divided')) || forceDivided) {

--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -73,7 +73,7 @@
                         course_settings: this.course_settings,
                         group_name: this.getGroupName()
                     });
-                    this.topicView.on('thread:topic_change', this.toggleGroupDropDown);
+                    this.topicView.on('thread:topic_change', this.toggleGroupDropdown);
                     if (this.course_settings.get('is_discussion_division_enabled')) {
                         this.topicView.on('thread:topic_change', this.updateVisibilityMessage);
                     }

--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -112,21 +112,21 @@
             NewPostView.prototype.getGroupName = function() {
                 var userGroupId;
                 var group;
-                var group_name = null;
+                var groupName = null;
                 if (this.course_settings.get('is_discussion_division_enabled')) {
                     userGroupId = $('#discussion-container').data('user-group-id');
                     if (!userGroupId) {
                         userGroupId = this.user_group_id;
                     }
-                    group = this.course_settings.get('groups').find(function(group) {
-                        return group.id == userGroupId;
+                    group = this.course_settings.get('groups').find(function(courseSettingsGroup) {
+                        return courseSettingsGroup.id === String(userGroupId);
                     });
                     if (group) {
-                        group_name = group.name;
+                        groupName = group.name;
                     }
                 }
 
-                return group_name;
+                return groupName;
             };
 
             NewPostView.prototype.events = {
@@ -150,15 +150,15 @@
                 }
             };
 
-            NewPostView.prototype.updateVisibilityMessage = function($target, force_divided) {
-                var visEl = $('.group-visibility .field-label-text');
+            NewPostView.prototype.updateVisibilityMessage = function($target, forceDivided) {
+                var $visEl = $('.group-visibility .field-label-text');
                 var visTemplate = edx.HtmlUtils.template($('#new-post-visibility-template').html());
-                var group_name = null;
-                if (($target && $target.data('divided')) || force_divided) {
-                    group_name = this.group_name;
+                var groupName = null;
+                if (($target && $target.data('divided')) || forceDivided) {
+                    groupName = this.group_name;
                 }
 
-                edx.HtmlUtils.setHtml(visEl, visTemplate({group_name: group_name}));
+                edx.HtmlUtils.setHtml($visEl, visTemplate({group_name: groupName}));
             };
 
             NewPostView.prototype.postOptionChange = function(event) {

--- a/common/static/common/js/spec/discussion/view/discussion_inline_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/discussion_inline_view_spec.js
@@ -43,10 +43,21 @@
         };
 
         showDiscussion = function(test, testView) {
+            var courseSettings = DiscussionSpecHelper.createTestCourseSettings({
+                groups: [
+                    {
+                        id: 1,
+                        name: 'Cohort1'
+                    }, {
+                        id: 2,
+                        name: 'Cohort2'
+                    }
+                ]
+            });
             setNextAjaxResult(test, {
                 user_info: DiscussionSpecHelper.getTestUserInfo(),
                 roles: DiscussionSpecHelper.getTestRoleInfo(),
-                course_settings: DiscussionSpecHelper.createTestCourseSettings().attributes,
+                course_settings: courseSettings.attributes,
                 discussion_data: DiscussionViewSpecHelper.makeThreadWithProps({
                     commentable_id: 'test-topic',
                     title: TEST_THREAD_TITLE

--- a/common/static/common/js/spec_helpers/discussion_spec_helper.js
+++ b/common/static/common/js/spec_helpers/discussion_spec_helper.js
@@ -95,7 +95,7 @@
                 'thread-response-edit', 'response-comment-show', 'response-comment-edit', 'thread-list-item',
                 'search-alert', 'new-post', 'thread-type', 'new-post-menu-entry', 'new-post-alert',
                 'new-post-menu-category', 'topic', 'post-user-display', 'inline-discussion', 'pagination',
-                'profile-thread', 'customwmd-prompt', 'nav-loading'
+                'profile-thread', 'customwmd-prompt', 'nav-loading', 'new-post-visibility'
             ];
             templateNamesNoTrailingTemplate = [
                 'forum-action-endorse', 'forum-action-answer', 'forum-action-follow', 'forum-action-vote',

--- a/common/static/common/templates/discussion/new-post-visibility.underscore
+++ b/common/static/common/templates/discussion/new-post-visibility.underscore
@@ -1,0 +1,11 @@
+<% if (group_name) { %>
+    <%-
+    interpolate(
+        gettext('This post will be visible only to %(group_name)s.'),
+        {group_name: group_name},
+        true
+    )
+    %>
+<% } else { %>
+    <%- gettext('This post will be visible to everyone.') %>
+<% } %>

--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -29,9 +29,8 @@
             </div>
         </label>
     </div>
-    <% } else if (is_discussion_division_enabled) { %>
-    <div class="post-field group-visibility" id="wrapper-visibility-message"></div>
     <% } %>
+    <div class="post-field group-visibility" id="wrapper-visibility-message"></div>
     <div class="post-field">
         <label class="field-label">
             <span class="field-label-text"><%- gettext("Title") %></span>

--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -30,12 +30,7 @@
         </label>
     </div>
     <% } else if (is_discussion_division_enabled) { %>
-    <div class="post-field group-visibility">
-        <label class="field-label">
-            <!-- Wrapper for the visibility message filled out by a separate template -->
-            <span class="field-label-text"></span>
-	</label>
-    </div>
+    <div class="post-field group-visibility" id="wrapper-visibility-message"></div>
     <% } %>
     <div class="post-field">
         <label class="field-label">

--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -29,6 +29,13 @@
             </div>
         </label>
     </div>
+    <% } else if (is_discussion_division_enabled) { %>
+    <div class="post-field group-visibility">
+        <label class="field-label">
+            <!-- Wrapper for the visibility message filled out by a separate template -->
+            <span class="field-label-text"></span>
+	</label>
+    </div>
     <% } %>
     <div class="post-field">
         <label class="field-label">

--- a/common/static/common/templates/discussion/topic.underscore
+++ b/common/static/common/templates/discussion/topic.underscore
@@ -6,7 +6,7 @@
         <%- gettext("Add your post to a relevant topic to help others find it. (Required)") %>
     </div>
     <div class="field-input">
-        <select class="post-topic field-input" aria-describedby="field_help_topic_area" required>
+        <select class="post-topic field-input" aria-describedby="field_help_topic_area wrapper-visibility-message" required>
             <%= edx.HtmlUtils.ensureHtml(topics_html) %>
         </select>
     </div>

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -223,11 +223,13 @@ def inline_discussion(request, course_key, discussion_id):
     threads = [utils.prepare_content(thread, course_key, is_staff) for thread in threads]
     with newrelic_function_trace("add_courseware_context"):
         add_courseware_context(threads, course, request.user)
+    course_discussion_settings = get_course_discussion_settings(course.id)
 
     return utils.JsonResponse({
         'is_commentable_divided': is_commentable_divided(course_key, discussion_id),
         'discussion_data': threads,
         'user_info': user_info,
+        'user_group_id': get_group_id_for_user(request.user, course_discussion_settings),
         'annotated_content_info': annotated_content_info,
         'page': query_params['page'],
         'num_pages': query_params['num_pages'],

--- a/lms/templates/discussion/_underscore_templates.html
+++ b/lms/templates/discussion/_underscore_templates.html
@@ -13,10 +13,29 @@
 
 <%
 template_names = [
-    'thread', 'thread-show', 'thread-edit', 'thread-response', 'thread-response-show', 'thread-response-edit',
-    'response-comment-show', 'response-comment-edit', 'thread-list-item', 'search-alert',
-    'new-post', 'new-post-menu-entry', 'new-post-menu-category', 'new-post-alert', 'topic', 'post-user-display',
-    'inline-discussion', 'pagination', 'profile-thread', 'customwmd-prompt', 'nav-loading', 'thread-type'
+    'thread',
+    'thread-show',
+    'thread-edit',
+    'thread-response',
+    'thread-response-show',
+    'thread-response-edit',
+    'response-comment-show',
+    'response-comment-edit',
+    'thread-list-item',
+    'search-alert',
+    'new-post',
+    'new-post-menu-entry',
+    'new-post-menu-category',
+    'new-post-alert',
+    'new-post-visibility',
+    'topic',
+    'post-user-display',
+    'inline-discussion',
+    'pagination',
+    'profile-thread',
+    'customwmd-prompt',
+    'nav-loading',
+    'thread-type'
 ]
 
 ## same, but without trailing "-template" in script ID - these templates does not contain any free variables


### PR DESCRIPTION
This PR is based on https://github.com/edx/edx-platform/pull/15115.

## Description

When creating a new post, show the cohort visibility warning if appropriate.

## Dependencies

N/A

## JIRA

N/A

## OSPR

[OSPR-1815](https://openedx.atlassian.net/browse/OSPR-1815)

## Sandbox URLs

* [Discussion tab](https://pr15490.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/)
* [Inline discussion](https://pr15490.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/)

## Testing instructions

1. Go to the [Discussion tab](https://pr15490.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/) of the demo course, and log in as `staff@example.com`. The staff user has been pre-assigned to `cohort0`.
1. Click on `Add post`. Because the course has been cohorted, the staff user has been assigned to `cohort0`, but the "General" topic has not been divided into groups, you should see the following default message: "This post will be visible to everyone."
1. Click on `Topic area`, and choose any other topic. Because all content-specific topics are divided into groups, the message changes to: "This post will be visible only to cohort0".
1. Open a unit with an [inline discussion](https://pr15490.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/), and click on `Show discussion`.
1. Click on `Add post`. Because all content topics are divided, you should see the following message: "This post will be visible only to cohort0."
1. Go to the [Instructor Dashboard](https://pr15490.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/instructor) and click on the Discussion management tab. Select `Not divided`.
1. Go back to the [course discussion tab](https://pr15490.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/), and click on `Add post`. You should no longer see a post visibility status message.
1. Go back to the unit with an [inline discussion](https://pr15490.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/), show the discussion and click on `add post`. You should also no longer see a post visibility message.
1. Reenable divided discussions in the instructor dashboard, but disable cohorts entirely for the course, in the [cohort management tab](https://pr15490.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-cohort_management) in the Instructor Dashboard. Repeat steps 7 and 8 above. The results should be the same.

## Screenshots

![1](https://user-images.githubusercontent.com/560781/27935237-1ff09a02-6267-11e7-939a-1ad0e4d3d5be.png)
![2](https://user-images.githubusercontent.com/560781/27935238-1ff19c0e-6267-11e7-91bc-4007ebbbbe23.png)
![3](https://user-images.githubusercontent.com/560781/27935236-1ff0464c-6267-11e7-9950-780bb6de7906.png)

## Reviewer

- [ ] @smarnach 