### PR TITLE
PLAT-1677 Switch to pytest for unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,6 +17,7 @@ omit =
     cms/djangoapps/contentstore/views/dev.py
     cms/djangoapps/*/migrations/*
     cms/djangoapps/*/features/*
+    cms/lib/*/migrations/*
     lms/debug/*
     lms/envs/*
     lms/djangoapps/*/migrations/*
@@ -25,6 +26,7 @@ omit =
     common/djangoapps/*/migrations/*
     openedx/core/djangoapps/*/migrations/*
     openedx/core/djangoapps/debug/*
+    openedx/features/*/migrations/*
 
 concurrency=multiprocessing
 

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ conf/locale/messages.mo
 .testids/
 .noseids
 nosetests.xml
+.cache/
 .coverage
 .coverage.*
 coverage.xml

--- a/cms/conftest.py
+++ b/cms/conftest.py
@@ -1,0 +1,44 @@
+"""
+Studio unit test configuration and fixtures.
+
+This module needs to exist because the pytest.ini in the cms package stops
+pytest from looking for the conftest.py module in the parent directory when
+only running cms tests.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import importlib
+import os
+import contracts
+import pytest
+
+
+def pytest_configure(config):
+    """
+    Do core setup operations from manage.py before collecting tests.
+    """
+    if config.getoption('help'):
+        return
+    enable_contracts = os.environ.get('ENABLE_CONTRACTS', False)
+    if not enable_contracts:
+        contracts.disable_all()
+    settings_module = os.environ.get('DJANGO_SETTINGS_MODULE')
+    startup_module = 'cms.startup' if settings_module.startswith('cms') else 'lms.startup'
+    startup = importlib.import_module(startup_module)
+    startup.run()
+
+
+@pytest.fixture(autouse=True, scope='function')
+def _django_clear_site_cache():
+    """
+    pytest-django uses this fixture to automatically clear the Site object
+    cache by replacing it with a new dictionary.  edx-django-sites-extensions
+    grabs the cache dictionary at startup, and uses that one for all lookups
+    from then on.  Our CacheIsolationMixin class tries to clear the cache by
+    grabbing the current dictionary from the site models module and clearing
+    it.  Long story short: if you use this all together, neither cache
+    clearing mechanism actually works.  So override this fixture to not mess
+    with what has been working for us so far.
+    """
+    pass

--- a/cms/pytest.ini
+++ b/cms/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = cms.envs.test
+addopts = --nomigrations --reuse-db --durations=20 -p no:randomly
+norecursedirs = envs
+python_classes =
+python_files = tests.py test_*.py *_tests.py

--- a/common/lib/conftest.py
+++ b/common/lib/conftest.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+def pytest_configure():
+    """
+    Use Django's default settings for tests in common/lib.
+    """
+    settings.configure()

--- a/common/lib/pytest.ini
+++ b/common/lib/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --nomigrations --reuse-db --durations=20
+norecursedirs = .cache
+python_classes =
+python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -13,12 +13,6 @@ import uuid
 import ddt
 from contracts import contract
 from nose.plugins.attrib import attr
-# For the cache tests to work, we need to be using the Django default
-# settings (not our usual cms or lms test settings) and they need to
-# be configured before importing from django.core.cache
-from django.conf import settings
-if not settings.configured:
-    settings.configure()
 from django.core.cache import caches, InvalidCacheBackendError
 
 from openedx.core.lib import tempdir

--- a/common/test/pytest.ini
+++ b/common/test/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -p no:randomly --durations=20
+norecursedirs = .cache

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+"""
+Default unit test configuration and fixtures.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+# Import hooks and fixture overrides from the cms package to
+# avoid duplicating the implementation
+
+from cms.conftest import _django_clear_site_cache, pytest_configure  # pylint: disable=unused-import

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -207,16 +207,17 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
         )
 
     @ddt.data(
-        (False, datetime.now(pytz.UTC) + timedelta(days=2), False),
-        (False, datetime.now(pytz.UTC) - timedelta(days=2), True),
-        (True, datetime.now(pytz.UTC) + timedelta(days=2), True)
+        (False, timedelta(days=2), False),
+        (False, -timedelta(days=2), True),
+        (True, timedelta(days=2), True)
     )
     @ddt.unpack
     @patch.dict(settings.FEATURES, {'CERTIFICATES_HTML_VIEW': True})
-    def test_cert_api_return(self, self_paced, cert_avail_date, cert_downloadable_status):
+    def test_cert_api_return(self, self_paced, cert_avail_delta, cert_downloadable_status):
         """
         Test 'downloadable status'
         """
+        cert_avail_date = datetime.now(pytz.UTC) + cert_avail_delta
         self.course.self_paced = self_paced
         self.course.certificate_available_date = cert_avail_date
         self.course.save()

--- a/lms/djangoapps/certificates/tests/test_tasks.py
+++ b/lms/djangoapps/certificates/tests/test_tasks.py
@@ -1,9 +1,7 @@
-from unittest import TestCase
-
 import ddt
+from django.test import TestCase
 from mock import call, patch
 from opaque_keys.edx.keys import CourseKey
-from nose.tools import assert_true
 
 from lms.djangoapps.certificates.tasks import generate_certificate
 from student.tests.factories import UserFactory

--- a/lms/djangoapps/courseware/field_overrides.py
+++ b/lms/djangoapps/courseware/field_overrides.py
@@ -257,6 +257,7 @@ class OverrideFieldData(FieldData):
 
 class OverrideModulestoreFieldData(OverrideFieldData):
     """Apply field data overrides at the modulestore level. No student context required."""
+    provider_classes = None
 
     @classmethod
     def wrap(cls, block, field_data):  # pylint: disable=arguments-differ

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -133,6 +133,7 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         Set up the course and user context
         """
         super(ModuleRenderTestCase, self).setUp()
+        OverrideFieldData.provider_classes = None
 
         self.mock_user = UserFactory()
         self.mock_user.id = 1
@@ -153,6 +154,10 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
                 dispatch=self.dispatch
             )
         )
+
+    def tearDown(self):
+        OverrideFieldData.provider_classes = None
+        super(ModuleRenderTestCase, self).tearDown()
 
     def test_get_module(self):
         self.assertEqual(

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -1707,28 +1707,24 @@ class GroupModeratorPermissionsTestCase(ModuleStoreTestCase):
         # cohorted_user (who is in the cohort but not the verified enrollment track),
         # and plain_user (who is neither in the cohort nor the verified enrollment track)
         self.group_moderator = UserFactory(username='group_moderator', email='group_moderator@edx.org')
-        self.group_moderator.id = 1
         CourseEnrollmentFactory(
             course_id=self.course.id,
             user=self.group_moderator,
             mode=verified_coursemode
         )
         self.verified_user = UserFactory(username='verified', email='verified@edx.org')
-        self.verified_user.id = 2
         CourseEnrollmentFactory(
             course_id=self.course.id,
             user=self.verified_user,
             mode=verified_coursemode
         )
         self.cohorted_user = UserFactory(username='cohort', email='cohort@edx.org')
-        self.cohorted_user.id = 3
         CourseEnrollmentFactory(
             course_id=self.course.id,
             user=self.cohorted_user,
             mode=audit_coursemode
         )
         self.plain_user = UserFactory(username='plain', email='plain@edx.org')
-        self.plain_user.id = 4
         CourseEnrollmentFactory(
             course_id=self.course.id,
             user=self.plain_user,
@@ -1737,7 +1733,7 @@ class GroupModeratorPermissionsTestCase(ModuleStoreTestCase):
         CohortFactory(
             course_id=self.course.id,
             name='Test Cohort',
-            users=[self.verified_user, self.cohorted_user]
+            users=[self.group_moderator, self.cohorted_user]
         )
 
         # Give group moderator permissions to group_moderator

--- a/openedx/core/djangoapps/certificates/tests/test_api.py
+++ b/openedx/core/djangoapps/certificates/tests/test_api.py
@@ -1,11 +1,11 @@
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 import itertools
-from unittest import TestCase
 
 import ddt
 import pytz
 import waffle
+from django.test import TestCase
 
 from course_modes.models import CourseMode
 from openedx.core.djangoapps.certificates import api

--- a/openedx/core/djangoapps/credit/tests/test_views.py
+++ b/openedx/core/djangoapps/credit/tests/test_views.py
@@ -549,11 +549,15 @@ class CreditProviderCallbackViewTests(UserMixin, TestCase):
         self.assertEqual(response.status_code, 403)
 
     @ddt.data(
-        to_timestamp(datetime.datetime.now(pytz.UTC) - datetime.timedelta(0, 60 * 15 + 1)),
+        -datetime.timedelta(0, 60 * 15 + 1),
         'invalid'
     )
-    def test_post_with_invalid_timestamp(self, timestamp):
+    def test_post_with_invalid_timestamp(self, timedelta):
         """ Verify HTTP 400 is returned for requests with an invalid timestamp. """
+        if timedelta == 'invalid':
+            timestamp = timedelta
+        else:
+            timestamp = to_timestamp(datetime.datetime.now(pytz.UTC) + timedelta)
         request_uuid = self._create_credit_request_and_get_uuid()
         response = self._credit_provider_callback(request_uuid, 'approved', timestamp=timestamp)
         self.assertEqual(response.status_code, 400)

--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -47,7 +47,6 @@ class TestPaverBokChoyCmd(unittest.TestCase):
             "-m",
             "pytest",
             "{}/common/test/acceptance/{}".format(REPO_DIR, name),
-            "--durations=20",
             "--junitxml={}/reports/bok_choy{}/xunit.xml".format(REPO_DIR, shard_str),
             "--verbose",
         ]

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -31,11 +31,15 @@ __test__ = False  # do not collect
     ("fail-fast", "x", "Fail suite on first failed test"),
     ("fasttest", "a", "Run without collectstatic"),
     make_option(
+        "--eval-attr", dest="eval_attr",
+        help="Only run tests matching given attribute expression."
+    ),
+    make_option(
         '-c', '--cov-args', default='',
         help='adds as args to coverage for the test run'
     ),
     ('skip-clean', 'C', 'skip cleaning repository before running tests'),
-    ('processes=', 'p', 'number of processes to use running tests'),
+    make_option('-p', '--processes', dest='processes', default=0, help='number of processes to use running tests'),
     make_option('-r', '--randomize', action='store_true', help='run the tests in a random order'),
     make_option('--no-randomize', action='store_false', dest='randomize', help="don't run the tests in a random order"),
     make_option("--verbose", action="store_const", const=2, dest="verbosity"),
@@ -53,14 +57,6 @@ __test__ = False  # do not collect
         dest='disable_migrations',
         help="Create tables by applying migrations."
     ),
-    ("fail_fast", None, "deprecated in favor of fail-fast"),
-    ("test_id=", None, "deprecated in favor of test-id"),
-    ('cov_args=', None, 'deprecated in favor of cov-args'),
-    make_option(
-        "-e", "--extra_args", default="",
-        help="deprecated, pass extra options directly in the paver commandline"
-    ),
-    ('skip_clean', None, 'deprecated in favor of skip-clean'),
 ], share_with=['pavelib.utils.test.utils.clean_reports_dir'])
 @PassthroughTask
 @timed
@@ -119,14 +115,6 @@ def test_system(options, passthrough_options):
     make_option("--verbose", action="store_const", const=2, dest="verbosity"),
     make_option("-q", "--quiet", action="store_const", const=0, dest="verbosity"),
     make_option("-v", "--verbosity", action="count", dest="verbosity", default=1),
-    ('cov_args=', None, 'deprecated in favor of cov-args'),
-    make_option(
-        '-e', '--extra_args', default='',
-        help='deprecated, pass extra options directly in the paver commandline'
-    ),
-    ("fail_fast", None, "deprecated in favor of fail-fast"),
-    ('skip_clean', None, 'deprecated in favor of skip-clean'),
-    ("test_id=", None, "deprecated in favor of test-id"),
 ], share_with=['pavelib.utils.test.utils.clean_reports_dir'])
 @PassthroughTask
 @timed
@@ -153,8 +141,9 @@ def test_lib(options, passthrough_options):
             suites.LibTestSuite(
                 d,
                 passthrough_options=passthrough_options,
+                append_coverage=(i != 0),
                 **options.test_lib
-            ) for d in Env.LIB_TEST_DIRS
+            ) for i, d in enumerate(Env.LIB_TEST_DIRS)
         ]
 
     test_suite = suites.PythonTestSuite(
@@ -186,12 +175,6 @@ def test_lib(options, passthrough_options):
         dest='disable_migrations',
         help="Create tables directly from apps' models. Can also be used by exporting DISABLE_MIGRATIONS=1."
     ),
-    ('cov_args=', None, 'deprecated in favor of cov-args'),
-    make_option(
-        '-e', '--extra_args', default='',
-        help='deprecated, pass extra options directly in the paver commandline'
-    ),
-    ("fail_fast", None, "deprecated in favor of fail-fast"),
 ])
 @PassthroughTask
 @timed
@@ -220,11 +203,6 @@ def test_python(options, passthrough_options):
     make_option("--verbose", action="store_const", const=2, dest="verbosity"),
     make_option("-q", "--quiet", action="store_const", const=0, dest="verbosity"),
     make_option("-v", "--verbosity", action="count", dest="verbosity", default=1),
-    ('cov_args=', None, 'deprecated in favor of cov-args'),
-    make_option(
-        '-e', '--extra_args', default='',
-        help='deprecated, pass extra options directly in the paver commandline'
-    ),
 ])
 @PassthroughTask
 @timed
@@ -249,7 +227,6 @@ def test(options, passthrough_options):
 @needs('pavelib.prereqs.install_coverage_prereqs')
 @cmdopts([
     ("compare-branch=", "b", "Branch to compare against, defaults to origin/master"),
-    ("compare_branch=", None, "deprecated in favor of compare-branch"),
 ])
 @timed
 def coverage():
@@ -287,7 +264,6 @@ def coverage():
 @needs('pavelib.prereqs.install_coverage_prereqs')
 @cmdopts([
     ("compare-branch=", "b", "Branch to compare against, defaults to origin/master"),
-    ("compare_branch=", None, "deprecated in favor of compare-branch"),
 ], share_with=['coverage'])
 @timed
 def diff_coverage(options):

--- a/pavelib/utils/test/suites/__init__.py
+++ b/pavelib/utils/test/suites/__init__.py
@@ -2,7 +2,7 @@
 TestSuite class and subclasses
 """
 from .suite import TestSuite
-from .nose_suite import NoseTestSuite, SystemTestSuite, LibTestSuite
+from .pytest_suite import PytestSuite, SystemTestSuite, LibTestSuite
 from .python_suite import PythonTestSuite
 from .js_suite import JsTestSuite
 from .acceptance_suite import AcceptanceTestSuite

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -343,7 +343,6 @@ class BokChoyTestSuite(TestSuite):
             "-m",
             "pytest",
             test_spec,
-            "--durations=20",
         ] + self.verbosity_processes_command
         if self.extra_args:
             cmd.append(self.extra_args)

--- a/pavelib/utils/test/suites/python_suite.py
+++ b/pavelib/utils/test/suites/python_suite.py
@@ -5,7 +5,7 @@ import os
 
 from pavelib.utils.test import utils as test_utils
 from pavelib.utils.test.suites.suite import TestSuite
-from pavelib.utils.test.suites.nose_suite import LibTestSuite, SystemTestSuite
+from pavelib.utils.test.suites.pytest_suite import LibTestSuite, SystemTestSuite
 from pavelib.utils.envs import Env
 
 __test__ = False  # do not collect

--- a/pavelib/utils/test/suites/suite.py
+++ b/pavelib/utils/test/suites/suite.py
@@ -61,6 +61,14 @@ class TestSuite(object):
         """
         return None
 
+    @staticmethod
+    def is_success(exit_code):
+        """
+        Determine if the given exit code represents a success of the test
+        suite.  By default, only a zero counts as a success.
+        """
+        return exit_code == 0
+
     def run_test(self):
         """
         Runs a self.cmd in a subprocess and waits for it to finish.
@@ -88,7 +96,7 @@ class TestSuite(object):
 
         try:
             process = subprocess.Popen(cmd, **kwargs)
-            return (process.wait() == 0)
+            return self.is_success(process.wait())
         except KeyboardInterrupt:
             kill_process(process)
             sys.exit(1)

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -48,7 +48,7 @@
 
 # Third-party:
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
-git+https://github.com/edx/django-wiki.git@v0.0.11#egg=django-wiki==0.0.11
+git+https://github.com/edx/django-wiki.git@v0.0.14#egg=django-wiki==0.0.14
 git+https://github.com/edx/django-openid-auth.git@0.14#egg=django-openid-auth==0.14
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -15,5 +15,8 @@ pysqlite==2.8.3
 pytest==3.1.3
 pytest-attrib==0.1.3
 pytest-catchlog==1.2.2
+pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest-xdist==1.18.1
+pytest-forked==0.2
+pytest-randomly==1.2.1
+pytest-xdist==1.20.0

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -29,7 +29,7 @@ set -e
 #   `SHARD` is a number indicating which subset of the tests to build.
 #
 #       For "bok-choy" and "lms-unit", the tests are put into shard groups
-#       using the nose 'attr' decorator (e.g. "@attr(shard=1)"). Anything with
+#       using the 'attr' decorator (e.g. "@attr(shard=1)"). Anything with
 #       the 'shard=n' attribute will run in the nth shard. If there isn't a
 #       shard explicitly assigned, the test will run in the last shard.
 #
@@ -68,8 +68,9 @@ function emptyxunit {
 END
 
 }
-PAVER_ARGS="--cov-args='-p' --with-xunitmp -v"
+PAVER_ARGS="-v"
 PARALLEL="--processes=-1"
+export SUBSET_JOB=$JOB_NAME
 case "$TEST_SUITE" in
 
     "quality")
@@ -108,10 +109,10 @@ case "$TEST_SUITE" in
                 paver test_system -s lms $PAVER_ARGS $PARALLEL 2> lms-tests.log
                 ;;
             [1-3])
-                paver test_system -s lms --attr="shard=$SHARD" $PAVER_ARGS $PARALLEL 2> lms-tests.$SHARD.log
+                paver test_system -s lms --eval-attr="shard==$SHARD" $PAVER_ARGS $PARALLEL 2> lms-tests.$SHARD.log
                 ;;
             4|"noshard")
-                paver test_system -s lms --attr='!shard' $PAVER_ARGS $PARALLEL 2> lms-tests.4.log
+                paver test_system -s lms --eval-attr='not shard' $PAVER_ARGS $PARALLEL 2> lms-tests.4.log
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,11 @@ process-timeout=300
 #pdb=1
 
 [tool:pytest]
-norecursedirs = .git conf node_modules test_root cms/envs lms/envs
+DJANGO_SETTINGS_MODULE = lms.envs.test
+addopts = --nomigrations --reuse-db --durations=20
+norecursedirs = .* *.egg build conf dist node_modules test_root cms/envs lms/envs
+python_classes =
+python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py
 
 [pep8]
 # error codes: http://pep8.readthedocs.org/en/latest/intro.html#error-codes


### PR DESCRIPTION
Switch our python unit tests from nose to pytest.  Points of note:

* pytest uses `.cache` directories to store information about the tests that failed during the last run, so that had to be added to `.gitignore`.
* The default pytest configuration varies a little between cms, common/lib, and other directories.  This should keep all of our paver test collections passing, but does mean that just running "pytest" on the whole repo will usually result in some failures under cms and common/lib (pytest uses the first settings file it encounters in or above the first directory to contain all of the discovered tests).
* The first pass of documentation edits is intended primarily to keep it accurate.  We may want to update it further in a separate PR to highlight more of the new features that pytest allows.
* This PR removes some options of the paver test commands which were deprecated more than a year ago.
* django-wiki is upgraded to fix a problematic migration which interferes with running the tests in a random order; this also adds a new migration that drops some unused tables which belong to plugin apps and shouldn't have been created in the first place.
* The lib tests are run in a random sequence, but the lms tests no longer are.  The lms test randomization seems to have broken a while back due to interference from other nose plugins, and enough problems have crept in that fixing them all will take a little while.  Getting the cms tests to also work in random order shouldn't require too much additional effort, but again that can be done after the rest of this gets merged.

Additional cleanup (removing nose and django-nose from the requirements, removing usage of nose.tools, etc.) is covered by separate tickets and will be done in later pull requests.