### PR TITLE
Do not overwrite external YouTube with value from VAL

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -722,7 +722,6 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
         })
 
         source_url = self.create_youtube_url(youtube_id_1_0['value'])
-
         # First try a lookup in VAL. If any video encoding is found given the video id then
         # override the source_url with it.
         if self.edx_video_id and edxval_api:
@@ -734,15 +733,18 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
             # Get video encodings for val profiles.
             val_video_encodings = edxval_api.get_urls_for_profiles(self.edx_video_id, val_profiles)
 
-            # If multiple encodings are there in val, the priority will be: youtube > hls > mp4 and webm.
+            # VAL's youtube source has greater priority over external youtube source.
             if val_video_encodings.get('youtube'):
                 source_url = self.create_youtube_url(val_video_encodings['youtube'])
-            elif val_video_encodings.get('hls'):
-                source_url = val_video_encodings['hls']
-            elif val_video_encodings.get('desktop_mp4'):
-                source_url = val_video_encodings['desktop_mp4']
-            elif val_video_encodings.get('desktop_webm'):
-                source_url = val_video_encodings['desktop_webm']
+
+            # If no youtube source is provided externally or in VAl, update source_url in order: hls > mp4 and webm
+            if not source_url:
+                if val_video_encodings.get('hls'):
+                    source_url = val_video_encodings['hls']
+                elif val_video_encodings.get('desktop_mp4'):
+                    source_url = val_video_encodings['desktop_mp4']
+                elif val_video_encodings.get('desktop_webm'):
+                    source_url = val_video_encodings['desktop_webm']
 
         # Only add if html5 sources do not already contain source_url.
         if source_url and source_url not in video_url['value']:


### PR DESCRIPTION
## [EDUCATOR-1089](https://openedx.atlassian.net/browse/EDUCATOR-1089)

### Description

This PR is made in an effort to stop overwriting of youtube source with non-youtube VAL's encoding(s). YouTube source now has the highest priority over any non-youtube encoding available against Video ID. 

### How to Test?

**Stage** 

- Create a video component in any course. (Component will be created with a default YouTube source, you can give any youtube source of your choice too.)
- Edit component to provide a valid Video ID in basic tab.
- Use a Video ID which do not have youtube source.
- Observe YouTube source is overwritten with one of the sources from corresponding Video ID's encodings. 

**Sandbox**
- [Studio](https://studio-encoding.sandbox.edx.org)
- Repeat above steps and observe that YouTube source is preserved.
- Test video ids: 
     - **test_video_id** (Without youtube encoding)
     -  **test_video_id_yt** (Include youtube encoding)

**Notes**
- Overwriting from VAL will continue working in order _youtube > hls > mp4 > webm_ in case where no YouTube source is provided. 

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review:  @Qubad786
- [x] Code review: @muzaffaryousaf 
- [x] Code review: @awaisdar001 

FYI: @sstack22 
### Post-review
- [x] Rebase and squash commits