### PR TITLE
remove uses of django.util.unittest

### DIFF
--- a/openedx/core/djangoapps/service_status/test.py
+++ b/openedx/core/djangoapps/service_status/test.py
@@ -4,7 +4,7 @@ import json
 
 from django.core.urlresolvers import reverse
 from django.test.client import Client
-from django.utils import unittest
+import unittest
 
 
 class CeleryConfigTest(unittest.TestCase):

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -16,7 +16,6 @@ from django.conf.urls import patterns, url, include
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.test import TestCase
-from django.utils import unittest
 from django.utils.http import urlencode
 from nose.plugins.attrib import attr
 from oauth2_provider import models as dot_models


### PR DESCRIPTION
django.util.unittest was deprecated in django 1.7 and removed in 1.9.

PLAT-1551