### PR TITLE
ENT-550 Display only TOS for enterprise's configured to skip registration

### DIFF
--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -38,6 +38,7 @@
                     this.platformName = data.platformName;
                     this.autoSubmit = data.thirdPartyAuth.autoSubmitRegForm;
                     this.hideAuthWarnings = data.hideAuthWarnings;
+                    this.autoRegisterWelcomeMessage = data.thirdPartyAuth.autoRegisterWelcomeMessage || '';
 
                     this.listenTo(this.model, 'sync', this.saveSuccess);
                 },
@@ -55,7 +56,8 @@
                             currentProvider: this.currentProvider,
                             providers: this.providers,
                             hasSecondaryProviders: this.hasSecondaryProviders,
-                            platformName: this.platformName
+                            platformName: this.platformName,
+                            autoRegisterWelcomeMessage: this.autoRegisterWelcomeMessage
                         }
                     }));
 

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -224,6 +224,16 @@
         &:focus {
             outline: none;
         }
+
+        div[class*="hidden-"] {
+            margin: 0;
+            display: none;
+        }
+
+        .auto-register-message {
+            font-size: 1.1em;
+            line-height: 1.3em;
+        }
     }
 
     %bold-label {

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -45,6 +45,8 @@
                 </h3>
             </div>
         <% } %>
+    <% } else if (context.autoRegisterWelcomeMessage) { %>
+        <span class="auto-register-message"><%- context.autoRegisterWelcomeMessage %></span>
     <% } %>
 
     <%= context.fields %>


### PR DESCRIPTION
We have recently discovered that for any SSO Provider configured to skip
the registration form, we were auto checking the terms of service box,
which is a legal faux pas. Since a customer is planning to launch imminently and
is depending on this feature, we need to remedy this situation for enterprises
whose SSO Provider is configured to skip registration.

This PR hides all of the registration fields except TOS for this scenario
and disables the autoSubmit functionality that typically happens when skipping
registration.

**Testing Instructions**

Sandbox Link: https://business.sandbox.edx.org/enterprise/2b5a2956-7746-4fc9-9587-bc887ba45973/course/course-v1:edX+DemoX+Demo_Course/enroll/

Note that normal registration flow should not be impacted - the scope of this change is limited to TPA Providers linked to an enterprise and with skip_registration_form turned on.

1. Go to the sandbox link, authenticate with the SSO Provider (TestShib).
2. Arrive at the registration page. Note that there is a welcome message for the user, and that the password field and all fields that got passed via the SAML handshake with the IdP do not appear in the form. Terms of Service and fields that did not get data passed should display for the user.
3. Fill out the form fields that are available, and click submit. If a field is missing or invalid that you have access to change, it should behave as normal. None of the hidden fields should error :crossed_fingers: 
4. The rest of the flow should behave as expected.

**Caveats**
In Production, if the IdP is properly configured, only the TOS box should appear. However, @itsjeyd and @haikuginger were able to fake this data from TestShib somehow for testing purposes when we enabled population of the country field.

We are not addressing the possibility of the hidden fields erroring yet. If that becomes obviously prohibitive during testing, we may need to address that sooner rather than later.