### PR TITLE
Modulestore read-only bulk operations

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -418,7 +418,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
     #    wildcard query, 6! load pertinent items for inheritance calls, load parents, course root fetch (why)
     # Split:
     #    active_versions (with regex), structure, and spurious active_versions refetch
-    @ddt.data((ModuleStoreEnum.Type.mongo, 14, 0), (ModuleStoreEnum.Type.split, 3, 0))
+    @ddt.data((ModuleStoreEnum.Type.mongo, 14, 0), (ModuleStoreEnum.Type.split, 2, 0))
     @ddt.unpack
     def test_get_items(self, default_ms, max_find, max_send):
         self.initdb(default_ms)
@@ -1043,7 +1043,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
     #   1) wildcard split search,
     #   2-4) active_versions, structure, definition (s/b lazy; so, unnecessary)
     #   5) wildcard draft mongo which has none
-    @ddt.data((ModuleStoreEnum.Type.mongo, 3, 0), (ModuleStoreEnum.Type.split, 5, 0))
+    @ddt.data((ModuleStoreEnum.Type.mongo, 3, 0), (ModuleStoreEnum.Type.split, 4, 0))
     @ddt.unpack
     def test_get_courses(self, default_ms, max_find, max_send):
         self.initdb(default_ms)

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -380,7 +380,7 @@ class ViewsQueryCountTestCase(
 
     @ddt.data(
         (ModuleStoreEnum.Type.mongo, 3, 4, 31),
-        (ModuleStoreEnum.Type.split, 3, 13, 31),
+        (ModuleStoreEnum.Type.split, 3, 12, 31),
     )
     @ddt.unpack
     @count_queries
@@ -389,7 +389,7 @@ class ViewsQueryCountTestCase(
 
     @ddt.data(
         (ModuleStoreEnum.Type.mongo, 3, 3, 27),
-        (ModuleStoreEnum.Type.split, 3, 10, 27),
+        (ModuleStoreEnum.Type.split, 3, 9, 27),
     )
     @ddt.unpack
     @count_queries


### PR DESCRIPTION
From my investigations at https://openedx.atlassian.net/browse/EDUCATOR-274, it would appear that a large consumer of CMS memory is the creation of a `defaultdict` using `LibraryLocator` objects as keys, and `SplitBulkWriteRecord` objects as values. This dict gets created as a member of an `ActiveBulkRecordsThread`, which is created when bulk operations begin (see linked ticket for further discussion of this setup).

My idea/proposal is simple - this defaultdict is being created for *every* library a user has access to when viewing the studio homepage. It seems odd to create a bunch of SplitBulk**Write**Records for an operation that is strictly read-only, so I've taken a stab at modifying the `bulk_operations` contextmanager to do nothing in these cases.

This is a bit deeper into modulestore code than I've ventured in the past, does this proposal seem sane to you @ormsbee @cpennington? If so, I can flesh it out a bit further and write up tests as needed.

Note that a PR to restrict the listing of libraries to a single org is in-flight here: https://github.com/edx/edx-platform/pull/15501, this work is a separate way of addressing the gigantic defaultdict problem.