### PR TITLE
EDUCATOR-1127 Override grade to zero when exam attempt is rejected Final

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -412,7 +412,22 @@ class PersistentSubsectionGrade(DeleteGradesMixin, TimeStampedModel):
         usage_key = params.pop('usage_key')
 
         # apply grade override if one exists before saving model
-        # EDUCTATOR-1127: remove override until this behavior is verified in production
+        try:
+            override = PersistentSubsectionGradeOverride.objects.get(
+                grade__user_id=user_id,
+                grade__course_id=usage_key.course_key,
+                grade__usage_key=usage_key,
+            )
+            if override.earned_all_override is not None:
+                params['earned_all'] = override.earned_all_override
+            if override.possible_all_override is not None:
+                params['possible_all'] = override.possible_all_override
+            if override.earned_graded_override is not None:
+                params['earned_graded'] = override.earned_graded_override
+            if override.possible_graded_override is not None:
+                params['possible_graded'] = override.possible_graded_override
+        except PersistentSubsectionGradeOverride.DoesNotExist:
+            pass
 
         grade, _ = cls.objects.update_or_create(
             user_id=user_id,

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -312,9 +312,8 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
         override = PersistentSubsectionGradeOverride(grade=grade, earned_all_override=0.0, earned_graded_override=0.0)
         override.save()
         grade = PersistentSubsectionGrade.update_or_create_grade(**self.params)
-        # EDUCATOR-1127 Override is not enabled yet, change to 0.0 when enabled
-        self.assertEqual(grade.earned_all, 6.0)
-        self.assertEqual(grade.earned_graded, 6.0)
+        self.assertEqual(grade.earned_all, 0.0)
+        self.assertEqual(grade.earned_graded, 0.0)
 
     def _assert_tracker_emitted_event(self, tracker_mock, grade):
         """

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -163,10 +163,10 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             self.assertEquals(mock_block_structure_create.call_count, 1)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 29, True),
-        (ModuleStoreEnum.Type.mongo, 1, 25, False),
-        (ModuleStoreEnum.Type.split, 3, 29, True),
-        (ModuleStoreEnum.Type.split, 3, 25, False),
+        (ModuleStoreEnum.Type.mongo, 1, 30, True),
+        (ModuleStoreEnum.Type.mongo, 1, 26, False),
+        (ModuleStoreEnum.Type.split, 3, 30, True),
+        (ModuleStoreEnum.Type.split, 3, 26, False),
     )
     @ddt.unpack
     def test_query_counts(self, default_store, num_mongo_calls, num_sql_calls, create_multiple_subsections):
@@ -178,8 +178,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
                     self._apply_recalculate_subsection_grade()
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 29),
-        (ModuleStoreEnum.Type.split, 3, 29),
+        (ModuleStoreEnum.Type.mongo, 1, 30),
+        (ModuleStoreEnum.Type.split, 3, 30),
     )
     @ddt.unpack
     def test_query_counts_dont_change_with_more_content(self, default_store, num_mongo_calls, num_sql_calls):
@@ -239,8 +239,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             self.assertEqual(len(PersistentSubsectionGrade.bulk_read_grades(self.user.id, self.course.id)), 0)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 26),
-        (ModuleStoreEnum.Type.split, 3, 26),
+        (ModuleStoreEnum.Type.mongo, 1, 27),
+        (ModuleStoreEnum.Type.split, 3, 27),
     )
     @ddt.unpack
     def test_persistent_grades_enabled_on_course(self, default_store, num_mongo_queries, num_sql_queries):

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -183,18 +183,15 @@ from django.utils.http import urlquote_plus
                                                 <em class="localized-datetime" data-datetime="${section.due}" data-string="${_('due {date}')}" data-timezone="${user_timezone}" data-language="${user_language}"></em>
                                             %endif
                                         </p>
-                                        <%doc>
-                                            EDUCATOR-1127: Do not display override notice until override is enabled
+                                        <p class="override-notice">
                                             %if section.override is not None:
-                                                <p class="override-notice">
-                                                    %if section.format is not None and section.format == "Exam":
-                                                        ${_("Exam grade has been overridden due to a failed proctoring review.")}
-                                                    %else:
-                                                        ${_("Section grade has been overridden.")}
-                                                    %endif
-                                                </p>
+                                                %if section.format is not None and section.format == "Exam":
+                                                    ${_("Suspicious activity detected during proctored exam review. Exam score 0.")}
+                                                %else:
+                                                    ${_("Section grade has been overridden.")}
+                                                %endif
                                             %endif
-                                        </%doc>
+                                        </p>
                                         %if len(section.problem_scores.values()) > 0:
                                           %if section.show_grades(staff_access):
                                           <dl class="scores">


### PR DESCRIPTION
These changes were originally in https://github.com/edx/edx-platform/pull/15726 but were replaced with logging instead so that we could test the behavior in production by analyzing the logs without actually affecting any grades.

Do not merge until we have verified in the splunk logs that:

1. When a learner's proctored exam software secure review is saved as Suspicious in the Django admin, a log is emitted about overriding the exam grade to zero.
2. When that learner's review is later changed from Suspicious to Clean, a log is emitted about deleting the override.

Once this is merged, overrides will begin affecting grades in response to new proctored exam reviews unless there is a course waffle flag disabling the override feature on the course that contains the proctored exam.

@edx/educator-dahlia @efischer19 