### PR TITLE
Adding link to proctor review rules in Studio

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1194,6 +1194,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             elif xblock.category == 'sequential':
                 xblock_info.update({
                     'is_proctored_exam': xblock.is_proctored_exam,
+                    'online_proctoring_rules': settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('online_proctoring_rules', {}),
                     'is_practice_exam': xblock.is_practice_exam,
                     'is_time_limited': xblock.is_time_limited,
                     'exam_review_rules': xblock.exam_review_rules,

--- a/cms/templates/js/timed-examination-preference-editor.underscore
+++ b/cms/templates/js/timed-examination-preference-editor.underscore
@@ -42,7 +42,18 @@
                     <textarea cols="50" maxlength="255" aria-describedby="review-rules-description"
                         class="review-rules input input-text" autocomplete="off" />
                 </label>
-                <p class='field-message' id='review-rules-description'><%- gettext('Specify any additional rules or rule exceptions that the proctoring review team should enforce when reviewing the videos. For example, you could specify that calculators are allowed.') %></p>
+                <% var online_proctoring_rules = xblockInfo.get('online_proctoring_rules'); %>
+                <p class='field-message' id='review-rules-description'>
+                <%= edx.HtmlUtils.interpolateHtml(
+                    gettext('Specify any rules or rule exceptions that the proctoring review team should enforce when reviewing the videos. For example, you could specify that calculators are allowed. These specified rules are visible to learners before the learners start the exam, along with the {linkStart}general proctored exam rules{linkEnd}.'),
+                    {
+                        linkStart: edx.HtmlUtils.interpolateHtml(
+                            edx.HtmlUtils.HTML('<a href="{onlineProctoringUrl}" title="{onlineProctoringTitle}">'),
+                            { onlineProctoringUrl: online_proctoring_rules, onlineProctoringTitle: gettext('General Proctored Exam Rules')}),
+                        linkEnd: edx.HtmlUtils.HTML('</a>')
+                    })
+                %>
+                </p>
             </div>
         </div>
     </div>

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -91,7 +91,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.5#egg=lti_consumer-xblock==1.1.5
-git+https://github.com/edx/edx-proctoring.git@0.18.2#egg=edx-proctoring==0.18.2
+git+https://github.com/edx/edx-proctoring.git@0.19.0#egg=edx-proctoring==0.19.0
 
 # Third Party XBlocks
 git+https://github.com/open-craft/xblock-poll@v1.2.7#egg=xblock-poll==1.2.7


### PR DESCRIPTION
Allows instructors to see a link to the online proctoring review rules documentation while configuring an exam to be a proctored exam.

Before:
![image](https://user-images.githubusercontent.com/16583647/29033859-610ab818-7b64-11e7-89b2-759eadcee18e.png)

After:
![image](https://user-images.githubusercontent.com/16583647/29033878-72f71922-7b64-11e7-8138-80a94c800559.png)

https://openedx.atlassian.net/browse/EDUCATOR-757
https://studio-proctor-review-rules.sandbox.edx.org

To see the affected page log in as staff and go to the course outline of the edX Demonstration course, open the configuration settings on any of the subsections, and go to the advanced tab. I currently have the exam under About Exams and Certificates set as a proctored exam.

PR in edx-proctoring for LMS changes: https://github.com/edx/edx-proctoring/pull/366

Updated link to sandbox with new text: https://studio-proctor-review-rules-2.sandbox.edx.org

@edx/educator-dahlia 