### PR TITLE
PLAT-1676 Use pytest for bok-choy tests

### DIFF
--- a/common/test/acceptance/.coveragerc
+++ b/common/test/acceptance/.coveragerc
@@ -10,20 +10,31 @@ source =
 omit =
     lms/envs/*
     cms/envs/*
+    cms/manage.py
+    cms/djangoapps/contentstore/views/dev.py
     common/djangoapps/terrain/*
     common/djangoapps/*/migrations/*
+    openedx/core/djangoapps/debug/*
     openedx/core/djangoapps/*/migrations/*
     */test*
     */management/*
     */urls*
     */wsgi*
+    lms/debug/*
+    lms/djangoapps/*/features/*
     lms/djangoapps/*/migrations/*
+    cms/djangoapps/*/features/*
     cms/djangoapps/*/migrations/*
 
+concurrency = multiprocessing
 parallel = True
 
 [report]
 ignore_errors = True
+
+exclude_lines =
+   pragma: no cover
+   raise NotImplementedError
 
 [html]
 title = Bok Choy Test Coverage Report

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -1226,6 +1226,7 @@ class DiscussionUserProfileTest(UniqueCourseTest):
         self.profiled_user_id = self.setup_user(username=self.PROFILED_USERNAME)
         # now create a second user who will view the profile.
         self.user_id = self.setup_user()
+        UserProfileViewFixture([]).push()
 
     def setup_course(self):
         """

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -437,14 +437,14 @@ To test only a certain feature, specify the file and the testcase class.
 
 ::
 
-    paver test_bokchoy -t studio/test_studio_bad_data.py:BadComponentTest
+    paver test_bokchoy -t studio/test_studio_bad_data.py::BadComponentTest
 
 To execute only a certain test case, specify the file name, class, and
 test case method.
 
 ::
 
-    paver test_bokchoy -t lms/test_lms.py:RegistrationTest.test_register
+    paver test_bokchoy -t lms/test_lms.py::RegistrationTest::test_register
 
 During acceptance test execution, log files and also screenshots of
 failed tests are captured in test\_root/log.
@@ -454,7 +454,7 @@ If you check this in, your tests will hang on jenkins.
 
 ::
 
-    from nose.tools import set_trace; set_trace()
+    import pdb; pdb.set_trace()
 
 By default, all bokchoy tests are run with the 'split' ModuleStore. To
 override the modulestore that is used, use the default\_store option.
@@ -506,7 +506,7 @@ relative to the ``common/test/acceptance/tests`` directory. This is an example f
 
 ::
 
-    paver test_a11y -t lms/test_lms_dashboard.py:LmsDashboardA11yTest.test_dashboard_course_listings_a11y
+    paver test_a11y -t lms/test_lms_dashboard.py::LmsDashboardA11yTest::test_dashboard_course_listings_a11y
 
 **Coverage**:
 
@@ -644,7 +644,7 @@ Running Tests on Paver Scripts
 
 To run tests on the scripts that power the various Paver commands, use the following command::
 
-  nosetests paver
+  nosetests pavelib
 
 
 Testing internationalization with dummy translations

--- a/pavelib/paver_tests/test_utils.py
+++ b/pavelib/paver_tests/test_utils.py
@@ -6,9 +6,11 @@ import unittest
 
 from mock import patch
 
+from pavelib.utils.envs import Env
 from pavelib.utils.test.utils import MINIMUM_FIREFOX_VERSION, check_firefox_version
 
 
+@unittest.skipIf(Env.USING_DOCKER, 'Firefox version check works differently under Docker Devstack')
 class TestUtils(unittest.TestCase):
     """
     Test utils.py under pavelib/utils/test

--- a/pavelib/utils/test/bokchoy_options.py
+++ b/pavelib/utils/test/bokchoy_options.py
@@ -19,8 +19,16 @@ BOKCHOY_DEFAULT_STORE_DEPR = make_option(
     default=os.environ.get('DEFAULT_STORE', 'split'),
     help='deprecated in favor of default-store'
 )
-BOKCHOY_FASTTEST = make_option('-a', '--fasttest', action='store_true', help='Skip some setup')
-BOKCHOY_COVERAGERC = make_option('--coveragerc', help='coveragerc file to use during this test')
+BOKCHOY_EVAL_ATTR = make_option(
+    "-a", "--eval-attr",
+    dest="eval_attr", help="Only run tests matching given attribute expression."
+)
+BOKCHOY_FASTTEST = make_option('--fasttest', action='store_true', help='Skip some setup')
+BOKCHOY_COVERAGERC = make_option(
+    '--coveragerc',
+    default=Env.BOK_CHOY_COVERAGERC,
+    help='coveragerc file to use during this test'
+)
 
 BOKCHOY_OPTS = [
     ('test-spec=', 't', 'Specific test to run'),
@@ -28,7 +36,9 @@ BOKCHOY_OPTS = [
     ('skip-clean', 'C', 'Skip cleaning repository before running tests'),
     make_option('-r', '--serversonly', action='store_true', help='Prepare suite and leave servers running'),
     make_option('-o', '--testsonly', action='store_true', help='Assume servers are running and execute tests only'),
+    BOKCHOY_COVERAGERC,
     BOKCHOY_DEFAULT_STORE,
+    BOKCHOY_EVAL_ATTR,
     make_option(
         '-d', '--test-dir',
         default='tests',

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -9,4 +9,11 @@
 #   * @edx/testeng - to discuss it's impact on test infrastructure
 #   * @edx/devops - to check system requirements
 
+execnet==1.4.1
+py==1.4.34
 pysqlite==2.8.3
+pytest==3.1.3
+pytest-attrib==0.1.3
+pytest-catchlog==1.2.2
+pytest-django==3.1.2
+pytest-xdist==1.18.1

--- a/scripts/accessibility-tests.sh
+++ b/scripts/accessibility-tests.sh
@@ -6,7 +6,7 @@ echo "Setting up for accessibility tests..."
 source scripts/jenkins-common.sh
 
 echo "Running explicit accessibility tests..."
-SELENIUM_BROWSER=phantomjs paver test_a11y --with-xunitmp
+SELENIUM_BROWSER=phantomjs paver test_a11y
 
 echo "Generating coverage report..."
 paver a11y_coverage

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -162,7 +162,7 @@ case "$TEST_SUITE" in
 
     "bok-choy")
 
-        PAVER_ARGS="-n $NUMBER_OF_BOKCHOY_THREADS --with-flaky --with-xunit"
+        PAVER_ARGS="-n $NUMBER_OF_BOKCHOY_THREADS"
 
         case "$SHARD" in
 
@@ -171,11 +171,11 @@ case "$TEST_SUITE" in
                 ;;
 
             [1-9]|10)
-                paver test_bokchoy --attr="shard=$SHARD" $PAVER_ARGS
+                paver test_bokchoy --eval-attr="shard==$SHARD" $PAVER_ARGS
                 ;;
 
             11|"noshard")
-                paver test_bokchoy --attr='!shard,a11y=False' $PAVER_ARGS
+                paver test_bokchoy --eval-attr='not shard and not a11y' $PAVER_ARGS
                 ;;
 
             # Default case because if we later define another bok-choy shard on Jenkins
@@ -190,7 +190,7 @@ case "$TEST_SUITE" in
                 # May be unnecessary if we changed the "Skip if there are no test files"
                 # option to True in the jenkins job definitions.
                 mkdir -p reports/bok_choy
-                emptyxunit "bok_choy/nosetests"
+                emptyxunit "bok_choy/xunit"
                 ;;
         esac
         ;;

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,9 @@ process-timeout=300
 #nocapture=1
 #pdb=1
 
+[tool:pytest]
+norecursedirs = .git conf node_modules test_root cms/envs lms/envs
+
 [pep8]
 # error codes: http://pep8.readthedocs.org/en/latest/intro.html#error-codes
 # E501: line too long


### PR DESCRIPTION
Switching bok-choy and a11y tests to use pytest instead of nose, as a first step in switching over all of the edx-platform tests.

* Added pytest and the plugins we immediately need
* Switched the appropriate paver commands to run pytest instead of nosetests, using equivalent arguments
* Fixed code coverage data collection for bok-choy tests
* Made some minimal changes to the Jenkins testing scripts
* Fixed one test class which had been depending on another class running first to install a fixture
* Updated the testing doc accordingly