### PR TITLE
Fix learner profile bug and tests that didn't catch it

### DIFF
--- a/openedx/features/learner_profile/templates/learner_profile/learner-achievements-fragment.html
+++ b/openedx/features/learner_profile/templates/learner_profile/learner-achievements-fragment.html
@@ -19,10 +19,10 @@ from openedx.core.djangolib.markup import HTML, Text
                 course = certificate['course']
 
                 completion_date_message_html = Text(_('Completed {completion_date_html}')).format(
-                    completion_date=HTML(
+                    completion_date_html=HTML(
                         '<span'
                         '    class="localized-datetime start-date"'
-                        '    data-datetime="{completion_date_html}"'
+                        '    data-datetime="{completion_date}"'
                         '    data-format="shortDate"'
                         '    data-timezone="{user_timezone}"'
                         '    data-language="{user_language}"'


### PR DESCRIPTION
This is a small fix for a typo in the new learner profile achievements template that I introduced in a code review clean-up. I've also fixed the tests that were meant to be verifying this but were in fact not generating the page.