### PR TITLE
EDUCATOR-565 | Pass routing_key as a real kwarg

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -932,6 +932,9 @@ INSTALLED_APPS = (
     # Site configuration for theming and behavioral modification
     'openedx.core.djangoapps.site_configuration',
 
+    # Ability to detect and special-case crawler behavior
+    'openedx.core.djangoapps.crawlers',
+
     # comment common
     'django_comment_common',
 

--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -779,7 +779,6 @@
                 Caption.fetchAvailableTranslations();
 
                 expect($.ajaxWithPrefix).toHaveBeenCalled();
-                expect(Caption.fetchCaption).toHaveBeenCalled();
                 expect(state.config.transcriptLanguages).toEqual({
                     'uk': 'Ukrainian',
                     'de': 'German'
@@ -799,7 +798,6 @@
                 Caption.fetchAvailableTranslations();
 
                 expect($.ajaxWithPrefix).toHaveBeenCalled();
-                expect(Caption.fetchCaption).not.toHaveBeenCalled();
                 expect(state.config.transcriptLanguages).toEqual({});
                 expect(Caption.renderLanguageMenu).not.toHaveBeenCalled();
             });

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -596,8 +596,8 @@
             },
 
             /**
-            * @desc Fetch the list of available translations. Upon successful receipt,
-            *    the list of available translations will be updated.
+            * @desc Fetch the list of available language codes. Upon successful receipt
+            * the list of available languages will be updated.
             *
             * @returns {jquery Promise}
             */
@@ -618,8 +618,6 @@
                         self.container.find('.langs-list').remove();
 
                         if (_.keys(newLanguages).length) {
-                            // And try again to fetch transcript.
-                            self.fetchCaption();
                             self.renderLanguageMenu(newLanguages);
                         }
                     },

--- a/common/test/acceptance/tests/lms/test_progress_page.py
+++ b/common/test/acceptance/tests/lms/test_progress_page.py
@@ -326,6 +326,9 @@ class SubsectionGradingPolicyTest(ProgressPageBaseTest):
             self._answer_problem_correctly()
             self.progress_page.visit()
 
+            # Verify the basic a11y of the progress page
+            self.progress_page.a11y_audit.check_for_accessibility_errors()
+
             # Verify that y-Axis labels are aria-hidden
             self.assertEqual(['100%', 'true'], self.progress_page.y_tick_label(0))
             self.assertEqual(['0%', 'true'], self.progress_page.y_tick_label(1))

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -131,6 +131,19 @@ def check_course_access(course, user, action, check_if_enrolled=False):
             raise CourseAccessRedirect(reverse('about_course', args=[unicode(course.id)]))
 
 
+def can_self_enroll_in_course(course_key):
+    """
+    Returns True if the user can enroll themselves in a course.
+
+    Note: an example of a course that a user cannot enroll in directly
+    is a CCX course. For such courses, a user can only be enrolled by
+    a CCX coach.
+    """
+    if hasattr(course_key, 'ccx'):
+        return False
+    return True
+
+
 def find_file(filesystem, dirs, filename):
     """
     Looks for a filename in a list of dirs on a filesystem, in the specified order.

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -46,6 +46,7 @@ from courseware.access import has_access, has_ccx_coach_role
 from courseware.access_response import StartDateError
 from courseware.access_utils import in_preview_mode, is_course_open_for_learner
 from courseware.courses import (
+    can_self_enroll_in_course,
     get_course,
     get_course_by_id,
     get_course_overview_with_access,
@@ -287,10 +288,10 @@ def course_info(request, course_id):
         # if user is not enrolled in a course then app will show enroll/get register link inside course info page.
         user_is_enrolled = CourseEnrollment.is_enrolled(user, course.id)
         show_enroll_banner = request.user.is_authenticated() and not user_is_enrolled
-        if show_enroll_banner and hasattr(course_key, 'ccx'):
-            # if course is CCX and user is not enrolled/registered then do not let him open course direct via link for
-            # self registration. Because only CCX coach can register/enroll a student. If un-enrolled user try
-            # to access CCX redirect him to dashboard.
+
+        # If the user is not enrolled but this is a course that does not support
+        # direct enrollment then redirect them to the dashboard.
+        if not user_is_enrolled and not can_self_enroll_in_course(course_key):
             return redirect(reverse('dashboard'))
 
         # Redirect the user if they are not yet allowed to view this course
@@ -351,6 +352,7 @@ def course_info(request, course_id):
             # TODO: (Experimental Code). See https://openedx.atlassian.net/wiki/display/RET/2.+In-course+Verification+Prompts
             'upgrade_link': check_and_get_upgrade_link(request, user, course.id),
             'upgrade_price': get_cosmetic_verified_display_price(course),
+            'course_tools': course_tools,
             # ENDTODO
         }
 
@@ -681,11 +683,9 @@ def course_about(request, course_id):
     """
     course_key = CourseKey.from_string(course_id)
 
-    if hasattr(course_key, 'ccx'):
-        # if un-enrolled/non-registered user try to access CCX (direct for registration)
-        # then do not show him about page to avoid self registration.
-        # Note: About page will only be shown to user who is not register. So that he can register. But for
-        # CCX only CCX coach can enroll students.
+    # If a user is not able to enroll in a course then redirect
+    # them away from the about page to the dashboard.
+    if not can_self_enroll_in_course(course_key):
         return redirect(reverse('dashboard'))
 
     with modulestore().bulk_operations(course_key):

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -64,9 +64,8 @@ def compute_all_grades_for_course(**kwargs):
             'course_key': course_key_string,
             'offset': offset,
             'batch_size': batch_size,
-            'routing_key': settings.POLICY_CHANGE_GRADES_ROUTING_KEY,
         })
-        compute_grades_for_course_v2.apply_async(kwargs=kwargs)
+        compute_grades_for_course_v2.apply_async(kwargs=kwargs, routing_key=settings.POLICY_CHANGE_GRADES_ROUTING_KEY)
 
 
 @task(base=_BaseTask, bind=True, default_retry_delay=30, max_retries=1)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -398,6 +398,10 @@ FEATURES = {
 COURSE_REVIEWS_TOOL_PROVIDER_FRAGMENT_NAME = 'coursetalk-reviews-fragment.html'
 COURSE_REVIEWS_TOOL_PROVIDER_PLATFORM_KEY = 'edx'
 
+# CDN links to CourseTalk scripts to load read and write widgets
+COURSE_TALK_READ_ONLY_SOURCE = '//d3q6qq2zt8nhwv.cloudfront.net/s/js/widgets/coursetalk-read-reviews.js'
+COURSE_TALK_WRITE_ONLY_SOURCE = '//d3q6qq2zt8nhwv.cloudfront.net/s/js/widgets/coursetalk-write-reviews.js'
+
 # Ignore static asset files on import which match this pattern
 ASSET_IGNORE_REGEX = r"(^\._.*$)|(^\.DS_Store$)|(^.*~$)"
 

--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -200,6 +200,21 @@
 }
 
 // Course Reviews Page
-.course-reviews-tool {
-  margin: ($baseline * 2) ($baseline * 3);
+.course-reviews {
+  .page-header.has-secondary > .page-header-main  {
+    display: block;
+    position: relative;
+
+    .toggle-read-write-reviews {
+      position: absolute;
+      top: $baseline * (-1/2);
+      right: $baseline / 2;
+      cursor: pointer;
+    }
+  }
+
+  .course-reviews-tool {
+    margin: ($baseline * 2) ($baseline * 3);
+    position: relative;
+  }
 }

--- a/lms/static/sass/views/_program-marketing-page.scss
+++ b/lms/static/sass/views/_program-marketing-page.scss
@@ -154,6 +154,11 @@
           background: linear-gradient(to bottom, #008100 0%,#0a570a 100%);
           filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#008100', endColorstr='#0a570a',GradientType=0 );
           border: 0;
+          &:hover{
+            background: -moz-linear-gradient(top, #006200 0%, #006200 100%);
+            background: -webkit-linear-gradient(top, #006200 0%,#006200 100%);
+            background: linear-gradient(to bottom, #006200 0%,#006200 100%);
+          }
         }
       }
     }
@@ -584,8 +589,8 @@
 
               p,
               ul {
-                  color: #4a4a4a;
-                  font-size: .85em;
+                  color: $dark-gray1 !important;
+                  font-size: 1em !important;
                   line-height: 1.5em;
                   margin-bottom: 15px;
 
@@ -605,7 +610,9 @@
 
                   li {
                       padding-left: 0 !important;
-                      color: #4a4a4a;
+                      + div {
+                        color: $dark-gray1;
+                      }
                   }
               }
           }
@@ -1044,7 +1051,7 @@
                 @extend .tbl-col;
                 display: block;
                 width: 100%;
-                color: palette(primary, dark);
+                color: $dark-gray1 !important;
                 line-height: 1.4em;
 
                 @media (min-width: 768px) {
@@ -1069,7 +1076,7 @@
                 }
 
                 &:first-child {
-                    color: palette(primary, dark);
+                    color: $dark-gray1 !important;
                     margin-bottom: 5px;
                     @media (max-width: 767px) {
                         margin-bottom: 0;
@@ -1080,7 +1087,7 @@
                     }
                     @media (min-width: 768px) {
                         width: 48%;
-                        color: palette(primary, dark);
+                        color: $dark-gray1 !important;
                         margin-bottom: 0;
                         font-size: 1.024em;
                     }
@@ -1204,7 +1211,7 @@
                 & + div {
                     padding: 10px 30px;
                     font-size: 1rem;
-                    color: $black;
+                    color: $dark-gray1 !important;
                 }
             }
             &.expanded {

--- a/openedx/core/djangoapps/crawlers/models.py
+++ b/openedx/core/djangoapps/crawlers/models.py
@@ -2,6 +2,7 @@
 This module handles the detection of crawlers, so that we can handle them
 appropriately in other parts of the code.
 """
+import six
 from config_models.models import ConfigurationModel
 from django.db import models
 
@@ -38,6 +39,14 @@ class CrawlersConfig(ConfigurationModel):
         # then just return False.
         if (not req_user_agent) or (not crawler_agents):
             return False
+
+        # The crawler_agents list we pull from our model always has unicode objects, but the
+        # req_user_agent we get from HTTP headers ultimately comes to us via WSGI. That
+        # value is an ISO-8859-1 encoded byte string in Python 2.7 (and in the HTTP spec), but
+        # it will be a unicode str when we move to Python 3.x. This code should work under
+        # either version.
+        if isinstance(req_user_agent, six.binary_type):
+            crawler_agents = [crawler_agent.encode('iso-8859-1') for crawler_agent in crawler_agents]
 
         # We perform prefix matching of the crawler agent here so that we don't
         # have to worry about version bumps.

--- a/openedx/core/djangoapps/crawlers/tests/test_models.py
+++ b/openedx/core/djangoapps/crawlers/tests/test_models.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Tests that the request came from a crawler or not.
+"""
+import ddt
+from django.test import TestCase
+from django.http import HttpRequest
+from ..models import CrawlersConfig
+
+
+@ddt.ddt
+class CrawlersConfigTest(TestCase):
+
+    def setUp(self):
+        super(CrawlersConfigTest, self).setUp()
+        CrawlersConfig(known_user_agents='edX-downloader,crawler_foo', enabled=True).save()
+
+    @ddt.data(
+        "Mozilla/5.0 (Linux; Android 5.1; Nexus 5 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Version/4.0 Chrome/47.0.2526.100 Mobile Safari/537.36 edX/org.edx.mobile/2.0.0",
+        "Le Héros des Deux Mondes",
+    )
+    def test_req_user_agent_is_not_crawler(self, req_user_agent):
+        """
+        verify that the request did not come from a crawler.
+        """
+        fake_request = HttpRequest()
+        fake_request.META['HTTP_USER_AGENT'] = req_user_agent
+        self.assertFalse(CrawlersConfig.is_crawler(fake_request))
+
+    @ddt.data(
+        u"edX-downloader",
+        "crawler_foo".encode("utf-8")
+    )
+    def test_req_user_agent_is_crawler(self, req_user_agent):
+        """
+        verify that the request came from a crawler.
+        """
+        fake_request = HttpRequest()
+        fake_request.META['HTTP_USER_AGENT'] = req_user_agent
+        self.assertTrue(CrawlersConfig.is_crawler(fake_request))

--- a/openedx/features/course_experience/static/course_experience/js/CourseTalkReviews.js
+++ b/openedx/features/course_experience/static/course_experience/js/CourseTalkReviews.js
@@ -1,0 +1,31 @@
+/**
+  Enable users to switch between viewing and writing CourseTalk reviews.
+ */
+
+export class CourseTalkReviews {  // eslint-disable-line import/prefer-default-export
+  constructor(options) {
+    const $courseTalkToggleReadWriteReviews = $(options.toggleButton);
+
+    const toReadBtnText = 'View Reviews';
+    const toWriteBtnText = 'Write a Review';
+
+    // Initialize page to the read reviews view
+    self.currentSrc = options.readSrc;
+    $.getScript(options.readSrc);
+    $courseTalkToggleReadWriteReviews.text(toWriteBtnText);
+
+    $courseTalkToggleReadWriteReviews.on('click', () => {
+      // Cache js file for future button clicks
+      $.ajaxSetup({ cache: true });
+
+      // Toggle the new coursetalk script object
+      const switchToReadView = self.currentSrc === options.writeSrc;
+      self.currentSrc = switchToReadView ? options.readSrc : options.writeSrc;
+      $.getScript(self.currentSrc);
+
+      // Toggle button text on switch to the other view
+      const newText = switchToReadView ? toWriteBtnText : toReadBtnText;
+      $courseTalkToggleReadWriteReviews.text(newText);
+    });
+  }
+}

--- a/openedx/features/course_experience/static/course_experience/js/WelcomeMessage.js
+++ b/openedx/features/course_experience/static/course_experience/js/WelcomeMessage.js
@@ -3,11 +3,11 @@ import 'jquery.cookie';
 
 export class WelcomeMessage {  // eslint-disable-line import/prefer-default-export
 
-  constructor(dismissUrl) {
+  constructor(options) {
     $('.dismiss-message button').click(() => {
       $.ajax({
         type: 'POST',
-        url: dismissUrl,
+        url: options.dismissUrl,
         headers: {
           'X-CSRFToken': $.cookie('csrftoken'),
         },

--- a/openedx/features/course_experience/static/course_experience/js/spec/WelcomeMessage_spec.js
+++ b/openedx/features/course_experience/static/course_experience/js/spec/WelcomeMessage_spec.js
@@ -13,7 +13,7 @@ describe('Welcome Message factory', () => {
 
     beforeEach(() => {
       loadFixtures('course_experience/fixtures/welcome-message-fragment.html');
-      new WelcomeMessage(endpointUrl);  // eslint-disable-line no-new
+      new WelcomeMessage({ dismissUrl: endpointUrl });  // eslint-disable-line no-new
     });
 
     it('When button click is made, ajax call is made and message is hidden.', () => {

--- a/openedx/features/course_experience/templates/course_experience/course-reviews-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-reviews-fragment.html
@@ -27,11 +27,14 @@ from openedx.features.course_experience import course_home_page_title
                     </div>
                 </div>
             </nav>
+            % if is_enrolled:
+                <div class="btn toggle-read-write-reviews"></div>
+            % endif
         </div>
     </header>
     <div class="course-reviews-tool">
-        % if course_reviews_provider_fragment:
-            ${HTML(course_reviews_provider_fragment.body_html())}
+        % if course_reviews_fragment:
+            ${HTML(course_reviews_fragment.body_html())}
         % endif
     </div>
 </div>

--- a/openedx/features/course_experience/templates/course_experience/course_reviews_modules/coursetalk-reviews-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course_reviews_modules/coursetalk-reviews-fragment.html
@@ -2,9 +2,11 @@
 
 <%page expression_filter="h"/>
 
-<%namespace name='static' file='../static_content.html'/>
+<%namespace name='static' file='../../static_content.html'/>
 
 <%!
+from django.conf import settings
+from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.features.course_experience import SHOW_REVIEWS_TOOL_FLAG
 %>
 
@@ -13,6 +15,12 @@ from openedx.features.course_experience import SHOW_REVIEWS_TOOL_FLAG
         ## Coursetalk Widget
         <div id="ct-custom-read-review-widget" data-provider="${platform_key}" data-course="${course.id}"></div>
     </div>
-
-    <script src="//d3q6qq2zt8nhwv.cloudfront.net/s/js/widgets/coursetalk-read-reviews.js"></script>
 % endif
+
+<%static:webpack entry="CourseTalkReviews">
+    new CourseTalkReviews({
+        toggleButton: '.toggle-read-write-reviews',
+        readSrc: "${settings.COURSE_TALK_READ_ONLY_SOURCE | n, js_escaped_string}",
+        writeSrc: "${settings.COURSE_TALK_WRITE_ONLY_SOURCE | n, js_escaped_string}"
+    });
+</%static:webpack>

--- a/openedx/features/course_experience/templates/course_experience/welcome-message-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/welcome-message-fragment.html
@@ -4,8 +4,8 @@
 <%namespace name='static' file='../static_content.html'/>
 
 <%!
-from openedx.core.djangolib.js_utils import js_escaped_string
 from django.utils.translation import ugettext as _
+from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import HTML
 %>
 
@@ -20,5 +20,7 @@ from openedx.core.djangolib.markup import HTML
 </%block>
 
 <%static:webpack entry="WelcomeMessage">
-    new WelcomeMessage("${dismiss_url | n, js_escaped_string}");
+    new WelcomeMessage({
+        dismissUrl: "${dismiss_url | n, js_escaped_string}",
+    });
 </%static:webpack>

--- a/openedx/features/course_experience/views/course_reviews.py
+++ b/openedx/features/course_experience/views/course_reviews.py
@@ -11,6 +11,7 @@ from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
 from courseware.courses import get_course_with_access
+from student.models import CourseEnrollment
 from lms.djangoapps.courseware.views.views import CourseTabView
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.features.course_experience import default_course_url_name
@@ -45,12 +46,14 @@ class CourseReviewsFragmentView(EdxFragmentView):
 
         """
         course_key = CourseKey.from_string(course_id)
-        course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=True)
+        course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=False)
         course_url_name = default_course_url_name(course.id)
         course_url = reverse(course_url_name, kwargs={'course_id': unicode(course.id)})
 
+        is_enrolled = CourseEnrollment.is_enrolled(request.user, course.id)
+
         # Create the fragment
-        course_reviews_provider_fragment = CourseReviewsModuleFragmentView().render_to_fragment(
+        course_reviews_fragment = CourseReviewsModuleFragmentView().render_to_fragment(
             request,
             course=course,
             **kwargs
@@ -59,7 +62,8 @@ class CourseReviewsFragmentView(EdxFragmentView):
         context = {
             'course': course,
             'course_url': course_url,
-            'course_reviews_provider_fragment': course_reviews_provider_fragment
+            'course_reviews_fragment': course_reviews_fragment,
+            'is_enrolled': is_enrolled,
         }
 
         html = render_to_string('course_experience/course-reviews-fragment.html', context)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ var wpconfig = {
     entry: {
         CourseOutline: './openedx/features/course_experience/static/course_experience/js/CourseOutline.js',
         CourseSock: './openedx/features/course_experience/static/course_experience/js/CourseSock.js',
+        CourseTalkReviews: './openedx/features/course_experience/static/course_experience/js/CourseTalkReviews.js',
         WelcomeMessage: './openedx/features/course_experience/static/course_experience/js/WelcomeMessage.js',
         Import: './cms/static/js/features/import/factories/import.js'
     },


### PR DESCRIPTION
## [EDUCATOR-565](https://openedx.atlassian.net/browse/EDUCATOR-565)

### Description

Was passing `routing_key` in the `kwargs` dict instead of an actual keyword argument.  This fixes it, so that `compute_grades_for_course_v2` ends up in the new queue when applied from `compute_all_grades_for_course`.

### Sandbox
https://studio-iloveagent57.sandbox.edx.org
http://iloveagent57.sandbox.edx.org:5555/task/cc10cabd-c934-412d-92fa-2fb69f4fdb3b (see how this ended up in the right worker queue)

### Reviewers
- [ ] @sanfordstudent 

List optional/FYI reviewers here:
@jibsheet 