### PR TITLE
Update Enterprise to 0.38.3 to fix dependency issues

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -51,7 +51,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.38.2
+edx-enterprise==0.38.3
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.5


### PR DESCRIPTION
This pull request updates edx-enterprise to a version that knows how to install its own dependencies.

**Dependencies**: None

**Merge deadline**: ASAP

**Testing instructions**:

1. In a devstack environment, do the following:
    ```bash
    pip uninstall django-object-actions
    pip uninstall django-waffle
    pip uninstall edx-enterprise
    ```
1. Do `paver run_all_servers`.
1. After waiting for paver to start, do `pip freeze`, and observe that all three of the above uninstalled requirements above are again installed.

FYI @jibsheet.