### PR TITLE
Remove "final course details" message, replace with another

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -31,7 +31,7 @@ VERIFY_STATUS_NEED_TO_REVERIFY = "verify_need_to_reverify"
 
 DISABLE_UNENROLL_CERT_STATES = [
     'generating',
-    'ready',
+    'downloadable',
 ]
 
 

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -84,6 +84,7 @@ class CourseEndingTest(TestCase):
             {
                 'status': 'processing',
                 'show_disabled_download_button': False,
+                'certificate_message_viewable': False,
                 'show_download_url': False,
                 'show_survey_button': False,
                 'can_unenroll': True,
@@ -96,6 +97,7 @@ class CourseEndingTest(TestCase):
             {
                 'status': 'processing',
                 'show_disabled_download_button': False,
+                'certificate_message_viewable': True,
                 'show_download_url': False,
                 'show_survey_button': False,
                 'mode': None,
@@ -112,6 +114,7 @@ class CourseEndingTest(TestCase):
                 {
                     'status': 'generating',
                     'show_disabled_download_button': True,
+                    'certificate_message_viewable': True,
                     'show_download_url': False,
                     'show_survey_button': True,
                     'survey_url': survey_url,
@@ -128,6 +131,7 @@ class CourseEndingTest(TestCase):
             {
                 'status': 'generating',
                 'show_disabled_download_button': True,
+                'certificate_message_viewable': True,
                 'show_download_url': False,
                 'show_survey_button': True,
                 'survey_url': survey_url,
@@ -140,7 +144,8 @@ class CourseEndingTest(TestCase):
 
         download_url = 'http://s3.edx/cert'
         cert_status = {
-            'status': 'downloadable', 'grade': '0.67',
+            'status': 'downloadable',
+            'grade': '0.67',
             'download_url': download_url,
             'mode': 'honor'
         }
@@ -148,8 +153,9 @@ class CourseEndingTest(TestCase):
         self.assertEqual(
             _cert_info(user, course, cert_status, course_mode),
             {
-                'status': 'ready',
+                'status': 'downloadable',
                 'show_disabled_download_button': False,
+                'certificate_message_viewable': True,
                 'show_download_url': True,
                 'download_url': download_url,
                 'show_survey_button': True,
@@ -171,6 +177,7 @@ class CourseEndingTest(TestCase):
             {
                 'status': 'notpassing',
                 'show_disabled_download_button': False,
+                'certificate_message_viewable': True,
                 'show_download_url': False,
                 'show_survey_button': True,
                 'survey_url': survey_url,
@@ -192,6 +199,7 @@ class CourseEndingTest(TestCase):
             {
                 'status': 'notpassing',
                 'show_disabled_download_button': False,
+                'certificate_message_viewable': True,
                 'show_download_url': False,
                 'show_survey_button': False,
                 'grade': '0.67',
@@ -251,6 +259,7 @@ class CourseEndingTest(TestCase):
                 {
                     'status': 'generating',
                     'show_disabled_download_button': True,
+                    'certificate_message_viewable': True,
                     'show_download_url': False,
                     'show_survey_button': True,
                     'survey_url': survey_url,
@@ -283,6 +292,7 @@ class CourseEndingTest(TestCase):
                 _cert_info(user, course, cert_status, course_mode),
                 {
                     'status': 'processing',
+                    'certificate_message_viewable': False,
                     'show_disabled_download_button': False,
                     'show_download_url': False,
                     'show_survey_button': False,

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -18,103 +18,132 @@ from course_modes.models import CourseMode
 %>
 
 <%
-if cert_status['status'] == 'generating':
+if (cert_status['status'] == 'generating' or cert_status['status'] == 'downloadable') and not cert_status['certificate_message_viewable']:
+    status_css_class = 'course-status-processing'
+elif cert_status['status'] == 'generating':
     status_css_class = 'course-status-certrendering'
-elif cert_status['status'] == 'ready':
+elif cert_status['status'] == 'downloadable':
     status_css_class = 'course-status-certavailable'
 elif cert_status['status'] == 'notpassing':
     status_css_class = 'course-status-certnotavailable'
 else:
     status_css_class = 'course-status-processing'
 %>
-% if not (cert_status['status'] == 'processing' and course_overview.self_paced):
+
+% if cert_status['status'] != 'processing':
   <div class="message message-status ${status_css_class} is-shown">
-  % if cert_status['status'] == 'processing' and not course_overview.self_paced:
-    <p class="message-copy">${_("Final course details are being wrapped up at this time. Your final standing will be available shortly.")}</p>
-  % elif cert_status['status'] in ('generating', 'ready', 'notpassing', 'restricted', 'auditing', 'unverified'):
-    <p class="message-copy">${_("Your final grade:")}
-    <span class="grade-value">${"{0:.0f}%".format(float(cert_status['grade'])*100)}</span>.
-      % if cert_status['status'] == 'notpassing':
-        % if enrollment.mode != 'audit':
-          ${_("Grade required for a {cert_name_short}:").format(cert_name_short=cert_name_short)} <span class="grade-value">
-        % else:
-          ${_("Grade required to pass this course:")} <span class="grade-value">
-        % endif
-        ${"{0:.0f}%".format(float(course_overview.lowest_passing_grade)*100)}</span>.
-      % elif cert_status['status'] == 'restricted' and enrollment.mode == 'verified':
-      <p class="message-copy">
-        ${Text(_("Your verified {cert_name_long} is being held pending confirmation that the issuance of your {cert_name_short} is in compliance with strict U.S. embargoes on Iran, Cuba, Syria and Sudan. If you think our system has mistakenly identified you as being connected with one of those countries, please let us know by contacting {email}. If you would like a refund on your {cert_name_long}, please contact our billing address {billing_email}")).format(email=HTML('<a class="contact-link" href="mailto:{email}">{email}</a>.').format(email=settings.CONTACT_EMAIL), billing_email=HTML('<a class="contact-link" href="mailto:{email}">{email}</a>').format(email=settings.PAYMENT_SUPPORT_EMAIL), cert_name_short=cert_name_short, cert_name_long=cert_name_long)}
-      </p>
-      % elif cert_status['status'] == 'restricted':
-      <p class="message-copy">
-        ${Text(_("Your {cert_name_long} is being held pending confirmation that the issuance of your {cert_name_short} is in compliance with strict U.S. embargoes on Iran, Cuba, Syria and Sudan. If you think our system has mistakenly identified you as being connected with one of those countries, please let us know by contacting {email}.")).format(email=HTML('<a class="contact-link" href="mailto:{email}">{email}</a>.').format(email=settings.CONTACT_EMAIL), cert_name_short=cert_name_short, cert_name_long=cert_name_long)}
-      </p>
-      % elif cert_status['status'] == 'unverified':
-      <p class="message-copy">
-        ${Text(_("Your certificate was not issued because you do not have a current verified identity with {platform_name}. ")).format(platform_name=settings.PLATFORM_NAME)}
-        <a href="${reverify_link}"> ${Text(_("Verify your identity now."))}</a>
-      </p>
+    % if not cert_status['certificate_message_viewable']:
+      % if (cert_status['status'] == 'generating' or cert_status['status'] == 'downloadable'):
+        <p class="message-copy">
+          <%
+            certificate_available_date_string = course_overview.certificate_available_date.strftime('%Y-%m-%dT%H:%M:%S%z')
+            container_string = _("Your certificate will be available on or before {date}")
+            format = 'shortDate'
+          %>
+          <span class="info-date-block localized-datetime" data-language="${user_language}" data-timezone="${user_timezone}" data-datetime="${certificate_available_date_string}" data-format=${format} data-string="${container_string}"></span>
+        </p>
       % endif
-    </p>
-  % endif
+    % else:
+      <p class="message-copy">${_("Your final grade:")}
+        <span class="grade-value">${"{0:.0f}%".format(float(cert_status['grade'])*100)}</span>.
 
-  % if cert_status['show_disabled_download_button'] or cert_status['show_download_url'] or cert_status['show_survey_button']:
-    <div class="wrapper-message-primary">
-      <ul class="actions actions-primary">
-        % if cert_status['show_disabled_download_button']:
-          <li class="action"><span class="disabled">
-              ${_("Your {cert_name_short} is Generating").format(cert_name_short=cert_name_short)}</span></li>
-        % elif cert_status['show_download_url'] and cert_status.get('show_cert_web_view', False):
-          <li class="action action-certificate">
-          <a class="btn" href="${cert_status['cert_web_view_url']}" target="_blank"
-             title="${_('This link will open the certificate web view')}">
-             ${_("View {cert_name_short}").format(cert_name_short=cert_name_short,)}</a></li>
-        % elif cert_status['show_download_url'] and enrollment.mode in CourseMode.NON_VERIFIED_MODES:
-          <li class="action action-certificate">
-          <a class="btn" href="${cert_status['download_url']}"
-             title="${_('This link will open/download a PDF document')}">
-             ${_("Download {cert_name_short} (PDF)").format(cert_name_short=cert_name_short,)}</a></li>
-        % elif cert_status['show_download_url'] and enrollment.mode == 'verified' and cert_status['mode'] == 'honor':
-          <li class="action">
-          <a class="btn" href="${cert_status['download_url']}"
-             title="${_('This link will open/download a PDF document')}">
-             ${_("Download Your {cert_name_short} (PDF)").format(cert_name_short=cert_name_short)}</a></li>
-        % elif cert_status['show_download_url'] and enrollment.mode in CourseMode.VERIFIED_MODES:
-          <li class="action">
-          <a class="btn" href="${cert_status['download_url']}"
-             title="${_('This link will open/download a PDF document of your verified {cert_name_long}.').format(cert_name_long=cert_name_long)}">
-             ${_("Download Your ID Verified {cert_name_short} (PDF)").format(cert_name_short=cert_name_short)}</a></li>
+        % if cert_status['status'] == 'notpassing':
+          % if enrollment.mode != 'audit':
+            ${_("Grade required for a {cert_name_short}:").format(cert_name_short=cert_name_short)}
+          % else:
+            ${_("Grade required to pass this course:")}
+          % endif
+          <span class="grade-value">${"{0:.0f}%".format(float(course_overview.lowest_passing_grade)*100)}</span>.
+        % elif cert_status['status'] == 'restricted' and enrollment.mode == 'verified':
+          <p class="message-copy">
+            ${Text(_("Your verified {cert_name_long} is being held pending confirmation that the issuance of your {cert_name_short} is in compliance with strict U.S. embargoes on Iran, Cuba, Syria and Sudan. If you think our system has mistakenly identified you as being connected with one of those countries, please let us know by contacting {email}. If you would like a refund on your {cert_name_long}, please contact our billing address {billing_email}")).format(email=HTML('<a class="contact-link" href="mailto:{email}">{email}</a>.').format(email=settings.CONTACT_EMAIL), billing_email=HTML('<a class="contact-link" href="mailto:{email}">{email}</a>').format(email=settings.PAYMENT_SUPPORT_EMAIL), cert_name_short=cert_name_short, cert_name_long=cert_name_long)}
+          </p>
+        % elif cert_status['status'] == 'restricted':
+          <p class="message-copy">
+            ${Text(_("Your {cert_name_long} is being held pending confirmation that the issuance of your {cert_name_short} is in compliance with strict U.S. embargoes on Iran, Cuba, Syria and Sudan. If you think our system has mistakenly identified you as being connected with one of those countries, please let us know by contacting {email}.")).format(email=HTML('<a class="contact-link" href="mailto:{email}">{email}</a>.').format(email=settings.CONTACT_EMAIL), cert_name_short=cert_name_short, cert_name_long=cert_name_long)}
+          </p>
+        % elif cert_status['status'] == 'unverified':
+          <p class="message-copy">
+            ${Text(_("Your certificate was not issued because you do not have a current verified identity with {platform_name}. ")).format(platform_name=settings.PLATFORM_NAME)}
+            <a href="${reverify_link}"> ${Text(_("Verify your identity now."))}</a>
+          </p>
         % endif
 
-        % if cert_status['show_survey_button']:
-          <li class="action"><a class="cta" href="${cert_status['survey_url']}">
-                 ${_("Complete our course feedback survey")}</a></li>
+      </p>
+
+      % if cert_status['show_disabled_download_button'] or cert_status['show_download_url'] or cert_status['show_survey_button']:
+        <div class="wrapper-message-primary">
+          <ul class="actions actions-primary">
+            % if cert_status['show_disabled_download_button']:
+              <li class="action">
+                <span class="disabled">
+                  ${_("Your {cert_name_short} is Generating").format(cert_name_short=cert_name_short)}
+                </span>
+              </li>
+            % elif cert_status['show_download_url'] and cert_status.get('show_cert_web_view', False):
+              <li class="action action-certificate">
+                <a class="btn" href="${cert_status['cert_web_view_url']}" target="_blank"
+                   title="${_('This link will open the certificate web view')}">
+                  ${_("View {cert_name_short}").format(cert_name_short=cert_name_short,)}
+                </a>
+              </li>
+            % elif cert_status['show_download_url'] and enrollment.mode in CourseMode.NON_VERIFIED_MODES:
+              <li class="action action-certificate">
+                <a class="btn" href="${cert_status['download_url']}"
+                   title="${_('This link will open/download a PDF document')}">
+                  ${_("Download {cert_name_short} (PDF)").format(cert_name_short=cert_name_short,)}
+                </a>
+              </li>
+            % elif cert_status['show_download_url'] and enrollment.mode == 'verified' and cert_status['mode'] == 'honor':
+              <li class="action">
+                <a class="btn" href="${cert_status['download_url']}"
+                   title="${_('This link will open/download a PDF document')}">
+                  ${_("Download Your {cert_name_short} (PDF)").format(cert_name_short=cert_name_short)}
+                </a>
+              </li>
+            % elif cert_status['show_download_url'] and enrollment.mode in CourseMode.VERIFIED_MODES:
+              <li class="action">
+                <a class="btn" href="${cert_status['download_url']}"
+                   title="${_('This link will open/download a PDF document of your verified {cert_name_long}.').format(cert_name_long=cert_name_long)}">
+                  ${_("Download Your ID Verified {cert_name_short} (PDF)").format(cert_name_short=cert_name_short)}
+                </a>
+              </li>
+            % endif
+
+            % if cert_status['show_survey_button']:
+              <li class="action">
+                <a class="cta" href="${cert_status['survey_url']}">
+                  ${_("Complete our course feedback survey")}
+                </a>
+              </li>
+            % endif
+          </ul>
+        </div>
+
+        % if cert_status['show_download_url'] and cert_status['linked_in_url']:
+          <ul class="actions actions-secondary">
+              <li class="action action-share">
+                <a class="action-linkedin-profile" target="_blank" href="${cert_status['linked_in_url']}"
+                 title="${_('Add Certificate to LinkedIn Profile')}"
+                 data-course-id="${course_overview.id}"
+                 data-certificate-mode="${cert_status['mode']}"
+                >
+                  <img class="action-linkedin-profile-img"
+                       src="${static.url('images/linkedin_add_to_profile.png')}"
+                       alt="${_('Share on LinkedIn')}">
+                </a>
+            </li>
+          </ul>
         % endif
-      </ul>
-    </div>
+      % endif
 
-    % if cert_status['show_download_url'] and cert_status['linked_in_url']:
-    <ul class="actions actions-secondary">
-        <li class="action action-share">
-          <a class="action-linkedin-profile" target="_blank" href="${cert_status['linked_in_url']}"
-           title="${_('Add Certificate to LinkedIn Profile')}"
-           data-course-id="${course_overview.id}"
-           data-certificate-mode="${cert_status['mode']}"
-          >
-            <img class="action-linkedin-profile-img"
-                 src="${static.url('images/linkedin_add_to_profile.png')}"
-                 alt="${_('Share on LinkedIn')}">
-          </a>
-      </li>
-    </ul>
-    % endif
+      % if cert_status['show_download_url'] and cert_status['certificate_message_viewable'] and enrollment.mode == 'verified' and cert_status['mode'] == 'honor':
+        <div class="certificate-explanation">
+            ${_('Since we did not have a valid set of verification photos from you when your {cert_name_long} was generated, we could not grant you a verified {cert_name_short}. An honor code {cert_name_short} has been granted instead.').format(cert_name_short=cert_name_short, cert_name_long=cert_name_long)}
+        </div>
+      % endif
 
-    % if cert_status['show_download_url'] and enrollment.mode == 'verified' and cert_status['mode'] == 'honor':
-    <div class="certificate-explanation">
-        ${_('Since we did not have a valid set of verification photos from you when your {cert_name_long} was generated, we could not grant you a verified {cert_name_short}. An honor code {cert_name_short} has been granted instead.').format(cert_name_short=cert_name_short, cert_name_long=cert_name_long)}
-    </div>
     % endif
-  % endif
   </div>
 % endif
 

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -281,9 +281,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
       </div>
       % endif
 
-      % if course_overview.may_certify() and cert_status:
         <%include file='_dashboard_certificate_information.html' args='cert_status=cert_status,course_overview=course_overview, enrollment=enrollment, reverify_link=reverify_link'/>
-      % endif
 
       % if credit_status is not None:
         <%include file="_dashboard_credit_info.html" args="credit_status=credit_status"/>


### PR DESCRIPTION
For verified learners who passed the course before the CAD, in both self paced and instructor paced courses ... show "Your certificate will be available on or before [CAD]"

"Final course details are being wrapped up at this time. Your final standing will be available shortly." will not show up for anyone anymore.

This also means that the default is no message at all, rather than the "final course details" message that we had previously.
