### PR TITLE
Adding spanish certificate template learner-1996 

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -253,16 +253,16 @@ def _update_course_context(request, context, course, course_key, platform_name):
     if CertificateGenerationCourseSetting.is_language_specific_templates_enabled_for_course(course_key):
         fields = ['start', 'end', 'max_effort', 'content_language']
         course_run_data = get_course_run_details(course_key, fields)
-        if course_run_data['start'] and course_run_data['end'] and course_run_data['max_effort']:
+        if course_run_data.get('start') and course_run_data.get('end') and course_run_data.get('max_effort'):
             # Calculate duration of the course run in weeks, multiplied by max_effort for total Hours of Effort
             try:
-                start = parser.parse(course_run_data['start'])
-                end = parser.parse(course_run_data['end'])
-                max_effort = int(course_run_data['max_effort'])
+                start = parser.parse(course_run_data.get('start'))
+                end = parser.parse(course_run_data.get('end'))
+                max_effort = int(course_run_data.get('max_effort'))
                 context['hours_of_effort'] = ((end - start).days / 7) * max_effort
             except ValueError:
                 log.exception('Error occurred while parsing course run details')
-        context['content_language'] = course_run_data['content_language']
+        context['content_language'] = course_run_data.get('content_language')
 
 
 def _update_social_context(request, context, course, user, user_certificate, platform_name):

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -15,10 +15,10 @@ course_mode_class = course_mode if course_mode else ''
 
             <div class="accomplishment-type">
                 <span class="accomplishment-type-symbol">
-                    <img class="src" src="/static/certificates/images/ico-${course_mode_class}.png" alt="">
+                    <img class="src" src="/static/certificates/images/ico-${course_mode_class}.png" alt="Image for course mode of type ${course_mode_class}">
                 </span>
 
-                <span class="accomplishment-type-label hd-4">${document_title}</span>
+                <span class="accomplishment-type-label hd-3">${document_title}</span>
             </div>
 
             <div class="wrapper-statement-and-signatories">
@@ -93,7 +93,7 @@ course_mode_class = course_mode if course_mode else ''
                     <dt class="label sr-only">Awarded to:</dt>
                     <dd class="value copy copy-meta">
                         <span class="recipient-img">
-                            <img class="src" src="/static/certificates/images/demo-user-profile.png" alt="">
+                            <img class="src" src="/static/certificates/images/demo-user-profile.png" alt="Recipient Image">
                         </span>
                         <div class="recipient-details">
                             <h3 class="recipient-name">${accomplishment_copy_name | h}</h3>

--- a/lms/templates/certificates/_edx-accomplishment-print-help.html
+++ b/lms/templates/certificates/_edx-accomplishment-print-help.html
@@ -1,0 +1,17 @@
+<%page expression_filter="h"/>
+<%! 
+from django.utils.translation import ugettext as _ 
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<div class="wrapper-accomplishment-support">
+    <div class="accomplishment-support">
+        <div class="accomplishment-support-print">
+            <p class="accomplishment-metadata-copy">
+                ${Text(_("For tips and tricks on printing your certificate, view the {link_start}Web Certificates help documentation{link_end}.")).format(
+                    link_start=HTML('<a href="http://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/SFD_certificates.html#web-certificates">'),
+                    link_end=HTML('</a>'),
+                )}
+            </p>
+        </div>
+    </div>
+</div>

--- a/themes/edx.org/lms/templates/certificates/_about-accomplishments.html
+++ b/themes/edx.org/lms/templates/certificates/_about-accomplishments.html
@@ -1,0 +1,9 @@
+<%page expression_filter="h"/>
+<%! 
+from django.utils.translation import ugettext as _ 
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<div class="accomplishment-metadata-bit accomplishment-metadata-aboutcert">
+    <h3 class="accomplishment-metadata-title">${_("About edX Verified Certificates")}</h3>
+    <p class="accomplishment-metadata-copy">${_("An edX Verified Certificate signifies that the learner has agreed to abide by the edX honor code and completed all of the required tasks of this course under its guidelines, as well as having their photo ID checked to verify their identity.")}</p>
+</div>

--- a/themes/edx.org/lms/templates/certificates/_about-edx.html
+++ b/themes/edx.org/lms/templates/certificates/_about-edx.html
@@ -1,0 +1,14 @@
+<%page expression_filter="h"/>
+<%! 
+from django.utils.translation import ugettext as _ 
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<div class="accomplishment-metadata-bit accomplishment-metadata-aboutedx">
+    <h3 class="accomplishment-metadata-title">${_("About edX")}</h3>
+    <p class="accomplishment-metadata-copy">
+        ${Text(_("{link_start}edX{link_end} offers interactive online classes and MOOCs from the world's best universities, including MIT, Harvard, Berkeley, University of Texas, and many others. edX is a non-profit online initiative created by founding partners Harvard and MIT.")).format(
+            link_start=HTML('<a href="http://www.edx.org">'),
+            link_end=HTML('</a>'),
+        )}
+    </p>
+</div>

--- a/themes/edx.org/lms/templates/certificates/_accomplishment-banner.html
+++ b/themes/edx.org/lms/templates/certificates/_accomplishment-banner.html
@@ -1,0 +1,59 @@
+<%page expression_filter="h"/>
+<%! 
+from django.utils.translation import ugettext as _ 
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<%
+accomplishment_course_title = accomplishment_copy_course_name
+if certificate_data and certificate_data.get('course_title', ''):
+    accomplishment_course_title = certificate_data.get('course_title', '')
+course_mode_class = course_mode if course_mode else ''
+%>
+<div id="fb-root"></div>
+<div class="wrapper-banner wrapper-banner-user">
+    <section class="banner banner-user">
+    <div class="message message-block message-notice">
+        <div class="message-text">
+            <h2 class="message-title">${Text(_("Congratulations, {user_name}!")).format(
+                        user_name=accomplishment_copy_name
+                    )}
+            </h2>
+            <p class="message-copy">
+                ${Text(_("You worked hard to earn your certificate from {accomplishment_copy_course_org} {dash} share it with colleagues, friends, and family to get the word out about what you mastered in {accomplishment_course_title}.")).format(
+                    dash=HTML('&mdash;'),
+                    accomplishment_copy_course_org=accomplishment_copy_course_org,
+                    accomplishment_course_title=accomplishment_course_title
+                )}
+            </p>
+        </div>
+        <div class="message-actions">
+            <div class="message-actions-box">
+                <h3 class="sr-only">${_("Print or share your certificate:")}</h3>
+                    % if facebook_share_enabled:
+                    <button class="action action-share-facebook btn icon-only" id="action-share-facebook" title="${_('Share on Facebook')}">
+                        <i class="icon fa fa-facebook-official" aria-hidden="true"></i>
+                        <span class="action-label">${_("Share this certificate on Facebook (opens a new tab/window)")}</span>
+                    </button>
+                    %endif
+                    % if twitter_share_enabled:
+                    <button title="${_('Share on Twitter')}"
+                        class="action action-share-twitter btn icon-only">
+                        <i class="icon fa fa-twitter" aria-hidden="true"></i>
+                        <span class="action-label">${_("Tweet this certificate (opens a new tab/window)")}</span>
+                    </button>
+                    %endif
+                    %if linked_in_url:
+                    <button class="action action-share-linkedin btn icon-only" id="action-share-linkedin" title="${_('Add to LinkedIn Profile')}" data-course-id="${course_id}" data-certificate-mode="${course_mode}">
+                        <i class="icon fa fa-linkedin" aria-hidden="true"></i>
+                        <span class="action-label">${_("Add this certificate to your LinkedIn profile (opens a new tab/window)")}</span>
+                    </button>
+                    %endif
+                    <button title="${_('Print')}" class="action action-print btn icon-only" id="action-print-view">
+                        <i class="icon fa fa-print" aria-hidden="true"></i>
+                        <span class="action-label">${_("Print this certificate")}</span>
+                    </button>
+            </div>
+        </div>
+    </div>
+    </section>
+</div>

--- a/themes/edx.org/lms/templates/certificates/_accomplishment-footer.html
+++ b/themes/edx.org/lms/templates/certificates/_accomplishment-footer.html
@@ -1,0 +1,31 @@
+<%page expression_filter="h"/>
+<%! 
+from django.utils.translation import ugettext as _ 
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<div class="wrapper-footer">
+    <footer class="footer-app" role="contentinfo" id="company-info">
+        <div class="footer-app-legal">
+            <nav class="footer-app-nav">
+                <ul class="list list-legal">
+                    <li class="nav-item">
+                        <a class="action" href="${company_tos_url}">${_("Terms of Service & Honor Code")}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="action" href="https://www.edx.org/edx-privacy-policy">${_("Privacy Policy")}</a>
+                    </li>
+                </ul>
+            </nav>
+            <div class="copyright-trademarks">
+                <p class="copy">
+                    <span class="copyright">&copy;
+                        <a href="http://www.edx.org">${_("edX Inc.")}</a>
+                    </span>
+                    ${_("All rights reserved except where noted. edX, Open edX and the edX and Open edX logos are registered trademarks or trademarks of edX Inc.")}</p>
+            </div>
+        </div>
+        <div class="footer-app-related">
+            <a class="img-link" href="http://edx.org/about"><img class="logo-img logo-openedx" src="https://edxuploads.s3.amazonaws.com/certificate_template_assets/3/edx-openedx-logo-tag.png" alt="${_('Powered by Open edX')}" /></a>
+        </div>
+    </footer>
+</div>


### PR DESCRIPTION
[LEARNER-1996](https://openedx.atlassian.net/browse/learner-1996)
Subtask: [LEARNER-2800](https://openedx.atlassian.net/browse/learner-2800)

Sets up partial templates in themes/edx.org so a spanish template can be created with localized footer and header content.

Also changes context updating to use get('key') instead of ['key'] indexing. 
