### PR TITLE
catch WebpackLoaderBadStatsError in test runs

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -93,6 +93,7 @@ source, template_path = Loader(engine).load_template_source(path)
     </%doc>
     <%
         from django.template import Template, Context
+        from webpack_loader.exceptions import WebpackLoaderBadStatsError
         try:
             return Template("""
                 {% load render_bundle from webpack_loader %}
@@ -105,9 +106,9 @@ source, template_path = Loader(engine).load_template_source(path)
                 'entry': entry,
                 'body': capture(caller.body)
             }))
-        except IOError as e:
+        except (IOError, WebpackLoaderBadStatsError) as e:
             # Don't break Mako template rendering if the bundle or webpack-stats can't be found, but log it
-            logger.error(e)
+            logger.error('[LEARNER-1938] {error}'.format(error=e))
     %>
 </%def>
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-1938

With 6 passing builds, I'm inclined to call this fixed.

I also stress tested this in #15607. That PR places webpack includes on *every* page in platform and thus is at very high risk for this particular failure. Although the python build on that branch is still failing, failure counts are down from [165](https://build.testeng.edx.org/job/edx-platform-python-unittests-pr/38366/) to [9](https://build.testeng.edx.org/job/edx-platform-python-unittests-pr/38495/) and the remaining failures appear to be unrelated to the WebpackLoaderBadStatsError.