### PR TITLE
Bug fix: Reset "Notify users by email" check box to initial state.

### DIFF
--- a/lms/static/js/instructor_dashboard/membership.js
+++ b/lms/static/js/instructor_dashboard/membership.js
@@ -598,6 +598,7 @@ such that the value can be defined later than this assignment (file load order).
             this.$reason_field = this.$container.find("textarea[name='reason-field']");
             this.$checkbox_autoenroll = this.$container.find("input[name='auto-enroll']");
             this.$checkbox_emailstudents = this.$container.find("input[name='email-students']");
+            this.checkbox_emailstudents_initialstate = this.$checkbox_emailstudents.is(':checked');
             this.$task_response = this.$container.find('.request-response');
             this.$request_response_error = this.$container.find('.request-response-error');
             this.$enrollment_button.click(function(event) {
@@ -634,7 +635,7 @@ such that the value can be defined later than this assignment (file load order).
         batchEnrollment.prototype.clear_input = function() {
             this.$identifier_input.val('');
             this.$reason_field.val('');
-            this.$checkbox_emailstudents.attr('checked', true);
+            this.$checkbox_emailstudents.attr('checked', this.checkbox_emailstudents_initialstate);
             return this.$checkbox_autoenroll.attr('checked', true);
         };
 


### PR DESCRIPTION
This is a bug fix for #15392.

This PR introduced a setting to determine the initial state of the "Notify users by email" checkbox on the bulk enrollment page.  The setting works fine when the page is first loaded.  However, after submitting a batch the JS code resets the state of the check boxes, and does not reflect the new setting when doing so.

**JIRA tickets**: [OSPR-1847](https://openedx.atlassian.net/browse/OSPR-1847)

**Discussions**: None

**Dependencies**: None

**Screenshots**:

![image](https://user-images.githubusercontent.com/249196/27481330-50cdfe58-581c-11e7-822b-672efd329a1c.png)

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

On the devstack, add the `BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT` feature flag to the `FEATURES` dictionary in `lms.env.json`:

    ...
    "FEATURES": {
        "BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT": false,
        ...

Log in as the staff user, navigate to the "Membership" tab in the instructor dashboard on some course and notice that the status of the "Notify users by email" check box matches the setting.  Then click the "Enroll" button and notice that the state of the check box is reverted to its original state.

**Author notes and concerns**:

1. I don't understand why the JS code needs to reset the state of the check boxes after a batch has been sent.  In most cases, users won't want to submit a second batch, and if they do, I can't see why it should be more likely that they want to use the original state of the check boxes rather than the state they used for the previous batch.  However, since someone wrote code to reset the state I assume there is some reason to do so and modified the code accordingly.

1. My first attempt was to pass the `BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT` setting from the Python code via the HTML template to the JS code.  However, this became cumbersome quickly, so I chose to deduce the value of that setting from the initial state of the check box.

**Reviewers**
- [ ] @bdero 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT: false
```