### PR TITLE
Increase rate-limit staff or superusers for enrollment API.

### DIFF
--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -547,6 +547,32 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             expected_status = status.HTTP_429_TOO_MANY_REQUESTS if attempt >= self.rate_limit else status.HTTP_200_OK
             self.assert_enrollment_status(expected_status=expected_status)
 
+    def test_enrollment_throttle_for_staff_user(self):
+        """ Make sure throttle rate is higher for staff users """
+        self.rate_limit_config.enabled = True
+        self.rate_limit_config.save()
+        self.client.logout()
+        staff_user = UserFactory.create(password=self.PASSWORD, is_staff=True)
+        self.client.login(username=staff_user.username, password=self.PASSWORD)
+
+        CourseModeFactory(
+            course_id=self.course.id,
+            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
+            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
+        )
+
+        throttle = EnrollmentUserThrottle()
+        throttle.scope = 'staff'
+        rate_limit, __ = throttle.parse_rate(throttle.get_rate())
+
+        # Make enough requests to reach the rate limit
+        for attempt in xrange(rate_limit):
+            self.assert_enrollment_status(username=staff_user.username, expected_status=status.HTTP_200_OK)
+
+        # Once the limit is reached, subsequent requests should fail
+        for attempt in xrange(rate_limit + 10):
+            self.assert_enrollment_status(username=staff_user.username, expected_status=status. HTTP_429_TOO_MANY_REQUESTS)
+
     def test_enrollment_throttle_for_service(self):
         """Make sure a service can call the enrollment API as many times as needed. """
         self.rate_limit_config.enabled = True


### PR DESCRIPTION
Increase rate limit super or staff users for accessing the enrollment API.