### PR TITLE
EDUCATOR-139 Add charset to the WebOb response

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
+++ b/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
@@ -363,6 +363,7 @@ class TestStudioView(XBlockWrapperTestMixin, TestCase):
         self.assertEqual(html, rendered_content)
 
 
+@ddt.ddt
 class TestXModuleHandler(TestCase):
     """
     Tests that the xmodule_handler function correctly wraps handle_ajax
@@ -386,6 +387,21 @@ class TestXModuleHandler(TestCase):
         response = self.module.xmodule_handler(self.request)
         self.assertIsInstance(response, webob.Response)
         self.assertEqual(response.body, '{}')
+
+    @ddt.data(
+        u'{"test_key": "test_value"}',
+        '{"test_key": "test_value"}',
+    )
+    def test_xmodule_handler_with_data(self, response_data):
+        """
+        Tests that xmodule_handler function correctly wraps handle_ajax when handle_ajax response is either
+        str or unicode.
+        """
+
+        self.module.handle_ajax = Mock(return_value=response_data)
+        response = self.module.xmodule_handler(self.request)
+        self.assertIsInstance(response, webob.Response)
+        self.assertEqual(response.body, '{"test_key": "test_value"}')
 
 
 class TestXmlExport(XBlockWrapperTestMixin, TestCase):

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -881,21 +881,7 @@ class XModule(HTMLSnippet, XModuleMixin):
                 request_post[key] = map(FileObjForWebobFiles, request.POST.getall(key))
 
         response_data = self.handle_ajax(suffix, request_post)
-
-        try:
-            return Response(response_data, content_type='application/json')
-        except TypeError:
-            request_environ = getattr(request, 'environ')
-            log.exception(
-                'Response creation failed for problem url: %s, response_data type: %s, LANG: %s, '
-                'LC_ALL: %s and HTTP_ACCEPT_ENCODING: %s',
-                request_environ.get('HTTP_REFERER'),
-                type(response_data),
-                request_environ.get('LANG'),
-                request_environ.get('LC_ALL'),
-                request_environ.get('HTTP_ACCEPT_ENCODING')
-            )
-            raise
+        return Response(response_data, content_type='application/json', charset='UTF-8')
 
     def get_child(self, usage_id):
         if usage_id in self._child_cache:


### PR DESCRIPTION
# [You cannot set the body to a text value without a charset - EDUCATOR-139](https://openedx.atlassian.net/browse/EDUCATOR-139)

### Description

This PR fixes **TypeError: You cannot set the body to a text value without a charset** in xmodule `xmodule_handler` method.

**WebOb response** (version 1.7.1 ) raises the `TypeError` in Splunk and New Relic on `problem_check` or `problem_show` handlers. We were unable to reproduce this issue on prod, stage or on devstack. We added more logging in [PR#16120](https://github.com/edx/edx-platform/pull/16120) (Removing the logs as part of this PR) to get more sense about the error. The cause of the [error](https://github.com/Pylons/webob/blob/master/src/webob/response.py#L309-L311) was when [response_data](https://github.com/edx/edx-platform/blob/7a66f12b534f6dce7ba191d40828f0a704c43a93/common/lib/xmodule/xmodule/x_module.py#L883) is of `unicode` type for application/json content-type that does not have charset. 

Below is the **traceback** from [Splunk](https://splunk.edx.org/en-US/app/search/search?earliest=-24h%40h&latest=now&q=search%20index%3Dprod-edx%20%22Response%20creation%20failed%20for%20problem%20url%3A%22%20source%3D%22%2Fedx%2Fvar%2Flog%2Flms%2Fedx.log%22&display.page.search.mode=smart&dispatch.sample_ratio=1&sid=1507206428.89970) related to log that was added previously:

```
Oct  5 00:17:15 ip-10-2-12-21 [service_variant=lms][xmodule.x_module][env:prod-edx-edxapp] ERROR [ip-10-2-12-21  3952] [x_module.py:896] - 
Response creation failed for problem url: https://courses.edx.org/courses/course-v1:MITx+8.04.1x+3T2017/courseware/week3/pset3/?child=first, 
response_data type: <type 'unicode'>, LANG: None, LC_ALL: None and HTTP_ACCEPT_ENCODING: gzip, deflate
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 886, in xmodule_handler
    return Response(response_data, content_type='application/json')
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/webob/response.py", line 310, in __init__
    "You cannot set the body to a text value without a "
TypeError: You cannot set the body to a text value without a charset
```

For the fix, I have passed charset to the WebOb response. 

For further details,  check the following links for WebOb reported the issues.

1. https://github.com/Pylons/webob/issues/304
2. https://github.com/Pylons/webob/issues/298
3. https://docs.pylonsproject.org/projects/webob/en/1.7-branch/whatsnew-1.7.html#backwards-incompatibility

### How to Test?

**Stage** 
Not Applicable.

**Screenshots**
Not Applicable.


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @awaisdar001
- [x] Code review: @efischer19 

### Post-review
- [x] Rebase and squash commits