### PR TITLE
have coursegraph cache nodes on block_ids rather than locations (EDUC…

### DIFF
--- a/openedx/core/djangoapps/coursegraph/tasks.py
+++ b/openedx/core/djangoapps/coursegraph/tasks.py
@@ -167,17 +167,18 @@ def serialize_course(course_id):
             fields[field_name] = coerce_types(value)
 
         node = Node(block_type, 'item', **fields)
-        location_to_node[item.location] = node
+        location_to_node[item.location.block_id] = node
 
     # create relationships
     relationships = []
     for item in items:
         previous_child_node = None
-        for index, child_loc in enumerate(item.get_children()):
-            parent_node = location_to_node.get(item.location)
-            child_node = location_to_node.get(child_loc.location)
-            child_node["index"] = index
+        for index, child in enumerate(item.get_children()):
+            parent_node = location_to_node.get(item.location.block_id)
+            child_node = location_to_node.get(child.location.block_id)
             if parent_node is not None and child_node is not None:
+                child_node["index"] = index
+
                 relationship = Relationship(parent_node, "PARENT_OF", child_node)
                 relationships.append(relationship)
 


### PR DESCRIPTION
…ATOR-1133)

In [EDUCATOR-1133](https://openedx.atlassian.net/browse/EDUCATOR-1133), we were seeing `location_to_node` cache misses when creating the parent/child relationship in coursegraph, because locations from `get_children` started—at some point—using versions and branches. This PR caches Node representations of xblocks by block_id, instead of the full location, to circumvent that problem.

@fredsmith , could you please review?
@tobz , I'm tagging you as an optional reviewer
