### PR TITLE
Bump edx-submissions to v2.0.5 for better logging.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -57,7 +57,7 @@ edx-opaque-keys==0.4.0
 edx-organizations==0.4.5
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
-edx-submissions==2.0.4
+edx-submissions==2.0.5
 facebook-sdk==0.4.0
 feedparser==5.1.3
 firebase-token-generator==1.3.2

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -74,7 +74,7 @@ git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@1.4.7#egg=ora2==1.4.7
+git+https://github.com/edx/edx-ora2.git@1.4.8#egg=ora2==1.4.8
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/edx-val.git@0.0.18#egg=edxval==0.0.18
 git+https://github.com/edx/RecommenderXBlock.git@0e744b393cf1f8b886fe77bc697e7d9d78d65cd6#egg=recommender-xblock==1.2


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-1977

The v2.0.4 edx-submissions version was *supposed* to show the field errors when a SubmissionRequestError exception was raised. But the change was incorrect and is corrected here in v2.0.5.