### PR TITLE
Add search box to CourseEnrollmentAllowed admin interface.

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -197,8 +197,17 @@ class UserAttributeAdmin(admin.ModelAdmin):
         model = UserAttribute
 
 
+@admin.register(CourseEnrollmentAllowed)
+class CourseEnrollmentAllowedAdmin(admin.ModelAdmin):
+    """ Admin interface for the CourseEnrollmentAllowed model. """
+    list_display = ('email', 'course_id', 'auto_enroll',)
+    search_fields = ('email', 'course_id',)
+
+    class Meta(object):
+        model = CourseEnrollmentAllowed
+
+
 admin.site.register(UserTestGroup)
-admin.site.register(CourseEnrollmentAllowed)
 admin.site.register(Registration)
 admin.site.register(PendingNameChange)
 admin.site.register(DashboardConfiguration, ConfigurationModelAdmin)


### PR DESCRIPTION
This adds a search field to the `CourseEnrollmentAllowed` admin interface, and configures the list view to show individual fields instead of a string representation of the whole instance.

**JIRA tickets**: [OSPR-1943](https://openedx.atlassian.net/browse/OSPR-1943)

**Discussions**: None

**Dependencies**: None

**Screenshots**:

Without this change:
![image](https://user-images.githubusercontent.com/249196/31184524-e35cfa2c-a929-11e7-845c-ae18cb47f2d5.png)

With this change applied:
![image](https://user-images.githubusercontent.com/249196/31184457-ba864dc4-a929-11e7-87ec-ca8bde584be5.png)

**Sandbox URL**: https://pr16166.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

Navigate to https://pr16166.sandbox.opencraft.hosting/admin/student/courseenrollmentallowed/, log in as the standard staff user and try it.

**Author notes and concerns**: None

**Reviewers**
- [ ] @cgopalan
- [ ] edX reviewer[s] TBD
