### PR TITLE
Update problem-builder xblock install version (PLAT-1644)

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@v2.6.5#egg=xblock-problem-builder==2.6.5
+git+https://github.com/open-craft/problem-builder.git@v2.6.10#egg=xblock-problem-builder==2.6.10
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
Quick PR to update edx-private requirements to include the latest version of problem-builder.

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

From repo root: 
1. `pip install -r requirements/edx/edx-private.txt`
2. See no errors

**Reviewers**
- [ ] @pomegranited 