### PR TITLE
Add language mapping for zh_CN to zh_HANS

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -41,7 +41,7 @@ enum34==1.1.6
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.6
 edx-drf-extensions==1.2.3
-edx-i18n-tools==0.3.9
+edx-i18n-tools==0.3.10
 edx-lint==0.4.3
 # astroid 1.3.8 is an unmet dependency of the version of pylint used in edx-lint 0.4.3
 # when upgrading edx-lint, we should try to remove this from the platform


### PR DESCRIPTION
- Will allow i18n_tools to copy the zh_CN translations to zh_HANS in
preparation for the Django 1.11 upgrade.