### PR TITLE
[ENT-491] Check for Enterprise-linked TPA pipeline when asked for Enterprise on request

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -22,6 +22,8 @@ from openedx.core.djangoapps.catalog.models import CatalogIntegration
 from openedx.core.djangoapps.catalog.utils import create_catalog_api_client
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.token_utils import JwtBuilder
+from third_party_auth.pipeline import get as get_partial_pipeline
+from third_party_auth.provider import Registry
 
 try:
     from enterprise import utils as enterprise_utils
@@ -241,13 +243,22 @@ def enterprise_customer_for_request(request, tpa_hint=None):
 
     ec = None
 
+    running_pipeline = get_partial_pipeline(request)
+    if running_pipeline:
+        # Determine if the user is in the middle of a third-party auth pipeline,
+        # and set the tpa_hint parameter to match if so.
+        tpa_hint = Registry.get_from_pipeline(running_pipeline).provider_id
+
     if tpa_hint:
+        # If we have a third-party auth provider, get the linked enterprise customer.
         try:
             ec = EnterpriseCustomer.objects.get(enterprise_customer_identity_provider__provider_id=tpa_hint)
         except EnterpriseCustomer.DoesNotExist:
             pass
 
     ec_uuid = request.GET.get('enterprise_customer') or request.COOKIES.get(settings.ENTERPRISE_CUSTOMER_COOKIE_NAME)
+    # If we haven't obtained an EnterpriseCustomer through the other methods, check the
+    # session cookies and URL parameters for an explicitly-passed EnterpriseCustomer.
     if not ec and ec_uuid:
         try:
             ec = EnterpriseCustomer.objects.get(uuid=ec_uuid)


### PR DESCRIPTION
This pull request fixes a bug found in ENT-491 where users entering logistration via Enterprise-linked SSO providers were not showed the branded logistration page.

**JIRA tickets**: Fixes bug in [ENT-491](https://openedx.atlassian.net/browse/ENT-491)

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

1. Create SSO provider linked to EnterpriseCustomer.
2. Sign in directly via the SSO provider.
3. Verify that the Enterprise branding shows on the logistration page.

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
  ENABLE_THIRD_PARTY_AUTH: true
```