### PR TITLE
Move the user_attribute creation for site 

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1680,7 +1680,7 @@ def user_signup_handler(sender, **kwargs):  # pylint: disable=unused-argument
             log.info(u'user {} originated from a white labeled "Microsite"'.format(kwargs['instance'].id))
 
 
-def _do_create_account(form, custom_form=None, site=None):
+def _do_create_account(form, custom_form=None):
     """
     Given cleaned post variables, create the User and UserProfile objects, as well as the
     registration for this user.
@@ -1721,10 +1721,6 @@ def _do_create_account(form, custom_form=None, site=None):
                 custom_model = custom_form.save(commit=False)
                 custom_model.user = user
                 custom_model.save()
-
-            if site:
-                # Set UserAttribute indicating the site the user account was created on.
-                UserAttribute.set_user_attribute(user, 'created_on_site', site.domain)
     except IntegrityError:
         # Figure out the cause of the integrity error
         if len(User.objects.filter(username=user.username)) > 0:
@@ -1765,6 +1761,13 @@ def _do_create_account(form, custom_form=None, site=None):
         raise
 
     return (user, profile, registration)
+
+
+def _create_or_set_user_attribute_created_on_site(user, site):
+    # Create or Set UserAttribute indicating the microsite site the user account was created on.
+    # User maybe created on 'courses.edx.org', or a white-label site
+    if site:
+        UserAttribute.set_user_attribute(user, 'created_on_site', site.domain)
 
 
 def create_account_with_params(request, params):
@@ -1873,7 +1876,7 @@ def create_account_with_params(request, params):
     # Perform operations within a transaction that are critical to account creation
     with transaction.atomic():
         # first, create the account
-        (user, profile, registration) = _do_create_account(form, custom_form, site=request.site)
+        (user, profile, registration) = _do_create_account(form, custom_form)
 
         # If a 3rd party auth provider and credentials were provided in the API, link the account with social auth
         # (If the user is using the normal register page, the social auth pipeline does the linking, not this code)
@@ -1910,6 +1913,8 @@ def create_account_with_params(request, params):
                 raise ValidationError({'access_token': [error_message]})
 
     # Perform operations that are non-critical parts of account creation
+    _create_or_set_user_attribute_created_on_site(user, request.site)
+
     preferences_api.set_user_preference(user, LANGUAGE_KEY, get_language())
 
     if settings.FEATURES.get('ENABLE_DISCUSSION_EMAIL_DIGEST'):
@@ -2230,7 +2235,7 @@ def auto_auth(request):
     # If successful, this will return a tuple containing
     # the new user object.
     try:
-        user, profile, reg = _do_create_account(form, site=request.site)
+        user, profile, reg = _do_create_account(form)
     except (AccountValidationError, ValidationError):
         # Attempt to retrieve the existing user.
         user = User.objects.get(username=username)
@@ -2256,6 +2261,8 @@ def auto_auth(request):
     age_limit = settings.PARENTAL_CONSENT_AGE_LIMIT
     profile.year_of_birth = (year - age_limit) - 1
     profile.save()
+
+    _create_or_set_user_attribute_created_on_site(user, request.site)
 
     # Enroll the user in a course
     course_key = None


### PR DESCRIPTION
[LEARNER-1521](https://openedx.atlassian.net/browse/LEARNER-1521)
Move the block of code from within the user creation DB transaction to outside

For the current state, we suffer from db deadlock when there is a wave of user registration requests being processed.

@douglashall @hasnain-naveed Please review
