### PR TITLE
Patch the bulk_enroll request to use a form content type

### DIFF
--- a/lms/djangoapps/bulk_enroll/views.py
+++ b/lms/djangoapps/bulk_enroll/views.py
@@ -60,6 +60,12 @@ class BulkEnrollView(APIView):
     def post(self, request):
         serializer = BulkEnrollmentSerializer(data=request.data)
         if serializer.is_valid():
+            # Setting the content type to be form data makes Django Rest Framework v3.6.3 treat all passed JSON data as
+            # POST parameters. This is necessary because this request is forwarded on to the student_update_enrollment
+            # view, which requires all of the parameters to be passed in via POST parameters.
+            metadata = request._request.META  # pylint: disable=protected-access
+            metadata['CONTENT_TYPE'] = 'application/x-www-form-urlencoded'
+
             response_dict = {
                 'auto_enroll': serializer.data.get('auto_enroll'),
                 'email_students': serializer.data.get('email_students'),


### PR DESCRIPTION
The plot thickens with with yet another follow-up fix (related to https://github.com/edx/edx-platform/pull/15584). :) It turns out that the line removed there *was* necessary for older versions of DRF. I neglected to notice that buried in the response that I received back during testing was actually an error from the downstream `student_update_enrollment` view. Because that view directly pulls the parameters out of POST data, certain conditions need to be met in order for DRF to pull POST data from the "_data" dict.

From my inline comment:

> Setting the content type to be form data makes Django Rest Framework v3.6.3 treat all passed JSON data as
> POST parameters. This is necessary because this request is forwarded on to the student_update_enrollment
> view, which requires all of the parameters to be passed in via POST parameters.

**JIRA tickets**: [OSPR-1835](https://openedx.atlassian.net/browse/OSPR-1835)

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**:

Follow the exact same testing instructions that are listed in #15579, except be sure to double-check that the response does NOT contain an error field.

**Reviewers**
- [ ] @pomegranited 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
  ENABLE_BULK_ENROLLMENT_VIEW: true
```
