### PR TITLE
[ENT-469] Upgrade edx-enterprise to 0.38.1, along with related dependencies

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -17,7 +17,7 @@ defusedxml==0.4.1
 django-babel-underscore==0.5.1
 markey==0.8  # From django-babel-underscore
 django-celery==3.2.1
-django-config-models==0.1.3
+django-config-models==0.1.5
 django-countries==4.0
 django-extensions==1.5.9
 django-filter==0.11.0
@@ -53,7 +53,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.36.5
+edx-enterprise==0.38.1
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.5
@@ -112,7 +112,7 @@ sure==1.2.3
 sympy==0.7.1
 xmltodict==0.4.1
 django-ratelimit-backend==1.0
-unicodecsv==0.9.4
+unicodecsv==0.14.1
 django-require==1.0.11
 django-webpack-loader==0.4.1
 pyuca==1.1


### PR DESCRIPTION
This pull request updates `edx-enterprise` to 0.38.0, which is Django 1.11-compatible, along with some related dependencies:

- `django-config-models` 0.1.3 has a version conflict with the installed version of `djangorestframework`, which causes issues for packages doing automatic dependency compilation.
- `unicodecsv` 0.9.4 is not compatible with Python 3, which causes issues for edx-enterprise testing with Python 3.
- `django-simple-history` 1.9.0 is required for Django 1.11 compatibility, and results in an additional migration in the Enterprise app; therefore, we are upgrading it now, rather than waiting for Hawthorn to reach it organically.

The django-simple-history upgrade results in additional migrations at other points in edx-platform, which are included in this PR.

**JIRA tickets**: [ENT-469](https://openedx.atlassian.net/browse/ENT-469)

**Dependencies**: [Upstream django-simple-history pull request](https://github.com/treyhunner/django-simple-history/pull/301) 

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: 16 July 2017

**Testing instructions**:

1. No manual testing required; verify existing behavior continues if desired

**Author notes and concerns**:

1. The current master version of `django-simple-history` makes non-lazy `ugettext` calls in its `models.py` file; this is imported by the XBlock runtime prior to the app registry being ready. The [upstream pull request linked here](https://github.com/treyhunner/django-simple-history/pull/301) changes those calls to `ugettext_lazy` calls, and is currently installed here via hash.

**Enterprise requirement deviations**:

- `django-config-models` for `test-master.in` needs to be set back to 0.1.5.
- `django-simple-history` for `test-master.in` and `test-hawthorn.in` will need to be updated to an as-of-yet unknown version.

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```