### PR TITLE
EDUCATOR-1029 | More defensive version of ZeroSubsectionGrade.problem_scores

### DIFF
--- a/lms/djangoapps/grades/new/subsection_grade.py
+++ b/lms/djangoapps/grades/new/subsection_grade.py
@@ -81,9 +81,11 @@ class ZeroSubsectionGrade(SubsectionGradeBase):
         ):
             block = self.course_data.structure[block_key]
             if getattr(block, 'has_score', False):
-                locations[block_key] = get_score(
+                problem_score = get_score(
                     submissions_scores={}, csm_scores={}, persisted_block=None, block=block,
                 )
+                if problem_score is not None:
+                    locations[block_key] = problem_score
         return locations
 
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-1029

Also added a unit test to surface the bug that this change fixes.

**Reviewers**
- [ ] @nasthagiri 
- [x] @sanfordstudent 

**FYI**
@nedbat 