### PR TITLE
PIN version number of ACE

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -97,7 +97,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.5#egg=lti_consumer-xblock==1.1.5
 git+https://github.com/edx/edx-proctoring.git@1.2.0#egg=edx-proctoring==1.2.0
-git+https://github.com/edx/edx-ace.git@v0.1.1#egg=edx-ace
+git+https://github.com/edx/edx-ace.git@v0.1.1#egg=edx-ace==0.1.1
 
 # Third Party XBlocks
 git+https://github.com/open-craft/xblock-poll@7ba819b968fe8faddb78bb22e1fe7637005eb414#egg=xblock-poll==1.2.7


### PR DESCRIPTION
FYI @edx/rapid-experiments-team 

Thanks to @feanil for helping us debug this issue. The sandbox-int was still installing an older version of attrs. The top of the github.txt file "explains" why we need to specify the Version number here as well. 