### PR TITLE
pygments < 2.1 had a shell injection attack

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -82,7 +82,7 @@ piexif==1.0.2
 Pillow==3.4
 polib==1.0.3
 pycrypto>=2.6
-pygments==2.0.1
+pygments==2.2.0
 pygraphviz==1.1
 pyjwkest==1.3.2
 # TODO Replace PyJWT usage with pyjwkest


### PR DESCRIPTION
We only really use it in tests, but if tests still pass this should
be an easy upgrade.

https://gemnasium.com/github.com/edx/edx-platform/alerts
TE-1877