### PR TITLE
Make HTTP 500 error pages site-aware

### DIFF
--- a/lms/static/sass/multicourse/_error-pages.scss
+++ b/lms/static/sass/multicourse/_error-pages.scss
@@ -6,6 +6,7 @@ section.outside-app {
   h1 {
     @extend h2;
     margin-bottom: ($baseline*2);
+    text-align: center;
   }
 
   p, ul, form {

--- a/lms/templates/courseware/courseware-error.html
+++ b/lms/templates/courseware/courseware-error.html
@@ -3,6 +3,10 @@
 <%namespace name='static' file='../static_content.html'/>
 <%block name="bodyclass">courseware</%block>
 <%block name="pagetitle">${_("Courseware")}</%block>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
 
 <%block name="headextra">
 <%static:css group='style-course-vendor'/>
@@ -15,13 +19,13 @@
   <section class="outside-app">
     <h1>
       ${_('There has been an error on the {platform_name} servers').format(
-          platform_name=u'<span class="edx">{}</span>'.format(settings.PLATFORM_NAME)
+          platform_name=u'<span class="edx">{}</span>'.format(static.get_platform_name())
       )}
     </h1>
     <p>
       ${_("We're sorry, this module is temporarily unavailable. Our staff is working to fix "
       "it as soon as possible. Please email us at {tech_support_email} to report any problems or downtime.").format(
-      tech_support_email=u'<a href=\"mailto:{0}\">{0}</a>'.format(settings.TECH_SUPPORT_EMAIL)
+      tech_support_email=u'<a href=\"mailto:{0}\">{0}</a>'.format(static.get_tech_support_email_address())
       )}
     </p>
   </section>

--- a/lms/templates/courseware/error-message.html
+++ b/lms/templates/courseware/error-message.html
@@ -1,7 +1,10 @@
 ## mako
-
-<%! from django.utils.translation import ugettext as _ %>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
 <%
-    tech_support_email='<a href=\"mailto:{tech_support_email}\">{tech_support_email}</a>'.format(tech_support_email=settings.TECH_SUPPORT_EMAIL)
+    tech_support_email='<a href=\"mailto:{tech_support_email}\">{tech_support_email}</a>'.format(tech_support_email=static.get_tech_support_email_address())
 %>
 <p>${_("We're sorry, this module is temporarily unavailable. Our staff is working to fix it as soon as possible. Please email us at {tech_support_email} to report any problems or downtime.").format(tech_support_email=tech_support_email)}</p>

--- a/lms/templates/module-error.html
+++ b/lms/templates/module-error.html
@@ -1,16 +1,20 @@
-<%! from django.utils.translation import ugettext as _ %>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<%namespace name='static' file='../static_content.html'/>
 
 <section class="outside-app">
   <h1>
     ${_("There has been an error on the {platform_name} servers").format(
-        platform_name=u"<em>{}</em>".format(settings.PLATFORM_NAME)
+        platform_name=u"<em>{}</em>".format(static.get_platform_name())
     )}
   </h1>
   <p>
     ${_("We're sorry, this module is temporarily unavailable. Our staff is working "
     "to fix it as soon as possible. Please email us at {tech_support_email} to "
     "report any problems or downtime.").format(
-        tech_support_email=u"<a href=\"mailto:{0}\">{0}</a>".format(settings.TECH_SUPPORT_EMAIL)
+        tech_support_email=u"<a href=\"mailto:{0}\">{0}</a>".format(static.get_tech_support_email_address())
     )}
   </p>
 

--- a/lms/templates/static_templates/server-down.html
+++ b/lms/templates/static_templates/server-down.html
@@ -4,18 +4,19 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />
+<%namespace name='static' file='../static_content.html'/>
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="outside-app">
       <h1>
         ${Text(_("Currently the {platform_name} servers are down")).format(
-            platform_name=HTML(u"<em>{}</em>").format(Text(settings.PLATFORM_NAME))
+            platform_name=HTML(u"<em>{}</em>").format(Text(static.get_platform_name()))
         )}
       </h1>
       <p>
         ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
         "Please email us at {tech_support_email} to report any problems or downtime.")).format(
-            tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(Text(settings.TECH_SUPPORT_EMAIL))
+            tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(Text(static.get_tech_support_email_address()))
         )}</p>
     </section>
 </main>

--- a/lms/templates/static_templates/server-overloaded.html
+++ b/lms/templates/static_templates/server-overloaded.html
@@ -4,18 +4,19 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <%inherit file="../main.html" />
+<%namespace name='static' file='../static_content.html'/>
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="outside-app">
       <h1>
         ${Text(_("Currently the {platform_name} servers are overloaded")).format(
-            platform_name=HTML("<em>{}</em>").format(platform_name=Text(settings.PLATFORM_NAME))
+            platform_name=HTML("<em>{}</em>").format(platform_name=Text(static.get_platform_name()))
         )}
       </h1>
       <p>
         ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
         "Please email us at {tech_support_email} to report any problems or downtime.")).format(
-            tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(tech_support_email=Text(settings.TECH_SUPPORT_EMAIL))
+            tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(tech_support_email=Text(static.get_tech_support_email_address()))
         )}
       </p>
     </section>

--- a/openedx/core/djangoapps/external_auth/views.py
+++ b/openedx/core/djangoapps/external_auth/views.py
@@ -36,6 +36,7 @@ import student.views
 from edxmako.shortcuts import render_to_response, render_to_string
 from openedx.core.djangoapps.external_auth.djangostore import DjangoOpenIDStore
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
+from openedx.core.djangoapps.site_configuration.helpers import get_value
 from student.helpers import get_next_url_for_login_page
 from student.models import UserProfile
 from xmodule.modulestore.django import modulestore
@@ -171,7 +172,7 @@ def _external_login_or_signup(request,
                         "an external login like WebAuth or Shibboleth. "
                         "Please contact {tech_support_email} for support."
                     ).format(
-                        tech_support_email=settings.TECH_SUPPORT_EMAIL,
+                        tech_support_email=get_value('email_from_address', settings.TECH_SUPPORT_EMAIL),
                     )
                     return default_render_failure(request, failure_msg)
             except User.DoesNotExist:


### PR DESCRIPTION
Current 500 error pages aren't setup for multi-tenancy. These changes allow it to show the correct platform name and email address for the site on the page.