### PR TITLE
Fix WL sites from causing multiple zendesk emails

### DIFF
--- a/common/djangoapps/util/tests/test_submit_feedback.py
+++ b/common/djangoapps/util/tests/test_submit_feedback.py
@@ -294,7 +294,7 @@ class SubmitFeedbackTest(EnterpriseServiceMockMixin, TestCase):
             email=fields["email"],
             subject=fields["subject"],
             details=fields["details"],
-            tags=[fields["issue_type"], "LMS", "whitelabel_{}".format(fake_get_value("course_org_filter"))]
+            tags=[fields["issue_type"], "LMS", "site_name_{}".format(fake_get_value("SITE_NAME").replace(".", "_"))]
         )
 
         ticket_update = self._build_zendesk_ticket_update(TEST_REQUEST_HEADERS)

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -299,10 +299,10 @@ def _record_feedback_in_zendesk(
     zendesk_tags = list(tags.values()) + ["LMS"]
 
     # Per edX support, we would like to be able to route feedback items by site via tagging
-    current_site_orgs = configuration_helpers.get_current_site_orgs()
-    if current_site_orgs:
-        for org in current_site_orgs:
-            zendesk_tags.append("whitelabel_{org}".format(org=org))
+    current_site_name = configuration_helpers.get_value("SITE_NAME")
+    if current_site_name:
+        current_site_name = current_site_name.replace(".", "_")
+        zendesk_tags.append("site_name_{site}".format(site=current_site_name))
 
     new_ticket = {
         "ticket": {


### PR DESCRIPTION
WL-1109. Currently the system is using org filters to tag zendesk
tickets. MITxPro uses both MITxPro and MITProfessionalX org filters
to pull courses from both orgs. This is causing multiple emails to
be sent from Zendesk as they are getting tagged with both
whitelabel_MITProfessionalX and whitelabel_MITxPRO. This fix changes
to using SITE_NAME instead.