### PR TITLE
Restore more specific error messages.

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -1602,8 +1602,9 @@ class NumericalResponse(LoncapaResponse):
             student_float = evaluator({}, {}, student_answer)
         except UndefinedVariable as undef_var:
             raise StudentInputError(
-                _(u"Answers can include numerals, operation signs, and a few specific characters, "
-                  u"such as the constants e and i.")
+                _(u"You may not use variables ({bad_variables}) in numerical problems.").format(
+                    bad_variables=undef_var.message,
+                )
             )
         except ValueError as val_err:
             if 'factorial' in val_err.message:
@@ -3108,8 +3109,7 @@ class FormulaResponse(LoncapaResponse):
                     cgi.escape(answer)
                 )
                 raise StudentInputError(
-                    _(u"Answers can include numerals, operation signs, and a few specific characters, "
-                      u"such as the constants e and i.")
+                    _("Invalid input: {bad_input} not permitted in answer.").format(bad_input=err.message)
                 )
             except ValueError as err:
                 if 'factorial' in err.message:

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -1669,8 +1669,7 @@ class NumericalResponseTest(ResponseTest):  # pylint: disable=missing-docstring
         problem = self.build_problem(answer=4)
 
         errors = [  # (exception raised, message to student)
-            (calc.UndefinedVariable("x"), "Answers can include numerals, operation signs, "
-                                          "and a few specific characters, such as the constants e and i."),
+            (calc.UndefinedVariable("x"), r"You may not use variables \(x\) in numerical problems"),
             (ValueError("factorial() mess-up"), "Factorial function evaluated outside its domain"),
             (ValueError(), "Could not interpret '.*' as a number"),
             (pyparsing.ParseException("oopsie"), "Invalid math syntax"),


### PR DESCRIPTION
[EDUCATOR-929](https://openedx.atlassian.net/browse/EDUCATOR-929)

Reverts parts of #15012 where specific error messages were removed in favor of generalized ones.

Sandbox: [Two example problems (view as Learner)](https://cahrens.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/1bbd05420f88437da01c41a842736a9b/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%401bbd05420f88437da01c41a842736a9b)