### PR TITLE
EDUCATOR-526 Update view certificate button

### DIFF
--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -516,6 +516,7 @@ class DashboardTest(ModuleStoreTestCase):
             expiration_datetime=datetime.now(pytz.UTC) - timedelta(days=1)
         )
 
+        self.course.certificate_available_date = datetime.now(pytz.UTC) - timedelta(days=1)
         CourseEnrollment.enroll(self.user, self.course.id, mode='honor')
 
         self.course.start = datetime.now(pytz.UTC) - timedelta(days=2)

--- a/common/lib/xmodule/xmodule/course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/course_metadata_utils.py
@@ -93,7 +93,12 @@ def course_start_date_is_default(start, advertised_start):
     return advertised_start is None and start == DEFAULT_START_DATE
 
 
-def may_certify_for_course(certificates_display_behavior, certificates_show_before_end, has_ended):
+def may_certify_for_course(
+        certificates_display_behavior,
+        certificates_show_before_end,
+        has_ended,
+        certificate_available_date
+):
     """
     Returns whether it is acceptable to show the student a certificate download
     link for a course.
@@ -105,12 +110,24 @@ def may_certify_for_course(certificates_display_behavior, certificates_show_befo
         certificates_show_before_end (bool): whether user can download the
             course's certificates before the course has ended.
         has_ended (bool): Whether the course has ended.
+        certificate_available_date (datetime): the date the certificate is available on for the course.
     """
     show_early = (
         certificates_display_behavior in ('early_with_info', 'early_no_info')
         or certificates_show_before_end
     )
-    return show_early or has_ended
+    past_availability_date = (
+        certificate_available_date
+        and certificate_available_date < datetime.now(utc)
+    )
+
+    if show_early:
+        return True
+    if past_availability_date:
+        return True
+    if (certificate_available_date is None) and has_ended:
+        return True
+    return False
 
 
 def sorting_score(start, advertised_start, announcement):

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1065,7 +1065,8 @@ class CourseDescriptor(CourseFields, SequenceDescriptor, LicenseMixin):
         return course_metadata_utils.may_certify_for_course(
             self.certificates_display_behavior,
             self.certificates_show_before_end,
-            self.has_ended()
+            self.has_ended(),
+            self.certificate_available_date
         )
 
     def has_started(self):

--- a/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
@@ -161,11 +161,14 @@ class CourseMetadataUtilsTestCase(TestCase):
                 TestScenario((DEFAULT_START_DATE, None), True),
             ]),
             FunctionTest(may_certify_for_course, [
-                TestScenario(('early_with_info', True, True), True),
-                TestScenario(('early_no_info', False, False), True),
-                TestScenario(('end', True, False), True),
-                TestScenario(('end', False, True), True),
-                TestScenario(('end', False, False), False),
+                TestScenario(('early_with_info', True, True, test_datetime), True),
+                TestScenario(('early_no_info', False, False, test_datetime), True),
+                TestScenario(('end', True, False, test_datetime), True),
+                TestScenario(('end', False, True, test_datetime), True),
+                TestScenario(('end', False, False, _NEXT_WEEK), False),
+                TestScenario(('end', False, False, _LAST_WEEK), True),
+                TestScenario(('end', False, False, None), False),
+                TestScenario(('early_with_info', False, False, None), True),
             ]),
         ]
 

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from functools import wraps
 
 import ddt
+from datetime import datetime
 from config_models.models import cache
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -92,7 +93,8 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
         self.course = CourseFactory.create(
             org='edx',
             number='verified',
-            display_name='Verified Course'
+            display_name='Verified Course',
+            end=datetime.now()
         )
 
         self.request_factory = RequestFactory()

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1215,6 +1215,8 @@ class ProgressPageBaseTests(ModuleStoreTestCase):
         self.course = CourseFactory.create(
             start=datetime(2013, 9, 16, 7, 17, 28),
             grade_cutoffs={u'çü†øƒƒ': 0.75, 'Pass': 0.5},
+            end=datetime.now(),
+            certificate_available_date=datetime.now(),
             **options
         )
 
@@ -2051,6 +2053,7 @@ class GenerateUserCertTests(ModuleStoreTestCase):
         self.course = CourseFactory.create(
             org='edx',
             number='verified',
+            end=datetime.now(),
             display_name='Verified Course',
             grade_cutoffs={'cutoff': 0.75, 'Pass': 0.5}
         )

--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -13,6 +13,7 @@ Test utilities for mobile API tests:
 from datetime import timedelta
 
 import ddt
+import datetime
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils import timezone
@@ -39,7 +40,10 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
     """
     def setUp(self):
         super(MobileAPITestCase, self).setUp()
-        self.course = CourseFactory.create(mobile_available=True, static_asset_path="needed_for_split")
+        self.course = CourseFactory.create(
+            mobile_available=True,
+            static_asset_path="needed_for_split",
+            end=datetime.datetime.now())
         self.user = UserFactory.create()
         self.password = 'test'
         self.username = self.user.username

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -67,6 +67,7 @@ from django.utils.http import urlquote_plus
                                 <h4 class="hd hd-4 title">${certificate_data.title}</h4>
                                 <p class="copy">${certificate_data.msg}</p>
                             </div>
+                            %if certificate_data.may_view_certificate:
                             <div class="msg-actions">
                                 %if certificate_data.cert_web_view_url:
                                 <a class="btn" href="${certificate_data.cert_web_view_url}" target="_blank">${_("View Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
@@ -76,6 +77,7 @@ from django.utils.http import urlquote_plus
                                 <button class="btn generate_certs" data-endpoint="${post_url}" id="btn_generate_cert">${_('Request Certificate')}</button>
                                 %endif
                             </div>
+                            %endif
                         </div>
                     </div>
                     %endif

--- a/openedx/core/djangoapps/content/course_overviews/migrations/0014_courseoverview_certificate_available_date.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0014_courseoverview_certificate_available_date.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_overviews', '0013_courseoverview_language'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseoverview',
+            name='certificate_available_date',
+            field=models.DateTimeField(default=None, null=True),
+        ),
+    ]

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -75,6 +75,7 @@ class CourseOverview(TimeStampedModel):
     has_any_active_web_certificate = BooleanField(default=False)
     cert_name_short = TextField()
     cert_name_long = TextField()
+    certificate_available_date = DateTimeField(default=None, null=True)
 
     # Grading
     lowest_passing_grade = DecimalField(max_digits=5, decimal_places=2, null=True)
@@ -172,6 +173,7 @@ class CourseOverview(TimeStampedModel):
         course_overview.has_any_active_web_certificate = (get_active_web_certificate(course) is not None)
         course_overview.cert_name_short = course.cert_name_short
         course_overview.cert_name_long = course.cert_name_long
+        course_overview.certificate_available_date = course.certificate_available_date
         course_overview.lowest_passing_grade = lowest_passing_grade
         course_overview.end_of_course_survey_url = course.end_of_course_survey_url
 
@@ -476,7 +478,8 @@ class CourseOverview(TimeStampedModel):
         return course_metadata_utils.may_certify_for_course(
             self.certificates_display_behavior,
             self.certificates_show_before_end,
-            self.has_ended()
+            self.has_ended(),
+            self.certificate_available_date
         )
 
     @property


### PR DESCRIPTION
## [EDUCATOR-526](https://openedx.atlassian.net/browse/EDUCATOR-526)

### Description

Update view certificate button to only show after the certificate availability date has passed.

### Sandbox
- [ ] https://ssemenova.sandbox.edx.org/courses/course-v1:Test+Test+Test/progress
(Log in with honor)

### Testing
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Performance
- [ ] Database migrations are backwards-compatible

### Reviewers
- [ ] @sanfordstudent 

List optional/FYI reviewers here:
 
### Post-review
- [ ] Rebase and squash commits
