### PR TITLE
Remove single line of whitespace.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,5 @@ deps =
     -rrequirements/edx/development.txt
     -rrequirements/edx/testing.txt
     -rrequirements/edx/post.txt
-
 commands =
     pytest {posargs}


### PR DESCRIPTION
Simple a no-op to get a new Docker devstack build.