### PR TITLE
[ENT-497] Update user-facing consent view to reflect new data model

### DIFF
--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -217,4 +217,4 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
                 (reverse('course_wiki', kwargs={'course_id': course_id}), 302),
                 ('/courses/{}/wiki/'.format(course_id), 200),
         ):
-            self.verify_consent_required(self.client, url, status_code)
+            self.verify_consent_required(self.client, url, status_code=status_code)

--- a/openedx/features/enterprise_support/tests/mixins/enterprise.py
+++ b/openedx/features/enterprise_support/tests/mixins/enterprise.py
@@ -191,9 +191,12 @@ class EnterpriseServiceMockMixin(object):
                     },
                     'data_sharing_consent': [
                         {
-                            'user': 1,
-                            'state': 'enabled',
-                            'enabled': True
+                            "username": "verified",
+                            "enterprise_customer_uuid": enterprise_customer_uuid,
+                            "exists": True,
+                            "course_id": "course-v1:edX DemoX Demo_Course",
+                            "consent_provided": True,
+                            "consent_required": False
                         }
                     ]
                 }
@@ -216,41 +219,48 @@ class EnterpriseTestConsentRequired(SimpleTestCase):
     """
     Mixin to help test the data_sharing_consent_required decorator.
     """
-    def verify_consent_required(self, client, url, status_code=200):
+
+    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
+    @mock.patch('openedx.features.enterprise_support.api.reverse')
+    @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
+    @mock.patch('openedx.features.enterprise_support.api.consent_needed_for_course')
+    def verify_consent_required(
+            self,
+            client,
+            url,
+            mock_consent_necessary,
+            mock_enterprise_enabled,
+            mock_reverse,
+            mock_enterprise_customer_uuid_for_request,
+            status_code=200,
+    ):
         """
         Verify that the given URL redirects to the consent page when consent is required,
         and doesn't redirect to the consent page when consent is not required.
-
-        Arguments:
-        * self: ignored
-        * client: the TestClient instance to be used
-        * url: URL to test
-        * status_code: expected status code of URL when no data sharing consent is required.
         """
+
         def mock_consent_reverse(*args, **kwargs):
             if args[0] == 'grant_data_sharing_permissions':
                 return '/enterprise/grant_data_sharing_permissions'
             return reverse(*args, **kwargs)
 
-        with mock.patch('openedx.features.enterprise_support.api.reverse', side_effect=mock_consent_reverse):
-            with mock.patch('openedx.features.enterprise_support.api.enterprise_enabled', return_value=True):
-                with mock.patch(
-                    'openedx.features.enterprise_support.api.consent_needed_for_course'
-                ) as mock_consent_necessary:
-                    # Ensure that when consent is necessary, the user is redirected to the consent page.
-                    mock_consent_necessary.return_value = True
-                    response = client.get(url)
-                    while(response.status_code == 302 and 'grant_data_sharing_permissions' not in response.url):
-                        response = client.get(response.url)
-                    self.assertEqual(response.status_code, 302)
-                    self.assertIn('grant_data_sharing_permissions', response.url)  # pylint: disable=no-member
+        mock_reverse.side_effect = mock_consent_reverse
+        mock_enterprise_enabled.return_value = True
+        mock_enterprise_customer_uuid_for_request.return_value = 'fake-uuid'
+        # Ensure that when consent is necessary, the user is redirected to the consent page.
+        mock_consent_necessary.return_value = True
+        response = client.get(url)
+        while(response.status_code == 302 and 'grant_data_sharing_permissions' not in response.url):
+            response = client.get(response.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('grant_data_sharing_permissions', response.url)  # pylint: disable=no-member
 
-                    # Ensure that when consent is not necessary, the user continues through to the requested page.
-                    mock_consent_necessary.return_value = False
-                    response = client.get(url)
-                    self.assertEqual(response.status_code, status_code)
+        # Ensure that when consent is not necessary, the user continues through to the requested page.
+        mock_consent_necessary.return_value = False
+        response = client.get(url)
+        self.assertEqual(response.status_code, status_code)
 
-                    # If we were expecting a redirect, ensure it's not to the data sharing permission page
-                    if status_code == 302:
-                        self.assertNotIn('grant_data_sharing_permissions', response.url)  # pylint: disable=no-member
-                    return response
+        # If we were expecting a redirect, ensure it's not to the data sharing permission page
+        if status_code == 302:
+            self.assertNotIn('grant_data_sharing_permissions', response.url)  # pylint: disable=no-member
+        return response

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -47,7 +47,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.51.0
+edx-enterprise==0.51.1
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
## Note

This PR will probably end up containing the version bump for edx-enterprise for when https://github.com/edx/edx-enterprise/pull/207 merges.

---

**Description:** This PR updates any variables in code/mocks/docs that point to the user-facing data sharing consent view from edx-enterprise that may be changed as part of https://github.com/edx/edx-enterprise/pull/207.

**JIRA:** [ENT-497](https://openedx.atlassian.net/browse/ENT-497)

**Dependencies**: https://github.com/edx/edx-enterprise/pull/207 & https://github.com/edx/ecommerce/pull/1494 (I believe the ecommerce PR must be released together with this to prevent any discrepancies).

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: End of week.

**Testing instructions**:

1. Setup an Enterprise Customer that requires DSC.
1. Enroll a user in a course through the EC's Manage Learner admin panel.
1. Login through the user and attempt to open up the course.
1. Ensure that you're shown the consent page.

**Reviewers**
- [ ] @haikuginger 
- [ ] @brittneyexline @douglashall 

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```