### PR TITLE
Update Certificate Task Call

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -235,6 +235,7 @@ class XQueueCertInterface(object):
             status.auditing,
             status.audit_passing,
             status.audit_notpassing,
+            status.unverified,
         ]
 
         cert_status = certificate_status_for_student(student, course_id)['status']

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -520,8 +520,11 @@ class GenerateUserCertificatesTest(EventTestMixin, WebCertificateTestMixin, Modu
 
     def test_generate_user_certificates_with_unverified_cert_status(self):
         """
-        Generate user certificate will not raise exception in case of certificate is None.
+        Generate user certificate when the certificate is unverified
+        will trigger an update to the certificate if the user has since
+        verified.
         """
+        self._setup_course_certificate()
         # generate certificate with unverified status.
         GeneratedCertificateFactory.create(
             user=self.student,
@@ -531,9 +534,9 @@ class GenerateUserCertificatesTest(EventTestMixin, WebCertificateTestMixin, Modu
         )
 
         with mock_passing_grade():
-            with self._mock_queue(is_successful=False):
+            with self._mock_queue():
                 status = certs_api.generate_user_certificates(self.student, self.course.id)
-                self.assertEqual(status, None)
+                self.assertEqual(status, 'generating')
 
     @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
     def test_new_cert_requests_returns_generating_for_html_certificate(self):

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1007,8 +1007,9 @@ def _get_cert_data(student, course, course_key, is_active, enrollment_mode):
 
     # If the learner is in verified modes and the student did not have
     # their ID verified, we need to show message to ask learner to verify their ID first
-    missing_required_verification = enrollment_mode in CourseMode.VERIFIED_MODES and \
-        not SoftwareSecurePhotoVerification.user_is_verified(student)
+    missing_required_verification = (
+        enrollment_mode in CourseMode.VERIFIED_MODES and not SoftwareSecurePhotoVerification.user_is_verified(student)
+    )
 
     if missing_required_verification or cert_downloadable_status['is_unverified']:
         platform_name = configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)


### PR DESCRIPTION
## Update certificate generation task 

### Description
Only enqueue verified/paid learners for certificate generation, and update certificates in an unverified state when the learner's identity has been verified.

### NOTE
This is a specific proposal per my conversations with devops, and is open for debate as to its necessity).

### Testing
- [x] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @iloveagent57 

FYI: @edx/educator-neem @feanil 

### Post-review
- [x] Rebase and squash commits
