### PR TITLE
Disable Git Import view for professor's who are not staff

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -104,7 +104,7 @@ from openedx.core.djangolib.markup import HTML, Text
     </li>
   </ul>
 
-  %if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD', ''):
+  %if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD', '') and user.is_staff:
       <p>
         ## Translators: git is a version-control system; see http://git-scm.com/about
         ${Text(_("View detailed Git import logs for this course {link_start}by clicking here{link_end}.")).format(


### PR DESCRIPTION
Reason: Before this fix, if the user is not staff (user.is_staff=0) and ENABLE_SYSADMIN_DASHBOARD=True
happens that the user can access the Git Import in Sysadmin dashboard and get to see the links in the menu
of the sysadmin dashboard (Users, Courses, Staffing and enrollment). When this user clicks on one of
these links, it gets an error from the server.

The PR represents a rebase of #15233.