### PR TITLE
Org label styling on openedx course about pages

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -112,8 +112,9 @@ from openedx.core.lib.courses import course_image_url
         <div class="heading-group">
           <h1>
             ${course.display_name_with_default_escaped}
-            <button type="button">${course.display_org_with_default | h}</button>
           </h1>
+          <br />
+          <span>${course.display_org_with_default | h}</span>
         </div>
 
         <div class="main-cta">


### PR DESCRIPTION
Modify organization label on openedx course index pages to not look like a button, since it isn't a button. 

Current: 
![image](https://user-images.githubusercontent.com/2023680/30217818-4ed64e20-9485-11e7-9953-1e4f08a54bf4.png)

With Changes:
![image](https://user-images.githubusercontent.com/2023680/30217846-628b82a0-9485-11e7-956a-6ffa55657bf7.png)
