### PR TITLE
Strip `c` from `.pyc` for error message comparison

### DIFF
--- a/openedx/core/djangoapps/user_api/tests/test_helpers.py
+++ b/openedx/core/djangoapps/user_api/tests/test_helpers.py
@@ -60,7 +60,7 @@ class InterceptErrorsTest(TestCase):
             u"keyword arguments '{{'raise_error': <class '{}'>}}' "
             u"from File \"{}\", line XXX, in test_logs_errors\n"
             u"    intercepted_function(raise_error=FakeInputException): FakeInputException()"
-        ).format(exception, __file__)
+        ).format(exception, __file__.rstrip('c'))
 
         # Verify that the raised exception has the error message
         try:


### PR DESCRIPTION
In Python 2.7, `__file__` returns `.pyc` by default, this breaks our comparison
so let's strip out the trailing `c`.