### PR TITLE
Show advertised start date on course details page

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -7,6 +7,7 @@ from django.conf import settings
 from edxmako.shortcuts import marketing_link
 from openedx.core.djangolib.markup import HTML
 from openedx.core.lib.courses import course_image_url
+from six import string_types
 %>
 
 <%inherit file="../main.html" />
@@ -221,12 +222,12 @@ from openedx.core.lib.courses import course_image_url
           <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
           % if not course.start_date_is_still_default:
               <%
-                  course_start_date = course.start
+                  course_start_date = course.advertised_start or course.start
               %>
             <li class="important-dates-item">
               <span class="icon fa fa-calendar" aria-hidden="true"></span>
               <p class="important-dates-item-title">${_("Classes Start")}</p>
-              % if isinstance(course_start_date, str):
+              % if isinstance(course_start_date, string_types):
                   <span class="important-dates-item-text start-date">${course_start_date}</span>
               % else:
                   <%


### PR DESCRIPTION
This pull request allows a course's "Advertised Start Date" to be shown on the course details page when set. At the same time, this fixes a bug where the platform default course start date is shown when the course start date is set to that value, but an advertised start date is set.

**Dependencies**: None

**Screenshots**:

Before:

<img width="1248" alt="screen shot 2017-08-29 at 3 50 59 pm" src="https://user-images.githubusercontent.com/7773758/29841085-1fd2468e-8cd2-11e7-9d0f-dfea9d7e023b.png">

After:

<img width="1231" alt="screen shot 2017-08-29 at 3 50 26 pm" src="https://user-images.githubusercontent.com/7773758/29841096-27d75478-8cd2-11e7-8e2f-021acbf714c1.png">

**Sandbox URL**: TBD - sandbox is being provisioned.

**Partner information**: 3rd party-hosted open edX instance

**Testing instructions**:

1. With your devstack on master, set a course to start at the default start date (2013-01-01T00:00Z).
2. In the course's advanced settings, set the Advertised Start Date to have a custom, recognizable string.
3. At the URL `/courses` on your devstack, observe that the course shows your custom advertised start date.
4. Click on the course, and observe that the start date indicated is the platform default start date, rather than your custom string.
5. Update your devstack to this version.
6. Refresh the course details page.
7. Observe that your custom advertised start date is now used.

**Reviewers**
- [ ] @clemente
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```