### PR TITLE
Fixing flaky edx-proctoring acceptance tests

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -119,9 +119,11 @@ class InstructorDashboardPage(CoursePage):
         return ecommerce_section
 
     def is_rescore_unsupported_message_visible(self):
-        return u'This component cannot be rescored.' in unicode(
-            self.q(css='.request-response-error').html
-        )
+        if (self.q(css='.request-response-error').present):
+            return u'This component cannot be rescored.' in unicode(
+                self.q(css='.request-response-error').html
+            )
+        return False
 
     @staticmethod
     def get_asset_path(file_name):

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -285,6 +285,7 @@ class ProctoredExamTest(UniqueCourseTest):
         self.assertTrue(self.courseware_page.is_timer_bar_present)
 
         self.courseware_page.stop_timed_exam()
+        self.courseware_page.wait_for_page()
         self.assertTrue(self.courseware_page.has_submitted_exam_message())
 
         LogoutPage(self.browser).visit()

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -395,8 +395,8 @@ class ProctoredExamsTest(BaseInstructorDashboardTest):
 
         # Stop the timed exam.
         self.courseware_page.stop_timed_exam()
+        LogoutPage(self.browser).visit()
 
-    @skip("EDUCATOR-949")
     def test_can_add_remove_allowance(self):
         """
         Make sure that allowances can be added and removed.
@@ -426,7 +426,6 @@ class ProctoredExamsTest(BaseInstructorDashboardTest):
         # Then, the added record should be visible
         self.assertTrue(allowance_section.is_allowance_record_visible)
 
-    @skip("EDUCATOR-551, EDUCATOR-949")
     def test_can_reset_attempts(self):
         """
         Make sure that Exam attempts are visible and can be reset.
@@ -1375,7 +1374,6 @@ class StudentAdminTest(BaseInstructorDashboardTest):
         self.username, _ = self.log_in_as_instructor()
         self.instructor_dashboard_page = self.visit_instructor_dashboard()
 
-    @skip("EDUCATOR-552, EDUCATOR-949")
     def test_rescore_nonrescorable(self):
         student_admin_section = self.instructor_dashboard_page.select_student_admin(StudentSpecificAdmin)
         student_admin_section.set_student_email_or_username(self.username)


### PR DESCRIPTION
Fixing three flaky proctoring tests in `test_lms_instructor_dashboard.py`.

`test_can_add_remove_allowance()` and `test_can_reset_attempts()`: Both of these tests begin by logging in as a student, starting and finishing a timed exam, and then logging in as an instructor. These tests were failing when attempting to visit the instructor dashboard after logging in as an instructor and receiving a 404 error. These tests were fixed by explicitly logging out the student user before logging in as an instructor. These tests have passed ~140 times on Jenkins.

`test_rescore_nonrescorable():` This test calls the function `is_rescore_unsupported_message_visible()`. This function checks to see if an error message is displayed. I added a `.present` check inside this function to ensure that styling has been applied before checking for the error message. This test has passed ~100 times on Jenkins.

Fixing one flaky proctoring test in `test_lms_courseware.py`:

`test_timed_exam_flow()`: Added a `wait_for_page()` call before checking that the proper exam message is displayed. This test has passed ~60 times on Jenkins.

https://openedx.atlassian.net/browse/EDUCATOR-949
https://openedx.atlassian.net/browse/EDUCATOR-551 - `test_can_reset_attempts()`
https://openedx.atlassian.net/browse/EDUCATOR-552 - `test_rescore_nonrescorable()`
https://openedx.atlassian.net/browse/EDUCATOR-312 - `test_timed_exam_flow()`

@edx/educator-dahlia 

