### PR TITLE
LEARNER-174 Make country label and error message more user friendly

### DIFF
--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -165,7 +165,7 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
                     'Email Address',
                     'Password',
                     'Language',
-                    'Country or Region',
+                    'Country or Region of Residence',
                     'Time Zone',
                 ]
             },
@@ -410,7 +410,7 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
         """
         self._test_dropdown_field(
             u'country',
-            u'Country or Region',
+            u'Country or Region of Residence',
             u'',
             [u'Pakistan', u'Palau'],
         )

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -345,7 +345,7 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
         errors = self.register_page.wait_for_errors()
         self.assertIn(u'Please enter your Public Username.', errors)
         self.assertIn(u'You must agree to the édX Terms of Service and Honor Code', errors)
-        self.assertIn(u'Please select your Country.', errors)
+        self.assertIn(u'Select your country or region of residence.', errors)
         self.assertIn(u'Please tell us your favorite movie.', errors)
 
     def test_toggle_to_login_form(self):

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -124,10 +124,11 @@
                             view: new AccountSettingsFieldViews.DropdownFieldView({
                                 model: userAccountModel,
                                 required: true,
-                                title: gettext('Country or Region'),
+                                title: gettext('Country or Region of Residence'),
                                 valueAttribute: 'country',
                                 options: fieldsData.country.options,
-                                persistChanges: true
+                                persistChanges: true,
+                                helpMessage: gettext('The country or region where you live.')
                             })
                         },
                         {

--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -66,7 +66,7 @@ USERNAME_BAD_LENGTH_MSG = _(u"Username must be between {min} and {max} character
 EMAIL_BAD_LENGTH_MSG = _(u"Enter a valid email address that contains at least {min} characters.").format(
     min=EMAIL_MIN_LENGTH
 )
-PASSWORD_EMPTY_MSG = _(u"Please enter a password.")
+PASSWORD_EMPTY_MSG = _(u"Enter a password.")
 PASSWORD_BAD_MIN_LENGTH_MSG = _(u"Password is not long enough.")
 PASSWORD_BAD_MAX_LENGTH_MSG = _(u"Password cannot be longer than {max} character.").format(max=PASSWORD_MAX_LENGTH)
 
@@ -81,10 +81,10 @@ PASSWORD_CANT_EQUAL_USERNAME_MSG = _(u"Password cannot be the same as the userna
 
 # Translators: These messages are shown to users who do not enter information
 # into the required field or enter it incorrectly.
-REQUIRED_FIELD_NAME_MSG = _(u"Please enter your Full Name.")
+REQUIRED_FIELD_NAME_MSG = _(u"Enter your full name.")
 REQUIRED_FIELD_CONFIRM_EMAIL_MSG = _(u"The email addresses do not match.")
-REQUIRED_FIELD_COUNTRY_MSG = _(u"Please select your Country.")
-REQUIRED_FIELD_CITY_MSG = _(u"Please enter your City.")
-REQUIRED_FIELD_GOALS_MSG = _(u"Please tell us your goals.")
-REQUIRED_FIELD_LEVEL_OF_EDUCATION_MSG = _(u"Please select your highest level of education completed.")
-REQUIRED_FIELD_MAILING_ADDRESS_MSG = _(u"Please enter your mailing address.")
+REQUIRED_FIELD_COUNTRY_MSG = _(u"Select your country or region of residence.")
+REQUIRED_FIELD_CITY_MSG = _(u"Enter your city.")
+REQUIRED_FIELD_GOALS_MSG = _(u"Tell us your goals.")
+REQUIRED_FIELD_LEVEL_OF_EDUCATION_MSG = _(u"Select the highest level of education you have completed.")
+REQUIRED_FIELD_MAILING_ADDRESS_MSG = _(u"Enter your mailing address.")

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -633,7 +633,14 @@ class RegistrationFormFactory(object):
         """
         # Translators: This label appears above a dropdown menu on the registration
         # form used to select the country in which the user lives.
-        country_label = _(u"Country")
+        country_label = _(u"Country or Region of Residence")
+
+        country_instructions = _(
+            # Translators: These instructions appear on the registration form, immediately
+            # below a field meant to hold the user's country.
+            u"The country or region where you live."
+        )
+
         error_msg = accounts.REQUIRED_FIELD_COUNTRY_MSG
 
         # If we set a country code, make sure it's uppercase for the sake of the form.
@@ -647,6 +654,7 @@ class RegistrationFormFactory(object):
         form_desc.add_field(
             "country",
             label=country_label,
+            instructions=country_instructions,
             field_type="select",
             options=list(countries),
             include_default_option=True,

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1165,14 +1165,15 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
             self._assert_reg_field(
                 {u"country": u"required"},
                 {
-                    u"label": u"Country",
+                    u"label": u"Country or Region of Residence",
                     u"name": u"country",
                     u"defaultValue": expected_country_code,
                     u"type": u"select",
                     u"required": True,
                     u"options": country_options,
+                    u"instructions": u"The country or region where you live.",
                     u"errorMessages": {
-                        u"required": u"Please select your Country."
+                        u"required": u"Select your country or region of residence."
                     },
                 }
             )
@@ -1198,7 +1199,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                     {"value": "other", "name": "Other education", "default": False},
                 ],
                 "errorMessages": {
-                    "required": "Please select your highest level of education completed."
+                    "required": "Select the highest level of education you have completed."
                 }
             }
         )
@@ -1227,7 +1228,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                     {"value": "other", "name": "Other education TRANSLATED", "default": False},
                 ],
                 "errorMessages": {
-                    "required": "Please select your highest level of education completed."
+                    "required": "Select the highest level of education you have completed."
                 }
             }
         )
@@ -1307,7 +1308,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 "required": False,
                 "label": "Mailing address",
                 "errorMessages": {
-                    "required": "Please enter your mailing address."
+                    "required": "Enter your mailing address."
                 }
             }
         )
@@ -1323,7 +1324,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                     platform_name=settings.PLATFORM_NAME
                 ),
                 "errorMessages": {
-                    "required": "Please tell us your goals."
+                    "required": "Tell us your goals."
                 }
             }
         )
@@ -1337,7 +1338,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 "required": False,
                 "label": "City",
                 "errorMessages": {
-                    "required": "Please enter your City."
+                    "required": "Enter your city."
                 }
             }
         )
@@ -1373,13 +1374,14 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
         self._assert_reg_field(
             {"country": "required"},
             {
-                "label": "Country",
+                "label": "Country or Region of Residence",
                 "name": "country",
                 "type": "select",
+                "instructions": "The country or region where you live.",
                 "required": True,
                 "options": country_options,
                 "errorMessages": {
-                    "required": "Please select your Country."
+                    "required": "Select your country or region of residence."
                 },
             }
         )


### PR DESCRIPTION
[LEARNER-174](https://openedx.atlassian.net/browse/LEARNER-174)

**Description:**
Learners are misinterpreting this field to mean country of origin, resulting in learners who are from embargoed countries and now live in other parts of the world from being unable to access certain courses.
This text label should eliminate some of the confusion caused here.

**Sandbox:**
Sandbox Link: https://learner-174.sandbox.edx.org
Expiry: 29-Aug-2017
