### PR TITLE
EDUCATOR-139 add log to identify the cause of error

### DIFF
--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -881,7 +881,21 @@ class XModule(HTMLSnippet, XModuleMixin):
                 request_post[key] = map(FileObjForWebobFiles, request.POST.getall(key))
 
         response_data = self.handle_ajax(suffix, request_post)
-        return Response(response_data, content_type='application/json')
+
+        try:
+            return Response(response_data, content_type='application/json')
+        except TypeError:
+            request_environ = getattr(request, 'environ')
+            log.exception(
+                'Response creation failed for problem url: %s, response_data type: %s, LANG: %s, '
+                'LC_ALL: %s and HTTP_ACCEPT_ENCODING: %s',
+                request_environ.get('HTTP_REFERER'),
+                type(response_data),
+                request_environ.get('LANG'),
+                request_environ.get('LC_ALL'),
+                request_environ.get('HTTP_ACCEPT_ENCODING')
+            )
+            raise
 
     def get_child(self, usage_id):
         if usage_id in self._child_cache:


### PR DESCRIPTION
# [You cannot set the body to a text value without a charset - EDUCATOR-139](https://openedx.atlassian.net/browse/EDUCATOR-139)

### Description

For some problems, we are facing an error from **WebOb response** when clicks on `Submit` or `Show Answer` button or giving an `Input` when access from LMS. We are not sure what the cause is, or how to reproduce it. We have added a log to understand the nature of the problem a little deeper. Then we'll be more confident about what behavior we'll want to see in this case.

### How to Test?

**Stage** 
Not Applicable.

**Screenshots**
Not Applicable.


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @noraiz-anwar 
- [x] Code review: @awaisdar001 

### Post-review
- [x] Rebase and squash commits