### PR TITLE
Add zh_HANS language mapping to locale config

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -1,5 +1,10 @@
 # Configuration for i18n workflow.
 
+# This will copy each source language to a new directory at the end of the i18n generate step
+# which allows us to migrate to a new locale code without re-creating the Transifex project.
+edx-lang-map:
+    zh_CN: zh_HANS
+
 locales:
     - en  # English - Source Language
     # - am  # Amharic


### PR DESCRIPTION
This change will cause edx-i18n-tools to start making a full copy of the zh_CN translations to zh_HANS to prepare for the Django 1.11 upgrade. zh_CN is deprecated as of Django 1.9, but in order to avoid having to move our entire Transifex project we're going to keep those files and just copy them over. This change shouldn't enable the zh_HANS locale in Django, allowing us to test it as a dark lang first.