### PR TITLE
EDUCATOR-783 | Upgrade to edxval 0.1.0 (supports django 1.11).

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -56,6 +56,7 @@ edx-organizations==0.4.5
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
 edx-submissions==2.0.5
+edxval==0.1.0
 event-tracking==0.2.4
 facebook-sdk==0.4.0
 feedparser==5.1.3

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -82,7 +82,6 @@ git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4b
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 git+https://github.com/edx/edx-ora2.git@1.4.8#egg=ora2==1.4.8
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
-git+https://github.com/edx/edx-val.git@0.0.18#egg=edxval==0.0.18
 git+https://github.com/edx/RecommenderXBlock.git@0e744b393cf1f8b886fe77bc697e7d9d78d65cd6#egg=recommender-xblock==1.2
 git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock


### PR DESCRIPTION
We can pull this from PyPI now, instead of github.