### PR TITLE
500 errors on Group Configurations divided content links

### DIFF
--- a/cms/djangoapps/contentstore/course_group_config.py
+++ b/cms/djangoapps/contentstore/course_group_config.py
@@ -7,6 +7,7 @@ import logging
 from django.utils.translation import ugettext as _
 
 from contentstore.utils import reverse_usage_url
+from lms.lib.utils import get_parent_unit
 from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition
 from util.db import MYSQL_MAX_INT, generate_int_id
 from xmodule.partitions.partitions import MINIMUM_STATIC_PARTITION_ID, UserPartition
@@ -111,9 +112,30 @@ class GroupConfiguration(object):
         """
         Get usage info for unit/module.
         """
+        parent_unit = get_parent_unit(item)
+
+        if unit == parent_unit and not item.has_children:
+            # Display the topmost unit page if
+            # the item is a child of the topmost unit and doesn't have its own children.
+            unit_for_url = unit
+        elif (not parent_unit and unit.get_parent()) or (unit == parent_unit and item.has_children):
+            # Display the item's page rather than the unit page if
+            # the item is one level below the topmost unit and has children, or
+            # the item itself *is* the topmost unit (and thus does not have a parent unit, but is not an orphan).
+            unit_for_url = item
+        else:
+            # If the item is nested deeper than two levels (the topmost unit > vertical > ... > item)
+            # display the page for the nested vertical element.
+            parent = item.get_parent()
+            nested_vertical = item
+            while parent != parent_unit:
+                nested_vertical = parent
+                parent = parent.get_parent()
+            unit_for_url = nested_vertical
+
         unit_url = reverse_usage_url(
             'container_handler',
-            course.location.course_key.make_usage_key(unit.location.block_type, unit.location.name)
+            course.location.course_key.make_usage_key(unit_for_url.location.block_type, unit_for_url.location.name)
         )
 
         usage_dict = {'label': u"{} / {}".format(unit.display_name, item.display_name), 'url': unit_url}

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -38,15 +38,22 @@ class HelperMethods(object):
     """
     Mixin that provides useful methods for Group Configuration tests.
     """
-    def _create_content_experiment(self, cid=-1, name_suffix='', special_characters=''):
+    def _create_content_experiment(self, cid=-1, group_id=None, cid_for_problem=None,
+                                   name_suffix='', special_characters=''):
         """
         Create content experiment.
 
         Assign Group Configuration to the experiment if cid is provided.
+        Assigns a problem to the first group in the split test if group_id and cid_for_problem is provided.
         """
+        sequential = ItemFactory.create(
+            category='sequential',
+            parent_location=self.course.location,
+            display_name='Test Subsection {}'.format(name_suffix)
+        )
         vertical = ItemFactory.create(
             category='vertical',
-            parent_location=self.course.location,
+            parent_location=sequential.location,
             display_name='Test Unit {}'.format(name_suffix)
         )
         c0_url = self.course.id.make_usage_key("vertical", "split_test_cond0")
@@ -65,7 +72,7 @@ class HelperMethods(object):
             display_name="Condition 0 vertical",
             location=c0_url,
         )
-        ItemFactory.create(
+        c1_vertical = ItemFactory.create(
             parent_location=split_test.location,
             category="vertical",
             display_name="Condition 1 vertical",
@@ -78,6 +85,19 @@ class HelperMethods(object):
             location=c2_url,
         )
 
+        problem = None
+        if group_id and cid_for_problem:
+            problem = ItemFactory.create(
+                category='problem',
+                parent_location=c1_vertical.location,
+                display_name=u"Test Problem"
+            )
+            self.client.ajax_post(
+                reverse_usage_url("xblock_handler", problem.location),
+                data={'metadata': {'group_access': {cid_for_problem: [group_id]}}}
+            )
+            c1_vertical.children.append(problem.location)
+
         partitions_json = [p.to_json() for p in self.course.user_partitions]
 
         self.client.ajax_post(
@@ -86,16 +106,25 @@ class HelperMethods(object):
         )
 
         self.save_course()
-        return (vertical, split_test)
+        return vertical, split_test, problem
 
     def _create_problem_with_content_group(self, cid, group_id, name_suffix='', special_characters='', orphan=False):
         """
         Create a problem
         Assign content group to the problem.
         """
+        vertical_parent_location = self.course.location
+        if not orphan:
+            subsection = ItemFactory.create(
+                category='sequential',
+                parent_location=self.course.location,
+                display_name="Test Subsection {}".format(name_suffix)
+            )
+            vertical_parent_location = subsection.location
+
         vertical = ItemFactory.create(
             category='vertical',
-            parent_location=self.course.location,
+            parent_location=vertical_parent_location,
             display_name="Test Unit {}".format(name_suffix)
         )
 
@@ -113,7 +142,7 @@ class HelperMethods(object):
         )
 
         if not orphan:
-            self.course.children.append(vertical.location)
+            self.course.children.append(subsection.location)
         self.save_course()
 
         return vertical, problem
@@ -757,12 +786,108 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
         }]
         self.assertEqual(actual, expected)
 
+    def test_can_get_correct_usage_info_for_split_test(self):
+        """
+        When a split test is created and content group access is set for a problem within a group,
+        the usage info should return a url to the split test, not to the group.
+        """
+        # Create user partition for groups in the split test,
+        # and another partition to set group access for the problem within the split test.
+        self._add_user_partitions(count=1)
+        self.course.user_partitions += [
+            UserPartition(
+                id=1,
+                name='Cohort User Partition',
+                scheme=UserPartition.get_scheme('cohort'),
+                description='Cohort User Partition',
+                groups=[
+                    Group(id=3, name="Problem Group")
+                ],
+            ),
+        ]
+        self.store.update_item(self.course, ModuleStoreEnum.UserID.test)
+
+        __, split_test, problem = self._create_content_experiment(cid=0, name_suffix='0', group_id=3, cid_for_problem=1)
+
+        expected = {
+            'id': 1,
+            'name': 'Cohort User Partition',
+            'scheme': 'cohort',
+            'description': 'Cohort User Partition',
+            'version': UserPartition.VERSION,
+            'groups': [
+                {'id': 3, 'name': 'Problem Group', 'version': 1, 'usage': [
+                    {
+                        'url': '/container/{}'.format(split_test.location),
+                        'label': 'Condition 1 vertical / Test Problem'
+                    }
+                ]},
+            ],
+            u'parameters': {},
+            u'active': True,
+        }
+        actual = self._get_user_partition('cohort')
+
+        self.assertEqual(actual, expected)
+
+    def test_can_get_correct_usage_info_for_unit(self):
+        """
+        When group access is set on the unit level, the usage info should return a url to the unit, not
+        the sequential parent of the unit.
+        """
+        self.course.user_partitions = [
+            UserPartition(
+                id=0,
+                name='User Partition',
+                scheme=UserPartition.get_scheme('cohort'),
+                description='User Partition',
+                groups=[
+                    Group(id=0, name="Group")
+                ],
+            ),
+        ]
+        vertical, __ = self._create_problem_with_content_group(
+            cid=0, group_id=0, name_suffix='0'
+        )
+
+        self.client.ajax_post(
+            reverse_usage_url("xblock_handler", vertical.location),
+            data={'metadata': {'group_access': {0: [0]}}}
+        )
+
+        actual = self._get_user_partition('cohort')
+        expected = {
+            'id': 0,
+            'name': 'User Partition',
+            'scheme': 'cohort',
+            'description': 'User Partition',
+            'version': UserPartition.VERSION,
+            'groups': [
+                {'id': 0, 'name': 'Group', 'version': 1, 'usage': [
+                    {
+                        'url': u"/container/{}".format(vertical.location),
+                        'label': u"Test Subsection 0 / Test Unit 0"
+                    },
+                    {
+                        'url': u"/container/{}".format(vertical.location),
+                        'label': u"Test Unit 0 / Test Problem 0"
+                    }
+                ]},
+            ],
+            u'parameters': {},
+            u'active': True,
+        }
+
+        self.maxDiff = None
+
+        self.assertEqual(actual, expected)
+
     def test_can_get_correct_usage_info(self):
         """
         Test if group configurations json updated successfully with usage information.
         """
         self._add_user_partitions(count=2)
-        vertical, __ = self._create_content_experiment(cid=0, name_suffix='0')
+        __, split_test, __ = self._create_content_experiment(cid=0, name_suffix='0')
         self._create_content_experiment(name_suffix='1')
 
         actual = GroupConfiguration.get_split_test_partitions_with_usage(self.store, self.course)
@@ -779,7 +904,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 {'id': 2, 'name': 'Group C', 'version': 1},
             ],
             'usage': [{
-                'url': '/container/{}'.format(vertical.location),
+                'url': '/container/{}'.format(split_test.location),
                 'label': 'Test Unit 0 / Test Content Experiment 0',
                 'validation': None,
             }],
@@ -809,7 +934,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
          characters are being used in content experiment
         """
         self._add_user_partitions(count=1)
-        vertical, __ = self._create_content_experiment(cid=0, name_suffix='0', special_characters=u"JOSÉ ANDRÉS")
+        __, split_test, __ = self._create_content_experiment(cid=0, name_suffix='0', special_characters=u"JOSÉ ANDRÉS")
 
         actual = GroupConfiguration.get_split_test_partitions_with_usage(self.store, self.course, )
 
@@ -825,7 +950,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 {'id': 2, 'name': 'Group C', 'version': 1},
             ],
             'usage': [{
-                'url': '/container/{}'.format(vertical.location),
+                'url': reverse_usage_url("container_handler", split_test.location),
                 'label': u"Test Unit 0 / Test Content Experiment 0JOSÉ ANDRÉS",
                 'validation': None,
             }],
@@ -841,8 +966,8 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
         group configuration.
         """
         self._add_user_partitions()
-        vertical, __ = self._create_content_experiment(cid=0, name_suffix='0')
-        vertical1, __ = self._create_content_experiment(cid=0, name_suffix='1')
+        __, split_test, __ = self._create_content_experiment(cid=0, name_suffix='0')
+        __, split_test1, __ = self._create_content_experiment(cid=0, name_suffix='1')
 
         actual = GroupConfiguration.get_split_test_partitions_with_usage(self.store, self.course)
 
@@ -858,11 +983,11 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
                 {'id': 2, 'name': 'Group C', 'version': 1},
             ],
             'usage': [{
-                'url': '/container/{}'.format(vertical.location),
+                'url': '/container/{}'.format(split_test.location),
                 'label': 'Test Unit 0 / Test Content Experiment 0',
                 'validation': None,
             }, {
-                'url': '/container/{}'.format(vertical1.location),
+                'url': '/container/{}'.format(split_test1.location),
                 'label': 'Test Unit 1 / Test Content Experiment 1',
                 'validation': None,
             }],


### PR DESCRIPTION
## [EDUCATOR-649](https://openedx.atlassian.net/browse/EDUCATOR-649)

### Description

Fixed 500 errors that occur on the "group configuration" page in studio after setting unit-level access and clicking on the link that points back to where the access is set.

### Sandbox
- [ ] ssemenova-500error.sandbox.edx.org

### Testing
- [ ] Unit, integration, acceptance tests as appropriate

### Reviewers
- [x] @cahrens 
- [x] @jlajoie 

FYI @staubina @bbaker6225 @sstack22 
 
### Post-review
- [x] Rebase and squash commits