### PR TITLE
Updated set_user_attribute method

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2551,8 +2551,7 @@ class UserAttribute(TimeStampedModel):
         user. Overwrites any previous value for that name, if it
         exists.
         """
-        cls.objects.filter(user=user, name=name).delete()
-        cls.objects.create(user=user, name=name, value=value)
+        cls.objects.update_or_create(user=user, name=name, defaults={'value': value})
 
     @classmethod
     def get_user_attribute(cls, user, name):


### PR DESCRIPTION
[LEARNER-2165](https://openedx.atlassian.net/browse/LEARNER-2165)

System was facing a lot of db locks because of two separate calls to db to set user attribute one to remove previous record and one to create new record. Removed both remove old record call and create new value call and used the update method to directly change the value of existing record in the database. 

Kindly Review @edx/learner-spartans 