### PR TITLE
ENT-605: On edx.org instances, next URL for login page cannot contain 'edx.org'.

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -297,7 +297,7 @@ def get_redirect_to(request):
     # get information about a user on edx.org. In any such case drop the parameter.
     if redirect_to:
         mime_type, _ = mimetypes.guess_type(redirect_to, strict=False)
-        if not http.is_safe_url(redirect_to):
+        if not http.is_safe_url(redirect_to, host=request.get_host()):
             log.warning(
                 u'Unsafe redirect parameter detected after login page: %(redirect_to)r',
                 {"redirect_to": redirect_to}
@@ -327,8 +327,9 @@ def get_redirect_to(request):
             redirect_to = None
         else:
             themes = get_themes()
+            next_path = urlparse.urlparse(redirect_to).path
             for theme in themes:
-                if theme.theme_dir_name in redirect_to:
+                if theme.theme_dir_name in next_path:
                     log.warning(
                         u'Redirect to theme content detected after login page: %(redirect_to)r',
                         {"redirect_to": redirect_to}


### PR DESCRIPTION
__Description:__
As a protection, the login page is set up so that if the next URL contains the name of the active theme (for example, edx.org) the redirect is disallowed. Since the Enterprise consent endpoint uses absolute redirect URLs, this is a problem; those URLs obviously contain edx.org. Update theme name check to make sure only url path is tested instead of complete url.

__Testing instructions:__

1. Set up an EnterpriseCustomer, enable consent, and set the consent requirement level to "at enrollment".
2. Add a user to the EnterpriseCustomer manually using the Manage Learners admin panel, while simultaneously enrolling the user in a course.
3. In the dashboard, click on the course and verify the consent interstitial appears. Make a note of the full URL of the interstitial.
4. Leaving that view alone, open a new tab and log out of your LMS session.
5. Back in the original tab, decline consent; note that you're redirected to the login page.
6. Upon logging in, verify that you're returned to the consent page. Verify that the URL is the same as the one you noted earlier.