### PR TITLE
Add middleware classes dynamically from configuration

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -264,7 +264,7 @@ if FEATURES.get('AUTH_USE_CAS'):
         'django_cas.backends.CASBackend',
     )
     INSTALLED_APPS += ('django_cas',)
-    MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
+    MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware')
     CAS_ATTRIBUTE_CALLBACK = ENV_TOKENS.get('CAS_ATTRIBUTE_CALLBACK', None)
     if CAS_ATTRIBUTE_CALLBACK:
         import importlib
@@ -523,3 +523,8 @@ PARENTAL_CONSENT_AGE_LIMIT = ENV_TOKENS.get(
     'PARENTAL_CONSENT_AGE_LIMIT',
     PARENTAL_CONSENT_AGE_LIMIT
 )
+
+########################## Extra middleware classes  #######################
+
+# Allow extra middleware classes to be added to the app through configuration.
+MIDDLEWARE_CLASSES.extend(ENV_TOKENS.get('EXTRA_MIDDLEWARE_CLASSES', []))

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -395,7 +395,7 @@ simplefilter('ignore')
 
 ################################# Middleware ###################################
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     'crum.CurrentRequestUserMiddleware',
     'request_cache.middleware.RequestCache',
 
@@ -453,7 +453,7 @@ MIDDLEWARE_CLASSES = (
 
     # This must be last so that it runs first in the process_response chain
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
-)
+]
 
 # Clickjacking protection can be enabled by setting this to 'DENY'
 X_FRAME_OPTIONS = 'ALLOW'

--- a/cms/envs/dev.py
+++ b/cms/envs/dev.py
@@ -142,7 +142,7 @@ CELERY_ALWAYS_EAGER = True
 
 ################################ DEBUG TOOLBAR #################################
 INSTALLED_APPS += ('debug_toolbar', 'debug_toolbar_mongo', 'djpyfs')
-MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+MIDDLEWARE_CLASSES.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -64,7 +64,7 @@ CELERY_ALWAYS_EAGER = True
 
 ################################ DEBUG TOOLBAR ################################
 INSTALLED_APPS += ('debug_toolbar', 'debug_toolbar_mongo')
-MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+MIDDLEWARE_CLASSES.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (

--- a/cms/envs/yaml_config.py
+++ b/cms/envs/yaml_config.py
@@ -209,7 +209,7 @@ if AUTH_USE_CAS:
         'django_cas.backends.CASBackend',
     )
     INSTALLED_APPS += ('django_cas',)
-    MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
+    MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware')
     if CAS_ATTRIBUTE_CALLBACK:
         import importlib
         CAS_USER_DETAILS_RESOLVER = getattr(
@@ -257,3 +257,8 @@ BROKER_USE_SSL = ENV_TOKENS.get('CELERY_BROKER_USE_SSL', False)
 ######################## CUSTOM COURSES for EDX CONNECTOR ######################
 if FEATURES.get('CUSTOM_COURSES_EDX'):
     INSTALLED_APPS += ('openedx.core.djangoapps.ccxcon',)
+
+########################## Extra middleware classes  #######################
+
+# Allow extra middleware classes to be added to the app through configuration.
+MIDDLEWARE_CLASSES.extend(ENV_TOKENS.get('EXTRA_MIDDLEWARE_CLASSES', []))

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -11,9 +11,9 @@ If true, it:
 """
 
 _FIELDS_STORED_IN_SESSION = ['auth_entry', 'next']
-_MIDDLEWARE_CLASSES = (
+_MIDDLEWARE_CLASSES = [
     'third_party_auth.middleware.ExceptionMiddleware',
-)
+]
 _SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/dashboard'
 _SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS = {
     'msafed': 0
@@ -28,7 +28,7 @@ def apply_settings(django_settings):
     django_settings.FIELDS_STORED_IN_SESSION = _FIELDS_STORED_IN_SESSION
 
     # Inject exception middleware to make redirects fire.
-    django_settings.MIDDLEWARE_CLASSES += _MIDDLEWARE_CLASSES
+    django_settings.MIDDLEWARE_CLASSES.extend(_MIDDLEWARE_CLASSES)
 
     # Where to send the user if there's an error during social authentication
     # and we cannot send them to a more specific URL

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -7,7 +7,7 @@ from third_party_auth.tests import testutil
 
 _ORIGINAL_AUTHENTICATION_BACKENDS = ('first_authentication_backend',)
 _ORIGINAL_INSTALLED_APPS = ('first_installed_app',)
-_ORIGINAL_MIDDLEWARE_CLASSES = ('first_middleware_class',)
+_ORIGINAL_MIDDLEWARE_CLASSES = ['first_middleware_class']
 _ORIGINAL_TEMPLATE_CONTEXT_PROCESSORS = ('first_template_context_preprocessor',)
 _SETTINGS_MAP = {
     'AUTHENTICATION_BACKENDS': _ORIGINAL_AUTHENTICATION_BACKENDS,

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -404,7 +404,7 @@ if FEATURES.get('AUTH_USE_CAS'):
         'django_cas.backends.CASBackend',
     )
     INSTALLED_APPS += ('django_cas',)
-    MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
+    MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware')
     CAS_ATTRIBUTE_CALLBACK = ENV_TOKENS.get('CAS_ATTRIBUTE_CALLBACK', None)
     if CAS_ATTRIBUTE_CALLBACK:
         import importlib
@@ -1050,3 +1050,8 @@ ACE_CHANNEL_SAILTHRU_TEMPLATE_NAME = ENV_TOKENS.get('ACE_CHANNEL_SAILTHRU_TEMPLA
 ACE_CHANNEL_SAILTHRU_API_KEY = AUTH_TOKENS.get('ACE_CHANNEL_SAILTHRU_API_KEY', ACE_CHANNEL_SAILTHRU_API_KEY)
 ACE_CHANNEL_SAILTHRU_API_SECRET = AUTH_TOKENS.get('ACE_CHANNEL_SAILTHRU_API_SECRET', ACE_CHANNEL_SAILTHRU_API_SECRET)
 ACE_ROUTING_KEY = ENV_TOKENS.get('ACE_ROUTING_KEY', ACE_ROUTING_KEY)
+
+########################## Extra middleware classes  #######################
+
+# Allow extra middleware classes to be added to the app through configuration.
+MIDDLEWARE_CLASSES.extend(ENV_TOKENS.get('EXTRA_MIDDLEWARE_CLASSES', []))

--- a/lms/envs/cms/acceptance.py
+++ b/lms/envs/cms/acceptance.py
@@ -15,8 +15,7 @@ from .dev import *
 INSTALLED_APPS = tuple(e for e in INSTALLED_APPS if e != 'debug_toolbar')
 INSTALLED_APPS = tuple(e for e in INSTALLED_APPS if e != 'debug_toolbar_mongo')
 
-MIDDLEWARE_CLASSES = tuple(e for e in MIDDLEWARE_CLASSES
-                           if e != 'debug_toolbar.middleware.DebugToolbarMiddleware')
+MIDDLEWARE_CLASSES = [e for e in MIDDLEWARE_CLASSES if e != 'debug_toolbar.middleware.DebugToolbarMiddleware']
 
 
 ########################### LETTUCE TESTING ##########################

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1168,7 +1168,7 @@ simplefilter('ignore')
 
 ################################# Middleware ###################################
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     'crum.CurrentRequestUserMiddleware',
 
     'request_cache.middleware.RequestCache',
@@ -1253,7 +1253,7 @@ MIDDLEWARE_CLASSES = (
 
     # This must be last
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
-)
+]
 
 # Clickjacking protection can be enabled by setting this to 'DENY'
 X_FRAME_OPTIONS = 'ALLOW'
@@ -2474,7 +2474,7 @@ if FEATURES.get('AUTH_USE_CAS'):
         'django_cas.backends.CASBackend',
     )
     INSTALLED_APPS += ('django_cas',)
-    MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
+    MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware')
 
 ############# Cross-domain requests #################
 

--- a/lms/envs/content.py
+++ b/lms/envs/content.py
@@ -16,7 +16,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 ################################ DEBUG TOOLBAR #################################
 INSTALLED_APPS += ('debug_toolbar',)
-MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+MIDDLEWARE_CLASSES.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 
 DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.versions.VersionsPanel',

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -197,10 +197,10 @@ CELERY_ALWAYS_EAGER = True
 ################################ DEBUG TOOLBAR ################################
 
 INSTALLED_APPS += ('debug_toolbar', 'djpyfs',)
-MIDDLEWARE_CLASSES += (
+MIDDLEWARE_CLASSES.extend([
     'django_comment_client.utils.QueryCountDebugMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-)
+])
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -58,10 +58,10 @@ DJFS = {
 ################################ DEBUG TOOLBAR ################################
 
 INSTALLED_APPS += ('debug_toolbar', 'debug_toolbar_mongo')
-MIDDLEWARE_CLASSES += (
+MIDDLEWARE_CLASSES.extend([
     'django_comment_client.utils.QueryCountDebugMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-)
+])
 INTERNAL_IPS = ('127.0.0.1',)
 
 DEBUG_TOOLBAR_PANELS = (

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -252,7 +252,7 @@ if FEATURES.get('AUTH_USE_CAS'):
         'django_cas.backends.CASBackend',
     )
     INSTALLED_APPS += ('django_cas',)
-    MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
+    MIDDLEWARE_CLASSES.append('django_cas.middleware.CASMiddleware',)
     if CAS_ATTRIBUTE_CALLBACK:
         import importlib
         CAS_USER_DETAILS_RESOLVER = getattr(
@@ -321,3 +321,8 @@ if FEATURES.get('ENABLE_LTI_PROVIDER'):
 ################################ Settings for Credentials Service ################################
 
 CREDENTIALS_GENERATION_ROUTING_KEY = HIGH_PRIORITY_QUEUE
+
+########################## Extra middleware classes  #######################
+
+# Allow extra middleware classes to be added to the app through configuration.
+MIDDLEWARE_CLASSES.extend(ENV_TOKENS.get('EXTRA_MIDDLEWARE_CLASSES', []))


### PR DESCRIPTION
This pull request adds the capability to add additional middleware classes to edxapp through configuration, and without explicitly adding them to a `settings.py` file.

**Dependencies**: Works in conjunction with edx/configuration#4112

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**:

1. On the sandbox, check that the marketing parameter middleware takes effect ([see testing details here](https://github.com/open-craft/edx-theme/pull/16)), OR
2. On a devstack, create a middleware to do something, install it in your devstack's Python environment, and add it to the `EXTRA_MIDDLEWARE_CLASSES` list in `lms.env.json`; verify that it takes effect for incoming requests.

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
EDXAPP_EXTRA_REQUIREMENTS:
  - name: "git+https://gitlab.com/opencraft/client/pearsonx-marketing-middleware.git@haikuginger/create-middleware#egg=marketing-middleware==0.0"
EDXAPP_EXTRA_MIDDLEWARE_CLASSES:
  - "marketing_middleware.middleware.CacheMarketingParametersMiddleware"
# Theme
EDXAPP_ENABLE_COMPREHENSIVE_THEMING: true
EDXAPP_COMPREHENSIVE_THEME_DIRS:
  - '/edx/app/edxapp/themes'
EDXAPP_DEFAULT_SITE_THEME: 'pearsonx'
edxapp_theme_name: 'pearsonx'
edxapp_theme_source_repo: 'https://github.com/open-craft/edx-theme.git'
edxapp_theme_version: 'haikuginger/pearsonx-marketing-params'
```