### PR TITLE
ENT-496 Set consent_granted to None when calling enterprise-course-enrollment endpoint

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -603,7 +603,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                 # We received an explicitly-linked EnterpriseCustomer for the enrollment
                 if explicit_linked_enterprise is not None:
                     try:
-                        enterprise_api_client.post_enterprise_course_enrollment(username, unicode(course_id), True)
+                        enterprise_api_client.post_enterprise_course_enrollment(username, unicode(course_id), None)
                     except EnterpriseApiException as error:
                         log.exception("An unexpected error occurred while creating the new EnterpriseCourseEnrollment "
                                       "for user [%s] in course run [%s]", username, course_id)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.42.0
+edx-enterprise==0.43.1
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
I discovered an error on the business sandbox where the user wasn't being enrolled in the course when doing a verified purchase. The root cause was that we were calling the enterprise-course-enrollment endpoint attempting to write the consent_granted field. However, the record existed with consent_granted set to NULL, as expected from the changes from ENT-496, but the api save method used get_or_create with that and threw an DB integrity error. There is an associated edx-enterprise PR to address that (https://github.com/edx/edx-enterprise/pull/180)