### PR TITLE
LEARNER-2453: Allow social usernames to contain periods.

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -35,6 +35,7 @@ class UserAccountSettingsTest(TestCase):
         ('twitter', 'https://www.twitter.com/edX/123s', None, False),
         ('twitter', 'twitter.com/edX', 'https://www.twitter.com/edX', True),
         ('twitter', 'twitter.com/edX?foo=bar', 'https://www.twitter.com/edX', True),
+        ('twitter', 'twitter.com/test.user', 'https://www.twitter.com/test.user', True),
         ('linkedin', 'www.linkedin.com/harryrein', None, False),
         ('linkedin', 'www.linkedin.com/in/harryrein-1234', 'https://www.linkedin.com/in/harryrein-1234', True),
         ('linkedin', 'www.evilwebsite.com/123?www.linkedin.com/edX', None, False),

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -85,6 +85,7 @@ def _get_username_from_social_link(platform_name, new_social_link):
 def _is_valid_social_username(value):
     """
     Given a particular string, returns whether the string can be considered a safe username.
-    A safe username contains only hyphens, underscores or other alphanumerical characters.
+    This is a very liberal validation step, simply assuring forward slashes do not exist
+    in the username.
     """
-    return bool(re.match('^[a-zA-Z0-9_-]*$', value))
+    return '/' not in value


### PR DESCRIPTION
## [LEARNER-2453](https://openedx.atlassian.net/browse/LEARNER-2453)
Allow users to use periods in their social link usernames.

FYI: @edx/learner-mercury