### PR TITLE
Improve documentation for the Open edX features

### DIFF
--- a/lms/djangoapps/learner_dashboard/README.rst
+++ b/lms/djangoapps/learner_dashboard/README.rst
@@ -1,28 +1,38 @@
 Learner Dashboard
 =================
 
-This Django app hosts dashboard pages used by edX learners. The intent is for this Django app to include the following three important dashboard tabs:
+This Django app hosts dashboard pages used by edX learners. The intent is for
+this Django app to include the following dashboard tabs:
+
  - Courses
  - Programs
- - Profile
 
 Courses
----------------
-The learner-facing dashboard listing active and archived enrollments. The current implementation of the dashboard resides in ``common/djangoapps/student/``. The goal is to replace the existing dashboard with a Backbone app served by this Django app.
+-------
+
+The learner-facing dashboard listing active and archived enrollments. The
+current implementation of the dashboard resides in
+``common/djangoapps/student/``. The goal is to replace the existing dashboard
+with a Backbone app served by this Django app.
 
 Programs
----------------
-A page listing programs in which the learner is engaged. The page also shows learners' progress towards completing the programs. Programs are structured collections of course runs which culminate into a certificate.
+--------
+
+A page listing programs in which the learner is engaged. The page also shows
+learners' progress towards completing the programs. Programs are structured
+collections of course runs which culminate into a certificate.
 
 Implementation
-^^^^^^^^^^^^^^^^^^^^^
-The ``views`` module contains the Django views used to serve the Program listing page. The corresponding Backbone app is in the ``edx-platform/static/js/learner_dashboard``.
+^^^^^^^^^^^^^^
+
+The ``views`` module contains the Django views used to serve the Program listing
+page. The corresponding Backbone app is in the
+``edx-platform/static/js/learner_dashboard``.
 
 Configuration
-^^^^^^^^^^^^^^^^^^^^^
-In order to turn on the Programs tab, you need to update the ``Programs API Config`` object in the lms Django admin. Make sure you set the values ``Enabled``, ``Do we want to show program listing page`` and ``Do we want to show xseries program advertising`` to be true
+^^^^^^^^^^^^^
 
-Profile
----------------
-A page allowing learners to see what they have accomplished and view credits or certificates they have earned on the edX platform.
-
+In order to turn on the Programs tab, you need to update the ``Programs API
+Config`` object in the lms Django admin. Make sure you set the values
+``Enabled``, ``Do we want to show program listing page`` and ``Do we want to
+show xseries program advertising`` to be true

--- a/openedx/features/course_bookmarks/README.rst
+++ b/openedx/features/course_bookmarks/README.rst
@@ -1,0 +1,9 @@
+Course Bookmarks
+----------------
+
+This directory contains a Django application that provides a page
+for a user to see all of their course bookmarks. It also registers
+a course tool called "Bookmarks" that provides a link to this page.
+For more information about the feature, see `Bookmarking Course Content`_.
+
+.. _Bookmarking Course Content: https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/SFD_bookmarks.html

--- a/openedx/features/course_experience/README.rst
+++ b/openedx/features/course_experience/README.rst
@@ -1,0 +1,56 @@
+Course Experience
+-----------------
+
+This directory contains a Django application that provides the Course Home page
+(or course landing page), and various resources in support of the landing
+experience.
+
+The course experience consists of a number of views:
+
+1. **Course Home**
+
+   The course home page is the landing page for the course. It presents
+   the learner with information necessary to understand the purpose of the
+   course, its content, and its milestones. It includes a "Course Tools"
+   section that provides links to other tools associated with the course.
+   For example, it includes tools such as reviews, updates and bookmarks.
+
+2. **Welcome Message**
+
+   The welcome message is a fragment view which is typically shown on the
+   course home page. It provides the user with a description of the course
+   and helps them to understand its requirements.
+
+3. **Course Outline**
+
+   The course outline is a fragment view which shows an outline of the content
+   of the course.
+
+4. **Course Dates**
+
+   The course dates fragment is a view which shows users important dates for the
+   course, such as the start and end dates.
+
+5. **Course Sock**
+
+   The course sock is a fragment view which is typically shown just above
+   the footer of course pages (hence the name). The default implementation
+   presents the users with a message encouraging them to purchase a verified
+   certificate.
+
+6. **Course Updates**
+
+   The course updates page shows the user all of the course team's updates
+   in a scrolling list. The updates page is also provided as a course tool.
+
+7. **Course Reviews**
+
+   This page shows the user reviews of the course from an external provider.
+   The default provider is `CourseTalk`_. The reviews page is also provided
+   as a course tool.
+
+A number of the features in the course experience are controlled via Waffle
+flags. For documentation, see `Waffle flag definitions`_.
+
+.. _CourseTalk: https://www.coursetalk.com/
+.. _Waffle flag definitions: https://github.com/edx/edx-platform/blob/master/openedx/features/course_experience/__init__.py

--- a/openedx/features/course_search/README.rst
+++ b/openedx/features/course_search/README.rst
@@ -1,0 +1,7 @@
+Course Search
+-------------
+
+This directory contains a Django application that allows a learner to search
+the content of their course. To learn more, see `Enabling Open edX Search`_.
+
+.. _Enabling Open edX Search: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/edx_search.html

--- a/openedx/features/coursetalk/README.rst
+++ b/openedx/features/coursetalk/README.rst
@@ -1,0 +1,7 @@
+CourseTalk
+----------
+
+This directory contains a Django application that integrates `CourseTalk`_
+as a course review provider for Open edX.
+
+.. _CourseTalk: https://www.coursetalk.com/

--- a/openedx/features/learner_profile/README.rst
+++ b/openedx/features/learner_profile/README.rst
@@ -1,0 +1,8 @@
+Learner Profile
+---------------
+
+This directory contains a Django application that provides a view to render
+a profile for any Open edX learner. See `Exploring Your Dashboard and Profile`_
+for more details.
+
+.. _Exploring Your Dashboard and Profile: https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/SFD_dashboard_profile_SectionHead.html?highlight=profile


### PR DESCRIPTION
This commit adds a README for each Open edX feature which was missing one.

It also removes mention of the Learner Profile from the Learner Dashboard's README as they are separate features, and we don't plan to consolidate them. @schenedx, does this seem reasonable to you?