### PR TITLE
Deactivate date display if no cert active

### DIFF
--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -803,7 +803,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         """
         self.course.self_paced = is_self_paced
         self.course.save()
-        self._add_course_certificates(count=1, signatory_count=1)
+        self._add_course_certificates(count=1, signatory_count=1, is_active=True)
         test_url = get_certificate_url(
             user_id=self.user.id,
             course_id=unicode(self.course.id)

--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -204,15 +204,25 @@ class CertificateAvailableDate(DateSummary):
     title = ugettext_lazy('Certificate Available')
 
     @property
+    def active_certificates(self):
+        return [
+            certificate for certificate in self.course.certificates.get('certificates', [])
+            if certificate.get('is_active', False)
+        ]
+
+    @property
     def is_enabled(self):
         return (
-            self.date is not None and datetime.datetime.now(utc) <= self.date and not self.course.self_paced and
-            waffle.waffle().is_enabled(waffle.INSTRUCTOR_PACED_ONLY)
+            self.date is not None and
+            datetime.datetime.now(utc) <= self.date and
+            not self.course.self_paced and
+            waffle.waffle().is_enabled(waffle.INSTRUCTOR_PACED_ONLY) and
+            len(self.active_certificates) > 0
         )
 
     @property
     def description(self):
-        return _('Day certificates will become available for passing verified learners.')
+        return _('Day certificates will become available for passing verified learners.' + str(self.active_certificates))
 
     @property
     def date(self):

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -382,6 +382,13 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         verified_user = self.create_user()
         CourseEnrollmentFactory(course_id=course.id, user=verified_user, mode=CourseMode.VERIFIED)
         course.certificate_available_date = datetime.now(utc) + timedelta(days=7)
+        course.certificates = {
+            u'certificates': [{
+                u'course_title': u'Test',
+                u'name': u'',
+                u'is_active': True,
+            }]
+        }
         course.save()
         CertificateAvailableDate(course, audit_user)
         for block in (CertificateAvailableDate(course, audit_user), CertificateAvailableDate(course, verified_user)):


### PR DESCRIPTION
## [EDUCATOR-1234](https://openedx.atlassian.net/browse/EDUCATOR-1234)

### Description
Disable "Certificate availability date" display on course home page if no active cert is available.

### Testing
- [ ] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @ssemenova 

FYI: @edx/educator-neem

### Post-review
- [ ] Rebase and squash commits
