### PR TITLE
Allow i18n strings to be scraped from openedx/features

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -110,7 +110,7 @@ ignore_dirs:
     - '*/terrain'
     - '*/spec'
     - '*/tests'
-    - '*/features'
+    - '*/djangoapps/*/features'
     # Directories full of auto-generated JS
     - lms/static/js/i18n
     - cms/static/js/i18n


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-2304

I verified locally that this allows the strings in openedx/features to be scraped, and that they are reflected on the Learner profile.