### PR TITLE
Add pyinotify to development requirements for docker devstack perf

### DIFF
--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -10,6 +10,7 @@
 
 click==3.3
 isort==4.2.5
+pyinotify==0.9.6
 
 # Third-party:
 -e git+https://github.com/doctoryes/code_block_timer.git@f3d0629f086bcc649c3c77f4bc5b9c2c8172c3bf#egg=code_block_timer

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1,7 +1,7 @@
 #
 # Dependencies that are used in development only - and are *NOT* needed to be installed in staging/production.
 #
-# These must be installed manually in your development environment using:
+# These are installed automatically in devstack, and can also be installed manually using:
 #
 #    pip install -r requirements/edx/development.txt
 #


### PR DESCRIPTION
Django can use pyinotify for watching files in runserver which should
save a lot of CPU in docker devstack (mine went from 150% cpu to 10%).