### PR TITLE
Use S3 transcripts as a fallback on a video component

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """ Tests for transcripts_utils. """
 import copy
+import ddt
 import textwrap
 import unittest
 from uuid import uuid4
-import ddt
 
 from django.conf import settings
 from django.test.utils import override_settings

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -27,16 +27,18 @@ from xmodule.exceptions import NotFoundError
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.video_module.transcripts_utils import (
-    GetTranscriptsFromYouTubeException,
-    TranscriptsRequestValidationException,
     copy_or_rename_transcript,
     download_youtube_subs,
+    GetTranscriptsFromYouTubeException,
+    get_video_transcript_content,
     generate_srt_from_sjson,
     generate_subs_from_source,
     get_transcripts_from_youtube,
     manage_video_subtitles_save,
     remove_subs_from_store,
-    youtube_video_transcript_name
+    Transcript,
+    TranscriptsRequestValidationException,
+    youtube_video_transcript_name,
 )
 
 __all__ = [
@@ -144,6 +146,7 @@ def download_transcripts(request):
     Raises Http404 if unsuccessful.
     """
     locator = request.GET.get('locator')
+    subs_id = request.GET.get('subs_id')
     if not locator:
         log.debug('GET data without "locator" property.')
         raise Http404
@@ -154,30 +157,44 @@ def download_transcripts(request):
         log.debug("Can't find item by locator.")
         raise Http404
 
-    subs_id = request.GET.get('subs_id')
-    if not subs_id:
-        log.debug('GET data without "subs_id" property.')
-        raise Http404
-
     if item.category != 'video':
         log.debug('transcripts are supported only for video" modules.')
         raise Http404
 
-    filename = 'subs_{0}.srt.sjson'.format(subs_id)
-    content_location = StaticContent.compute_location(item.location.course_key, filename)
     try:
-        sjson_transcripts = contentstore().find(content_location)
-        log.debug("Downloading subs for %s id", subs_id)
-        str_subs = generate_srt_from_sjson(json.loads(sjson_transcripts.data), speed=1.0)
-        if not str_subs:
-            log.debug('generate_srt_from_sjson produces no subtitles')
-            raise Http404
-        response = HttpResponse(str_subs, content_type='application/x-subrip')
-        response['Content-Disposition'] = 'attachment; filename="{0}.srt"'.format(subs_id)
-        return response
+        if not subs_id:
+            raise NotFoundError
+
+        filename = subs_id
+        content_location = StaticContent.compute_location(
+            item.location.course_key,
+            'subs_{filename}.srt.sjson'.format(filename=filename),
+        )
+        sjson_transcript = contentstore().find(content_location).data
     except NotFoundError:
-        log.debug("Can't find content in storage for %s subs", subs_id)
+        # Try searching in VAL for the transcript as a last resort
+        transcript = get_video_transcript_content(
+            course_id=item.location.course_key,
+            language_code=u'en',
+            edx_video_id=item.edx_video_id,
+            youtube_id_1_0=item.youtube_id_1_0,
+            html5_sources=item.html5_sources,
+        )
+        if not transcript:
+            raise Http404
+
+        filename = os.path.splitext(os.path.basename(transcript['file_name']))[0].encode('utf8')
+        sjson_transcript = transcript['content']
+
+    # convert sjson content into srt format.
+    transcript_content = Transcript.convert(sjson_transcript, input_format='sjson', output_format='srt')
+    if not transcript_content:
         raise Http404
+
+    # Construct an HTTP response
+    response = HttpResponse(transcript_content, content_type='application/x-subrip; charset=utf-8')
+    response['Content-Disposition'] = 'attachment; filename="{filename}.srt"'.format(filename=filename)
+    return response
 
 
 @login_required
@@ -284,6 +301,17 @@ def check_transcripts(request):
             transcripts_presence['html5_equal'] = json.loads(html5_subs[0]) == json.loads(html5_subs[1])
 
     command, subs_to_use = _transcripts_logic(transcripts_presence, videos)
+    if command == 'not_found':
+        # Try searching in VAL for the transcript as a last resort
+        video_transcript = get_video_transcript_content(
+            course_id=item.location.course_key,
+            language_code=u'en',
+            edx_video_id=item.edx_video_id,
+            youtube_id_1_0=item.youtube_id_1_0,
+            html5_sources=item.html5_sources,
+        )
+        command = 'found' if video_transcript else command
+
     transcripts_presence.update({
         'command': command,
         'subs': subs_to_use,

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -11,7 +11,7 @@ import ddt
 import freezegun
 from mock import MagicMock, Mock, patch
 from nose.plugins.attrib import attr
-from webob import Request
+from webob import Request, Response
 
 from common.test.utils import normalize_repr
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
@@ -370,6 +370,55 @@ class TestTranscriptDownloadDispatch(TestVideo):
         self.assertEqual(response.headers['Content-Type'], 'application/x-subrip; charset=utf-8')
         self.assertEqual(response.headers['Content-Disposition'], 'attachment; filename="塞.srt"')
 
+    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
+    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
+    @patch('xmodule.video_module.VideoModule.get_transcript', Mock(side_effect=NotFoundError))
+    def test_download_fallback_transcript(self, mock_get_video_transcript_data):
+        """
+        Verify val transcript is returned as a fallback if it is not found in the content store.
+        """
+        mock_get_video_transcript_data.return_value = {
+            'content': json.dumps({
+                "start": [10],
+                "end": [100],
+                "text": ["Hi, welcome to Edx."],
+            }),
+            'file_name': 'edx.sjson'
+        }
+
+        # Make request to XModule transcript handler
+        request = Request.blank('/download')
+        response = self.item.transcript(request=request, dispatch='download')
+
+        # Expected response
+        expected_content = u'0\n00:00:00,010 --> 00:00:00,100\nHi, welcome to Edx.\n\n'
+        expected_headers = {
+            'Content-Disposition': 'attachment; filename="edx.srt"',
+            'Content-Language': u'en',
+            'Content-Type': 'application/x-subrip; charset=utf-8'
+        }
+
+        # Assert the actual response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, expected_content)
+        for attribute, value in expected_headers.iteritems():
+            self.assertEqual(response.headers[attribute], value)
+
+    @patch(
+        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
+        Mock(return_value=False),
+    )
+    @patch('xmodule.video_module.VideoModule.get_transcript', Mock(side_effect=NotFoundError))
+    def test_download_fallback_transcript_feature_disabled(self):
+        """
+        Verify val transcript if its feature is disabled.
+        """
+        # Make request to XModule transcript handler
+        request = Request.blank('/download')
+        response = self.item.transcript(request=request, dispatch='download')
+        # Assert the actual response
+        self.assertEqual(response.status_code, 404)
+
 
 @attr(shard=1)
 @ddt.ddt
@@ -601,6 +650,55 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
         store = modulestore()
         with store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, self.course.id):
             store.update_item(self.course, self.user.id)
+
+    @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
+    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
+    @patch('xmodule.video_module.VideoModule.translation', Mock(side_effect=NotFoundError))
+    @patch('xmodule.video_module.VideoModule.get_static_transcript', Mock(return_value=Response(status=404)))
+    def test_translation_fallback_transcript(self, mock_get_video_transcript_data):
+        """
+        Verify that the val transcript is returned as a fallback,
+        if it is not found in the content store.
+        """
+        transcript = {
+            'content': json.dumps({
+                "start": [10],
+                "end": [100],
+                "text": ["Hi, welcome to Edx."],
+            }),
+            'file_name': 'edx.sjson'
+        }
+        mock_get_video_transcript_data.return_value = transcript
+
+        # Make request to XModule transcript handler
+        response = self.item.transcript(request=Request.blank('/translation/en'), dispatch='translation/en')
+
+        # Expected headers
+        expected_headers = {
+            'Content-Language': 'en',
+            'Content-Type': 'application/json'
+        }
+
+        # Assert the actual response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, transcript['content'])
+        for attribute, value in expected_headers.iteritems():
+            self.assertEqual(response.headers[attribute], value)
+
+    @patch(
+        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
+        Mock(return_value=False),
+    )
+    @patch('xmodule.video_module.VideoModule.translation', Mock(side_effect=NotFoundError))
+    @patch('xmodule.video_module.VideoModule.get_static_transcript', Mock(return_value=Response(status=404)))
+    def test_translation_fallback_transcript_feature_disabled(self):
+        """
+        Verify that val transcript is not returned when its feature is disabled.
+        """
+        # Make request to XModule transcript handler
+        response = self.item.transcript(request=Request.blank('/translation/en'), dispatch='translation/en')
+        # Assert the actual response
+        self.assertEqual(response.status_code, 404)
 
 
 @attr(shard=1)

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -97,7 +97,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.5#egg=lti_consumer-xblock==1.1.5
 git+https://github.com/edx/edx-proctoring.git@1.2.1#egg=edx-proctoring==1.2.1
-git+https://github.com/edx/edx-val.git@f3f08d0ab327c8e73292e8079da67fb4fa8396a0#egg=edxval==0.0.17
+git+https://github.com/edx/edx-val.git@8f695d27218c76f57d6b681f795eb3b97f8122bb#egg=edxval==0.0.17
 
 # Third Party XBlocks
 git+https://github.com/open-craft/xblock-poll@7ba819b968fe8faddb78bb22e1fe7637005eb414#egg=xblock-poll==1.2.7

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -97,6 +97,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.5#egg=lti_consumer-xblock==1.1.5
 git+https://github.com/edx/edx-proctoring.git@1.2.1#egg=edx-proctoring==1.2.1
+git+https://github.com/edx/edx-val.git@f3f08d0ab327c8e73292e8079da67fb4fa8396a0#egg=edxval==0.0.17
 
 # Third Party XBlocks
 git+https://github.com/open-craft/xblock-poll@7ba819b968fe8faddb78bb22e1fe7637005eb414#egg=xblock-poll==1.2.7


### PR DESCRIPTION
## Description
This PR adds functionality to use transcripts coming from edx-val as a fallback options (i.e. when there isn't any transcript in the content-store)

Implement possible fallback mechanisms for
- video component's basic tab buttons
- video component's transcript download links
- video component get translation dispatch `i.e. /translations/{lang_code}`


Sandbox: https://studio-s3-video-component.sandbox.edx.org/container/block-v1:UOG+CS101+2017_LT+type@vertical+block@537249d213c84050bae1ae1755032044