### PR TITLE
Fixing util to gather course_run data from catalog

### DIFF
--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -890,7 +890,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         Tests custom template search and rendering.
         This test should check template matching when org={org}, course={course}, mode={mode}.
         """
-        mock_get_course_run_details.return_value = {'language': 'en'}
+        mock_get_course_run_details.return_value = {'content_language': 'en'}
         self._add_course_certificates(count=1, signatory_count=2)
         self._create_custom_template(org_id=1, mode='honor', course_key=unicode(self.course.id))
         self._create_custom_template(org_id=2, mode='honor')
@@ -922,7 +922,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         with course set to Null.
         This test should check template matching when org={org}, course=Null, mode={mode}.
         """
-        mock_get_course_run_details.return_value = {'language': 'en'}
+        mock_get_course_run_details.return_value = {'content_language': 'en'}
         course = CourseFactory.create(
             org='cstX', number='cst_22', display_name='custom template course'
         )
@@ -950,7 +950,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         Tests custom template search when we have a single template for a organization.
         This test should check template matching when org={org}, course=Null, mode=null.
         """
-        mock_get_course_run_details.return_value = {'language': 'en'}
+        mock_get_course_run_details.return_value = {'content_language': 'en'}
         self._add_course_certificates(count=1, signatory_count=2)
         self._create_custom_template(org_id=1, mode='honor')
         self._create_custom_template(org_id=1, mode='honor', course_key=self.course.id)
@@ -974,7 +974,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         Tests custom template search if we have a single template for a course mode.
         This test should check template matching when org=null, course=Null, mode={mode}.
         """
-        mock_get_course_run_details.return_value = {'language': 'en'}
+        mock_get_course_run_details.return_value = {'content_language': 'en'}
         mode = 'honor'
         self._add_course_certificates(count=1, signatory_count=2)
         self._create_custom_template(mode=mode)
@@ -995,7 +995,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         """
         Tests custom template renders properly with unicode data.
         """
-        mock_get_course_run_details.return_value = {'language': 'en'}
+        mock_get_course_run_details.return_value = {'content_language': 'en'}
         mode = 'honor'
         self._add_course_certificates(count=1, signatory_count=2)
         self._create_custom_template(mode=mode)
@@ -1029,7 +1029,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         """
         Tests certificate template asset display by slug using static.certificate_asset_url method.
         """
-        mock_get_course_run_details.return_value = {'language': 'en'}
+        mock_get_course_run_details.return_value = {'content_language': 'en'}
         self._add_course_certificates(count=1, signatory_count=2)
         self._create_custom_template(mode='honor')
         test_url = get_certificate_url(

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -250,7 +250,7 @@ def _update_course_context(request, context, course, course_key, platform_name):
             platform_name=platform_name)
     # If language specific templates are enabled for the course, add course_run specific information to the context
     if CertificateGenerationCourseSetting.is_language_specific_templates_enabled_for_course(course_key):
-        fields = ['start', 'end', 'max_effort', 'language']
+        fields = ['start', 'end', 'max_effort', 'content_language']
         course_run_data = get_course_run_details(course_key, fields)
         context.update(course_run_data)
 
@@ -418,7 +418,7 @@ def _render_certificate_template(request, context, course, user_certificate):
     Picks appropriate certificate templates and renders it.
     """
     if settings.FEATURES.get('CUSTOM_CERTIFICATE_TEMPLATES_ENABLED', False):
-        custom_template = get_certificate_template(course.id, user_certificate.mode, context.get('language'))
+        custom_template = get_certificate_template(course.id, user_certificate.mode, context.get('content_language'))
         if custom_template:
             template = Template(
                 custom_template,

--- a/openedx/core/djangoapps/catalog/tests/factories.py
+++ b/openedx/core/djangoapps/catalog/tests/factories.py
@@ -118,7 +118,7 @@ class CourseRunFactory(DictFactoryBase):
     title = factory.Faker('catch_phrase')
     type = 'verified'
     uuid = factory.Faker('uuid4')
-    language = 'en'
+    content_language = 'en'
     max_effort = 5
 
 

--- a/openedx/core/djangoapps/catalog/tests/test_utils.py
+++ b/openedx/core/djangoapps/catalog/tests/test_utils.py
@@ -324,12 +324,12 @@ class TestGetCourseRunDetails(CatalogIntegrationMixin, TestCase):
         """
         course_run = CourseRunFactory()
         course_run_details = {
-            'language': course_run['language'],
+            'content_language': course_run['content_language'],
             'start': course_run['start'],
             'end': course_run['end'],
             'max_effort': course_run['max_effort']
         }
         mock_get_edx_api_data.return_value = course_run_details
-        data = get_course_run_details(course_run['key'], ['language', 'start', 'end', 'max_effort'])
+        data = get_course_run_details(course_run['key'], ['content_language', 'start', 'end', 'max_effort'])
         self.assertTrue(mock_get_edx_api_data.called)
         self.assertEqual(data, course_run_details)

--- a/openedx/core/lib/edx_api_utils.py
+++ b/openedx/core/lib/edx_api_utils.py
@@ -25,6 +25,7 @@ def get_fields(fields, response):
         except:
             msg = '{resource} does not have the attribute {field}'.format(resource, field)
             log.exception(msg)
+    return results
 
 
 def get_edx_api_data(api_config, resource, api, resource_id=None, querystring=None, cache_key=None, many=True,


### PR DESCRIPTION
Endpoint I thought I was accessing : 
http://localhost:18381/api-docs/#!/api/v1_search_course_runs_read

Endpoint the code actually accesses : 
http://localhost:18381/api-docs/#!/api/v1_course_runs_read