### PR TITLE
increase staff rate limit on enrollment API.

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -75,7 +75,7 @@ class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
     """Limit the number of requests users can make to the enrollment API."""
     THROTTLE_RATES = {
         'user': '40/minute',
-        'staff': '300/minute',
+        'staff': '400/minute',
     }
 
     def allow_request(self, request, view):


### PR DESCRIPTION
Still seeing an occasional 429 rate limit error when trying to get user enrollments.
Increasing staff rate limit.