### PR TITLE
Fix login page password min length restriction.

### DIFF
--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -609,7 +609,6 @@ class LoginSessionViewTest(UserAPITestCase):
                 "placeholder": "",
                 "instructions": "",
                 "restrictions": {
-                    "min_length": PASSWORD_MIN_LENGTH,
                     "max_length": PASSWORD_MAX_LENGTH
                 },
                 "errorMessages": {},

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -98,7 +98,6 @@ class LoginSessionView(APIView):
             label=password_label,
             field_type="password",
             restrictions={
-                "min_length": accounts.PASSWORD_MIN_LENGTH,
                 "max_length": accounts.PASSWORD_MAX_LENGTH,
             }
         )


### PR DESCRIPTION
In the reset password flow one can enter a single character password and subsequently cannot login to the site as password complexity is apparently enforced on the login page. Login page should not enforce password complexity.

LEARNER-1209

