### PR TITLE
WIP: Increase paver asset watch timeout

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -802,7 +802,7 @@ def watch_assets(options):
         theme_dirs = [path(_dir) for _dir in theme_dirs]
 
     sass_directories = get_watcher_dirs(theme_dirs, themes)
-    observer = PollingObserver()
+    observer = PollingObserver(timeout=10)
 
     CoffeeScriptWatcher().register(observer)
     SassWatcher().register(observer, sass_directories)


### PR DESCRIPTION
@efischer19 increasing this timeout will stop the continuous filesystem polling for changed assets. On the flip side, asset updates will not come as quickly. I'll let you decide what you would like to set this at. 

We may also want to make the watcher containers optional? Not sure.