### PR TITLE
Use an X icon instead of text.

### DIFF
--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -86,6 +86,9 @@
 
   .dismiss-message {
     @include float(right);
+    .btn-link {
+        color: palette(grayscale, base);
+    }
   }
 }
 

--- a/openedx/features/course_experience/static/course_experience/fixtures/latest-update-fragment.html
+++ b/openedx/features/course_experience/static/course_experience/fixtures/latest-update-fragment.html
@@ -1,7 +1,10 @@
 <div class="update-message">
     <h3>Latest Update</h3>
     <div class="dismiss-message">
-        <button type="button" class="btn-link">Dismiss</button>
+        <button type="button" class="btn-link">
+            <span class="sr">Dismiss</span>
+            <span class="icon fa fa-times" aria-hidden="true"></span>
+        </button>
     </div>
     This is an update.
 </div>

--- a/openedx/features/course_experience/static/course_experience/fixtures/welcome-message-fragment.html
+++ b/openedx/features/course_experience/static/course_experience/fixtures/welcome-message-fragment.html
@@ -1,6 +1,9 @@
 <div class="welcome-message">
     <div class="dismiss-message">
-        <button type="button" class="btn-link">${_("Dismiss")}</button>
+        <button type="button" class="btn-link">
+            <span class="sr">Dismiss</span>
+            <span class="icon fa fa-times" aria-hidden="true"></span>
+        </button>
     </div>
     This is a useful welcome message!
 </div>

--- a/openedx/features/course_experience/templates/course_experience/latest-update-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/latest-update-fragment.html
@@ -11,7 +11,10 @@ from openedx.core.djangolib.markup import HTML
 <%block name="content">
 <div class="update-message">
     <div class="dismiss-message">
-        <button type="button" class="btn-link">${_("Dismiss")}</button>
+        <button type="button" class="btn-link">
+            <span class="sr">${_("Dismiss")}</span>
+            <span class="icon fa fa-times" aria-hidden="true"></span>
+        </button>
     </div>
     <h3>${_("Latest Update")}</h3>
 

--- a/openedx/features/course_experience/templates/course_experience/welcome-message-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/welcome-message-fragment.html
@@ -12,7 +12,10 @@ from openedx.core.djangolib.markup import HTML
 <%block name="content">
 <div class="welcome-message">
     <div class="dismiss-message">
-        <button type="button" class="btn-link">${_("Dismiss")}</button>
+        <button type="button" class="btn-link">
+            <span class="sr">${_("Dismiss")}</span>
+            <span class="icon fa fa-times" aria-hidden="true"></span>
+        </button>
     </div>
 
     ${HTML(welcome_message_html)}


### PR DESCRIPTION
## [LEARNER-1969](https://openedx.atlassian.net/browse/LEARNER-1969)

### Description

* Verify that clicking the x action dismisses the course update from the course home page
* Verify that screenreaders can still get to this labeled action using screenreader text.

### Sandbox
Welcome message version:
- [x] https://dismiss-icon-change.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/

Latest update version:
- [x] https://dismiss-icon-change.sandbox.edx.org/courses/course-v1:edX+Test101+course/course/

### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] safecommit violation code review process

Front-end changes:
- [x] Accessibility (Check for a11y violations, ensure keyboard accessible, screen reader testing as appropriate)
- [x] i18n
- [x] RTL

### Optional Reviewers
- [ ] Assign GitHub reviewers for engineering, product, UX, and documentation (as needed)

FYI: @edx/learner-mercury
 
### Post-review
- [x] Rebase and squash commits