### PR TITLE
ENT-612: Version upgrade for edx-enterprise that contains fix for 500 error on enterprise landing page.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.40.3
+edx-enterprise==0.40.4
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
**Description:**

edx-enterprise version bump. This edx-enterprise upgrade fixes 500 error on enterprise landing page.