### PR TITLE
PLAT-1590 Fixes for Docker Devstack e2e tests

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -90,8 +90,9 @@ DEBUG_TOOLBAR_CONFIG = {
 }
 
 
-def should_show_debug_toolbar(_):
-    return True  # We always want the toolbar on devstack regardless of IP, auth, etc.
+def should_show_debug_toolbar(request):
+    # We always want the toolbar on devstack unless running tests from another Docker container
+    return not request.get_host().startswith('edx.devstack.studio:')
 
 
 # To see stacktraces for MongoDB queries, set this to True.

--- a/cms/envs/devstack_docker.py
+++ b/cms/envs/devstack_docker.py
@@ -10,7 +10,7 @@ LOGGING['handlers']['local'] = LOGGING['handlers']['tracking'] = {
 LOGGING['loggers']['tracking']['handlers'] = ['console']
 
 LMS_BASE = 'edx.devstack.lms:18000'
-CMS_BASE = 'edx.devstack.cms:18010'
+CMS_BASE = 'edx.devstack.studio:18010'
 LMS_ROOT_URL = 'http://{}'.format(LMS_BASE)
 
 

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -87,8 +87,9 @@ DEBUG_TOOLBAR_CONFIG = {
 }
 
 
-def should_show_debug_toolbar(_):
-    return True  # We always want the toolbar on devstack regardless of IP, auth, etc.
+def should_show_debug_toolbar(request):
+    # We always want the toolbar on devstack unless running tests from another Docker container
+    return not request.get_host().startswith('edx.devstack.lms:')
 
 
 ########################### PIPELINE #################################

--- a/lms/envs/devstack_docker.py
+++ b/lms/envs/devstack_docker.py
@@ -10,7 +10,7 @@ LOGGING['handlers']['local'] = LOGGING['handlers']['tracking'] = {
 LOGGING['loggers']['tracking']['handlers'] = ['console']
 
 LMS_BASE = 'edx.devstack.lms:18000'
-CMS_BASE = 'edx.devstack.cms:18010'
+CMS_BASE = 'edx.devstack.studio:18010'
 SITE_NAME = LMS_BASE
 LMS_ROOT_URL = 'http://{}'.format(LMS_BASE)
 


### PR DESCRIPTION
Fixed a couple of issues which were preventing end-to-end tests from passing under Docker Devstack:

* We had configured CMS_BASE with the wrong container name
* The Django Debug Toolbar was interfering with the tests; this turns it off only for requests from other Docker containers (usually tests from the Chrome and Firefox Selenium containers)