### PR TITLE
[ENT-587] Bump edx-enterprise to 0.43.5

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.1.4
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.43.4
+edx-enterprise==0.43.5
 edx-oauth2-provider==1.2.0
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
Bumps the edx-enterprise to 0.43.5; note that this doesn't actually introduce any new functionality; if anything, just changes log messages.

**JIRA tickets**: [ENT-587](https://openedx.atlassian.net/browse/ENT-587)

**Dependencies**: None

**Merge deadline**: Whenever.

**Testing instructions**:

1. See https://github.com/edx/edx-enterprise/pull/182 -- there's not much to test here.

**Reviewers**
- [ ] @haikuginger 
- [ ] @brittneyexline @douglashall 

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```