### PR TITLE
Remove request.POST save - incompatible with DRF v3.6.3.

### DIFF
--- a/lms/djangoapps/bulk_enroll/views.py
+++ b/lms/djangoapps/bulk_enroll/views.py
@@ -60,7 +60,6 @@ class BulkEnrollView(APIView):
     def post(self, request):
         serializer = BulkEnrollmentSerializer(data=request.data)
         if serializer.is_valid():
-            request.POST = request.data
             response_dict = {
                 'auto_enroll': serializer.data.get('auto_enroll'),
                 'email_students': serializer.data.get('email_students'),


### PR DESCRIPTION
DRF v3.6.3 doesn't allow `request.POST` to be changed for DRF Requests. This change makes the Python unittests pass again.

@bdero Was there a reason for this statement? The `request` isn't accessed further in this method.