### PR TITLE
remove try/catch block and associated test for EDUCATOR-1134 followin…

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1453,13 +1453,4 @@ class CourseSummary(object):
         """
         Returns whether the course has ended.
         """
-        try:
-            return course_metadata_utils.has_course_ended(self.end)
-        except TypeError as e:
-            log.warning(
-                "Course '{course_id}' has an improperly formatted end date '{end_date}'. Error: '{err}'.".format(
-                    course_id=unicode(self.id), end_date=self.end, err=e
-                )
-            )
-            modified_end = self.end.replace(tzinfo=utc)
-            return course_metadata_utils.has_course_ended(modified_end)
+        return course_metadata_utils.has_course_ended(self.end)

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -2,7 +2,6 @@
 import ddt
 import unittest
 from datetime import datetime, timedelta
-from dateutil import parser
 
 import itertools
 from fs.memoryfs import MemoryFS
@@ -141,16 +140,6 @@ class HasEndedMayCertifyTestCase(unittest.TestCase):
         self.assertTrue(self.future_show_certs.may_certify())
         self.assertTrue(self.future_show_certs_no_info.may_certify())
         self.assertFalse(self.future_noshow_certs.may_certify())
-
-
-class CourseSummaryHasEnded(unittest.TestCase):
-    """ Test for has_ended method when end date is missing timezone information. """
-
-    def test_course_end(self):
-        test_course = get_dummy_course("2012-01-01T12:00")
-        bad_end_date = parser.parse("2012-02-21 10:28:45")
-        summary = xmodule.course_module.CourseSummary(test_course.id, end=bad_end_date)
-        self.assertTrue(summary.has_ended())
 
 
 @ddt.ddt


### PR DESCRIPTION
…g verification that no stage or production courses have issues related to dates

[EDUCATOR-11344](https://openedx.atlassian.net/browse/EDUCATOR-1134)

This pull request removes the try/catch block and associated test meant to determine which courses had offending end dates that were causing 500 errors on the course listing page on stage. It essentially undoes https://github.com/edx/edx-platform/pull/15801, with the exception of the change to ENABLE_SEPARATE_ARCHIVED_COURSES. 

The courses with problematic end dates were fixed manually on stage. No errors were logged in Splunk for either prod or edge. However, since the course listing page in prod studio does not display all courses the way it does in stage, I took the extra precaution of searching via the organization search bar. I searched for all letters a-z and digits 1-9, which should display courses from all organizations containing at least one of the aforementioned characters (i.e. theoretically, all the courses). No errors were logged, so I think it's safe to remove the try/catch block and test.