### PR TITLE
Force hint notification to take up entire width.

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -111,6 +111,7 @@ h2 {
 
 .problem-hint {
   margin-bottom: 20px;
+  width: 100%;
 }
 
 .hint-label {


### PR DESCRIPTION
[EDUCATOR-1136](https://openedx.atlassian.net/browse/EDUCATOR-1136)

This fixes a bug I saw in the demo where short hint messages did not force the hint notification area to take up the full width. Stage with bug: https://courses.stage.edx.org/courses/course-v1:edx+999+999/courseware/e10b7ff8daf6470fb2aef2cadf7b34df/61a8573d562f4ac89e977265a2b9a2b3/1?activate_block_id=block-v1%3Aedx%2B999%2B999%2Btype%40vertical%2Bblock%40f6a160a8bed74f4e8329d815ee3fc447

![image](https://user-images.githubusercontent.com/484484/29223480-b118f954-7e94-11e7-81b7-492cfe6493f4.png)

Sandbox with fix: https://cahrens.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/8?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%401072ecf441a144b5aeca5fb6eca0d0cf