### PR TITLE
LEARNER-2521 - Only show 'Explore New Courses' button when courses are browsable.

### DIFF
--- a/openedx/features/learner_profile/templates/learner_profile/learner-achievements-fragment.html
+++ b/openedx/features/learner_profile/templates/learner_profile/learner-achievements-fragment.html
@@ -71,12 +71,14 @@ from openedx.core.djangolib.markup import HTML, Text
         % elif own_profile:
             <div class="learner-message">
                 <h4 class="message-header">${_("You haven't earned any certificates yet.")}</h4>
-                <p class="message-actions">
-                    <a class="btn btn-brand" href="${marketing_link('COURSES')}">
-                        <span class="icon fa fa-search" aria-hidden="true"></span>
-                        ${_('Explore New Courses')}
-                    </a>
-                </p>
+                % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
+                    <p class="message-actions">
+                        <a class="btn btn-brand" href="${marketing_link('COURSES')}">
+                            <span class="icon fa fa-search" aria-hidden="true"></span>
+                            ${_('Explore New Courses')}
+                        </a>
+                    </p>
+                % endif
             </div>
         % endif
     % endif

--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -3,6 +3,7 @@
 
 import datetime
 import ddt
+import mock
 
 from certificates.tests.factories import GeneratedCertificateFactory  # pylint: disable=import-error
 from course_modes.models import CourseMode
@@ -197,3 +198,13 @@ class LearnerProfileViewTest(UrlResetMixin, ModuleStoreTestCase):
             self.assertContains(response, 'You haven&#39;t earned any certificates yet.')
         else:
             self.assertNotContains(response, 'You haven&#39;t earned any certificates yet.')
+
+    @ddt.data(True, False)
+    @override_waffle_flag(SHOW_ACHIEVEMENTS_FLAG, active=True)
+    def test_explore_courses_visibility(self, courses_browsable):
+        with mock.patch.dict('django.conf.settings.FEATURES', {'COURSES_ARE_BROWSABLE': courses_browsable}):
+            response = self.client.get('/u/{username}'.format(username=self.user.username))
+            if courses_browsable:
+                self.assertContains(response, 'Explore New Courses')
+            else:
+                self.assertNotContains(response, 'Explore New Courses')


### PR DESCRIPTION
## [LEARNER-2521](https://openedx.atlassian.net/browse/LEARNER-2521)

### Description

Hide the 'Explore New Courses' button from the profile page when the site's courses aren't browsable.

### Acceptance Criteria

- [x] Hide blue CTA for "Find New Courses" on own profile page if discovery is disabled on a given site:

### Sandbox
- [x] https://dianakhuang.sandbox.edx.org/

### Assign Github reviewers (as needed)
- [x] engineering 
- [ ] product

FYI: @edx/learner-mercury
 
### Post-review
- [ ] Rebase and squash commits