### PR TITLE
Disable ENABLE_SEPARATE_ARCHIVED_COURSES due to server error.

### DIFF
--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -101,6 +101,10 @@ FEATURES['ENABLE_VIDEO_BUMPER'] = True  # Enable video bumper in Studio settings
 
 FEATURES['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = True
 
+# Whether archived courses (courses with end dates in the past) should be
+# shown in Studio in a separate list.
+FEATURES['ENABLE_SEPARATE_ARCHIVED_COURSES'] = True
+
 # Enable support for OpenBadges accomplishments
 FEATURES['ENABLE_OPENBADGES'] = True
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -254,8 +254,9 @@ FEATURES = {
     'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': True,
 
     # Whether archived courses (courses with end dates in the past) should be
-    # shown in Studio in a separate list.
-    'ENABLE_SEPARATE_ARCHIVED_COURSES': True
+    # shown in Studio in a separate list. Note that attempting to enable this
+    # failed on stage-- see EDUCATOR-1134.
+    'ENABLE_SEPARATE_ARCHIVED_COURSES': False
 }
 
 ENABLE_JASMINE = False


### PR DESCRIPTION
[EDUCATOR-1134](https://openedx.atlassian.net/browse/EDUCATOR-1134)

This feature flag was enabled in #15390, which was enabling functionality actually merged to master in #15431.

FYI @pomegranited 