### PR TITLE
ED-1319 Cert not accessible by learner

### DIFF
--- a/lms/djangoapps/certificates/tasks.py
+++ b/lms/djangoapps/certificates/tasks.py
@@ -4,6 +4,7 @@ from logging import getLogger
 from celery_utils.logged_task import LoggedTask
 from celery_utils.persist_on_failure import PersistOnFailureTask
 from django.contrib.auth.models import User
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from opaque_keys.edx.keys import CourseKey
 
 from .api import generate_user_certificates
@@ -18,11 +19,27 @@ class _BaseCertificateTask(PersistOnFailureTask, LoggedTask):  # pylint: disable
     abstract = True
 
 
-@task(base=_BaseCertificateTask)
-def generate_certificate(**kwargs):
+@task(base=_BaseCertificateTask, bind=True, default_retry_delay=30, max_retries=2)
+def generate_certificate(self, **kwargs):
     """
     Generates a certificate for a single user.
+
+    kwargs:
+        - student: The student for whom to generate a certificate.
+        - course_key: The course key for the course that the student is
+            receiving a certificate in.
+        - expected_verification_status: The expected verification status
+            for the user.  When the status has changed, we double check
+            that the actual verification status is as expected before
+            generating a certificate, in the off chance that the database
+            has not yet updated with the user's new verification status.
     """
+    original_kwargs = kwargs.copy()
     student = User.objects.get(id=kwargs.pop('student'))
     course_key = CourseKey.from_string(kwargs.pop('course_key'))
+    expected_verification_status = kwargs.pop('expected_verification_status', None)
+    if expected_verification_status:
+        actual_verification_status, _ = SoftwareSecurePhotoVerification.user_status(student)
+        if expected_verification_status != actual_verification_status:
+            raise self.retry(kwargs=original_kwargs)
     generate_user_certificates(student=student, course_key=course_key, **kwargs)

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -15,6 +15,7 @@ from lms.djangoapps.grades.new.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from openedx.core.djangoapps.certificates.config import waffle
+from lms.djangoapps.certificates.signals import CERTIFICATE_DELAY_SECONDS
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -91,10 +92,13 @@ class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):
                     user=self.user,
                     course_id=self.course.id
                 )
-                mock_generate_certificate_apply_async.assert_called_with(kwargs={
-                    'student': unicode(self.user.id),
-                    'course_key': unicode(self.course.id),
-                })
+                mock_generate_certificate_apply_async.assert_called_with(
+                    countdown=CERTIFICATE_DELAY_SECONDS,
+                    kwargs={
+                        'student': unicode(self.user.id),
+                        'course_key': unicode(self.course.id),
+                    }
+                )
 
     def test_cert_generation_on_whitelist_append_instructor_paced(self):
         """
@@ -116,10 +120,13 @@ class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):
                     user=self.user,
                     course_id=self.ip_course.id
                 )
-                mock_generate_certificate_apply_async.assert_called_with(kwargs={
-                    'student': unicode(self.user.id),
-                    'course_key': unicode(self.ip_course.id),
-                })
+                mock_generate_certificate_apply_async.assert_called_with(
+                    countdown=CERTIFICATE_DELAY_SECONDS,
+                    kwargs={
+                        'student': unicode(self.user.id),
+                        'course_key': unicode(self.ip_course.id),
+                    }
+                )
 
 
 class PassingGradeCertsTest(ModuleStoreTestCase):
@@ -164,10 +171,13 @@ class PassingGradeCertsTest(ModuleStoreTestCase):
                 # Certs fired after passing
                 with mock_passing_grade():
                     grade_factory.update(self.user, self.course)
-                    mock_generate_certificate_apply_async.assert_called_with(kwargs={
-                        'student': unicode(self.user.id),
-                        'course_key': unicode(self.course.id),
-                    })
+                    mock_generate_certificate_apply_async.assert_called_with(
+                        countdown=CERTIFICATE_DELAY_SECONDS,
+                        kwargs={
+                            'student': unicode(self.user.id),
+                            'course_key': unicode(self.course.id),
+                        }
+                    )
 
     def test_cert_generation_on_passing_instructor_paced(self):
         with mock.patch(
@@ -182,10 +192,13 @@ class PassingGradeCertsTest(ModuleStoreTestCase):
                 # Certs fired after passing
                 with mock_passing_grade():
                     grade_factory.update(self.user, self.ip_course)
-                    mock_generate_certificate_apply_async.assert_called_with(kwargs={
-                        'student': unicode(self.user.id),
-                        'course_key': unicode(self.ip_course.id),
-                    })
+                    mock_generate_certificate_apply_async.assert_called_with(
+                        countdown=CERTIFICATE_DELAY_SECONDS,
+                        kwargs={
+                            'student': unicode(self.user.id),
+                            'course_key': unicode(self.ip_course.id),
+                        }
+                    )
 
     def test_cert_already_generated(self):
         with mock.patch(
@@ -244,10 +257,14 @@ class LearnerTrackChangeCertsTest(ModuleStoreTestCase):
                     status='submitted'
                 )
                 attempt.approve()
-                mock_generate_certificate_apply_async.assert_called_with(kwargs={
-                    'student': unicode(self.user_one.id),
-                    'course_key': unicode(self.course_one.id),
-                })
+                mock_generate_certificate_apply_async.assert_called_with(
+                    countdown=CERTIFICATE_DELAY_SECONDS,
+                    kwargs={
+                        'student': unicode(self.user_one.id),
+                        'course_key': unicode(self.course_one.id),
+                        'expected_verification_status': SoftwareSecurePhotoVerification.STATUS.approved
+                    }
+                )
 
     def test_cert_generation_on_photo_verification_instructor_paced(self):
         with mock.patch(
@@ -261,7 +278,11 @@ class LearnerTrackChangeCertsTest(ModuleStoreTestCase):
                     status='submitted'
                 )
                 attempt.approve()
-                mock_generate_certificate_apply_async.assert_called_with(kwargs={
-                    'student': unicode(self.user_two.id),
-                    'course_key': unicode(self.course_two.id),
-                })
+                mock_generate_certificate_apply_async.assert_called_with(
+                    countdown=CERTIFICATE_DELAY_SECONDS,
+                    kwargs={
+                        'student': unicode(self.user_two.id),
+                        'course_key': unicode(self.course_two.id),
+                        'expected_verification_status': SoftwareSecurePhotoVerification.STATUS.approved
+                    }
+                )

--- a/lms/djangoapps/certificates/tests/test_tasks.py
+++ b/lms/djangoapps/certificates/tests/test_tasks.py
@@ -1,20 +1,27 @@
 from unittest import TestCase
 
 import ddt
-from mock import patch
+from mock import call, patch
 from opaque_keys.edx.keys import CourseKey
+from nose.tools import assert_true
 
 from lms.djangoapps.certificates.tasks import generate_certificate
+from student.tests.factories import UserFactory
 
 
 @ddt.ddt
 class GenerateUserCertificateTest(TestCase):
     @patch('lms.djangoapps.certificates.tasks.generate_user_certificates')
     @patch('lms.djangoapps.certificates.tasks.User.objects.get')
-    def test_cert_task(self, user_get_mock, generate_user_certs_mock):
+    def test_generate_user_certs(self, user_get_mock, generate_user_certs_mock):
         course_key = 'course-v1:edX+CS101+2017_T2'
-
-        generate_certificate(student='student-id', course_key=course_key, otherarg='c', otherotherarg='d')
+        kwargs = {
+            'student': 'student-id',
+            'course_key': course_key,
+            'otherarg': 'c',
+            'otherotherarg': 'd'
+        }
+        generate_certificate.apply_async(kwargs=kwargs).get()
 
         expected_student = user_get_mock.return_value
         generate_user_certs_mock.assert_called_with(
@@ -26,10 +33,36 @@ class GenerateUserCertificateTest(TestCase):
         user_get_mock.assert_called_once_with(id='student-id')
 
     @ddt.data('student', 'course_key')
-    def test_cert_task_missing_args(self, missing_arg):
+    def test_missing_args(self, missing_arg):
         kwargs = {'student': 'a', 'course_key': 'b', 'otherarg': 'c'}
         del kwargs[missing_arg]
 
         with patch('lms.djangoapps.certificates.tasks.User.objects.get'):
             with self.assertRaisesRegexp(KeyError, missing_arg):
-                generate_certificate(**kwargs)
+                generate_certificate.apply_async(kwargs=kwargs).get()
+
+    @patch('lms.djangoapps.certificates.tasks.generate_user_certificates')
+    @patch('lms.djangoapps.verify_student.models.SoftwareSecurePhotoVerification.user_status')
+    def test_retry_until_verification_status_updates(self, user_status_mock, generate_user_certs_mock):
+        course_key = 'course-v1:edX+CS101+2017_T2'
+        student = UserFactory()
+
+        kwargs = {
+            'student': student.id,
+            'course_key': course_key,
+            'expected_verification_status': 'approved'
+        }
+
+        user_status_mock.side_effect = [('pending', ''), ('approved', '')]
+
+        generate_certificate.apply_async(kwargs=kwargs).get()
+
+        user_status_mock.assert_has_calls([
+            call(student),
+            call(student)
+        ])
+
+        generate_user_certs_mock.assert_called_once_with(
+            student=student,
+            course_key=CourseKey.from_string(course_key)
+        )


### PR DESCRIPTION
## [EDUCATOR-1319](https://openedx.atlassian.net/browse/EDUCATOR-1319)

### Description

A user already qualified for everything needed for a certificate, but is missing validation. Then the user's verified status is validated, thus kicking off a certificate generation task. Occasionally, the user's new validated status is not yet saved to the database before the task runs, so the certificate isn't generated.

Fix: If the generate_certificate function is called because a user's verification status has changed to accepted, check in the generate_certificate function that the verification status is as expected. If not, retry the function.

### Testing
- [x] Unit, integration, acceptance tests as appropriate

### Reviewers
- [ ] @nasthagiri  
- [ ] @sanfordstudent 
 
### Post-review
- [ ] Rebase and squash commits
