### PR TITLE
Add button on Instructor Dashboard to download profile for active students

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -944,7 +944,7 @@ class CourseEnrollmentManager(models.Manager):
 
         return is_course_full
 
-    def users_enrolled_in(self, course_id, include_inactive=False):
+    def users_enrolled_in(self, course_id, include_inactive=False, only_active=False):
         """
         Return a queryset of User for every user enrolled in the course.  If
         `include_inactive` is True, returns both active and inactive enrollees
@@ -955,6 +955,8 @@ class CourseEnrollmentManager(models.Manager):
         }
         if not include_inactive:
             filter_kwargs['courseenrollment__is_active'] = True
+        if only_active:
+            filter_kwargs['is_active'] = True
         return User.objects.filter(**filter_kwargs)
 
     def enrollment_counts(self, course_id):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1203,7 +1203,7 @@ def get_issued_certificates(request, course_id):
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_level('staff')
 @common_exceptions_400
-def get_students_features(request, course_id, csv=False):  # pylint: disable=redefined-outer-name
+def get_students_features(request, course_id, csv=False, only_active=False):  # pylint: disable=redefined-outer-name
     """
     Respond with json which contains a summary of all enrolled students profile information.
 
@@ -1284,7 +1284,8 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
         lms.djangoapps.instructor_task.api.submit_calculate_students_features_csv(
             request,
             course_key,
-            query_features
+            query_features,
+            only_active
         )
         success_status = SUCCESS_MESSAGE_TEMPLATE.format(report_type=report_type)
 

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -21,7 +21,7 @@ urlpatterns = patterns(
         'lms.djangoapps.instructor.views.api.get_problem_responses', name="get_problem_responses"),
     url(r'^get_grading_config$',
         'lms.djangoapps.instructor.views.api.get_grading_config', name="get_grading_config"),
-    url(r'^get_students_features(?P<csv>/csv)?$',
+    url(r'^get_students_features(?P<only_active>/active)?/?(?P<csv>/csv)?$',
         'lms.djangoapps.instructor.views.api.get_students_features', name="get_students_features"),
     url(r'^get_issued_certificates/$',
         'lms.djangoapps.instructor.views.api.get_issued_certificates', name="get_issued_certificates"),

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -203,7 +203,7 @@ def issued_certificates(course_key, features):
     return generated_certificates
 
 
-def enrolled_students_features(course_key, features):
+def enrolled_students_features(course_key, features, only_active=False):
     """
     Return list of student features as dictionaries.
 
@@ -219,10 +219,14 @@ def enrolled_students_features(course_key, features):
     include_enrollment_mode = 'enrollment_mode' in features
     include_verification_status = 'verification_status' in features
 
-    students = User.objects.filter(
-        courseenrollment__course_id=course_key,
-        courseenrollment__is_active=1,
-    ).order_by('username').select_related('profile')
+    filter_kwargs = {
+        'courseenrollment__course_id': course_key,
+        'courseenrollment__is_active': True
+    }
+    if only_active:
+        filter_kwargs['is_active'] = True
+
+    students = User.objects.filter(**filter_kwargs).order_by('username').select_related('profile')
 
     if include_cohort_column:
         students = students.prefetch_related('course_groups')

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -360,7 +360,7 @@ def submit_problem_grade_report(request, course_key):
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
 
-def submit_calculate_students_features_csv(request, course_key, features):
+def submit_calculate_students_features_csv(request, course_key, features, only_active=False):
     """
     Submits a task to generate a CSV containing student profile info.
 
@@ -368,7 +368,7 @@ def submit_calculate_students_features_csv(request, course_key, features):
     """
     task_type = 'profile_info_csv'
     task_class = calculate_students_features_csv
-    task_input = features
+    task_input = {"query_features": features, "only_active": only_active}
     task_key = ""
 
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)

--- a/lms/djangoapps/instructor_task/tasks_helper/enrollments.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/enrollments.py
@@ -196,15 +196,15 @@ def upload_students_csv(_xmodule_instance_args, _entry_id, course_id, task_input
     """
     start_time = time()
     start_date = datetime.now(UTC)
-    enrolled_students = CourseEnrollment.objects.users_enrolled_in(course_id)
+    enrolled_students = CourseEnrollment.objects.users_enrolled_in(course_id, only_active=task_input['only_active'])
     task_progress = TaskProgress(action_name, enrolled_students.count(), start_time)
 
     current_step = {'step': 'Calculating Profile Info'}
     task_progress.update_task_state(extra_meta=current_step)
 
     # compute the student features table and format it
-    query_features = task_input
-    student_data = enrolled_students_features(course_id, query_features)
+    query_features = task_input['query_features']
+    student_data = enrolled_students_features(course_id, query_features, only_active=task_input['only_active'])
     header, rows = format_dictlist(student_data, query_features)
 
     task_progress.attempted = task_progress.succeeded = len(rows)

--- a/lms/djangoapps/instructor_task/tasks_helper/enrollments.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/enrollments.py
@@ -215,8 +215,10 @@ def upload_students_csv(_xmodule_instance_args, _entry_id, course_id, task_input
     current_step = {'step': 'Uploading CSV'}
     task_progress.update_task_state(extra_meta=current_step)
 
+    csv_name = 'active_student_profile_info' if task_input['only_active'] else 'student_profile_info'
+
     # Perform the upload
-    upload_csv_to_report_store(rows, 'student_profile_info', course_id, start_date)
+    upload_csv_to_report_store(rows, csv_name, course_id, start_date)
 
     return task_progress.update_task_state(extra_meta=current_step)
 

--- a/lms/static/js/instructor_dashboard/data_download.js
+++ b/lms/static/js/instructor_dashboard/data_download.js
@@ -97,6 +97,7 @@
             this.ddc = new DataDownloadCertificate(this.$section.find('.issued_certificates'));
             this.$list_studs_btn = this.$section.find("input[name='list-profiles']");
             this.$list_studs_csv_btn = this.$section.find("input[name='list-profiles-csv']");
+            this.$list_studs_active_csv_btn = this.$section.find("input[name='list-profiles-active-csv']");
             this.$proctored_exam_csv_btn = this.$section.find("input[name='proctored-exam-results-report']");
             this.$survey_results_csv_btn = this.$section.find("input[name='survey-results-report']");
             this.$list_may_enroll_csv_btn = this.$section.find("input[name='list-may-enroll-csv']");
@@ -173,7 +174,7 @@
                 });
             });
             this.$list_studs_csv_btn.click(function() {
-                var url = dataDownloadObj.$list_studs_csv_btn.data('endpoint') + '/csv';
+                var url = $(this).data('endpoint') + '/csv';
                 var errorMessage = gettext('Error generating student profile information. Please try again.');
                 dataDownloadObj.clear_display();
                 return $.ajax({
@@ -197,6 +198,7 @@
                     }
                 });
             });
+            this.$list_studs_active_csv_btn.click(this.$list_studs_csv_btn.data("events").click[0].handler);
             this.$list_studs_btn.click(function() {
                 var url = dataDownloadObj.$list_studs_btn.data('endpoint');
                 dataDownloadObj.clear_display();

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -32,6 +32,10 @@ from openedx.core.djangolib.markup import HTML, Text
 
     <p><input type="button" name="list-profiles-csv" value="${_("Download profile information as a CSV")}" data-endpoint="${ section_data['get_students_features_url'] }" data-csv="true"></p>
 
+    <p>${_("Click to generate a CSV file of all active students enrolled in this course, along with profile information such as email address and username:")}</p>
+
+    <p><input type="button" name="list-profiles-active-csv" value="${_("Download active student profile information as a CSV")}" data-endpoint="${ section_data['get_students_features_url'] + "/active" }" data-csv="true" ></p>
+
     <p>${_("Click to generate a CSV file that lists learners who can enroll in the course but have not yet done so.")}</p>
 
     <p><input type="button" name="list-may-enroll-csv" value="${_("Download a CSV of learners who can enroll")}" data-endpoint="${ section_data['get_students_who_may_enroll_url'] }" data-csv="true"></p>


### PR DESCRIPTION
This will add a new button on the Instructor Dashboard which functions the same as the "Download profile information as CSV", with an additional filter to exclude deactivated accounts.

**Sandbox URL**: https://pr16126.sandbox.opencraft.hosting/

**Testing instructions**:

1. Enroll a user in the course.
2. Marked user not active from the User admin console at `/admin/auth/user/`
3. Generate report from the Instructor Dashboard for the course. `/courses/course-v1:edX+DemoX+Demo_Course/instructor`, then click button labeled "Download active student profile information as a CSV".
4. Check the generated CSV to ensure the deactivated user is not included.

**Reviewers**
- [ ] (UmanShahzad)