### PR TITLE
[ENT-616] Bump edx-enterprise to 0.49.0.

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -237,6 +237,6 @@ class MigrationTests(TestCase):
         call_command('makemigrations', dry_run=True, verbosity=3, stdout=out)
         output = out.getvalue()
         # Temporary for `edx-enterprise` version bumps with migrations.
-        # Please delete when `edx-enterprise==0.48.3`.
+        # Please delete when `edx-enterprise==0.49.1`.
         if 'Remove field' not in output and 'Delete model' not in output:
             self.assertIn('No changes detected', output)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.48.2
+edx-enterprise==0.49.0
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.6


### PR DESCRIPTION
This PR bumps `edx-enterprise` to 0.49.0; see https://github.com/edx/edx-enterprise/compare/0.48.2...0.49.0

**JIRA tickets**: [ENT-616](https://openedx.atlassian.net/browse/ENT-616)

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: Soon

**Testing instructions**:

1. Go to the program & course enrollment landing pages and ensure the course modals render, look, and function correctly.

**Reviewers**
- [ ] @haikuginger 
- [ ] @brittneyexline @douglashall 

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```