### PR TITLE
Clearing the cache if the site's configuration was removed.

### DIFF
--- a/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
+++ b/openedx/core/djangoapps/catalog/management/commands/cache_programs.py
@@ -50,6 +50,7 @@ class Command(BaseCommand):
                 site_config = getattr(site, 'configuration', None)
                 if site_config is None or not site_config.get_value('COURSE_CATALOG_API_URL'):
                     logger.info('Skipping site {domain}. No configuration.'.format(domain=site.domain))
+                    cache.set(SITE_PROGRAM_UUIDS_CACHE_KEY_TPL.format(domain=site.domain), [], None)
                     continue
 
                 client = create_catalog_api_client(user, site=site)


### PR DESCRIPTION
If the site's configuration does not contain the API URL, it should not keep on displaying the old cached list of uuids.
LEARNER-1146