### PR TITLE
Upgrade lxml in its other versioned requirement location.

### DIFF
--- a/requirements/edx-sandbox/post.txt
+++ b/requirements/edx-sandbox/post.txt
@@ -6,5 +6,6 @@
 
 # Packages to install in the Python sandbox for secured execution.
 scipy==0.14.0
-lxml==3.4.4
+# lxml is also in requirements/edx/base.txt
+lxml==3.8.0
 matplotlib==1.3.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -115,6 +115,7 @@ pyuca==1.1
 wrapt==1.10.5
 zendesk==1.1.1
 
+# lxml is also in requirements/edx-sandbox/post.txt
 lxml==3.8.0
 
 # Used for shopping cart's pdf invoice/receipt generation


### PR DESCRIPTION
In a devstack, the edx-sandbox requirements are also applied due to `EDXAPP_PYTHON_SANDBOX` being false:
https://github.com/edx/configuration/blob/master/docker/build/edxapp/ansible_overrides.yml#L28

However, this file has a different version of lxml than in requirements/edx/base.txt. This PR upgrades the version in post.txt to match.