### PR TITLE
Only show passing certificates on a learner profile

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -513,8 +513,6 @@ def certificate_status(generated_certificate):
                    certificate generation yet.
     generating   - A request has been made to generate a certificate,
                    but it has not been generated yet.
-    regenerating - A request has been made to regenerate a certificate,
-                   but it has not been generated yet.
     deleting     - A request has been made to delete a certificate.
 
     deleted      - The certificate has been deleted.


### PR DESCRIPTION
## [LEARNER-2486](https://openedx.atlassian.net/browse/LEARNER-2486)

### Description

This fix updates the learner profile to only show passing certificates. It also adds tests for the two conditions where it was failing before (a valid certificate with a non-passing status, and a certificate for a course that no longer exists).

### Sandbox
- [ ] If helpful for review, build a sandbox for your branch and add a link here

### Testing
- [ ] Unit, integration, acceptance tests as appropriate

### Assign Github reviewers (as needed)
- [ ] engineering 

FYI: @edx/learner-mercury
 
### Post-review
- [ ] Rebase and squash commits