### PR TITLE
Educator-986 large space in show answer view for instructors

### DIFF
--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -19,7 +19,6 @@ html.video-fullscreen {
   @extend %ui-print-excluded;
 
   margin: ($baseline/2) ($baseline/4) 0 0;
-  overflow: hidden;
 
   &.studio-view {
     margin: 0;

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -244,7 +244,6 @@
       &.studio-view {
         position: relative;
         margin: ($baseline/2) 0 0 0;
-        overflow: hidden;
       }
 
       .instructor-info-action {


### PR DESCRIPTION
## [EDUCATOR-986](https://openedx.atlassian.net/browse/EDUCATOR-986)

### Description

Removed large amount of white space in "show answer" view for instructors.

### Sandbox
- [x] ssemenova-ed986.sandbox.edx.org
Direct link to problem: https://ssemenova-ed986.sandbox.edx.org/courses/course-v1:asdf+asdf+asdf/courseware/b3f368aebc49498c898d97d95e96cc7d/ecc37ae9a2f44c57a0ccc691b0e007c1/?activate_block_id=block-v1%3Aasdf%2Basdf%2Basdf%2Btype%40sequential%2Bblock%40ecc37ae9a2f44c57a0ccc691b0e007c1

### Reviewers
- [x] @cahrens 
 
### Post-review
- [x] Rebase and squash commits
