### PR TITLE
Initialize enterprise api client with provided user

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -30,8 +30,8 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeade
 from openedx.core.lib.exceptions import CourseNotFoundError
 from openedx.core.lib.log_utils import audit_log
 from openedx.features.enterprise_support.api import (
-    ConsentApiClient,
-    EnterpriseApiClient,
+    ConsentApiServiceClient,
+    EnterpriseApiServiceClient,
     EnterpriseApiException,
     enterprise_enabled
 )
@@ -598,8 +598,8 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
             enterprise_course_consent = request.data.get('enterprise_course_consent')
             explicit_linked_enterprise = request.data.get('linked_enterprise_customer')
             if (enterprise_course_consent or explicit_linked_enterprise) and has_api_key_permissions and enterprise_enabled():
-                enterprise_api_client = EnterpriseApiClient()
-                consent_client = ConsentApiClient()
+                enterprise_api_client = EnterpriseApiServiceClient()
+                consent_client = ConsentApiServiceClient()
                 # We received an explicitly-linked EnterpriseCustomer for the enrollment
                 if explicit_linked_enterprise is not None:
                     try:

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -1,25 +1,19 @@
 """
 APIs providing support for enterprise functionality.
 """
-import hashlib
 import logging
 from functools import wraps
 
-import six
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.utils.http import urlencode
 from django.utils.translation import ugettext as _
 from edx_rest_api_client.client import EdxRestApiClient
-from requests.exceptions import ConnectionError, Timeout
 from slumber.exceptions import HttpClientError, HttpNotFoundError, HttpServerError, SlumberBaseException
 
-from openedx.core.djangoapps.catalog.models import CatalogIntegration
-from openedx.core.djangoapps.catalog.utils import create_catalog_api_client
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.token_utils import JwtBuilder
 from third_party_auth.pipeline import get as get_partial_pipeline
@@ -29,6 +23,7 @@ try:
     from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomer
 except ImportError:
     pass
+
 
 CONSENT_FAILED_PARAMETER = 'consent_failed'
 LOGGER = logging.getLogger("edx.enterprise_helpers")
@@ -46,12 +41,12 @@ class ConsentApiClient(object):
     Class for producing an Enterprise Consent service API client
     """
 
-    def __init__(self):
+    def __init__(self, user):
         """
-        Initialize a consent service API client, authenticated using the Enterprise worker username.
+        Initialize an authenticated Consent service API client by using the
+        provided user.
         """
-        self.user = User.objects.get(username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME)
-        jwt = JwtBuilder(self.user).build_token([])
+        jwt = JwtBuilder(user).build_token([])
         url = configuration_helpers.get_value('ENTERPRISE_CONSENT_API_URL', settings.ENTERPRISE_CONSENT_API_URL)
         self.client = EdxRestApiClient(
             url,
@@ -97,17 +92,38 @@ class ConsentApiClient(object):
         return response['consent_required']
 
 
+class EnterpriseServiceClientMixin(object):
+    """
+    Class for initializing an Enterprise API clients with service user.
+    """
+
+    def __init__(self):
+        """
+        Initialize an authenticated Enterprise API client by using the
+        Enterprise worker user by default.
+        """
+        user = User.objects.get(username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME)
+        super(EnterpriseServiceClientMixin, self).__init__(user)
+
+
+class ConsentApiServiceClient(EnterpriseServiceClientMixin, ConsentApiClient):
+    """
+    Class for producing an Enterprise Consent API client with service user.
+    """
+    pass
+
+
 class EnterpriseApiClient(object):
     """
     Class for producing an Enterprise service API client.
     """
 
-    def __init__(self):
+    def __init__(self, user):
         """
-        Initialize an Enterprise service API client, authenticated using the Enterprise worker username.
+        Initialize an authenticated Enterprise service API client by using the
+        provided user.
         """
-        self.user = User.objects.get(username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME)
-        jwt = JwtBuilder(self.user).build_token([])
+        jwt = JwtBuilder(user).build_token([])
         self.client = EdxRestApiClient(
             configuration_helpers.get_value('ENTERPRISE_API_URL', settings.ENTERPRISE_API_URL),
             jwt=jwt
@@ -241,6 +257,13 @@ class EnterpriseApiClient(object):
         return response
 
 
+class EnterpriseApiServiceClient(EnterpriseServiceClientMixin, EnterpriseApiClient):
+    """
+    Class for producing an Enterprise service API client with service user.
+    """
+    pass
+
+
 def data_sharing_consent_required(view_func):
     """
     Decorator which makes a view method redirect to the Data Sharing Consent form if:
@@ -294,7 +317,7 @@ def enterprise_customer_for_request(request):
     if not enterprise_enabled():
         return None
 
-    ec = None
+    enterprise_customer = None
     sso_provider_id = request.GET.get('tpa_hint')
 
     running_pipeline = get_partial_pipeline(request)
@@ -311,34 +334,38 @@ def enterprise_customer_for_request(request):
             # Check if there's an Enterprise Customer such that the linked SSO provider
             # has an ID equal to the ID we got from the running pipeline or from the
             # request tpa_hint URL parameter.
-            ec_uuid = EnterpriseCustomer.objects.get(
+            enterprise_customer_uuid = EnterpriseCustomer.objects.get(
                 enterprise_customer_identity_provider__provider_id=sso_provider_id
             ).uuid
         except EnterpriseCustomer.DoesNotExist:
             # If there is not an EnterpriseCustomer linked to this SSO provider, set
             # the UUID variable to be null.
-            ec_uuid = None
+            enterprise_customer_uuid = None
     else:
         # Check if we got an Enterprise UUID passed directly as either a query
         # parameter, or as a value in the Enterprise cookie.
-        ec_uuid = request.GET.get('enterprise_customer') or request.COOKIES.get(settings.ENTERPRISE_CUSTOMER_COOKIE_NAME)
+        enterprise_customer_uuid = request.GET.get('enterprise_customer') or request.COOKIES.get(
+            settings.ENTERPRISE_CUSTOMER_COOKIE_NAME
+        )
 
-    if not ec_uuid and request.user.is_authenticated():
+    if not enterprise_customer_uuid and request.user.is_authenticated():
         # If there's no way to get an Enterprise UUID for the request, check to see
         # if there's already an Enterprise attached to the requesting user on the backend.
         learner_data = get_enterprise_learner_data(request.site, request.user)
         if learner_data:
-            ec_uuid = learner_data[0]['enterprise_customer']['uuid']
-    if ec_uuid:
+            enterprise_customer_uuid = learner_data[0]['enterprise_customer']['uuid']
+    if enterprise_customer_uuid:
         # If we were able to obtain an EnterpriseCustomer UUID, go ahead
         # and use it to attempt to retrieve EnterpriseCustomer details
         # from the EnterpriseCustomer API.
         try:
-            ec = EnterpriseApiClient().get_enterprise_customer(ec_uuid)
+            enterprise_customer = EnterpriseApiClient(user=request.user).get_enterprise_customer(
+                enterprise_customer_uuid
+            )
         except HttpNotFoundError:
-            ec = None
+            enterprise_customer = None
 
-    return ec
+    return enterprise_customer
 
 
 def consent_needed_for_course(request, user, course_id, enrollment_exists=False):
@@ -358,7 +385,7 @@ def consent_needed_for_course(request, user, course_id, enrollment_exists=False)
     if not enterprise_learner_details:
         consent_needed = False
     else:
-        client = ConsentApiClient()
+        client = ConsentApiClient(user=request.user)
         consent_needed = any(
             client.consent_required(
                 username=user.username,
@@ -426,7 +453,7 @@ def get_enterprise_learner_data(site, user):
     if not enterprise_enabled():
         return None
 
-    enterprise_learner_data = EnterpriseApiClient().fetch_enterprise_learner_data(site=site, user=user)
+    enterprise_learner_data = EnterpriseApiClient(user=user).fetch_enterprise_learner_data(site=site, user=user)
     if enterprise_learner_data:
         return enterprise_learner_data['results']
 
@@ -461,7 +488,7 @@ def get_dashboard_consent_notification(request, user, course_enrollments):
                 enrollment = course_enrollment
                 break
 
-        client = ConsentApiClient()
+        client = ConsentApiClient(user=request.user)
         consent_needed = client.consent_required(
             enterprise_customer_uuid=enterprise_customer['uuid'],
             username=user.username,


### PR DESCRIPTION
ENT-624
@asadiqbal08 @saleem-latif @douglashall 
Initialize and authenticate enterprise api client with the provided user or use enterprise service user by default.