### PR TITLE
Limit requests urllib3 logging to quiet log spam

### DIFF
--- a/openedx/core/lib/logsettings.py
+++ b/openedx/core/lib/logsettings.py
@@ -141,6 +141,8 @@ def get_logger_config(log_dir,
         # for production environments we will only
         # log INFO and up
         logger_config['loggers']['']['level'] = 'INFO'
+        # requests is so loud at INFO (logs every connection) that we force it to warn in production environments
+        logger_config['loggers']['requests.packages.urllib3'] = {'level': 'WARN'}
         logger_config['handlers'].update({
             'local': {
                 'level': local_loglevel,


### PR DESCRIPTION
This logs for every API call to an external service

It accounts for a large chunk of our splunk logs and is often
repetitive.  See forums connections which on a sandbox do:

```
Starting new HTTP connection (1): localhost
```
and
```
comment_client_request_log: request_id=06ac65d3-61b9-4882-9edb-c6b65709318a, method=get, url=http://localhost:18080/api/v1/users/5, duration=0.0101051330566
```

Add this for any other IDA call.