### PR TITLE
Use django file storage URLs for all course export downloads.

### DIFF
--- a/cms/envs/openstack.py
+++ b/cms/envs/openstack.py
@@ -27,3 +27,6 @@ elif SWIFT_AUTH_URL and SWIFT_USERNAME and SWIFT_KEY:
     DEFAULT_FILE_STORAGE = 'swift.storage.SwiftStorage'
 else:
     DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+
+# Use default file storage class set above for course import/export
+COURSE_IMPORT_EXPORT_STORAGE = DEFAULT_FILE_STORAGE


### PR DESCRIPTION
Uses django storage to provide the downloadable course export file size.

Fixes bug with course exports where OpenStack SWIFT is the default django storage.

**JIRA tickets**: OC-3079, [OSPR-1890](https://openedx.atlassian.net/browse/OSPR-1890)

**Sandbox URL**:

* LMS: https://pr15992.sandbox.opencraft.hosting/
* Studio: https://studio-pr15992.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

Perform these steps on both the OpenStack sandbox and your local devstack to ensure that using the generic django storage URL works for both types.  No change has been made to AWS storage.

1. Create a new course in Studio.
1. Export the course.  Ensure you can download the course zip file.
1. Add some content to the course.
1. Import the previously-exported zip file.  Ensure that is successful, and overrides the content added in the previous step.

**Author notes and concerns**:

I can spin up an AWS sandbox if testing is required there.

**Reviewers**
- [x] @clemente
- [ ] edX reviewer[s] TBD - CC @gsong 