### PR TITLE
address coursegraph issue where components had the same block id but …

### DIFF
--- a/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
+++ b/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
@@ -56,15 +56,20 @@ class TestDumpToNeo4jCommandBase(SharedModuleStoreTestCase):
 
         The side-pointing arrows (->) are PRECEDES relationships; the more
         vertical lines are PARENT_OF relationships.
+
+        The vertical in this course and the first video have the same
+        display_name, so that their block_ids are the same. This is to
+        test for a bug where xblocks with the same block_ids (but different
+        locations) pointed to themselves erroneously.
         """
         super(TestDumpToNeo4jCommandBase, cls).setUpClass()
         cls.course = CourseFactory.create()
         cls.chapter = ItemFactory.create(parent=cls.course, category='chapter')
         cls.sequential = ItemFactory.create(parent=cls.chapter, category='sequential')
-        cls.vertical = ItemFactory.create(parent=cls.sequential, category='vertical')
+        cls.vertical = ItemFactory.create(parent=cls.sequential, category='vertical', display_name='subject')
         cls.html = ItemFactory.create(parent=cls.vertical, category='html')
         cls.problem = ItemFactory.create(parent=cls.vertical, category='problem')
-        cls.video = ItemFactory.create(parent=cls.vertical, category='video')
+        cls.video = ItemFactory.create(parent=cls.vertical, category='video', display_name='subject')
         cls.video2 = ItemFactory.create(parent=cls.vertical, category='video')
 
         cls.course2 = CourseFactory.create()

--- a/openedx/core/djangoapps/coursegraph/tasks.py
+++ b/openedx/core/djangoapps/coursegraph/tasks.py
@@ -167,15 +167,16 @@ def serialize_course(course_id):
             fields[field_name] = coerce_types(value)
 
         node = Node(block_type, 'item', **fields)
-        location_to_node[item.location.block_id] = node
+        location_to_node[item.location.version_agnostic()] = node
 
     # create relationships
     relationships = []
     for item in items:
         previous_child_node = None
         for index, child in enumerate(item.get_children()):
-            parent_node = location_to_node.get(item.location.block_id)
-            child_node = location_to_node.get(child.location.block_id)
+            parent_node = location_to_node.get(item.location.version_agnostic())
+            child_node = location_to_node.get(child.location.version_agnostic())
+
             if parent_node is not None and child_node is not None:
                 child_node["index"] = index
 


### PR DESCRIPTION
…different locations

Hi Fred and Toby, this PR corrects a rare case when two modules had the same block id but had different locations.