### PR TITLE
LEARNER-2026: Revert remains of 'upgrade upsell to course info banner'.

### DIFF
--- a/common/static/sass/edx-pattern-library-shims/base/_variables.scss
+++ b/common/static/sass/edx-pattern-library-shims/base/_variables.scss
@@ -203,6 +203,7 @@ $btn-border-radius:                         $component-border-radius !default;
 $btn-large-padding-vertical: spacing-vertical(small);
 $btn-large-padding-horizontal: spacing-horizontal(mid-large);
 
+
 $btn-base-padding-vertical: spacing-vertical(x-small);
 $btn-base-padding-horizontal: spacing-horizontal(base);
 $btn-base-font-size: font-size(base);

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -30,7 +30,6 @@ from courseware.courses import (
     sort_by_announcement,
     sort_by_start_date
 )
-from courseware.date_summary import VerifiedUpgradeDeadlineDate
 from courseware.masquerade import setup_masquerade
 from courseware.model_data import FieldDataCache
 from courseware.models import BaseStudentModuleHistory, StudentModule
@@ -402,9 +401,6 @@ def course_info(request, course_id):
             context['supports_preview_menu'] = False
 
         return render_to_response('courseware/info.html', context)
-
-
-UPGRADE_COOKIE_NAME = 'show_upgrade_notification'
 
 
 class StaticCourseTabView(EdxFragmentView):

--- a/lms/static/js/courseware/course_home_events.js
+++ b/lms/static/js/courseware/course_home_events.js
@@ -11,12 +11,6 @@
             $('.date-summary-verified-upgrade-deadline .date-summary-link').on('click', function() {
                 Logger.log('edx.course.enrollment.upgrade.clicked', {location: 'sidebar'});
             });
-            $('.upgrade-banner-button').on('click', function() {
-                Logger.log('edx.course.enrollment.upgrade.clicked', {location: 'notification'});
-            });
-            $('.view-verified-info').on('click', function() {
-                Logger.log('edx.course.home.learn_about_verified.clicked', {location: 'notification'});
-            });
         };
     });
 }).call(this, define || RequireJS.define);

--- a/lms/static/js/courseware/course_home_events.js
+++ b/lms/static/js/courseware/course_home_events.js
@@ -9,7 +9,7 @@
                 });
             });
             $('.date-summary-verified-upgrade-deadline .date-summary-link').on('click', function() {
-                Logger.log('edx.course.enrollment.upgrade.clicked', {location: 'sidebar'});
+                Logger.log('edx.course.enrollment.upgrade.clicked', {location: 'date-sidebar'});
             });
         };
     });

--- a/lms/static/js/fixtures/courseware/course_home_events.html
+++ b/lms/static/js/fixtures/courseware/course_home_events.html
@@ -1,21 +1,3 @@
-<div class="upgrade-banner">
-  <div class="notification-color-border"></div>
-  <div class="notification-content">
-    <div class="upgrade-icon">
-      <img src="${STATIC_URL}images/edx-verified-mini-cert.png">
-    </div>
-    <div class="upgrade-msg">
-      <h4 class="upgrade-msg">Give yourself an additional incentive to complete</h4>
-      <p class="view-verified-info">Earn a verified certificate
-        <a href="https://www.edx.org/verified-certificate" target="_blank">Learn More</a>
-      </p>
-    </div>
-    <div class="upgrade-banner-button">
-      <a href="/verify_student/upgrade/course-v1:Test+TestX+2015" class="btn-upgrade">Upgrade Now</a>
-    </div>
-  </div>
-</div>
-
 <div class="date-summary-container">
   <div class="date-summary date-summary-verified-upgrade-deadline">
     <h3 class="heading">Verification Upgrade Deadline</h3>

--- a/lms/static/js/spec/courseware/course_home_events_spec.js
+++ b/lms/static/js/spec/courseware/course_home_events_spec.js
@@ -17,9 +17,11 @@ define(['jquery', 'logger', 'js/courseware/course_home_events'], function($, Log
             });
         });
 
-        it('sends an event when "Upgrade to Verified" is clicked from the sidebar', function() {
+        it('sends an event when "Upgrade to Verified" is clicked from the date sidebar', function() {
             $('.date-summary-link').click();
-            expect(Logger.log).toHaveBeenCalledWith('edx.course.enrollment.upgrade.clicked', {location: 'sidebar'});
+            expect(Logger.log).toHaveBeenCalledWith('edx.course.enrollment.upgrade.clicked',
+                {location: 'date-sidebar'}
+            );
         });
     });
 });

--- a/lms/static/js/spec/courseware/course_home_events_spec.js
+++ b/lms/static/js/spec/courseware/course_home_events_spec.js
@@ -21,19 +21,5 @@ define(['jquery', 'logger', 'js/courseware/course_home_events'], function($, Log
             $('.date-summary-link').click();
             expect(Logger.log).toHaveBeenCalledWith('edx.course.enrollment.upgrade.clicked', {location: 'sidebar'});
         });
-
-        it('sends an event when "Upgrade Now" is clicked from the upsell notification', function() {
-            $('.upgrade-banner-button').click();
-            expect(Logger.log).toHaveBeenCalledWith(
-                'edx.course.enrollment.upgrade.clicked', {location: 'notification'}
-            );
-        });
-
-        it('sends an event when "Learn More" is clicked from the upsell notification', function() {
-            $('.view-verified-info').click();
-            expect(Logger.log).toHaveBeenCalledWith(
-                'edx.course.home.learn_about_verified.clicked', {location: 'notification'}
-            );
-        });
     });
 });

--- a/lms/static/sass/course/_info.scss
+++ b/lms/static/sass/course/_info.scss
@@ -104,34 +104,6 @@ div.info-wrapper {
             min-width: 80px;
           }
         }
-
-        .upgrade-msg {
-          flex: 5 1 60%; //This percentage was required to get the text
-                         // in the message to wrap when collapsed.
-          flex-direction: column;
-          margin: 0;
-          padding: $baseline/2 0;
-          .msg-title {
-            font-weight: font-weight(semi-bold);
-            font-size: font-size(large);
-            line-height: $base-line-height;
-            margin: 0;
-          }
-          .view-verified-info {
-            margin-top: $baseline/4;
-            font-weight: font-weight(normal);
-            font-size: font-size(base);
-          }
-
-          a:link, a:hover, a:visited, a:active {
-            text-decoration: underline !important;
-          }
-        }
-
-        .upgrade-banner-button {
-          @include margin(0, 0, 0, auto);
-          padding: $baseline/2 $baseline;
-        }
       }
     }
 

--- a/openedx/features/course_experience/static/course_experience/js/CourseHome.js
+++ b/openedx/features/course_experience/static/course_experience/js/CourseHome.js
@@ -96,7 +96,7 @@ export class CourseHome {  // eslint-disable-line import/prefer-default-export
     const $vcDismissToggle = $('.vc-toggle', $vcMessage);
     const logEventProperties = { courseRunKey: this.courseRunKey };
 
-    Logger.log('edx.course.upgrade.hero.displayed', logEventProperties);
+    Logger.log('edx.bi.course.upgrade.hero.displayed', logEventProperties);
 
     // Get height of container and button
     let vcHeight = $vcMessage.outerHeight();
@@ -125,7 +125,7 @@ export class CourseHome {  // eslint-disable-line import/prefer-default-export
     $vcDismissToggle.click(() => {
       if ($vcMessage.hasClass('polite')) {
         // Expand message
-        Logger.log('edx.course.upgrade.hero.expanded', logEventProperties);
+        Logger.log('edx.bi.course.upgrade.hero.expanded', logEventProperties);
         this.persistUpgradeMessageState(false);
 
         $('.vc-fade').fadeOut(400);
@@ -136,14 +136,15 @@ export class CourseHome {  // eslint-disable-line import/prefer-default-export
         });
       } else {
         // Collapse message
-        Logger.log('edx.course.upgrade.hero.collapsed', logEventProperties);
+        Logger.log('edx.bi.course.upgrade.hero.collapsed', logEventProperties);
         this.persistUpgradeMessageState(true);
         collapseMessage();
       }
     });
 
     $('.btn-upgrade', $vcMessage).click(() => {
-      Logger.log('edx.course.upgrade.hero.clicked', logEventProperties);
+      Logger.log('edx.bi.course.upgrade.hero.clicked', logEventProperties);
+      Logger.log('edx.course.enrollment.upgrade.clicked', { location: 'hero' });
     });
   }
 }

--- a/openedx/features/course_experience/static/course_experience/js/spec/CourseHome_spec.js
+++ b/openedx/features/course_experience/static/course_experience/js/spec/CourseHome_spec.js
@@ -57,13 +57,14 @@ describe('Course Home factory', () => {
 
     it('should send events to Segment and edX on initial load', () => {
       expect(window.analytics.track).toHaveBeenCalledWith('Promotion Viewed', segmentEventProperties);
-      expect(Logger.log).toHaveBeenCalledWith('edx.course.upgrade.hero.displayed', { courseRunKey: runKey });
+      expect(Logger.log).toHaveBeenCalledWith('edx.bi.course.upgrade.hero.displayed', { courseRunKey: runKey });
     });
 
     it('should send events to Segment and edX after clicking the upgrade button ', () => {
       $('.vc-message .btn-upgrade').click();
       expect(window.analytics.track).toHaveBeenCalledWith('Promotion Viewed', segmentEventProperties);
-      expect(Logger.log).toHaveBeenCalledWith('edx.course.upgrade.hero.clicked', { courseRunKey: runKey });
+      expect(Logger.log).toHaveBeenCalledWith('edx.bi.course.upgrade.hero.clicked', { courseRunKey: runKey });
+      expect(Logger.log).toHaveBeenCalledWith('edx.course.enrollment.upgrade.clicked', { location: 'hero' });
     });
   });
 


### PR DESCRIPTION
## [LEARNER-2026](https://openedx.atlassian.net/browse/LEARNER-2026)

### Description

When the upgrade upsell course info banner was taken over by the RET team, it was moved and reworked, but some old code was left over (including some unused events).  This is the remains of the cleanup work.

Here is the PR for the course info upgrade message where this was introduced: https://github.com/edx/edx-platform/pull/14444

Here is the PR where the course info upgrade banner was partially removed: https://github.com/edx/edx-platform/pull/15265

### Acceptance Criteria

- [x] Remove the unused 'edx.course.home.learn_about_verified.clicked' event.
- [x] Update Confluence to reflect these changes.

### Sandbox
- [ ] https://robrap.sandbox.edx.org (building as of 3:11pm on 10/5)

### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] Analytics
- [x] Performance
- [x] Database migrations are backwards-compatible
- [x] safecommit violation code review process

Front-end changes:
- [x] Accessibility (Check for a11y violations, ensure keyboard accessible, screen reader testing as appropriate)
- [x] i18n
- [x] RTL

### Assign Github reviewers (as needed)
- [x] engineering 
- [x] product

FYI: @edx/learner-mercury
 
### Post-review
- [x] Rebase and squash commits