### PR TITLE
edx-video-id strip fix

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -304,16 +304,20 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
             if xblock_settings and 'YOUTUBE_API_KEY' in xblock_settings:
                 yt_api_key = xblock_settings['YOUTUBE_API_KEY']
 
+        poster = None
+        if edxval_api and self.edx_video_id:
+            poster = edxval_api.get_course_video_image_url(
+                course_id=self.runtime.course_id.for_branch(None),
+                edx_video_id=self.edx_video_id.strip()
+            )
+
         metadata = {
             'saveStateUrl': self.system.ajax_url + '/save_user_state',
             'autoplay': settings.FEATURES.get('AUTOPLAY_VIDEOS', False),
             'streams': self.youtube_streams,
             'sub': self.sub,
             'sources': sources,
-            'poster': edxval_api and edxval_api.get_course_video_image_url(
-                course_id=self.runtime.course_id.for_branch(None),
-                edx_video_id=self.edx_video_id.strip()
-            ),
+            'poster': poster,
             # This won't work when we move to data that
             # isn't on the filesystem
             'captionDataDir': getattr(self, 'data_dir', None),
@@ -508,7 +512,7 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
                     break
 
         if metadata_was_changed_by_user:
-            self.edx_video_id = self.edx_video_id.strip()
+            self.edx_video_id = self.edx_video_id and self.edx_video_id.strip()
 
             # We want to override `youtube_id_1_0` with val youtube profile in the first place when someone adds/edits
             # an `edx_video_id` or its underlying YT val profile. Without this, override will only happen when a user

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -934,6 +934,19 @@ class TestGetHtmlMethod(BaseTestXmodule):
 
         self.assertIn('"poster": "/media/video-images/poster.png"', context)
 
+    @patch('xmodule.video_module.video_module.edxval_api.get_course_video_image_url')
+    def test_poster_image_without_edx_video_id(self, get_course_video_image_url):
+        """
+        Verify that poster image is set to None and there is no crash when no edx_video_id.
+        """
+        video_xml = '<video display_name="Video" download_video="true" edx_video_id="null">[]</video>'
+        get_course_video_image_url.return_value = '/media/video-images/poster.png'
+
+        self.initialize_module(data=video_xml)
+        context = self.item_descriptor.render(STUDENT_VIEW).content
+
+        self.assertIn("\'poster\': \'null\'", context)
+
 
 @attr(shard=1)
 class TestVideoCDNRewriting(BaseTestXmodule):


### PR DESCRIPTION
This fixes the [LEARNER-1871](release-candidate-673). It was found that course xml has a video with incorrect video id set to `null` value. Due to this `null` value `edx_video_id` is set to `None` in python code and when we try to apply `strip` function on `None` we got crash.

