### PR TITLE
Add student_view_data to HTML XBlock

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_html_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_html_module.py
@@ -1,6 +1,9 @@
 import unittest
-
 from mock import Mock
+import ddt
+
+from django.test.utils import override_settings
+
 from opaque_keys.edx.locator import CourseLocator
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
@@ -22,6 +25,60 @@ def instantiate_descriptor(**field_data):
         scope_ids=ScopeIds(None, None, usage_key, usage_key),
         field_data=DictFieldData(field_data),
     )
+
+
+@ddt.ddt
+class HtmlModuleCourseApiTestCase(unittest.TestCase):
+    """
+    Test the HTML XModule's student_view_data method.
+    """
+
+    @ddt.data(
+        dict(),
+        dict(FEATURES={}),
+        dict(FEATURES=dict(ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA=False))
+    )
+    def test_disabled(self, settings):
+        """
+        Ensure that student_view_data does not return html if the ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA feature flag
+        is not set.
+        """
+        descriptor = Mock()
+        field_data = DictFieldData({'data': '<h1>Some HTML</h1>'})
+        module_system = get_test_system()
+        module = HtmlModule(descriptor, module_system, field_data, Mock())
+
+        with override_settings(**settings):
+            self.assertEqual(module.student_view_data(), dict(
+                enabled=False,
+                message='To enable, set FEATURES["ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA"]',
+            ))
+
+    @ddt.data(
+        '<h1>Some content</h1>',  # Valid HTML
+        '',
+        None,
+        '<h1>Some content</h',  # Invalid HTML
+        '<script>alert()</script>',  # Does not escape tags
+        '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">',  # Images allowed
+        'short string ' * 100,  # May contain long strings
+    )
+    @override_settings(FEATURES=dict(ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA=True))
+    def test_common_values(self, html):
+        """
+        Ensure that student_view_data will return HTML data when enabled,
+        can handle likely input,
+        and doesn't modify the HTML in any way.
+
+        This means that it does NOT protect against XSS, escape HTML tags, etc.
+
+        Note that the %%USER_ID%% substitution is tested below.
+        """
+        descriptor = Mock()
+        field_data = DictFieldData({'data': html})
+        module_system = get_test_system()
+        module = HtmlModule(descriptor, module_system, field_data, Mock())
+        self.assertEqual(module.student_view_data(), dict(enabled=True, html=html))
 
 
 class HtmlModuleSubstitutionTestCase(unittest.TestCase):

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -22,7 +22,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
     Test class for BlocksView
     """
     requested_fields = ['graded', 'format', 'student_view_multi_device', 'children', 'not_a_field', 'due']
-    BLOCK_TYPES_WITH_STUDENT_VIEW_DATA = ['video', 'discussion']
+    BLOCK_TYPES_WITH_STUDENT_VIEW_DATA = ['video', 'discussion', 'html']
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
@@ -44,7 +44,7 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
 
         # verify html data
         html_block_key = self.course_key.make_usage_key('html', 'toyhtml')
-        self.assertIsNone(
+        self.assertIsNotNone(
             self.block_structure.get_transformer_block_field(
                 html_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_DATA,
             )

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
@@ -1,9 +1,9 @@
 """
 Tests for StudentViewTransformer.
 """
+import ddt
 
 # pylint: disable=protected-access
-
 from openedx.core.djangoapps.content.block_structure.factory import BlockStructureFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ToyCourseFactory
@@ -11,6 +11,7 @@ from xmodule.modulestore.tests.factories import ToyCourseFactory
 from ..student_view import StudentViewTransformer
 
 
+@ddt.ddt
 class TestStudentViewTransformer(ModuleStoreTestCase):
     """
     Test proper behavior for StudentViewTransformer
@@ -21,20 +22,27 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
         self.course_usage_key = self.store.make_course_usage_key(self.course_key)
         self.block_structure = BlockStructureFactory.create_from_modulestore(self.course_usage_key, self.store)
 
-    def test_transform(self):
+    @ddt.data(
+        'video', 'html', ['video', 'html'], [],
+    )
+    def test_transform(self, requested_student_view_data):
         # collect phase
         StudentViewTransformer.collect(self.block_structure)
         self.block_structure._collect_requested_xblock_fields()
 
         # transform phase
-        StudentViewTransformer('video').transform(usage_info=None, block_structure=self.block_structure)
+        StudentViewTransformer(requested_student_view_data).transform(
+            usage_info=None,
+            block_structure=self.block_structure,
+        )
 
-        # verify video data
+        # verify video data returned iff requested
         video_block_key = self.course_key.make_usage_key('video', 'sample_video')
-        self.assertIsNotNone(
+        self.assertEqual(
             self.block_structure.get_transformer_block_field(
                 video_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_DATA,
-            )
+            ) is not None,
+            'video' in requested_student_view_data
         )
         self.assertFalse(
             self.block_structure.get_transformer_block_field(
@@ -42,12 +50,13 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
             )
         )
 
-        # verify html data
+        # verify html data returned iff requested
         html_block_key = self.course_key.make_usage_key('html', 'toyhtml')
-        self.assertIsNotNone(
+        self.assertEqual(
             self.block_structure.get_transformer_block_field(
                 html_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_DATA,
-            )
+            ) is not None,
+            'html' in requested_student_view_data
         )
         self.assertTrue(
             self.block_structure.get_transformer_block_field(

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -413,6 +413,9 @@ FEATURES = {
 
     # Set to enable Enterprise integration
     'ENABLE_ENTERPRISE_INTEGRATION': False,
+
+    # Whether HTML XBlocks/XModules return HTML content with the Course Blocks API student_view_data
+    'ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA': False,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews

--- a/openedx/core/djangoapps/content/block_structure/block_structure.py
+++ b/openedx/core/djangoapps/content/block_structure/block_structure.py
@@ -312,7 +312,7 @@ class FieldData(object):
         if self._is_own_field(field_name):
             return super(FieldData, self).__delattr__(field_name)
         else:
-            delattr(self.fields, field_name)
+            del self.fields[field_name]
 
     def _is_own_field(self, field_name):
         """


### PR DESCRIPTION
Allows HTML content of the HtmlBlock to be downloaded via the course blocks API.

* Adds `student_view_data` to the HTML XBlock (xmodule)
* Adds some tests for html xblock student_view_data

Also fixes a bug related to the Course Blocks API's `student_view_data` query parameter: Providing anything for the  `?student_view_data=...` parameter was enough to make all XBlock types return their `student_view_data`.  This contradicts the [Course Blocks API docs](http://edx.readthedocs.io/projects/edx-platform-api/en/latest/courses/blocks.html#query-parameters).

**JIRA tickets**: [OSPR-1880](https://openedx.atlassian.net/browse/OSPR-1880), OC-2995, MCKIN-5637

**Sandbox URL**:

Running ae15e69

* LMS: https://pr15905.sandbox.opencraft.hosting/
* Studio: https://studio-pr15905.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

With `settings.FEATURES['ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA'] = True`:
1. Create a course with a Text Html XBlock, e.g., [sandbox DemoX](https://studio-pr15905.sandbox.opencraft.hosting/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc)
1. Login as a staff user.
1. Navigate to `/api/courses/v1/blocks/?course_id=$COURSE_ID&all_blocks=true&depth=all&student_view_data=html`, e.g.
 [sandbox /api/courses/v1/blocks](https://pr15905.sandbox.opencraft.hosting/api/courses/v1/blocks/?course_id=course-v1%3aedX%2bDemoX%2bDemo_Course&all_blocks=true&depth=all&student_view_data=html)
1. See that the block's HTML content is available in the API output as:
   ```json
   "student_view_data": {
     "enabled": true,
     "html": "<p><strong>Welcome to the edX Demo Course Introduction.</strong>&nbsp;This is where you can explore how to take an edX course (like this one). Most courses have an \"intro\" video that shows you how it all works.&nbsp;</p>\n<p style=\"margin-right: 0px; font-size: 16px; margin-left: 0px; font-family: 'Open Sans', Verdana, Geneva, sans-serif;\">You can watch the introduction video (below) or scroll though the course studies and assignments using the toolbar (above). &nbsp;Just for fun, we'll keep track of your work in this demo course, and show you your progress in the toolbar just like in a real course.</p>\n<p style=\"margin-right: 0px; font-size: 16px; margin-left: 0px; font-family: 'Open Sans', Verdana, Geneva, sans-serif;\">Watch the overview video, then click on \"Example Week One\" in the left hand navigation to get started.</p>"
   }
   ```
1. Note that any `%%USER_ID%%` variables will not be filled in.  See [comments](#discussion_r145593828) for why not.


With `settings.FEATURES['ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA'] = False`:
*Note:* You will have to make a change to your course and re-publish, and wait for the the Course Blocks API cache to update after changing the feature flag.

1. Repeat the above steps.
1. See that the block's HTML content is not available in the API output:
   ```json
   "student_view_data":{
     "enabled": false,
     "message": "Enable using feature flag ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA"
   }
   ```

To test the Course Blocks API `student_view_data` bug fix included here:
1. Add a video XBlock to your course, e.g., [sandbox DemoX](https://studio-pr15905.sandbox.opencraft.hosting/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc)
1. Navigate to `/api/courses/v1/blocks/?course_id=$COURSE_ID&all_blocks=true&depth=all&student_view_data=video`, e.g.
 [sandbox](https://pr15905.sandbox.opencraft.hosting/api/courses/v1/blocks/?course_id=course-v1%3aedX%2bDemoX%2bDemo_Course&all_blocks=true&depth=all&student_view_data=video)
  Note that only the `video` blocks return `student_view_data`.
1. Navigate to `/api/courses/v1/blocks/?course_id=$COURSE_ID&all_blocks=true&depth=all&student_view_data=html,video`, e.g.
 [/sandbox](https://pr15905.sandbox.opencraft.hosting/api/courses/v1/blocks/?course_id=course-v1%3aedX%2bDemoX%2bDemo_Course&all_blocks=true&depth=all&student_view_data=html,video)
  Note that both the `html` and `video` blocks return `student_view_data`.

**Author notes & concerns:**

1. Because the Course Blocks API caches its data, the cache must be cleared (e.g. by re-publishing the course) in order for changes to the `ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA` flag to take effect.

**Reviewers**
- [x] @e-kolpakov 
- [x] @nasthagiri 

**Settings**

```yaml
EDXAPP_FEATURES:
  ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA: true
```