### PR TITLE
Upgrading the edx-organizations package to 0.4.6.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -51,7 +51,7 @@ edx-django-sites-extensions==2.3.0
 edx-enterprise==0.40.2
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
-edx-organizations==0.4.5
+edx-organizations==0.4.6
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
 edx-submissions==2.0.11


### PR DESCRIPTION
This fixes a bug with the organizations API's get_organization function.