### PR TITLE
LEARNER-1787 Update the admin table to allow the insert of course cert settings

### DIFF
--- a/lms/djangoapps/certificates/admin.py
+++ b/lms/djangoapps/certificates/admin.py
@@ -64,8 +64,7 @@ class CertificateGenerationCourseSettingAdmin(admin.ModelAdmin):
     """
     Django admin customizations for CertificateGenerationCourseSetting model
     """
-    list_display = ('course_key',)
-    readonly_fields = ('course_key',)
+    list_display = ('course_key', 'enabled')
     search_fields = ('course_key',)
     show_full_result_count = False
 


### PR DESCRIPTION
[LEARNER-1787](https://openedx.atlassian.net/browse/LEARNER-1787)

Want to enable the addition of GenerateCertificateCourseSetting in django admin to help resolve bug described in the ticket.

@waheedahmed @mattdrayer please code review