### PR TITLE
Update configuration to translate jsx files

### DIFF
--- a/conf/locale/babel_third_party.cfg
+++ b/conf/locale/babel_third_party.cfg
@@ -4,3 +4,6 @@ input_encoding = utf-8
 
 [django: **/template/**.html]
 input_encoding = utf-8
+
+[reactjs: **.jsx]
+input_encoding = utf-8

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,7 +93,7 @@ var wpconfig = {
                 )
             },
             {
-                test: /\.js$/,
+                test: /\.(js|jsx)$/,
                 exclude: [
                     /node_modules/,
                     namespacedRequireFiles
@@ -125,7 +125,7 @@ var wpconfig = {
     },
 
     resolve: {
-        extensions: ['.js', '.json', '.coffee'],
+        extensions: ['.js', '.jsx', '.json', '.coffee'],
         alias: {
             'edx-ui-toolkit': 'edx-ui-toolkit/src/',  // @TODO: some paths in toolkit are not valid relative paths
             'jquery.ui': 'jQuery-File-Upload/js/vendor/jquery.ui.widget.js',


### PR DESCRIPTION
Updating configuration of webpack and translation tools to look for getttext in .jsx files so .jsx files can be translated.

https://openedx.atlassian.net/browse/EDUCATOR-823
https://translation-jsx.sandbox.edx.org
https://components-with-translation.sandbox.edx.org -- example with React Components
https://github.com/edx/edx-platform/pull/15477 -- bad PR with comments for this PR