### PR TITLE
[ENT-538] Configure country field for SAP SuccessFactors IdP

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -36,6 +36,7 @@ from lms.envs.test import (
     MEDIA_URL,
     COMPREHENSIVE_THEME_DIRS,
     JWT_AUTH,
+    REGISTRATION_EXTRA_FIELDS,
 )
 
 # mongo connection settings

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -54,7 +54,7 @@ class IntegrationTestMixin(object):
         self.addCleanup(patcher.stop)
         # Override this method in a subclass and enable at least one provider.
 
-    def test_register(self):
+    def test_register(self, **extra_defaults):
         # The user goes to the register page, and sees a button to register with the provider:
         provider_register_url = self._check_register_page()
         # The user clicks on the Dummy button:
@@ -76,6 +76,8 @@ class IntegrationTestMixin(object):
         self.assertEqual(form_fields['email']['defaultValue'], self.USER_EMAIL)
         self.assertEqual(form_fields['name']['defaultValue'], self.USER_NAME)
         self.assertEqual(form_fields['username']['defaultValue'], self.USER_USERNAME)
+        for field_name, value in extra_defaults.items():
+            self.assertEqual(form_fields[field_name]['defaultValue'], value)
         registration_values = {
             'email': 'email-edited@tpa-test.none',
             'name': 'My Customized Name',

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -309,6 +309,7 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
                         'lastName': 'Smith',
                         'defaultFullName': 'John Smith',
                         'email': 'john@smith.com',
+                        'country': 'Australia',
                     }
                 })
             )
@@ -331,23 +332,119 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
         self.USER_USERNAME = "myself"
         super(SuccessFactorsIntegrationTest, self).test_register()
 
+    @patch.dict('django.conf.settings.REGISTRATION_EXTRA_FIELDS', country='optional')
     def test_register_sapsf_metadata_present(self):
         """
         Configure the provider such that it can talk to a mocked-out version of the SAP SuccessFactors
         API, and ensure that the data it gets that way gets passed to the registration form.
+
+        Check that value mappings overrides work in cases where we override a value other than
+        what we're looking for, and when an empty override is provided (expected behavior is that
+        existing value maps will be left alone).
         """
+        expected_country = 'AU'
+        provider_settings = {
+            'sapsf_oauth_root_url': 'http://successfactors.com/oauth/',
+            'sapsf_private_key': 'fake_private_key_here',
+            'odata_api_root_url': 'http://api.successfactors.com/odata/v2/',
+            'odata_company_id': 'NCC1701D',
+            'odata_client_id': 'TatVotSEiCMteSNWtSOnLanCtBGwNhGB',
+        }
+
         self._configure_testshib_provider(
             identity_provider_type='sap_success_factors',
             metadata_source=TESTSHIB_METADATA_URL,
-            other_settings=json.dumps({
-                'sapsf_oauth_root_url': 'http://successfactors.com/oauth/',
-                'sapsf_private_key': 'fake_private_key_here',
-                'odata_api_root_url': 'http://api.successfactors.com/odata/v2/',
-                'odata_company_id': 'NCC1701D',
-                'odata_client_id': 'TatVotSEiCMteSNWtSOnLanCtBGwNhGB',
-            })
+            other_settings=json.dumps(provider_settings)
         )
-        super(SuccessFactorsIntegrationTest, self).test_register()
+        super(SuccessFactorsIntegrationTest, self).test_register(country=expected_country)
+
+    @patch.dict('django.conf.settings.REGISTRATION_EXTRA_FIELDS', country='optional')
+    def test_register_sapsf_metadata_present_override_relevant_value(self):
+        """
+        Configure the provider such that it can talk to a mocked-out version of the SAP SuccessFactors
+        API, and ensure that the data it gets that way gets passed to the registration form.
+
+        Check that value mappings overrides work in cases where we override a value other than
+        what we're looking for, and when an empty override is provided (expected behavior is that
+        existing value maps will be left alone).
+        """
+        value_map = {'country': {'Australia': 'NZ'}}
+        expected_country = 'NZ'
+        provider_settings = {
+            'sapsf_oauth_root_url': 'http://successfactors.com/oauth/',
+            'sapsf_private_key': 'fake_private_key_here',
+            'odata_api_root_url': 'http://api.successfactors.com/odata/v2/',
+            'odata_company_id': 'NCC1701D',
+            'odata_client_id': 'TatVotSEiCMteSNWtSOnLanCtBGwNhGB',
+        }
+        if value_map:
+            provider_settings['sapsf_value_mappings'] = value_map
+
+        self._configure_testshib_provider(
+            identity_provider_type='sap_success_factors',
+            metadata_source=TESTSHIB_METADATA_URL,
+            other_settings=json.dumps(provider_settings)
+        )
+        super(SuccessFactorsIntegrationTest, self).test_register(country=expected_country)
+
+    @patch.dict('django.conf.settings.REGISTRATION_EXTRA_FIELDS', country='optional')
+    def test_register_sapsf_metadata_present_override_other_value(self):
+        """
+        Configure the provider such that it can talk to a mocked-out version of the SAP SuccessFactors
+        API, and ensure that the data it gets that way gets passed to the registration form.
+
+        Check that value mappings overrides work in cases where we override a value other than
+        what we're looking for, and when an empty override is provided (expected behavior is that
+        existing value maps will be left alone).
+        """
+        value_map = {'country': {'United States': 'blahfake'}}
+        expected_country = 'AU'
+        provider_settings = {
+            'sapsf_oauth_root_url': 'http://successfactors.com/oauth/',
+            'sapsf_private_key': 'fake_private_key_here',
+            'odata_api_root_url': 'http://api.successfactors.com/odata/v2/',
+            'odata_company_id': 'NCC1701D',
+            'odata_client_id': 'TatVotSEiCMteSNWtSOnLanCtBGwNhGB',
+        }
+        if value_map:
+            provider_settings['sapsf_value_mappings'] = value_map
+
+        self._configure_testshib_provider(
+            identity_provider_type='sap_success_factors',
+            metadata_source=TESTSHIB_METADATA_URL,
+            other_settings=json.dumps(provider_settings)
+        )
+        super(SuccessFactorsIntegrationTest, self).test_register(country=expected_country)
+
+    @patch.dict('django.conf.settings.REGISTRATION_EXTRA_FIELDS', country='optional')
+    def test_register_sapsf_metadata_present_empty_value_override(self):
+        """
+        Configure the provider such that it can talk to a mocked-out version of the SAP SuccessFactors
+        API, and ensure that the data it gets that way gets passed to the registration form.
+
+        Check that value mappings overrides work in cases where we override a value other than
+        what we're looking for, and when an empty override is provided (expected behavior is that
+        existing value maps will be left alone).
+        """
+
+        value_map = {'country': {}}
+        expected_country = 'AU'
+        provider_settings = {
+            'sapsf_oauth_root_url': 'http://successfactors.com/oauth/',
+            'sapsf_private_key': 'fake_private_key_here',
+            'odata_api_root_url': 'http://api.successfactors.com/odata/v2/',
+            'odata_company_id': 'NCC1701D',
+            'odata_client_id': 'TatVotSEiCMteSNWtSOnLanCtBGwNhGB',
+        }
+        if value_map:
+            provider_settings['sapsf_value_mappings'] = value_map
+
+        self._configure_testshib_provider(
+            identity_provider_type='sap_success_factors',
+            metadata_source=TESTSHIB_METADATA_URL,
+            other_settings=json.dumps(provider_settings)
+        )
+        super(SuccessFactorsIntegrationTest, self).test_register(country=expected_country)
 
     def test_register_http_failure(self):
         """


### PR DESCRIPTION
This pull request provides three primary benefits:

1. Allow a custom mapping between SAPSuccessFactors user entity fields and Open edX registration form fields to be created
2. Allow the values of thusly related fields to be mutated via a simple mapping
3. Apply both of the above to allow countries to be transmitted from SAPSF to Open edX.

**JIRA tickets**: Implements [ENT-538](https://openedx.atlassian.net/browse/ENT-538)

**Dependencies**: None

**Screenshots**: N/A

**Sandbox URL**: https://business.sandbox.edx.org

**Merge deadline**: 14 August 2017

**Testing instructions**:

1. On a configured sandbox, attempt to register via SSO with SAP SuccessFactors
2. Observe that the country field is filled in automatically.

**Author notes and concerns**:

1. SAPSF transmits country names, rather than country codes, which is an awful and ugly way to do it. @mattdrayer, do you know of any resources that lists a mapping between the two so that we can include that from the getgo? If not, we do still have the ability to customize value maps on a customer-by-customer basis, so this shouldn't be a blocker.

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```