### PR TITLE
EDUCATOR-1072 | Don't validate certificate_available_date field just yet

### DIFF
--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -52,14 +52,6 @@ define(['backbone', 'underscore', 'gettext', 'js/models/validation_helpers', 'js
                 if (newattrs.start_date && newattrs.enrollment_start && newattrs.start_date < newattrs.enrollment_start) {
                     errors.enrollment_start = gettext('The course start date must be later than the enrollment start date.');
                 }
-                if (
-                    newattrs.start_date && newattrs.certificate_available_date && newattrs.start_date >
-                    newattrs.certificate_available_date
-                ) {
-                    errors.enrollment_start = gettext(
-                        'The certificate available date must be later than the enrollment start date.'
-                    );
-                }
                 if (newattrs.enrollment_start && newattrs.enrollment_end && newattrs.enrollment_start >= newattrs.enrollment_end) {
                     errors.enrollment_end = gettext('The enrollment start date cannot be after the enrollment end date.');
                 }


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-1072

The simplest option here was to leave the backend alone w.r.t. this field and just remove the validation code related to it in the front end.

*Reviewers*
- [ ] @sanfordstudent 
- [ ] @nasthagiri 