### PR TITLE
Fix the BulkEnrollSerializer courses field to internally behave with strings and lists

### DIFF
--- a/lms/djangoapps/bulk_enroll/serializers.py
+++ b/lms/djangoapps/bulk_enroll/serializers.py
@@ -8,10 +8,11 @@ from rest_framework import serializers
 
 class StringListField(serializers.ListField):
     def to_internal_value(self, data):
-        try:
-            return data[0].split(',')
-        except IndexError:
+        if not data:
             return []
+        if isinstance(data, list):
+            data = data[0]
+        return data.split(',')
 
 
 class BulkEnrollmentSerializer(serializers.Serializer):

--- a/lms/djangoapps/bulk_enroll/tests/test_views.py
+++ b/lms/djangoapps/bulk_enroll/tests/test_views.py
@@ -9,6 +9,7 @@ from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
 
+from bulk_enroll.serializers import BulkEnrollmentSerializer
 from bulk_enroll.views import BulkEnrollView
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from microsite_configuration import microsite
@@ -73,6 +74,22 @@ class BulkEnrollmentTest(ModuleStoreTestCase, LoginEnrollmentTestCase, APITestCa
         response = self.view(request)
         response.render()
         return response
+
+    def test_course_list_serializer(self):
+        """
+        Test that the course serializer will work when passed a string or list.
+
+        Internally, DRF passes the data into the value conversion method as a list instead of
+        a string, so StringListField needs to work with both.
+        """
+        for key in [self.course_key, [self.course_key]]:
+            serializer = BulkEnrollmentSerializer(data={
+                'identifiers': 'percivaloctavius',
+                'action': 'enroll',
+                'email_students': False,
+                'courses': key,
+            })
+            self.assertTrue(serializer.is_valid())
 
     def test_non_staff(self):
         """ Test that non global staff users are forbidden from API use. """


### PR DESCRIPTION
Follow up to https://github.com/edx/edx-platform/pull/15006: Internally, DRF may pass data into the value conversion method of ListFields `to_internal_value` as a list instead of a string in some cases, so `StringListField` in the Bulk Enroll API needs to work with both. This change adds this support and tests.

**Sandbox URL:** Sandbox URL: https://pr15579.sandbox.opencraft.hosting/

**Test setup instructions:**
1. [Add a new OAuth2 client](http://localhost:8000/admin/oauth2/client/add/):
    1. For the "User", set it to the `staff` user (likely the user ID is 5 if on a devstack)
    1. For the "Url", set it to anything: `http://example.com/`
    1. For the "Redirect uri", set it to anything: `http://example.com/callback`
    1. Copy the "Client id" and "Client secret" for use when constructing requests
    1. For "Client type", select "Confidential (Web applications)"
    1. Click "Save" 

**Testing instructions:**
Replace the "client_id" and "client_secret" with the respective keys copied suring the test setup instructions, and run the following to obtain an access token:
```terminal
# Get a token:
curl -X POST -d "client_id=6f663d9f3425fade127c&client_secret=8a3a91e83f61fd54e9f7c074acfed909cbcc196e&grant_type=client_credentials&token_type=bearer" http://localhost:8000/oauth2/access_token/

# Example Response:
{"access_token": "773b8ef9fb8747e62360b0215f133c2793ed267a", "id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmYW1pbHlfbmFtZSI6IkFkYW1hIiwiYWRtaW5pc3RyYXRvciI6dHJ1ZSwic3ViIjoiNjZjNmQxNzE4MTZlZjgxZGM4ODg1OWYwZTg3YWU3MzIiLCJpc3MiOiJodHRwOi8vMTI3LjAuMC4xOjgwMDAvb2F1dGgyIiwidXNlcl90cmFja2luZ19pZCI6NSwicHJlZmVycmVkX3VzZXJuYW1lIjoic3RhZmYiLCJuYW1lIjoic3RhZmYiLCJsb2NhbGUiOiJlbiIsImdpdmVuX25hbWUiOiJCaWxsIiwiZXhwIjoxNTAwMDczNDQwLCJpYXQiOjE1MDAwNjk4NDAsImVtYWlsIjoic3RhZmZAZXhhbXBsZS5jb20iLCJhdWQiOiI2ZjY2M2Q5ZjM0MjVmYWRlMTI3YyJ9.xO187GzdbvFqDuju_URXWewX7Dn-foQH60srrR1jHa0", "expires_in": 31535999, "token_type": "Bearer", "scope": "profile openid email permissions"}
```

Using the access token in the response from the previous step, construct an authenticated request to the bulk_enroll endpoint (replace "course-v1:asdf+asdf+asdf" with a course on your devstack):
```terminal
# Post the enrollment:
curl -X POST --header "Authorization: Bearer 773b8ef9fb8747e62360b0215f133c2793ed267a" -H "Content-Type: application/json" -d '{"action": "enroll","auto_enroll": true,"email_students": true,"courses": "course-v1:asdf+asdf+asdf","identifiers": "staff@example.com"}' http://localhost:8000/api/bulk_enroll/v1/bulk_enroll

# Example Response:
{"action":"enroll","courses":{"course-v1:asdf+asdf+asdf":{"action":"enroll","results":[{"identifier":"staff@example.com","after":{"enrollment":true,"allowed":false,"user":true,"auto_enroll":false},"before":{"enrollment":true,"allowed":false,"user":true,"auto_enroll":false}}],"auto_enroll":true}},"email_students":true,"auto_enroll":true}
```

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
  ENABLE_BULK_ENROLLMENT_VIEW: true