### PR TITLE
TESTING: Add default OAUTH_DELETE_EXPIRED to CMS & LMS settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1329,6 +1329,9 @@ OAUTH_OIDC_ISSUER = 'https://www.example.com/oauth2'
 # 5 minute expiration time for JWT id tokens issued for external API requests.
 OAUTH_ID_TOKEN_EXPIRATION = 5 * 60
 
+# Remove grants, access tokens, refresh tokens as they are used
+OAUTH_DELETE_EXPIRED = True
+
 # Partner support link for CMS footer
 PARTNER_SUPPORT_EMAIL = ''
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2881,6 +2881,9 @@ ENROLLMENT_COURSE_DETAILS_CACHE_TIMEOUT = 60
 
 OAUTH_ID_TOKEN_EXPIRATION = 60 * 60
 
+# Remove grants, access tokens, refresh tokens as they are used
+OAUTH_DELETE_EXPIRED = True
+
 # These tabs are currently disabled
 NOTES_DISABLED_TABS = ['course_structure', 'tags']
 


### PR DESCRIPTION
Checking that changing this setting doesn't break tests.