### PR TITLE
Upgrade celery modules to Django 1.11-compatible versions.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,7 +16,6 @@ dealer==2.0.4
 defusedxml==0.4.1
 django-babel-underscore==0.5.1
 markey==0.8  # From django-babel-underscore
-django-celery==3.2.1
 django-config-models==0.1.8
 django-countries==4.0
 django-extensions==1.5.9
@@ -34,13 +33,13 @@ django-simple-history==1.6.3
 django-statici18n==1.4.0
 django-storages==1.4.1
 django-method-override==0.1.0
-django-user-tasks==0.1.4
+django-user-tasks==0.1.5
 django==1.8.18
 django-waffle==0.12.0
 djangorestframework-jwt==1.11.0
 enum34==1.1.6
 edx-ccx-keys==0.2.1
-edx-celeryutils==0.2.4
+edx-celeryutils==0.2.6
 edx-drf-extensions==1.2.3
 edx-i18n-tools==0.3.9
 edx-lint==0.4.3

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -76,6 +76,10 @@ git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc8685
 # This dependency will be removed by this work: https://openedx.atlassian.net/browse/PLAT-1660
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 
+# Why a django-celery fork? To add Django 1.11 compatibility to the abandoned repo.
+# This dependency will be removed by the Celery 4 upgrade: https://openedx.atlassian.net/browse/PLAT-1684
+git+https://github.com/edx/django-celery.git@f87c6f914a1410463f54aebf68458c0653b20602#egg=django-celery==3.2.1+edx.1
+
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail==0.0
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2


### PR DESCRIPTION
This PR simply moves edx-platform to use the Django 1.11-compatible version of all celery-dependent modules. Here's the diffs:
https://github.com/edx/django-user-tasks/compare/0.1.4...0.1.5
https://github.com/edx/edx-celeryutils/compare/v0.2.4...0.2.6
https://github.com/celery/django-celery/compare/master...edx:master