### PR TITLE
Log courses with improper end dates.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -254,9 +254,8 @@ FEATURES = {
     'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': True,
 
     # Whether archived courses (courses with end dates in the past) should be
-    # shown in Studio in a separate list. Note that attempting to enable this
-    # failed on stage-- see EDUCATOR-1134.
-    'ENABLE_SEPARATE_ARCHIVED_COURSES': False
+    # shown in Studio in a separate list.
+    'ENABLE_SEPARATE_ARCHIVED_COURSES': True
 }
 
 ENABLE_JASMINE = False

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1451,4 +1451,13 @@ class CourseSummary(object):
         """
         Returns whether the course has ended.
         """
-        return course_metadata_utils.has_course_ended(self.end)
+        try:
+            return course_metadata_utils.has_course_ended(self.end)
+        except TypeError as e:
+            log.warning(
+                "Course '{course_id}' has an improperly formatted end date '{end_date}'. Error: '{err}'.".format(
+                    course_id=unicode(self.id), end_date=self.end, err=e
+                )
+            )
+            modified_end = self.end.replace(tzinfo=utc)
+            return course_metadata_utils.has_course_ended(modified_end)

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -2,6 +2,7 @@
 import ddt
 import unittest
 from datetime import datetime, timedelta
+from dateutil import parser
 
 import itertools
 from fs.memoryfs import MemoryFS
@@ -140,6 +141,16 @@ class HasEndedMayCertifyTestCase(unittest.TestCase):
         self.assertTrue(self.future_show_certs.may_certify())
         self.assertTrue(self.future_show_certs_no_info.may_certify())
         self.assertFalse(self.future_noshow_certs.may_certify())
+
+
+class CourseSummaryHasEnded(unittest.TestCase):
+    """ Test for has_ended method when end date is missing timezone information. """
+
+    def test_course_end(self):
+        test_course = get_dummy_course("2012-01-01T12:00")
+        bad_end_date = parser.parse("2012-02-21 10:28:45")
+        summary = xmodule.course_module.CourseSummary(test_course.id, end=bad_end_date)
+        self.assertTrue(summary.has_ended())
 
 
 @ddt.ddt


### PR DESCRIPTION
[EDUCATOR-1134](https://openedx.atlassian.net/browse/EDUCATOR-1134)

This change will allow us to determine which courses in stage (and production) have improper course dates. It also should be pretty safe, since it simply assumes UTC when no timezone exists.

Related to #15788. Note that I was never able to reproduce the error on my devstack (through editing the date and doing import/export); the date without a timezone would "correct itself". However, I could reproduce it in the debugger if I modified the date.