### PR TITLE
BOOK_URL hasn't been used since the 6.00 courses

### DIFF
--- a/cms/envs/bok_choy.env.json
+++ b/cms/envs/bok_choy.env.json
@@ -1,5 +1,4 @@
 {
-    "BOOK_URL": "",
     "BUGS_EMAIL": "bugs@example.com",
     "BULK_EMAIL_DEFAULT_FROM_EMAIL": "no-reply@example.com",
     "CACHES": {

--- a/cms/envs/bok_choy_docker.env.json
+++ b/cms/envs/bok_choy_docker.env.json
@@ -1,5 +1,4 @@
 {
-    "BOOK_URL": "",
     "BUGS_EMAIL": "bugs@example.com",
     "BULK_EMAIL_DEFAULT_FROM_EMAIL": "no-reply@example.com",
     "CACHES": {

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -212,7 +212,6 @@ if ENV_TOKENS.get('SESSION_COOKIE_NAME', None):
     # NOTE, there's a bug in Django (http://bugs.python.org/issue18012) which necessitates this being a str()
     SESSION_COOKIE_NAME = str(ENV_TOKENS.get('SESSION_COOKIE_NAME'))
 
-BOOK_URL = ENV_TOKENS['BOOK_URL']
 LOG_DIR = ENV_TOKENS['LOG_DIR']
 
 CACHES = ENV_TOKENS['CACHES']

--- a/lms/envs/bok_choy.env.json
+++ b/lms/envs/bok_choy.env.json
@@ -1,6 +1,5 @@
 {
     "ANALYTICS_DASHBOARD_URL": "",
-    "BOOK_URL": "",
     "BUGS_EMAIL": "bugs@example.com",
     "BULK_EMAIL_DEFAULT_FROM_EMAIL": "no-reply@example.com",
     "CACHES": {

--- a/lms/envs/bok_choy_docker.env.json
+++ b/lms/envs/bok_choy_docker.env.json
@@ -1,6 +1,5 @@
 {
     "ANALYTICS_DASHBOARD_URL": "",
-    "BOOK_URL": "",
     "BUGS_EMAIL": "bugs@example.com",
     "BULK_EMAIL_DEFAULT_FROM_EMAIL": "no-reply@example.com",
     "CACHES": {

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -591,11 +591,6 @@ AUTHENTICATION_BACKENDS = (
 STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
-# Dev machines shouldn't need the book
-# BOOK_URL = '/static/book/'
-BOOK_URL = 'https://mitxstatic.s3.amazonaws.com/book_images/'  # For AWS deploys
-RSS_TIMEOUT = 600
-
 # Configuration option for when we want to grab server error pages
 STATIC_GRAB = False
 DEV_CONTENT = True


### PR DESCRIPTION
RSS_TIMEOUT was removed in e8ee29786fdfe2f39d780f0f64cc5592d19b0fb9
but missed in lms/envs