### PR TITLE
Fix attrib check code for library_content import

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -624,7 +624,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
         ]
         definition = {
             attr_name: json.loads(attr_value)
-            for attr_name, attr_value in xml_object.attrib
+            for attr_name, attr_value in xml_object.attrib.items()
         }
         return definition, children
 


### PR DESCRIPTION
Attributes come in as a list of dicts with strings as keys and values.
Implicitly casting each result as a tuple causes the code to split the key string into it's characters.
This yields a list of characters, the first two of which are placed into the variables "attr_name" and "attr_value".
This is not only wrong, but because keys tend to be more than 2 characters, the net result is:

`ValueError: too many values to unpack`