### PR TITLE
CommentClientRequestError - Discussion Forum inaccessible for user that deleted from admin and registered back again !

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -285,3 +285,4 @@ Brandon Baker <bcbaker@wesleyan.edu>
 Salah Alomari <salomari@qrf.org>
 Shirley He <she@edx.org>
 Po Tsui <potsui@stanford.edu>
+Keyur Rathod <keyur.rathod1993@gmail.com>


### PR DESCRIPTION
**Background :** Any registered user either LMS or Studio, gets deleted from admin panel and If it is registered again to LMS or Studio then It's unable to access discussion forum. Let's just dive into this issue. When user gets deleted from admin then all Django model data is get deleted but User information regarding discussion forum is still there with id in Mongodb. Now if that user again gets signed up then it gets new id in Django model which is not same as Mongodb user. So that user is unable to access discussion forum. 

**URL for JIRA issue is :** https://openedx.atlassian.net/browse/OPEN-2095

**Solution to this :** With this push I have just overrided default delete_selected action in admin for User model which will also delete the discussion forum user from Mongodb

**Common:** Overrided default delete action for User model in Admin Panel.

**Studio Updates:** None.

**LMS Updates:** None

![df-issue](https://user-images.githubusercontent.com/21530655/28968284-efad2102-793c-11e7-9fc7-2c7ca4bc9806.png)