### PR TITLE
Fix Proctoring doc link

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1192,9 +1192,10 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
                     'enable_timed_exams': xblock.enable_timed_exams
                 })
             elif xblock.category == 'sequential':
+                rules_url = settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('online_proctoring_rules', ""),
                 xblock_info.update({
                     'is_proctored_exam': xblock.is_proctored_exam,
-                    'online_proctoring_rules': settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('online_proctoring_rules', {}),
+                    'online_proctoring_rules': rules_url,
                     'is_practice_exam': xblock.is_practice_exam,
                     'is_time_limited': xblock.is_time_limited,
                     'exam_review_rules': xblock.exam_review_rules,

--- a/cms/templates/js/timed-examination-preference-editor.underscore
+++ b/cms/templates/js/timed-examination-preference-editor.underscore
@@ -44,15 +44,19 @@
                 </label>
                 <% var online_proctoring_rules = xblockInfo.get('online_proctoring_rules'); %>
                 <p class='field-message' id='review-rules-description'>
-                <%= edx.HtmlUtils.interpolateHtml(
-                    gettext('Specify any rules or rule exceptions that the proctoring review team should enforce when reviewing the videos. For example, you could specify that calculators are allowed. These specified rules are visible to learners before the learners start the exam, along with the {linkStart}general proctored exam rules{linkEnd}.'),
-                    {
-                        linkStart: edx.HtmlUtils.interpolateHtml(
-                            edx.HtmlUtils.HTML('<a href="{onlineProctoringUrl}" title="{onlineProctoringTitle}">'),
-                            { onlineProctoringUrl: online_proctoring_rules, onlineProctoringTitle: gettext('General Proctored Exam Rules')}),
-                        linkEnd: edx.HtmlUtils.HTML('</a>')
-                    })
-                %>
+                <% if (online_proctoring_rules) { %>
+                    <%= edx.HtmlUtils.interpolateHtml(
+                        gettext('Specify any rules or rule exceptions that the proctoring review team should enforce when reviewing the videos. For example, you could specify that calculators are allowed. These specified rules are visible to learners before the learners start the exam, along with the {linkStart}general proctored exam rules{linkEnd}.'),
+                        {
+                            linkStart: edx.HtmlUtils.interpolateHtml(
+                                edx.HtmlUtils.HTML('<a href="{onlineProctoringUrl}" title="{onlineProctoringTitle}">'),
+                                { onlineProctoringUrl: online_proctoring_rules, onlineProctoringTitle: gettext('General Proctored Exam Rules')}),
+                            linkEnd: edx.HtmlUtils.HTML('</a>')
+                        })
+                    %>
+                <% } else { %>
+                    <%- gettext('Specify any rules or rule exceptions that the proctoring review team should enforce when reviewing the videos. For example, you could specify that calculators are allowed. These specified rules are visible to learners before the learners start the exam.') %>
+                <% } %>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
# [EDUCATOR-1142](https://openedx.atlassian.net/browse/EDUCATOR-1142)

tl;dr: `{}` is not a good choice of default value for this url, it should always be a string.

I'm curious as to why a seemingly-static and always-relevant documentation link about the platform itself has to go through the [settings](https://github.com/edx/edx-platform/blob/941605cc7ed3c562e9b675443a20ce238dc325b6/cms/envs/aws.py#L477) -> [configuration](https://github.com/edx/configuration/blob/6cdd340524c664fa74c34ba9ecad028256ab9902/playbooks/roles/edxapp/defaults/main.yml#L1178) -> [edx-internal](https://github.com/edx/edx-internal/blob/e1bc34ca128cb7065a41067e9431ec34424fd1cd/ansible/vars/edx.yml#L452) indirection system; *every* open installation could use that same link no?

At any rate, we need to provide a default value in case the settings value does not exist or cannot be found. What should I use there? Should I focus on fixing the settings value not getting passed all the way through, or make a more-easily-accessible default value?

The currently existing code on this PR is confirmed working for me locally, but I know defining the default value there isn't the ideal solution.

@edx/doc @edx/educator-dahlia 