### PR TITLE
Don't allow any user to create courses by default

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -149,8 +149,8 @@ FEATURES = {
     'AUTOPLAY_VIDEOS': False,
 
     # If set to True, new Studio users won't be able to author courses unless
-    # edX has explicitly added them to the course creator group.
-    'ENABLE_CREATOR_GROUP': False,
+    # an Open edX admin has added them to the course creator group.
+    'ENABLE_CREATOR_GROUP': True,
 
     # whether to use password policy enforcement or not
     'ENFORCE_PASSWORD_POLICY': False,

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -119,6 +119,9 @@ SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
 ########################## Certificates Web/HTML View #######################
 FEATURES['CERTIFICATES_HTML_VIEW'] = True
 
+########################## AUTHOR PERMISSION #######################
+FEATURES['ENABLE_CREATOR_GROUP'] = False
+
 ################################# DJANGO-REQUIRE ###############################
 
 # Whether to run django-require in debug mode.

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -323,6 +323,9 @@ SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
 
 FEATURES['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = True
 
+########################## AUTHOR PERMISSION #######################
+FEATURES['ENABLE_CREATOR_GROUP'] = False
+
 # teams feature
 FEATURES['ENABLE_TEAMS'] = True
 


### PR DESCRIPTION
* Change settings default
* Set `ENABLE_CREATOR_GROUP` to False for devstack
* Set `ENABLE_CREATOR_GROUP` to False for tests

In f095c5fec6507ba38552b0e02530e8ce981ffcbe it was decided to enable
anyone to make courses in Studio by default in order to make things
easier in dev environments. This was before the code was open source.
This default is likely in effect for many Open edX instances, but almost
no one would want this setting outside of development.

Cherry picked from #15343 6b0852819360a2c0096bef52c612338e7254a970.