### PR TITLE
Allow enrollment into expired seats if the api is called by ECOM service

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -637,7 +637,9 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                     unicode(course_id),
                     mode=mode,
                     is_active=is_active,
-                    enrollment_attributes=enrollment_attributes
+                    enrollment_attributes=enrollment_attributes,
+                    # If we are updating enrollment by authorized api caller, we should allow expired modes
+                    include_expired=has_api_key_permissions
                 )
             else:
                 # Will reactivate inactive enrollments.


### PR DESCRIPTION
LEARNER-683
With this change, if the ECOM service is upgrading the learner from audit to verify, or from verified to credit. Even if the seat has expired, as long as we collected the money, we should allow the enrollment to happen without error.

@rlucioni @clintonb @douglashall Please review.