### PR TITLE
min and max length used from user_api LEARNER-1494

### DIFF
--- a/common/djangoapps/student/tests/test_reset_password.py
+++ b/common/djangoapps/student/tests/test_reset_password.py
@@ -288,23 +288,20 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertFalse(User.objects.get(pk=self.user.pk).is_active)
 
-    @override_settings(PASSWORD_MIN_LENGTH=2)
-    @override_settings(PASSWORD_MAX_LENGTH=10)
     @ddt.data(
         {
             'password': '1',
             'error_message': 'Password: Invalid Length (must be 2 characters or more)',
         },
         {
-            'password': '01234567891',
-            'error_message': 'Password: Invalid Length (must be 10 characters or fewer)'
+            'password': '01234567891' * 10,
+            'error_message': 'Password: Invalid Length (must be 75 characters or fewer)'
         }
     )
     def test_password_reset_with_invalid_length(self, password_dict):
         """Tests that if we provide password characters less then PASSWORD_MIN_LENGTH,
         or more than PASSWORD_MAX_LENGTH, password reset will fail with error message.
         """
-
         url = reverse(
             'password_reset_confirm',
             kwargs={'uidb36': self.uidb36, 'token': self.token}

--- a/common/djangoapps/util/password_policy_validators.py
+++ b/common/djangoapps/util/password_policy_validators.py
@@ -14,6 +14,8 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
+from openedx.core.djangoapps.user_api.accounts import PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH
+
 
 def validate_password_strength(value):
     """
@@ -42,12 +44,12 @@ def validate_password_length(value):
     message = _("Invalid Length ({0})")
     code = "length"
 
-    min_length = getattr(settings, 'PASSWORD_MIN_LENGTH', None)
-    max_length = getattr(settings, 'PASSWORD_MAX_LENGTH', None)
+    min_length = PASSWORD_MIN_LENGTH
+    max_length = PASSWORD_MAX_LENGTH
 
-    if min_length and len(value) < min_length:
+    if len(value) < PASSWORD_MIN_LENGTH:
         raise ValidationError(message.format(_("must be {0} characters or more").format(min_length)), code=code)
-    elif max_length and len(value) > max_length:
+    elif len(value) > PASSWORD_MAX_LENGTH:
         raise ValidationError(message.format(_("must be {0} characters or fewer").format(max_length)), code=code)
 
 


### PR DESCRIPTION
I missed this in #15699. Util method was still expecting `PASSWORD_MIN_LENGTH` and `PASSWORD_MAX_LENGTH` from settings. I have updated to use constants defined in https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/user_api/accounts/__init__.py#L21-L22

Please review @edx/learner-spartans 