### PR TITLE
Shift to edx fork of drf-oauth module.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -35,11 +35,9 @@ django-statici18n==1.4.0
 django-storages==1.4.1
 django-method-override==0.1.0
 django-user-tasks==0.1.4
-git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 django==1.8.18
 django-waffle==0.12.0
 djangorestframework-jwt==1.11.0
-djangorestframework-oauth==1.1.0
 enum34==1.1.6
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.4

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -69,6 +69,13 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 # Used for testing
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 
+# Why a DRF fork? See: https://openedx.atlassian.net/browse/PLAT-1581
+git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
+
+# Why a drf-oauth fork? To add Django 1.11 compatibility to the abandoned repo.
+# This dependency will be removed by this work: https://openedx.atlassian.net/browse/PLAT-1660
+git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
+
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail==0.0
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1


### PR DESCRIPTION
Django 1.11 compatibility was added to this unmaintained module in the edx-forked repo:
https://github.com/edx/django-rest-framework-oauth/pull/4
This PR shifts edx-platform to use that forked version.

There's a separate ticket to remove this dependency altogether:
https://openedx.atlassian.net/browse/PLAT-1660