### PR TITLE
Use edx-val translations collectively with existing translations on the video component

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -633,6 +633,16 @@ class TestTranscript(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             transcripts_utils.Transcript.convert(self.srt_transcript, 'srt', 'sjson')
 
+    def test_dummy_non_existent_transcript(self):
+        """
+        Test `Transcript.asset` raises `NotFoundError` for dummy non-existent transcript.
+        """
+        with self.assertRaises(NotFoundError):
+            transcripts_utils.Transcript.asset(None, transcripts_utils.NON_EXISTENT_TRANSCRIPT)
+
+        with self.assertRaises(NotFoundError):
+            transcripts_utils.Transcript.asset(None, None, filename=transcripts_utils.NON_EXISTENT_TRANSCRIPT)
+
 
 class TestSubsFilename(unittest.TestCase):
     """

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -1001,7 +1001,8 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
             {
                 'provider': TranscriptProvider.THREE_PLAY_MEDIA,
                 'three_play_turnaround': 'default',
-                'preferred_languages': ['en']
+                'preferred_languages': ['en'],
+                'video_source_language': None,  # TODO change this once we support source language in platform.
             },
             True,
             '',
@@ -1020,6 +1021,7 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
             'cielo24_turnaround': preferences.get('cielo24_turnaround'),
             'three_play_turnaround': preferences.get('three_play_turnaround'),
             'preferred_languages': preferences.get('preferred_languages', []),
+            'video_source_language': preferences.get('video_source_language'),
         }
 
         with patch(

--- a/cms/templates/js/course-video-settings.underscore
+++ b/cms/templates/js/course-video-settings.underscore
@@ -10,7 +10,7 @@
     </div>
     <div class='course-video-settings-wrapper'>
         <div class='course-video-settings-message-wrapper'></div>
-        <span class="course-video-settings-title"><%- gettext('Transcript Settings') %></span>
+        <span class="course-video-settings-title"><%- gettext('Course Video Settings') %></span>
         <div class='transcript-preferance-wrapper transcript-provider-wrapper'>
             <label class='transcript-preferance-label' for='transcript-provider'><%- gettext('Transcript Provider') %><span class='error-icon' aria-hidden="true"></span></label>
             <div class='transcript-provider-group' id='transcript-provider'></div>

--- a/lms/djangoapps/mobile_api/video_outlines/serializers.py
+++ b/lms/djangoapps/mobile_api/video_outlines/serializers.py
@@ -11,6 +11,7 @@ from courseware.module_render import get_module_for_descriptor
 from util.module_utils import get_dynamic_descriptor_children
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.mongo.base import BLOCK_TYPES_WITH_CHILDREN
+from xmodule.video_module.transcripts_utils import is_val_transcript_feature_enabled_for_course
 
 
 class BlockOutline(object):
@@ -208,8 +209,12 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
     size = default_encoded_video.get('file_size', 0)
 
     # Transcripts...
-    transcripts_info = video_descriptor.get_transcripts_info()
-    transcript_langs = video_descriptor.available_translations(transcripts_info)
+    feature_enabled = is_val_transcript_feature_enabled_for_course(course_id)
+    transcripts_info = video_descriptor.get_transcripts_info(include_val_transcripts=feature_enabled)
+    transcript_langs = video_descriptor.available_translations(
+        transcripts=transcripts_info,
+        include_val_transcripts=feature_enabled
+    )
 
     transcripts = {
         lang: reverse(

--- a/lms/djangoapps/mobile_api/video_outlines/views.py
+++ b/lms/djangoapps/mobile_api/video_outlines/views.py
@@ -6,6 +6,7 @@ only displayed at the course level. This is because it makes it a lot easier to
 optimize and reason about, and it avoids having to tackle the bigger problem of
 general XBlock representation in this rather specialized formatting.
 """
+import os
 from functools import partial
 
 from django.http import Http404, HttpResponse
@@ -16,6 +17,11 @@ from rest_framework.response import Response
 from mobile_api.models import MobileApiConfig
 from xmodule.exceptions import NotFoundError
 from xmodule.modulestore.django import modulestore
+from xmodule.video_module.transcripts_utils import (
+    get_video_transcript_content,
+    is_val_transcript_feature_enabled_for_course,
+    Transcript,
+)
 
 from ..decorators import mobile_course_access, mobile_view
 from .serializers import BlockOutline, video_summary
@@ -111,14 +117,31 @@ class VideoTranscripts(generics.RetrieveAPIView):
         block_id = kwargs['block_id']
         lang = kwargs['lang']
 
-        usage_key = BlockUsageLocator(
-            course.id, block_type="video", block_id=block_id
-        )
+        usage_key = BlockUsageLocator(course.id, block_type='video', block_id=block_id)
+        video_descriptor = modulestore().get_item(usage_key)
+        feature_enabled = is_val_transcript_feature_enabled_for_course(usage_key.course_key)
         try:
-            video_descriptor = modulestore().get_item(usage_key)
-            transcripts = video_descriptor.get_transcripts_info()
+            transcripts = video_descriptor.get_transcripts_info(include_val_transcripts=feature_enabled)
             content, filename, mimetype = video_descriptor.get_transcript(transcripts, lang=lang)
-        except (NotFoundError, ValueError, KeyError):
+        except (ValueError, NotFoundError):
+            # Fallback mechanism for edx-val transcripts
+            transcript = None
+            if feature_enabled:
+                transcript = get_video_transcript_content(
+                    language_code=lang,
+                    edx_video_id=video_descriptor.edx_video_id,
+                    youtube_id_1_0=video_descriptor.youtube_id_1_0,
+                    html5_sources=video_descriptor.html5_sources,
+                )
+
+            if not transcript:
+                raise Http404(u'Transcript not found for {}, lang: {}'.format(block_id, lang))
+
+            base_name, __ = os.path.splitext(os.path.basename(transcript['file_name']))
+            filename = '{base_name}.srt'.format(base_name=base_name)
+            content = Transcript.convert(transcript['content'], 'sjson', 'srt')
+            mimetype = Transcript.mime_types['srt']
+        except KeyError:
             raise Http404(u"Transcript not found for {}, lang: {}".format(block_id, lang))
 
         response = HttpResponse(content, content_type=mimetype)

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -97,7 +97,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.6#egg=lti_consumer-xblock==1.1.6
 git+https://github.com/edx/edx-proctoring.git@1.2.1#egg=edx-proctoring==1.2.1
-git+https://github.com/edx/edx-val.git@8f695d27218c76f57d6b681f795eb3b97f8122bb#egg=edxval==0.0.17
+git+https://github.com/edx/edx-val.git@3847f0dc927d0d982e8cebad453b860fe9519d85#egg=edxval==0.0.17
 
 # Third Party XBlocks
 git+https://github.com/open-craft/xblock-poll@7ba819b968fe8faddb78bb22e1fe7637005eb414#egg=xblock-poll==1.2.7


### PR DESCRIPTION
## [EDUCATOR-1379](https://openedx.atlassian.net/browse/EDUCATOR-1379) 
### Use edx-val translations collectively with existing translations on the video component

- Add edx-val transcript languages to language menu.
- Add download urls for edx-val transcript languages as well – i.e. in `student_view_data`.
- Modify translations and download dispatches to work with edx-val languages.
- Add fallback mechanism for **mobile accessible transcript endpoint**. 
- Add **mobile accessible transcript endpoint**'s urls for edx-val transcript languages as well.

Sandbox: https://studio-component-val-translations.sandbox.edx.org/container/block-v1:UOF+CS101+2017_LT+type@vertical+block@eb38c9162a8c4f81a61c96bbc13daf08?action=new