### PR TITLE
Add VIDEO_IMAGE_SETTINGS to devstack settings

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -144,3 +144,15 @@ MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)
 
 # Dummy secret key for dev
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
+
+########################## VIDEO IMAGE STORAGE ############################
+VIDEO_IMAGE_SETTINGS = dict(
+    VIDEO_IMAGE_MAX_BYTES=2 * 1024 * 1024,    # 2 MB
+    VIDEO_IMAGE_MIN_BYTES=2 * 1024,       # 2 KB
+    STORAGE_KWARGS=dict(
+        location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
+    ),
+    DIRECTORY_PREFIX='video-images/',
+)
+VIDEO_IMAGE_DEFAULT_FILENAME = 'default_video_image.png'


### PR DESCRIPTION
@muhammad-ammar & @muzaffaryousaf Lack of these settings is preventing Studio from starting in devstack (docker and vagrant). Can we either add the correct settings to devstack or turn this feature off? 

My attempt is here, I have simply copied the cms test settings over to devstack. 