### PR TITLE
Remove flaky SettingsMilestonesTest.test_enable_entrance_exam_for_course

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_settings_details.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_details.py
@@ -138,39 +138,6 @@ class SettingsMilestonesTest(StudioSettingsDetailsTest):
         """
         self.assertTrue(self.settings_detail.entrance_exam_field)
 
-    def test_enable_entrance_exam_for_course(self):
-        """
-        Test that entrance exam should be created after checking the 'enable entrance exam' checkbox.
-        And also that the entrance exam is destroyed after deselecting the checkbox.
-        """
-        self.settings_detail.require_entrance_exam(required=True)
-        self.settings_detail.save_changes()
-
-        # getting the course outline page.
-        course_outline_page = CourseOutlinePage(
-            self.browser, self.course_info['org'], self.course_info['number'], self.course_info['run']
-        )
-        course_outline_page.visit()
-
-        # title with text 'Entrance Exam' should be present on page.
-        self.assertTrue(element_has_text(
-            page=course_outline_page,
-            css_selector='span.section-title',
-            text='Entrance Exam'
-        ))
-
-        # Delete the currently created entrance exam.
-        self.settings_detail.visit()
-        self.settings_detail.require_entrance_exam(required=False)
-        self.settings_detail.save_changes()
-
-        course_outline_page.visit()
-        self.assertFalse(element_has_text(
-            page=course_outline_page,
-            css_selector='span.section-title',
-            text='Entrance Exam'
-        ))
-
     def test_entrance_exam_has_unit_button(self):
         """
         Test that entrance exam should be created after checking the 'enable entrance exam' checkbox.


### PR DESCRIPTION
SettingsMilestonesTest test_enable_entrance_exam_for_course has failed for me on the same commit in [this PR](https://github.com/edx/edx-platform/pull/16042). I made a [ticket](https://openedx.atlassian.net/browse/SOL-2212) for the problem with the links to the jenkins runs.

Review:
- [ ] @jzoldak 
- [ ] @mattdrayer 