### PR TITLE
Ent 624 update enterprise api support

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -30,8 +30,8 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeade
 from openedx.core.lib.exceptions import CourseNotFoundError
 from openedx.core.lib.log_utils import audit_log
 from openedx.features.enterprise_support.api import (
-    ConsentApiClient,
-    EnterpriseApiClient,
+    ConsentApiServiceClient,
+    EnterpriseApiServiceClient,
     EnterpriseApiException,
     enterprise_enabled
 )
@@ -598,8 +598,8 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
             enterprise_course_consent = request.data.get('enterprise_course_consent')
             explicit_linked_enterprise = request.data.get('linked_enterprise_customer')
             if (enterprise_course_consent or explicit_linked_enterprise) and has_api_key_permissions and enterprise_enabled():
-                enterprise_api_client = EnterpriseApiClient()
-                consent_client = ConsentApiClient()
+                enterprise_api_client = EnterpriseApiServiceClient()
+                consent_client = ConsentApiServiceClient()
                 # We received an explicitly-linked EnterpriseCustomer for the enrollment
                 if explicit_linked_enterprise is not None:
                     try:

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -8,21 +8,26 @@ import ddt
 import httpretty
 import mock
 from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
-from django.test import TestCase
 from django.test.utils import override_settings
 
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.features.enterprise_support.api import (
+    ConsentApiClient,
+    ConsentApiServiceClient,
     consent_needed_for_course,
     data_sharing_consent_required,
+    EnterpriseApiClient,
+    EnterpriseApiServiceClient,
     enterprise_customer_for_request,
-    enterprise_enabled,
     get_dashboard_consent_notification,
     get_enterprise_consent_url,
 )
-
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
+from openedx.features.enterprise_support.utils import get_cache_key
 from student.tests.factories import UserFactory
 
 
@@ -38,27 +43,123 @@ class MockEnrollment(mock.MagicMock):
 @ddt.ddt
 @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-class TestEnterpriseApi(EnterpriseServiceMockMixin, TestCase):
+class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
     """
     Test enterprise support APIs.
     """
+    ENABLED_CACHES = ['default']
+
     @classmethod
     def setUpTestData(cls):
-        UserFactory.create(
-            username='enterprise_worker',
+        cls.user = UserFactory.create(
+            username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME,
             email='ent_worker@example.com',
             password='password123',
         )
         super(TestEnterpriseApi, cls).setUpTestData()
 
+    def _assert_api_service_client(self, api_client, mocked_jwt_builder):
+        """
+        Verify that the provided api client uses the enterprise service user to generate
+        JWT token for auth.
+        """
+        mocked_jwt_builder.return_value.build_token.return_value = 'test-token'
+        enterprise_service_user = User.objects.get(username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME)
+        enterprise_api_service_client = api_client()
+
+        mocked_jwt_builder.assert_called_once_with(enterprise_service_user)
+        # pylint: disable=protected-access
+        self.assertEqual(enterprise_api_service_client.client._store['session'].auth.token, 'test-token')
+
+    def _assert_api_client_with_user(self, api_client, mocked_jwt_builder):
+        """
+        Verify that the provided api client uses the expected user to generate
+        JWT token for auth.
+        """
+        mocked_jwt_builder.return_value.build_token.return_value = 'test-token'
+        dummy_enterprise_user = UserFactory.create(
+            username='dummy-enterprise-user',
+            email='dummy-enterprise-user@example.com',
+            password='password123',
+        )
+        enterprise_api_service_client = api_client(dummy_enterprise_user)
+
+        mocked_jwt_builder.assert_called_once_with(dummy_enterprise_user)
+        # pylint: disable=protected-access
+        self.assertEqual(enterprise_api_service_client.client._store['session'].auth.token, 'test-token')
+
+    def _assert_get_enterprise_customer(self, api_client):
+        """
+        DRY method to verify caching for get enterprise customer method.
+        """
+        dummy_enterprise_api_data = {'name': 'dummy-enterprise-customer', 'uuid': 'enterprise-uuid'}
+        cache_key = get_cache_key(
+            resource='enterprise-customer',
+            username=settings.ENTERPRISE_SERVICE_WORKER_USERNAME,
+        )
+        self.mock_get_enterprise_customer('enterprise-uuid', dummy_enterprise_api_data, 200)
+        self._assert_get_enterprise_customer_with_cache(api_client, dummy_enterprise_api_data, cache_key)
+
+    def _assert_get_enterprise_customer_with_cache(self, api_client, enterprise_customer_data, cache_key):
+        """
+        DRY method to verify that get enterprise customer response is cached.
+        """
+        cached_enterprise_customer = cache.get(cache_key)
+        self.assertIsNone(cached_enterprise_customer)
+
+        enterprise_customer = api_client.get_enterprise_customer(enterprise_customer_data['uuid'])
+        self.assertEqual(enterprise_customer_data, enterprise_customer)
+        cached_enterprise_customer = cache.get(cache_key)
+        self.assertEqual(cached_enterprise_customer, enterprise_customer)
+
     @httpretty.activate
-    @override_settings(ENTERPRISE_SERVICE_WORKER_USERNAME='enterprise_worker')
+    @mock.patch('openedx.features.enterprise_support.api.JwtBuilder')
+    def test_enterprise_api_client_with_service_user(self, mock_jwt_builder):
+        """
+        Verify that enterprise API service client uses enterprise service user
+        by default to authenticate and access enterprise API.
+        """
+        self._assert_api_service_client(EnterpriseApiServiceClient, mock_jwt_builder)
+
+        # Now verify that enterprise customer data is cached properly for
+        # the enterprise api client.
+        enterprise_api_client = EnterpriseApiServiceClient()
+        self._assert_get_enterprise_customer(enterprise_api_client)
+
+    @httpretty.activate
+    @mock.patch('openedx.features.enterprise_support.api.JwtBuilder')
+    def test_enterprise_api_client_with_user(self, mock_jwt_builder):
+        """
+        Verify that enterprise API client uses the provided user to
+        authenticate and access enterprise API.
+        """
+        self._assert_api_client_with_user(EnterpriseApiClient, mock_jwt_builder)
+
+    @httpretty.activate
+    @mock.patch('openedx.features.enterprise_support.api.JwtBuilder')
+    def test_enterprise_consent_api_client_with_service_user(self, mock_jwt_builder):
+        """
+        Verify that enterprise API consent service client uses enterprise
+        service user by default to authenticate and access enterprise API.
+        """
+        self._assert_api_service_client(ConsentApiServiceClient, mock_jwt_builder)
+
+    @httpretty.activate
+    @mock.patch('openedx.features.enterprise_support.api.JwtBuilder')
+    def test_enterprise_consent_api_client_with_user(self, mock_jwt_builder):
+        """
+        Verify that enterprise API consent service client uses the provided
+        user to authenticate and access enterprise API.
+        """
+        self._assert_api_client_with_user(ConsentApiClient, mock_jwt_builder)
+
+    @httpretty.activate
     def test_consent_needed_for_course(self):
         user = mock.MagicMock(
             username='janedoe',
             is_authenticated=lambda: True,
         )
-        request = mock.MagicMock(session={})
+        request = mock.MagicMock(session={}, user=user)
         self.mock_enterprise_learner_api()
         self.mock_consent_missing(user.username, 'fake-course', 'cf246b88-d5f6-4908-a522-fc307e0b0c59')
         self.assertTrue(consent_needed_for_course(request, user, 'fake-course'))
@@ -70,67 +171,61 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, TestCase):
         self.assertFalse(consent_needed_for_course(request, user, 'fake-course'))
 
     @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_enterprise_learner_data')
     @mock.patch('openedx.features.enterprise_support.api.EnterpriseCustomer')
     @mock.patch('openedx.features.enterprise_support.api.get_partial_pipeline')
     @mock.patch('openedx.features.enterprise_support.api.Registry')
-    @override_settings(ENTERPRISE_SERVICE_WORKER_USERNAME='enterprise_worker')
     def test_enterprise_customer_for_request(
             self,
             mock_registry,
             mock_partial,
-            mock_ec_model,
-            mock_get_el_data
+            mock_enterprise_customer_model,
     ):
-        def mock_get_ec(**kwargs):
+        def mock_get_enterprise_customer(**kwargs):
             uuid = kwargs.get('enterprise_customer_identity_provider__provider_id')
             if uuid:
-                return mock.MagicMock(uuid=uuid)
+                return mock.MagicMock(uuid=uuid, user=self.user)
             raise Exception
 
-        mock_ec_model.objects.get.side_effect = mock_get_ec
-        mock_ec_model.DoesNotExist = Exception
-
+        dummy_request = mock.MagicMock(session={}, user=self.user)
+        mock_enterprise_customer_model.objects.get.side_effect = mock_get_enterprise_customer
+        mock_enterprise_customer_model.DoesNotExist = Exception
         mock_partial.return_value = True
         mock_registry.get_from_pipeline.return_value.provider_id = 'real-ent-uuid'
 
-        self.mock_get_enterprise_customer('real-ent-uuid', {"real": "enterprisecustomer"}, 200)
-
-        ec = enterprise_customer_for_request(mock.MagicMock())
-
-        self.assertEqual(ec, {"real": "enterprisecustomer"})
+        # Verify that the method `enterprise_customer_for_request` returns
+        # expected enterprise customer against the requesting user.
+        self.mock_get_enterprise_customer('real-ent-uuid', {'real': 'enterprisecustomer'}, 200)
+        enterprise_customer = enterprise_customer_for_request(dummy_request)
+        self.assertEqual(enterprise_customer, {'real': 'enterprisecustomer'})
 
         httpretty.reset()
 
-        self.mock_get_enterprise_customer('real-ent-uuid', {"detail": "Not found."}, 404)
+        # Verify that the method `enterprise_customer_for_request` returns no
+        # enterprise customer if the enterprise customer API throws 404.
+        self.mock_get_enterprise_customer('real-ent-uuid', {'detail': 'Not found.'}, 404)
+        enterprise_customer = enterprise_customer_for_request(dummy_request)
+        self.assertIsNone(enterprise_customer)
 
-        ec = enterprise_customer_for_request(mock.MagicMock())
+        httpretty.reset()
 
-        self.assertIsNone(ec)
-
+        # Verify that the method `enterprise_customer_for_request` returns
+        # expected enterprise customer against the requesting user even if
+        # the third-party auth pipeline has no `provider_id`.
         mock_registry.get_from_pipeline.return_value.provider_id = None
-
-        httpretty.reset()
-
-        self.mock_get_enterprise_customer('real-ent-uuid', {"real": "enterprisecustomer"}, 200)
-
-        ec = enterprise_customer_for_request(mock.MagicMock(GET={"enterprise_customer": 'real-ent-uuid'}))
-
-        self.assertEqual(ec, {"real": "enterprisecustomer"})
-
-        ec = enterprise_customer_for_request(
-            mock.MagicMock(GET={}, COOKIES={settings.ENTERPRISE_CUSTOMER_COOKIE_NAME: 'real-ent-uuid'})
+        self.mock_get_enterprise_customer('real-ent-uuid', {'real': 'enterprisecustomer'}, 200)
+        enterprise_customer = enterprise_customer_for_request(
+            mock.MagicMock(GET={'enterprise_customer': 'real-ent-uuid'}, user=self.user)
         )
+        self.assertEqual(enterprise_customer, {'real': 'enterprisecustomer'})
 
-        self.assertEqual(ec, {"real": "enterprisecustomer"})
-
-        mock_get_el_data.return_value = [{'enterprise_customer': {'uuid': 'real-ent-uuid'}}]
-
-        ec = enterprise_customer_for_request(
-            mock.MagicMock(GET={}, COOKIES={}, user=mock.MagicMock(is_authenticated=lambda: True), site=1)
+        # Verify that the method `enterprise_customer_for_request` returns
+        # expected enterprise customer against the requesting user even if
+        # the third-party auth pipeline has no `provider_id` but there is
+        # enterprise customer UUID in the cookie.
+        enterprise_customer = enterprise_customer_for_request(
+            mock.MagicMock(GET={}, COOKIES={settings.ENTERPRISE_CUSTOMER_COOKIE_NAME: 'real-ent-uuid'}, user=self.user)
         )
-
-        self.assertEqual(ec, {"real": "enterprisecustomer"})
+        self.assertEqual(enterprise_customer, {'real': 'enterprisecustomer'})
 
     def check_data_sharing_consent(self, consent_required=False, consent_url=None):
         """

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -1,0 +1,29 @@
+from __future__ import unicode_literals
+
+import hashlib
+
+import six
+
+
+def get_cache_key(**kwargs):
+    """
+    Get MD5 encoded cache key for given arguments.
+
+    Here is the format of key before MD5 encryption.
+        key1:value1__key2:value2 ...
+
+    Example:
+        >>> get_cache_key(site_domain="example.com", resource="enterprise-learner")
+        # Here is key format for above call
+        # "site_domain:example.com__resource:enterprise-learner"
+        a54349175618ff1659dee0978e3149ca
+
+    Arguments:
+        **kwargs: Key word arguments that need to be present in cache key.
+
+    Returns:
+         An MD5 encoded key uniquely identified by the key word arguments.
+    """
+    key = '__'.join(['{}:{}'.format(item, value) for item, value in six.iteritems(kwargs)])
+
+    return hashlib.md5(key).hexdigest()


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @douglashall 
* Initialize and authenticate enterprise api client with the provided user or use enterprise service user by default.
* Get enterprise customer data with enterprise service user in case requesting user in unauthenticated (logistration pages when user comes from SSO for the first time).
* Cache enterprise customer data for service user as the enterprise customer data does not change often.

Intitial PR: https://github.com/edx/edx-platform/pull/16001
Revert PR: https://github.com/edx/edx-platform/pull/15987
