### PR TITLE
Increased timeout value for sailthru api call.

### DIFF
--- a/lms/djangoapps/email_marketing/migrations/0006_auto_20170711_0615.py
+++ b/lms/djangoapps/email_marketing/migrations/0006_auto_20170711_0615.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('email_marketing', '0005_emailmarketingconfiguration_user_registration_cookie_timeout_delay'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='emailmarketingconfiguration',
+            name='user_registration_cookie_timeout_delay',
+            field=models.FloatField(default=3.0, help_text='The number of seconds to delay/timeout wait to get cookie values from sailthru.'),
+        ),
+    ]

--- a/lms/djangoapps/email_marketing/models.py
+++ b/lms/djangoapps/email_marketing/models.py
@@ -138,7 +138,7 @@ class EmailMarketingConfiguration(ConfigurationModel):
 
     # The number of seconds to delay/timeout wait to get cookie values from sailthru.
     user_registration_cookie_timeout_delay = models.fields.FloatField(
-        default=1.5,
+        default=3.0,
         help_text=_(
             "The number of seconds to delay/timeout wait to get cookie values from sailthru."
         )

--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -63,6 +63,7 @@ def add_email_marketing_cookies(sender, response=None, user=None,
         sailthru_response.get(timeout=email_config.user_registration_cookie_timeout_delay,
                               propagate=True)
         cookie = sailthru_response.result
+        _log_sailthru_api_call_time(time_before_call)
 
     except TimeoutError as exc:
         log.error("Timeout error while attempting to obtain cookie from Sailthru: %s", unicode(exc))
@@ -82,7 +83,7 @@ def add_email_marketing_cookies(sender, response=None, user=None,
             domain=settings.SESSION_COOKIE_DOMAIN,
             path='/',
         )
-        _log_sailthru_api_call_time(time_before_call)
+        log.info("sailthru_hid cookie:%s successfully retrieved for user %s", cookie, user.email)
 
     return response
 

--- a/lms/djangoapps/email_marketing/tests/test_signals.py
+++ b/lms/djangoapps/email_marketing/tests/test_signals.py
@@ -98,7 +98,9 @@ class EmailMarketingTests(TestCase):
         })
         self.request.COOKIES['anonymous_interest'] = 'cookie_content'
         mock_get_current_request.return_value = self.request
-        mock_sailthru.return_value = SailthruResponse(JsonResponse({'keys': {'cookie': 'test_cookie'}}))
+
+        cookies = {'cookie': 'test_cookie'}
+        mock_sailthru.return_value = SailthruResponse(JsonResponse({'keys': cookies}))
 
         with LogCapture(LOGGER_NAME, level=logging.INFO) as logger:
             add_email_marketing_cookies(None, response=response, user=self.user)
@@ -108,6 +110,11 @@ class EmailMarketingTests(TestCase):
                         start=datetime.datetime.now().isoformat(' '),
                         end=datetime.datetime.now().isoformat(' '),
                         delta=0)
+                 ),
+                (LOGGER_NAME, 'INFO',
+                    'sailthru_hid cookie:{cookies[cookie]} successfully retrieved for user {user}'.format(
+                        cookies=cookies,
+                        user=TEST_EMAIL)
                  )
             )
         mock_sailthru.assert_called_with('user',


### PR DESCRIPTION
LEARNER-1186

Increases timeout time for Sailthru api call from 1.5s to 3s. Increasing time is to cater for celery/rabbitmq scheduling time. This increase would remove timeout error generated because of celery scheduling/processing and would produce genuine timeouts    