### PR TITLE
Fixes for test order dependence

### DIFF
--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -152,9 +152,9 @@ class TestCreateAccount(SiteMixin, TestCase):
             'country': self.params['country'],
         }
 
-        self.create_account_and_fetch_profile()
+        profile = self.create_account_and_fetch_profile()
 
-        mock_segment_identify.assert_called_with(1, expected_payload)
+        mock_segment_identify.assert_called_with(profile.user.id, expected_payload)
 
     @unittest.skipUnless(
         "microsite_configuration.middleware.MicrositeMiddleware" in settings.MIDDLEWARE_CLASSES,

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -2,6 +2,7 @@
 Slightly customized python-social-auth backend for SAML 2.0 support
 """
 import logging
+from copy import deepcopy
 
 import requests
 from django.contrib.sites.models import Site
@@ -191,7 +192,7 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
         Open edX platform registration form.
         """
         overrides = self.conf.get('sapsf_value_mappings', {})
-        base = self.default_value_mapping.copy()
+        base = deepcopy(self.default_value_mapping)
         for field, override in overrides.items():
             if field in base:
                 base[field].update(override)

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -70,9 +70,8 @@ def remove_course_updates(user, course):
     updates_usage_key = get_course_info_usage_key(course, 'updates')
     try:
         course_updates = modulestore().get_item(updates_usage_key)
-        course_updates.items = []
-        modulestore().update_item(course_updates, user.id)
-    except ItemNotFoundError:
+        modulestore().delete_item(course_updates.location, user.id)
+    except (ItemNotFoundError, ValueError):
         pass
 
 


### PR DESCRIPTION
Fixed a few tests (and one spot in actual application code) which could cause other tests to fail depending on the order in which they were executed:

* `test_segment_tracking()` in `test_create_account.py` assumed that the user it created would end up with ID 1; switched to actually get the ID from the created user
* `SapSuccessFactorsIdentityProvider.value_mappings` was performing a shallow copy of the `default_value_mapping` to create the return value, but that's actually a nested dictionary.  Now performing a deep copy instead to prevent consecutive calls from modifying either of the default value dictionaries.
* `test_course_home.py` had a few tests which added updates to the course structure but never removed them afterwards; this could throw off query counts in later tests.  I had to fix the `remove_course_updates()` utility from `test_course_updates()` to remove the entire updates item instead of just its children to leave the course structure completely consistent between tests.
* `TestEnterpriseApi` was directly subclassing `django.test.SimpleTestCase` instead of its subclass `django.test.TestCase`, so its test methods weren't being run in transactions or savepoints; this resulted in users and other data being left behind in the database after it finished.  Switching to subclass `django.test.TestCase` like most of our other tests resolved this and doesn't seem to have caused any new problems.

I also changed a couple of mock objects used as ddt parameters to have consistent string representations so they'll always generate the same test method names.