### PR TITLE
pytest compatibility fixes

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -171,8 +171,21 @@ class TestSaveSubsToStore(SharedModuleStoreTestCase):
             contentstore().find(self.content_location_unjsonable)
 
 
+class TestYoutubeSubsBase(SharedModuleStoreTestCase):
+    """
+    Base class for tests of Youtube subs.  Using override_settings and
+    a setUpClass() override in a test class which is inherited by another
+    test class doesn't work well with pytest-django.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super(TestYoutubeSubsBase, cls).setUpClass()
+        cls.course = CourseFactory.create(
+            org=cls.org, number=cls.number, display_name=cls.display_name)
+
+
 @override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
-class TestDownloadYoutubeSubs(SharedModuleStoreTestCase):
+class TestDownloadYoutubeSubs(TestYoutubeSubsBase):
     """Tests for `download_youtube_subs` function."""
 
     org = 'MITx'
@@ -199,12 +212,6 @@ class TestDownloadYoutubeSubs(SharedModuleStoreTestCase):
         """
         for subs_id in youtube_subs.values():
             self.clear_sub_content(subs_id)
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestDownloadYoutubeSubs, cls).setUpClass()
-        cls.course = CourseFactory.create(
-            org=cls.org, number=cls.number, display_name=cls.display_name)
 
     def test_success_downloading_subs(self):
 

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -6,6 +6,7 @@ Group Configuration Tests.
 import json
 import ddt
 from mock import patch
+from operator import itemgetter
 
 from contentstore.utils import reverse_course_url, reverse_usage_url
 from contentstore.course_group_config import GroupConfiguration, CONTENT_GROUP_CONFIGURATION_NAME
@@ -857,6 +858,8 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
         )
 
         actual = self._get_user_partition('cohort')
+        # order of usage list is arbitrary, sort for reliable comparison
+        actual['groups'][0]['usage'].sort(key=itemgetter('label'))
         expected = {
             'id': 0,
             'name': 'User Partition',
@@ -881,7 +884,7 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
 
         self.maxDiff = None
 
-        self.assertEqual(actual, expected)
+        assert actual == expected
 
     def test_can_get_correct_usage_info(self):
         """

--- a/cms/envs/test_docker.py
+++ b/cms/envs/test_docker.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-""" Test settings for Docker-based devstack. """
-
-import os
-
-os.environ['EDXAPP_TEST_MONGO_HOST'] = os.environ.get('EDXAPP_TEST_MONGO_HOST', 'edx.devstack.mongo')
-
-# noinspection PyUnresolvedReferences
-from .test import *  # pylint: disable=wildcard-import

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -393,7 +393,7 @@ class TestDeserialize(unittest.TestCase):
         """
         Asserts the result of deserialize_field.
         """
-        assert_equals(expected, deserialize_field(self.test_field(), arg))
+        assert_equals(expected, deserialize_field(self.field_type(), arg))
 
     def assertDeserializeNonString(self):
         """
@@ -412,7 +412,7 @@ class TestDeserialize(unittest.TestCase):
 class TestDeserializeInteger(TestDeserialize):
     """ Tests deserialize as related to Integer type. """
 
-    test_field = Integer
+    field_type = Integer
 
     def test_deserialize(self):
         self.assertDeserializeEqual(-2, '-2')
@@ -437,7 +437,7 @@ class TestDeserializeInteger(TestDeserialize):
 class TestDeserializeFloat(TestDeserialize):
     """ Tests deserialize as related to Float type. """
 
-    test_field = Float
+    field_type = Float
 
     def test_deserialize(self):
         self.assertDeserializeEqual(-2, '-2')
@@ -460,7 +460,7 @@ class TestDeserializeFloat(TestDeserialize):
 class TestDeserializeBoolean(TestDeserialize):
     """ Tests deserialize as related to Boolean type. """
 
-    test_field = Boolean
+    field_type = Boolean
 
     def test_deserialize(self):
         # json.loads converts the value to Python bool
@@ -485,7 +485,7 @@ class TestDeserializeBoolean(TestDeserialize):
 class TestDeserializeString(TestDeserialize):
     """ Tests deserialize as related to String type. """
 
-    test_field = String
+    field_type = String
 
     def test_deserialize(self):
         self.assertDeserializeEqual('hAlf', '"hAlf"')
@@ -503,7 +503,7 @@ class TestDeserializeString(TestDeserialize):
 class TestDeserializeAny(TestDeserialize):
     """ Tests deserialize as related to Any type. """
 
-    test_field = Any
+    field_type = Any
 
     def test_deserialize(self):
         self.assertDeserializeEqual('hAlf', '"hAlf"')
@@ -519,7 +519,7 @@ class TestDeserializeAny(TestDeserialize):
 class TestDeserializeList(TestDeserialize):
     """ Tests deserialize as related to List type. """
 
-    test_field = List
+    field_type = List
 
     def test_deserialize(self):
         self.assertDeserializeEqual(['foo', 'bar'], '["foo", "bar"]')
@@ -536,7 +536,7 @@ class TestDeserializeList(TestDeserialize):
 class TestDeserializeDate(TestDeserialize):
     """ Tests deserialize as related to Date type. """
 
-    test_field = Date
+    field_type = Date
 
     def test_deserialize(self):
         self.assertDeserializeEqual('2012-12-31T23:59:59Z', "2012-12-31T23:59:59Z")
@@ -547,7 +547,7 @@ class TestDeserializeDate(TestDeserialize):
 class TestDeserializeTimedelta(TestDeserialize):
     """ Tests deserialize as related to Timedelta type. """
 
-    test_field = Timedelta
+    field_type = Timedelta
 
     def test_deserialize(self):
         self.assertDeserializeEqual(
@@ -564,7 +564,7 @@ class TestDeserializeTimedelta(TestDeserialize):
 class TestDeserializeRelativeTime(TestDeserialize):
     """ Tests deserialize as related to Timedelta type. """
 
-    test_field = RelativeTime
+    field_type = RelativeTime
 
     def test_deserialize(self):
         """

--- a/lms/djangoapps/courseware/tests/test_field_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_field_overrides.py
@@ -45,21 +45,28 @@ class TestOverrideProvider(FieldOverrideProvider):
         return True
 
 
-@attr(shard=1)
-@override_settings(FIELD_OVERRIDE_PROVIDERS=(
-    'courseware.tests.test_field_overrides.TestOverrideProvider',))
-class OverrideFieldDataTests(SharedModuleStoreTestCase):
+class OverrideFieldBase(SharedModuleStoreTestCase):
     """
-    Tests for `OverrideFieldData`.
+    Base class for field data override tests.  Using override_settings and
+    a setUpClass() override in a test class which is inherited by another
+    test class doesn't work well with pytest-django.
     """
-
     @classmethod
     def setUpClass(cls):
         """
         Course is created here and shared by all the class's tests.
         """
-        super(OverrideFieldDataTests, cls).setUpClass()
+        super(OverrideFieldBase, cls).setUpClass()
         cls.course = CourseFactory.create(enable_ccx=True)
+
+
+@attr(shard=1)
+@override_settings(FIELD_OVERRIDE_PROVIDERS=(
+    'courseware.tests.test_field_overrides.TestOverrideProvider',))
+class OverrideFieldDataTests(OverrideFieldBase):
+    """
+    Tests for `OverrideFieldData`.
+    """
 
     def setUp(self):
         super(OverrideFieldDataTests, self).setUp()

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -794,7 +794,7 @@ class ViewsTestCase(
             )
         ]
 
-        assert_equal(call_list, mock_request.call_args_list)
+        assert mock_request.call_args_list == call_list
 
         assert_equal(response.status_code, 200)
 
@@ -872,7 +872,7 @@ class ViewsTestCase(
             )
         ]
 
-        assert_equal(call_list, mock_request.call_args_list)
+        assert mock_request.call_args_list == call_list
 
         assert_equal(response.status_code, 200)
 
@@ -944,7 +944,7 @@ class ViewsTestCase(
             )
         ]
 
-        assert_equal(call_list, mock_request.call_args_list)
+        assert mock_request.call_args_list == call_list
 
         assert_equal(response.status_code, 200)
 
@@ -1016,7 +1016,7 @@ class ViewsTestCase(
             )
         ]
 
-        assert_equal(call_list, mock_request.call_args_list)
+        assert mock_request.call_args_list == call_list
 
         assert_equal(response.status_code, 200)
 

--- a/lms/envs/test_docker.py
+++ b/lms/envs/test_docker.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-""" Test settings for Docker-based devstack. """
-
-import os
-
-os.environ['EDXAPP_TEST_MONGO_HOST'] = os.environ.get('EDXAPP_TEST_MONGO_HOST', 'edx.devstack.mongo')
-
-# noinspection PyUnresolvedReferences
-from .test import *  # pylint: disable=wildcard-import

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -98,7 +98,7 @@ class Env(object):
     USING_DOCKER = SERVER_HOST != '0.0.0.0'
     SETTINGS = 'bok_choy_docker' if USING_DOCKER else 'bok_choy'
     DEVSTACK_SETTINGS = 'devstack_docker' if USING_DOCKER else 'devstack'
-    TEST_SETTINGS = 'test_docker' if USING_DOCKER else 'test'
+    TEST_SETTINGS = 'test'
 
     BOK_CHOY_SERVERS = {
         'lms': {


### PR DESCRIPTION
Fixed a few tests which would fail under pytest even though there wasn't anything particularly wrong with them when run via nosetests:

* pytest-django doesn't cleanly handle the use of `override_settings` as a class decorator for a `TestCase` subclass which has a `setUpClass()` or `tearDownClass()` method override and is itself inherited by another test class; the logic for temporarily moving aside those class methods so they can be run when the plugin chooses instead of when `unittest` wants to breaks down in this case (the wrong class in the inheritance tree gets passed into the method).  This is a pretty rare set of conditions, but we had two different test modules that ran afoul of it; I refactored them to no longer hit this bug.
* One test in `test_group_configurations.py` did a comparison where the actual value included a list which has technically arbitrary sorting order.  It was in fact occasionally varying under pytest (but rarely seems to under nose), so I adjusted the test to put that in a consistent order first.
* The test class hierarchy in `test_xml_module.py` used a `test_field` attribute to specify the type of field being tested, but that ran afoul of pytest's test discovery algorithm.  I renamed it to `field_type` to avoid this.
* Some of the `django_comment_client` tests were using nose's `assert_equal` utility to compare the arguments to mocked functions, which under pytest wasn't treating `call()` structures and argument tuples as equivalent.  Switched to plain assertions, which work under both test runners and give better failure output under pytest anyway.

I also removed the `test_docker` settings modules, since their only purpose in existing was to provide a default value for `EDXAPP_TEST_MONGO_HOST`, but we now set that default in devstack's `docker-compose.yml`.  This makes it possible to use the same default test settings module in pytest configuration files for both Vagrant and Docker devstacks.