### PR TITLE
Added new signal to refund on un-enrollment from LMS dashboard.

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -60,6 +60,7 @@ from util.query import use_read_replica_if_available
 
 UNENROLL_DONE = Signal(providing_args=["course_enrollment", "skip_refund"])
 ENROLL_STATUS_CHANGE = Signal(providing_args=["event", "user", "course_id", "mode", "cost", "currency"])
+REFUND_ORDER = Signal(providing_args=["course_enrollment"])
 log = logging.getLogger(__name__)
 AUDIT_LOG = logging.getLogger("audit")
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore  # pylint: disable=invalid-name

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -119,7 +119,8 @@ from student.models import (
     UserStanding,
     anonymous_id_for_user,
     create_comments_service_user,
-    unique_id_for_user
+    unique_id_for_user,
+    REFUND_ORDER
 )
 from student.tasks import send_activation_email
 from third_party_auth import pipeline, provider
@@ -1267,6 +1268,7 @@ def change_enrollment(request, check_access=True):
             return HttpResponseBadRequest(_("Your certificate prevents you from unenrolling from this course"))
 
         CourseEnrollment.unenroll(user, course_id)
+        REFUND_ORDER.send(sender=None, course_enrollment=enrollment)
         return HttpResponse()
     else:
         return HttpResponseBadRequest(_("Enrollment action is invalid"))

--- a/lms/djangoapps/commerce/signals.py
+++ b/lms/djangoapps/commerce/signals.py
@@ -19,21 +19,19 @@ from openedx.core.djangoapps.commerce.utils import ecommerce_api_client, is_comm
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming import helpers as theming_helpers
 from request_cache.middleware import RequestCache
-from student.models import UNENROLL_DONE
+from student.models import REFUND_ORDER
 
 log = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-argument
-@receiver(UNENROLL_DONE)
-def handle_unenroll_done(sender, course_enrollment=None, skip_refund=False, **kwargs):
+@receiver(REFUND_ORDER)
+def handle_refund_order(sender, course_enrollment=None, **kwargs):
     """
     Signal receiver for unenrollments, used to automatically initiate refunds
     when applicable.
-
-    N.B. this signal is also consumed by lms.djangoapps.shoppingcart.
     """
-    if not is_commerce_service_configured() or skip_refund:
+    if not is_commerce_service_configured():
         return
 
     if course_enrollment and course_enrollment.refundable():


### PR DESCRIPTION
LEARNER-1801

For support created refunds, as part of the refund fulfillment, an api request sent from ecommerce was made to the enrollment api on LMS at this point, we try to make a call to ecommerce api again. But at this moment, there won't be a good authenticated user on LMS to make this API call. Therefore, the authentication on ecommerce api would fail because of "Client error". This means, the support initiated refund would result in "Revocation Error" status.

To fix this created a new signal `REFUND_ORDER`, which will be sent on unenroll from LMS dashboard.
