### PR TITLE
[ENT-495] Bump edx-enterprise to 0.40.1.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2822,6 +2822,7 @@ OPTIONAL_APPS = (
 
     # Enterprise Apps (http://github.com/edx/edx-enterprise)
     ('enterprise', None),
+    ('consent', None),
     ('integrated_channels.integrated_channel', None),
     ('integrated_channels.sap_success_factors', None),
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.40.0
+edx-enterprise==0.40.1
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.5


### PR DESCRIPTION
**Description:** This bumps edx-enterprise up to 0.40.1 to incorporate the new `DataSharingConsent` model in the `consent` application from https://github.com/edx/edx-enterprise/pull/167, but it is unused for now.

**JIRA:** [ENT-495](https://openedx.atlassian.net/browse/ENT-495)

**Merge deadline:** Asap.

**Note:** This contains a new model and thus a migration for the `consent` app, which we are only now adding to the `OPTIONAL_APPS` list on `master`. CC @jdmulloy just in case because of all the recent migration issues in deployment.