### PR TITLE
[ENT-341] Bump edx-enterprise to 0.40.0.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.39.9
+edx-enterprise==0.40.0
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.5


### PR DESCRIPTION
**Description:** This bumps edx-enterprise up to 0.40.0 to incorporate the new Programs and Catalogs endpoints from https://github.com/edx/edx-enterprise/pull/164.

**JIRA:** [ENT-341](https://openedx.atlassian.net/browse/ENT-341)

**Merge deadline:** Asap.

**Note:** This contains a new model and thus a migration for the `enterprise` app. CC @jdmulloy just in case because of all the recent migration issues in deployment.