### PR TITLE
Update UBCPI to 0.6.3

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -30,7 +30,7 @@ git+https://github.com/open-craft/problem-builder.git@v2.6.5#egg=xblock-problem-
 -e git+https://github.com/edx/AnimationXBlock.git@d2b551bb8f49a138088e10298576102164145b87#egg=animation-xblock
 
 # Peer instruction XBlock
-ubcpi-xblock==0.6.2
+ubcpi-xblock==0.6.3
 
 # Vector Drawing and ActiveTable XBlocks (Davidson)
 -e git+https://github.com/open-craft/xblock-vectordraw.git@v0.2.1#egg=xblock-vectordraw==0.2.1


### PR DESCRIPTION
This update fixes a critical issue causing UBCPI failed to render. https://github.com/ubc/ubcpi/pull/133