### PR TITLE
Catch exception with duplicate username/email

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -282,3 +282,4 @@ Jeff LaJoie <jlajoie@edx.org>
 Ivan Ivić <iivic@edx.org>
 Brandon Baker <bcbaker@wesleyan.edu>
 Shirley He <she@edx.org>
+Po Tsui <potsui@stanford.edu>

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1728,6 +1728,11 @@ def _do_create_account(form, custom_form=None, site=None):
                 UserAttribute.set_user_attribute(user, 'created_on_site', site.domain)
     except IntegrityError:
         # Figure out the cause of the integrity error
+        # TODO duplicate email is already handled by form.errors above as a ValidationError.
+        # The checks for duplicate email/username should occur in the same place with an
+        # AccountValidationError and a consistent user message returned (i.e. both should
+        # return "It looks like {username} belongs to an existing account. Try again with a
+        # different username.")
         if len(User.objects.filter(username=user.username)) > 0:
             raise AccountValidationError(
                 _("An account with the Public Username '{username}' already exists.").format(username=user.username),
@@ -1794,6 +1799,14 @@ def create_account_with_params(request, params):
     * The user-facing text is rather unfriendly (e.g. "Username must be a
       minimum of two characters long" rather than "Please use a username of
       at least two characters").
+    * Duplicate email raises a ValidationError (rather than the expected
+      AccountValidationError). Duplicate username returns an inconsistent
+      user message (i.e. "An account with the Public Username '{username}'
+      already exists." rather than "It looks like {username} belongs to an
+      existing account. Try again with a different username.") The two checks
+      occur at different places in the code; as a result, registering with
+      both a duplicate username and email raises only a ValidationError for
+      email only.
     """
     # Copy params so we can modify it; we can't just do dict(params) because if
     # params is request.POST, that results in a dict containing lists of values

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -365,7 +365,9 @@ class RegistrationView(APIView):
         try:
             user = create_account_with_params(request, data)
         except AccountValidationError as err:
-            errors = { err.field: [{"user_message": err.message}] }
+            errors = {
+                err.field: [{"user_message": err.message}]
+            }
             return JsonResponse(errors, status=409)
         except ValidationError as err:
             # Should only get non-field errors from this function

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -25,7 +25,7 @@ from openedx.core.lib.api.authentication import SessionAuthenticationAllowInacti
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 from student.cookies import set_logged_in_cookies
 from student.forms import get_registration_extension_form
-from student.views import create_account_with_params
+from student.views import create_account_with_params, AccountValidationError
 from util.json_request import JsonResponse
 
 from .accounts import (
@@ -364,6 +364,9 @@ class RegistrationView(APIView):
 
         try:
             user = create_account_with_params(request, data)
+        except AccountValidationError as err:
+            errors = { err.field: [{"user_message": err.message}] }
+            return JsonResponse(errors, status=409)
         except ValidationError as err:
             # Should only get non-field errors from this function
             assert NON_FIELD_ERRORS not in err.message_dict


### PR DESCRIPTION
Replaces #14630.

Previously, there was no catch for the AccountValidationError
exception raised by the account creation function. If, for some
reason, the user made it past the first check for a duplicate
username/email, then the exception was raised, uncaught, and
crashed the server.

CC: @stvstnfrd 