### PR TITLE
ENT-512 Revert ENT-457 to avoid production error noise

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -141,7 +141,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         for mode in ('audit', 'honor', 'verified'):
             CourseModeFactory.create(mode_slug=mode, course_id=self.course.id)
 
-        catalog_integration = self.create_catalog_integration(internal_api_url=settings.COURSE_CATALOG_API_URL)
+        catalog_integration = self.create_catalog_integration()
         UserFactory(username=catalog_integration.service_username)
 
         self.mock_course_discovery_api_for_catalog_contains(
@@ -254,7 +254,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         for mode in ('audit', 'honor', 'verified'):
             CourseModeFactory.create(mode_slug=mode, course_id=self.course.id)
 
-        catalog_integration = self.create_catalog_integration(internal_api_url=settings.COURSE_CATALOG_API_URL)
+        catalog_integration = self.create_catalog_integration()
         UserFactory(username=catalog_integration.service_username)
 
         courses_in_catalog = [str(self.course.id)] if course_in_catalog else []

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -58,32 +58,6 @@ class EnterpriseApiClient(object):
             jwt=jwt
         )
 
-    def get_enterprise_course_enrollment(self, ec_user_id, course_id):
-        """
-        Check for an EnterpriseCourseEnrollment linking a particular EnterpriseCustomerUser to a particular course.
-        """
-        params = {
-            'enterprise_customer_user': ec_user_id,
-            'course_id': course_id,
-        }
-        try:
-            response = getattr(self.client, 'enterprise-course-enrollment').get(**params)
-        except (HttpClientError, HttpServerError):
-            message = (
-                "An error occured while getting EnterpriseCourseEnrollment for EnterpriseCustomerUser with "
-                "ID {ec_user_id} and course run {course_id}."
-            ).format(
-                username=username,
-                course_id=course_id,
-            )
-            LOGGER.exception(message)
-            raise EnterpriseApiException(message)
-        else:
-            if response.get('results'):
-                return response['results'][0]
-            else:
-                return None
-
     def post_enterprise_course_enrollment(self, username, course_id, consent_granted):
         """
         Create an EnterpriseCourseEnrollment by using the corresponding serializer (for validation).
@@ -294,7 +268,7 @@ def consent_needed_for_course(user, course_id):
     return consent_necessary_for_course(user, course_id)
 
 
-def get_enterprise_consent_url(request, course_id, user=None, return_to=None, course_specific_return=True):
+def get_enterprise_consent_url(request, course_id, user=None, return_to=None):
     """
     Build a URL to redirect the user to the Enterprise app to provide data sharing
     consent for a specific course ID.
@@ -312,15 +286,10 @@ def get_enterprise_consent_url(request, course_id, user=None, return_to=None, co
     if not consent_needed_for_course(user, course_id):
         return None
 
-    if course_specific_return:
-        reverse_args = (course_id,)
-    else:
-        reverse_args = tuple()
-
     if return_to is None:
         return_path = request.path
     else:
-        return_path = reverse(return_to, args=reverse_args)
+        return_path = reverse(return_to, args=(course_id,))
 
     url_params = {
         'course_id': course_id,

--- a/openedx/features/enterprise_support/tests/mixins/enterprise.py
+++ b/openedx/features/enterprise_support/tests/mixins/enterprise.py
@@ -57,18 +57,6 @@ class EnterpriseServiceMockMixin(object):
             status=500
         )
 
-    def mock_enterprise_course_enrollment_get_api(self, **kwargs):
-        result = {
-            'results': [kwargs] if kwargs else []
-        }
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri=self.get_enterprise_url('enterprise-course-enrollment'),
-            body=json.dumps(result),
-            content_type='application/json',
-            status=200
-        )
-
     def mock_enterprise_learner_api(
             self,
             catalog_id=1,

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -194,29 +194,6 @@ class TestEnterpriseApi(unittest.TestCase):
         actual_url = get_enterprise_consent_url(request_mock, course_id, return_to=return_to)
         self.assertEqual(actual_url, expected_url)
 
-    @mock.patch('openedx.features.enterprise_support.api.consent_needed_for_course')
-    def test_get_enterprise_consent_url_next_provided_not_course_specific(self, needed_for_course_mock):
-        """
-        Verify that get_enterprise_consent_url correctly builds URLs.
-        """
-        needed_for_course_mock.return_value = True
-
-        request_mock = mock.MagicMock(
-            user=None,
-            build_absolute_uri=lambda x: 'http://localhost:8000' + x  # Don't do it like this in prod. Ever.
-        )
-
-        course_id = 'course-v1:edX+DemoX+Demo_Course'
-
-        expected_url = (
-            '/enterprise/grant_data_sharing_permissions?course_id=course-v1%3AedX%2BDemoX%2BDemo_'
-            'Course&failure_url=http%3A%2F%2Flocalhost%3A8000%2Fdashboard%3Fconsent_failed%3Dcou'
-            'rse-v1%253AedX%252BDemoX%252BDemo_Course&next=http%3A%2F%2Flocalhost%3A8000%2Fdashboard'
-        )
-
-        actual_url = get_enterprise_consent_url(request_mock, course_id, return_to='dashboard', course_specific_return=False)
-        self.assertEqual(actual_url, expected_url)
-
     def test_get_dashboard_consent_notification_no_param(self):
         """
         Test that the output of the consent notification renderer meets expectations.


### PR DESCRIPTION
ENT-457 introduced a spike in errors due to a race condition caused by directly writing the CourseEnrollment record. We have decided to revert the change as we no longer plan to use the track selection page as a landing page for enterprise learners, which is what originally necessitated the change.