### PR TITLE
Educator-1260 - Course teams unable to save changes to dates

### DIFF
--- a/cms/static/js/factories/settings.js
+++ b/cms/static/js/factories/settings.js
@@ -2,7 +2,7 @@ define([
     'jquery', 'js/models/settings/course_details', 'js/views/settings/main'
 ], function($, CourseDetailsModel, MainView) {
     'use strict';
-    return function(detailsUrl, showMinGradeWarning) {
+    return function(detailsUrl, showMinGradeWarning, showCertificateAvailableDate) {
         var model;
         // highlighting labels when fields are focused in
         $('form :input')
@@ -15,6 +15,7 @@ define([
 
         model = new CourseDetailsModel();
         model.urlRoot = detailsUrl;
+        model.showCertificateAvailableDate = showCertificateAvailableDate;
         model.fetch({
             success: function(model) {
                 var editor = new MainView({

--- a/cms/static/js/models/settings/course_details.js
+++ b/cms/static/js/models/settings/course_details.js
@@ -60,7 +60,7 @@ define(['backbone', 'underscore', 'gettext', 'js/models/validation_helpers', 'js
                 if (newattrs.end_date && newattrs.enrollment_end && newattrs.end_date < newattrs.enrollment_end) {
                     errors.enrollment_end = gettext('The enrollment end date cannot be after the course end date.');
                 }
-                if (!this.get('self_paced') && newattrs.end_date && newattrs.certificate_available_date &&
+                if (this.showCertificateAvailableDate && newattrs.end_date && newattrs.certificate_available_date &&
                     newattrs.certificate_available_date < newattrs.end_date) {
                     errors.certificate_available_date = gettext(
                         'The certificate available date must be later than the course end date.'

--- a/cms/static/js/spec/views/settings/main_spec.js
+++ b/cms/static/js/spec/views/settings/main_spec.js
@@ -350,10 +350,12 @@ define([
             AjaxHelpers.respondWithJson(requests, expectedJson);
         });
         it('should disallow save with a certificate available date before end date', function() {
+            this.model.showCertificateAvailableDate = true;
             $('#course-end-date').val('01/01/2030').trigger('change');
             expect(this.view.$('.message-error')).toExist();
         });
         it('should allow save with a certificate available date before end date for self-paced course', function() {
+            this.model.showCertificateAvailableDate = false;
             this.model.set('self_paced', true);
             $('#course-end-date').val('01/01/2030').trigger('change');
             expect(this.view.$('.message-error')).not.toExist();

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -38,7 +38,8 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
     require(["js/factories/settings"], function(SettingsFactory) {
         SettingsFactory(
             "${details_url | n, js_escaped_string}",
-            ${show_min_grade_warning | n, dump_js_escaped_json}
+            ${show_min_grade_warning | n, dump_js_escaped_json},
+            ${can_show_certificate_available_date_field(context_course) | n, dump_js_escaped_json}
         );
     });
 </%block>


### PR DESCRIPTION
## [EDUCATOR-1260](https://openedx.atlassian.net/browse/EDUCATOR-1260)

### Description

For courses that show the CAD, validate that the course end date is before the CAD if the course date is changed.
For courses that don't show the CAD, do not validate.

### Sandbox
- [ ] ed1260.sandbox.edx.org

### Testing
- [ ] Unit, integration, acceptance tests as appropriate

### Reviewers
- [ ] @iloveagent57 
- [ ] @sanfordstudent 
 
### Post-review
- [ ] Rebase and squash commits
