### PR TITLE
Show page banner for anonymous and unenrolled users

### DIFF
--- a/lms/static/sass/elements/_banners.scss
+++ b/lms/static/sass/elements/_banners.scss
@@ -51,6 +51,13 @@ $full-width-banner-margin: 20px;
 
     .user-messages {
         padding-top: $baseline;
+
+        // Hack: force override the global important rule
+        // that courseware links don't have an underline.
+        a:hover {
+            color: $link-color;
+            text-decoration: underline !important;
+        }
     }
 
     .alert {

--- a/lms/templates/page_banner.html
+++ b/lms/templates/page_banner.html
@@ -10,10 +10,14 @@ from openedx.core.djangolib.markup import HTML
 from openedx.core.djangoapps.util.user_messages import user_messages
 %>
 
-% if user_messages:
+<%
+banner_messages = list(user_messages(request))
+%>
+
+% if banner_messages:
     <div class="page-banner">
         <div class="user-messages">
-            % for message in user_messages(request):
+            % for message in banner_messages:
                 <div class="alert ${message.css_class}" role="alert">
                     <span class="icon icon-alert fa ${message.icon_class}" aria-hidden="true"></span>
                     ${HTML(message.message_html)}

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -186,12 +186,13 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=True)
     @override_waffle_flag(SHOW_REVIEWS_TOOL_FLAG, active=True)
     @ddt.data(
-        CourseUserType.ANONYMOUS,
-        CourseUserType.ENROLLED,
-        CourseUserType.UNENROLLED,
-        CourseUserType.UNENROLLED_STAFF,
+        [CourseUserType.ANONYMOUS, 'To see course content'],
+        [CourseUserType.ENROLLED, None],
+        [CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
+        [CourseUserType.UNENROLLED_STAFF, None],
     )
-    def test_home_page(self, user_type):
+    @ddt.unpack
+    def test_home_page(self, user_type, expected_message):
         self.user = self.create_user_for_course(self.course, user_type)
 
         # Render the course home page
@@ -212,15 +213,21 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         self.assertContains(response, 'Learn About Verified Certificate', count=expected_count)
         self.assertContains(response, TEST_WELCOME_MESSAGE, count=expected_count)
 
+        # Verify that the expected message is shown to the user
+        self.assertContains(response, '<div class="user-messages">', count=1 if expected_message else 0)
+        if expected_message:
+            self.assertContains(response, expected_message)
+
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
     @override_waffle_flag(SHOW_REVIEWS_TOOL_FLAG, active=True)
     @ddt.data(
-        CourseUserType.ANONYMOUS,
-        CourseUserType.ENROLLED,
-        CourseUserType.UNENROLLED,
-        CourseUserType.UNENROLLED_STAFF,
+        [CourseUserType.ANONYMOUS, 'To see course content'],
+        [CourseUserType.ENROLLED, None],
+        [CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
+        [CourseUserType.UNENROLLED_STAFF, None],
     )
-    def test_home_page_not_unified(self, user_type):
+    @ddt.unpack
+    def test_home_page_not_unified(self, user_type, expected_message):
         """
         Verifies the course home tab when not unified.
         """
@@ -245,6 +252,11 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         self.assertContains(response, TEST_CHAPTER_NAME, count=expected_count)
         self.assertContains(response, 'Start Course', count=expected_count)
         self.assertContains(response, 'Learn About Verified Certificate', count=expected_count)
+
+        # Verify that the expected message is shown to the user
+        self.assertContains(response, '<div class="user-messages">', count=1 if expected_message else 0)
+        if expected_message:
+            self.assertContains(response, expected_message)
 
     def test_sign_in_button(self):
         """


### PR DESCRIPTION
## [LEARNER-1697](https://openedx.atlassian.net/browse/LEARNER-1697)

### Description

This change introduces two new messages in the page banner for course pages that can be viewed by unenrolled/anonymous users. For now, this means the message is shown on the unified "Course" tab and on static pages. I chose not to implement this on the current course info page since that already has a message, and the page will be going away.

1. Anonymous user

![image](https://user-images.githubusercontent.com/5985072/28241992-44ccb19a-696e-11e7-86f1-71cc2341995d.png)

2. Unenrolled user

![image](https://user-images.githubusercontent.com/5985072/28242001-5f6c2f6c-696e-11e7-865b-07dd1644a50e.png)

### Sandbox
- [ ] Try these two URLs when logged out or when using honor@example.com:

https://andy-armstrong.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/

https://andy-armstrong.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/ebf94dcfafbc4b61a5f2efafe010024a/

### Testing
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible
- [ ] safecommit violation code review process

Front-end changes:
- [ ] i18n
- [ ] Accessibility (Check for a11y violations, ensure keyboard accessible, screen reader testing as appropriate)
- [ ] RTL

### Reviewers

FYI: @marcotuts @lizcohen @HarryRein @robrap @dianakhuang @catong 
 
### Post-review
- [ ] Rebase and squash commits