### PR TITLE
ENT-555: Continue button is not appearing on registration page.

### DIFF
--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -591,6 +591,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
             "secondaryProviders": [],
             "finishAuthUrl": finish_auth_url,
             "errorMessage": None,
+            "registerFormSubmitButtonText": "Create Account",
         }
         if expected_ec is not None:
             # If we set an EnterpriseCustomer, third-party auth providers ought to be hidden.

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -316,6 +316,7 @@ def _third_party_auth_context(request, redirect_to, tpa_hint=None):
         "secondaryProviders": [],
         "finishAuthUrl": None,
         "errorMessage": None,
+        "registerFormSubmitButtonText": _("Create Account"),
     }
 
     if third_party_auth.is_enabled():
@@ -361,6 +362,7 @@ def _third_party_auth_context(request, redirect_to, tpa_hint=None):
                         ).format(
                             configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
                         )
+                        context["registerFormSubmitButtonText"] = _("Continue")
 
         # Check for any error messages we may want to display:
         for msg in messages.get_messages(request):

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -58,6 +58,8 @@
                     this.autoSubmit = data.thirdPartyAuth.autoSubmitRegForm;
                     this.hideAuthWarnings = data.hideAuthWarnings;
                     this.autoRegisterWelcomeMessage = data.thirdPartyAuth.autoRegisterWelcomeMessage || '';
+                    this.registerFormSubmitButtonText =
+                        data.thirdPartyAuth.registerFormSubmitButtonText || _('Create Account');
 
                     this.listenTo(this.model, 'sync', this.saveSuccess);
                     this.listenTo(this.model, 'validation', this.renderLiveValidations);
@@ -77,7 +79,8 @@
                             providers: this.providers,
                             hasSecondaryProviders: this.hasSecondaryProviders,
                             platformName: this.platformName,
-                            autoRegisterWelcomeMessage: this.autoRegisterWelcomeMessage
+                            autoRegisterWelcomeMessage: this.autoRegisterWelcomeMessage,
+                            registerFormSubmitButtonText: this.registerFormSubmitButtonText
                         }
                     }));
 

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -51,5 +51,7 @@
 
     <%= context.fields %>
 
-    <button type="submit" class="action action-primary action-update js-register register-button"><%- gettext("Create account") %></button>
+    <button type="submit" class="action action-primary action-update js-register register-button">
+    	<% if ( context.registerFormSubmitButtonText ) { %><%- context.registerFormSubmitButtonText %><% } else { %><%- gettext("Create Account") %><% } %>
+    </button>
 </form>


### PR DESCRIPTION
Hi @douglashall , @brittneyexline , @zubair-arbi , @asadiqbal08 

Please take a look at the changes, this PR updates "Create Account" button to "Continue" button for account registration form submission for enterprise learners coming through SSO flow.

**Description:**
When Auto-registration is turned on and the user redirects to registration page, "Create Account" button text should appear as "Continue".
