### PR TITLE
reduce celery heartbeat frequency

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -62,7 +62,7 @@ CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 
 # When the broker is behind an ELB, use a heartbeat to refresh the
 # connection and to detect if it has been dropped.
-BROKER_HEARTBEAT = 10.0
+BROKER_HEARTBEAT = 60.0
 BROKER_HEARTBEAT_CHECKRATE = 2
 
 # Each worker should only fetch one message at a time

--- a/cms/envs/yaml_config.py
+++ b/cms/envs/yaml_config.py
@@ -107,7 +107,7 @@ CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 
 # When the broker is behind an ELB, use a heartbeat to refresh the
 # connection and to detect if it has been dropped.
-BROKER_HEARTBEAT = 10.0
+BROKER_HEARTBEAT = 60.0
 BROKER_HEARTBEAT_CHECKRATE = 2
 
 # Each worker should only fetch one message at a time

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -73,7 +73,7 @@ CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 
 # When the broker is behind an ELB, use a heartbeat to refresh the
 # connection and to detect if it has been dropped.
-BROKER_HEARTBEAT = 10.0
+BROKER_HEARTBEAT = 60.0
 BROKER_HEARTBEAT_CHECKRATE = 2
 
 # Each worker should only fetch one message at a time

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -130,7 +130,7 @@ CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 
 # When the broker is behind an ELB, use a heartbeat to refresh the
 # connection and to detect if it has been dropped.
-BROKER_HEARTBEAT = 10.0
+BROKER_HEARTBEAT = 60.0
 BROKER_HEARTBEAT_CHECKRATE = 2
 
 # Each worker should only fetch one message at a time


### PR DESCRIPTION
This is closer to the 120.0 second defaults, and aligns with the default ELB connection timeout.

http://docs.celeryproject.org/en/3.0/userguide/configuration.html#std:setting-broker_heartbeat

We think that this will reduce the load on rabbitmq.