### PR TITLE
Fix Studio context-sensitive help link to video documentation

### DIFF
--- a/cms/envs/help_tokens.ini
+++ b/cms/envs/help_tokens.ini
@@ -30,7 +30,7 @@ content_groups = course_author:course_features/cohorts/cohorted_courseware.html
 enrollment_tracks = course_author:course_features/diff_content/enroll_track_courseware.html
 group_configurations = course_author:course_features/content_experiments/content_experiments_configure.html#set-up-group-configurations-in-edx-studio
 container = course_author:developing_course/course_components.html#components-that-contain-other-components
-video = course_author:video/video_uploads.html
+video = course_author:video/index.html
 certificates = course_author:set_up_course/studio_add_course_information/studio_creating_certificates.html
 
 # below are the language directory names for the different locales


### PR DESCRIPTION
Update one line in cms/envs/help_tokens.ini to reflect changes to the video documentation.