### PR TITLE
Optimize grade reports for ZeroCourseGrades

### DIFF
--- a/lms/djangoapps/grades/course_grade.py
+++ b/lms/djangoapps/grades/course_grade.py
@@ -44,6 +44,20 @@ class CourseGradeBase(object):
         """
         return False
 
+    def subsection_grade(self, subsection_key):
+        """
+        Returns the subsection grade for given subsection usage key.
+        Raises KeyError if the user doesn't have access to that subsection.
+        """
+        return self._get_subsection_grade(self.course_data.structure[subsection_key])
+
+    @abstractmethod
+    def assignment_average(self, assignment_type):
+        """
+        Returns the average of all assignments of the given assignment type.
+        """
+        raise NotImplementedError
+
     @lazy
     def graded_subsections_by_format(self):
         """
@@ -207,6 +221,9 @@ class ZeroCourseGrade(CourseGradeBase):
     Course Grade class for Zero-value grades when no problems were
     attempted in the course.
     """
+    def assignment_average(self, assignment_type):
+        return 0.0
+
     def _get_subsection_grade(self, subsection):
         return ZeroSubsectionGrade(subsection, self.course_data)
 
@@ -247,6 +264,9 @@ class CourseGrade(CourseGradeBase):
                 if subsection_grade.all_total.first_attempted:
                     return True
         return False
+
+    def assignment_average(self, assignment_type):
+        return self.grader_result['grade_breakdown'].get(assignment_type, {}).get('percent')
 
     def _get_subsection_grade(self, subsection):
         if self.force_update_subsections:

--- a/lms/djangoapps/grades/subsection_grade.py
+++ b/lms/djangoapps/grades/subsection_grade.py
@@ -53,6 +53,13 @@ class SubsectionGradeBase(object):
         """
         return ShowCorrectness.correctness_available(self.show_correctness, self.due, has_staff_access)
 
+    @property
+    def attempted_graded(self):
+        """
+        Returns whether the user had attempted a graded problem in this subsection.
+        """
+        raise NotImplementedError
+
 
 class ZeroSubsectionGrade(SubsectionGradeBase):
     """
@@ -62,6 +69,10 @@ class ZeroSubsectionGrade(SubsectionGradeBase):
     def __init__(self, subsection, course_data):
         super(ZeroSubsectionGrade, self).__init__(subsection)
         self.course_data = course_data
+
+    @property
+    def attempted_graded(self):
+        return False
 
     @property
     def all_total(self):
@@ -173,6 +184,10 @@ class SubsectionGrade(SubsectionGradeBase):
         if self._should_persist_per_attempted(score_deleted):
             self._log_event(log.debug, u"update_or_create_model", student)
             return PersistentSubsectionGrade.update_or_create_grade(**self._persisted_model_params(student))
+
+    @property
+    def attempted_graded(self):
+        return self.graded_total.first_attempted is not None
 
     def _should_persist_per_attempted(self, score_deleted=False):
         """

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -36,7 +36,7 @@ class TestCourseGradeFactory(GradeTestBase):
 
     def test_course_grade_no_access(self):
         """
-        Test to ensure a grade can ba calculated for a student in a course, even if they themselves do not have access.
+        Test to ensure a grade can be calculated for a student in a course, even if they themselves do not have access.
         """
         invisible_course = CourseFactory.create(visible_to_staff_only=True)
         access = has_access(self.request.user, 'load', invisible_course)

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -306,19 +306,17 @@ class CourseGradeReport(object):
         for assignment_type, assignment_info in context.graded_assignments.iteritems():
             for subsection_location in assignment_info['subsection_headers']:
                 try:
-                    subsection_grade = course_grade.graded_subsections_by_format[assignment_type][subsection_location]
+                    subsection_grade = course_grade.subsection_grade(subsection_location)
                 except KeyError:
                     grade_result = u'Not Available'
                 else:
-                    if subsection_grade.graded_total.first_attempted is not None:
+                    if subsection_grade.attempted_graded:
                         grade_result = subsection_grade.graded_total.earned / subsection_grade.graded_total.possible
                     else:
                         grade_result = u'Not Attempted'
                 grade_results.append([grade_result])
             if assignment_info['separate_subsection_avg_headers']:
-                assignment_average = course_grade.grader_result['grade_breakdown'].get(assignment_type, {}).get(
-                    'percent'
-                )
+                assignment_average = course_grade.assignment_average(assignment_type)
                 grade_results.append([assignment_average])
         return [course_grade.percent] + _flatten(grade_results)
 

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -679,7 +679,7 @@ class TestGradeReportConditionalContent(TestReportMixin, TestConditionalContent,
                     {
                         self.student_b: {
                             u'Grade': '0.0',
-                            u'Homework': u'Not Available',
+                            u'Homework': u'Not Attempted',
                         }
                     },
                 ],


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-558

As described in the ticket, this PR introduces new methods on Grades objects (`attempted_graded`, `assignment_average`, and `subsection_grade`) to avoid traversing all problems and calling the grader for `ZeroCourseGrades`.

Although this won't dramatically reduce the time of grade reports, it will at least perform as expected for Zero grades.

**Note:** I've confirmed with @sstack22 that the distinction between "Not Available" and "Not Attempted" isn't necessary at the subsection level.