### PR TITLE
[ENT-496] Bump edx-enterprise to 0.41.0.

### DIFF
--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -966,9 +966,15 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.assertTrue(is_active)
         self.assertEqual(course_mode, updated_mode)
 
+    @override_settings(ENTERPRISE_SERVICE_WORKER_USERNAME='enterprise_worker')
     @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
     def test_enterprise_course_enrollment_invalid_consent(self):
         """Verify that the enterprise_course_consent must be a boolean. """
+        UserFactory.create(
+            username='enterprise_worker',
+            email=self.EMAIL,
+            password=self.PASSWORD,
+        )
         CourseModeFactory.create(
             course_id=self.course.id,
             mode_slug=CourseMode.DEFAULT_MODE_SLUG,
@@ -1056,6 +1062,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             'course_id': unicode(self.course.id),
             'ec_uuid': 'this-is-a-real-uuid'
         }
+        self.mock_enterprise_course_enrollment_post_api()
         self.mock_consent_missing(**consent_kwargs)
         self.mock_consent_post(**consent_kwargs)
         self.assert_enrollment_status(

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.40.7
+edx-enterprise==0.41.0
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
This incorporates a migration that copies data from certain models to another.

**JIRA tickets**: [ENT-496](https://openedx.atlassian.net/browse/ENT-496)

**Merge deadline**: None

**Dependencies**: https://github.com/edx/edx-platform/pull/15893 which bumps to 0.40.7, first.

**Testing instructions**:

1. Make sure this can be installed successfully.
1. Make sure migrations run without issues.
1. To be extra careful, populate a bunch of fake data on `EnterpriseCourseEnrollments` and `UserDataSharingConsentAudit` with varying consent statuses, then run the migration.

**Author notes and concerns**:

1. We tested the migration and there exists test code on the `edx-enterprise` repository for this, but it would be nice if DevOps is ready for this migration.

2. Because this merged after the ecommerce upgrade, we didn't need to do any particular special steps, but if it had merged before, we would have needed to upgrade the (now-deprecated) code branch to create a DSC record, since we would still be creating (also-deprecated) EnterpriseCourseEnrollment records to track consent, which would not be upgraded to DSC records, since the migration would have already run. However, this is irrelevant.

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```