### PR TITLE
EDUCATOR-1001

### DIFF
--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -3,6 +3,7 @@
 from django.utils.translation import ugettext as _
 from contentstore.views.helpers import xblock_studio_url
 from contentstore.utils import is_visible_to_specific_partition_groups
+from lms.lib.utils import is_unit
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
@@ -14,7 +15,7 @@ section_class = "level-nesting" if show_inline else "level-element"
 collapsible_class = "is-collapsible" if xblock.has_children else ""
 label = xblock.display_name_with_default or xblock.scope_ids.block_type
 messages = xblock.validate().to_json()
-is_unit = xblock.is_unit()
+block_is_unit = is_unit(xblock)
 %>
 
 <%namespace name='static' file='static_content.html'/>
@@ -31,7 +32,7 @@ is_unit = xblock.is_unit()
             ${messages | n, dump_js_escaped_json},
             ${bool(xblock_url) | n, dump_js_escaped_json},  // xblock_url will be None or a string
             ${bool(is_root) | n, dump_js_escaped_json},  // is_root will be None or a boolean
-            ${bool(is_unit) | n, dump_js_escaped_json},  // is_unit will be None or a boolean
+            ${bool(block_is_unit) | n, dump_js_escaped_json},  // block_is_unit will be None or a boolean
             $('div.xblock-validation-messages[data-locator="${xblock.location | n, js_escaped_string}"]')
         );
     });

--- a/cms/templates/visibility_editor.html
+++ b/cms/templates/visibility_editor.html
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 from contentstore.utils import ancestor_has_staff_lock, get_visibility_partition_info
 from openedx.core.djangolib.markup import HTML, Text
+from lms.lib.utils import is_unit
 
 partition_info = get_visibility_partition_info(xblock)
 selectable_partitions = partition_info["selectable_partitions"]
@@ -11,18 +12,30 @@ selected_partition_index = partition_info["selected_partition_index"]
 selected_groups_label = partition_info["selected_groups_label"]
 
 is_staff_locked = ancestor_has_staff_lock(xblock)
+block_is_unit = is_unit(xblock)
 %>
-
 <div class="modal-section visibility-summary">
     % if len(selectable_partitions) == 0:
         <div class="is-not-configured has-actions">
             <h3 class="title">${_('Access is not restricted')}</h3>
             <div class="copy">
-                <p>${_('Access to this component is not restricted, but visibility might be affected by inherited settings.')}</p>
-                % if settings.FEATURES.get('ENABLE_ENROLLMENT_TRACK_USER_PARTITION'):
-                <p>${_('You can restrict access to this component to learners in specific enrollment tracks or content groups.')}</p>
+                % if block_is_unit:
+                    <p>${_('Access to this unit is not restricted, but visibility might be affected by inherited settings.')}</p>
                 % else:
-                <p>${_('You can restrict access to this component to learners in specific content groups.')}</p>
+                    <p>${_('Access to this component is not restricted, but visibility might be affected by inherited settings.')}</p>
+                %endif
+                % if settings.FEATURES.get('ENABLE_ENROLLMENT_TRACK_USER_PARTITION'):
+                    % if block_is_unit:
+                        <p>${_('You can restrict access to this unit to learners in specific enrollment tracks or content groups.')}</p>
+                    % else:
+                        <p>${_('You can restrict access to this component to learners in specific enrollment tracks or content groups.')}</p>
+                    % endif
+                % else:
+                    % if block_is_unit:
+                        <p>${_('You can restrict access to this unit to learners in specific content groups.')}</p>
+                    % else:
+                        <p>${_('You can restrict access to this component to learners in specific content groups.')}</p>
+                    % endif
                 % endif
             </div>
 
@@ -98,7 +111,9 @@ is_staff_locked = ancestor_has_staff_lock(xblock)
                             % if group["deleted"]:
                             <label for="visibility-group-${partition["id"]}-${group["id"]}" class="label">
                                 ${_("Deleted Group")}
-                                <span class="note">${_('This group no longer exists. Choose another group or do not restrict access to this component.')}</span>
+                                <span class="note">
+                                    ${_('This group no longer exists.  Choose another group or remove the access restriction.')}
+                                </span>
                             </label>
                             % else:
                             <label for="visibility-group-${partition["id"]}-${group["id"]}" class="label">${group["name"]}</label>

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -319,7 +319,7 @@ class BaseGroupConfigurationsTest(ContainerBase):
     CHOOSE_ONE = "Select a group type"
     CONTENT_GROUP_PARTITION = XBlockVisibilityEditorView.CONTENT_GROUP_PARTITION
     ENROLLMENT_TRACK_PARTITION = XBlockVisibilityEditorView.ENROLLMENT_TRACK_PARTITION
-    MISSING_GROUP_LABEL = 'Deleted Group\nThis group no longer exists. Choose another group or do not restrict access to this component.'
+    MISSING_GROUP_LABEL = 'Deleted Group\nThis group no longer exists. Choose another group or remove the access restriction.'
     VALIDATION_ERROR_LABEL = 'This component has validation issues.'
     VALIDATION_ERROR_MESSAGE = "Error:\nThis component's access settings refer to deleted or invalid groups."
     GROUP_VISIBILITY_MESSAGE = 'Access to some content in this unit is restricted to specific groups of learners.'

--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -8,7 +8,7 @@ from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Scope, String, XBlockMixin
 from xblock.validation import ValidationMessage
 
-from lms.lib.utils import get_parent_unit
+from lms.lib.utils import is_unit
 from xmodule.modulestore.inheritance import UserPartitionList
 from xmodule.partitions.partitions import NoSuchUserPartitionError, NoSuchUserPartitionGroupError
 
@@ -16,10 +16,16 @@ from xmodule.partitions.partitions import NoSuchUserPartitionError, NoSuchUserPa
 # more information can be found here: https://openedx.atlassian.net/browse/PLAT-902
 _ = lambda text: text
 
-INVALID_USER_PARTITION_VALIDATION = _(u"This component's access settings refer to deleted or invalid group configurations.")
-INVALID_USER_PARTITION_GROUP_VALIDATION_COMPONENT = _(u"This component's access settings refer to deleted or invalid groups.")
+INVALID_USER_PARTITION_VALIDATION_COMPONENT = _(
+    u"This component's access settings refer to deleted or invalid group configurations."
+)
+INVALID_USER_PARTITION_VALIDATION_UNIT = _(
+    u"This unit's access settings refer to deleted or invalid group configurations."
+)
+INVALID_USER_PARTITION_GROUP_VALIDATION_COMPONENT = _(
+    u"This component's access settings refer to deleted or invalid groups."
+)
 INVALID_USER_PARTITION_GROUP_VALIDATION_UNIT = _(u"This unit's access settings refer to deleted or invalid groups.")
-NONSENSICAL_ACCESS_RESTRICTION = _(u"This component's access settings contradict the unit's access settings.")
 NONSENSICAL_ACCESS_RESTRICTION = _(u"This component's access settings contradict its parent's access settings.")
 
 
@@ -35,6 +41,7 @@ class GroupAccessDict(Dict):
 
 
 @XBlock.needs('partitions')
+@XBlock.needs('i18n')
 class LmsBlockMixin(XBlockMixin):
     """
     Mixin that defines fields common to all blocks used in the LMS
@@ -180,16 +187,6 @@ class LmsBlockMixin(XBlockMixin):
         else:
             return False
 
-    def is_unit(self):
-        """
-        Returns whether the xblock is a unit.
-
-        Get_parent_unit() returns None if the current xblock either does not have a parent unit or is itself a unit.
-        To make sure that get_parent_unit() isn't returning None because the xblock is an orphan, we check that the
-        xblock has a parent.
-        """
-        return get_parent_unit(self) is None and self.get_parent()
-
     def validate(self):
         """
         Validates the state of this xblock instance.
@@ -198,6 +195,7 @@ class LmsBlockMixin(XBlockMixin):
         validation = super(LmsBlockMixin, self).validate()
         has_invalid_user_partitions = False
         has_invalid_groups = False
+        block_is_unit = is_unit(self)
 
         for user_partition_id, group_ids in self.group_access.iteritems():
             try:
@@ -217,7 +215,9 @@ class LmsBlockMixin(XBlockMixin):
             validation.add(
                 ValidationMessage(
                     ValidationMessage.ERROR,
-                    INVALID_USER_PARTITION_VALIDATION
+                    (INVALID_USER_PARTITION_VALIDATION_UNIT
+                     if block_is_unit
+                     else INVALID_USER_PARTITION_VALIDATION_COMPONENT)
                 )
             )
 
@@ -225,7 +225,9 @@ class LmsBlockMixin(XBlockMixin):
             validation.add(
                 ValidationMessage(
                     ValidationMessage.ERROR,
-                    INVALID_USER_PARTITION_GROUP_VALIDATION_UNIT if self.is_unit() else INVALID_USER_PARTITION_GROUP_VALIDATION_COMPONENT
+                    (INVALID_USER_PARTITION_GROUP_VALIDATION_UNIT
+                     if block_is_unit
+                     else INVALID_USER_PARTITION_GROUP_VALIDATION_COMPONENT)
                 )
             )
 

--- a/lms/lib/tests/test_utils.py
+++ b/lms/lib/tests/test_utils.py
@@ -57,3 +57,11 @@ class LmsUtilsTest(ModuleStoreTestCase):
         self.assertIsNone(utils.get_parent_unit(self.course))
         self.assertIsNone(utils.get_parent_unit(self.chapter))
         self.assertIsNone(utils.get_parent_unit(self.sequential))
+
+    def test_is_unit(self):
+        """
+        Tests `is_unit` method for the successful result.
+        """
+        self.assertFalse(utils.is_unit(self.html_module_1))
+        self.assertFalse(utils.is_unit(self.child_vertical))
+        self.assertTrue(utils.is_unit(self.vertical))

--- a/lms/lib/utils.py
+++ b/lms/lib/utils.py
@@ -28,3 +28,19 @@ def get_parent_unit(xblock):
         if parent.category == "vertical" and grandparent.category == "sequential":
             return parent
         xblock = parent
+
+
+def is_unit(xblock):
+    """
+    Checks whether the xblock is a unit.
+
+    Get_parent_unit() returns None if the current xblock either does
+    not have a parent unit or is itself a unit.
+    To make sure that get_parent_unit() isn't returning None because
+    the xblock is an orphan, we check that the xblock has a parent.
+
+    Returns:
+        True if the xblock is itself a unit, False otherwise.
+    """
+
+    return get_parent_unit(xblock) is None and xblock.get_parent()

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -5,7 +5,11 @@ import ddt
 from nose.plugins.attrib import attr
 
 from lms_xblock.mixin import (
-    INVALID_USER_PARTITION_VALIDATION, INVALID_USER_PARTITION_GROUP_VALIDATION_COMPONENT, INVALID_USER_PARTITION_GROUP_VALIDATION_UNIT, NONSENSICAL_ACCESS_RESTRICTION
+    INVALID_USER_PARTITION_GROUP_VALIDATION_COMPONENT,
+    INVALID_USER_PARTITION_GROUP_VALIDATION_UNIT,
+    INVALID_USER_PARTITION_VALIDATION_COMPONENT,
+    INVALID_USER_PARTITION_VALIDATION_UNIT,
+    NONSENSICAL_ACCESS_RESTRICTION
 )
 from xblock.validation import ValidationMessage
 from xmodule.modulestore import ModuleStoreEnum
@@ -92,14 +96,14 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
 
     def test_validate_invalid_user_partitions(self):
         """
-        Test the validation messages produced for an xblock referring to non-existent user partitions.
+        Test the validation messages produced for a component referring to non-existent user partitions.
         """
         self.set_group_access(self.video_location, {999: [self.group1.id]})
         validation = self.store.get_item(self.video_location).validate()
         self.assertEqual(len(validation.messages), 1)
         self.verify_validation_message(
             validation.messages[0],
-            INVALID_USER_PARTITION_VALIDATION,
+            INVALID_USER_PARTITION_VALIDATION_COMPONENT,
             ValidationMessage.ERROR,
         )
 
@@ -111,7 +115,32 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         self.assertEqual(len(validation.messages), 1)
         self.verify_validation_message(
             validation.messages[0],
-            INVALID_USER_PARTITION_VALIDATION,
+            INVALID_USER_PARTITION_VALIDATION_COMPONENT,
+            ValidationMessage.ERROR,
+        )
+
+    def test_validate_invalid_user_partitions_unit(self):
+        """
+        Test the validation messages produced for a unit referring to non-existent user partitions.
+        """
+        self.set_group_access(self.vertical_location, {999: [self.group1.id]})
+        validation = self.store.get_item(self.vertical_location).validate()
+        self.assertEqual(len(validation.messages), 1)
+        self.verify_validation_message(
+            validation.messages[0],
+            INVALID_USER_PARTITION_VALIDATION_UNIT,
+            ValidationMessage.ERROR,
+        )
+
+        # Now add a second invalid user partition and validate again.
+        # Note that even though there are two invalid configurations,
+        # only a single error message will be returned.
+        self.set_group_access(self.vertical_location, {998: [self.group2.id]})
+        validation = self.store.get_item(self.vertical_location).validate()
+        self.assertEqual(len(validation.messages), 1)
+        self.verify_validation_message(
+            validation.messages[0],
+            INVALID_USER_PARTITION_VALIDATION_UNIT,
             ValidationMessage.ERROR,
         )
 


### PR DESCRIPTION
## [EDUCATOR-1001](https://openedx.atlassian.net/browse/EDUCATOR-1001)

### Description

Fix validation messages and visibility editor to use language for units and components, depending on the type of the block.
Also adds a fix for some unit tests that need the i18n service

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Sandbox
- [x] Sandbox up at: https://studio-change-wording.sandbox.edx.org
        Unit page for course with no groups: https://studio-change-wording.sandbox.edx.org/container/block-v1:B+C+D+type@vertical+block@d4523fa404ff48648f31c3ab584a2c1a?action=new 
 
### Post-review
- [ ] Rebase and squash commits