### PR TITLE
Grade reports: eliminate CSM calls, user-transformed structures

### DIFF
--- a/lms/djangoapps/grades/course_data.py
+++ b/lms/djangoapps/grades/course_data.py
@@ -32,14 +32,14 @@ class CourseData(object):
             if self._course:
                 self._course_key = self._course.id
             else:
-                structure = self._effective_structure
+                structure = self.effective_structure
                 self._course_key = structure.root_block_usage_key.course_key
         return self._course_key
 
     @property
     def location(self):
         if not self._location:
-            structure = self._effective_structure
+            structure = self.effective_structure
             if structure:
                 self._location = structure.root_block_usage_key
             elif self._course:
@@ -72,7 +72,7 @@ class CourseData(object):
 
     @property
     def grading_policy_hash(self):
-        structure = self._effective_structure
+        structure = self.effective_structure
         if structure:
             return structure.get_transformer_block_field(
                 structure.root_block_usage_key,
@@ -84,14 +84,14 @@ class CourseData(object):
 
     @property
     def version(self):
-        structure = self._effective_structure
+        structure = self.effective_structure
         course_block = structure[self.location] if structure else self.course
         return getattr(course_block, 'course_version', None)
 
     @property
     def edited_on(self):
         # get course block from structure only; subtree_edited_on field on modulestore's course block isn't optimized.
-        structure = self._effective_structure
+        structure = self.effective_structure
         if structure:
             course_block = structure[self.location]
             return getattr(course_block, 'subtree_edited_on', None)
@@ -100,7 +100,7 @@ class CourseData(object):
         return u'Course: course_key: {}'.format(self.course_key)
 
     def full_string(self):
-        if self._effective_structure:
+        if self.effective_structure:
             return u'Course: course_key: {}, version: {}, edited_on: {}, grading_policy: {}'.format(
                 self.course_key, self.version, self.edited_on, self.grading_policy_hash,
             )
@@ -108,5 +108,5 @@ class CourseData(object):
             return u'Course: course_key: {}, empty course structure'.format(self.course_key)
 
     @property
-    def _effective_structure(self):
+    def effective_structure(self):
         return self._structure or self._collected_block_structure

--- a/lms/djangoapps/grades/course_grade_factory.py
+++ b/lms/djangoapps/grades/course_grade_factory.py
@@ -85,7 +85,7 @@ class CourseGradeFactory(object):
         If an error occurred, course_grade will be None and err_msg will be an
         exception message. If there was no error, err_msg is an empty string.
         """
-        # Pre-fetch the collected course_structure so:
+        # Pre-fetch the collected course_structure (in _iter_grade_result) so:
         # 1. Correctness: the same version of the course is used to
         #    compute the grade for all students.
         # 2. Optimization: the collected course_structure is not

--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -80,9 +80,7 @@ class SubsectionGradeFactory(object):
                 except PersistentSubsectionGrade.DoesNotExist:
                     pass
                 else:
-                    orig_subsection_grade = ReadSubsectionGrade(
-                        subsection, grade_model, self.course_data.structure, self._submissions_scores, self._csm_scores,
-                    )
+                    orig_subsection_grade = ReadSubsectionGrade(subsection, grade_model, self)
                     if not is_score_higher_or_equal(
                             orig_subsection_grade.graded_total.earned,
                             orig_subsection_grade.graded_total.possible,
@@ -125,9 +123,7 @@ class SubsectionGradeFactory(object):
             saved_subsection_grades = self._get_bulk_cached_subsection_grades()
             grade = saved_subsection_grades.get(subsection.location)
             if grade:
-                return ReadSubsectionGrade(
-                    subsection, grade, self.course_data.structure, self._submissions_scores, self._csm_scores,
-                )
+                return ReadSubsectionGrade(subsection, grade, self)
 
     def _get_bulk_cached_subsection_grades(self):
         """

--- a/lms/djangoapps/grades/tests/base.py
+++ b/lms/djangoapps/grades/tests/base.py
@@ -6,6 +6,7 @@ from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
+from ..course_data import CourseData
 from ..subsection_grade_factory import SubsectionGradeFactory
 
 
@@ -75,6 +76,7 @@ class GradeTestBase(SharedModuleStoreTestCase):
         self.client.login(username=self.request.user.username, password="test")
         self._set_grading_policy()
         self.course_structure = get_course_blocks(self.request.user, self.course.location)
+        self.course_data = CourseData(self.request.user, structure=self.course_structure)
         self.subsection_grade_factory = SubsectionGradeFactory(self.request.user, self.course, self.course_structure)
         CourseEnrollment.enroll(self.request.user, self.course.id)
 
@@ -90,6 +92,13 @@ class GradeTestBase(SharedModuleStoreTestCase):
                     "drop_count": 0,
                     "short_label": "HW",
                     "weight": 1.0,
+                },
+                {
+                    "type": "NoCredit",
+                    "min_count": 0,
+                    "drop_count": 0,
+                    "short_label": "NC",
+                    "weight": 0.0,
                 },
             ],
             "GRADE_CUTOFFS": {

--- a/lms/djangoapps/grades/tests/test_subsection_grade.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade.py
@@ -15,6 +15,7 @@ class SubsectionGradeTest(GradeTestBase):
                 self.subsection_grade_factory._csm_scores,
             )
             self.assertEqual(PersistentSubsectionGrade.objects.count(), 0)
+            self.assertEqual(created_grade.percent_graded, 0.5)
 
             # save to db, and verify object is in database
             created_grade.update_or_create_model(self.request.user)
@@ -28,11 +29,10 @@ class SubsectionGradeTest(GradeTestBase):
             read_grade = ReadSubsectionGrade(
                 self.sequence,
                 saved_model,
-                self.course_structure,
-                self.subsection_grade_factory._submissions_scores,
-                self.subsection_grade_factory._csm_scores,
+                self.subsection_grade_factory
             )
 
             self.assertEqual(created_grade.url_name, read_grade.url_name)
             read_grade.all_total.first_attempted = created_grade.all_total.first_attempted = None
             self.assertEqual(created_grade.all_total, read_grade.all_total)
+            self.assertEqual(created_grade.percent_graded, 0.5)

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -164,10 +164,10 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             self.assertEquals(mock_block_structure_create.call_count, 1)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 25, True),
-        (ModuleStoreEnum.Type.mongo, 1, 25, False),
-        (ModuleStoreEnum.Type.split, 3, 25, True),
-        (ModuleStoreEnum.Type.split, 3, 25, False),
+        (ModuleStoreEnum.Type.mongo, 1, 23, True),
+        (ModuleStoreEnum.Type.mongo, 1, 23, False),
+        (ModuleStoreEnum.Type.split, 3, 23, True),
+        (ModuleStoreEnum.Type.split, 3, 23, False),
     )
     @ddt.unpack
     def test_query_counts(self, default_store, num_mongo_calls, num_sql_calls, create_multiple_subsections):
@@ -179,8 +179,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
                     self._apply_recalculate_subsection_grade()
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 25),
-        (ModuleStoreEnum.Type.split, 3, 25),
+        (ModuleStoreEnum.Type.mongo, 1, 23),
+        (ModuleStoreEnum.Type.split, 3, 23),
     )
     @ddt.unpack
     def test_query_counts_dont_change_with_more_content(self, default_store, num_mongo_calls, num_sql_calls):
@@ -240,8 +240,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             self.assertEqual(len(PersistentSubsectionGrade.bulk_read_grades(self.user.id, self.course.id)), 0)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 26),
-        (ModuleStoreEnum.Type.split, 3, 26),
+        (ModuleStoreEnum.Type.mongo, 1, 24),
+        (ModuleStoreEnum.Type.split, 3, 24),
     )
     @ddt.unpack
     def test_persistent_grades_enabled_on_course(self, default_store, num_mongo_queries, num_sql_queries):

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -518,7 +518,7 @@ def dump_grading_context(course):
     msg += hbar
     msg += "Listing grading context for course %s\n" % course.id.to_deprecated_string()
 
-    gcontext = grading_context_for_course(course.id)
+    gcontext = grading_context_for_course(course)
     msg += "graded sections:\n"
 
     msg += '%s\n' % gcontext['all_graded_subsections_by_type'].keys()
@@ -541,6 +541,6 @@ def dump_grading_context(course):
             msg += "      %s (format=%s, Assignment=%s%s)\n"\
                 % (sdesc.display_name, frmat, aname, notes)
     msg += "all graded blocks:\n"
-    msg += "length=%d\n" % len(gcontext['all_graded_blocks'])
+    msg += "length=%d\n" % gcontext['count_all_graded_blocks']
     msg = '<pre>%s</pre>' % msg.replace('<', '&lt;')
     return msg

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -103,7 +103,7 @@ class _CourseGradeReportContext(object):
         Returns an OrderedDict that maps an assignment type to a dict of
         subsection-headers and average-header.
         """
-        grading_cxt = grading_context(self.course_structure)
+        grading_cxt = grading_context(self.course, self.course_structure)
         graded_assignments_map = OrderedDict()
         for assignment_type_name, subsection_infos in grading_cxt['all_graded_subsections_by_type'].iteritems():
             graded_subsections_map = OrderedDict()
@@ -127,7 +127,8 @@ class _CourseGradeReportContext(object):
             graded_assignments_map[assignment_type_name] = {
                 'subsection_headers': graded_subsections_map,
                 'average_header': average_header,
-                'separate_subsection_avg_headers': separate_subsection_avg_headers
+                'separate_subsection_avg_headers': separate_subsection_avg_headers,
+                'grader': grading_cxt['subsection_type_graders'].get(assignment_type_name),
             }
         return graded_assignments_map
 
@@ -297,28 +298,55 @@ class CourseGradeReport(object):
         users = users.select_related('profile__allow_certificate')
         return grouper(users)
 
-    def _user_grade_results(self, course_grade, context):
+    def _user_grades(self, course_grade, context):
         """
         Returns a list of grade results for the given course_grade corresponding
         to the headers for this report.
         """
         grade_results = []
         for assignment_type, assignment_info in context.graded_assignments.iteritems():
-            for subsection_location in assignment_info['subsection_headers']:
-                try:
-                    subsection_grade = course_grade.subsection_grade(subsection_location)
-                except KeyError:
-                    grade_result = u'Not Available'
-                else:
-                    if subsection_grade.attempted_graded:
-                        grade_result = subsection_grade.graded_total.earned / subsection_grade.graded_total.possible
-                    else:
-                        grade_result = u'Not Attempted'
-                grade_results.append([grade_result])
-            if assignment_info['separate_subsection_avg_headers']:
-                assignment_average = course_grade.assignment_average(assignment_type)
+
+            subsection_grades, subsection_grades_results = self._user_subsection_grades(
+                course_grade,
+                assignment_info['subsection_headers'],
+            )
+            grade_results.extend(subsection_grades_results)
+
+            assignment_average = self._user_assignment_average(course_grade, subsection_grades, assignment_info)
+            if assignment_average is not None:
                 grade_results.append([assignment_average])
+
         return [course_grade.percent] + _flatten(grade_results)
+
+    def _user_subsection_grades(self, course_grade, subsection_headers):
+        """
+        Returns a list of grade results for the given course_grade corresponding
+        to the headers for this report.
+        """
+        subsection_grades = []
+        grade_results = []
+        for subsection_location in subsection_headers:
+            subsection_grade = course_grade.subsection_grade(subsection_location)
+            if subsection_grade.attempted_graded:
+                grade_result = subsection_grade.percent_graded
+            else:
+                grade_result = u'Not Attempted'
+            grade_results.append([grade_result])
+            subsection_grades.append(subsection_grade)
+        return subsection_grades, grade_results
+
+    def _user_assignment_average(self, course_grade, subsection_grades, assignment_info):
+        if assignment_info['separate_subsection_avg_headers']:
+            if assignment_info['grader']:
+                if course_grade.attempted:
+                    subsection_breakdown = [
+                        {'percent': subsection_grade.percent_graded}
+                        for subsection_grade in subsection_grades
+                    ]
+                    assignment_average, _ = assignment_info['grader'].total_with_drops(subsection_breakdown)
+                else:
+                    assignment_average = 0.0
+                return assignment_average
 
     def _user_cohort_group_names(self, user, context):
         """
@@ -411,7 +439,7 @@ class CourseGradeReport(object):
                 else:
                     success_rows.append(
                         [user.id, user.email, user.username] +
-                        self._user_grade_results(course_grade, context) +
+                        self._user_grades(course_grade, context) +
                         self._user_cohort_group_names(user, context) +
                         self._user_experiment_group_names(user, context) +
                         self._user_team_names(user, bulk_context.teams) +
@@ -440,7 +468,8 @@ class ProblemGradeReport(object):
         # as the keys.  It is structured in this way to keep the values related.
         header_row = OrderedDict([('id', 'Student ID'), ('email', 'Email'), ('username', 'Username')])
 
-        graded_scorable_blocks = cls._graded_scorable_blocks_to_header(course_id)
+        course = get_course_by_id(course_id)
+        graded_scorable_blocks = cls._graded_scorable_blocks_to_header(course)
 
         # Just generate the static fields for now.
         rows = [list(header_row.values()) + ['Enrollment Status', 'Grade'] + _flatten(graded_scorable_blocks.values())]
@@ -451,7 +480,6 @@ class ProblemGradeReport(object):
         # whether each user is currently enrolled in the course.
         CourseEnrollment.bulk_fetch_enrollment_states(enrolled_students, course_id)
 
-        course = get_course_by_id(course_id)
         for student, course_grade, error in CourseGradeFactory().iter(enrolled_students, course):
             student_fields = [getattr(student, field_name) for field_name in header_row]
             task_progress.attempted += 1
@@ -495,13 +523,13 @@ class ProblemGradeReport(object):
         return task_progress.update_task_state(extra_meta={'step': 'Uploading CSV'})
 
     @classmethod
-    def _graded_scorable_blocks_to_header(cls, course_key):
+    def _graded_scorable_blocks_to_header(cls, course):
         """
         Returns an OrderedDict that maps a scorable block's id to its
         headers in the final report.
         """
         scorable_blocks_map = OrderedDict()
-        grading_context = grading_context_for_course(course_key)
+        grading_context = grading_context_for_course(course)
         for assignment_type_name, subsection_infos in grading_context['all_graded_subsections_by_type'].iteritems():
             for subsection_index, subsection_info in enumerate(subsection_infos, start=1):
                 for scorable_block in subsection_info['scored_descendants']:


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-558

This is the 3rd in the series of PRs to optimize grade reports.
This PR eliminates the following code when generating grade reports:

- calls to the `CoursewareStudentModule` table
- calls to the `Submissions` table
- transforming the block-structure for each learner to determine per-learner access
