### PR TITLE
Remove fb-sdk from base.txt requirements

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -57,7 +57,6 @@ edx-search==1.1.0
 edx-submissions==2.0.12
 edxval==0.1.1
 event-tracking==0.2.4
-facebook-sdk==0.4.0
 feedparser==5.1.3
 firebase-token-generator==1.3.2
 GitPython==0.3.2.RC1


### PR DESCRIPTION
**JIRA tickets**: [LEARNER-2620](https://openedx.atlassian.net/browse/LEARNER-2620)

Remove fb-sdk from requirements

**Description**

Facebook wants from edX to upgrade all graphAPI calls to v2.9,after investigation it can be seen that edX-platform is accessing graphAPI through python-social-auth package that is already accessing v2.9.'base.txt' of the requirements has fb-sdk package that is also used to access graphAPI,but currently, there is no area in our code that is using this library that's why there is no need of it in requirements.