### PR TITLE
Make the welcome message disappear after seven days of first viewing.

### DIFF
--- a/openedx/features/course_experience/static/course_experience/js/WelcomeMessage.js
+++ b/openedx/features/course_experience/static/course_experience/js/WelcomeMessage.js
@@ -3,18 +3,37 @@ import 'jquery.cookie';
 
 export class WelcomeMessage {  // eslint-disable-line import/prefer-default-export
 
-  constructor(options) {
-    $('.dismiss-message button').click(() => {
-      $.ajax({
-        type: 'POST',
-        url: options.dismissUrl,
-        headers: {
-          'X-CSRFToken': $.cookie('csrftoken'),
-        },
-        success: () => {
-          $('.welcome-message').hide();
-        },
-      });
+  static dismissWelcomeMessage(dismissUrl) {
+    $.ajax({
+      type: 'POST',
+      url: dismissUrl,
+      headers: {
+        'X-CSRFToken': $.cookie('csrftoken'),
+      },
+      success: () => {
+        $('.welcome-message').hide();
+      },
     });
+  }
+
+  constructor(options) {
+    // Dismiss the welcome message if the user clicks dismiss, or auto-dismiss if
+    // the user doesn't click dismiss in 7 days from when it was first viewed.
+
+    // Check to see if the welcome message has been displayed at all.
+    if ($('.welcome-message').length > 0) {
+      // If the welcome message has been viewed.
+      if ($.cookie('welcome-message-viewed') === 'True') {
+        // If the timer cookie no longer exists, dismiss the welcome message permanently.
+        if ($.cookie('welcome-message-timer') !== 'True') {
+          WelcomeMessage.dismissWelcomeMessage(options.dismissUrl);
+        }
+      } else {
+        // Set both the viewed cookie and the timer cookie.
+        $.cookie('welcome-message-viewed', 'True', { expires: 365 });
+        $.cookie('welcome-message-timer', 'True', { expires: 7 });
+      }
+    }
+    $('.dismiss-message button').click(() => WelcomeMessage.dismissWelcomeMessage(options.dismissUrl));
   }
 }


### PR DESCRIPTION
## [LEARNER-2240](https://openedx.atlassian.net/browse/LEARNER-2240)

### Description

Dismiss the welcome message seven days after first viewing it.

### Acceptance Criteria

- [x] Verify that learners are no longer shown the welcome message directly on the home page 7 days after initial view (as measured by land in the course home)
- [x] This does not affect the courses using the latest update waffle flag.

### Sandbox
- [x] https://dianakhuang.sandbox.edx.org/courses/course-v1:edX+Test101+course/course/

#### To test sandbox:
1. Visit the page and log into a student account.
2. Verify that the 'welcome-message-timer' has been set with an expiration date seven days from today
3. Delete the 'welcome-message-timer' cookie.
4. Refresh the page and verify that the message disappears

### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] safecommit violation code review process

### Assign Github reviewers (as needed)
- [x] engineering 
- [ ] product

FYI: @edx/learner-mercury
 
### Post-review
- [ ] Rebase and squash commits