### PR TITLE
Pin Jasmine version to fix js failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-config-edx": "^3.0.0",
     "eslint-config-edx-es5": "^2.0.0",
     "eslint-import-resolver-webpack": "^0.8.1",
-    "jasmine-core": "^2.6.4",
+    "jasmine-core": "2.6.4",
     "jasmine-jquery": "^2.1.1",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.3",


### PR DESCRIPTION
Jasmine 2.70 was causing all js builds to fail.

https://github.com/jasmine/jasmine/blob/master/release_notes/2.7.0.md