### PR TITLE
Dont fetch caption on getting translations

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_caption_spec.js
@@ -779,7 +779,6 @@
                 Caption.fetchAvailableTranslations();
 
                 expect($.ajaxWithPrefix).toHaveBeenCalled();
-                expect(Caption.fetchCaption).toHaveBeenCalled();
                 expect(state.config.transcriptLanguages).toEqual({
                     'uk': 'Ukrainian',
                     'de': 'German'
@@ -799,7 +798,6 @@
                 Caption.fetchAvailableTranslations();
 
                 expect($.ajaxWithPrefix).toHaveBeenCalled();
-                expect(Caption.fetchCaption).not.toHaveBeenCalled();
                 expect(state.config.transcriptLanguages).toEqual({});
                 expect(Caption.renderLanguageMenu).not.toHaveBeenCalled();
             });

--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -596,8 +596,8 @@
             },
 
             /**
-            * @desc Fetch the list of available translations. Upon successful receipt,
-            *    the list of available translations will be updated.
+            * @desc Fetch the list of available language codes. Upon successful receipt
+            * the list of available languages will be updated.
             *
             * @returns {jquery Promise}
             */
@@ -618,8 +618,6 @@
                         self.container.find('.langs-list').remove();
 
                         if (_.keys(newLanguages).length) {
-                            // And try again to fetch transcript.
-                            self.fetchCaption();
                             self.renderLanguageMenu(newLanguages);
                         }
                     },


### PR DESCRIPTION
This fixes the endless loop of fetchCaptions ajax requests. fetchCaption on error calls fetchAvailableTranslations which again calls fetchCaption on success and so on. We don't see any significance for calling fetchCaption in fetchAvailableTranslations.