### PR TITLE
remove all occurrences of flaky decorator

### DIFF
--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -5,7 +5,6 @@ Tests for discussion pages
 import datetime
 from uuid import uuid4
 
-from flaky import flaky
 from nose.plugins.attrib import attr
 from nose.tools import nottest
 from pytz import UTC
@@ -792,7 +791,6 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
         self.edit_response(page, "response_other_author")
 
     @attr(shard=2)
-    @flaky  # TODO fix this, see TNL-5453
     def test_vote_report_endorse_after_edit(self):
         """
         Scenario: Moderator should be able to vote, report or endorse after editing the response.

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -7,7 +7,6 @@ import json
 from datetime import datetime, timedelta
 
 import ddt
-from flaky import flaky
 from nose.plugins.attrib import attr
 
 from ...fixtures.course import CourseFixture, XBlockFixtureDesc
@@ -440,7 +439,6 @@ class CoursewareMultipleVerticalsTest(CoursewareMultipleVerticalsTestBase):
     Test courseware with multiple verticals
     """
 
-    @flaky  # PLAT-1198; should be fixed, but verify that failures stop before removing
     def test_navigation_buttons(self):
         self.courseware_page.visit()
 

--- a/common/test/acceptance/tests/lms/test_lms_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware_search.py
@@ -3,7 +3,6 @@ Test courseware search
 """
 import json
 
-from flaky import flaky
 from nose.plugins.attrib import attr
 
 from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
@@ -199,7 +198,6 @@ class CoursewareSearchTest(UniqueCourseTest):
         # Do the search again in the legacy sidebar, this time we expect results.
         self.assertTrue(self._search_for_content_in_sidebar(self.SEARCH_STRING, False))
 
-    @flaky  # TNL-5771
     def test_reindex(self):
         """
         Make sure new content gets reindexed on button press.

--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from unittest import skip
 from uuid import uuid4
 
-from flaky import flaky
 from nose.plugins.attrib import attr
 
 from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
@@ -276,7 +275,6 @@ class EdxNotesDefaultInteractionsTest(EdxNotesTestMixin):
         components = self.note_unit_page.components
         self.assert_notes_are_removed(components)
 
-    @flaky  # TODO: fix this, see TNL-6494
     def test_can_create_note_with_tags(self):
         """
         Scenario: a user of notes can define one with tags
@@ -1064,7 +1062,6 @@ class EdxNotesPageTest(EventsTestMixin, EdxNotesTestMixin):
         self.assertNotIn(u"Search Results", self.notes_page.tabs)
         self.assertEqual(len(self.notes_page.notes), 5)
 
-    @flaky  # TODO: fix this, see TNL-6493
     def test_open_note_when_accessed_from_notes_page(self):
         """
         Scenario: Ensure that the link to the Unit opens a note only once.

--- a/common/test/acceptance/tests/lms/test_lms_matlab_problem.py
+++ b/common/test/acceptance/tests/lms/test_lms_matlab_problem.py
@@ -5,8 +5,6 @@ Test for matlab problems
 import time
 from textwrap import dedent
 
-from flaky import flaky
-
 from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 from common.test.acceptance.fixtures.xqueue import XQueueResponseFixture
 from common.test.acceptance.pages.lms.matlab_problem import MatlabProblemPage
@@ -61,7 +59,6 @@ class MatlabProblemTest(ProblemsTest):
         self.assertEqual(matlab_problem_page.problem_name, 'Test Matlab Problem')
         return matlab_problem_page
 
-    @flaky  # TNL-4132
     def test_run_code(self):
         """
         Test "Run Code" button functionality.

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -6,7 +6,6 @@ See also lettuce tests in lms/djangoapps/courseware/features/problems.feature
 import random
 import textwrap
 from abc import ABCMeta, abstractmethod
-from flaky import flaky
 
 import ddt
 from nose import SkipTest
@@ -144,7 +143,6 @@ class ProblemTypeA11yTestMixin(object):
     Shared a11y tests for all problem types.
     """
     @attr('a11y')
-    @flaky  # TE-2179
     def test_problem_type_a11y(self):
         """
         Run accessibility audit for the problem type.

--- a/common/test/acceptance/tests/studio/test_studio_asset.py
+++ b/common/test/acceptance/tests/studio/test_studio_asset.py
@@ -4,8 +4,6 @@ Acceptance tests for Studio related to the asset index page.
 
 from unittest import skip
 
-from flaky import flaky
-
 from common.test.acceptance.fixtures.base import StudioApiLoginError
 from common.test.acceptance.pages.studio.asset_index import AssetIndexPage
 from common.test.acceptance.tests.helpers import skip_if_browser
@@ -34,7 +32,6 @@ class AssetIndexTest(StudioCourseTest):
         self.course_fixture.add_asset(['image.jpg', 'textbook.pdf'])
 
     @skip_if_browser('chrome')  # TODO Need to fix test_page_existance for this for chrome browser
-    @flaky      # TODO fix this FEDX-88
     def test_type_filter_exists(self):
         """
         Make sure type filter is on the page.
@@ -43,7 +40,6 @@ class AssetIndexTest(StudioCourseTest):
         assert self.asset_page.type_filter_on_page() is True
 
     @skip_if_browser('chrome')  # TODO Need to fix test_page_existance for this for chrome browser
-    @flaky    # TODO FEDX-88
     def test_filter_results(self):
         """
         Make sure type filter actually filters the results.

--- a/common/test/acceptance/tests/studio/test_studio_home.py
+++ b/common/test/acceptance/tests/studio/test_studio_home.py
@@ -3,7 +3,6 @@ Acceptance tests for Home Page (My Courses / My Libraries).
 """
 from uuid import uuid4
 
-from flaky import flaky
 from opaque_keys.edx.locator import LibraryLocator
 
 from common.test.acceptance.pages.common.auto_auth import AutoAuthPage
@@ -70,7 +69,6 @@ class StudioLanguageTest(AcceptanceTest):
         self.account_settings = AccountSettingsPage(self.browser)
         AutoAuthPage(self.browser).visit()
 
-    @flaky  # TODO fix this, see WL-963
     def test_studio_language_change(self):
         """
         Scenario: Ensure that language selection is working fine.

--- a/common/test/acceptance/tests/studio/test_studio_settings_details.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_details.py
@@ -4,7 +4,6 @@ Acceptance tests for Studio's Settings Details pages
 from datetime import datetime, timedelta
 from unittest import skip
 
-from flaky import flaky
 from nose.plugins.attrib import attr
 
 from common.test.acceptance.fixtures.config import ConfigModelFixture
@@ -175,7 +174,6 @@ class SettingsMilestonesTest(StudioSettingsDetailsTest):
             text='Entrance Exam'
         ))
 
-    @flaky  # TODO: SOL-1595
     def test_entrance_exam_has_unit_button(self):
         """
         Test that entrance exam should be created after checking the 'enable entrance exam' checkbox.

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -7,7 +7,6 @@ import os
 from unittest import skip, skipIf
 
 from ddt import data, ddt, unpack
-from flaky import flaky
 from mock import patch
 from nose.plugins.attrib import attr
 from selenium.webdriver.common.action_chains import ActionChains
@@ -944,7 +943,6 @@ class YouTubeVideoTest(VideoBaseTest):
 class YouTubeHtml5VideoTest(VideoBaseTest):
     """ Test YouTube HTML5 Video Player """
 
-    @flaky  # TODO fix this, see TNL-1642
     def test_youtube_video_rendering_with_unsupported_sources(self):
         """
         Scenario: Video component is rendered in the LMS in Youtube mode

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -11,7 +11,6 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from edx_rest_api_client import exceptions
-from flaky import flaky
 from nose.plugins.attrib import attr
 from rest_framework.utils.encoders import JSONEncoder
 
@@ -163,7 +162,6 @@ class CourseRetrieveUpdateViewTests(CourseApiViewTestMixin, ModuleStoreTestCase)
 
         return response, expected
 
-    @flaky  # TODO This test will fail if one of the timestamps (in actual or expected) ends in .000
     def test_update(self):
         """ Verify the view supports updating a course. """
         # Sanity check: Ensure no verification deadline is set


### PR DESCRIPTION
There are 13 tests marked with the "flaky" decorator in the platform. This PR will remove all instances of them, following our plan to remove flaky tests (see https://openedx.atlassian.net/wiki/spaces/TE/pages/161427235/Updated+Flaky+Test+Process). I am intentionally not removing the flaky library from requirements.