### PR TITLE
EDUCATOR-1204 | can always view certs when ready for self-paced cours…

### DIFF
--- a/common/test/acceptance/tests/lms/test_certificate_web_view.py
+++ b/common/test/acceptance/tests/lms/test_certificate_web_view.py
@@ -128,7 +128,8 @@ class CertificateProgressPageTest(UniqueCourseTest):
         )
 
         self.course_fixture.add_advanced_settings({
-            "cert_html_view_enabled": {"value": "true"}
+            "cert_html_view_enabled": {"value": "true"},
+            "certificates_show_before_end": {"value": "true"}
         })
 
         self.course_fixture.add_update(
@@ -176,7 +177,7 @@ class CertificateProgressPageTest(UniqueCourseTest):
         """
         Scenario: View Certificate option should be present on Course Progress menu if the user is
         awarded a certificate.
-        And their should be no padding around the box containing certificate info. (See SOL-1196 for details on this)
+        And there should be no padding around the box containing certificate info. (See SOL-1196 for details on this)
 
         As a Student
         Given there is a course with certificate configuration

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1398,7 +1398,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         resp = self._get_progress_page()
         self.assertContains(resp, u"View Certificate")
 
-        self.assertContains(resp, u"You can keep working for a higher grade")
+        self.assertContains(resp, u"earned a certificate for this course")
         cert_url = certs_api.get_certificate_url(course_id=self.course.id, uuid=certificate.verify_uuid)
         self.assertContains(resp, cert_url)
 
@@ -1447,7 +1447,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         """Test that query counts remain the same for self-paced and instructor-paced courses."""
         SelfPacedConfiguration(enabled=self_paced_enabled).save()
         self.setup_course(self_paced=self_paced)
-        with self.assertNumQueries(42, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST), check_mongo_calls(1):
+        with self.assertNumQueries(42, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST), check_mongo_calls(2):
             self._get_progress_page()
 
     @ddt.data(
@@ -1460,14 +1460,14 @@ class ProgressPageTests(ProgressPageBaseTests):
         with grades_waffle().override(ASSUME_ZERO_GRADE_IF_ABSENT, active=enable_waffle):
             with self.assertNumQueries(
                 initial, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST
-            ), check_mongo_calls(1):
+            ), check_mongo_calls(2):
                 self._get_progress_page()
 
             # subsequent accesses to the progress page require fewer queries.
             for _ in range(2):
                 with self.assertNumQueries(
                     subsequent, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST
-                ), check_mongo_calls(1):
+                ), check_mongo_calls(2):
                     self._get_progress_page()
 
     @patch(

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -113,7 +113,7 @@ log = logging.getLogger("edx.courseware")
 REQUIREMENTS_DISPLAY_MODES = CourseMode.CREDIT_MODES + [CourseMode.VERIFIED]
 
 CertData = namedtuple(
-    "CertData", ["cert_status", "title", "msg", "download_url", "cert_web_view_url", "may_view_certificate"]
+    "CertData", ["cert_status", "title", "msg", "download_url", "cert_web_view_url"]
 )
 
 
@@ -929,19 +929,26 @@ def _get_cert_data(student, course, course_key, is_active, enrollment_mode):
             _('Your enrollment: Audit track'),
             _('You are enrolled in the audit track for this course. The audit track does not include a certificate.'),
             download_url=None,
-            cert_web_view_url=None,
-            may_view_certificate=None
+            cert_web_view_url=None
         )
 
-    show_message = (
-        is_active and CourseMode.is_eligible_for_certificate(enrollment_mode)
-        and certs_api.cert_generation_enabled(course_key)
-    )
+    may_view_certificate = False
+    # https://openedx.atlassian.net/browse/EDUCATOR-1204: historically,
+    # certificates for self-paced courses are displayed no matter the
+    # state of advanced course settings regarding certificates.
+    if course_key:
+        course = get_course_by_id(course_key)
+        may_view_certificate = course.self_paced or course.may_certify()
+
+    show_message = all([
+        is_active,
+        CourseMode.is_eligible_for_certificate(enrollment_mode),
+        certs_api.cert_generation_enabled(course_key),
+        may_view_certificate
+    ])
 
     if not show_message:
         return None
-
-    may_view_certificate = course_key and get_course_by_id(course_key).may_certify()
 
     if certs_api.is_certificate_invalid(student, course_key):
         return CertData(
@@ -949,8 +956,7 @@ def _get_cert_data(student, course, course_key, is_active, enrollment_mode):
             _('Your certificate has been invalidated'),
             _('Please contact your course team if you have any questions.'),
             download_url=None,
-            cert_web_view_url=None,
-            may_view_certificate=None
+            cert_web_view_url=None
         )
 
     cert_downloadable_status = certs_api.certificate_downloadable_status(student, course_key)
@@ -958,18 +964,19 @@ def _get_cert_data(student, course, course_key, is_active, enrollment_mode):
     if cert_downloadable_status['is_downloadable']:
         cert_status = CertificateStatuses.downloadable
         title = _('Your certificate is available')
-        msg = _('You can keep working for a higher grade, or request your certificate now.')
+        msg = _("You've earned a certificate for this course.")
         if certs_api.has_html_certificates_enabled(course_key, course):
             if certs_api.get_active_web_certificate(course) is not None:
                 cert_web_view_url = certs_api.get_certificate_url(
                     course_id=course_key, uuid=cert_downloadable_status['uuid']
                 )
-                return CertData(cert_status,
-                                title,
-                                msg,
-                                download_url=None,
-                                cert_web_view_url=cert_web_view_url,
-                                may_view_certificate=may_view_certificate)
+                return CertData(
+                    cert_status,
+                    title,
+                    msg,
+                    download_url=None,
+                    cert_web_view_url=cert_web_view_url
+                )
             else:
                 return CertData(
                     CertificateStatuses.generating,
@@ -979,8 +986,7 @@ def _get_cert_data(student, course, course_key, is_active, enrollment_mode):
                         "to it will appear here and on your Dashboard when it is ready."
                     ),
                     download_url=None,
-                    cert_web_view_url=None,
-                    may_view_certificate=None
+                    cert_web_view_url=None
                 )
 
         return CertData(
@@ -988,8 +994,7 @@ def _get_cert_data(student, course, course_key, is_active, enrollment_mode):
             title,
             msg,
             download_url=cert_downloadable_status['download_url'],
-            cert_web_view_url=None,
-            may_view_certificate=may_view_certificate
+            cert_web_view_url=None
         )
 
     if cert_downloadable_status['is_generating']:
@@ -1001,8 +1006,7 @@ def _get_cert_data(student, course, course_key, is_active, enrollment_mode):
                 "it will appear here and on your Dashboard when it is ready."
             ),
             download_url=None,
-            cert_web_view_url=None,
-            may_view_certificate=None
+            cert_web_view_url=None
         )
 
     # If the learner is in verified modes and the student did not have
@@ -1020,17 +1024,15 @@ def _get_cert_data(student, course, course_key, is_active, enrollment_mode):
                 'verified identity.'
             ).format(platform_name=platform_name),
             download_url=None,
-            cert_web_view_url=None,
-            may_view_certificate=None
+            cert_web_view_url=None
         )
 
     return CertData(
         CertificateStatuses.requesting,
         _('Congratulations, you qualified for a certificate!'),
-        _('You can keep working for a higher grade, or request your certificate now.'),
+        _("You've earned a certificate for this course."),
         download_url=None,
-        cert_web_view_url=None,
-        may_view_certificate=may_view_certificate
+        cert_web_view_url=None
     )
 
 

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -67,7 +67,6 @@ from django.utils.http import urlquote_plus
                                 <h4 class="hd hd-4 title">${certificate_data.title}</h4>
                                 <p class="copy">${certificate_data.msg}</p>
                             </div>
-                            %if certificate_data.may_view_certificate:
                             <div class="msg-actions">
                                 %if certificate_data.cert_web_view_url:
                                 <a class="btn" href="${certificate_data.cert_web_view_url}" target="_blank">${_("View Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
@@ -77,7 +76,6 @@ from django.utils.http import urlquote_plus
                                 <button class="btn generate_certs" data-endpoint="${post_url}" id="btn_generate_cert">${_('Request Certificate')}</button>
                                 %endif
                             </div>
-                            %endif
                         </div>
                     </div>
                     %endif


### PR DESCRIPTION
…es; don't hide cert buttons.

https://openedx.atlassian.net/browse/EDUCATOR-1204

Hiding certificate buttons on the progress page was a little bit off in the following regard:
If a verified learner passed a self-paced course, they could see the messaging around certs in their progress page but not the buttons.  This was due to our call to `may_certify()`, which does the right thing w.r.t. instructor-paced courses.  However, for self-paced courses, we had never before checked the various course certificate settings (like `certificates_display_behavior` or `certificates_show_before_end`), and since the default values for those settings are falsey, `may_certify()` pretty much always returns False for self-paced courses.  So, the logic path in `_get_cert_data()` would determine that we should indeed show a certificate message on the progress page for these users, but the `may_view_certificate` flag we passed into the template context made it so that the user couldn't see the certificate button(s).

This change makes it so that a verified, passing user can always see their certificate in a self-paced course as soon as it's available (as long as student-generated certificates are enabled for the course).  It also removes the check around the block of certificate buttons from the progress page template.

Reviewers:
- [ ] @ssemenova 
- [ ] @sanfordstudent 

FYI: @edx/educator-neem 