### PR TITLE
Show Enroll Now banner to staff.

### DIFF
--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -204,7 +204,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         [CourseUserType.ANONYMOUS, 'To see course content'],
         [CourseUserType.ENROLLED, None],
         [CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
-        [CourseUserType.UNENROLLED_STAFF, None],
+        [CourseUserType.UNENROLLED_STAFF, 'You must be enrolled in the course to see course content.'],
     )
     @ddt.unpack
     def test_home_page(self, user_type, expected_message):
@@ -239,7 +239,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         [CourseUserType.ANONYMOUS, 'To see course content'],
         [CourseUserType.ENROLLED, None],
         [CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
-        [CourseUserType.UNENROLLED_STAFF, None],
+        [CourseUserType.UNENROLLED_STAFF, 'You must be enrolled in the course to see course content.'],
     )
     @ddt.unpack
     def test_home_page_not_unified(self, user_type, expected_message):


### PR DESCRIPTION
LEARNER-2249

Allow staff to see the Enroll Now banner, matching the functionality of
the in course home messaging and showing the actual page that the
students can see before being enrolled.

Sandbox: http://pr2249.sandbox.edx.org

@marcotuts @edx/learner-mercury 