### PR TITLE
Cache enterprise learner api response

### DIFF
--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -1,0 +1,29 @@
+from __future__ import unicode_literals
+
+import hashlib
+
+import six
+
+
+def get_cache_key(**kwargs):
+    """
+    Get MD5 encoded cache key for given arguments.
+
+    Here is the format of key before MD5 encryption.
+        key1:value1__key2:value2 ...
+
+    Example:
+        >>> get_cache_key(site_domain="example.com", resource="enterprise-learner")
+        # Here is key format for above call
+        # "site_domain:example.com__resource:catalogs"
+        a54349175618ff1659dee0978e3149ca
+
+    Arguments:
+        **kwargs: Key word arguments that need to be present in cache key.
+
+    Returns:
+         An MD5 encoded key uniquely identified by the key word arguments.
+    """
+    key = '__'.join(['{}:{}'.format(item, value) for item, value in six.iteritems(kwargs)])
+
+    return hashlib.md5(key).hexdigest()


### PR DESCRIPTION
ENT-624
@asadiqbal08 @saleem-latif @douglashall @haikuginger 
Add caching again for the enterprise learner API response.

Related PR's:
* Initial implementation for accessing enterprise learner API https://github.com/edx/edx-platform/pull/14711/
* Updated implementation with caching removed: https://github.com/edx/edx-platform/pull/15706