### PR TITLE
Update problem-builder requirement to 2.6.5patch2 to migrate keys.

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@e502a5565105571ab0303c330dc1a06036a7816f#egg=xblock-problem-builder==2.6.5
+git+https://github.com/open-craft/problem-builder.git@v2.6.5patch2#egg=xblock-problem-builder==2.6.5patch2
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
@feanil @fredsmith @bradenmacdonald 

This pulls in https://github.com/open-craft/problem-builder/pull/160, which provides a new script to run the key migration.
