### PR TITLE
Fix styling on non-Bootstrap pages

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -141,7 +141,7 @@ from pipeline_mako import render_require_js_path_overrides
         <%include file="/preview_menu.html" />
     % endif
 
-    <div class="content-wrapper ${"container-fluid" if uses_bootstrap else "container" } main-container" id="content">
+    <div class="content-wrapper ${"container-fluid" if uses_bootstrap else "" } main-container" id="content">
       ${self.body()}
       <%block name="bodyextra"/>
     </div>


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-1798

This fixes a bug introduced by https://github.com/edx/edx-platform/pull/15415. The problem was that an extra "container" class was added to all pages, and that interfered with styling on non-Bootstrap pages. The fix is to only add the class when rendering Bootstrap.

This will need to be fixed for the Ginkgo release too.

FYI @dianakhuang @jibsheet @nedbat @HarryRein 