### PR TITLE
Add Configuration to Enable Translated Web-Certificates

### DIFF
--- a/common/test/db_fixtures/certificates_web_view.json
+++ b/common/test/db_fixtures/certificates_web_view.json
@@ -14,7 +14,8 @@
     "fields": {
       "modified": "2015-06-18 11:02:13.007790+00:00",
       "course_key": "course-v1:test_org+3355358979513794782079645765720179311111+test_run",
-      "enabled": true
+      "enabled": true,
+      "self_generation_enabled": true
     }
   },
   {

--- a/lms/djangoapps/certificates/admin.py
+++ b/lms/djangoapps/certificates/admin.py
@@ -64,7 +64,7 @@ class CertificateGenerationCourseSettingAdmin(admin.ModelAdmin):
     """
     Django admin customizations for CertificateGenerationCourseSetting model
     """
-    list_display = ('course_key', 'enabled')
+    list_display = ('course_key', 'self_generation_enabled', 'language_specific_templates_enabled')
     search_fields = ('course_key',)
     show_full_result_count = False
 

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -267,7 +267,7 @@ def set_cert_generation_enabled(course_key, is_enabled):
             certificates for this course.
 
     """
-    CertificateGenerationCourseSetting.set_enabled_for_course(course_key, is_enabled)
+    CertificateGenerationCourseSetting.set_self_generatation_enabled_for_course(course_key, is_enabled)
     cert_event_type = 'enabled' if is_enabled else 'disabled'
     event_name = '.'.join(['edx', 'certificate', 'generation', cert_event_type])
     tracker.emit(event_name, {
@@ -321,7 +321,7 @@ def cert_generation_enabled(course_key):
     """
     return (
         CertificateGenerationConfiguration.current().enabled and
-        CertificateGenerationCourseSetting.is_enabled_for_course(course_key)
+        CertificateGenerationCourseSetting.is_self_generation_enabled_for_course(course_key)
     )
 
 

--- a/lms/djangoapps/certificates/migrations/0009_certificategenerationcoursesetting_language_self_generation.py
+++ b/lms/djangoapps/certificates/migrations/0009_certificategenerationcoursesetting_language_self_generation.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.apps import apps
+from django.db import migrations, models
+from django.db.models import F
+
+def copy_field(apps, schema_editor):
+    CertificateGenerationCourseSetting = apps.get_model('certificates', 'CertificateGenerationCourseSetting')
+    CertificateGenerationCourseSetting.objects.all().update(self_generation_enabled=F('enabled'))
+
+def undo_copy(apps, schema_editor):
+    CertificateGenerationCourseSetting = apps.get_model('certificates', 'CertificateGenerationCourseSetting')
+    CertificateGenerationCourseSetting.objects.all().update(enabled=F('self_generation_enabled'))
+
+class Migration(migrations.Migration):
+    """
+    Adds new field 'language_specific_templates_enabled'.
+    Also adds field 'self_generation_enabled' which is a 
+    replacement for 'enabled'
+    Lastly, copies data from 'enabled' to 'self_generation_enabled'
+    """
+    dependencies = [
+        ('certificates', '0008_schema__remove_badges'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='certificategenerationcoursesetting',
+            name='language_specific_templates_enabled',
+            field=models.BooleanField(default=False, help_text="Render translated certificates rather than using the platform's default language. Available translations are controlled by the certificate template."),
+        ),
+        migrations.AddField(
+            model_name='certificategenerationcoursesetting',
+            name='self_generation_enabled',
+            field=models.BooleanField(default=False, help_text='Allow students to generate their own certificates for the course. Enabling this does NOT affect usage of the management command used for batch certificate generation.'),
+        ),
+        migrations.AlterField(
+            model_name='certificategenerationcoursesetting',
+            name='enabled',
+            field=models.BooleanField(default=False, help_text='DEPRECATED, please use self_generation_enabled instead.'),
+        ),
+        migrations.RunPython(copy_field, reverse_code=undo_copy),
+    ]

--- a/openedx/core/djangoapps/signals/handlers.py
+++ b/openedx/core/djangoapps/signals/handlers.py
@@ -27,4 +27,4 @@ def toggle_self_generated_certs(course_key, course_self_paced):
     """
     Enable or disable self-generated certificates for a course according to pacing.
     """
-    CertificateGenerationCourseSetting.set_enabled_for_course(course_key, course_self_paced)
+    CertificateGenerationCourseSetting.set_self_generatation_enabled_for_course(course_key, course_self_paced)


### PR DESCRIPTION
Add Configuration for Translated Web Certificates

Adds support for certificates to be generated for specific languages. 
Also adds a new column to replace old 'enabled' column, to increase clarity.

https://openedx.atlassian.net/browse/LEARNER-1993