### PR TITLE
Change Django settings from tuples to lists to prep for 1.11 upgrade

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -107,13 +107,13 @@ FEATURES['ENABLE_DISCUSSION_SERVICE'] = False
 USE_I18N = True
 
 # Override the test stub webpack_loader that is installed in test.py.
-INSTALLED_APPS = tuple(app for app in INSTALLED_APPS if app != 'openedx.tests.util.webpack_loader')
-INSTALLED_APPS += ('webpack_loader',)
+INSTALLED_APPS = [app for app in INSTALLED_APPS if app != 'openedx.tests.util.webpack_loader']
+INSTALLED_APPS.append('webpack_loader')
 
 # Include the lettuce app for acceptance testing, including the 'harvest' django-admin command
 # django.contrib.staticfiles used to be loaded by lettuce, now we must add it ourselves
 # django.contrib.staticfiles is not added to lms as there is a ^/static$ route built in to the app
-INSTALLED_APPS += ('lettuce.django',)
+INSTALLED_APPS.append('lettuce.django')
 LETTUCE_APPS = ('contentstore',)
 LETTUCE_BROWSER = os.environ.get('LETTUCE_BROWSER', 'chrome')
 

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -236,7 +236,7 @@ for feature, value in ENV_FEATURES.items():
 
 # Additional installed apps
 for app in ENV_TOKENS.get('ADDL_INSTALLED_APPS', []):
-    INSTALLED_APPS += (app,)
+    INSTALLED_APPS.append(app)
 
 WIKI_ENABLED = ENV_TOKENS.get('WIKI_ENABLED', WIKI_ENABLED)
 
@@ -259,11 +259,13 @@ if "TRACKING_IGNORE_URL_PATTERNS" in ENV_TOKENS:
 CAS_EXTRA_LOGIN_PARAMS = ENV_TOKENS.get("CAS_EXTRA_LOGIN_PARAMS", None)
 if FEATURES.get('AUTH_USE_CAS'):
     CAS_SERVER_URL = ENV_TOKENS.get("CAS_SERVER_URL", None)
-    AUTHENTICATION_BACKENDS = (
+    AUTHENTICATION_BACKENDS = [
         'django.contrib.auth.backends.ModelBackend',
         'django_cas.backends.CASBackend',
-    )
-    INSTALLED_APPS += ('django_cas',)
+    ]
+
+    INSTALLED_APPS.append('django_cas')
+
     MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware')
     CAS_ATTRIBUTE_CALLBACK = ENV_TOKENS.get('CAS_ATTRIBUTE_CALLBACK', None)
     if CAS_ATTRIBUTE_CALLBACK:
@@ -504,7 +506,7 @@ JWT_AUTH.update(ENV_TOKENS.get('JWT_AUTH', {}))
 
 ######################## CUSTOM COURSES for EDX CONNECTOR ######################
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-    INSTALLED_APPS += ('openedx.core.djangoapps.ccxcon',)
+    INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon')
 
 # Partner support link for CMS footer
 PARTNER_SUPPORT_EMAIL = ENV_TOKENS.get('PARTNER_SUPPORT_EMAIL', PARTNER_SUPPORT_EMAIL)

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -57,9 +57,9 @@ DEBUG = True
 # Serve static files at /static directly from the staticfiles directory under test root
 # Note: optimized files for testing are generated with settings from test_static_optimized
 STATIC_URL = "/static/"
-STATICFILES_FINDERS = (
+STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
-)
+]
 STATICFILES_DIRS = [
     (TEST_ROOT / "staticfiles" / "cms").abspath(),
 ]

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -356,10 +356,10 @@ LOGIN_REDIRECT_URL = EDX_ROOT_URL + '/signin'
 LOGIN_URL = EDX_ROOT_URL + '/signin'
 
 # use the ratelimit backend to prevent brute force attacks
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS = [
     'rules.permissions.ObjectPermissionBackend',
     'ratelimitbackend.backends.RateLimitModelBackend',
-)
+]
 
 LMS_BASE = None
 LMS_ROOT_URL = "http://localhost:8000"
@@ -561,7 +561,7 @@ EMAIL_HOST_PASSWORD = ''
 DEFAULT_FROM_EMAIL = 'registration@example.com'
 DEFAULT_FEEDBACK_EMAIL = 'feedback@example.com'
 SERVER_EMAIL = 'devops@example.com'
-ADMINS = ()
+ADMINS = []
 MANAGERS = ADMINS
 
 EDX_PLATFORM_REVISION = os.environ.get('EDX_PLATFORM_REVISION')
@@ -1211,7 +1211,7 @@ for app_name, insert_before in OPTIONAL_APPS:
     try:
         INSTALLED_APPS.insert(INSTALLED_APPS.index(insert_before), app_name)
     except (IndexError, ValueError):
-        INSTALLED_APPS += (app_name,)
+        INSTALLED_APPS.append(app_name)
 
 
 ### ADVANCED_SECURITY_CONFIG

--- a/cms/envs/debug_upload.py
+++ b/cms/envs/debug_upload.py
@@ -5,8 +5,8 @@ progress bars in uploads
 # pylint: disable=unused-wildcard-import
 from .dev import *  # pylint: disable=wildcard-import
 
-FILE_UPLOAD_HANDLERS = (
+FILE_UPLOAD_HANDLERS = [
     'contentstore.debug_file_uploader.DebugFileUploader',
     'django.core.files.uploadhandler.MemoryFileUploadHandler',
     'django.core.files.uploadhandler.TemporaryFileUploadHandler',
-)
+]

--- a/cms/envs/dev.py
+++ b/cms/envs/dev.py
@@ -141,7 +141,8 @@ PIPELINE_SASS_ARGUMENTS = '--debug-info'
 CELERY_ALWAYS_EAGER = True
 
 ################################ DEBUG TOOLBAR #################################
-INSTALLED_APPS += ('debug_toolbar', 'debug_toolbar_mongo', 'djpyfs')
+INSTALLED_APPS += ['debug_toolbar', 'debug_toolbar_mongo', 'djpyfs']
+
 MIDDLEWARE_CLASSES.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 INTERNAL_IPS = ('127.0.0.1',)
 

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -63,7 +63,9 @@ DJFS = {
 CELERY_ALWAYS_EAGER = True
 
 ################################ DEBUG TOOLBAR ################################
-INSTALLED_APPS += ('debug_toolbar', 'debug_toolbar_mongo')
+
+INSTALLED_APPS += ['debug_toolbar', 'debug_toolbar_mongo']
+
 MIDDLEWARE_CLASSES.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 INTERNAL_IPS = ('127.0.0.1',)
 

--- a/cms/envs/devstack_optimized.py
+++ b/cms/envs/devstack_optimized.py
@@ -43,9 +43,9 @@ STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 #  Serve static files at /static directly from the staticfiles directory under test root.
 # Note: optimized files for testing are generated with settings from test_static_optimized
 STATIC_URL = "/static/"
-STATICFILES_FINDERS = (
+STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
-)
+]
 STATICFILES_DIRS = [
     (TEST_ROOT / "staticfiles" / "cms").abspath(),
 ]

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -67,8 +67,8 @@ TEST_ROOT = path('test_root')
 
 # Want static files in the same dir for running on jenkins.
 STATIC_ROOT = TEST_ROOT / "staticfiles"
-INSTALLED_APPS = tuple(app for app in INSTALLED_APPS if app != 'webpack_loader')
-INSTALLED_APPS += ('openedx.tests.util.webpack_loader',)
+INSTALLED_APPS = [app for app in INSTALLED_APPS if app != 'webpack_loader']
+INSTALLED_APPS.append('openedx.tests.util.webpack_loader')
 WEBPACK_LOADER['DEFAULT']['STATS_FILE'] = STATIC_ROOT / "webpack-stats.json"
 
 GITHUB_REPO_ROOT = TEST_ROOT / "data"
@@ -215,10 +215,10 @@ VIDEO_SOURCE_PORT = 8777
 
 ################### Make tests faster
 # http://slacy.com/blog/2012/04/make-your-tests-faster-in-django-1-4/
-PASSWORD_HASHERS = (
+PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.SHA1PasswordHasher',
     'django.contrib.auth.hashers.MD5PasswordHasher',
-)
+]
 
 # No segment key
 CMS_SEGMENT_KEY = None
@@ -336,11 +336,11 @@ FEATURES['ENABLE_TEAMS'] = True
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
 
 ######### custom courses #########
-INSTALLED_APPS += ('openedx.core.djangoapps.ccxcon',)
+INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon')
 FEATURES['CUSTOM_COURSES_EDX'] = True
 
 # API access management -- needed for simple-history to run.
-INSTALLED_APPS += ('openedx.core.djangoapps.api_admin',)
+INSTALLED_APPS.append('openedx.core.djangoapps.api_admin')
 
 ########################## VIDEO IMAGE STORAGE ############################
 VIDEO_IMAGE_SETTINGS = dict(

--- a/cms/envs/yaml_config.py
+++ b/cms/envs/yaml_config.py
@@ -194,7 +194,7 @@ if SESSION_COOKIE_NAME:
 
 # Additional installed apps
 for app in ADDL_INSTALLED_APPS:
-    INSTALLED_APPS += (app,)
+    INSTALLED_APPS.append(app)
 
 
 LOGGING = get_logger_config(LOG_DIR,
@@ -204,11 +204,13 @@ LOGGING = get_logger_config(LOG_DIR,
                             service_variant=SERVICE_VARIANT)
 
 if AUTH_USE_CAS:
-    AUTHENTICATION_BACKENDS = (
+    AUTHENTICATION_BACKENDS = [
         'django.contrib.auth.backends.ModelBackend',
         'django_cas.backends.CASBackend',
-    )
-    INSTALLED_APPS += ('django_cas',)
+    ]
+
+    INSTALLED_APPS.append('django_cas')
+
     MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware')
     if CAS_ATTRIBUTE_CALLBACK:
         import importlib
@@ -256,7 +258,7 @@ BROKER_USE_SSL = ENV_TOKENS.get('CELERY_BROKER_USE_SSL', False)
 
 ######################## CUSTOM COURSES for EDX CONNECTOR ######################
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-    INSTALLED_APPS += ('openedx.core.djangoapps.ccxcon',)
+    INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon')
 
 ########################## Extra middleware classes  #######################
 

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -11,9 +11,7 @@ If true, it:
 """
 
 _FIELDS_STORED_IN_SESSION = ['auth_entry', 'next']
-_MIDDLEWARE_CLASSES = [
-    'third_party_auth.middleware.ExceptionMiddleware',
-]
+_MIDDLEWARE_CLASSES = ['third_party_auth.middleware.ExceptionMiddleware']
 _SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/dashboard'
 _SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS = {
     'msafed': 0

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -5,10 +5,11 @@ import unittest
 from third_party_auth import provider, settings
 from third_party_auth.tests import testutil
 
-_ORIGINAL_AUTHENTICATION_BACKENDS = ('first_authentication_backend',)
-_ORIGINAL_INSTALLED_APPS = ('first_installed_app',)
+
+_ORIGINAL_AUTHENTICATION_BACKENDS = ['first_authentication_backend']
+_ORIGINAL_INSTALLED_APPS = ['first_installed_app']
 _ORIGINAL_MIDDLEWARE_CLASSES = ['first_middleware_class']
-_ORIGINAL_TEMPLATE_CONTEXT_PROCESSORS = ('first_template_context_preprocessor',)
+_ORIGINAL_TEMPLATE_CONTEXT_PROCESSORS = ['first_template_context_preprocessor']
 _SETTINGS_MAP = {
     'AUTHENTICATION_BACKENDS': _ORIGINAL_AUTHENTICATION_BACKENDS,
     'INSTALLED_APPS': _ORIGINAL_INSTALLED_APPS,

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -142,7 +142,7 @@ USE_I18N = True
 FEATURES['ENABLE_FEEDBACK_SUBMISSION'] = False
 
 # Include the lettuce app for acceptance testing, including the 'harvest' django-admin command
-INSTALLED_APPS += ('lettuce.django',)
+INSTALLED_APPS.append('lettuce.django')
 LETTUCE_APPS = ('courseware', 'instructor')
 
 # Lettuce appears to have a bug that causes it to search

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -339,7 +339,7 @@ USE_I18N = ENV_TOKENS.get('USE_I18N', USE_I18N)
 
 # Additional installed apps
 for app in ENV_TOKENS.get('ADDL_INSTALLED_APPS', []):
-    INSTALLED_APPS += (app,)
+    INSTALLED_APPS.append(app)
 
 WIKI_ENABLED = ENV_TOKENS.get('WIKI_ENABLED', WIKI_ENABLED)
 local_loglevel = ENV_TOKENS.get('LOCAL_LOGLEVEL', 'INFO')
@@ -399,11 +399,13 @@ SSL_AUTH_DN_FORMAT_STRING = ENV_TOKENS.get(
 CAS_EXTRA_LOGIN_PARAMS = ENV_TOKENS.get("CAS_EXTRA_LOGIN_PARAMS", None)
 if FEATURES.get('AUTH_USE_CAS'):
     CAS_SERVER_URL = ENV_TOKENS.get("CAS_SERVER_URL", None)
-    AUTHENTICATION_BACKENDS = (
+    AUTHENTICATION_BACKENDS = [
         'django.contrib.auth.backends.ModelBackend',
         'django_cas.backends.CASBackend',
-    )
-    INSTALLED_APPS += ('django_cas',)
+    ]
+
+    INSTALLED_APPS.append('django_cas')
+
     MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware')
     CAS_ATTRIBUTE_CALLBACK = ENV_TOKENS.get('CAS_ATTRIBUTE_CALLBACK', None)
     if CAS_ATTRIBUTE_CALLBACK:
@@ -675,16 +677,17 @@ X_FRAME_OPTIONS = ENV_TOKENS.get('X_FRAME_OPTIONS', X_FRAME_OPTIONS)
 
 ##### Third-party auth options ################################################
 if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
-    AUTHENTICATION_BACKENDS = (
-        ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
-            'social_core.backends.google.GoogleOAuth2',
-            'social_core.backends.linkedin.LinkedinOAuth2',
-            'social_core.backends.facebook.FacebookOAuth2',
-            'social_core.backends.azuread.AzureADOAuth2',
-            'third_party_auth.saml.SAMLAuthBackend',
-            'third_party_auth.lti.LTIAuthBackend',
-        ]) + list(AUTHENTICATION_BACKENDS)
-    )
+    tmp_backends = ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
+        'social_core.backends.google.GoogleOAuth2',
+        'social_core.backends.linkedin.LinkedinOAuth2',
+        'social_core.backends.facebook.FacebookOAuth2',
+        'social_core.backends.azuread.AzureADOAuth2',
+        'third_party_auth.saml.SAMLAuthBackend',
+        'third_party_auth.lti.LTIAuthBackend',
+    ])
+
+    AUTHENTICATION_BACKENDS = list(tmp_backends) + list(AUTHENTICATION_BACKENDS)
+    del tmp_backends
 
     # The reduced session expiry time during the third party login pipeline. (Value in seconds)
     SOCIAL_AUTH_PIPELINE_TIMEOUT = ENV_TOKENS.get('SOCIAL_AUTH_PIPELINE_TIMEOUT', 600)
@@ -819,7 +822,7 @@ ECOMMERCE_SERVICE_WORKER_USERNAME = ENV_TOKENS.get(
 
 ##### Custom Courses for EdX #####
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-    INSTALLED_APPS += ('lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon')
+    INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon']
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
         'lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider',
     )
@@ -865,8 +868,8 @@ CREDIT_PROVIDER_SECRET_KEYS = AUTH_TOKENS.get("CREDIT_PROVIDER_SECRET_KEYS", {})
 
 ##################### LTI Provider #####################
 if FEATURES.get('ENABLE_LTI_PROVIDER'):
-    INSTALLED_APPS += ('lti_provider',)
-    AUTHENTICATION_BACKENDS += ('lti_provider.users.LtiBackend', )
+    INSTALLED_APPS.append('lti_provider')
+    AUTHENTICATION_BACKENDS.append('lti_provider.users.LtiBackend')
 
 LTI_USER_EMAIL_DOMAIN = ENV_TOKENS.get('LTI_USER_EMAIL_DOMAIN', 'lti.example.com')
 
@@ -918,7 +921,7 @@ CREDENTIALS_GENERATION_ROUTING_KEY = ENV_TOKENS.get('CREDENTIALS_GENERATION_ROUT
 
 # The extended StudentModule history table
 if FEATURES.get('ENABLE_CSMH_EXTENDED'):
-    INSTALLED_APPS += ('coursewarehistoryextended',)
+    INSTALLED_APPS.append('coursewarehistoryextended')
 
 API_ACCESS_MANAGER_EMAIL = ENV_TOKENS.get('API_ACCESS_MANAGER_EMAIL')
 API_ACCESS_FROM_EMAIL = ENV_TOKENS.get('API_ACCESS_FROM_EMAIL')

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -57,9 +57,7 @@ DEBUG = True
 # Serve static files at /static directly from the staticfiles directory under test root
 # Note: optimized files for testing are generated with settings from test_static_optimized
 STATIC_URL = "/static/"
-STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-)
+STATICFILES_FINDERS = ['django.contrib.staticfiles.finders.FileSystemFinder']
 STATICFILES_DIRS = [
     (TEST_ROOT / "staticfiles" / "lms").abspath(),
 ]
@@ -221,7 +219,7 @@ PROFILE_IMAGE_BACKEND = {
 
 # Make sure we test with the extended history table
 FEATURES['ENABLE_CSMH_EXTENDED'] = True
-INSTALLED_APPS += ('coursewarehistoryextended',)
+INSTALLED_APPS.append('coursewarehistoryextended')
 
 BADGING_BACKEND = 'lms.djangoapps.badges.backends.tests.dummy_backend.DummyBackend'
 

--- a/lms/envs/cms/acceptance.py
+++ b/lms/envs/cms/acceptance.py
@@ -12,8 +12,7 @@ from .dev import *
 
 #  REMOVE DEBUG TOOLBAR
 
-INSTALLED_APPS = tuple(e for e in INSTALLED_APPS if e != 'debug_toolbar')
-INSTALLED_APPS = tuple(e for e in INSTALLED_APPS if e != 'debug_toolbar_mongo')
+INSTALLED_APPS = [e for e in INSTALLED_APPS if e != 'debug_toolbar' and e != 'debug_toolbar_mongo']
 
 MIDDLEWARE_CLASSES = [e for e in MIDDLEWARE_CLASSES if e != 'debug_toolbar.middleware.DebugToolbarMiddleware']
 
@@ -21,7 +20,6 @@ MIDDLEWARE_CLASSES = [e for e in MIDDLEWARE_CLASSES if e != 'debug_toolbar.middl
 ########################### LETTUCE TESTING ##########################
 FEATURES['DISPLAY_TOY_COURSES'] = True
 
-INSTALLED_APPS += ('lettuce.django',)
-# INSTALLED_APPS += ('portal',)
+INSTALLED_APPS.append('lettuce.django')
 
 LETTUCE_APPS = ('portal',)  # dummy app covers the home page, login, registration, and course enrollment

--- a/lms/envs/cms/dev.py
+++ b/lms/envs/cms/dev.py
@@ -28,10 +28,7 @@ CONTENTSTORE = {
     }
 }
 
-INSTALLED_APPS += (
-    # Mongo perf stats
-    'debug_toolbar_mongo',
-)
+INSTALLED_APPS.append('debug_toolbar_mongo')
 
 
 DEBUG_TOOLBAR_PANELS += (

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -599,9 +599,7 @@ DEFAULT_TEMPLATE_ENGINE = TEMPLATES[0]
 ###############################################################################################
 
 # use the ratelimit backend to prevent brute force attacks
-AUTHENTICATION_BACKENDS = (
-    'ratelimitbackend.backends.RateLimitModelBackend',
-)
+AUTHENTICATION_BACKENDS = ['ratelimitbackend.backends.RateLimitModelBackend']
 STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
@@ -918,7 +916,7 @@ LANGUAGES_BIDI = ("he", "ar", "fa", "ur", "fa-ir", "rtl")
 LANGUAGE_COOKIE = "openedx-language-preference"
 
 # Sourced from http://www.localeplanet.com/icu/ and wikipedia
-LANGUAGES = (
+LANGUAGES = [
     ('en', u'English'),
     ('rtl', u'Right-to-Left Test Language'),
     ('eo', u'Dummy Language (Esperanto)'),  # Dummy languaged used for testing
@@ -1000,7 +998,7 @@ LANGUAGES = (
     ('zh-cn', u'中文 (简体)'),  # Chinese (China)
     ('zh-hk', u'中文 (香港)'),  # Chinese (Hong Kong)
     ('zh-tw', u'中文 (台灣)'),  # Chinese (Taiwan)
-)
+]
 
 LANGUAGE_DICT = dict(LANGUAGES)
 
@@ -2459,7 +2457,7 @@ DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH = "verify_student_disable_account_
 ### This enables the Metrics tab for the Instructor dashboard ###########
 FEATURES['CLASS_DASHBOARD'] = False
 if FEATURES.get('CLASS_DASHBOARD'):
-    INSTALLED_APPS += ('class_dashboard',)
+    INSTALLED_APPS.append('class_dashboard')
 
 ################ Enable credit eligibility feature ####################
 ENABLE_CREDIT_ELIGIBILITY = True
@@ -2469,11 +2467,13 @@ FEATURES['ENABLE_CREDIT_ELIGIBILITY'] = ENABLE_CREDIT_ELIGIBILITY
 
 if FEATURES.get('AUTH_USE_CAS'):
     CAS_SERVER_URL = 'https://provide_your_cas_url_here'
-    AUTHENTICATION_BACKENDS = (
+    AUTHENTICATION_BACKENDS = [
         'django.contrib.auth.backends.ModelBackend',
         'django_cas.backends.CASBackend',
-    )
-    INSTALLED_APPS += ('django_cas',)
+    ]
+
+    INSTALLED_APPS.append('django_cas')
+
     MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware')
 
 ############# Cross-domain requests #################
@@ -2627,7 +2627,7 @@ VIDEO_TRANSCRIPTS_SETTINGS = dict(
 # http://loc.gov/standards/iso639-2/ISO-639-2_utf-8.txt according to http://en.wikipedia.org/wiki/ISO_639-1
 # Note that this is used as the set of choices to the `code` field of the
 # `LanguageProficiency` model.
-ALL_LANGUAGES = (
+ALL_LANGUAGES = [
     [u"aa", u"Afar"],
     [u"ab", u"Abkhazian"],
     [u"af", u"Afrikaans"],
@@ -2814,13 +2814,13 @@ ALL_LANGUAGES = (
     [u"yo", u"Yoruba"],
     [u"za", u"Zhuang"],
     [u"zu", u"Zulu"]
-)
+]
 
 
 ### Apps only installed in some instances
 # The order of INSTALLED_APPS matters, so this tuple is the app name and the item in INSTALLED_APPS
 # that this app should be inserted *before*. A None here means it should be appended to the list.
-OPTIONAL_APPS = (
+OPTIONAL_APPS = [
     ('mentoring', None),
     ('problem_builder', 'openedx.core.djangoapps.content.course_overviews'),
     ('edx_sga', None),
@@ -2850,7 +2850,7 @@ OPTIONAL_APPS = (
 
     # Required by the Enterprise App
     ('django_object_actions', None),  # https://github.com/crccheck/django-object-actions
-)
+]
 
 for app_name, insert_before in OPTIONAL_APPS:
     # First attempt to only find the module rather than actually importing it,
@@ -2867,7 +2867,7 @@ for app_name, insert_before in OPTIONAL_APPS:
     try:
         INSTALLED_APPS.insert(INSTALLED_APPS.index(insert_before), app_name)
     except (IndexError, ValueError):
-        INSTALLED_APPS += (app_name,)
+        INSTALLED_APPS.append(app_name)
 
 ### ADVANCED_SECURITY_CONFIG
 # Empty by default

--- a/lms/envs/content.py
+++ b/lms/envs/content.py
@@ -15,7 +15,8 @@ TEMPLATE_DEBUG = True
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 ################################ DEBUG TOOLBAR #################################
-INSTALLED_APPS += ('debug_toolbar',)
+INSTALLED_APPS.append('debug_toolbar')
+
 MIDDLEWARE_CLASSES.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 
 DEBUG_TOOLBAR_PANELS = (

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -161,7 +161,7 @@ EDX_PLATFORM_VERSION_STRING = os.popen('cd %s; git describe' % REPO_ROOT).read()
 FEATURES['ENABLE_LMS_MIGRATION'] = True
 FEATURES['XQA_SERVER'] = 'http://xqa:server@content-qa.edX.mit.edu/xqa'
 
-INSTALLED_APPS += ('lms_migration',)
+INSTALLED_APPS.append('lms_migration')
 
 LMS_MIGRATION_ALLOWED_IPS = ['127.0.0.1']
 
@@ -196,11 +196,12 @@ CELERY_ALWAYS_EAGER = True
 
 ################################ DEBUG TOOLBAR ################################
 
-INSTALLED_APPS += ('debug_toolbar', 'djpyfs',)
-MIDDLEWARE_CLASSES.extend([
+INSTALLED_APPS += ['debug_toolbar', 'djpyfs']
+MIDDLEWARE_CLASSES += [
     'django_comment_client.utils.QueryCountDebugMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-])
+]
+
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (
@@ -222,10 +223,10 @@ MEDIA_ROOT = ENV_ROOT / "uploads"
 MEDIA_URL = "/static/uploads/"
 STATICFILES_DIRS.append(("uploads", MEDIA_ROOT))
 FILE_UPLOAD_TEMP_DIR = ENV_ROOT / "uploads"
-FILE_UPLOAD_HANDLERS = (
+FILE_UPLOAD_HANDLERS = [
     'django.core.files.uploadhandler.MemoryFileUploadHandler',
     'django.core.files.uploadhandler.TemporaryFileUploadHandler',
-)
+]
 
 FEATURES['AUTH_USE_SHIB'] = True
 FEATURES['RESTRICT_ENROLL_BY_REG_METHOD'] = True

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -57,11 +57,12 @@ DJFS = {
 
 ################################ DEBUG TOOLBAR ################################
 
-INSTALLED_APPS += ('debug_toolbar', 'debug_toolbar_mongo')
-MIDDLEWARE_CLASSES.extend([
+INSTALLED_APPS += ['debug_toolbar', 'debug_toolbar_mongo']
+MIDDLEWARE_CLASSES += [
     'django_comment_client.utils.QueryCountDebugMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-])
+]
+
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (

--- a/lms/envs/devstack_optimized.py
+++ b/lms/envs/devstack_optimized.py
@@ -43,9 +43,7 @@ STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 #  Serve static files at /static directly from the staticfiles directory under test root.
 # Note: optimized files for testing are generated with settings from test_static_optimized
 STATIC_URL = "/static/"
-STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-)
+STATICFILES_FINDERS = ['django.contrib.staticfiles.finders.FileSystemFinder']
 STATICFILES_DIRS = [
     (TEST_ROOT / "staticfiles" / "lms").abspath(),
 ]

--- a/lms/envs/static.py
+++ b/lms/envs/static.py
@@ -65,7 +65,7 @@ DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 MEDIA_ROOT = ENV_ROOT / "uploads"
 MEDIA_URL = "/discussion/upfiles/"
 FILE_UPLOAD_TEMP_DIR = ENV_ROOT / "uploads"
-FILE_UPLOAD_HANDLERS = (
+FILE_UPLOAD_HANDLERS = [
     'django.core.files.uploadhandler.MemoryFileUploadHandler',
     'django.core.files.uploadhandler.TemporaryFileUploadHandler',
-)
+]

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -113,8 +113,8 @@ NOSE_PLUGINS = [
 TEST_ROOT = path("test_root")
 # Want static files in the same dir for running on jenkins.
 STATIC_ROOT = TEST_ROOT / "staticfiles"
-INSTALLED_APPS = tuple(app for app in INSTALLED_APPS if app != 'webpack_loader')
-INSTALLED_APPS += ('openedx.tests.util.webpack_loader',)
+INSTALLED_APPS = [app for app in INSTALLED_APPS if app != 'webpack_loader']
+INSTALLED_APPS.append('openedx.tests.util.webpack_loader')
 WEBPACK_LOADER['DEFAULT']['STATS_FILE'] = STATIC_ROOT / "webpack-stats.json"
 
 STATUS_MESSAGE_PATH = TEST_ROOT / "status_message.json"
@@ -208,7 +208,7 @@ if os.environ.get('DISABLE_MIGRATIONS'):
 
 # Make sure we test with the extended history table
 FEATURES['ENABLE_CSMH_EXTENDED'] = True
-INSTALLED_APPS += ('coursewarehistoryextended',)
+INSTALLED_APPS.append('coursewarehistoryextended')
 
 CACHES = {
     # This is the cache used for most things.
@@ -263,7 +263,7 @@ PASSWORD_COMPLEXITY = {}
 ######### Third-party auth ##########
 FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
 
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS = [
     'social_core.backends.google.GoogleOAuth2',
     'social_core.backends.linkedin.LinkedinOAuth2',
     'social_core.backends.facebook.FacebookOAuth2',
@@ -272,7 +272,7 @@ AUTHENTICATION_BACKENDS = (
     'third_party_auth.dummy.DummyBackend',
     'third_party_auth.saml.SAMLAuthBackend',
     'third_party_auth.lti.LTIAuthBackend',
-) + AUTHENTICATION_BACKENDS
+] + AUTHENTICATION_BACKENDS
 
 THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS = {
     'custom1': {
@@ -390,10 +390,10 @@ for static_dir in STATICFILES_DIRS:
 STATICFILES_DIRS = _NEW_STATICFILES_DIRS
 
 FILE_UPLOAD_TEMP_DIR = TEST_ROOT / "uploads"
-FILE_UPLOAD_HANDLERS = (
+FILE_UPLOAD_HANDLERS = [
     'django.core.files.uploadhandler.MemoryFileUploadHandler',
     'django.core.files.uploadhandler.TemporaryFileUploadHandler',
-)
+]
 
 ########################### Server Ports ###################################
 
@@ -415,15 +415,10 @@ HOSTNAME_MODULESTORE_DEFAULT_MAPPINGS = {
 
 ################### Make tests faster
 
-#http://slacy.com/blog/2012/04/make-your-tests-faster-in-django-1-4/
-PASSWORD_HASHERS = (
-    # 'django.contrib.auth.hashers.PBKDF2PasswordHasher',
-    # 'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
-    # 'django.contrib.auth.hashers.BCryptPasswordHasher',
+PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.SHA1PasswordHasher',
     'django.contrib.auth.hashers.MD5PasswordHasher',
-    # 'django.contrib.auth.hashers.CryptPasswordHasher',
-)
+]
 
 ### This enables the Metrics tab for the Instructor dashboard ###########
 FEATURES['CLASS_DASHBOARD'] = True
@@ -562,7 +557,7 @@ FACEBOOK_APP_ID = "Test"
 FACEBOOK_API_VERSION = "v2.8"
 
 ######### custom courses #########
-INSTALLED_APPS += ('lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon')
+INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon']
 FEATURES['CUSTOM_COURSES_EDX'] = True
 
 # Set dummy values for profile image settings.
@@ -581,8 +576,8 @@ PROFILE_IMAGE_MIN_BYTES = 100
 
 # Enable the LTI provider feature for testing
 FEATURES['ENABLE_LTI_PROVIDER'] = True
-INSTALLED_APPS += ('lti_provider',)
-AUTHENTICATION_BACKENDS += ('lti_provider.users.LtiBackend',)
+INSTALLED_APPS.append('lti_provider')
+AUTHENTICATION_BACKENDS.append('lti_provider.users.LtiBackend')
 
 # ORGANIZATIONS
 FEATURES['ORGANIZATIONS_APP'] = True

--- a/lms/envs/test_with_mysql.py
+++ b/lms/envs/test_with_mysql.py
@@ -7,9 +7,9 @@ from .aws import *  # pylint: disable=wildcard-import
 # Dummy secret key for dev
 SECRET_KEY = 'dev key'
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
 
     'lms.djangoapps.verify_student',
-)
+]

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -229,7 +229,7 @@ LANGUAGE_DICT = dict(LANGUAGES)
 
 # Additional installed apps
 for app in ADDL_INSTALLED_APPS:
-    INSTALLED_APPS += (app,)
+    INSTALLED_APPS.append(app)
 
 LOGGING = get_logger_config(LOG_DIR,
                             logging_env=LOGGING_ENV,
@@ -247,12 +247,15 @@ for name, value in ENV_TOKENS.get("CODE_JAIL", {}).items():
 
 
 if FEATURES.get('AUTH_USE_CAS'):
-    AUTHENTICATION_BACKENDS = (
+    AUTHENTICATION_BACKENDS = [
         'django.contrib.auth.backends.ModelBackend',
         'django_cas.backends.CASBackend',
-    )
-    INSTALLED_APPS += ('django_cas',)
-    MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware',)
+    ]
+
+    INSTALLED_APPS.append('django_cas')
+
+    MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware')
+
     if CAS_ATTRIBUTE_CALLBACK:
         import importlib
         CAS_USER_DETAILS_RESOLVER = getattr(
@@ -302,7 +305,7 @@ GRADES_DOWNLOAD_ROUTING_KEY = HIGH_MEM_QUEUE
 
 ##### Custom Courses for EdX #####
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-    INSTALLED_APPS += ('lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon')
+    INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon']
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
         'lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider',
     )
@@ -315,8 +318,8 @@ if FEATURES.get('INDIVIDUAL_DUE_DATES'):
 
 ##################### LTI Provider #####################
 if FEATURES.get('ENABLE_LTI_PROVIDER'):
-    INSTALLED_APPS += ('lti_provider',)
-    AUTHENTICATION_BACKENDS += ('lti_provider.users.LtiBackend', )
+    INSTALLED_APPS.append('lti_provider')
+    AUTHENTICATION_BACKENDS.append('lti_provider.users.LtiBackend')
 
 ################################ Settings for Credentials Service ################################
 


### PR DESCRIPTION
Django 1.9+ has moved to using lists for their iterable settings that were previously tuples. This PR is an attempt to switch over early and uncover any other places in configuration where the move to Django 1.11 may cause issues with these changes (thus the moves to `append` instead of `+=`). See PLAT-1530.