### PR TITLE
EDUCATOR-1333 - Auto-certs: Courses w/o certificates still display certificate issue date

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -214,6 +214,7 @@ class CertificateAvailableDate(DateSummary):
     def is_enabled(self):
         return (
             can_show_certificate_available_date_field(self.course) and
+            self.has_certificate_modes and
             self.date is not None and
             datetime.datetime.now(utc) <= self.date and
             len(self.active_certificates) > 0
@@ -226,6 +227,14 @@ class CertificateAvailableDate(DateSummary):
     @property
     def date(self):
         return self.course.certificate_available_date
+
+    @property
+    def has_certificate_modes(self):
+        return any([
+            mode.slug for mode in CourseMode.modes_for_course(
+                course_id=self.course.id, include_expired=True
+            ) if mode.slug != CourseMode.AUDIT
+        ])
 
 
 class VerifiedUpgradeDeadlineDate(DateSummary):


### PR DESCRIPTION
## [EDUCATOR-1333](https://openedx.atlassian.net/browse/EDUCATOR-1333)

### Description
Courses which do not have certificates, but "_Certificate Available_", with date and explanation, is visible on the course page. As a learner, I would not expect to see that message since receiving a cert isn't an option.


### Sandbox
- [x] awaisdar001.sandbox.edx.org

#### Steps to Reproduce


- Go to https://studio-awaisdar001.sandbox.edx.org/admin/course_modes/coursemode/
- Create a verified enrollment mode of the course
- Verify the course has Certificate Available Date appearing at https://awaisdar001.sandbox.edx.org/courses/course-v1:DemoX+PERF101+course/course/
- Remove the verified mode
- Observe the Certificate Available Date does not appear. 


### Reviewers

List optional/FYI reviewers here:
 
### Post-review
- [ ] Rebase and squash commits