### PR TITLE
Track program purchase attempts from learner programs dashboard

### DIFF
--- a/lms/static/js/learner_dashboard/views/program_details_view.js
+++ b/lms/static/js/learner_dashboard/views/program_details_view.js
@@ -30,6 +30,10 @@
 
                  tpl: HtmlUtils.template(pageTpl),
 
+                 events: {
+                     'click .complete-program': 'trackPurchase'
+                 },
+
                  initialize: function(options) {
                      this.options = options;
 
@@ -115,6 +119,15 @@
                          model: this.programModel,
                          courseModel: this.courseData,
                          certificateCollection: this.certificateCollection
+                     });
+                 },
+
+                 trackPurchase: function() {
+                     var data = this.options.programData;
+                     window.analytics.track('edx.bi.user.dashboard.program.purchase', {
+                         category: data.variant + ' bundle',
+                         label: data.title,
+                         uuid: data.uuid
                      });
                  }
              });

--- a/lms/static/js/spec/learner_dashboard/program_details_view_spec.js
+++ b/lms/static/js/spec/learner_dashboard/program_details_view_spec.js
@@ -603,6 +603,27 @@ define([
             expect($(view.$('.select-choice')[0]).attr('for')).toEqual($(view.$('.run-select')[0]).attr('id'));
             expect($(view.$('.enroll-button button')[0]).text().trim()).toEqual('Enroll Now');
         });
+
+        it('should send analytic event when purchase button clicked', function() {
+            var properties = {
+                category: 'partial bundle',
+                label: 'Test Course Title',
+                uuid: '0ffff5d6-0177-4690-9a48-aa2fecf94610'
+            };
+            view = initView({
+                programData: $.extend({}, options.programData, {
+                    is_learner_eligible_for_one_click_purchase: true,
+                    variant: 'partial'
+                })
+            });
+            view.render();
+            $('.complete-program').click();
+            // Verify that analytics event fires when the purchase button is clicked.
+            expect(window.analytics.track).toHaveBeenCalledWith(
+                'edx.bi.user.dashboard.program.purchase',
+                properties
+            );
+        });
     });
 }
 );

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -602,6 +602,7 @@ class ProgramMarketingDataExtender(ProgramDataExtender):
         applicable_seat_types = self.data['applicable_seat_types']
         is_learner_eligible_for_one_click_purchase = self.data['is_program_eligible_for_one_click_purchase']
         skus = []
+        bundle_variant = 'full'
         if is_learner_eligible_for_one_click_purchase:
             for course in self.data['courses']:
                 add_course_sku = False
@@ -626,6 +627,8 @@ class ProgramMarketingDataExtender(ProgramDataExtender):
                         is_learner_eligible_for_one_click_purchase = False
                         skus = []
                         break
+                else:
+                    bundle_variant = 'partial'
 
         if skus:
             try:
@@ -647,7 +650,8 @@ class ProgramMarketingDataExtender(ProgramDataExtender):
 
                 self.data.update({
                     'discount_data': discount_data,
-                    'full_program_price': discount_data['total_incl_tax']
+                    'full_program_price': discount_data['total_incl_tax'],
+                    'variant': bundle_variant
                 })
             except (ConnectionError, SlumberBaseException, Timeout):
                 log.exception('Failed to get discount price for following product SKUs: %s ', ', '.join(skus))


### PR DESCRIPTION
Adding a GA tracking event to learner programs dashboard one-click-purchase button

[LEARNER-2228](https://openedx.atlassian.net/browse/LEARNER-2228)