### PR TITLE
Fix inline discussions to use cached static assets.

### DIFF
--- a/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
@@ -4,7 +4,7 @@ Discussion XBlock
 """
 import logging
 
-from django.templatetags.static import static
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.translation import get_language_bidi
 
 from xblockutils.resources import ResourceLoader
@@ -136,14 +136,14 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):
         """
         # Head dependencies
         for vendor_js_file in self.vendor_js_dependencies():
-            fragment.add_resource_url(static(vendor_js_file), "application/javascript", "head")
+            fragment.add_resource_url(staticfiles_storage.url(vendor_js_file), "application/javascript", "head")
 
         for css_file in self.css_dependencies():
-            fragment.add_css_url(static(css_file))
+            fragment.add_css_url(staticfiles_storage.url(css_file))
 
         # Body dependencies
         for js_file in self.js_dependencies():
-            fragment.add_javascript_url(static(js_file))
+            fragment.add_javascript_url(staticfiles_storage.url(js_file))
 
     def has_permission(self, permission):
         """


### PR DESCRIPTION
In production environments, the DiscussionXBlock was generating CSS and
JS asset URLs that pointed to the unminified versions of those bundled
assets. Due to our nginx rules, this would cause the assets to be
served without the long expiration times, forcing the user's browser to
constantly refetch these assets while browsing a course.

[PERF-431]

@andy-armstrong: Please let me know if I should be directing this somewhere else for review. Thank you.