### PR TITLE
Fixed problem with non-Latin characters in loncapa/python problems

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     dog_stats_api = None
 from pytz import utc
+from django.utils.encoding import smart_text
 
 from capa.capa_problem import LoncapaProblem, LoncapaSystem
 from capa.inputtypes import Status
@@ -700,7 +701,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
 
         content = {
             'name': self.display_name_with_default,
-            'html': html,
+            'html': smart_text(html),
             'weight': self.weight,
         }
 

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -2541,15 +2541,10 @@ class CapaDescriptorTest(unittest.TestCase):
         name = "Non latin Input"
         descriptor = self._create_descriptor(sample_text_input_problem_xml, name=name)
         capa_content = " FX1_VAL='Καλημέρα' Δοκιμή με μεταβλητές με Ελληνικούς χαρακτήρες μέσα σε python: $FX1_VAL "
+
+        descriptor_dict = descriptor.index_dictionary()
         self.assertEquals(
-            descriptor.index_dictionary(), {
-                'content_type': CapaDescriptor.INDEX_CONTENT_TYPE,
-                'problem_types': [],
-                'content': {
-                    'display_name': name,
-                    'capa_content': smart_text(capa_content)
-                }
-            }
+            descriptor_dict['content']['capa_content'], smart_text(capa_content)
         )
 
     def test_indexing_checkboxes_with_hints_and_feedback(self):

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -14,6 +14,7 @@ import textwrap
 import unittest
 
 import ddt
+from django.utils.encoding import smart_text
 from lxml import etree
 from mock import Mock, patch, DEFAULT
 import webob
@@ -2526,6 +2527,27 @@ class CapaDescriptorTest(unittest.TestCase):
                 'content': {
                     'display_name': name,
                     'capa_content': capa_content.replace("\n", " ")
+                }
+            }
+        )
+
+    def test_indexing_non_latin_problem(self):
+        sample_text_input_problem_xml = textwrap.dedent("""
+            <problem>
+                <script type="text/python">FX1_VAL='Καλημέρα'</script>
+                <p>Δοκιμή με μεταβλητές με Ελληνικούς χαρακτήρες μέσα σε python: $FX1_VAL</p>
+            </problem>
+        """)
+        name = "Non latin Input"
+        descriptor = self._create_descriptor(sample_text_input_problem_xml, name=name)
+        capa_content = " FX1_VAL='Καλημέρα' Δοκιμή με μεταβλητές με Ελληνικούς χαρακτήρες μέσα σε python: $FX1_VAL "
+        self.assertEquals(
+            descriptor.index_dictionary(), {
+                'content_type': CapaDescriptor.INDEX_CONTENT_TYPE,
+                'problem_types': [],
+                'content': {
+                    'display_name': name,
+                    'capa_content': smart_text(capa_content)
                 }
             }
         )


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://openedx.atlassian.net/browse/CRI-66
fixes https://github.com/mitodl/edx-platform/issues/25

#### What's this PR do?
It allows staff/problems to create problems with non latin characters. 
The solution was originally suggested by @nedbat in https://openedx.atlassian.net/browse/CRI-66, 
was `html.decode('utf8').encode('ascii', 'xmlcharrefreplace')`. It was was not working on a test, which has unique text.

```python
test_get_problem_html_error_w_debug(self):
    error_msg = u"Superterrible error happened: ☠"
```

Thats why i did not use that suggestion instead i used django [smart_text](https://docs.djangoproject.com/en/1.11/_modules/django/utils/encoding/).

#### How should this be manually tested?
- Open https://openedx.atlassian.net/browse/CRI-66 
- Go to studio and the course, create a empty problem then paste no latin problem from CRI-66  in it
- It will give you error on master
- But if you switch to my branch issue will be fix


@pdpinch 

#### Screenshots:
<img width="1150" alt="screen shot 2017-08-17 at 4 52 16 pm" src="https://user-images.githubusercontent.com/10431250/29410991-81be7b3e-836c-11e7-8359-a6170bdca5b7.png">

<img width="1138" alt="screen shot 2017-08-17 at 4 52 26 pm" src="https://user-images.githubusercontent.com/10431250/29410992-81beadac-836c-11e7-83c2-ad48c1e1afb5.png">
