### PR TITLE
Collect translation strings from the openedx folder

### DIFF
--- a/conf/locale/babel_mako.cfg
+++ b/conf/locale/babel_mako.cfg
@@ -10,6 +10,7 @@
 #   common/djangoapps/APPNAME/templates
 #   lms/templates
 #   lms/djangoapps/APPNAME/templates
+#   openedx/**/templates
 #   common/lib/capa/capa/templates
 #
 # Don't extract from these directory trees:
@@ -25,6 +26,8 @@ input_encoding = utf-8
 [mako: */templates/emails/**.txt]
 input_encoding = utf-8
 [mako: common/lib/capa/capa/templates/**.html]
+input_encoding = utf-8
+[mako: openedx/**/templates/**.html]
 input_encoding = utf-8
 [mako: themes/**.html]
 input_encoding = utf-8


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-2112

Pierre Mailhot reported in Slack that the Ginkgo release did not include translations for the new course landing experience. Upon further investigation, it was discovered that no Mako templates are being considered from the openedx directory. This has not been a problem until now because there were very few Mako templates in openedx/core/djangoapps as most of the features provided capabilities rather than user interfaces. 

This is a very simple change to add templates directories beneath openedx to the set of paths searched by the Babel-Mako plugin. I verified manually that all of the expected strings are generated, but I do not want to include them in this PR (they can be updated via the standard process).

FYI @bderusha @nedbat @gsong 