### PR TITLE
Toggle timer visibility on timed exams

### DIFF
--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -103,10 +103,10 @@
         .exam-timer-clock {
           background-color: transparent;
           border: 1px solid $white;
-          a, b {
+          #toggle_timer, b {
             color: $white;
           }
-          a {
+          #toggle_timer {
             // Overrides:
             border-top: none;
             border-right: none;
@@ -152,7 +152,7 @@
       background-color: $gray-l3;
       border-radius: 3px;
 
-      a {
+      #toggle_timer {
         @extend .exam-button-turn-in-exam;
 
         //Overrides:

--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -88,9 +88,6 @@
       }
       .pull-right {
         color: $gray-l3;
-        b {
-          color: $white;
-        }
 
         .exam-button-turn-in-exam {
           background-color: transparent;
@@ -101,6 +98,27 @@
             border: 1px solid $white;
             background-color: $white;
             color: $action-primary-bg;
+          }
+        }
+        .exam-timer-clock {
+          background-color: transparent;
+          border: 1px solid $white;
+          a, b {
+            color: $white;
+          }
+          a {
+            // Overrides:
+            border-top: none;
+            border-right: none;
+            border-bottom: none;
+            border-top-right-radius: 2px;
+            border-bottom-right-radius: 2px;
+            &:hover {
+              // Overrides:
+              border-top: none;
+              border-right: none;
+              border-bottom: none;
+            }
           }
         }
       }
@@ -126,6 +144,25 @@
       &:hover,
       &:focus {
         border: 0;
+      }
+    }
+    .exam-timer-clock {
+      display: inline-block;
+      padding: 0 0 0 ($baseline/3);
+      background-color: $gray-l3;
+      border-radius: 3px;
+
+      a {
+        @extend .exam-button-turn-in-exam;
+
+        //Overrides:
+        padding: ($baseline/5) ($baseline/3);
+        border-bottom-left-radius: 0;
+        border-top-left-radius: 0;
+        margin-right: 0;
+      }
+      b {
+        padding-right: ($baseline/5);
       }
     }
   }

--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -107,14 +107,13 @@
             color: $white;
           }
           #toggle_timer {
-            // Overrides:
             border-top: none;
             border-right: none;
             border-bottom: none;
             border-top-right-radius: 2px;
             border-bottom-right-radius: 2px;
+
             &:hover {
-              // Overrides:
               border-top: none;
               border-right: none;
               border-bottom: none;
@@ -155,7 +154,6 @@
       #toggle_timer {
         @extend .exam-button-turn-in-exam;
 
-        //Overrides:
         padding: ($baseline/5) ($baseline/3);
         border-bottom-left-radius: 0;
         border-top-left-radius: 0;

--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -163,6 +163,10 @@
       }
       b {
         padding-right: ($baseline/5);
+
+        &.timer-hidden {
+          visibility: hidden;
+        }
       }
     }
   }

--- a/lms/templates/courseware/proctored-exam-status.underscore
+++ b/lms/templates/courseware/proctored-exam-status.underscore
@@ -24,7 +24,9 @@
                 <b>
                 </b>
             </span>
-            <a id="toggle_timer" href="#" title="<%- gettext("Hide Timer") %>"><i class="fa fa-eye-slash" aria-hidden="true"></i></a>
+            <button id="toggle_timer" title="<%- gettext("Hide Timer") %>" aria-label="<%- gettext("Hide Timer") %>">
+                <i class="fa fa-eye-slash" aria-hidden="true"></i>
+            </button>
         </span>
     </div>
 </div>

--- a/lms/templates/courseware/proctored-exam-status.underscore
+++ b/lms/templates/courseware/proctored-exam-status.underscore
@@ -19,9 +19,26 @@
             <% } %>
         </span>
         <span class="sr timer-announce" aria-live="assertive"></span>
-        <span id="time_remaining_id">
-            <b>
-            </b>
+        <span class="exam-timer-clock">
+            <span id="time_remaining_id" style="visibility: visible;">
+                <b>
+                </b>
+            </span>
+            <a id="toggle_timer" href="#" title="<%- gettext("Hide Timer") %>"><i class="fa fa-eye-slash" aria-hidden="true"></i></a>
+            <script type="text/javascript">
+                $("#toggle_timer").click(function() {
+                    if ($("#time_remaining_id").css("visibility") === "visible") {
+                        $("#time_remaining_id").css("visibility", "hidden");
+                        $(this).attr("title", "<%- gettext("Show Timer") %>");
+                        $(this).find("i").removeClass("fa-eye-slash").addClass("fa-eye");
+                    } else {
+                        $("#time_remaining_id").css("visibility", "visible");
+                        $(this).attr("title", "<%- gettext("Hide Timer") %>");
+                        $(this).find("i").removeClass("fa-eye").addClass("fa-eye-slash");
+                    }
+                    return false; // prevents the window from scrolling up on click
+                });
+            </script>
         </span>
     </div>
 </div>

--- a/lms/templates/courseware/proctored-exam-status.underscore
+++ b/lms/templates/courseware/proctored-exam-status.underscore
@@ -24,7 +24,7 @@
                 <b>
                 </b>
             </span>
-            <button id="toggle_timer" title="<%- gettext("Hide Timer") %>" aria-label="<%- gettext("Hide Timer") %>">
+            <button role="button" id="toggle_timer" aria-label="<%- gettext("Hide Timer") %>" aria-pressed="false">
                 <i class="fa fa-eye-slash" aria-hidden="true"></i>
             </button>
         </span>

--- a/lms/templates/courseware/proctored-exam-status.underscore
+++ b/lms/templates/courseware/proctored-exam-status.underscore
@@ -20,7 +20,7 @@
         </span>
         <span class="sr timer-announce" aria-live="assertive"></span>
         <span class="exam-timer-clock">
-            <span id="time_remaining_id" style="visibility: visible;">
+            <span id="time_remaining_id">
                 <b>
                 </b>
             </span>

--- a/lms/templates/courseware/proctored-exam-status.underscore
+++ b/lms/templates/courseware/proctored-exam-status.underscore
@@ -25,20 +25,6 @@
                 </b>
             </span>
             <a id="toggle_timer" href="#" title="<%- gettext("Hide Timer") %>"><i class="fa fa-eye-slash" aria-hidden="true"></i></a>
-            <script type="text/javascript">
-                $("#toggle_timer").click(function() {
-                    if ($("#time_remaining_id").css("visibility") === "visible") {
-                        $("#time_remaining_id").css("visibility", "hidden");
-                        $(this).attr("title", "<%- gettext("Show Timer") %>");
-                        $(this).find("i").removeClass("fa-eye-slash").addClass("fa-eye");
-                    } else {
-                        $("#time_remaining_id").css("visibility", "visible");
-                        $(this).attr("title", "<%- gettext("Hide Timer") %>");
-                        $(this).find("i").removeClass("fa-eye").addClass("fa-eye-slash");
-                    }
-                    return false; // prevents the window from scrolling up on click
-                });
-            </script>
         </span>
     </div>
 </div>


### PR DESCRIPTION
This implements a feature request from a professor at Stanford. It adds the ability for students to toggle timer visibility on timed exams (some had said it was stressful to see the timer ticking down). This goes along with a PR to edx-proctoring here https://github.com/edx/edx-proctoring/pull/363. Here's what it looks like:

Normal with timer visible:
<img width="993" alt="screen_shot_2017-07-19_at_4 26 40_pm" src="https://user-images.githubusercontent.com/1097075/28486301-a97e049c-6e35-11e7-86e3-5cabae55ad43.png">

Normal with timer hidden:
<img width="993" alt="screen_shot_2017-07-19_at_4 27 17_pm" src="https://user-images.githubusercontent.com/1097075/28486308-b803f94a-6e35-11e7-9ed2-89050201150e.png">

Low time with timer visible:
<img width="993" alt="screen shot 2017-07-20 at 2 59 19 pm" src="https://user-images.githubusercontent.com/1097075/28486313-c19c9d54-6e35-11e7-9db5-b916cae9adbc.png">

Low time with timer hidden:
<img width="993" alt="screen shot 2017-07-20 at 2 59 42 pm" src="https://user-images.githubusercontent.com/1097075/28486322-cbfc259e-6e35-11e7-8a57-117a3baed6d5.png">

@stvstnfrd @caesar2164 @mondiaz
CC: @potsui @jlikhuva