### PR TITLE
Resolved multi-tenant program issues

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -739,7 +739,7 @@ def dashboard(request):
     # Find programs associated with course runs being displayed. This information
     # is passed in the template context to allow rendering of program-related
     # information on the dashboard.
-    meter = ProgramProgressMeter(user, enrollments=course_enrollments)
+    meter = ProgramProgressMeter(request.site, user, enrollments=course_enrollments)
     inverted_programs = meter.invert_programs()
 
     # Construct a dictionary of course mode information

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -838,7 +838,7 @@ def program_marketing(request, program_uuid):
     """
     Display the program marketing page.
     """
-    program_data = get_programs(uuid=program_uuid)
+    program_data = get_programs(request.site, uuid=program_uuid)
 
     if not program_data:
         raise Http404

--- a/lms/djangoapps/learner_dashboard/views.py
+++ b/lms/djangoapps/learner_dashboard/views.py
@@ -25,7 +25,7 @@ def program_listing(request):
     if not programs_config.enabled:
         raise Http404
 
-    meter = ProgramProgressMeter(request.user)
+    meter = ProgramProgressMeter(request.site, request.user)
 
     context = {
         'disable_courseware_js': True,
@@ -48,7 +48,7 @@ def program_details(request, program_uuid):
     if not programs_config.enabled:
         raise Http404
 
-    meter = ProgramProgressMeter(request.user, uuid=program_uuid)
+    meter = ProgramProgressMeter(request.site, request.user, uuid=program_uuid)
     program_data = meter.programs[0]
 
     if not program_data:

--- a/openedx/core/djangoapps/programs/management/commands/backpopulate_program_credentials.py
+++ b/openedx/core/djangoapps/programs/management/commands/backpopulate_program_credentials.py
@@ -1,17 +1,16 @@
 """Management command for backpopulating missing program credentials."""
-from collections import namedtuple
 import logging
+from collections import namedtuple
 
-from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
 from django.db.models import Q
 from opaque_keys.edx.keys import CourseKey
 
-from certificates.models import GeneratedCertificate, CertificateStatuses  # pylint: disable=import-error
+from certificates.models import CertificateStatuses, GeneratedCertificate  # pylint: disable=import-error
 from course_modes.models import CourseMode
 from openedx.core.djangoapps.catalog.utils import get_programs
 from openedx.core.djangoapps.programs.tasks.v1.tasks import award_program_certificates
-
 
 # TODO: Log to console, even with debug mode disabled?
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -73,7 +72,11 @@ class Command(BaseCommand):
 
     def _load_course_runs(self):
         """Find all course runs which are part of a program."""
-        programs = get_programs()
+        programs = []
+        for site in Site.objects.all():
+            logger.info('Loading programs from the catalog for site %s.', site.domain)
+            programs.extend(get_programs(site))
+
         self.course_runs = self._flatten(programs)
 
     def _flatten(self, programs):

--- a/openedx/core/djangoapps/programs/tests/test_signals.py
+++ b/openedx/core/djangoapps/programs/tests/test_signals.py
@@ -10,8 +10,8 @@ from student.tests.factories import UserFactory
 
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED
 from openedx.core.djangoapps.programs.signals import handle_course_cert_awarded
-from openedx.core.djangolib.testing.utils import skip_unless_lms
-
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms, get_mock_request
 
 TEST_USERNAME = 'test-user'
 

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -70,7 +70,8 @@ class ProgramProgressMeter(object):
             will only inspect this one program, not all programs the user may be
             engaged with.
     """
-    def __init__(self, user, enrollments=None, uuid=None):
+    def __init__(self, site, user, enrollments=None, uuid=None):
+        self.site = site
         self.user = user
 
         self.enrollments = enrollments or list(CourseEnrollment.enrollments_for_user(self.user))
@@ -89,9 +90,9 @@ class ProgramProgressMeter(object):
             self.course_run_ids.append(enrollment_id)
 
         if uuid:
-            self.programs = [get_programs(uuid=uuid)]
+            self.programs = [get_programs(self.site, uuid=uuid)]
         else:
-            self.programs = attach_program_detail_url(get_programs())
+            self.programs = attach_program_detail_url(get_programs(self.site))
 
     def invert_programs(self):
         """Intersect programs and enrollments.

--- a/openedx/core/djangoapps/site_configuration/tests/factories.py
+++ b/openedx/core/djangoapps/site_configuration/tests/factories.py
@@ -26,5 +26,7 @@ class SiteFactory(DjangoModelFactory):
         model = Site
         django_get_or_create = ('domain',)
 
+    # TODO These should be generated. Otherwise, code that creates multiple Site
+    # objects will only end up with a single Site since domain has a unique constraint.
     domain = 'testserver.fake'
     name = 'testserver.fake'


### PR DESCRIPTION
A site must be passed so the system knows which URL to use to contact
the Discovery Service.

This will need to be modified to account for the fact that we cannot safely assume we ever have a request.

- [x] Iterate over `Site` objects in `award_program_certificates` instead of accepting a site_id parameter
- [x] Update the backpopulate management command to only call the task once per user