### PR TITLE
Update raw sql that uses datetimes to be Django 1.9 compatible

### DIFF
--- a/openedx/core/djangoapps/heartbeat/default_checks.py
+++ b/openedx/core/djangoapps/heartbeat/default_checks.py
@@ -51,7 +51,7 @@ def check_database():
     """
     cursor = connection.cursor()
     try:
-        cursor.execute("SELECT CURRENT_DATE")
+        cursor.execute("SELECT 1")
         cursor.fetchone()
         return 'sql', True, u'OK'
     except DatabaseError as fail:


### PR DESCRIPTION
For PLAT-1531, see [Diango 1.9 Release Notes](https://docs.djangoproject.com/en/1.11/releases/1.9/#removal-of-time-zone-aware-global-adapters-and-converters-for-datetimes)