### PR TITLE
Fixes for pytest database usage

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -8,6 +8,7 @@ from unittest import skip
 from uuid import uuid4
 
 import ddt
+import pytest
 from dateutil.tz import tzutc
 from django.conf import settings
 from lazy.lazy import lazy
@@ -181,6 +182,7 @@ class MixedWithOptionsTestCase(MixedSplitTestCase):
             store.update_item(item, ModuleStoreEnum.UserID.test)
 
 
+@pytest.mark.django_db
 @ddt.ddt
 class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
     """ Tests the operation of the CoursewareSearchIndexer """

--- a/common/djangoapps/static_replace/test/test_static_replace.py
+++ b/common/djangoapps/static_replace/test/test_static_replace.py
@@ -6,6 +6,7 @@ from cStringIO import StringIO
 from urlparse import parse_qsl, urlparse, urlunparse
 
 import ddt
+import pytest
 from django.test import override_settings
 from django.utils.http import urlencode, urlquote
 from mock import Mock, patch
@@ -162,6 +163,7 @@ def test_raw_static_check():
     assert_equals(path, replace_static_urls(path, text))
 
 
+@pytest.mark.django_db
 @patch('static_replace.staticfiles_storage', autospec=True)
 @patch('static_replace.modulestore', autospec=True)
 def test_static_url_with_query(mock_modulestore, mock_storage):

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -7,6 +7,7 @@ import json
 import unittest
 
 import mock
+from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.timezone import utc
 from nose.plugins.attrib import attr
@@ -65,7 +66,7 @@ class TestHandleDashboardError(unittest.TestCase):
 
 
 @attr(shard=1)
-class TestRequireStudentIdentifier(unittest.TestCase):
+class TestRequireStudentIdentifier(TestCase):
     """
     Test require_student_from_identifier()
     """

--- a/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/tests/test_partition_schemes.py
@@ -2,6 +2,8 @@
 Test the user api's partition extensions.
 """
 from collections import defaultdict
+
+import pytest
 from django.test import TestCase
 from mock import patch
 
@@ -32,6 +34,7 @@ class MemoryCourseTagAPI(object):
             return False
 
 
+@pytest.mark.django_db
 class TestRandomUserPartitionScheme(PartitionTestCase):
     """
     Test getting a user's group out of a partition

--- a/openedx/core/lib/tests/test_time_zone_utils.py
+++ b/openedx/core/lib/tests/test_time_zone_utils.py
@@ -1,6 +1,5 @@
 """Tests covering time zone utilities."""
-from unittest import TestCase
-
+from django.test import TestCase
 from freezegun import freeze_time
 from pytz import timezone, utc
 


### PR DESCRIPTION
To improve efficiency and minimize risk of database changes leaking between test cases, pytest-django only allows subclasses of `django.test.TestCase` and tests with the `django_db` mark to access the database.  The vast majority of our database-using tests fall in the former category, but I found a handful of exceptions.  This PR changes the base class of these when appropriate, and resorts to the mark instead when the nature of the tests requires it.  This shouldn't have any significant impact on running the tests with `nosetests`.