### PR TITLE
Bump problem-builder to 2.7.6.

### DIFF
--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -8,7 +8,7 @@
 
 # For Harvard courses:
 -e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
-git+https://github.com/open-craft/problem-builder.git@v2.6.5patch2#egg=xblock-problem-builder==2.6.5patch2
+git+https://github.com/open-craft/problem-builder.git@v2.7.6#egg=xblock-problem-builder==2.7.6
 
 # Oppia XBlock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock


### PR DESCRIPTION
Removes deprecated Answer.course_id field, without migrating the associated database table.
Merges in https://github.com/open-craft/problem-builder/pull/166 (and several other outstanding releases).

# Reviewers

- [x] @bradenmacdonald 
- [x] @feanil 