### PR TITLE
Add COURSE_CATALOG_API_URL settings value to devstack_docker

### DIFF
--- a/lms/envs/devstack_docker.py
+++ b/lms/envs/devstack_docker.py
@@ -68,3 +68,5 @@ MKTG_URLS = {
 }
 
 CREDENTIALS_SERVICE_USERNAME = 'credentials_worker'
+
+COURSE_CATALOG_API_URL = 'http://edx.devstack.discovery:18381/api/v1/'

--- a/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
+++ b/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
                 user = User.objects.get(username=username)
             except User.DoesNotExist:
                 logger.error(
-                    'Failed to create API client. Service user {username} does not exist.'.format(username)
+                    'Failed to create API client. Service user {username} does not exist.'.format(username=username)
                 )
                 raise
 
@@ -85,7 +85,7 @@ class Command(BaseCommand):
                 client = create_catalog_api_client(user)
             except User.DoesNotExist:
                 logger.error(
-                    'Failed to create API client. Service user {username} does not exist.'.format(username)
+                    'Failed to create API client. Service user {username} does not exist.'.format(username=username)
                 )
                 raise
 


### PR DESCRIPTION
Since the field in the model is going to be [deprecated](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/catalog/models.py#L21) it might be good to add a default COURSE_CATALOG_API_URL value to the docker settings.