### PR TITLE
Teltek/i18n certificate date utils

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -43,6 +43,7 @@ from openedx.core.lib.courses import course_image_url
 from student.models import LinkedInAddToProfileConfiguration
 from util import organizations_helpers as organization_api
 from util.views import handle_500
+from util.date_utils import strftime_localized
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
@@ -98,7 +99,7 @@ def _update_certificate_context(context, user_certificate, platform_name):
 
     # Translators:  The format of the date includes the full name of the month
     context['certificate_date_issued'] = _('{month} {day}, {year}').format(
-        month=user_certificate.modified_date.strftime("%B"),
+        month=strftime_localized(user_certificate.modified_date,"%B"),
         day=user_certificate.modified_date.day,
         year=user_certificate.modified_date.year
     )

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -99,7 +99,7 @@ def _update_certificate_context(context, user_certificate, platform_name):
 
     # Translators:  The format of the date includes the full name of the month
     context['certificate_date_issued'] = _('{month} {day}, {year}').format(
-        month=strftime_localized(user_certificate.modified_date,"%B"),
+        month=strftime_localized(user_certificate.modified_date, "%B"),
         day=user_certificate.modified_date.day,
         year=user_certificate.modified_date.year
     )


### PR DESCRIPTION
The month in the date of generated certificates is not being translated by the strings pulled from Transifex. The string in Transifex is like this:
```
{month} {day}, {year}
```

We can only change the format of the date without translating the month name. 

In this commit, the translation of the month is being added before the assignment of the value of the month into the date format.

For example, the English date `April 6, 2017`, in Spanish appears as `April 6, 2017`. By adding the translation of the date format in Transifex, from `{month}
{day}, {year}` in English to `{day}
{month}
{year}
` in Spanish, we still have the name of the month in English language, `6 April 2017`. With this commit, this problem is being solved and now the date in Spanish appears as `6 abril 2017`.

**The solution applied was defined in #14836** 