### PR TITLE
Adds settings.FEATURES['THIRD_PARTY_AUTH_HINT']

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -2,6 +2,7 @@
 import logging
 import mimetypes
 import urllib
+import urlparse
 from datetime import datetime
 
 from django.conf import settings
@@ -16,6 +17,7 @@ from pytz import UTC
 import third_party_auth
 from course_modes.models import CourseMode
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, VerificationDeadline
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming.helpers import get_themes
 
 # Enumeration of per-course verification statuses
@@ -240,6 +242,8 @@ def get_next_url_for_login_page(request):
 
     Otherwise, we go to the ?next= query param or to the dashboard if nothing else is
     specified.
+
+    If THIRD_PARTY_AUTH_HINT is set, then `tpa_hint=<hint>` is added as a query parameter.
     """
     redirect_to = get_redirect_to(request)
     if not redirect_to:
@@ -247,6 +251,7 @@ def get_next_url_for_login_page(request):
             redirect_to = reverse('dashboard')
         except NoReverseMatch:
             redirect_to = reverse('home')
+
     if any(param in request.GET for param in POST_AUTH_PARAMS):
         # Before we redirect to next/dashboard, we need to handle auto-enrollment:
         params = [(param, request.GET[param]) for param in POST_AUTH_PARAMS if param in request.GET]
@@ -255,6 +260,23 @@ def get_next_url_for_login_page(request):
         # Note: if we are resuming a third party auth pipeline, then the next URL will already
         # be saved in the session as part of the pipeline state. That URL will take priority
         # over this one.
+
+    # Append a tpa_hint query parameter, if one is configured
+    tpa_hint = configuration_helpers.get_value(
+        "THIRD_PARTY_AUTH_HINT",
+        settings.FEATURES.get("THIRD_PARTY_AUTH_HINT", '')
+    )
+    if tpa_hint:
+        # Don't add tpa_hint if we're already in the TPA pipeline (prevent infinite loop),
+        # and don't overwrite any existing tpa_hint params (allow tpa_hint override).
+        running_pipeline = third_party_auth.pipeline.get(request)
+        (scheme, netloc, path, query, fragment) = list(urlparse.urlsplit(redirect_to))
+        if not running_pipeline and 'tpa_hint' not in query:
+            params = urlparse.parse_qs(query)
+            params['tpa_hint'] = [tpa_hint]
+            query = urllib.urlencode(params, doseq=True)
+            redirect_to = urlparse.urlunsplit((scheme, netloc, path, query, fragment))
+
     return redirect_to
 
 

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -4,12 +4,16 @@ import logging
 
 import ddt
 from django.conf import settings
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.test.utils import override_settings
+from mock import patch
 from testfixtures import LogCapture
 
 from student.helpers import get_next_url_for_login_page
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
 
 LOGGER_NAME = "student.helpers"
 
@@ -22,6 +26,13 @@ class TestLoginHelper(TestCase):
     def setUp(self):
         super(TestLoginHelper, self).setUp()
         self.request = RequestFactory()
+
+    @staticmethod
+    def _add_session(request):
+        """Annotate the request object with a session"""
+        middleware = SessionMiddleware()
+        middleware.process_request(request)
+        request.session.save()
 
     @ddt.data(
         ("https://www.amazon.com", "text/html", None,
@@ -56,3 +67,38 @@ class TestLoginHelper(TestCase):
         req.META["HTTP_ACCEPT"] = "text/html"  # pylint: disable=no-member
         next_page = get_next_url_for_login_page(req)
         self.assertEqual(next_page, u'/dashboard')
+
+    @patch('student.helpers.third_party_auth.pipeline.get')
+    @ddt.data(
+        # Test requests outside the TPA pipeline - tpa_hint should be added.
+        (None, '/dashboard', '/dashboard', False),
+        ('', '/dashboard', '/dashboard', False),
+        ('', '/dashboard?tpa_hint=oa2-google-oauth2', '/dashboard?tpa_hint=oa2-google-oauth2', False),
+        ('saml-idp', '/dashboard', '/dashboard?tpa_hint=saml-idp', False),
+        # THIRD_PARTY_AUTH_HINT can be overridden via the query string
+        ('saml-idp', '/dashboard?tpa_hint=oa2-google-oauth2', '/dashboard?tpa_hint=oa2-google-oauth2', False),
+
+        # Test requests inside the TPA pipeline - tpa_hint should not be added, preventing infinite loop.
+        (None, '/dashboard', '/dashboard', True),
+        ('', '/dashboard', '/dashboard', True),
+        ('', '/dashboard?tpa_hint=oa2-google-oauth2', '/dashboard?tpa_hint=oa2-google-oauth2', True),
+        ('saml-idp', '/dashboard', '/dashboard', True),
+        # OK to leave tpa_hint overrides in place.
+        ('saml-idp', '/dashboard?tpa_hint=oa2-google-oauth2', '/dashboard?tpa_hint=oa2-google-oauth2', True),
+    )
+    @ddt.unpack
+    def test_third_party_auth_hint(self, tpa_hint, next_url, expected_url, running_pipeline, mock_running_pipeline):
+        mock_running_pipeline.return_value = running_pipeline
+
+        def validate_login():
+            req = self.request.get(reverse("login") + "?next={url}".format(url=next_url))
+            req.META["HTTP_ACCEPT"] = "text/html"  # pylint: disable=no-member
+            self._add_session(req)
+            next_page = get_next_url_for_login_page(req)
+            self.assertEqual(next_page, expected_url)
+
+        with override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT=tpa_hint)):
+            validate_login()
+
+        with with_site_configuration_context(configuration=dict(THIRD_PARTY_AUTH_HINT=tpa_hint)):
+            validate_login()

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -458,15 +458,63 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         response = self.client.get(reverse('signin_user'), params, HTTP_ACCEPT="text/html")
         self.assertNotIn(response.content, tpa_hint)
 
-    def test_hinted_login_dialog_disabled(self):
+    @ddt.data(
+        ('signin_user', 'login'),
+        ('register_user', 'register'),
+    )
+    @ddt.unpack
+    def test_hinted_login_dialog_disabled(self, url_name, auth_entry):
         """Test that the dialog doesn't show up for hinted logins when disabled. """
         self.google_provider.skip_hinted_login_dialog = True
         self.google_provider.save()
         params = [("next", "/courses/something/?tpa_hint=oa2-google-oauth2")]
-        response = self.client.get(reverse('signin_user'), params, HTTP_ACCEPT="text/html")
+        response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
         self.assertRedirects(
             response,
-            'auth/login/google-oauth2/?auth_entry=login&next=%2Fcourses%2Fsomething%2F%3Ftpa_hint%3Doa2-google-oauth2',
+            'auth/login/google-oauth2/?auth_entry={}&next=%2Fcourses%2Fsomething%2F%3Ftpa_hint%3Doa2-google-oauth2'.format(auth_entry),
+            target_status_code=302
+        )
+
+    @override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT='oa2-google-oauth2'))
+    @ddt.data(
+        'signin_user',
+        'register_user',
+    )
+    def test_settings_tpa_hinted_login(self, url_name):
+        """
+        Ensure that settings.FEATURES['THIRD_PARTY_AUTH_HINT'] can set third_party_auth_hint.
+        """
+        params = [("next", "/courses/something/")]
+        response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
+        self.assertContains(response, '"third_party_auth_hint": "oa2-google-oauth2"')
+
+        # THIRD_PARTY_AUTH_HINT can be overridden via the query string
+        tpa_hint = self.hidden_enabled_provider.provider_id
+        params = [("next", "/courses/something/?tpa_hint={0}".format(tpa_hint))]
+        response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
+        self.assertContains(response, '"third_party_auth_hint": "{0}"'.format(tpa_hint))
+
+        # Even disabled providers in the query string will override THIRD_PARTY_AUTH_HINT
+        tpa_hint = self.hidden_disabled_provider.provider_id
+        params = [("next", "/courses/something/?tpa_hint={0}".format(tpa_hint))]
+        response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
+        self.assertNotIn(response.content, tpa_hint)
+
+    @override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT='oa2-google-oauth2'))
+    @ddt.data(
+        ('signin_user', 'login'),
+        ('register_user', 'register'),
+    )
+    @ddt.unpack
+    def test_settings_tpa_hinted_login_dialog_disabled(self, url_name, auth_entry):
+        """Test that the dialog doesn't show up for hinted logins when disabled via settings.THIRD_PARTY_AUTH_HINT. """
+        self.google_provider.skip_hinted_login_dialog = True
+        self.google_provider.save()
+        params = [("next", "/courses/something/")]
+        response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
+        self.assertRedirects(
+            response,
+            'auth/login/google-oauth2/?auth_entry={}&next=%2Fcourses%2Fsomething%2F%3Ftpa_hint%3Doa2-google-oauth2'.format(auth_entry),
             target_status_code=302
         )
 

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -86,13 +86,17 @@ def login_and_registration_form(request, initial_mode="login"):
                 if tpa_hint_provider.skip_hinted_login_dialog:
                     # Forward the user directly to the provider's login URL when the provider is configured
                     # to skip the dialog.
+                    if initial_mode == "register":
+                        auth_entry = pipeline.AUTH_ENTRY_REGISTER
+                    else:
+                        auth_entry = pipeline.AUTH_ENTRY_LOGIN
                     return redirect(
-                        pipeline.get_login_url(provider_id, pipeline.AUTH_ENTRY_LOGIN, redirect_url=redirect_to)
+                        pipeline.get_login_url(provider_id, auth_entry, redirect_url=redirect_to)
                     )
                 third_party_auth_hint = provider_id
                 initial_mode = "hinted_login"
-        except (KeyError, ValueError, IndexError):
-            pass
+        except (KeyError, ValueError, IndexError) as ex:
+            log.error("Unknown tpa_hint provider: %s", ex)
 
     # If this is a themed site, revert to the old login/registration pages.
     # We need to do this for now to support existing themes.


### PR DESCRIPTION
**Purpose**
This feature allows the /login, /register, and course enrollment links to be automatically redirected to the configured third-party authentication provider.  This is useful for sites that exclusively use a third-party authentication system, and don't want anyone created accounts outside that system.

Normal username + password logins and registrations are effectively disabled, though existing users can authenticate via the Django /admin URL.

**Description**
When provided, this setting appends `tpa_hint={value}` to the `next` URL provided for /login and /register page URLs.

This allows the [existing `tpa_hint` feature](https://github.com/edx/edx-documentation/blob/master/en_us/install_operations/source/configuration/tpa/tpa_advanced_features.rst#hinted-sign-in) to be automatically added to  login, registration, and enrolment URLs used throughout the platform.

When combined with the existing TPA "Skip hinted login dialog" feature, the built-in Open edX login/register screens are bypassed entirely in favour of the SSO login/registration process.

**JIRA tickets**: [OSPR-1836](https://openedx.atlassian.net/browse/OSPR-1836)

**Sandbox URL**:

Running 2ba3e49

* LMS: https://pr15587.sandbox.opencraft.hosting/
* Studio: https://studio-pr15587.sandbox.opencraft.hosting/

**Partner information**: 3rd party-hosted open edX instance

**Deployment targets**: edx.org and edge.edx.org, though the feature is disabled by default.

**Merge deadline**: None

**Testing setup**
These steps have already been run on the sandbox.
1. See **Settings** below for what to add to your `FEATURES` list in `/edx/app/edxapp/*.env.json`.  Restart your edxapp service to effect these changes.
1. Set up an IDP SSO.
    You can set up an [oauth2 provider](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_integrate_open/tpa_oauth.html), or follow the instructions below to set up SAML with TestShib.
    1. Generate `saml.crt` (public key) and `saml.key` (private key) by running:
       ```bash
       openssl req -new -x509 -days 3652 -nodes -out saml.crt -keyout saml.key
       ```
    1. Add SAML Configuration using above keys.
       https://{lms}/admin/third_party_auth/samlconfiguration/add/
        ```
        Enabled: yes
        Entity ID: ensure is unique, e.g. https://saml.prXXXX.sandbox.opencraft.hosting
        Other config string:
            {
               "SECURITY_CONFIG": {
                 "signMetadata": false,
                 "metadataCacheDuration": ""
               }
            }
        Public key: Paste in content of `saml.crt`
        Private key: Paste in content of `saml.key`
        ```
    1. Download SAML auth XML, to a unique name:
       https://{lms}/auth/saml/metadata.xml
       *Note* On devstack, I've had to wait a few min for the metadata.xml to appear
    1. Upload XML to http://www.testshib.org/register.html
       This will create a backend called `tpa-saml`.
    1. Add a Provider Configuration (SAML IdPs):
       https://{lms}/admin/third_party_auth/samlproviderconfig/add/
        ```
        Enabled: Yes
        Name: `TestShib`
        Skip hinted login dialog: yes
        Backend name: `tpa-saml`
        Idp Slug: `testshib`  # must match the second part of the THIRD_PARTY_AUTH_HINT
        Entity ID: `https://idp.testshib.org/idp/shibboleth`
        Metadata source: `https://www.testshib.org/metadata/testshib-providers.xml`
        ```
    1. After submitting, the Metadata Available flag should go to Green.  You may have to refresh to see this.

**Testing instructions**:

Use an Incognito tab to make it easier to fully logout of the TestShib auth provider.

1. Visit the Register page.
   Note redirect to testshib login form.
1. Finish registering an account with testshib:
    1. Fill in testshib login, and you'll be redirected back to the LMS to finish registration.
    1. <strike>Click "Create an Account" to</strike> fill in the details not provided by TestShib, and accept the Terms & conditions.  (issue fixed with 8277856).
    1. Note that a new LMS account is registered.
1. Close your Incognito window to logout.
1. Visit the Login page.
   Note redirect to testshib login.
1. Fill in testshib login, and note that you're logged into your new account.
1. Close your Incognito window to logout.
1. Visit the Courses page, and Enrol in a course.
   Note that you're first redirected through the testshib login process, and then enrolled in the course.

**Author notes and concerns**:

1. Feature needs to be added to [edx-documentation](https://github.com/edx/edx-documentation/blob/master/en_us/install_operations/source/configuration/tpa/tpa_advanced_features.rst#hinted-sign-in). CC @edx/doc 
1. The `settings.ENTERPRISE_SERVICE_WORKER_USERNAME` user isn't being created by default yet (cf https://github.com/edx/configuration/pull/3974), so had to create it manually:
   ```bash
   sudo -u edxapp -Hs
   source ~/edxapp_env
   ~/edx-platform/manage.py lms shell --settings=devstack
   from django.contrib.auth import get_user_model
   get_user_model().objects.create(username='enterprise_worker')
   ```

**Reviewers**
- [x] @snowcrshd
- [x] @mattdrayer - CC @gsong 

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
  ENABLE_THIRD_PARTY_AUTH: true
  THIRD_PARTY_AUTH_HINT: "saml-testshib"  # if using SAML, or "oa2-google-oauth2", if G+ OAuth2
```