### PR TITLE
Fixed bug for partial updates for Studio API course runs endpoint

### DIFF
--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -112,7 +112,9 @@ class CourseRunSerializer(CourseRunTeamSerializerMixin, serializers.Serializer):
             return instance
 
     def update_team(self, instance, team):
-        CourseAccessRole.objects.filter(course_id=instance.id).delete()
+        # Existing data should remain intact when performing a partial update.
+        if not self.partial:
+            CourseAccessRole.objects.filter(course_id=instance.id).delete()
 
         # TODO In the future we can optimize by getting users in a single query.
         CourseAccessRole.objects.bulk_create([


### PR DESCRIPTION
Existing data remains intact when performing a partial update.

LEARNER-2468