### PR TITLE
Create migration to remove field 'sailthru_activation_template' from DB table.

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -226,11 +226,4 @@ class MigrationTests(TestCase):
         out = StringIO()
         call_command('makemigrations', dry_run=True, verbosity=3, stdout=out)
         output = out.getvalue()
-
-        # Temporary check, remove it once migration is created and use the else part.
-        if settings.ROOT_URLCONF == 'lms.urls':
-            migrations_count = output.count('Migrations for')
-            self.assertIn('Remove field sailthru_activation_template', output)
-            self.assertEqual(migrations_count, 1)
-        else:
-            self.assertIn('No changes detected', output)
+        self.assertIn('No changes detected', output)

--- a/lms/djangoapps/email_marketing/migrations/0009_remove_emailmarketingconfiguration_sailthru_activation_template.py
+++ b/lms/djangoapps/email_marketing/migrations/0009_remove_emailmarketingconfiguration_sailthru_activation_template.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('email_marketing', '0008_auto_20170809_0539'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='emailmarketingconfiguration',
+            name='sailthru_activation_template',
+        ),
+    ]


### PR DESCRIPTION
Follow up PR for https://github.com/edx/edx-platform/pull/15863 to remove the field from database table. First PR is deployed to production in last release.

LEARNER-2201