### PR TITLE
PLAT-1619 karma and bok-choy Docker Devstack fixes

### DIFF
--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -462,7 +462,8 @@ class EventsTestMixin(TestCase):
     """
     def setUp(self):
         super(EventsTestMixin, self).setUp()
-        self.event_collection = MongoClient()["test"]["events"]
+        mongo_host = 'edx.devstack.mongo' if 'BOK_CHOY_HOSTNAME' in os.environ else 'localhost'
+        self.event_collection = MongoClient(mongo_host)["test"]["events"]
         self.start_time = datetime.now()
 
     def reset_event_tracking(self):
@@ -735,8 +736,9 @@ class AcceptanceTest(WebAppTest):
     """
 
     def __init__(self, *args, **kwargs):
-        # Hack until we upgrade Firefox and install geckodriver in devstack and Jenkins
-        DesiredCapabilities.FIREFOX['marionette'] = False
+        if 'BOK_CHOY_HOSTNAME' not in os.environ:
+            # Hack until we upgrade Firefox and install geckodriver in Vagrant and Jenkins
+            DesiredCapabilities.FIREFOX['marionette'] = False
         super(AcceptanceTest, self).__init__(*args, **kwargs)
 
         # Use long messages so that failures show actual and expected values

--- a/package.json
+++ b/package.json
@@ -47,11 +47,12 @@
     "karma-requirejs": "^0.2.6",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "^0.0.20",
-    "karma-webdriver-launcher": "^1.0.5",
+    "karma-selenium-webdriver-launcher": "^0.0.4",
     "karma-webpack": "^2.0.3",
     "pa11y": "4.0.1",
     "pa11y-reporter-json-oldnode": "1.0.0",
     "plato": "1.2.2",
+    "selenium-webdriver": "3.4.0",
     "sinon": "2.3.5",
     "squirejs": "^0.1.0"
   }

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -33,8 +33,8 @@ def repo_root():
             absolute_path = file_path.abspath()
             break
         except OSError:
-            print('Attempt {}/60 to get an absolute path failed'.format(attempt))
-            if attempt <= 60:
+            print('Attempt {}/180 to get an absolute path failed'.format(attempt))
+            if attempt < 180:
                 attempt += 1
                 sleep(1)
             else:
@@ -169,7 +169,11 @@ class Env(object):
     TEST_DIR = REPO_ROOT / ".testids"
 
     # Configured browser to use for the js test suites
-    KARMA_BROWSER = 'FirefoxDocker' if USING_DOCKER else 'FirefoxNoUpdates'
+    SELENIUM_BROWSER = os.environ.get('SELENIUM_BROWSER', 'firefox')
+    if USING_DOCKER:
+        KARMA_BROWSER = 'ChromeDocker' if SELENIUM_BROWSER == 'chrome' else 'FirefoxDocker'
+    else:
+        KARMA_BROWSER = 'FirefoxNoUpdates'
 
     # Files used to run each of the js test suites
     # TODO:  Store this as a dict. Order seems to matter for some

--- a/pavelib/utils/test/utils.py
+++ b/pavelib/utils/test/utils.py
@@ -83,9 +83,9 @@ def check_firefox_version():
         # Firefox is running in a separate Docker container; get its version via Selenium
         driver = browser()
         capabilities = driver.capabilities
-        if capabilities['browserName'] == 'firefox':
+        if capabilities['browserName'].lower() == 'firefox':
             firefox_version_regex = re.compile(r'^\d+\.\d+')
-            version_key = 'browserVersion' if 'browserVersion' in 'capabilities' else 'version'
+            version_key = 'browserVersion' if 'browserVersion' in capabilities else 'version'
             try:
                 firefox_ver = float(firefox_version_regex.search(capabilities[version_key]).group(0))
             except AttributeError:


### PR DESCRIPTION
* Add support for running JS tests in a Chrome Selenium container
* Fix problems with focus-related JS tests by enabling the `focusmanager.testmode` Firefox setting
* Switch to the official JS selenium driver in order to be able to set Firefox settings and control recent versions of Firefox
* Allow the JS tests to be debugged from the lms or studio containers with host-native browsers, without port conflicts
* Fixed setup for some bok-choy tests which was erroneously looking for mongo on localhost
* Configure bok-choy to drive newer versions of Firefox, instead of requiring the legacy driver and older versions

This gets us to a point where only 1 or 2 JS tests are failing in either the latest Chrome or Firefox (and those tests seem to have legitimate problems which need to be addressed), and many of the bok-choy tests are passing in both Chrome and Firefox.  The remaining bok-choy failures are mostly tests which weren't written to work reliably across different browsers and versions, and will need to be updated.