### PR TITLE
Hide passwords in crash reports

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -277,6 +277,3 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
 MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)
 
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
-# Begin test code
-ADMINS=[('Name', 'test@example.com')]
-# End test code

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -277,3 +277,6 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
 MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)
 
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
+# Begin test code
+ADMINS=[('Name', 'test@example.com')]
+# End test code

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -45,32 +45,6 @@ from .models import UserPreference, UserProfile
 from .preferences.api import get_country_time_zones, update_email_opt_in
 from .serializers import CountryTimeZoneSerializer, UserPreferenceSerializer, UserSerializer
 
-# Begin test code
-import sys
-import traceback
-from django.core import mail
-from django.views.debug import ExceptionReporter
-from django.views.debug import SafeExceptionReporterFilter
-
-# Necessary for testing because SafeExceptionReporterFilter is only active in production mode
-class CustomExceptionReporterFilter(SafeExceptionReporterFilter):
-    def is_active(self, request):
-        return True
-
-def send_manually_exception_email(request, e):
-    exc_info = sys.exc_info()
-    reporter = ExceptionReporter(request, is_email=True, *exc_info)
-    reporter.filter = CustomExceptionReporterFilter()
-    subject = e.message.replace('\n', '\\n').replace('\r', '\\r')[:989]
-    message = "%s\n\n%s" % (
-        '\n'.join(traceback.format_exception(*exc_info)),
-        reporter.filter.get_request_repr(request)
-    )
-    mail.mail_admins(
-        subject, message, fail_silently=True,
-        html_message=reporter.get_traceback_html()
-    )
-# End test code
 
 class LoginSessionView(APIView):
     """HTTP end-points for logging in users. """
@@ -149,14 +123,6 @@ class LoginSessionView(APIView):
     @method_decorator(require_post_params(["email", "password"]))
     @method_decorator(csrf_protect)
     def post(self, request):
-        # Begin test code
-        try:
-            raise Exception
-        except Exception as e:
-            request.META['SERVER_NAME'] = 'blah'
-            request.META['SERVER_PORT'] = 18010
-            send_manually_exception_email(request, e)
-        # End test code
         """Log in a user.
 
         You must send all required form fields with the request.
@@ -347,14 +313,6 @@ class RegistrationView(APIView):
 
     @method_decorator(csrf_exempt)
     def post(self, request):
-        # Begin test code
-        try:
-            raise Exception
-        except Exception as e:
-            request.META['SERVER_NAME'] = 'blah'
-            request.META['SERVER_PORT'] = 18010
-            send_manually_exception_email(request, e)
-        # End test code
         """Create the user's account.
 
         You must send all required form fields with the request.


### PR DESCRIPTION
There was a bug where if a crash occurred while registering or logging in, passwords were revealed in the list of POST parameters in email crash reports. This fix replaces them with asterisks.

There are two commits here. The most recent commit is code that is good to go for production (as far as I can tell). The earlier commit is mostly the same, but also includes testing code that manually sends crash reports when you login or register.

To test this on your devstack:
1. Check out the earlier of these two commits (433477abe412615309b3d9a15d7db07cb5dfce9a)
2. Run the LMS. I recommend redirecting stdout to some file since the crash reports (and all emails) are printed to the console, or at least were for me. The crash reports have a lot of HTML at then end that it's a pain to scroll up through to find the list of POST parameters.
3. Login or register.
4. Find the list of POST parameters in the crash report. (I just search for `password`).
5. The `password` parameter should show a string of asterisks for its value.

@stvstnfrd @caesar2164 