### PR TITLE
edx-submissions 2.0.6 upgrade

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -55,7 +55,7 @@ edx-opaque-keys==0.4.0
 edx-organizations==0.4.5
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
-edx-submissions==2.0.5
+edx-submissions==2.0.6
 edxval==0.1.1
 event-tracking==0.2.4
 facebook-sdk==0.4.0

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -80,7 +80,7 @@ git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4b
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail==0.0
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@1.4.8#egg=ora2==1.4.8
+git+https://github.com/edx/edx-ora2.git@1.4.9#egg=ora2==1.4.9
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/RecommenderXBlock.git@0e744b393cf1f8b886fe77bc697e7d9d78d65cd6#egg=recommender-xblock==1.2
 git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1


### PR DESCRIPTION
Pairs with https://github.com/edx/edx-ora2/pull/1029, tests will fail until the new ORA release tag is created, I'll re-run them at that point.