### PR TITLE
Remove deprecated field 'sailthru_activation_template'.

### DIFF
--- a/lms/djangoapps/email_marketing/models.py
+++ b/lms/djangoapps/email_marketing/models.py
@@ -47,14 +47,6 @@ class EmailMarketingConfiguration(ConfigurationModel):
         )
     )
 
-    sailthru_activation_template = models.fields.CharField(
-        max_length=20,
-        blank=True,
-        help_text=_(
-            "DEPRECATED: use sailthru_welcome_template instead."
-        )
-    )
-
     sailthru_welcome_template = models.fields.CharField(
         max_length=20,
         blank=True,


### PR DESCRIPTION
Remove deprecated field "sailthru_activation_template'" from EmailMarketingConfiguration model after releasing the following PR to production. https://github.com/edx/edx-platform/pull/15779

We will add migration for this in next PR when this change goes to stage, prod to support our deploying process.

LEARNER-2201

@feanil FYI.