### PR TITLE
[ENT-644] Bump edx-enterprise to 0.46.8.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -49,7 +49,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.46.7
+edx-enterprise==0.46.8
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
This bumps `edx-enterprise` to 0.46.8 and removes a field without generating the migration. The migration comes next. This is **step 2** in the safe deployment of the overall deletion of account-level consent.

**JIRA tickets**: [ENT-644](https://openedx.atlassian.net/browse/ENT-644)

**Dependencies**: https://github.com/edx/edx-platform/pull/16064 which is step 1 in this procedure.

**Testing instructions**:

1. Make sure you can install the package with this version without a problem.

**Reviewers**
- [ ] @haikuginger 
- [ ] @brittneyexline @douglashall 

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```