### PR TITLE
ENT-604 Updated the log level

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1368,7 +1368,7 @@ def login_user(request, error=""):  # pylint: disable=too-many-statements,unused
             user = pipeline.get_authenticated_user(requested_provider, username, third_party_uid)
             third_party_auth_successful = True
         except User.DoesNotExist:
-            AUDIT_LOG.warning(
+            AUDIT_LOG.info(
                 u"Login failed - user with username {username} has no social auth "
                 "with backend_name {backend_name}".format(
                     username=username, backend_name=backend_name)


### PR DESCRIPTION
@zubair-arbi @douglashall @mattdrayer Guys, please review it. 
Before that fix, The error response was not appearing on the UI and the error seems me the part of the implementation flow. It occurs when user provider name is not linked with the Edx account. 

<img width="1267" alt="screen shot 2017-09-11 at 2 31 24 pm" src="https://user-images.githubusercontent.com/7334669/30269327-dee5d624-9701-11e7-9ceb-fd0591d51958.png">
