### PR TITLE
Re-add to BlockStructure cache on miss.

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/store.py
+++ b/openedx/core/djangoapps/content/block_structure/store.py
@@ -93,6 +93,7 @@ class BlockStructureStore(object):
             serialized_data = self._get_from_cache(bs_model)
         except BlockStructureNotFound:
             serialized_data = self._get_from_store(bs_model)
+            self._add_to_cache(serialized_data, bs_model)
 
         return self._deserialize(serialized_data, root_block_usage_key)
 


### PR DESCRIPTION
BlockStructures are stored in S3, but they're cached in memcached. Prior to this commit, they were only written to memcached when first created. This commit adds a write to repopulate the cache entry every time there is a cache miss. Hopefully, this will help reduce the miss rate we're seeing.