### PR TITLE
Added support for dynamic upgrade deadlines

### DIFF
--- a/lms/djangoapps/courseware/admin.py
+++ b/lms/djangoapps/courseware/admin.py
@@ -1,13 +1,10 @@
-'''
-django admin pages for courseware model
-'''
-
+from config_models.admin import ConfigurationModelAdmin, KeyedConfigurationModelAdmin
 from ratelimitbackend import admin
 
-from courseware.models import OfflineComputedGrade, OfflineComputedGradeLog, StudentModule
+from courseware import models
 
-admin.site.register(StudentModule)
-
-admin.site.register(OfflineComputedGrade)
-
-admin.site.register(OfflineComputedGradeLog)
+admin.site.register(models.DynamicUpgradeDeadlineConfiguration, ConfigurationModelAdmin)
+admin.site.register(models.OfflineComputedGrade)
+admin.site.register(models.OfflineComputedGradeLog)
+admin.site.register(models.CourseDynamicUpgradeDeadlineConfiguration, KeyedConfigurationModelAdmin)
+admin.site.register(models.StudentModule)

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -18,7 +18,7 @@ from courseware.date_summary import (
     VerifiedUpgradeDeadlineDate
 )
 from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module, get_module_for_descriptor
+from courseware.module_render import get_module
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import Http404, QueryDict

--- a/lms/djangoapps/courseware/migrations/0002_coursedynamicupgradedeadlineconfiguration_dynamicupgradedeadlineconfiguration.py
+++ b/lms/djangoapps/courseware/migrations/0002_coursedynamicupgradedeadlineconfiguration_dynamicupgradedeadlineconfiguration.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+import django.db.models.deletion
+import openedx.core.djangoapps.xmodule_django.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('courseware', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CourseDynamicUpgradeDeadlineConfiguration',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
+                ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
+                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('deadline_days', models.PositiveSmallIntegerField(default=21, help_text='Number of days a learner has to upgrade after content is made available')),
+                ('opt_out', models.BooleanField(default=False, help_text='Disable the dynamic upgrade deadline for this course run.')),
+                ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='DynamicUpgradeDeadlineConfiguration',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
+                ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
+                ('deadline_days', models.PositiveSmallIntegerField(default=21, help_text='Number of days a learner has to upgrade after content is made available')),
+                ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
+            ],
+        ),
+    ]

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -15,10 +15,12 @@ ASSUMPTIONS: modules have unique IDs, even across different module_types
 import itertools
 import logging
 
+from config_models.models import ConfigurationModel
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.signals import post_save
+from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 
 import coursewarehistoryextended
@@ -40,6 +42,7 @@ class ChunkingManager(models.Manager):
     :class:`~Manager` that adds an additional method :meth:`chunked_filter` to provide
     the ability to make select queries with specific chunk sizes.
     """
+
     class Meta(object):
         app_label = "courseware"
 
@@ -130,16 +133,17 @@ class StudentModule(models.Model):
             return queryset
 
     def __repr__(self):
-        return 'StudentModule<%r>' % ({
-            'course_id': self.course_id,
-            'module_type': self.module_type,
-            # We use the student_id instead of username to avoid a database hop.
-            # This can actually matter in cases where we're logging many of
-            # these (e.g. on a broken progress page).
-            'student_id': self.student_id,
-            'module_state_key': self.module_state_key,
-            'state': str(self.state)[:20],
-        },)
+        return 'StudentModule<%r>' % (
+            {
+                'course_id': self.course_id,
+                'module_type': self.module_type,
+                # We use the student_id instead of username to avoid a database hop.
+                # This can actually matter in cases where we're logging many of
+                # these (e.g. on a broken progress page).
+                'student_id': self.student_id,
+                'module_state_key': self.module_state_key,
+                'state': str(self.state)[:20],
+            },)
 
     def __unicode__(self):
         return unicode(repr(self))
@@ -267,6 +271,7 @@ class XModuleUserStateSummaryField(XBlockFieldBase):
     """
     Stores data set in the Scope.user_state_summary scope by an xmodule field
     """
+
     class Meta(object):
         app_label = "courseware"
         unique_together = (('usage_id', 'field_name'),)
@@ -279,6 +284,7 @@ class XModuleStudentPrefsField(XBlockFieldBase):
     """
     Stores data set in the Scope.preferences scope by an xmodule field
     """
+
     class Meta(object):
         app_label = "courseware"
         unique_together = (('student', 'module_type', 'field_name'),)
@@ -293,6 +299,7 @@ class XModuleStudentInfoField(XBlockFieldBase):
     """
     Stores data set in the Scope.preferences scope by an xmodule field
     """
+
     class Meta(object):
         app_label = "courseware"
         unique_together = (('student', 'field_name'),)
@@ -310,11 +317,11 @@ class OfflineComputedGrade(models.Model):
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)
     updated = models.DateTimeField(auto_now=True, db_index=True)
 
-    gradeset = models.TextField(null=True, blank=True)		# grades, stored as JSON
+    gradeset = models.TextField(null=True, blank=True)  # grades, stored as JSON
 
     class Meta(object):
         app_label = "courseware"
-        unique_together = (('user', 'course_id'), )
+        unique_together = (('user', 'course_id'),)
 
     def __unicode__(self):
         return "[OfflineComputedGrade] %s: %s (%s) = %s" % (self.user, self.course_id, self.created, self.gradeset)
@@ -325,6 +332,7 @@ class OfflineComputedGradeLog(models.Model):
     Log of when offline grades are computed.
     Use this to be able to show instructor when the last computed grades were done.
     """
+
     class Meta(object):
         app_label = "courseware"
         ordering = ["-created"]
@@ -332,7 +340,7 @@ class OfflineComputedGradeLog(models.Model):
 
     course_id = CourseKeyField(max_length=255, db_index=True)
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)
-    seconds = models.IntegerField(default=0)  	# seconds elapsed for computation
+    seconds = models.IntegerField(default=0)  # seconds elapsed for computation
     nstudents = models.IntegerField(default=0)
 
     def __unicode__(self):
@@ -355,3 +363,40 @@ class StudentFieldOverride(TimeStampedModel):
 
     field = models.CharField(max_length=255)
     value = models.TextField(default='null')
+
+
+class DynamicUpgradeDeadlineConfiguration(ConfigurationModel):
+    """ Dynamic upgrade deadline configuration.
+
+    This model controls the behavior of the dynamic upgrade deadline for self-paced courses.
+    """
+    class Meta(object):
+        app_label = 'courseware'
+
+    deadline_days = models.PositiveSmallIntegerField(
+        default=21,
+        help_text=_('Number of days a learner has to upgrade after content is made available')
+    )
+
+
+class CourseDynamicUpgradeDeadlineConfiguration(ConfigurationModel):
+    """
+    Per-course run configuration for dynamic upgrade deadlines.
+
+    This model controls dynamic upgrade deadlines on a per-course run level, allowing course runs to
+    have different deadlines or opt out of the functionality altogether.
+    """
+    class Meta(object):
+        app_label = 'courseware'
+
+    KEY_FIELDS = ('course_id',)
+
+    course_id = CourseKeyField(max_length=255, db_index=True)
+    deadline_days = models.PositiveSmallIntegerField(
+        default=21,
+        help_text=_('Number of days a learner has to upgrade after content is made available')
+    )
+    opt_out = models.BooleanField(
+        default=False,
+        help_text=_('Disable the dynamic upgrade deadline for this course run.')
+    )

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -211,8 +211,8 @@ class IndexQueryTestCase(ModuleStoreTestCase):
     NUM_PROBLEMS = 20
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 10, 143),
-        (ModuleStoreEnum.Type.split, 4, 143),
+        (ModuleStoreEnum.Type.mongo, 10, 144),
+        (ModuleStoreEnum.Type.split, 4, 144),
     )
     @ddt.unpack
     def test_index_query_counts(self, store_type, expected_mongo_query_count, expected_mysql_query_count):

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -148,9 +148,9 @@ class RenderXBlockTestMixin(object):
         return response
 
     @ddt.data(
-        ('vertical_block', ModuleStoreEnum.Type.mongo, 10),
+        ('vertical_block', ModuleStoreEnum.Type.mongo, 14),
         ('vertical_block', ModuleStoreEnum.Type.split, 6),
-        ('html_block', ModuleStoreEnum.Type.mongo, 11),
+        ('html_block', ModuleStoreEnum.Type.mongo, 15),
         ('html_block', ModuleStoreEnum.Type.split, 6),
     )
     @ddt.unpack

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -160,7 +160,7 @@ class TestCourseHomePage(CourseHomePageTestCase):
         course_home_url(self.course)
 
         # Fetch the view and verify the query counts
-        with self.assertNumQueries(38, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(40, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_home_url(self.course)
                 self.client.get(url)


### PR DESCRIPTION
The verified seat upgrade deadline for self-paced course runs is now
dependent on when the learner was first able to access the content--the
latest of enrollment date and course run start date.