### PR TITLE
[LEARNER-1104] Allow staff members to view enrollment for any user

### DIFF
--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -385,7 +385,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
     def test_user_does_not_match_param(self):
         """
         The view should return status 404 if the enrollment username does not match the username of the user
-        making the request, unless the request is made by a superuser or with a server API key.
+        making the request, unless the request is made by a staff user or with a server API key.
         """
         CourseModeFactory.create(
             course_id=self.course.id,
@@ -403,9 +403,9 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         response = self.client.get(url, **{'HTTP_X_EDX_API_KEY': self.API_KEY})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Verify superusers have access to this endpoint
-        superuser = UserFactory.create(password=self.PASSWORD, is_superuser=True)
-        self.client.login(username=superuser.username, password=self.PASSWORD)
+        # Verify staff have access to this endpoint
+        staff_user = UserFactory.create(password=self.PASSWORD, is_staff=True)
+        self.client.login(username=staff_user.username, password=self.PASSWORD)
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -167,7 +167,7 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
 
         # TODO Implement proper permissions
         if request.user.username != username and not self.has_api_key_permissions(request) \
-                and not request.user.is_superuser:
+                and not request.user.is_staff:
             # Return a 404 instead of a 403 (Unauthorized). If one user is looking up
             # other users, do not let them deduce the existence of an enrollment.
             return Response(status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
JIRA task: https://openedx.atlassian.net/browse/LEARNER-1104

We need to allow a staff user to view enrollment for any user. This will be used in the acceptance test to test the autorefund generated by a user unenrolling from a course run that's a part of a recently purchased program.

Reviewers:
- [x] @clintonb, please take a look.
- [ ] @edx/learner-helio 