### PR TITLE
Add new Option to Show Answer Dropdown.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -108,8 +108,10 @@ class CapaFields(object):
     )
     max_attempts = Integer(
         display_name=_("Maximum Attempts"),
-        help=_("Defines the number of times a student can try to answer this problem. "
-               "If the value is not set, infinite attempts are allowed."),
+        help=_(
+            'Defines the number of times a student can try to answer this problem. '
+            'If the value is not set, infinite attempts are allowed. '
+        ),
         values={"min": 0}, scope=Scope.settings
     )
     due = Date(help=_("Date that this problem is due by"), scope=Scope.settings)
@@ -143,7 +145,16 @@ class CapaFields(object):
             {"display_name": _("Finished"), "value": SHOWANSWER.FINISHED},
             {"display_name": _("Correct or Past Due"), "value": SHOWANSWER.CORRECT_OR_PAST_DUE},
             {"display_name": _("Past Due"), "value": SHOWANSWER.PAST_DUE},
-            {"display_name": _("Never"), "value": SHOWANSWER.NEVER}]
+            {"display_name": _("Never"), "value": SHOWANSWER.NEVER},
+            {"display_name": _("After Some Number of Attempts"), "value": SHOWANSWER.AFTER_SOME_NUMBER_OF_ATTEMPTS},
+        ]
+    )
+    attempts_before_showanswer_button = Integer(
+        display_name=_("Show Answer: Number of Attempts"),
+        help=_("Number of times the student must attempt answering the question before the Show Answer button appears."),
+        values={"min": 0},
+        default=0,
+        scope=Scope.settings,
     )
     force_save_button = Boolean(
         help=_("Whether to force the save button to appear on the page"),
@@ -915,6 +926,11 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
             return self.is_correct() or self.is_past_due()
         elif self.showanswer == SHOWANSWER.PAST_DUE:
             return self.is_past_due()
+        elif self.showanswer == SHOWANSWER.AFTER_SOME_NUMBER_OF_ATTEMPTS:
+            required_attempts = self.attempts_before_showanswer_button
+            if self.max_attempts and required_attempts >= self.max_attempts:
+                required_attempts = self.max_attempts
+            return self.attempts >= required_attempts
         elif self.showanswer == SHOWANSWER.ALWAYS:
             return True
 

--- a/common/lib/xmodule/xmodule/capa_base_constants.py
+++ b/common/lib/xmodule/xmodule/capa_base_constants.py
@@ -16,6 +16,7 @@ class SHOWANSWER(object):
     CORRECT_OR_PAST_DUE = "correct_or_past_due"
     PAST_DUE = "past_due"
     NEVER = "never"
+    AFTER_SOME_NUMBER_OF_ATTEMPTS = "after_attempts"
 
 
 class RANDOMIZATION(object):

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -413,6 +413,115 @@ class CapaModuleTest(unittest.TestCase):
                                             graceperiod=self.two_day_delta_str)
         self.assertFalse(still_in_grace.answer_available())
 
+    def test_showanswer_after_attempts_with_max(self):
+        """
+        Button should not be visible when attempts < required attempts.
+
+        Even with max attempts set, the show answer button should only
+        show up after the user has attempted answering the question for
+        the requisite number of times, i.e `attempts_before_showanswer_button`
+        """
+        problem = CapaFactory.create(
+            showanswer='after_attempts',
+            attempts='2',
+            attempts_before_showanswer_button='3',
+            max_attempts='5',
+        )
+        self.assertFalse(problem.answer_available())
+
+    def test_showanswer_after_attempts_no_max(self):
+        """
+        Button should not be visible when attempts < required attempts.
+
+        Even when max attempts is NOT set, the answer should still
+        only be available after the student has attempted the
+        problem at least `attempts_before_showanswer_button` times
+        """
+        problem = CapaFactory.create(
+            showanswer='after_attempts',
+            attempts='2',
+            attempts_before_showanswer_button='3',
+        )
+        self.assertFalse(problem.answer_available())
+
+    def test_showanswer_after_attempts_used_all_attempts(self):
+        """
+        Button should be visible even after all attempts are used up.
+
+        As long as the student has attempted  the question for
+        the requisite number of times, then the show ans. button is
+        visible even after they have exhausted their attempts.
+        """
+        problem = CapaFactory.create(
+            showanswer='after_attempts',
+            attempts_before_showanswer_button='2',
+            max_attempts='3',
+            attempts='3',
+            due=self.tomorrow_str,
+        )
+        self.assertTrue(problem.answer_available())
+
+    def test_showanswer_after_attempts_past_due_date(self):
+        """
+        Show Answer button should be visible even after the due date.
+
+        As long as the student has attempted the problem for the requisite
+        number of times, the answer should be available past the due date.
+        """
+        problem = CapaFactory.create(
+            showanswer='after_attempts',
+            attempts_before_showanswer_button='2',
+            attempts='2',
+            due=self.yesterday_str,
+        )
+        self.assertTrue(problem.answer_available())
+
+    def test_showanswer_after_attempts_still_in_grace(self):
+        """
+        If attempts > required attempts, ans. is available in grace period.
+
+        As long as the user has attempted for the requisite # of times,
+        the show answer button is visible throughout the grace period.
+        """
+        problem = CapaFactory.create(
+            showanswer='after_attempts',
+            after_attempts='3',
+            attempts='4',
+            due=self.yesterday_str,
+            graceperiod=self.two_day_delta_str,
+        )
+        self.assertTrue(problem.answer_available())
+
+    def test_showanswer_after_attempts_large(self):
+        """
+        If required attempts > max attempts then required attempts = max attempts.
+
+        Ensure that if attempts_before_showanswer_button > max_attempts,
+        the button should show up after all attempts are used up,
+        i.e after_attempts falls back to max_attempts
+        """
+        problem = CapaFactory.create(
+            showanswer='after_attempts',
+            attempts_before_showanswer_button='5',
+            max_attempts='3',
+            attempts='3',
+        )
+        self.assertTrue(problem.answer_available())
+
+    def test_showanswer_after_attempts_zero(self):
+        """
+        Button should always be visible if required min attempts = 0.
+
+        If attempts_before_showanswer_button = 0, then the show answer
+        button should be visible at all times.
+        """
+        problem = CapaFactory.create(
+            showanswer='after_attempts',
+            attempts_before_showanswer_button='0',
+            attempts='0',
+        )
+        self.assertTrue(problem.answer_available())
+
     def test_showanswer_finished(self):
         """
         With showanswer="finished" should show answer after the problem is closed,


### PR DESCRIPTION
Studio's `Show Answer`
--
Introduces a new option, `after some number of attempts`
and a new entry box for specifying the number of attempts.
This allows course creators to specify that a given question's
answer is only viewable, i.e its show answer button is visible,
after the learner has attempted answering the question --
by hitting the submit button,  a given number of times. Included
in this commit are unit tests for the new feature.

Link to edX filed with same feature request: [link](https://openedx.atlassian.net/browse/TNL-4173)

All possible options that exist currently with configuring when the Show Answer button appears: from edx docs: [options](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_components/create_problem.html#show-answer)

Testing.
---
Go to studio and create a new question. In the `Show Answer` section of the question's settings, select `After Some number of Attempts`. In the new entry box labelled `Show Answer: Number of Attempts` enter the number of times the student is required to attempt the question before the show answer button appears. 
in LMS, when logged in as `Student` confirm that the show answer button to the question you just created only appears after you hit the submit button `Number of Attempts` times.

@stvstnfrd @caesar2164 @caseylitton 