### PR TITLE
Add force_update option to generate_course_overview command

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/management/commands/generate_course_blocks.py
+++ b/openedx/core/djangoapps/content/block_structure/management/commands/generate_course_blocks.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 class Command(BaseCommand):
     """
     Example usage:
-        $ ./manage.py lms generate_course_blocks --all --settings=devstack
+        $ ./manage.py lms generate_course_blocks --all_courses --settings=devstack
         $ ./manage.py lms generate_course_blocks 'edX/DemoX/Demo_Course' --settings=devstack
     """
     args = u'<course_id course_id ...>'

--- a/openedx/core/djangoapps/content/course_overviews/management/commands/generate_course_overview.py
+++ b/openedx/core/djangoapps/content/course_overviews/management/commands/generate_course_overview.py
@@ -33,7 +33,13 @@ class Command(BaseCommand):
             action='store_true',
             dest='all',
             default=False,
-            help='Generate course overview for all courses.',
+            help=u'Generate course overview for all courses.',
+        )
+        parser.add_argument(
+            '--force_update',
+            action='store_true',
+            default=False,
+            help=u'Force update course overviews for the requested courses.',
         )
 
     def handle(self, *args, **options):
@@ -48,4 +54,4 @@ class Command(BaseCommand):
             except InvalidKeyError:
                 raise CommandError('Invalid key specified.')
 
-        CourseOverview.get_select_courses(course_keys)
+        CourseOverview.get_select_courses(course_keys, force_update=options.get('force_update'))

--- a/openedx/core/djangoapps/content/course_overviews/management/commands/tests/test_generate_course_overview.py
+++ b/openedx/core/djangoapps/content/course_overviews/management/commands/tests/test_generate_course_overview.py
@@ -58,6 +58,23 @@ class TestGenerateCourseOverview(ModuleStoreTestCase):
         self._assert_courses_in_overview(self.course_key_1)
         self._assert_courses_not_in_overview(self.course_key_2)
 
+    def test_generate_force_update(self):
+        self.command.handle(all=True)
+
+        # update each course
+        updated_course_name = u'test_generate_course_overview.course_edit'
+        for course_key in (self.course_key_1, self.course_key_2):
+            course = self.store.get_course(course_key)
+            course.display_name = updated_course_name
+            self.store.update_item(course, self.user.id)
+
+        # force_update course_key_1, but not course_key_2
+        self.command.handle(unicode(self.course_key_1), all=False, force_update=True)
+        self.command.handle(unicode(self.course_key_2), all=False, force_update=False)
+
+        self.assertEquals(CourseOverview.get_from_id(self.course_key_1).display_name, updated_course_name)
+        self.assertNotEquals(CourseOverview.get_from_id(self.course_key_2).display_name, updated_course_name)
+
     def test_invalid_key(self):
         """
         Test that CommandError is raised for invalid key.

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -487,18 +487,27 @@ class CourseOverview(TimeStampedModel):
         return json.loads(self._pre_requisite_courses_json)
 
     @classmethod
-    def get_select_courses(cls, course_keys):
+    def get_select_courses(cls, course_keys, force_update=False):
         """
         Returns CourseOverview objects for the given course_keys.
+
+        Arguments:
+            course_keys (list[CourseKey]): Identifies for which courses to
+                return CourseOverview objects.
+            force_update (boolean): Optional parameter that indicates
+                whether the requested CourseOverview objects should be
+                forcefully updated (i.e., re-synched with the modulestore).
         """
         course_overviews = []
 
         log.info('Generating course overview for %d courses.', len(course_keys))
         log.debug('Generating course overview(s) for the following courses: %s', course_keys)
 
+        action = CourseOverview.load_from_module_store if force_update else CourseOverview.get_from_id
+
         for course_key in course_keys:
             try:
-                course_overviews.append(CourseOverview.get_from_id(course_key))
+                course_overviews.append(action(course_key))
             except Exception as ex:  # pylint: disable=broad-except
                 log.exception(
                     'An error occurred while generating course overview for %s: %s',


### PR DESCRIPTION
This PR adds support for a `force_update` optional parameter to the `generate_course_overview` management command.  It allows us to recover from production failures when the automatic synchronization communication between Studio and LMS fails (i.e., when Rabbit/Celery fails).

Please review: @jibsheet or @feanil 
FYI: @kdmccormick @Qubad786 