### PR TITLE
EDUCATOR-1043 | give zero grades non-null possible points

### DIFF
--- a/lms/djangoapps/grades/new/subsection_grade.py
+++ b/lms/djangoapps/grades/new/subsection_grade.py
@@ -33,9 +33,6 @@ class SubsectionGradeBase(object):
         self.course_version = getattr(subsection, 'course_version', None)
         self.subtree_edited_timestamp = getattr(subsection, 'subtree_edited_on', None)
 
-        self.graded_total = None  # aggregated grade for all graded problems
-        self.all_total = None  # aggregated grade for all problems, regardless of whether they are graded
-
     @property
     def attempted(self):
         """
@@ -63,9 +60,19 @@ class ZeroSubsectionGrade(SubsectionGradeBase):
 
     def __init__(self, subsection, course_data):
         super(ZeroSubsectionGrade, self).__init__(subsection)
-        self.graded_total = AggregatedScore(tw_earned=0, tw_possible=None, graded=False, first_attempted=None)
-        self.all_total = AggregatedScore(tw_earned=0, tw_possible=None, graded=self.graded, first_attempted=None)
         self.course_data = course_data
+
+    @property
+    def all_total(self):
+        return self._aggregate_scores[0]
+
+    @property
+    def graded_total(self):
+        return self._aggregate_scores[1]
+
+    @lazy
+    def _aggregate_scores(self):
+        return graders.aggregate_scores(self.problem_scores.values())
 
     @lazy
     def problem_scores(self):

--- a/lms/djangoapps/grades/tests/test_new.py
+++ b/lms/djangoapps/grades/tests/test_new.py
@@ -738,3 +738,48 @@ class TestCourseGradeLogging(ProblemSubmissionTestMixin, SharedModuleStoreTestCa
 
                 # read from persistence, using read
                 self._create_course_grade_and_check_logging(grade_factory.read, log_mock.debug, u'Read')
+
+
+class TestCourseGradeFactory(GradeTestBase):
+    def test_course_grade_summary(self):
+        with mock_get_score(1, 2):
+            self.subsection_grade_factory.update(self.course_structure[self.sequence.location])
+        course_grade = CourseGradeFactory().update(self.request.user, self.course)
+
+        actual_summary = course_grade.summary
+
+        # We should have had a zero subsection grade for sequential 2, since we never
+        # gave it a mock score above.
+        expected_summary = {
+            'grade': None,
+            'grade_breakdown': {
+                'Homework': {
+                    'category': 'Homework',
+                    'percent': 0.25,
+                    'detail': 'Homework = 25.00% of a possible 100.00%',
+                }
+            },
+            'percent': 0.25,
+            'section_breakdown': [
+                {
+                    'category': 'Homework',
+                    'detail': u'Homework 1 - Test Sequential 1 - 50% (1/2)',
+                    'label': u'HW 01',
+                    'percent': 0.5
+                },
+                {
+                    'category': 'Homework',
+                    'detail': u'Homework 2 - Test Sequential 2 - 0% (0/1)',
+                    'label': u'HW 02',
+                    'percent': 0.0
+                },
+                {
+                    'category': 'Homework',
+                    'detail': u'Homework Average = 25%',
+                    'label': u'HW Avg',
+                    'percent': 0.25,
+                    'prominent': True
+                },
+            ]
+        }
+        self.assertEqual(expected_summary, actual_summary)


### PR DESCRIPTION
ZeroSubsectionGrade's graded/all_total should have a non-zero possible score where appropriate.  This makes it so that `CourseGrade.grader_result` gives us back data for every subsection in the course, even if no attempt has been made for that subsection.

*Reviewers*
- [x] @nasthagiri 