### PR TITLE
EDUCATOR-1031 Fix discussion search by username.

### DIFF
--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -1342,6 +1342,13 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
         actual = self.page.get_search_alert_messages()
         self.assertTrue(all(map(lambda msg, sub: msg.lower().find(sub.lower()) >= 0, actual, expected)))
 
+    def check_search_alert_message_for_user(self, expected):
+        """
+        Check that the serached user has notification message.
+        """
+        actual = self.page.get_search_alert_messages()
+        self.assertEqual(actual, expected)
+
     @attr(shard=2)
     def test_no_rewrite(self):
         self.setup_corrected_text(None)
@@ -1374,13 +1381,13 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
     def test_rewrite_and_user(self):
         self.setup_corrected_text("foo")
         self.page.perform_search(self.SEARCHED_USERNAME)
-        self.check_search_alert_messages(["foo", self.SEARCHED_USERNAME])
+        self.check_search_alert_message_for_user([u'Show posts by %s.' % self.SEARCHED_USERNAME])
 
     @attr(shard=2)
     def test_user_only(self):
         self.setup_corrected_text(None)
         self.page.perform_search(self.SEARCHED_USERNAME)
-        self.check_search_alert_messages(["no posts", self.SEARCHED_USERNAME])
+        self.check_search_alert_message_for_user([u'Show posts by %s.' % self.SEARCHED_USERNAME])
         # make sure clicking the link leads to the user profile page
         UserProfileViewFixture([]).push()
         self.page.get_search_alert_links().first.click()


### PR DESCRIPTION
## [EDUCATOR-1031](https://openedx.atlassian.net/browse/EDUCATOR-1031)

### Description
This PR fixes that when you search your discussion post with a username it returns all the posts, posted by users.

### How to Test?

**Production** 
- Go to the Discussion page: https://courses.edx.org/courses/course-v1:W3Cx+CSS.0x+1T2017/discussion/forum/
- Search with username: **Syllie** , it only returns the three posts
- Go to this link: https://courses.edx.org/courses/course-v1:W3Cx+CSS.0x+1T2017/discussion/forum/users/1196285
- This user has so many discussion and comments.

**Sandbox**
- https://discussion-search.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/
- Username : _**staff**_

### Tests
 - [x] Acceptance Test
 - [x] Jasmine Test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @asadazam93 
- [ ] @Rabia23 


### Post-review
- [ ] Rebase and squash commits

