### PR TITLE
Have SubsectionGrade compute problem_scores lazily

### DIFF
--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -12,7 +12,7 @@ from student.models import anonymous_id_for_user
 from submissions import api as submissions_api
 
 from .course_data import CourseData
-from .subsection_grade import SubsectionGrade, ZeroSubsectionGrade
+from .subsection_grade import CreateSubsectionGrade, ReadSubsectionGrade, ZeroSubsectionGrade
 
 log = getLogger(__name__)
 
@@ -43,7 +43,7 @@ class SubsectionGradeFactory(object):
             if assume_zero_if_absent(self.course_data.course_key):
                 subsection_grade = ZeroSubsectionGrade(subsection, self.course_data)
             else:
-                subsection_grade = SubsectionGrade.create(
+                subsection_grade = CreateSubsectionGrade(
                     subsection, self.course_data.structure, self._submissions_scores, self._csm_scores,
                 )
                 if should_persist_grades(self.course_data.course_key):
@@ -58,7 +58,7 @@ class SubsectionGradeFactory(object):
         """
         Bulk creates all the unsaved subsection_grades to this point.
         """
-        SubsectionGrade.bulk_create_models(
+        CreateSubsectionGrade.bulk_create_models(
             self.student, self._unsaved_subsection_grades.values(), self.course_data.course_key
         )
         self._unsaved_subsection_grades.clear()
@@ -69,7 +69,7 @@ class SubsectionGradeFactory(object):
         """
         self._log_event(log.debug, u"update, subsection: {}".format(subsection.location), subsection)
 
-        calculated_grade = SubsectionGrade.create(
+        calculated_grade = CreateSubsectionGrade(
             subsection, self.course_data.structure, self._submissions_scores, self._csm_scores,
         )
 
@@ -80,7 +80,7 @@ class SubsectionGradeFactory(object):
                 except PersistentSubsectionGrade.DoesNotExist:
                     pass
                 else:
-                    orig_subsection_grade = SubsectionGrade.read(
+                    orig_subsection_grade = ReadSubsectionGrade(
                         subsection, grade_model, self.course_data.structure, self._submissions_scores, self._csm_scores,
                     )
                     if not is_score_higher_or_equal(
@@ -125,7 +125,7 @@ class SubsectionGradeFactory(object):
             saved_subsection_grades = self._get_bulk_cached_subsection_grades()
             grade = saved_subsection_grades.get(subsection.location)
             if grade:
-                return SubsectionGrade.read(
+                return ReadSubsectionGrade(
                     subsection, grade, self.course_data.structure, self._submissions_scores, self._csm_scores,
                 )
 

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -14,7 +14,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from ..config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT, waffle
 from ..course_grade import CourseGrade, ZeroCourseGrade
 from ..course_grade_factory import CourseGradeFactory
-from ..subsection_grade import SubsectionGrade, ZeroSubsectionGrade
+from ..subsection_grade import ReadSubsectionGrade, ZeroSubsectionGrade
 from .base import GradeTestBase
 from .utils import mock_get_score
 
@@ -131,7 +131,7 @@ class TestCourseGradeFactory(GradeTestBase):
         course_grade = CourseGradeFactory().update(self.request.user, self.course)
         subsection1_grade = course_grade.subsection_grades[self.sequence.location]
         subsection2_grade = course_grade.subsection_grades[self.sequence2.location]
-        self.assertIsInstance(subsection1_grade, SubsectionGrade)
+        self.assertIsInstance(subsection1_grade, ReadSubsectionGrade)
         self.assertIsInstance(subsection2_grade, ZeroSubsectionGrade)
 
     @ddt.data(True, False)

--- a/lms/djangoapps/grades/tests/test_subsection_grade.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade.py
@@ -1,5 +1,5 @@
 from ..models import PersistentSubsectionGrade
-from ..subsection_grade import SubsectionGrade
+from ..subsection_grade import CreateSubsectionGrade, ReadSubsectionGrade
 from .utils import mock_get_score
 from .base import GradeTestBase
 
@@ -8,7 +8,7 @@ class SubsectionGradeTest(GradeTestBase):
     def test_create_and_read(self):
         with mock_get_score(1, 2):
             # Create a grade that *isn't* saved to the database
-            created_grade = SubsectionGrade.create(
+            created_grade = CreateSubsectionGrade(
                 self.sequence,
                 self.course_structure,
                 self.subsection_grade_factory._submissions_scores,
@@ -25,7 +25,7 @@ class SubsectionGradeTest(GradeTestBase):
                 user_id=self.request.user.id,
                 usage_key=self.sequence.location,
             )
-            read_grade = SubsectionGrade.read(
+            read_grade = ReadSubsectionGrade(
                 self.sequence,
                 saved_model,
                 self.course_structure,

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -222,7 +222,7 @@ class CourseGradeReport(object):
         Returns a list of all applicable column headers for this grade report.
         """
         return (
-            ["Student ID", "Email", "Username", "Grade"] +
+            ["Student ID", "Email", "Username"] +
             self._grades_header(context) +
             (['Cohort Name'] if context.cohorts_enabled else []) +
             [u'Experiment Group ({})'.format(partition.name) for partition in context.course_experiments] +
@@ -278,7 +278,7 @@ class CourseGradeReport(object):
         Returns the applicable grades-related headers for this report.
         """
         graded_assignments = context.graded_assignments
-        grades_header = []
+        grades_header = ["Grade"]
         for assignment_info in graded_assignments.itervalues():
             if assignment_info['separate_subsection_avg_headers']:
                 grades_header.extend(assignment_info['subsection_headers'].itervalues())


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-558

This is the 2nd in a series of (expected) 3 PRs to optimize grade reports.
This PR separates `SubsectionGrade` into `ReadSubsectionGrade` and `CreateSubsectionGrade` so `problem_scores` can be computed lazily when SubsectionGrades are read from the database.  For example, `problem_scores` are not required for Course grade reports and so we can eliminate querying the CSM database altogether when generating these reports.