### PR TITLE
[ENT-428] Bump edx-enterprise to 0.46.4.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -49,7 +49,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.46.3
+edx-enterprise==0.46.4
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
This bumps `edx-enterprise` to 0.46.4 which abstracts away use of `configuration_helpers`.

**JIRA tickets**: [ENT-428](https://openedx.atlassian.net/browse/ENT-428)

**Testing instructions**:

1. Just make sure you can go to the course enrollment landing page and can see details like the platform name.

**Reviewers**
- [ ] @haikuginger 
- [ ] @douglashall @brittneyexline 

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```