### PR TITLE
upgrade lti-consumer xblock

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -95,7 +95,7 @@ git+https://github.com/edx/edx-milestones.git@v0.1.11#egg=edx-milestones==0.1.11
 git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.5#egg=lti_consumer-xblock==1.1.5
+git+https://github.com/edx/xblock-lti-consumer.git@v1.1.6#egg=lti_consumer-xblock==1.1.6
 git+https://github.com/edx/edx-proctoring.git@1.2.1#egg=edx-proctoring==1.2.1
 
 # Third Party XBlocks


### PR DESCRIPTION
Upgrade version of lti-consumer after fixing https://openedx.atlassian.net/browse/EDUCATOR-1218 
LTI Consumer xblock fix PR: https://github.com/edx/xblock-lti-consumer/pull/35
LTI Consumer xblock version update PR: https://github.com/edx/xblock-lti-consumer/pull/36