### PR TITLE
Fixed Studio API bug with course team updates

### DIFF
--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -60,6 +60,7 @@ class CourseRunTeamSerializerMixin(serializers.Serializer):
         for member in team:
             CourseAccessRole.objects.update_or_create(
                 course_id=instance.id,
+                org=instance.id.org,
                 user=User.objects.get(username=member['user']),
                 defaults={'role': member['role']}
             )

--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -3,12 +3,12 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from rest_framework import serializers
 from rest_framework.fields import empty
-from xmodule.modulestore.django import modulestore
 
 from cms.djangoapps.contentstore.views.course import create_new_course, get_course_and_check_access, rerun_course
 from contentstore.views.assets import update_course_run_asset
 from openedx.core.lib.courses import course_image_url
 from student.models import CourseAccessRole
+from xmodule.modulestore.django import modulestore
 
 IMAGE_TYPES = {
     'image/jpeg': 'jpg',
@@ -50,13 +50,19 @@ class CourseRunTeamSerializerMixin(serializers.Serializer):
     team = CourseRunTeamSerializer(required=False)
 
     def update_team(self, instance, team):
-        CourseAccessRole.objects.filter(course_id=instance.id).delete()
+        # Existing data should remain intact when performing a partial update.
+        if not self.partial:
+            CourseAccessRole.objects.filter(course_id=instance.id).delete()
 
-        # TODO In the future we can optimize by getting users in a single query.
-        CourseAccessRole.objects.bulk_create([
-            CourseAccessRole(course_id=instance.id, role=member['role'], user=User.objects.get(username=member['user']))
-            for member in team
-        ])
+        # We iterate here, instead of using a bulk operation, to avoid uniqueness errors that arise
+        # when using `bulk_create` with existing data. Given the relatively small number of team members
+        # in a course, this is not worth optimizing at this time.
+        for member in team:
+            CourseAccessRole.objects.update_or_create(
+                course_id=instance.id,
+                user=User.objects.get(username=member['user']),
+                defaults={'role': member['role']}
+            )
 
 
 def image_is_jpeg_or_png(value):
@@ -110,21 +116,6 @@ class CourseRunSerializer(CourseRunTeamSerializerMixin, serializers.Serializer):
 
             modulestore().update_item(instance, self.context['request'].user.id)
             return instance
-
-    def update_team(self, instance, team):
-        # Existing data should remain intact when performing a partial update.
-        if not self.partial:
-            CourseAccessRole.objects.filter(course_id=instance.id).delete()
-
-        # We iterate here, instead of using a bulk operation, to avoid uniqueness errors that arise
-        # when using `bulk_create` with existing data. Given the relatively small number of team members
-        # in a course, this is not worth optimizing at this time.
-        for member in team:
-            CourseAccessRole.objects.update_or_create(
-                course_id=instance.id,
-                user=User.objects.get(username=member['user']),
-                defaults={'role': member['role']}
-            )
 
 
 class CourseRunCreateSerializer(CourseRunSerializer):

--- a/cms/djangoapps/api/v1/tests/test_views/test_course_runs.py
+++ b/cms/djangoapps/api/v1/tests/test_views/test_course_runs.py
@@ -37,7 +37,7 @@ class CourseRunViewSetTests(ModuleStoreTestCase):
 
     def assert_access_role(self, course_run, user, role):
         # An error will be raised if the endpoint did not create the role
-        CourseAccessRole.objects.get(course_id=course_run.id, user=user, role=role)
+        CourseAccessRole.objects.get(course_id=course_run.id, org=course_run.id.org, user=user, role=role)
 
     def assert_course_access_role_count(self, course_run, expected):
         assert CourseAccessRole.objects.filter(course_id=course_run.id).count() == expected
@@ -143,9 +143,9 @@ class CourseRunViewSetTests(ModuleStoreTestCase):
 
         # The request should only update or create new team members
         existing_user = UserFactory()
-        CourseAccessRole.objects.create(course_id=course_run.id, role=role, user=existing_user)
+        CourseAccessRole.objects.create(course_id=course_run.id, org=course_run.id.org, role=role, user=existing_user)
         new_user = UserFactory()
-        CourseAccessRole.objects.create(course_id=course_run.id, role=role, user=new_user)
+        CourseAccessRole.objects.create(course_id=course_run.id, org=course_run.id.org, role=role, user=new_user)
         assert CourseAccessRole.objects.filter(course_id=course_run.id).count() == 2
 
         data = {


### PR DESCRIPTION
The org field is now set on the CourseAccessRole object, since Studio expects that value to be present.

LEARNER-2469