### PR TITLE
edx-val version bump from 0.16 to 0.17

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -77,7 +77,7 @@ git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 git+https://github.com/edx/edx-ora2.git@1.4.4#egg=ora2==1.4.4
 -e git+https://github.com/edx/edx-submissions.git@2.0.0#egg=edx-submissions==2.0.0
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
-git+https://github.com/edx/edx-val.git@0.0.16#egg=edxval==0.0.16
+git+https://github.com/edx/edx-val.git@0.0.17#egg=edxval==0.0.17
 git+https://github.com/edx/RecommenderXBlock.git@0e744b393cf1f8b886fe77bc697e7d9d78d65cd6#egg=recommender-xblock==1.2
 git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock


### PR DESCRIPTION
This PR bumps edx-val version to 0.17

Val Related PR: https://github.com/edx/edx-val/pull/78
[EDUCATOR-765](https://openedx.atlassian.net/browse/EDUCATOR-765)
