### PR TITLE
EDUCATOR-801 Certificate issued date should be the certificate availability date for instructor-paced courses

### DIFF
--- a/common/test/acceptance/tests/lms/test_certificate_web_view.py
+++ b/common/test/acceptance/tests/lms/test_certificate_web_view.py
@@ -32,7 +32,7 @@ class CertificateWebViewTest(EventsTestMixin, UniqueCourseTest):
             'course_title': 'Course title override',
             'signatories': [],
             'version': 1,
-            'is_active': True
+            'is_active': True,
         }
         course_settings = {'certificates': test_certificate_config}
         self.course_fixture = CourseFixture(

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -4,6 +4,7 @@ import json
 from uuid import uuid4
 
 import ddt
+import datetime
 from django.conf import settings
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
@@ -189,7 +190,10 @@ class MicrositeCertificatesViewsTests(ModuleStoreTestCase):
         super(MicrositeCertificatesViewsTests, self).setUp()
         self.client = Client()
         self.course = CourseFactory.create(
-            org='testorg', number='run1', display_name='refundable course'
+            org='testorg',
+            number='run1',
+            display_name='refundable course',
+            certificate_available_date=datetime.datetime.today() - datetime.timedelta(days=1)
         )
         self.course.cert_html_view_enabled = True
         self.course.save()


### PR DESCRIPTION
## [EDUCATOR-801](https://openedx.atlassian.net/browse/EDUCATOR-801)

### Description

Certificate issued date should be the certificate availability date for instructor-paced courses, and the certificate creation date for self-paced courses.

### Sandbox
- [ ] ed801.sandbox.edx.org

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
- [ ] @iloveagent57 
- [ ] @yro 
 
### Post-review
- [ ] Rebase and squash commits
