### PR TITLE
Clean up TestCase subclassing

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_create_course.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_create_course.py
@@ -1,9 +1,9 @@
 """
 Unittests for creating a course in an chosen modulestore
 """
-import unittest
 import ddt
 from django.core.management import CommandError, call_command
+from django.test import TestCase
 
 from contentstore.management.commands.create_course import Command
 from xmodule.modulestore import ModuleStoreEnum
@@ -11,7 +11,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.django import modulestore
 
 
-class TestArgParsing(unittest.TestCase):
+class TestArgParsing(TestCase):
     """
     Tests for parsing arguments for the `create_course` management command
     """

--- a/cms/djangoapps/contentstore/management/commands/tests/test_migrate_to_split.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_migrate_to_split.py
@@ -1,9 +1,8 @@
 """
 Unittests for migrating a course to split mongo
 """
-import unittest
-
 from django.core.management import CommandError, call_command
+from django.test import TestCase
 from contentstore.management.commands.migrate_to_split import Command
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -12,7 +11,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
 
-class TestArgParsing(unittest.TestCase):
+class TestArgParsing(TestCase):
     """
     Tests for parsing arguments for the `migrate_to_split` management command
     """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -78,7 +78,7 @@ class TestMongoModuleStoreBase(unittest.TestCase):
     courses = ['toy', 'simple', 'simple_with_draft', 'test_unicode']
 
     @classmethod
-    def setupClass(cls):
+    def setUpClass(cls):
         cls.connection = pymongo.MongoClient(
             host=HOST,
             port=PORT,
@@ -93,7 +93,7 @@ class TestMongoModuleStoreBase(unittest.TestCase):
         cls.content_store, cls.draft_store = cls.initdb()
 
     @classmethod
-    def teardownClass(cls):
+    def tearDownClass(cls):
         if cls.connection:
             cls.connection.drop_database(DB)
             cls.connection.close()
@@ -186,12 +186,12 @@ class TestMongoModuleStore(TestMongoModuleStoreBase):
         pass
 
     @classmethod
-    def setupClass(cls):
-        super(TestMongoModuleStore, cls).setupClass()
+    def setUpClass(cls):
+        super(TestMongoModuleStore, cls).setUpClass()
 
     @classmethod
-    def teardownClass(cls):
-        super(TestMongoModuleStore, cls).teardownClass()
+    def tearDownClass(cls):
+        super(TestMongoModuleStore, cls).tearDownClass()
 
     def test_init(self):
         '''Make sure the db loads'''
@@ -728,12 +728,12 @@ class TestMongoModuleStoreWithNoAssetCollection(TestMongoModuleStore):
         pass
 
     @classmethod
-    def setupClass(cls):
-        super(TestMongoModuleStoreWithNoAssetCollection, cls).setupClass()
+    def setUpClass(cls):
+        super(TestMongoModuleStoreWithNoAssetCollection, cls).setUpClass()
 
     @classmethod
-    def teardownClass(cls):
-        super(TestMongoModuleStoreWithNoAssetCollection, cls).teardownClass()
+    def tearDownClass(cls):
+        super(TestMongoModuleStoreWithNoAssetCollection, cls).tearDownClass()
 
     def test_no_asset_collection(self):
         courses = self.draft_store.get_courses()

--- a/openedx/core/djangoapps/content/block_structure/tests/test_factory.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_factory.py
@@ -1,8 +1,8 @@
 """
 Tests for block_structure_factory.py
 """
+from django.test import TestCase
 from nose.plugins.attrib import attr
-from unittest import TestCase
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from ..store import BlockStructureStore

--- a/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
@@ -2,8 +2,8 @@
 Tests for manager.py
 """
 import ddt
+from django.test import TestCase
 from nose.plugins.attrib import attr
-from unittest import TestCase
 
 from ..block_structure import BlockStructureBlockData
 from ..config import RAISE_ERROR_WHEN_NOT_FOUND, STORAGE_BACKING_FOR_CACHE, waffle

--- a/openedx/core/djangoapps/user_api/tests/test_middleware.py
+++ b/openedx/core/djangoapps/user_api/tests/test_middleware.py
@@ -1,8 +1,8 @@
 """Tests for user API middleware"""
 from mock import Mock, patch
-from unittest import TestCase
 
 from django.http import HttpResponse
+from django.test import TestCase
 from django.test.client import RequestFactory
 
 from student.tests.factories import UserFactory, AnonymousUserFactory

--- a/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
@@ -2,8 +2,8 @@
 Test the user api's partition extensions.
 """
 from collections import defaultdict
+from django.test import TestCase
 from mock import patch
-from unittest import TestCase
 
 from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme, UserPartitionError
 from student.tests.factories import UserFactory

--- a/openedx/core/djangoapps/util/tests/test_user_messages.py
+++ b/openedx/core/djangoapps/util/tests/test_user_messages.py
@@ -3,10 +3,9 @@ Unit tests for user messages.
 """
 
 import ddt
-from unittest import TestCase
 
 from django.contrib.messages.middleware import MessageMiddleware
-from django.test import RequestFactory
+from django.test import RequestFactory, TestCase
 from openedx.core.djangolib.markup import HTML, Text
 from student.tests.factories import UserFactory
 


### PR DESCRIPTION
Several of our unit test classes are derived directly from unittest.TestCase instead of django.test.TestCase.  This mostly works with nose (although the Django subclass takes some steps to make it less likely that tests will accidentally alter global database state), but pytest-django uses subclassing of the Django TestCase as an indicator that database access should be allowed.  Other test classes aren't allowed to perform database queries unless they're marked accordingly.

This PR updates a number of tests to inherit from a more appropriate test class in order to ease the pytest transition and enable us to make some database usage optimizations later.  It also fixes a few classes that got the capitalization of the setup and teardown methods wrong, which nose doesn't seem to care about but pytest does.