### PR TITLE
EDUCATOR-1354 | Get cert display date a little more safely; include c…

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -83,7 +83,7 @@ def get_certificate_description(mode, certificate_type, platform_name):
     return certificate_type_description
 
 
-def _update_certificate_context(context, user_certificate, platform_name):
+def _update_certificate_context(context, course, user_certificate, platform_name):
     """
     Build up the certificate web view context using the provided values
     (Helper method to keep the view clean)
@@ -100,7 +100,6 @@ def _update_certificate_context(context, user_certificate, platform_name):
     )
 
     # Translators:  The format of the date includes the full name of the month
-    course = get_course_by_id(user_certificate.course_id) if user_certificate.course_id else None
     date = display_date_for_certificate(course, user_certificate)
     context['certificate_date_issued'] = _('{month} {day}, {year}').format(
         month=strftime_localized(date, "%B"),
@@ -581,7 +580,7 @@ def render_html_view(request, user_id, course_id):
     _update_social_context(request, context, course, user, user_certificate, platform_name)
 
     # Append/Override the existing view context values with certificate specific values
-    _update_certificate_context(context, user_certificate, platform_name)
+    _update_certificate_context(context, course, user_certificate, platform_name)
 
     # Append badge info
     _update_badge_context(context, course, user)


### PR DESCRIPTION
…ourse when updating cert webview context.

https://openedx.atlassian.net/browse/EDUCATOR-1354

The issue we ran into: https://splunk.edx.org/en-US/app/search/search?q=search%20index%3Dprod-edx%20display_date_for_certificate&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=-24h%40h&latest=now&sid=1505327406.795660

This was caused by the course_id for an example certificate being null, which meant that the `course` variable we initialized inside the function body was also null, which caused an attribute error when we tried to get the `self_paced` field from it.  This PR addresses two things:
- The `display_date_for_certificate` function now checks if `course` is truthy.
- The `_update_certificate_context` function now just takes a `course` parameter, which is already available from the caller of that function (rather than us going to fetch the course again, from a course_id that possibly doesn't exist).

Note: I'm working in openedx...test_api.py a lot right now, will add tests for `display_date_for_certificate` in that file while doing other stuff.