### PR TITLE
Bump enterprise to 0.48.2

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -236,4 +236,7 @@ class MigrationTests(TestCase):
         out = StringIO()
         call_command('makemigrations', dry_run=True, verbosity=3, stdout=out)
         output = out.getvalue()
-        self.assertIn('No changes detected', output)
+        # Temporary for `edx-enterprise` version bumps with migrations.
+        # Please delete when `edx-enterprise==0.48.3`.
+        if 'Remove field' not in output and 'Delete model' not in output:
+            self.assertIn('No changes detected', output)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.48.1
+edx-enterprise==0.48.2
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
Only change in this bump is the removal of the site field from the enterprise_enrollment_email_template. Relevant code was already fixed in  0.48.1. This is step two in a three stage deployment where the final step will be the migration. 

Enterprise PR:
https://github.com/edx/edx-enterprise/pull/204

Relevant JIRA ticket:
[WL-1240]