### PR TITLE
Enable conditional pre-start-date access to courses

### DIFF
--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -19,7 +19,6 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 import courseware.access as access
 import courseware.access_response as access_response
-from ccx.tests.factories import CcxFactory
 from courseware.masquerade import CourseMasquerade
 from courseware.tests.factories import (
     BetaTesterFactory,
@@ -31,6 +30,7 @@ from courseware.tests.factories import (
 from courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_group_member
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from student.models import CourseEnrollment
 from student.roles import CourseCcxCoachRole, CourseStaffRole
 from student.tests.factories import (
@@ -45,7 +45,6 @@ from xmodule.course_module import (
     CATALOG_VISIBILITY_CATALOG_AND_ABOUT,
     CATALOG_VISIBILITY_NONE
 )
-from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import (
@@ -54,10 +53,9 @@ from xmodule.modulestore.tests.django_utils import (
     SharedModuleStoreTestCase
 )
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from xmodule.modulestore.xml import CourseLocationManager
 from xmodule.partitions.partitions import MINIMUM_STATIC_PARTITION_ID, Group, UserPartition
-from xmodule.tests import get_test_system
 
+QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 # pylint: disable=protected-access
 
@@ -847,5 +845,5 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
             num_queries = 0
 
         course_overview = CourseOverview.get_from_id(course.id)
-        with self.assertNumQueries(num_queries):
+        with self.assertNumQueries(num_queries, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             bool(access.has_access(user, action, course_overview, course_key=course.id))

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -11,6 +11,7 @@ from django.test.utils import override_settings
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 from nose.plugins.attrib import attr
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from pyquery import PyQuery as pq
 from student.models import CourseEnrollment
 from student.tests.factories import AdminFactory
@@ -26,6 +27,8 @@ from xmodule.modulestore.tests.utils import TEST_DATA_DIR
 from xmodule.modulestore.xml_importer import import_course_from_xml
 
 from .helpers import LoginEnrollmentTestCase
+
+QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 
 @attr(shard=1)
@@ -378,14 +381,14 @@ class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         and Mongo queries.
         """
         url = reverse('info', args=[unicode(course.id)])
-        with self.assertNumQueries(sql_queries):
+        with self.assertNumQueries(sql_queries, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(mongo_queries):
                 with mock.patch("openedx.core.djangoapps.theming.helpers.get_current_site", return_value=None):
                     resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
 
     def test_num_queries_instructor_paced(self):
-        self.fetch_course_info_with_queries(self.instructor_paced_course, 26, 3)
+        self.fetch_course_info_with_queries(self.instructor_paced_course, 22, 3)
 
     def test_num_queries_self_paced(self):
-        self.fetch_course_info_with_queries(self.self_paced_course, 26, 3)
+        self.fetch_course_info_with_queries(self.self_paced_course, 22, 3)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -20,7 +20,7 @@ from certificates.tests.factories import CertificateInvalidationFactory, Generat
 from commerce.models import CommerceConfiguration
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.access_utils import is_course_open_for_learner
+from courseware.access_utils import check_course_open_for_learner
 from courseware.model_data import FieldDataCache, set_score
 from courseware.module_render import get_module
 from courseware.tests.factories import GlobalStaffFactory, StudentModuleFactory
@@ -2567,9 +2567,10 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
         (-1, True)
     )
     @ddt.unpack
+    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_is_course_open_for_learner(self, start_date_modifier, expected_value):
         staff_user = AdminFactory()
         start_date = datetime.now(UTC) + timedelta(days=start_date_modifier)
         course = CourseFactory.create(start=start_date)
 
-        self.assertEqual(is_course_open_for_learner(staff_user, course), expected_value)
+        self.assertEqual(bool(check_course_open_for_learner(staff_user, course)), expected_value)

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -39,7 +39,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.x_module import STUDENT_VIEW
 
 from ..access import has_access
-from ..access_utils import in_preview_mode, is_course_open_for_learner
+from ..access_utils import in_preview_mode, check_course_open_for_learner
 from ..courses import get_course_with_access, get_current_child, get_studio_url
 from ..entrance_exams import (
     course_has_entrance_exam,
@@ -372,7 +372,7 @@ class CoursewareIndex(View):
         self._add_entrance_exam_to_context(courseware_context)
 
         # staff masquerading data
-        if not is_course_open_for_learner(self.effective_user, self.course):
+        if not check_course_open_for_learner(self.effective_user, self.course):
             # Disable student view button if user is staff and
             # course is not yet visible to students.
             courseware_context['disable_student_access'] = True

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -18,7 +18,7 @@ from commerce.utils import EcommerceService
 from course_modes.models import CourseMode
 from courseware.access import has_access, has_ccx_coach_role
 from courseware.access_response import StartDateError
-from courseware.access_utils import in_preview_mode, is_course_open_for_learner
+from courseware.access_utils import in_preview_mode, check_course_open_for_learner
 from courseware.courses import (
     can_self_enroll_in_course,
     get_course,
@@ -350,8 +350,7 @@ def course_info(request, course_id):
         if SelfPacedConfiguration.current().enable_course_home_improvements:
             context['resume_course_url'] = get_last_accessed_courseware(course, request, user)
 
-        # LEARNER-981/LEARNER-837: Hide masquerade as necessary in Course Home (DONE)
-        if not is_course_open_for_learner(user, course):
+        if not check_course_open_for_learner(user, course):
             # Disable student view button if user is staff and
             # course is not yet visible to students.
             context['disable_student_access'] = True
@@ -486,7 +485,7 @@ class CourseTabView(EdxFragmentView):
         else:
             masquerade = None
 
-        if course and not is_course_open_for_learner(request.user, course):
+        if course and not check_course_open_for_learner(request.user, course):
             # Disable student view button if user is staff and
             # course is not yet visible to students.
             supports_preview_menu = False

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -39,6 +39,7 @@ from lms.djangoapps.teams.tests.factories import CourseTeamFactory, CourseTeamMe
 from lms.lib.comment_client import Thread
 from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from student.roles import CourseStaffRole, UserBasedRole
 from student.tests.factories import CourseAccessRoleFactory, CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin
@@ -59,6 +60,8 @@ from event_transformers import ForumThreadViewedEventTransformer
 log = logging.getLogger(__name__)
 
 CS_PREFIX = "http://localhost:4567/api/v1"
+
+QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 # pylint: disable=missing-docstring
 
@@ -395,7 +398,7 @@ class ViewsQueryCountTestCase(
             with modulestore().default_store(default_store):
                 self.set_up_course(module_count=module_count)
                 self.clear_caches()
-                with self.assertNumQueries(sql_queries):
+                with self.assertNumQueries(sql_queries, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
                     with check_mongo_calls(mongo_calls):
                         func(self, *args, **kwargs)
         return inner

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -247,6 +247,13 @@ class WaffleFlag(object):
         self.flag_name = flag_name
         self.flag_undefined_default = flag_undefined_default
 
+    @property
+    def namespaced_flag_name(self):
+        """
+        Returns the fully namespaced flag name.
+        """
+        return self.waffle_namespace._namespaced_name(self.flag_name)
+
     def is_enabled(self):
         """
         Returns whether or not the flag is enabled.

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -18,6 +18,9 @@ UNIFIED_COURSE_TAB_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'unified_cours
 # Waffle flag to enable the sock on the footer of the home and courseware pages
 DISPLAY_COURSE_SOCK_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'display_course_sock')
 
+# Waffle flag to let learners access a course before its start date
+COURSE_PRE_START_ACCESS_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_access')
+
 # Waffle flag to enable a review page link from the unified home page
 SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_tool')
 

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -2,8 +2,12 @@
 """
 Tests for the course home page.
 """
+import datetime
 import ddt
 import mock
+import pytz
+from waffle.testutils import override_flag
+
 from courseware.tests.factories import StaffFactory
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -18,6 +22,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import CourseUserType, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
 
+from ... import COURSE_PRE_START_ACCESS_FLAG
 from .helpers import add_course_mode
 from .test_course_updates import create_course_update
 
@@ -141,6 +146,26 @@ class TestCourseHomePage(CourseHomePageTestCase):
             with check_mongo_calls(4):
                 url = course_home_url(self.course)
                 self.client.get(url)
+
+    @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    def test_start_date_handling(self):
+        """
+        Verify that the course home page handles start dates correctly.
+        """
+        now = datetime.datetime.now(pytz.UTC)
+        tomorrow = now + datetime.timedelta(days=1)
+        self.course.start = tomorrow
+
+        # The course home page should 404 for a course starting in the future
+        url = course_home_url(self.course)
+        response = self.client.get(url)
+        self.assertRedirects(response, '/dashboard?notlive=Jan+01%2C+2030')
+
+        # With the Waffle flag enabled, the course should be visible
+        with override_flag(COURSE_PRE_START_ACCESS_FLAG.namespaced_flag_name, True):
+            url = course_home_url(self.course)
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
 
 
 @ddt.ddt

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -71,9 +71,9 @@ def get_course_outline_block_tree(request, course_id):
         block_types_filter=['course', 'chapter', 'sequential']
     )
 
-    course_outline_root_block = all_blocks['blocks'][all_blocks['root']]
-    populate_children(course_outline_root_block, all_blocks['blocks'])
-    set_last_accessed_default(course_outline_root_block)
-    mark_last_accessed(request.user, course_key, course_outline_root_block)
-
+    course_outline_root_block = all_blocks['blocks'].get(all_blocks['root'], None)
+    if course_outline_root_block:
+        populate_children(course_outline_root_block, all_blocks['blocks'])
+        set_last_accessed_default(course_outline_root_block)
+        mark_last_accessed(request.user, course_key, course_outline_root_block)
     return course_outline_root_block

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -83,14 +83,14 @@ class CourseHomeFragmentView(EdxFragmentView):
             return block
 
         course_outline_root_block = get_course_outline_block_tree(request, course_id)
-        last_accessed_block = get_last_accessed_block(course_outline_root_block)
+        last_accessed_block = get_last_accessed_block(course_outline_root_block) if course_outline_root_block else None
         has_visited_course = bool(last_accessed_block)
         if last_accessed_block:
             resume_course_url = last_accessed_block['lms_web_url']
         else:
-            resume_course_url = course_outline_root_block['lms_web_url']
+            resume_course_url = course_outline_root_block['lms_web_url'] if course_outline_root_block else None
 
-        return (has_visited_course, resume_course_url)
+        return has_visited_course, resume_course_url
 
     def _get_course_handouts(self, request, course):
         """
@@ -137,9 +137,6 @@ class CourseHomeFragmentView(EdxFragmentView):
 
         # Get the handouts
         handouts_html = self._get_course_handouts(request, course)
-
-        # Get the course tools enabled for this user and course
-        course_tools = CourseToolsPluginManager.get_enabled_course_tools(request, course_key)
 
         # Get the course tools enabled for this user and course
         course_tools = CourseToolsPluginManager.get_enabled_course_tools(request, course_key)

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -25,6 +25,8 @@ class CourseOutlineFragmentView(EdxFragmentView):
         course_overview = get_course_overview_with_access(request.user, 'load', course_key, check_if_enrolled=True)
 
         course_block_tree = get_course_outline_block_tree(request, course_id)
+        if not course_block_tree:
+            return None
 
         context = {
             'csrf': csrf(request)['csrf_token'],


### PR DESCRIPTION
## [LEARNER-1854](https://openedx.atlassian.net/browse/LEARNER-1854)

### Description

This change conditionally allows learners to access courses before their start date (but after their enrollment date). It uses Waffle so that we can enable this only for certain courses so we can test the feasibility of a wider rollout.

### Sandbox

- [x] https://andy-armstrong.sandbox.edx.org/dashboard

I've set up this sandbox so that there are two courses that start in the future: "Future Course" which has been Waffle enabled, and "Future Course 2" which has not. You can try it with verified@example.com which has enrolled in both courses.

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
FYI: @robrap @dianakhuang @HarryRein @marcotuts @lizcohen @catong 
 
### Post-review
- [ ] Rebase and squash commits