### PR TITLE
Exposed ExperimentKeyValue model in Django admin

### DIFF
--- a/lms/djangoapps/experiments/admin.py
+++ b/lms/djangoapps/experiments/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import ExperimentData
+from .models import ExperimentData, ExperimentKeyValue
 
 
 @admin.register(ExperimentData)
@@ -11,3 +11,12 @@ class ExperimentDataAdmin(admin.ModelAdmin):
     raw_id_fields = ('user',)
     readonly_fields = ('created', 'modified',)
     search_fields = ('experiment_id', 'user', 'key',)
+
+
+@admin.register(ExperimentKeyValue)
+class ExperimentKeyValueAdmin(admin.ModelAdmin):
+    list_display = ('experiment_id', 'key',)
+    list_filter = ('experiment_id',)
+    ordering = ('experiment_id', 'key',)
+    readonly_fields = ('created', 'modified',)
+    search_fields = ('experiment_id', 'key',)

--- a/lms/djangoapps/experiments/migrations/0003_auto_20170713_1148.py
+++ b/lms/djangoapps/experiments/migrations/0003_auto_20170713_1148.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0002_auto_20170627_1402'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='experimentkeyvalue',
+            options={'verbose_name': 'Experiment Key-Value Pair', 'verbose_name_plural': 'Experiment Key-Value Pairs'},
+        ),
+    ]

--- a/lms/djangoapps/experiments/models.py
+++ b/lms/djangoapps/experiments/models.py
@@ -30,8 +30,8 @@ class ExperimentKeyValue(TimeStampedModel):
     value = models.TextField()
 
     class Meta(object):
-        verbose_name = 'Experiment Data'
-        verbose_name_plural = 'Experiment Data'
+        verbose_name = 'Experiment Key-Value Pair'
+        verbose_name_plural = 'Experiment Key-Value Pairs'
         unique_together = (
             ('experiment_id', 'key'),
         )


### PR DESCRIPTION
The model data can now be viewed/managed via Django admin. Additionally, the verbose name of the model has been corrected.