### PR TITLE
CMS memory leak fix

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -318,7 +318,7 @@ class TestCourseListing(ModuleStoreTestCase, XssTestMixin):
         )
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 3, 13),
+        (ModuleStoreEnum.Type.split, 4, 23),
         (ModuleStoreEnum.Type.mongo, USER_COURSES_COUNT, 2)
     )
     @ddt.unpack

--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -7,7 +7,6 @@ import logging
 import re
 import json
 import datetime
-import traceback
 
 from pytz import UTC
 from collections import defaultdict
@@ -158,19 +157,7 @@ class ActiveBulkThread(threading.local):
     """
     def __init__(self, bulk_ops_record_type, **kwargs):
         super(ActiveBulkThread, self).__init__(**kwargs)
-        self._records = defaultdict(bulk_ops_record_type)
-        self.CMS_LEAK_DEBUG_GLOBAL = True  # only log once per process
-
-    @property
-    def records(self):
-        if self.CMS_LEAK_DEBUG_GLOBAL and len(self._records) > 2000:  # arbitrary limit, we peak around ~2750 on edx.org
-            log.info(
-                "EDUCATOR-768: The memory leak issue may be in progress. How we got here:\n{}".format(
-                    "".join(traceback.format_stack())
-                )
-            )
-            self.CMS_LEAK_DEBUG_GLOBAL = False
-        return self._records
+        self.records = defaultdict(bulk_ops_record_type)
 
 
 class BulkOperationsMixin(object):

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -788,7 +788,8 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         if should_cache_items:
             self.cache_items(runtime, block_keys, course_entry.course_key, depth, lazy)
 
-        return [runtime.load_item(block_key, course_entry, **kwargs) for block_key in block_keys]
+        with self.bulk_operations(course_entry.course_key, emit_signals=False):
+            return [runtime.load_item(block_key, course_entry, **kwargs) for block_key in block_keys]
 
     def _get_cache(self, course_version_guid):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -418,7 +418,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
     #    wildcard query, 6! load pertinent items for inheritance calls, load parents, course root fetch (why)
     # Split:
     #    active_versions (with regex), structure, and spurious active_versions refetch
-    @ddt.data((ModuleStoreEnum.Type.mongo, 14, 0), (ModuleStoreEnum.Type.split, 3, 0))
+    @ddt.data((ModuleStoreEnum.Type.mongo, 14, 0), (ModuleStoreEnum.Type.split, 4, 0))
     @ddt.unpack
     def test_get_items(self, default_ms, max_find, max_send):
         self.initdb(default_ms)
@@ -1043,7 +1043,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
     #   1) wildcard split search,
     #   2-4) active_versions, structure, definition (s/b lazy; so, unnecessary)
     #   5) wildcard draft mongo which has none
-    @ddt.data((ModuleStoreEnum.Type.mongo, 3, 0), (ModuleStoreEnum.Type.split, 5, 0))
+    @ddt.data((ModuleStoreEnum.Type.mongo, 3, 0), (ModuleStoreEnum.Type.split, 6, 0))
     @ddt.unpack
     def test_get_courses(self, default_ms, max_find, max_send):
         self.initdb(default_ms)

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -405,7 +405,7 @@ class ViewsQueryCountTestCase(
 
     @ddt.data(
         (ModuleStoreEnum.Type.mongo, 3, 4, 31),
-        (ModuleStoreEnum.Type.split, 3, 12, 31),
+        (ModuleStoreEnum.Type.split, 3, 13, 31),
     )
     @ddt.unpack
     @count_queries
@@ -414,7 +414,7 @@ class ViewsQueryCountTestCase(
 
     @ddt.data(
         (ModuleStoreEnum.Type.mongo, 3, 3, 27),
-        (ModuleStoreEnum.Type.split, 3, 9, 27),
+        (ModuleStoreEnum.Type.split, 3, 10, 27),
     )
     @ddt.unpack
     @count_queries


### PR DESCRIPTION
We had been seeing entries be added to the problematic thread-local `records` defaultdict. Previously, I traced them through a full begin/end-bulk-ops cycle and saw the entries being removed as expected. However, there was a *second* method call that was not wrapped, meaning records were being added to the dict without ever being cleaned up.

This PR also reverts https://github.com/edx/edx-platform/pull/15593, as that logging has outlived its utility.

Here's a pdb debug log of how I found this problem, the breakpoints were set inside of `_begin_` and `_end_bulk_operation`, as well as inside the `records` property defined in the logging PR, which allowed me to find an instance of the default dict being accessed *outside* the context manager.

Initial, correct behavior: the bulk op ends and the record is cleaned up:
```
> /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py(317)_end_bulk_operation()
-> self._clear_bulk_ops_record(structure_key)

(Pdb) c(ontinue)
> /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py(167)records()
-> if self.CMS_LEAK_DEBUG_GLOBAL and len(self._records) > 2000:  # arbitrary limit, we peak around ~2750 on edx.org

(Pdb) w(here_am_i)
 …
/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/course.py(470)_accessible_libraries_iter()
-> return (lib for lib in modulestore().get_libraries(org=org) if has_studio_read_access(user, lib.location.library_key))
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mixed.py(90)inner()
-> retval = func(field_decorator=strip_key_collection, *args, **kwargs)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mixed.py(338)get_libraries()
-> for library in store.get_libraries(**kwargs):
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py(1031)get_libraries()
-> return self._get_structures_for_branch_and_locator(branch, self._create_library_locator, **kwargs)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py(939)_get_structures_for_branch_and_locator()
-> structures_list = self._load_items(envelope, [root], depth=0, **kwargs)
  <decorator-gen-79>(2)_load_items()
  /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/contracts/main.py(266)contracts_checker()
-> result = function_(*args, **kwargs)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py(789)_load_items()
-> self.cache_items(runtime, block_keys, course_entry.course_key, depth, lazy)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py(769)cache_items()
-> return system.module_data
  /usr/lib/python2.7/contextlib.py(24)__exit__()
-> self.gen.next()
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py(207)bulk_operations()
-> self._end_bulk_operation(course_id, emit_signals, ignore_case)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py(317)_end_bulk_operation()
-> self._clear_bulk_ops_record(structure_key)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py(225)_clear_bulk_ops_record()
-> del self._active_bulk_ops.records[course_key.replace(branch=None, version_guid=None)]
> /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py(167)records()
-> if self.CMS_LEAK_DEBUG_GLOBAL and len(self._records) > 2000:  # arbitrary limit, we peak around ~2750 on edx.org
```

That all looks great, let's continue
```
(Pdb) c
> /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py(167)records()
-> if self.CMS_LEAK_DEBUG_GLOBAL and len(self._records) > 2000:  # arbitrary limit, we peak around ~2750 on edx.org
```

Wait, we're inside the property again? How the hell did we get here?
```
(Pdb) w
…
  /edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/course.py(470)_accessible_libraries_iter()
-> return (lib for lib in modulestore().get_libraries(org=org) if has_studio_read_access(user, lib.location.library_key))
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mixed.py(90)inner()
-> retval = func(field_decorator=strip_key_collection, *args, **kwargs)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mixed.py(338)get_libraries()
-> for library in store.get_libraries(**kwargs):
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py(1031)get_libraries()
-> return self._get_structures_for_branch_and_locator(branch, self._create_library_locator, **kwargs)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py(939)_get_structures_for_branch_and_locator()
-> structures_list = self._load_items(envelope, [root], depth=0, **kwargs)
  <decorator-gen-79>(2)_load_items()
  /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/contracts/main.py(266)contracts_checker()
-> result = function_(*args, **kwargs)
```

NOTE: this point in the trace is where we diverge. We went to split.py(789) above, (791) here.

```
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py(791)_load_items()
-> return [runtime.load_item(block_key, course_entry, **kwargs) for block_key in block_keys]
  <decorator-gen-73>(2)_load_item()
  /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/contracts/main.py(266)contracts_checker()
-> result = function_(*args, **kwargs)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py(126)_load_item()
-> cached_module = self.modulestore.get_cached_block(course_key, version_guid, block_key)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py(358)get_cached_block()
-> bulk_write_record = self._get_bulk_ops_record(course_key)
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py(214)_get_bulk_ops_record()
-> course_key.replace(branch=None, version_guid=None), ignore_case
  /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py(231)_get_bulk_ops_record()
-> return self._active_bulk_ops.records[course_key.for_branch(None)]
> /edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/__init__.py(167)records()
-> if self.CMS_LEAK_DEBUG_GLOBAL and len(self._records) > 2000:  # arbitrary limit, we peak around ~2750 on edx.org
```

There it is, notice that defaultdict access? That’s how our extra objects are being created.