### PR TITLE
Upgrading the edx-organizations package to 0.4.7.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -50,7 +50,7 @@ edx-django-sites-extensions==2.3.0
 edx-enterprise==0.51.1
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
-edx-organizations==0.4.6
+edx-organizations==0.4.7
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
 edx-submissions==2.0.12


### PR DESCRIPTION
Added explicit 'fields' attribute to OrganizationSerializer. Creating a
ModelSerializer without either the 'fields' attribute or the 'exclude'
attribute has been deprecated since 3.3.0.

https://github.com/edx/edx-organizations/releases/tag/0.4.7

LEARNER-2320