### PR TITLE
Provide a first class Open edX theme

### DIFF
--- a/openedx/core/djangoapps/theming/tests/test_helpers.py
+++ b/openedx/core/djangoapps/theming/tests/test_helpers.py
@@ -22,11 +22,12 @@ class TestHelpers(TestCase):
         Tests template paths are returned from enabled theme.
         """
         expected_themes = [
-            Theme('test-theme', 'test-theme', get_theme_base_dir('test-theme')),
-            Theme('red-theme', 'red-theme', get_theme_base_dir('red-theme')),
             Theme('edge.edx.org', 'edge.edx.org', get_theme_base_dir('edge.edx.org')),
             Theme('edx.org', 'edx.org', get_theme_base_dir('edx.org')),
+            Theme('open-edx', 'open-edx', get_theme_base_dir('open-edx')),
+            Theme('red-theme', 'red-theme', get_theme_base_dir('red-theme')),
             Theme('stanford-style', 'stanford-style', get_theme_base_dir('stanford-style')),
+            Theme('test-theme', 'test-theme', get_theme_base_dir('test-theme')),
         ]
         actual_themes = get_themes()
         self.assertItemsEqual(expected_themes, actual_themes)

--- a/themes/open-edx/README.rst
+++ b/themes/open-edx/README.rst
@@ -1,0 +1,14 @@
+##############
+Open edX Theme
+##############
+
+This is the default theme used by Open edX installations. It doesn't
+provide any overrides, which means that it adopts the built-in themes,
+templates etc.
+
+The `Red Theme`_ is provided as an example of building a simple new theme.
+
+For more information on building your own theme, see `Changing Themes for an Open edX Site`_.
+
+.. _Changing Themes for an Open edX Site: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html
+.. _Red Theme: https://github.com/edx/edx-platform/tree/master/themes/red-theme

--- a/themes/open-edx/cms/README.rst
+++ b/themes/open-edx/cms/README.rst
@@ -1,0 +1,14 @@
+#####################
+Studio Open edX Theme
+#####################
+
+This is the default Studio theme used by Open edX installations. It doesn't
+provide any overrides, which means that it adopts the built-in themes,
+templates etc.
+
+The `Red Theme`_ is provided as an example of building a simple new theme.
+
+For more information on building your own theme, see `Changing Themes for an Open edX Site`_.
+
+.. _Changing Themes for an Open edX Site: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html
+.. _Red Theme: https://github.com/edx/edx-platform/tree/master/themes/red-theme

--- a/themes/open-edx/lms/README.rst
+++ b/themes/open-edx/lms/README.rst
@@ -1,0 +1,14 @@
+##################
+LMS Open edX Theme
+##################
+
+This is the default LMS theme used by Open edX installations. It doesn't
+provide any overrides, which means that it adopts the built-in themes,
+templates etc.
+
+The `Red Theme`_ is provided as an example of building a simple new theme.
+
+For more information on building your own theme, see `Changing Themes for an Open edX Site`_.
+
+.. _Changing Themes for an Open edX Site: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/index.html
+.. _Red Theme: https://github.com/edx/edx-platform/tree/master/themes/red-theme


### PR DESCRIPTION
## [LEARNER-2513](https://openedx.atlassian.net/browse/LEARNER-2513)

### Description

This is a very simple change that adds a first-class Open edX theme to the set of comprehensive themes. This theme doesn't override anything, so it should look just like an Open edX installation running without comprehensive theming.

### Acceptance Criteria

- [x] Add "openedx" to the theme drop down on the theming administration page
- [x] Ensure that the Open edX theme is shown when this option is presented

### Sandbox
- [x] https://andy-armstrong.sandbox.edx.org/theming/admin
- [x] https://studio-andy-armstrong.sandbox.edx.org/theming/admin

### Assign Github reviewers (as needed)
- [x] engineering 

FYI: @edx/learner-mercury
 
### Post-review
- [ ] Rebase and squash commits