### PR TITLE
LEARNER-2025: Update event naming for course sock.

### DIFF
--- a/lms/static/js/courseware/course_home_events.js
+++ b/lms/static/js/courseware/course_home_events.js
@@ -9,10 +9,10 @@
                 });
             });
             $('.date-summary-verified-upgrade-deadline .date-summary-link').on('click', function() {
-                Logger.log('edx.course.home.upgrade_verified.clicked', {location: 'sidebar'});
+                Logger.log('edx.course.enrollment.upgrade.clicked', {location: 'sidebar'});
             });
             $('.upgrade-banner-button').on('click', function() {
-                Logger.log('edx.course.home.upgrade_verified.clicked', {location: 'notification'});
+                Logger.log('edx.course.enrollment.upgrade.clicked', {location: 'notification'});
             });
             $('.view-verified-info').on('click', function() {
                 Logger.log('edx.course.home.learn_about_verified.clicked', {location: 'notification'});

--- a/lms/static/js/dashboard/legacy.js
+++ b/lms/static/js/dashboard/legacy.js
@@ -120,7 +120,7 @@
              var user = $(event.target).closest('.action-upgrade').data('user'),
                  course = $(event.target).closest('.action-upgrade').data('course-id');
 
-             Logger.log('edx.course.enrollment.upgrade.clicked', [user, course], null);
+             Logger.log('edx.course.enrollment.upgrade.clicked', [user, course], {location: 'learner_dashboard'});
          });
 
          $('.action-email-settings').click(function(event) {

--- a/lms/static/js/spec/courseware/course_home_events_spec.js
+++ b/lms/static/js/spec/courseware/course_home_events_spec.js
@@ -19,13 +19,13 @@ define(['jquery', 'logger', 'js/courseware/course_home_events'], function($, Log
 
         it('sends an event when "Upgrade to Verified" is clicked from the sidebar', function() {
             $('.date-summary-link').click();
-            expect(Logger.log).toHaveBeenCalledWith('edx.course.home.upgrade_verified.clicked', {location: 'sidebar'});
+            expect(Logger.log).toHaveBeenCalledWith('edx.course.enrollment.upgrade.clicked', {location: 'sidebar'});
         });
 
         it('sends an event when "Upgrade Now" is clicked from the upsell notification', function() {
             $('.upgrade-banner-button').click();
             expect(Logger.log).toHaveBeenCalledWith(
-                'edx.course.home.upgrade_verified.clicked', {location: 'notification'}
+                'edx.course.enrollment.upgrade.clicked', {location: 'notification'}
             );
         });
 

--- a/openedx/features/course_experience/static/course_experience/js/CourseSock.js
+++ b/openedx/features/course_experience/static/course_experience/js/CourseSock.js
@@ -57,9 +57,9 @@ export class CourseSock {  // eslint-disable-line import/prefer-default-export
 
       // Log open and close events
       const isOpening = $toggleActionButton.hasClass('active');
-      const logMessage = isOpening ? 'User opened the verification sock.'
-          : 'User closed the verification sock.';
-      Logger.log(
+      const logMessage = isOpening ? 'edx.bi.course.sock.toggle_opened'
+          : 'edx.bi.course.sock.toggle_closed';
+      window.analytics.track(
         logMessage,
         {
           from_page: pageLocation,
@@ -69,9 +69,9 @@ export class CourseSock {  // eslint-disable-line import/prefer-default-export
 
     $upgradeToVerifiedButton.on('click', () => {
       Logger.log(
-        'User clicked the upgrade button in the verification sock.',
+        'edx.course.enrollment.upgrade.clicked',
         {
-          from_page: pageLocation,
+          location: 'sock',
         },
       );
     });

--- a/openedx/features/course_experience/views/course_sock.py
+++ b/openedx/features/course_experience/views/course_sock.py
@@ -2,6 +2,7 @@
 Fragment for rendering the course's sock and associated toggle button.
 """
 from django.template.loader import render_to_string
+from django.utils.translation import get_language
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
@@ -37,7 +38,11 @@ class CourseSockFragmentView(EdxFragmentView):
         verification_deadline = VerifiedUpgradeDeadlineDate(course, request.user)
         deadline_has_passed = verification_deadline.deadline_has_passed()
 
-        show_course_sock = has_verified_mode and not is_already_verified and not deadline_has_passed
+        # If this proves its worth, we can internationalize and display for more than English speakers.
+        show_course_sock = (
+            has_verified_mode and not is_already_verified and
+            not deadline_has_passed and get_language() == 'en'
+        )
 
         # Get the price of the course and format correctly
         course_price = get_cosmetic_verified_display_price(course)


### PR DESCRIPTION
Only show course sock to English learners.

## [LEARNER-2025](https://openedx.atlassian.net/browse/LEARNER-2025)

### Acceptance Criteria
* Update 'User opened the verification sock.' to 'edx.bi.course.sock.toggle_opend'.
* Update 'User closed the verification sock.' to 'edx.bi.course.sock.toggle_closed'.
* Update 'User clicked the upgrade button in the verification sock.' to 'edx.course.enrollment.upgrade.clicked' (existing event), with location=sock.
* Make sure these events get to Google Analytics.
* Briefly document the bi events on [Confluence](https://openedx.atlassian.net/wiki/spaces/AN/pages/53510700/Course+Home+Page+Event+Design).
* Only show this feature for learners who have English set as their platform language. (will revisit with i18n story)

### Testing
- I have not added any new tests because I believe that some of this is intended to be temporary (especially limiting it to only English).

### Sandbox
- [ ] https://dianakhuang.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/

### Optional Reviewers
- [x] Assign GitHub reviewers for engineering, product, UX, and documentation (as needed)

FYI: @edx/learner-mercury
 
### Post-review
- [x] Rebase and squash commits