### PR TITLE
only show problem scores still in subsection

### DIFF
--- a/lms/djangoapps/grades/new/subsection_grade.py
+++ b/lms/djangoapps/grades/new/subsection_grade.py
@@ -114,6 +114,8 @@ class SubsectionGrade(SubsectionGradeBase):
         Load the subsection grade from the persisted model.
         """
         for block in model.visible_blocks.blocks:
+            if block.locator not in set(course_structure.post_order_traversal(start_node=self.location)):
+                continue
             self._compute_block_score(block.locator, course_structure, submissions_scores, csm_scores, block)
 
         self.graded_total = AggregatedScore(


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-915

@iloveagent57 @nasthagiri @awaisdar001 @Rabia23 @attiyaIshaque  here's the change that fixes what problem scores are displayed on the progress page.

Separately, we need to figure out why re-grading the whole course didn't change the affected learner's subsection grade. My suspicion is that we aren't updating visible blocks correctly when we run the regrade.