### PR TITLE
Revert "remove try/catch block and associated test for EDUCATOR-1134"

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1454,4 +1454,13 @@ class CourseSummary(object):
         """
         Returns whether the course has ended.
         """
-        return course_metadata_utils.has_course_ended(self.end)
+        try:
+            return course_metadata_utils.has_course_ended(self.end)
+        except TypeError as e:
+            log.warning(
+                "Course '{course_id}' has an improperly formatted end date '{end_date}'. Error: '{err}'.".format(
+                    course_id=unicode(self.id), end_date=self.end, err=e
+                )
+            )
+            modified_end = self.end.replace(tzinfo=utc)
+            return course_metadata_utils.has_course_ended(modified_end)

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -2,6 +2,7 @@
 import ddt
 import unittest
 from datetime import datetime, timedelta
+from dateutil import parser
 
 import itertools
 from fs.memoryfs import MemoryFS
@@ -140,6 +141,16 @@ class HasEndedMayCertifyTestCase(unittest.TestCase):
         self.assertTrue(self.future_show_certs.may_certify())
         self.assertTrue(self.future_show_certs_no_info.may_certify())
         self.assertFalse(self.future_noshow_certs.may_certify())
+
+
+class CourseSummaryHasEnded(unittest.TestCase):
+    """ Test for has_ended method when end date is missing timezone information. """
+
+    def test_course_end(self):
+        test_course = get_dummy_course("2012-01-01T12:00")
+        bad_end_date = parser.parse("2012-02-21 10:28:45")
+        summary = xmodule.course_module.CourseSummary(test_course.id, end=bad_end_date)
+        self.assertTrue(summary.has_ended())
 
 
 @ddt.ddt


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-1259
Reverts edx/edx-platform#15889
Issue caused by improper end dates has surfaced again and is causing home page at edge to throw 500.
FYI: @thallada, @efischer19, @MichaelRoytman 