### PR TITLE
increase staff user rate limit

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -75,7 +75,7 @@ class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
     """Limit the number of requests users can make to the enrollment API."""
     THROTTLE_RATES = {
         'user': '40/minute',
-        'staff': '200/minute',
+        'staff': '300/minute',
     }
 
     def allow_request(self, request, view):


### PR DESCRIPTION
Still seeing a few 429 errors, bumping up the limit.