### PR TITLE
only override the upgrade deadline in self-paced courses

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1722,7 +1722,12 @@ class CourseEnrollment(models.Model):
                 DynamicUpgradeDeadlineConfiguration.is_enabled()
                 or CourseDynamicUpgradeDeadlineConfiguration.is_enabled(self.course_id)
             )
-            if schedule_driven_deadlines_enabled and self.schedule and self.schedule.upgrade_deadline is not None:
+            if (
+                    schedule_driven_deadlines_enabled
+                    and self.course_overview.self_paced
+                    and self.schedule
+                    and self.schedule.upgrade_deadline is not None
+            ):
                 log.debug(
                     'Schedules: Pulling upgrade deadline for CourseEnrollment %d from Schedule %d.',
                     self.id, self.schedule.id


### PR DESCRIPTION
If a course is moved from self-paced to instructor paced, the learners will have schedules, however, we don't want the upgrade deadline to be visible to them.

At some point in the future we might want to support schedules in instructor paced courses, but until then, just disable the override in that context.