### PR TITLE
bump enterprise version to 0.40.5

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.40.3
+edx-enterprise==0.40.5
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
ENT-424
@asadiqbal08 @saleem-latif @douglashall @brittneyexline 
Bump `edx-enterprise` app to version `0.40.5`.

This upgrade includes update of `SAP` course export management command `transmit_courseware_data` to use enterprise api like `https://business.sandbox.edx.org/enterprise/api/v1/enterprise-customer/2b5a2956-7746-4fc9-9587-bc887ba45973/courses/` instead of course catalog api like `https://prod-edx-discovery.edx.org/api/v1/catalogs/1/courses/`

**Related PR:** https://github.com/edx/edx-enterprise/pull/169