### PR TITLE
Turn down grades logging; put policy change regrade behind a waffle switch

### DIFF
--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -11,6 +11,7 @@ WAFFLE_NAMESPACE = u'grades'
 WRITE_ONLY_IF_ENGAGED = u'write_only_if_engaged'
 ASSUME_ZERO_GRADE_IF_ABSENT = u'assume_zero_grade_if_absent'
 ESTIMATE_FIRST_ATTEMPTED = u'estimate_first_attempted'
+DISABLE_REGRADE_ON_POLICY_CHANGE = u'disable_regrade_on_policy_change'
 
 
 def waffle():

--- a/lms/djangoapps/grades/new/course_grade_factory.py
+++ b/lms/djangoapps/grades/new/course_grade_factory.py
@@ -154,7 +154,7 @@ class CourseGradeFactory(object):
         """
         Returns a ZeroCourseGrade object for the given user and course.
         """
-        log.info(u'Grades: CreateZero, %s, User: %s', unicode(course_data), user.id)
+        log.debug(u'Grades: CreateZero, %s, User: %s', unicode(course_data), user.id)
         return ZeroCourseGrade(user, course_data)
 
     @staticmethod

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -230,12 +230,6 @@ def enqueue_subsection_update(sender, **kwargs):  # pylint: disable=unused-argum
         ),
         countdown=RECALCULATE_GRADE_DELAY,
     )
-    log.info(
-        u'Grades: Request async calculation of subsection grades with args: {}. Task [{}]'.format(
-            ', '.join('{}:{}'.format(arg, kwargs[arg]) for arg in sorted(kwargs)),
-            getattr(result, 'id', 'N/A'),
-        )
-    )
 
 
 @receiver(SUBSECTION_SCORE_CHANGED)

--- a/lms/djangoapps/grades/tests/test_new.py
+++ b/lms/djangoapps/grades/tests/test_new.py
@@ -727,10 +727,6 @@ class TestCourseGradeLogging(ProblemSubmissionTestMixin, SharedModuleStoreTestCa
             enabled_for_course=True
         ):
             with patch('lms.djangoapps.grades.new.course_grade_factory.log') as log_mock:
-                # returns Zero when no grade, with ASSUME_ZERO_GRADE_IF_ABSENT
-                with waffle().override(ASSUME_ZERO_GRADE_IF_ABSENT, active=True):
-                    self._create_course_grade_and_check_logging(grade_factory.create, log_mock.info, u'CreateZero')
-
                 # read, but not persisted
                 self._create_course_grade_and_check_logging(grade_factory.create, log_mock.info, u'Update')
 

--- a/lms/djangoapps/grades/tests/test_signals.py
+++ b/lms/djangoapps/grades/tests/test_signals.py
@@ -197,28 +197,6 @@ class ScoreChangedSignalRelayTest(TestCase):
         expected_set_kwargs['score_deleted'] = False
         self.signal_mock.assert_called_with(**expected_set_kwargs)
 
-    @patch('lms.djangoapps.grades.signals.handlers.log.info')
-    def test_subsection_update_logging(self, mocklog):
-        enqueue_subsection_update(
-            sender='test',
-            user_id=1,
-            course_id=u'course-v1:edX+Demo_Course+DemoX',
-            usage_id=u'block-v1:block-key',
-            modified=FROZEN_NOW_DATETIME,
-            score_db_table=ScoreDatabaseTableEnum.courseware_student_module,
-        )
-        log_statement = mocklog.call_args[0][0]
-        log_statement = UUID_REGEX.sub(u'*UUID*', log_statement)
-        self.assertEqual(
-            log_statement,
-            (
-                u'Grades: Request async calculation of subsection grades with args: '
-                u'course_id:course-v1:edX+Demo_Course+DemoX, modified:{time}, '
-                u'score_db_table:csm, '
-                u'usage_id:block-v1:block-key, user_id:1. Task [*UUID*]'
-            ).format(time=FROZEN_NOW_DATETIME)
-        )
-
     @ddt.data(
         [score_set, 'lms.djangoapps.grades.signals.handlers.submissions_score_set_handler', SUBMISSION_SET_KWARGS],
         [score_reset, 'lms.djangoapps.grades.signals.handlers.submissions_score_reset_handler', SUBMISSION_RESET_KWARGS]


### PR DESCRIPTION
This is to make splunk work again.  One more change to fix up broken tests is coming.

Reviewers:
- [ ] @nasthagiri 
- [ ] @sanfordstudent 