### PR TITLE
Paver changes to run tox testing for system & lib tests.

### DIFF
--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -31,6 +31,10 @@ __test__ = False  # do not collect
     ("fail-fast", "x", "Fail suite on first failed test"),
     ("fasttest", "a", "Run without collectstatic"),
     make_option(
+        "--django_version", dest="django_version",
+        help="Run against which Django version (1.8 -or- 1.11)."
+    ),
+    make_option(
         "--eval-attr", dest="eval_attr",
         help="Only run tests matching given attribute expression."
     ),
@@ -66,28 +70,61 @@ def test_system(options, passthrough_options):
     """
     system = getattr(options, 'system', None)
     test_id = getattr(options, 'test_id', None)
+    django_version = getattr(options, 'django_version', None)
+
+    assert(system in (None, 'lms', 'cms'))
+    assert(django_version in (None, '1.8', '1.11'))
+
+    def _create_tox_system_test_suites(systems):
+        system_tests = []
+        test_paths = []
+        # Add all test directories for the specified systems.
+        for syst in systems:
+            test_paths.extend(suites.default_system_test_dirs(syst))
+        # Remove all duplicate paths.
+        test_paths = list(set(test_paths))
+        for test_id in test_paths:
+            system = test_id.split('/')[0]
+            syst = 'cms'
+            if system in ['common', 'openedx', 'lms']:
+                syst = 'lms'
+            system_tests.append(suites.SystemTestSuite(
+                syst,
+                passthrough_options=passthrough_options,
+                test_id=test_id,
+                **options.test_system
+            ))
+        return system_tests
 
     if test_id:
+        # Testing a single test ID.
+        # Ensure the proper system for the test id.
         if not system:
             system = test_id.split('/')[0]
         if system in ['common', 'openedx']:
             system = 'lms'
-        options.test_system['test_id'] = test_id
-
-    if test_id or system:
         system_tests = [suites.SystemTestSuite(
             system,
             passthrough_options=passthrough_options,
             **options.test_system
         )]
     else:
-        system_tests = []
-        for syst in ('cms', 'lms'):
-            system_tests.append(suites.SystemTestSuite(
-                syst,
-                passthrough_options=passthrough_options,
-                **options.test_system
-            ))
+        # Testing a single system -or- both systems.
+        if system:
+            systems = [system]
+        else:
+            # No specified system or test_id, so run all tests of both systems.
+            systems = ['cms', 'lms']
+        if django_version:
+            system_tests = _create_tox_system_test_suites(systems)
+        else:
+            system_tests = []
+            for syst in systems:
+                system_tests.append(suites.SystemTestSuite(
+                    syst,
+                    passthrough_options=passthrough_options,
+                    **options.test_system
+                ))
 
     test_suite = suites.PythonTestSuite(
         'python tests',
@@ -108,6 +145,10 @@ def test_system(options, passthrough_options):
     ("failed", "f", "Run only failed tests"),
     ("fail-fast", "x", "Run only failed tests"),
     make_option(
+        "--django_version", dest="django_version",
+        help="Run against which Django version (1.8 -or- 1.11)."
+    ),
+    make_option(
         '-c', '--cov-args', default='',
         help='adds as args to coverage for the test run'
     ),
@@ -124,8 +165,12 @@ def test_lib(options, passthrough_options):
     """
     lib = getattr(options, 'lib', None)
     test_id = getattr(options, 'test_id', lib)
+    django_version = getattr(options, 'django_version', None)
+
+    assert(django_version in (None, '1.8', '1.11'))
 
     if test_id:
+        # Testing a single test id.
         if '/' in test_id:
             lib = '/'.join(test_id.split('/')[0:3])
         else:
@@ -137,6 +182,7 @@ def test_lib(options, passthrough_options):
             **options.test_lib
         )]
     else:
+        # Testing all common/lib test dirs - plus pavelib.
         lib_tests = [
             suites.LibTestSuite(
                 d,

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -75,27 +75,6 @@ def test_system(options, passthrough_options):
     assert(system in (None, 'lms', 'cms'))
     assert(django_version in (None, '1.8', '1.11'))
 
-    def _create_tox_system_test_suites(systems):
-        system_tests = []
-        test_paths = []
-        # Add all test directories for the specified systems.
-        for syst in systems:
-            test_paths.extend(suites.default_system_test_dirs(syst))
-        # Remove all duplicate paths.
-        test_paths = list(set(test_paths))
-        for test_id in test_paths:
-            system = test_id.split('/')[0]
-            syst = 'cms'
-            if system in ['common', 'openedx', 'lms']:
-                syst = 'lms'
-            system_tests.append(suites.SystemTestSuite(
-                syst,
-                passthrough_options=passthrough_options,
-                test_id=test_id,
-                **options.test_system
-            ))
-        return system_tests
-
     if test_id:
         # Testing a single test ID.
         # Ensure the proper system for the test id.
@@ -115,16 +94,13 @@ def test_system(options, passthrough_options):
         else:
             # No specified system or test_id, so run all tests of both systems.
             systems = ['cms', 'lms']
-        if django_version:
-            system_tests = _create_tox_system_test_suites(systems)
-        else:
-            system_tests = []
-            for syst in systems:
-                system_tests.append(suites.SystemTestSuite(
-                    syst,
-                    passthrough_options=passthrough_options,
-                    **options.test_system
-                ))
+        system_tests = []
+        for syst in systems:
+            system_tests.append(suites.SystemTestSuite(
+                syst,
+                passthrough_options=passthrough_options,
+                **options.test_system
+            ))
 
     test_suite = suites.PythonTestSuite(
         'python tests',

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -203,7 +203,8 @@ class Env(object):
     # Directories used for common/lib/ tests
     LIB_TEST_DIRS = []
     for item in (REPO_ROOT / "common/lib").listdir():
-        if (REPO_ROOT / 'common/lib' / item).isdir():
+        dir_name = (REPO_ROOT / 'common/lib' / item)
+        if dir_name.isdir() and not dir_name.endswith(('__pycache__', '.cache')):
             LIB_TEST_DIRS.append(path("common/lib") / item.basename())
     LIB_TEST_DIRS.append(path("pavelib/paver_tests"))
 

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -200,11 +200,12 @@ class Env(object):
 
     JS_REPORT_DIR = REPORT_DIR / 'javascript'
 
-    # Directories used for common/lib/ tests
+    # Directories used for common/lib/tests
+    IGNORED_TEST_DIRS = ('__pycache__', '.cache')
     LIB_TEST_DIRS = []
     for item in (REPO_ROOT / "common/lib").listdir():
         dir_name = (REPO_ROOT / 'common/lib' / item)
-        if dir_name.isdir() and not dir_name.endswith(('__pycache__', '.cache')):
+        if dir_name.isdir() and not dir_name.endswith(IGNORED_TEST_DIRS):
             LIB_TEST_DIRS.append(path("common/lib") / item.basename())
     LIB_TEST_DIRS.append(path("pavelib/paver_tests"))
 

--- a/pavelib/utils/test/suites/__init__.py
+++ b/pavelib/utils/test/suites/__init__.py
@@ -2,7 +2,7 @@
 TestSuite class and subclasses
 """
 from .suite import TestSuite
-from .pytest_suite import PytestSuite, SystemTestSuite, LibTestSuite
+from .pytest_suite import PytestSuite, SystemTestSuite, LibTestSuite, default_system_test_dirs
 from .python_suite import PythonTestSuite
 from .js_suite import JsTestSuite
 from .acceptance_suite import AcceptanceTestSuite

--- a/pavelib/utils/test/suites/__init__.py
+++ b/pavelib/utils/test/suites/__init__.py
@@ -2,7 +2,7 @@
 TestSuite class and subclasses
 """
 from .suite import TestSuite
-from .pytest_suite import PytestSuite, SystemTestSuite, LibTestSuite, default_system_test_dirs
+from .pytest_suite import PytestSuite, SystemTestSuite, LibTestSuite
 from .python_suite import PythonTestSuite
 from .js_suite import JsTestSuite
 from .acceptance_suite import AcceptanceTestSuite

--- a/pavelib/utils/test/suites/pytest_suite.py
+++ b/pavelib/utils/test/suites/pytest_suite.py
@@ -191,7 +191,7 @@ class SystemTestSuite(PytestSuite):
             """
             Should this path be included in the pytest arguments?
             """
-            if path.endswith('__pycache__'):
+            if path.endswith(Env.IGNORED_TEST_DIRS):
                 return False
             return path.endswith('.py') or os.path.isdir(path)
 

--- a/pavelib/utils/test/suites/pytest_suite.py
+++ b/pavelib/utils/test/suites/pytest_suite.py
@@ -15,27 +15,6 @@ except ImportError:
 __test__ = False  # do not collect
 
 
-def default_system_test_dirs(system):
-    """
-    Return a list of all directories in which pytest should begin a search for tests.
-    """
-    default_test_dirs = [
-        "{system}/djangoapps".format(system=system),
-        "common/djangoapps",
-        "openedx/core/djangoapps",
-        "openedx/tests",
-        "openedx/core/lib",
-    ]
-    if system in ('lms', 'cms'):
-        default_test_dirs.append("{system}/lib".format(system=system))
-
-    if system == 'lms':
-        default_test_dirs.append("{system}/tests.py".format(system=system))
-        default_test_dirs.append("openedx/core/djangolib")
-        default_test_dirs.append("openedx/features")
-    return default_test_dirs
-
-
 class PytestSuite(TestSuite):
     """
     A subclass of TestSuite with extra methods that are specific

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -1,7 +1,3 @@
 # Requirements to run and test Paver
 Paver==1.2.4
-lazy==1.1
-path.py==8.2.1
-watchdog==0.8.3
-python-memcached
 libsass==0.10.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -20,3 +20,5 @@ pytest-django==3.1.2
 pytest-forked==0.2
 pytest-randomly==1.2.1
 pytest-xdist==1.20.0
+tox==2.8.2
+tox-battery==0.5

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ deps =
     -rrequirements/edx/local.txt
     -rrequirements/edx/base.txt
     -rrequirements/edx/development.txt
+    # There's 1-2 tests which call a paver command...
+    -rrequirements/edx/paver.txt
     -rrequirements/edx/testing.txt
     -rrequirements/edx/post.txt
 


### PR DESCRIPTION
These changes are designed to use the same test environment as always - unless the `django_version` option is specified.

When `--django_version=1.8` or `--django_version==1.11` is specified on the paver command line, paver will run the `test_system` or `test_lib` tests with tox (which uses pytest in the tox venv).

I've run the commands found in this file used on Jenkins:
https://github.com/edx/edx-platform/blob/master/scripts/generic-ci-tests.sh
and they still work as always.