### PR TITLE
bump edx-sga XBlock to v0.6.4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -211,4 +211,4 @@ web-fragments==0.2.2
 xblock==1.0.0
 
 # Third Party XBlocks
-edx-sga==0.6.2
+edx-sga==0.6.4


### PR DESCRIPTION
See https://github.com/mitodl/edx-sga/pull/166#issuecomment-318354732 for details:

> Due to a recent Django Rest Framework to v3.6.3 (old version was v3.2.3), the DRF serializers are now more strict. If a non-string is sent to a Django CharField field, the serializer marks the request as invalid. 

Note that the [only change in v0.6.3](https://github.com/mitodl/edx-sga/blob/master/RELEASE.rst#version-063) was a fix to improve compatibility with accessibility testing. It must have been released to edx.org without updating requirements here. 