### PR TITLE
Encode share course URLs and use the right protocol

### DIFF
--- a/lms/templates/courseware/course_about_sidebar_header.html
+++ b/lms/templates/courseware/course_about_sidebar_header.html
@@ -1,5 +1,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
+import urllib
+
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -24,7 +26,9 @@ from django.conf import settings
             account=static.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
             url=u"http://{domain}{path}".format(
                 domain=site_domain,
-                path=reverse('about_course', args=[course.id.to_deprecated_string()])
+                path=urllib.quote_plus(
+                    reverse('about_course', args=[course.id.to_deprecated_string()])
+                )
             )
         ).replace(u" ", u"+")
         tweet_action = u"http://twitter.com/intent/tweet?text={tweet_text}".format(tweet_text=tweet_text)
@@ -39,7 +43,9 @@ from django.conf import settings
                 platform=platform_name,
                 url=u"http://{domain}{path}".format(
                     domain=site_domain,
-                    path=reverse('about_course', args=[course.id.to_deprecated_string()]),
+                    path=urllib.quote_plus(
+                        reverse('about_course', args=[course.id.to_deprecated_string()]),
+                    )
                 )
             )
         ).replace(u" ", u"%20")

--- a/lms/templates/courseware/course_about_sidebar_header.html
+++ b/lms/templates/courseware/course_about_sidebar_header.html
@@ -16,6 +16,7 @@ from django.conf import settings
     ##       want here (and on this whole page, really).
       <%
         site_domain = static.get_value('site_domain', settings.SITE_NAME)
+        site_protocol = 'https' if settings.HTTPS == 'on' else 'http'
         platform_name = static.get_platform_name()
 
         ## Translators: This text will be automatically posted to the student's
@@ -24,7 +25,8 @@ from django.conf import settings
             number=course.number,
             title=course.display_name_with_default_escaped,
             account=static.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
-            url=u"http://{domain}{path}".format(
+            url=u"{protocol}://{domain}{path}".format(
+                protocol=site_protocol,
                 domain=site_domain,
                 path=urllib.quote_plus(
                     reverse('about_course', args=[course.id.to_deprecated_string()])
@@ -41,7 +43,8 @@ from django.conf import settings
                 number=course.number,
                 title=course.display_name_with_default_escaped,
                 platform=platform_name,
-                url=u"http://{domain}{path}".format(
+                url=u"{protocol}://{domain}{path}".format(
+                    protocol=site_protocol,
                     domain=site_domain,
                     path=urllib.quote_plus(
                         reverse('about_course', args=[course.id.to_deprecated_string()]),


### PR DESCRIPTION
This fixes the social buttons to recommend a course (through Twitter and e-mail) to URL-encode the shared URLs and to use `https://` when required.

Without this fix, the tweet contains this text:
```
I just enrolled in Some Scripting Course through @MyName: http://edu.mydomain.com/courses/course-v1:MyUniversity ABCD100 v1/about
```
With the fix, it gets `https://` and `+` and becomes:
```
I just enrolled in Some Scripting Course through @MyName: https://edu.mydomain.com/courses/course-v1:MyUniversity+ABCD100+v1/about
```

Description goes here. e.g. This PR contains the LibraryContent XBlock, which allows to display library content in a course.

**JIRA tickets**: https://openedx.atlassian.net/browse/OSPR-1923

**Discussions**: None

**Dependencies**: None

**Screenshots**: None

**Sandbox URL**: None

**Partner information**: None

**Deployment targets**: N/A

**Merge deadline**: None

**Testing instructions**:

1. Go to http://localhost:8000/courses/course-v1:edX+DemoX+Demo_Course/about
2. Locate the Twitter icon, in the right, and click it
3. Notice that the Twitter text box contains a URL in the format `http://your_local_hostname/courses/course-v1:edX+DemoX+Demo_Course/about`, with `+` signs (and not spaces)
4. Optionally, check in another instance (without this fix) that the URL had spaces instead of `+` 
5. Deploy an instance which has SSL enabled, with this fix
6. Check that the Twitter message uses `https`, not `http`

**Author notes and concerns**:
None

**Reviewers**
- [ ] @cgopalan
- [ ] edX reviewer[s] TBD

**Settings**
None