### PR TITLE
[DE-209] Switch to the PyPI-based version of eventtracking.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -56,6 +56,7 @@ edx-organizations==0.4.5
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
 edx-submissions==2.0.5
+event-tracking==0.2.4
 facebook-sdk==0.4.0
 feedparser==5.1.3
 firebase-token-generator==1.3.2

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -78,7 +78,6 @@ git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4b
 
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail==0.0
--e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 git+https://github.com/edx/edx-ora2.git@1.4.8#egg=ora2==1.4.8


### PR DESCRIPTION
Simple enough.  This is part of making edx-platform ready for Django 1.11.