### PR TITLE
Complete scored blocks

### DIFF
--- a/lms/djangoapps/completion/apps.py
+++ b/lms/djangoapps/completion/apps.py
@@ -12,3 +12,6 @@ class CompletionAppConfig(AppConfig):
     """
     name = 'lms.djangoapps.completion'
     verbose_name = 'Completion'
+
+    def ready(self):
+        from . import handlers  # pylint: disable=unused-variable

--- a/lms/djangoapps/completion/handlers.py
+++ b/lms/djangoapps/completion/handlers.py
@@ -1,0 +1,36 @@
+"""
+Signal handlers to trigger completion updates.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.contrib.auth.models import User
+from django.dispatch import receiver
+
+from opaque_keys.edx.keys import CourseKey, UsageKey
+from lms.djangoapps.grades.signals.signals import PROBLEM_WEIGHTED_SCORE_CHANGED
+
+from .models import BlockCompletion
+from . import waffle
+
+
+@receiver(PROBLEM_WEIGHTED_SCORE_CHANGED)
+def scorable_block_completion(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    When a problem is scored, submit a new BlockCompletion for that block.
+    """
+    if not waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING):
+        return
+    user = User.objects.get(id=kwargs['user_id'])
+    course_key = CourseKey.from_string(kwargs['course_id'])
+    block_key = UsageKey.from_string(kwargs['usage_id'])
+    if kwargs.get('score_deleted'):
+        completion = 0.0
+    else:
+        completion = 1.0
+    BlockCompletion.objects.submit_completion(
+        user=user,
+        course_key=course_key,
+        block_key=block_key,
+        completion=completion,
+    )

--- a/lms/djangoapps/completion/tests/test_handlers.py
+++ b/lms/djangoapps/completion/tests/test_handlers.py
@@ -1,0 +1,120 @@
+"""
+Test signal handlers.
+"""
+
+from datetime import datetime
+
+import ddt
+from django.test import TestCase
+from mock import patch
+from opaque_keys.edx.keys import CourseKey
+from pytz import utc
+import six
+
+from lms.djangoapps.grades.signals.signals import PROBLEM_WEIGHTED_SCORE_CHANGED
+from student.tests.factories import UserFactory
+
+from .. import handlers
+from ..models import BlockCompletion
+from .. import waffle
+
+
+class CompletionHandlerMixin(object):
+    """
+    Common functionality for completion handler tests.
+    """
+    def override_waffle_switch(self, override):
+        """
+        Override the setting of the ENABLE_COMPLETION_TRACKING waffle switch
+        for the course of the test.
+
+        Parameters:
+            override (bool): True if tracking should be enabled.
+        """
+        _waffle_overrider = waffle.waffle().override(waffle.ENABLE_COMPLETION_TRACKING, override)
+        _waffle_overrider.__enter__()
+        self.addCleanup(_waffle_overrider.__exit__, None, None, None)
+
+
+@ddt.ddt
+class ScorableCompletionHandlerTestCase(CompletionHandlerMixin, TestCase):
+    """
+    Test the signal handler
+    """
+
+    def setUp(self):
+        super(ScorableCompletionHandlerTestCase, self).setUp()
+        self.user = UserFactory.create()
+        self.course_key = CourseKey.from_string("course-v1:a+valid+course")
+        self.block_key = self.course_key.make_usage_key(block_type="video", block_id="mah-video")
+        self.override_waffle_switch(True)
+
+    @ddt.data(
+        ({'score_deleted': True}, 0.0),
+        ({'score_deleted': False}, 1.0),
+        ({}, 1.0),
+    )
+    @ddt.unpack
+    def test_handler_submits_completion(self, params, expected_completion):
+        handlers.scorable_block_completion(
+            sender=self,
+            user_id=self.user.id,
+            course_id=six.text_type(self.course_key),
+            usage_id=six.text_type(self.block_key),
+            weighted_earned=0.0,
+            weighted_possible=3.0,
+            modified=datetime.utcnow().replace(tzinfo=utc),
+            score_db_table='submissions',
+            **params
+        )
+        completion = BlockCompletion.objects.get(user=self.user, course_key=self.course_key, block_key=self.block_key)
+        self.assertEqual(completion.completion, expected_completion)
+
+    def test_signal_calls_handler(self):
+        user = UserFactory.create()
+        course_key = CourseKey.from_string("course-v1:a+valid+course")
+        block_key = course_key.make_usage_key(block_type="video", block_id="mah-video")
+
+        with patch('lms.djangoapps.completion.handlers.scorable_block_completion') as mock_handler:
+            PROBLEM_WEIGHTED_SCORE_CHANGED.send_robust(
+                sender=self,
+                user_id=user.id,
+                course_id=six.text_type(course_key),
+                usage_id=six.text_type(block_key),
+                weighted_earned=0.0,
+                weighted_possible=3.0,
+                modified=datetime.utcnow().replace(tzinfo=utc),
+                score_db_table='submissions',
+            )
+        mock_handler.assert_called()
+
+
+class DisabledCompletionHandlerTestCase(CompletionHandlerMixin, TestCase):
+    """
+    Test that disabling the ENABLE_COMPLETION_TRACKING waffle switch prevents
+    the signal handler from submitting a completion.
+    """
+    def setUp(self):
+        super(DisabledCompletionHandlerTestCase, self).setUp()
+        self.user = UserFactory.create()
+        self.course_key = CourseKey.from_string("course-v1:a+valid+course")
+        self.block_key = self.course_key.make_usage_key(block_type="video", block_id="mah-video")
+        self.override_waffle_switch(False)
+
+    def test_disabled_handler_does_not_submit_completion(self):
+        handlers.scorable_block_completion(
+            sender=self,
+            user_id=self.user.id,
+            course_id=six.text_type(self.course_key),
+            usage_id=six.text_type(self.block_key),
+            weighted_earned=0.0,
+            weighted_possible=3.0,
+            modified=datetime.utcnow().replace(tzinfo=utc),
+            score_db_table='submissions',
+        )
+        with self.assertRaises(BlockCompletion.DoesNotExist):
+            BlockCompletion.objects.get(
+                user=self.user,
+                course_key=self.course_key,
+                block_key=self.block_key
+            )

--- a/lms/djangoapps/completion/tests/test_models.py
+++ b/lms/djangoapps/completion/tests/test_models.py
@@ -47,9 +47,9 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
     """
     def setUp(self):
         super(SubmitCompletionTestCase, self).setUp()
-        self._overrider = waffle.waffle().override(waffle.ENABLE_COMPLETION_TRACKING, True)
-        self._overrider.__enter__()
-        self.addCleanup(self._overrider.__exit__, None, None, None)
+        _overrider = waffle.waffle().override(waffle.ENABLE_COMPLETION_TRACKING, True)
+        _overrider.__enter__()
+        self.addCleanup(_overrider.__exit__, None, None, None)
         self.set_up_completion()
 
     def test_changed_value(self):

--- a/lms/djangoapps/grades/signals/signals.py
+++ b/lms/djangoapps/grades/signals/signals.py
@@ -26,6 +26,8 @@ PROBLEM_RAW_SCORE_CHANGED = Signal(
         'modified',  # A datetime indicating when the database representation of
                      # this the problem score was saved.
         'score_db_table',  # The database table that houses the score that changed.
+        'score_deleted',  # Boolean indicating whether the score changed due to
+                          # the user state being deleted.
     ]
 )
 
@@ -49,6 +51,8 @@ PROBLEM_WEIGHTED_SCORE_CHANGED = Signal(
         'modified',  # A datetime indicating when the database representation of
                      # this the problem score was saved.
         'score_db_table',  # The database table that houses the score that changed.
+        'score_deleted',  # Boolean indicating whether the score changed due to
+                          # the user state being deleted.
     ]
 )
 


### PR DESCRIPTION
This contains the completion logic for scorable xblocks.  When a block is scored, it should be marked complete (completion = 1.0).  If an instructor resets the state of the xblock, it should also reset the completion of the xblock to 0.0.

**JIRA tickets**: N/A

**Discussions**: Architecture discussed extensively on the wiki and in meetings, then the revised proposal was presented to the Arch Council on Oct. 21 and given thumbs up.

**Dependencies**: None

**Screenshots**: N/A

**Sandbox URL**: TBD

**Merge deadline**: None



**Testing instructions**:

You will be going back and forth between the django shell and interacting with the devstack through the browser, so log into the devstack twice, and run `paver devstack lms` in one of the sessions. Then: 

1. Log in as an admin user.
2. In the admin, at http://localhost:18000/admin/grades/persistentgradesenabledflag/add/ select both "enable" and "enable for all courses."
3. Log in as a course staff user.
2. Find a scorable block that the user hasn't answered yet.  Get the block key for that user in the staff debug section.
3. In the django shell (`./manage.py lms --settings=devstack shell` in the other window), ensure that there is no completion object for that block, or if it does exist, ensure the completion value is set to zero.
4. Answer the problem.
5. Refetch the completion object for the block. If you already have a copy, I think you should be able to do `completion_object.refresh_from_db()`.  Otherwise `completion_object = BlockCompletion.objects.get(pk=completion_object.pk)` will work. Ensure the completion value is set to 1.0.
6. In the instructor control panel, reset student state for the given problem and the logged in user.
7. Refetch the completion object again, Ensure the completion value is set to 0.0.

**Reviewers**:

- [x] OpenCraft reviewer: @bradenmacdonald 
- [x] edX reviewer: @robrap

**Author notes and concerns**: N/A

**Settings**: N/A

