### PR TITLE
EDUCATOR-760

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -514,6 +514,31 @@ class GetUserPartitionInfoTest(ModuleStoreTestCase):
             "deleted": True
         })
 
+    def test_singular_deleted_group(self):
+        """
+        Verify that a partition with only one deleted group is
+        shown in the partition info with the group marked as deleted
+        """
+        self._set_partitions([
+            UserPartition(
+                id=0,
+                name="Cohort user partition",
+                scheme=UserPartition.get_scheme("cohort"),
+                description="Cohorted user partition",
+                groups=[],
+            ),
+        ])
+        self._set_group_access({0: [1]})
+        partitions = self._get_partition_info()
+        groups = partitions[0]["groups"]
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0], {
+            "id": 1,
+            "name": "Deleted Group",
+            "selected": True,
+            "deleted": True,
+        })
+
     def test_filter_by_partition_scheme(self):
         partitions = self._get_partition_info(schemes=["random"])
         self.assertEqual(len(partitions), 1)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -391,17 +391,18 @@ def get_user_partition_info(xblock, schemes=None, course=None):
     for p in sorted(get_all_partitions_for_course(course, active_only=True), key=lambda p: p.name):
 
         # Exclude disabled partitions, partitions with no groups defined
+        # The exception to this case is when there is a selected group within that partition, which means there is
+        # a deleted group
         # Also filter by scheme name if there's a filter defined.
-        if p.groups and (schemes is None or p.scheme.name in schemes):
+        selected_groups = set(xblock.group_access.get(p.id, []) or [])
+        if (p.groups or selected_groups) and (schemes is None or p.scheme.name in schemes):
 
             # First, add groups defined by the partition
             groups = []
             for g in p.groups:
-
                 # Falsey group access for a partition mean that all groups
                 # are selected.  In the UI, though, we don't show the particular
                 # groups selected, since there's a separate option for "all users".
-                selected_groups = set(xblock.group_access.get(p.id, []) or [])
                 groups.append({
                     "id": g.id,
                     "name": g.name,


### PR DESCRIPTION
## [EDUCATOR-760](https://openedx.atlassian.net/browse/EDUCATOR-760)

### Description

Change partitions logic to include partitions with one deleted group

### Sandbox
- [x] Sandbox up at: https://deleted-group-logic.sandbox.edx.org/home/
         Unit with one deleted group: https://studio-deleted-group-logic.sandbox.edx.org/container/block-v1:B+C+D+type@vertical+block@734ce3c1c1b046418d729fa6d4f04d1f?action=new

### Testing
- [x] Unit, integration, acceptance tests as appropriate
 
### Post-review
- [ ] Rebase and squash commits
