### PR TITLE
Update Enterprise to 0.40.6

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.40.4
+edx-enterprise==0.40.6
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
This pull request updates edx-enterprise to 0.40.6 and fixes an issue where nonprivileged users were unable to proceed through data sharing consent checks.

**JIRA tickets**: N/A

**Dependencies**: None

**Partner information**: (if applicable - see below)

**Merge deadline**: ASAP

**Testing instructions**:

See edx/edx-enterprise#174.

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```