### PR TITLE
Add activation_key var to user profile in SailThru.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -145,7 +145,7 @@ REGISTRATION_UTM_PARAMETERS = {
 }
 REGISTRATION_UTM_CREATED_AT = 'registration_utm_created_at'
 # used to announce a registration
-REGISTER_USER = Signal(providing_args=["user", "profile"])
+REGISTER_USER = Signal(providing_args=["user", "registration"])
 
 # Disable this warning because it doesn't make sense to completely refactor tests to appease Pylint
 # pylint: disable=logging-format-interpolation
@@ -2022,7 +2022,7 @@ def create_account_with_params(request, params):
         )
 
     # Announce registration
-    REGISTER_USER.send(sender=None, user=user, profile=profile)
+    REGISTER_USER.send(sender=None, user=user, registration=registration)
 
     create_comments_service_user(user)
 


### PR DESCRIPTION
As an email marketer, I would like to send an account activation reminder to learners who haven't activated
their accounts to increase their chances of coming back and engaging with our platform. Each user profile in SailThru will have a var with the correct activation_key originally assigned to the user.

LEARNER-2110

**Sandbox:** https://sailthru.sandbox.edx.org