### PR TITLE
Remove usages of deprecated SlashSeparatedCourseKey.

### DIFF
--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import AnonymousUser, Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from factory import lazy_attribute
 from factory.django import DjangoModelFactory
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 
 from course_modes.models import CourseMode
@@ -144,7 +144,7 @@ class CourseEnrollmentFactory(DjangoModelFactory):
         model = CourseEnrollment
 
     user = factory.SubFactory(UserFactory)
-    course_id = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+    course_id = CourseKey.from_string('edX/toy/2012_Fall')
 
 
 class CourseAccessRoleFactory(DjangoModelFactory):
@@ -152,7 +152,7 @@ class CourseAccessRoleFactory(DjangoModelFactory):
         model = CourseAccessRole
 
     user = factory.SubFactory(UserFactory)
-    course_id = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+    course_id = CourseKey.from_string('edX/toy/2012_Fall')
     role = 'TestRole'
 
 
@@ -161,7 +161,7 @@ class CourseEnrollmentAllowedFactory(DjangoModelFactory):
         model = CourseEnrollmentAllowed
 
     email = 'test@edx.org'
-    course_id = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+    course_id = CourseKey.from_string('edX/toy/2012_Fall')
 
 
 class PendingEmailChangeFactory(DjangoModelFactory):

--- a/common/djangoapps/student/tests/test_authz.py
+++ b/common/djangoapps/student/tests/test_authz.py
@@ -6,7 +6,7 @@ from ccx_keys.locator import CCXLocator
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 
 from student.auth import add_users, has_studio_read_access, has_studio_write_access, remove_users, user_has_role
 from student.roles import CourseCreatorRole, CourseInstructorRole, CourseStaffRole
@@ -182,7 +182,7 @@ class CourseGroupTest(TestCase):
         self.global_admin = AdminFactory()
         self.creator = User.objects.create_user('testcreator', 'testcreator+courses@edx.org', 'foo')
         self.staff = User.objects.create_user('teststaff', 'teststaff+courses@edx.org', 'foo')
-        self.course_key = SlashSeparatedCourseKey('mitX', '101', 'test')
+        self.course_key = CourseLocator('mitX', '101', 'test')
 
     def test_add_user_to_course_group(self):
         """

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -8,7 +8,7 @@ import unittest
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 
 # This import is for an lms djangoapp.
 # Its testcases are only run under lms.
@@ -101,7 +101,7 @@ class TestStudentDashboardEmailViewXMLBacked(SharedModuleStoreTestCase):
         student = UserFactory.create()
         CourseEnrollmentFactory.create(
             user=student,
-            course_id=SlashSeparatedCourseKey.from_deprecated_string(self.course_name)
+            course_id=CourseKey.from_string(self.course_name)
         )
         self.client.login(username=student.username, password="test")
 

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -3,7 +3,7 @@ Tests of student.roles
 """
 import ddt
 from django.test import TestCase
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 
 from courseware.tests.factories import InstructorFactory, StaffFactory, UserFactory
 from student.roles import (
@@ -26,7 +26,7 @@ class RolesTestCase(TestCase):
 
     def setUp(self):
         super(RolesTestCase, self).setUp()
-        self.course_key = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+        self.course_key = CourseKey.from_string('edX/toy/2012_Fall')
         self.course_loc = self.course_key.make_usage_key('course', '2012_Fall')
         self.anonymous_user = AnonymousUserFactory()
         self.student = UserFactory()
@@ -43,8 +43,8 @@ class RolesTestCase(TestCase):
     def test_group_name_case_sensitive(self):
         uppercase_course_id = "ORG/COURSE/NAME"
         lowercase_course_id = uppercase_course_id.lower()
-        uppercase_course_key = SlashSeparatedCourseKey.from_deprecated_string(uppercase_course_id)
-        lowercase_course_key = SlashSeparatedCourseKey.from_deprecated_string(lowercase_course_id)
+        uppercase_course_key = CourseKey.from_string(uppercase_course_id)
+        lowercase_course_key = CourseKey.from_string(lowercase_course_id)
 
         role = "role"
 
@@ -165,8 +165,8 @@ class RolesTestCase(TestCase):
 @ddt.ddt
 class RoleCacheTestCase(TestCase):
 
-    IN_KEY = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
-    NOT_IN_KEY = SlashSeparatedCourseKey('edX', 'toy', '2013_Fall')
+    IN_KEY = CourseKey.from_string('edX/toy/2012_Fall')
+    NOT_IN_KEY = CourseKey.from_string('edX/toy/2013_Fall')
 
     ROLES = (
         (CourseStaffRole(IN_KEY), ('staff', IN_KEY, 'edX')),

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -2,14 +2,12 @@
 """
 Miscellaneous tests for the student app.
 """
-import json
 import logging
 import unittest
 from datetime import datetime, timedelta
 from urllib import quote
 
 import ddt
-import httpretty
 import pytz
 from config_models.models import cache
 from django.conf import settings
@@ -21,7 +19,6 @@ from markupsafe import escape
 from mock import Mock, patch
 from nose.plugins.attrib import attr
 from opaque_keys.edx.locations import CourseLocator, SlashSeparatedCourseKey
-from provider.constants import CONFIDENTIAL
 from pyquery import PyQuery as pq
 
 import shoppingcart  # pylint: disable=import-error
@@ -753,6 +750,8 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
     def test_enrollment(self):
         user = User.objects.create_user("joe", "joe@joe.com", "password")
         course_id = SlashSeparatedCourseKey("edX", "Test101", "2013")
+        # Cannot be converted to CourseLocator or CourseKey.from_string because both do not support
+        # course keys without a run. The test specifically tests functionality when run is not specified.
         course_id_partial = SlashSeparatedCourseKey("edX", "Test101", None)
 
         # Test basic enrollment
@@ -799,7 +798,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
     def test_enrollment_non_existent_user(self):
         # Testing enrollment of newly unsaved user (i.e. no database entry)
         user = User(username="rusty", email="rusty@fake.edx.org")
-        course_id = SlashSeparatedCourseKey("edX", "Test101", "2013")
+        course_id = CourseLocator("edX", "Test101", "2013")
 
         self.assertFalse(CourseEnrollment.is_enrolled(user, course_id))
 
@@ -816,7 +815,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_enrollment_by_email(self):
         user = User.objects.create(username="jack", email="jack@fake.edx.org")
-        course_id = SlashSeparatedCourseKey("edX", "Test101", "2013")
+        course_id = CourseLocator("edX", "Test101", "2013")
 
         CourseEnrollment.enroll_by_email("jack@fake.edx.org", course_id)
         self.assertTrue(CourseEnrollment.is_enrolled(user, course_id))
@@ -854,8 +853,8 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_enrollment_multiple_classes(self):
         user = User(username="rusty", email="rusty@fake.edx.org")
-        course_id1 = SlashSeparatedCourseKey("edX", "Test101", "2013")
-        course_id2 = SlashSeparatedCourseKey("MITx", "6.003z", "2012")
+        course_id1 = CourseLocator("edX", "Test101", "2013")
+        course_id2 = CourseLocator("MITx", "6.003z", "2012")
 
         CourseEnrollment.enroll(user, course_id1)
         self.assert_enrollment_event_was_emitted(user, course_id1)
@@ -877,7 +876,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_activation(self):
         user = User.objects.create(username="jack", email="jack@fake.edx.org")
-        course_id = SlashSeparatedCourseKey("edX", "Test101", "2013")
+        course_id = CourseLocator("edX", "Test101", "2013")
         self.assertFalse(CourseEnrollment.is_enrolled(user, course_id))
 
         # Creating an enrollment doesn't actually enroll a student
@@ -914,7 +913,7 @@ class EnrollInCourseTest(EnrollmentEventTestMixin, CacheIsolationTestCase):
 
     def test_change_enrollment_modes(self):
         user = User.objects.create(username="justin", email="jh@fake.edx.org")
-        course_id = SlashSeparatedCourseKey("edX", "Test101", "2013")
+        course_id = CourseLocator("edX", "Test101", "2013")
 
         CourseEnrollment.enroll(user, course_id, "audit")
         self.assert_enrollment_event_was_emitted(user, course_id)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
@@ -12,7 +12,8 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.x_module import XModuleMixin
 
 from xmodule.tests import DATA_DIR
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locator import CourseLocator
 from xmodule.modulestore.tests.test_modulestore import check_has_course_method
 
 
@@ -51,13 +52,13 @@ class TestXMLModuleStore(unittest.TestCase):
             load_error_modules=False)
 
         # Look up the errors during load. There should be none.
-        errors = modulestore.get_course_errors(SlashSeparatedCourseKey("edX", "toy", "2012_Fall"))
+        errors = modulestore.get_course_errors(CourseKey.from_string("edX/toy/2012_Fall"))
         assert errors == []
 
     @patch("xmodule.modulestore.xml.glob.glob", side_effect=glob_tildes_at_end)
     def test_tilde_files_ignored(self, _fake_glob):
         modulestore = XMLModuleStore(DATA_DIR, source_dirs=['tilde'], load_error_modules=False)
-        about_location = SlashSeparatedCourseKey('edX', 'tilde', '2012_Fall').make_usage_key(
+        about_location = CourseKey.from_string('edX/tilde/2012_Fall').make_usage_key(
             'about', 'index',
         )
         about_module = modulestore.get_item(about_location)
@@ -78,7 +79,7 @@ class TestXMLModuleStore(unittest.TestCase):
         self.assertEqual(len(course_locations), 0)
 
         # now set toy course to share the wiki with simple course
-        toy_course = store.get_course(SlashSeparatedCourseKey('edX', 'toy', '2012_Fall'))
+        toy_course = store.get_course(CourseKey.from_string('edX/toy/2012_Fall'))
         toy_course.wiki_slug = 'simple'
 
         course_locations = store.get_courses_for_wiki('toy')
@@ -87,7 +88,7 @@ class TestXMLModuleStore(unittest.TestCase):
         course_locations = store.get_courses_for_wiki('simple')
         self.assertEqual(len(course_locations), 2)
         for course_number in ['toy', 'simple']:
-            self.assertIn(SlashSeparatedCourseKey('edX', course_number, '2012_Fall'), course_locations)
+            self.assertIn(CourseKey.from_string('/'.join(['edX', course_number, '2012_Fall'])), course_locations)
 
     def test_has_course(self):
         """
@@ -95,8 +96,8 @@ class TestXMLModuleStore(unittest.TestCase):
         """
         check_has_course_method(
             XMLModuleStore(DATA_DIR, source_dirs=['toy', 'simple']),
-            SlashSeparatedCourseKey('edX', 'toy', '2012_Fall'),
-            locator_key_fields=SlashSeparatedCourseKey.KEY_FIELDS
+            CourseKey.from_string('edX/toy/2012_Fall'),
+            locator_key_fields=CourseLocator.KEY_FIELDS
         )
 
     def test_branch_setting(self):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml_importer.py
@@ -11,7 +11,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.modulestore.xml_importer import _update_and_import_module, _update_module_location
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 from xmodule.tests import DATA_DIR
 from uuid import uuid4
 import unittest
@@ -143,7 +143,7 @@ class RemapNamespaceTest(ModuleStoreNoSettings):
         self.xblock.save()
 
         # Move to different runtime w/ different course id
-        target_location_namespace = SlashSeparatedCourseKey("org", "course", "run")
+        target_location_namespace = CourseKey.from_string("org/course/run")
         new_version = _update_and_import_module(
             self.xblock,
             modulestore(),

--- a/common/lib/xmodule/xmodule/tests/test_error_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_error_module.py
@@ -5,7 +5,8 @@ import unittest
 from xmodule.tests import get_test_system
 from xmodule.error_module import ErrorDescriptor, ErrorModule, NonStaffErrorDescriptor
 from xmodule.modulestore.xml import CourseLocationManager
-from opaque_keys.edx.locations import SlashSeparatedCourseKey, Location
+from opaque_keys.edx.locator import CourseLocator
+from opaque_keys.edx.locations import Location
 from xmodule.x_module import XModuleDescriptor, XModule, STUDENT_VIEW
 from mock import MagicMock, Mock, patch
 from xblock.runtime import Runtime, IdReader
@@ -19,7 +20,7 @@ class SetupTestErrorModules(unittest.TestCase):
     def setUp(self):
         super(SetupTestErrorModules, self).setUp()
         self.system = get_test_system()
-        self.course_id = SlashSeparatedCourseKey('org', 'course', 'run')
+        self.course_id = CourseLocator('org', 'course', 'run')
         self.location = self.course_id.make_usage_key('foo', 'bar')
         self.valid_xml = u"<problem>ABC \N{SNOWMAN}</problem>"
         self.error_msg = "Error"

--- a/common/lib/xmodule/xmodule/tests/test_html_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_html_module.py
@@ -1,7 +1,7 @@
 import unittest
 
 from mock import Mock
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 
@@ -15,7 +15,7 @@ def instantiate_descriptor(**field_data):
     Instantiate descriptor with most properties.
     """
     system = get_test_descriptor_system()
-    course_key = SlashSeparatedCourseKey('org', 'course', 'run')
+    course_key = CourseLocator('org', 'course', 'run')
     usage_key = course_key.make_usage_key('html', 'SampleHtml')
     return system.construct_xblock_from_class(
         HtmlDescriptor,

--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -19,6 +19,7 @@ from xmodule.x_module import XModuleMixin
 from xmodule.fields import Date
 from xmodule.tests import DATA_DIR
 from xmodule.modulestore.inheritance import InheritanceMixin
+from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from xblock.core import XBlock
@@ -576,7 +577,7 @@ class ImportTestCase(BaseCourseTestCase):
 
         modulestore = XMLModuleStore(DATA_DIR, source_dirs=['toy'])
 
-        toy_id = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+        toy_id = CourseKey.from_string('edX/toy/2012_Fall')
 
         course = modulestore.get_course(toy_id)
         chapters = course.get_children()
@@ -654,7 +655,7 @@ class ImportTestCase(BaseCourseTestCase):
         """
         modulestore = XMLModuleStore(DATA_DIR, source_dirs=['toy'])
 
-        toy_id = SlashSeparatedCourseKey('edX', 'toy', '2012_Fall')
+        toy_id = CourseKey.from_string('edX/toy/2012_Fall')
 
         course = modulestore.get_course(toy_id)
 

--- a/common/lib/xmodule/xmodule/tests/test_import_static.py
+++ b/common/lib/xmodule/xmodule/tests/test_import_static.py
@@ -4,7 +4,7 @@ Tests that check that we ignore the appropriate files when importing courses.
 import unittest
 from mock import Mock
 from xmodule.modulestore.xml_importer import import_static_content
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 from xmodule.tests import DATA_DIR
 
 
@@ -12,7 +12,7 @@ class IgnoredFilesTestCase(unittest.TestCase):
     "Tests for ignored files"
     def test_ignore_tilde_static_files(self):
         course_dir = DATA_DIR / "tilde"
-        course_id = SlashSeparatedCourseKey("edX", "tilde", "Fall_2012")
+        course_id = CourseLocator("edX", "tilde", "Fall_2012")
         content_store = Mock()
         content_store.generate_thumbnail.return_value = ("content", "location")
         import_static_content(course_dir, content_store, course_id)
@@ -27,7 +27,7 @@ class IgnoredFilesTestCase(unittest.TestCase):
         Test for ignored Mac OS metadata files (filename starts with "._")
         """
         course_dir = DATA_DIR / "dot-underscore"
-        course_id = SlashSeparatedCourseKey("edX", "dot-underscore", "2014_Fall")
+        course_id = CourseLocator("edX", "dot-underscore", "2014_Fall")
         content_store = Mock()
         content_store.generate_thumbnail.return_value = ("content", "location")
         import_static_content(course_dir, content_store, course_id)

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -24,7 +24,7 @@ import ddt
 from django.conf import settings
 from django.test.utils import override_settings
 
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 from opaque_keys.edx.keys import CourseKey
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
@@ -92,7 +92,7 @@ def instantiate_descriptor(**field_data):
     Instantiate descriptor with most properties.
     """
     system = get_test_descriptor_system()
-    course_key = SlashSeparatedCourseKey('org', 'course', 'run')
+    course_key = CourseLocator('org', 'course', 'run')
     usage_key = course_key.make_usage_key('video', 'SampleProblem')
     return system.construct_xblock_from_class(
         VideoDescriptor,

--- a/common/lib/xmodule/xmodule/tests/xml/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/xml/__init__.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 from xmodule.x_module import XMLParsingSystem, policy_key
 from xmodule.mako_module import MakoDescriptorSystem
 from xmodule.modulestore.xml import CourseLocationManager
-from opaque_keys.edx.locations import SlashSeparatedCourseKey, Location
+from opaque_keys.edx.keys import CourseKey
 
 from xblock.runtime import KvsFieldData, DictKeyValueStore
 
@@ -19,7 +19,7 @@ class InMemorySystem(XMLParsingSystem, MakoDescriptorSystem):  # pylint: disable
     The simplest possible XMLParsingSystem
     """
     def __init__(self, xml_import_data):
-        self.course_id = SlashSeparatedCourseKey.from_deprecated_string(xml_import_data.course_id)
+        self.course_id = CourseKey.from_string(xml_import_data.course_id)
         self.default_class = xml_import_data.default_class
         self._descriptors = {}
 

--- a/openedx/core/djangoapps/bookmarks/tests/factories.py
+++ b/openedx/core/djangoapps/bookmarks/tests/factories.py
@@ -7,10 +7,10 @@ from factory.django import DjangoModelFactory
 from functools import partial
 
 from student.tests.factories import UserFactory
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 from ..models import Bookmark, XBlockCache
 
-COURSE_KEY = SlashSeparatedCourseKey(u'edX', u'test_course', u'test')
+COURSE_KEY = CourseLocator(u'edX', u'test_course', u'test')
 LOCATION = partial(COURSE_KEY.make_usage_key, u'problem')
 
 

--- a/openedx/core/djangoapps/course_groups/tests/helpers.py
+++ b/openedx/core/djangoapps/course_groups/tests/helpers.py
@@ -8,7 +8,7 @@ from django_comment_common.models import CourseDiscussionSettings
 from django_comment_common.utils import set_course_discussion_settings
 from factory import Sequence, post_generation
 from factory.django import DjangoModelFactory
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 
@@ -24,7 +24,7 @@ class CohortFactory(DjangoModelFactory):
         model = CourseUserGroup
 
     name = Sequence("cohort{}".format)
-    course_id = SlashSeparatedCourseKey("dummy", "dummy", "dummy")
+    course_id = CourseLocator("dummy", "dummy", "dummy")
     group_type = CourseUserGroup.COHORT
 
     @post_generation
@@ -57,7 +57,7 @@ class CourseCohortSettingsFactory(DjangoModelFactory):
         model = CourseCohortsSettings
 
     is_cohorted = False
-    course_id = SlashSeparatedCourseKey("dummy", "dummy", "dummy")
+    course_id = CourseLocator("dummy", "dummy", "dummy")
     cohorted_discussions = json.dumps([])
     # pylint: disable=invalid-name
     always_cohort_inline_discussions = False

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import User
 from django.db import IntegrityError
 from django.http import Http404
 from django.test import TestCase
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
@@ -32,7 +32,7 @@ class TestCohortSignals(TestCase):
 
     def setUp(self):
         super(TestCohortSignals, self).setUp()
-        self.course_key = SlashSeparatedCourseKey("dummy", "dummy", "dummy")
+        self.course_key = CourseLocator("dummy", "dummy", "dummy")
 
     def test_cohort_added(self, mock_tracker):
         # Add cohort
@@ -164,7 +164,7 @@ class TestCohorts(ModuleStoreTestCase):
         self.assertTrue(cohorts.is_course_cohorted(course.id))
 
         # Make sure we get a Http404 if there's no course
-        fake_key = SlashSeparatedCourseKey('a', 'b', 'c')
+        fake_key = CourseLocator('a', 'b', 'c')
         self.assertRaises(Http404, lambda: cohorts.is_course_cohorted(fake_key))
 
     def test_get_cohort_id(self):
@@ -184,7 +184,7 @@ class TestCohorts(ModuleStoreTestCase):
 
         self.assertRaises(
             Http404,
-            lambda: cohorts.get_cohort_id(user, SlashSeparatedCourseKey("course", "does_not", "exist"))
+            lambda: cohorts.get_cohort_id(user, CourseLocator("course", "does_not", "exist"))
         )
 
     def test_assignment_type(self):
@@ -545,7 +545,7 @@ class TestCohorts(ModuleStoreTestCase):
 
         self.assertRaises(
             CourseUserGroup.DoesNotExist,
-            lambda: cohorts.get_cohort_by_name(SlashSeparatedCourseKey("course", "does_not", "exist"), cohort)
+            lambda: cohorts.get_cohort_by_name(CourseLocator("course", "does_not", "exist"), cohort)
         )
 
     def test_get_cohort_by_id(self):
@@ -584,7 +584,7 @@ class TestCohorts(ModuleStoreTestCase):
             ValueError,
             lambda: cohorts.add_cohort(course.id, "My Cohort", assignment_type)
         )
-        does_not_exist_course_key = SlashSeparatedCourseKey("course", "does_not", "exist")
+        does_not_exist_course_key = CourseLocator("course", "does_not", "exist")
         self.assertRaises(
             ValueError,
             lambda: cohorts.add_cohort(does_not_exist_course_key, "My Cohort", assignment_type)

--- a/openedx/core/djangoapps/course_groups/tests/test_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_views.py
@@ -13,7 +13,7 @@ from django.http import Http404
 from django.test.client import RequestFactory
 from django_comment_common.models import CourseDiscussionSettings
 from django_comment_common.utils import get_course_discussion_settings
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -1101,7 +1101,7 @@ class AddUsersToCohortTestCase(CohortViewsTestCase):
         """
         users = [UserFactory(username="user{0}".format(i)) for i in range(3)]
         usernames = [user.username for user in users]
-        wrong_course_key = SlashSeparatedCourseKey("some", "arbitrary", "course")
+        wrong_course_key = CourseLocator("some", "arbitrary", "course")
         wrong_course_cohort = CohortFactory(name="wrong_cohort", course_id=wrong_course_key, users=[])
         self.request_add_users_to_cohort(
             ",".join(usernames),

--- a/openedx/core/djangoapps/user_api/course_tag/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/course_tag/tests/test_api.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from student.tests.factories import UserFactory
 from nose.plugins.attrib import attr
 from openedx.core.djangoapps.user_api.course_tag import api as course_tag_api
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 
 
 @attr(shard=2)
@@ -17,7 +17,7 @@ class TestCourseTagAPI(TestCase):
     def setUp(self):
         super(TestCourseTagAPI, self).setUp()
         self.user = UserFactory.create()
-        self.course_id = SlashSeparatedCourseKey('test_org', 'test_course_number', 'test_run')
+        self.course_id = CourseLocator('test_org', 'test_course_number', 'test_run')
         self.test_key = 'test_key'
 
     def test_get_set_course_tag(self):

--- a/openedx/core/djangoapps/user_api/tests/factories.py
+++ b/openedx/core/djangoapps/user_api/tests/factories.py
@@ -2,7 +2,7 @@
 from factory.django import DjangoModelFactory
 from factory import SubFactory
 from student.tests.factories import UserFactory
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.locator import CourseLocator
 
 from ..models import UserPreference, UserCourseTag, UserOrgTag
 
@@ -23,7 +23,7 @@ class UserCourseTagFactory(DjangoModelFactory):
         model = UserCourseTag
 
     user = SubFactory(UserFactory)
-    course_id = SlashSeparatedCourseKey('org', 'course', 'run')
+    course_id = CourseLocator('org', 'course', 'run')
     key = None
     value = None
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -14,7 +14,7 @@ from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from django.test.testcases import TransactionTestCase
 from django.test.utils import override_settings
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from opaque_keys.edx.keys import CourseKey
 from pytz import common_timezones_set, UTC
 from social_django.models import UserSocialAuth, Partial
 
@@ -99,8 +99,8 @@ class EmptyUserTestCase(UserAPITestCase):
 
 class EmptyRoleTestCase(UserAPITestCase):
     """Test that the endpoint supports empty result sets"""
-    course_id = SlashSeparatedCourseKey.from_deprecated_string("org/course/run")
-    LIST_URI = ROLE_LIST_URI + "?course_id=" + course_id.to_deprecated_string()
+    course_id = CourseKey.from_string("org/course/run")
+    LIST_URI = ROLE_LIST_URI + "?course_id=" + unicode(course_id)
 
     def test_get_list_empty(self):
         """Test that the endpoint properly returns empty result sets"""
@@ -135,8 +135,8 @@ class RoleTestCase(UserApiTestCase):
     """
     Test cases covering Role-related views and their behaviors
     """
-    course_id = SlashSeparatedCourseKey.from_deprecated_string("org/course/run")
-    LIST_URI = ROLE_LIST_URI + "?course_id=" + course_id.to_deprecated_string()
+    course_id = CourseKey.from_string("org/course/run")
+    LIST_URI = ROLE_LIST_URI + "?course_id=" + unicode(course_id)
 
     def setUp(self):
         super(RoleTestCase, self).setUp()


### PR DESCRIPTION
Here is another set of test-only changes. There are a few tests that I can't change because we would lose test coverage specific to SlashSeparatedCourseKey, or the tests fail because a modulestore doesn't exist in the runtime (this is when the SlashSeparatedCourseKey instance doesn't refer to an existing course, so CourseLocator is assumed in CourseKey.from_string). Here are links to the locations:

- [test_auto_auth](https://github.com/edx/edx-platform/blob/d01d165e4c9cb1c9ac24b5bbaf4417bd7940fab5/common/djangoapps/student/tests/test_auto_auth.py#L34)
- [student/tests/tests.py](https://github.com/edx/edx-platform/blob/e8a36957b1f732974260e7b9b42b9c25148b492c/common/djangoapps/student/tests/tests.py#L756)
- [util/tests/test_file.py](https://github.com/edx/edx-platform/blob/e8a36957b1f732974260e7b9b42b9c25148b492c/common/djangoapps/util/tests/test_file.py#L29)
- [xmodule/xmodule/tests/__init__.py](https://github.com/edx/edx-platform/blob/fc57527c5a5f5e96f858eb648506b9062524f4a0/common/lib/xmodule/xmodule/tests/__init__.py#L89)
- [test_conditional](https://github.com/edx/edx-platform/blob/c873be0f5568d4147ac43d83106b690f8fe7a9ed/common/lib/xmodule/xmodule/tests/test_conditional.py#L32)
- [test_course_module](https://github.com/edx/edx-platform/blob/fb36c7df6c7a96a1fbb4a7776a814ce59f98fd76/common/lib/xmodule/xmodule/tests/test_course_module.py#L41)
- [test_import](https://github.com/edx/edx-platform/blob/fc57527c5a5f5e96f858eb648506b9062524f4a0/common/lib/xmodule/xmodule/tests/test_import.py#L42)
- [test_content](https://github.com/edx/edx-platform/blob/6d2468d0dcf782a7561ecc61946146d6fae2762f/common/lib/xmodule/xmodule/tests/test_content.py#L157)


