### PR TITLE
Throw error if celery task creation is not successfully completed.

### DIFF
--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -32,7 +32,7 @@ from lms.djangoapps.instructor_task.api import (
     submit_reset_problem_attempts_for_all_students,
     submit_reset_problem_attempts_in_entrance_exam
 )
-from lms.djangoapps.instructor_task.api_helper import AlreadyRunningError
+from lms.djangoapps.instructor_task.api_helper import AlreadyRunningError, QueueConnectionError
 from lms.djangoapps.instructor_task.models import PROGRESS, InstructorTask
 from lms.djangoapps.instructor_task.tasks import export_ora2_data
 from lms.djangoapps.instructor_task.tests.test_base import (
@@ -43,6 +43,7 @@ from lms.djangoapps.instructor_task.tests.test_base import (
     TestReportMixin
 )
 from xmodule.modulestore.exceptions import ItemNotFoundError
+from celery.states import FAILURE
 
 
 class InstructorTaskReportTest(InstructorTaskTestCase):
@@ -164,15 +165,31 @@ class InstructorTaskModuleSubmitTest(InstructorTaskModuleTestCase):
     )
     @ddt.unpack
     def test_submit_task(self, task_function, expected_task_type, params=None):
+        """
+        Tests submission of instructor task.
+        """
         if params is None:
             params = {}
         if params.get('student'):
             params['student'] = self.student
 
-        # tests submit, and then tests a second identical submission.
         problem_url_name = 'H1P1'
         self.define_option_problem(problem_url_name)
         location = InstructorTaskModuleTestCase.problem_location(problem_url_name)
+
+        # unsuccessful submission, exception raised while submitting.
+        with patch('lms.djangoapps.instructor_task.tasks_base.BaseInstructorTask.apply_async') as apply_async:
+
+            error = Exception()
+            apply_async.side_effect = error
+
+            with self.assertRaises(QueueConnectionError):
+                instructor_task = task_function(self.create_task_request(self.instructor), location, **params)
+
+            most_recent_task = InstructorTask.objects.latest('id')
+            self.assertEquals(most_recent_task.task_state, FAILURE)
+
+        # successful submission
         instructor_task = task_function(self.create_task_request(self.instructor), location, **params)
         self.assertEquals(instructor_task.task_type, expected_task_type)
 

--- a/lms/static/js/instructor_dashboard/data_download.js
+++ b/lms/static/js/instructor_dashboard/data_download.js
@@ -122,16 +122,18 @@
             });
             this.$proctored_exam_csv_btn.click(function() {
                 var url = dataDownloadObj.$proctored_exam_csv_btn.data('endpoint');
+                var errorMessage = gettext('Error generating proctored exam results. Please try again.');
                 return $.ajax({
                     type: 'POST',
                     dataType: 'json',
                     url: url,
-                    error: function() {
+                    error: function(error) {
+                        if (error.responseText) {
+                            errorMessage = JSON.parse(error.responseText);
+                        }
                         dataDownloadObj.clear_display();
-                        dataDownloadObj.$reports_request_response_error.text(
-                            gettext('Error generating proctored exam results. Please try again.')
-                        );
-                        return $('.msg-error').css({
+                        dataDownloadObj.$reports_request_response_error.text(errorMessage);
+                        return dataDownloadObj.$reports_request_response_error.css({
                             display: 'block'
                         });
                     },
@@ -146,16 +148,18 @@
             });
             this.$survey_results_csv_btn.click(function() {
                 var url = dataDownloadObj.$survey_results_csv_btn.data('endpoint');
+                var errorMessage = gettext('Error generating survey results. Please try again.');
                 return $.ajax({
                     type: 'POST',
                     dataType: 'json',
                     url: url,
-                    error: function() {
+                    error: function(error) {
+                        if (error.responseText) {
+                            errorMessage = JSON.parse(error.responseText);
+                        }
                         dataDownloadObj.clear_display();
-                        dataDownloadObj.$reports_request_response_error.text(
-                            gettext('Error generating survey results. Please try again.')
-                        );
-                        return $('.msg-error').css({
+                        dataDownloadObj.$reports_request_response_error.text(errorMessage);
+                        return dataDownloadObj.$reports_request_response_error.css({
                             display: 'block'
                         });
                     },
@@ -170,16 +174,18 @@
             });
             this.$list_studs_csv_btn.click(function() {
                 var url = dataDownloadObj.$list_studs_csv_btn.data('endpoint') + '/csv';
+                var errorMessage = gettext('Error generating student profile information. Please try again.');
                 dataDownloadObj.clear_display();
                 return $.ajax({
                     type: 'POST',
                     dataType: 'json',
                     url: url,
-                    error: function() {
-                        dataDownloadObj.$reports_request_response_error.text(
-                            gettext('Error generating student profile information. Please try again.')
-                        );
-                        return $('.msg-error').css({
+                    error: function(error) {
+                        if (error.responseText) {
+                            errorMessage = JSON.parse(error.responseText);
+                        }
+                        dataDownloadObj.$reports_request_response_error.text(errorMessage);
+                        return dataDownloadObj.$reports_request_response_error.css({
                             display: 'block'
                         });
                     },
@@ -201,9 +207,13 @@
                     url: url,
                     error: function() {
                         dataDownloadObj.clear_display();
-                        return dataDownloadObj.$download_request_response_error.text(
+                        dataDownloadObj.$download_request_response_error.text(
                             gettext('Error getting student list.')
                         );
+                        return dataDownloadObj.$download_request_response_error.css({
+                            display: 'block'
+                        });
+
                     },
                     success: function(data) {
                         var $tablePlaceholder, columns, feature, gridData, options;
@@ -251,7 +261,7 @@
                         dataDownloadObj.$reports_request_response_error.text(
                             JSON.parse(error.responseText)
                         );
-                        return $('.msg-error').css({
+                        return dataDownloadObj.$reports_request_response_error.css({
                             display: 'block'
                         });
                     },
@@ -265,16 +275,18 @@
             });
             this.$list_may_enroll_csv_btn.click(function() {
                 var url = dataDownloadObj.$list_may_enroll_csv_btn.data('endpoint');
+                var errorMessage = gettext('Error generating list of students who may enroll. Please try again.');
                 dataDownloadObj.clear_display();
                 return $.ajax({
                     type: 'POST',
                     dataType: 'json',
                     url: url,
-                    error: function() {
-                        dataDownloadObj.$reports_request_response_error.text(
-                            gettext('Error generating list of students who may enroll. Please try again.')
-                        );
-                        return $('.msg-error').css({
+                    error: function(error) {
+                        if (error.responseText) {
+                            errorMessage = JSON.parse(error.responseText);
+                        }
+                        dataDownloadObj.$reports_request_response_error.text(errorMessage);
+                        return dataDownloadObj.$reports_request_response_error.css({
                             display: 'block'
                         });
                     },
@@ -294,9 +306,12 @@
                     url: url,
                     error: function() {
                         dataDownloadObj.clear_display();
-                        return dataDownloadObj.$download_request_response_error.text(
+                        dataDownloadObj.$download_request_response_error.text(
                             gettext('Error retrieving grading configuration.')
                         );
+                        return dataDownloadObj.$download_request_response_error.css({
+                            display: 'block'
+                        });
                     },
                     success: function(data) {
                         dataDownloadObj.clear_display();
@@ -307,29 +322,27 @@
             });
             this.$async_report_btn.click(function(e) {
                 var url = $(e.target).data('endpoint');
+                var errorMessage = '';
                 dataDownloadObj.clear_display();
                 return $.ajax({
                     type: 'POST',
                     dataType: 'json',
                     url: url,
-                    error: statusAjaxError(function() {
-                        if (e.target.name === 'calculate-grades-csv') {
-                            dataDownloadObj.$grades_request_response_error.text(
-                                gettext('Error generating grades. Please try again.')
-                            );
+                    error: function(error) {
+                        if (error.responseText) {
+                            errorMessage = JSON.parse(error.responseText);
+                        } else if (e.target.name === 'calculate-grades-csv') {
+                            errorMessage = gettext('Error generating grades. Please try again.');
                         } else if (e.target.name === 'problem-grade-report') {
-                            dataDownloadObj.$grades_request_response_error.text(
-                                gettext('Error generating problem grade report. Please try again.')
-                            );
+                            errorMessage = gettext('Error generating problem grade report. Please try again.');
                         } else if (e.target.name === 'export-ora2-data') {
-                            dataDownloadObj.$grades_request_response_error.text(
-                                gettext('Error generating ORA data report. Please try again.')
-                            );
+                            errorMessage = gettext('Error generating ORA data report. Please try again.');
                         }
-                        return $('.msg-error').css({
+                        dataDownloadObj.$reports_request_response_error.text(errorMessage);
+                        return dataDownloadObj.$reports_request_response_error.css({
                             display: 'block'
                         });
-                    }),
+                    },
                     success: function(data) {
                         dataDownloadObj.$reports_request_response.text(data.status);
                         return $('.msg-confirm').css({

--- a/lms/static/js/spec/staff_debug_actions_spec.js
+++ b/lms/static/js/spec/staff_debug_actions_spec.js
@@ -96,7 +96,7 @@ define([
                         error_msg: 'Failed to reset attempts for user.'
                     };
                     StaffDebug.doInstructorDashAction(action);
-                    AjaxHelpers.respondWithError(requests);
+                    AjaxHelpers.respondWithTextError(requests);
                     expect($('#idash_msg').text()).toBe('Failed to reset attempts for user. ');
                     $('#result_' + locationName).remove();
                 });

--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -54,12 +54,12 @@ var StaffDebug = (function() {
                 try {
                     responseJSON = $.parseJSON(request.responseText);
                 } catch (e) {
-                    responseJSON = {error: gettext('Unknown Error Occurred.')};
+                    responseJSON = 'Unknown Error Occurred.';
                 }
                 var text = _.template('{error_msg} {error}', {interpolate: /\{(.+?)\}/g})(
                     {
                         error_msg: action.error_msg,
-                        error: responseJSON.error
+                        error: gettext(responseJSON)
                     }
             );
                 var html = _.template('<p id="idash_msg" class="error">{text}</p>', {interpolate: /\{(.+?)\}/g})(


### PR DESCRIPTION
## [EDUCATOR-444](https://openedx.atlassian.net/browse/EDUCATOR-444)

### Description
In this PR a scenario is covered where an attempt to create celery task is made but failed due to any error. One known way of task creation failure is when celery is unable to connect to Messaging Queue (RabbitMQ).
In case of failure at creation, corresponding database entry of celery task is marked as failed. Error message is shown to user and user is able to request a new task.
Attaching screenshot of error message shown in case of failure.
<img width="1176" alt="screen shot 2017-07-27 at 3 00 25 pm" src="https://user-images.githubusercontent.com/22347092/28665219-6cf89c5c-72dc-11e7-9976-963506c2cf04.png">

There is some additional work done here including:

- Improved error handling mechanism of instructor-task framework.
- Separate out error message generation logic from error handling.
- Resolved a bug which caused unexpected block rendering on data download page. (more description in ticket)

### How to Test?

**Stage** 
Problem can be tested in an environment where Messaging Queue server is down. 

**Sandbox**
- How a sandbox with non-working RabbitMQ server can be created?

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Style and readability review: @attiyaIshaque 
- [ ] Code review: @awaisdar001 
- [ ] Code review: @asadazam93 

FYI: @nasthagiri 

### Post-review
- [ ] Rebase and squash commits