### PR TITLE
Remove all usage of the django-simple-history module.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -912,9 +912,6 @@ INSTALLED_APPS = [
     # Common views
     'openedx.core.djangoapps.common_views',
 
-    # History tables
-    'simple_history',
-
     # Database-backed configuration
     'config_models',
     'waffle',

--- a/common/djangoapps/microsite_configuration/migrations/0003_delete_historical_records.py
+++ b/common/djangoapps/microsite_configuration/migrations/0003_delete_historical_records.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('microsite_configuration', '0002_auto_20160202_0228'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicalmicrositeorganizationmapping',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicalmicrositeorganizationmapping',
+            name='microsite',
+        ),
+        migrations.RemoveField(
+            model_name='historicalmicrositetemplate',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicalmicrositetemplate',
+            name='microsite',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalMicrositeOrganizationMapping',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalMicrositeTemplate',
+        ),
+    ]

--- a/common/djangoapps/microsite_configuration/models.py
+++ b/common/djangoapps/microsite_configuration/models.py
@@ -14,7 +14,6 @@ from django.db.models.signals import pre_delete, pre_save
 from django.dispatch import receiver
 from jsonfield.fields import JSONField
 from model_utils.models import TimeStampedModel
-from simple_history.models import HistoricalRecords
 
 
 class Microsite(models.Model):
@@ -115,9 +114,6 @@ class MicrositeOrganizationMapping(models.Model):
     organization = models.CharField(max_length=63, db_index=True, unique=True)
     microsite = models.ForeignKey(Microsite, db_index=True)
 
-    # for archiving
-    history = HistoricalRecords()
-
     def __unicode__(self):
         """String conversion"""
         return u'{microsite_key}: {organization}'.format(
@@ -154,9 +150,6 @@ class MicrositeTemplate(models.Model):
     microsite = models.ForeignKey(Microsite, db_index=True)
     template_uri = models.CharField(max_length=255, db_index=True)
     template = models.TextField()
-
-    # for archiving
-    history = HistoricalRecords()
 
     def __unicode__(self):
         """String conversion"""

--- a/common/djangoapps/student/migrations/0013_delete_historical_enrollment_records.py
+++ b/common/djangoapps/student/migrations/0013_delete_historical_enrollment_records.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('student', '0012_sociallink'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicalcourseenrollment',
+            name='course',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcourseenrollment',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcourseenrollment',
+            name='user',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalCourseEnrollment',
+        ),
+    ]

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -42,7 +42,6 @@ from eventtracking import tracker
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
-from simple_history.models import HistoricalRecords
 from slumber.exceptions import HttpClientError, HttpServerError
 
 import dogstats_wrapper as dog_stats_api
@@ -1026,9 +1025,6 @@ class CourseEnrollment(models.Model):
     mode = models.CharField(default=CourseMode.DEFAULT_MODE_SLUG, max_length=100)
 
     objects = CourseEnrollmentManager()
-
-    # Maintain a history of requirement status updates for auditing purposes
-    history = HistoricalRecords()
 
     # cache key format e.g enrollment.<username>.<course_key>.mode = 'honor'
     COURSE_ENROLLMENT_CACHE_KEY = u"enrollment.{}.{}.mode"  # TODO Can this be removed?  It doesn't seem to be used.

--- a/lms/djangoapps/verify_student/migrations/0004_delete_historical_records.py
+++ b/lms/djangoapps/verify_student/migrations/0004_delete_historical_records.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('verify_student', '0003_auto_20151113_1443'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicalverificationdeadline',
+            name='history_user',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalVerificationDeadline',
+        ),
+    ]

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -32,7 +32,6 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from model_utils import Choices
 from model_utils.models import StatusModel, TimeStampedModel
-from simple_history.models import HistoricalRecords
 
 from course_modes.models import CourseMode
 from lms.djangoapps.verify_student.ssencrypt import (
@@ -1042,9 +1041,6 @@ class VerificationDeadline(TimeStampedModel):
     # if the field is set manually we want a way to indicate that so we don't
     # overwrite the manual setting of the field.
     deadline_is_explicit = models.BooleanField(default=False)
-
-    # Maintain a history of changes to deadlines for auditing purposes
-    history = HistoricalRecords()
 
     ALL_DEADLINES_CACHE_KEY = "verify_student.all_verification_deadlines"
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1988,9 +1988,6 @@ INSTALLED_APPS = [
     # Common views
     'openedx.core.djangoapps.common_views',
 
-    # History tables
-    'simple_history',
-
     # Database-backed configuration
     'config_models',
     'waffle',

--- a/openedx/core/djangoapps/api_admin/migrations/0007_delete_historical_api_records.py
+++ b/openedx/core/djangoapps/api_admin/migrations/0007_delete_historical_api_records.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api_admin', '0006_catalog'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicalapiaccessrequest',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicalapiaccessrequest',
+            name='site',
+        ),
+        migrations.RemoveField(
+            model_name='historicalapiaccessrequest',
+            name='user',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalApiAccessRequest',
+        ),
+    ]

--- a/openedx/core/djangoapps/api_admin/models.py
+++ b/openedx/core/djangoapps/api_admin/models.py
@@ -14,7 +14,6 @@ from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from django.utils.translation import ugettext as _
 from django_extensions.db.models import TimeStampedModel
-from simple_history.models import HistoricalRecords
 
 from edxmako.shortcuts import render_to_string
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -47,8 +46,6 @@ class ApiAccessRequest(TimeStampedModel):
     company_address = models.CharField(max_length=255, default='')
     site = models.ForeignKey(Site)
     contacted = models.BooleanField(default=False)
-
-    history = HistoricalRecords()
 
     @classmethod
     def has_api_access(cls, user):

--- a/openedx/core/djangoapps/credit/migrations/0004_delete_historical_credit_records.py
+++ b/openedx/core/djangoapps/credit/migrations/0004_delete_historical_credit_records.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('credit', '0003_auto_20160511_2227'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicalcreditrequest',
+            name='course',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcreditrequest',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcreditrequest',
+            name='provider',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcreditrequirementstatus',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcreditrequirementstatus',
+            name='requirement',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalCreditRequest',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalCreditRequirementStatus',
+        ),
+    ]

--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -21,7 +21,6 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from jsonfield.fields import JSONField
 from model_utils.models import TimeStampedModel
-from simple_history.models import HistoricalRecords
 
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from request_cache.middleware import RequestCache, ns_request_cached
@@ -437,9 +436,6 @@ class CreditRequirementStatus(TimeStampedModel):
     # the grade to users later and to send the information to credit providers.
     reason = JSONField(default={})
 
-    # Maintain a history of requirement status updates for auditing purposes
-    history = HistoricalRecords()
-
     class Meta(object):
         unique_together = ('username', 'requirement')
         verbose_name_plural = _('Credit requirement statuses')
@@ -654,8 +650,6 @@ class CreditRequest(TimeStampedModel):
         choices=REQUEST_STATUS_CHOICES,
         default=REQUEST_STATUS_PENDING
     )
-
-    history = HistoricalRecords()
 
     class Meta(object):
         # Enforce the constraint that each user can have exactly one outstanding

--- a/openedx/core/djangoapps/credit/tests/test_api.py
+++ b/openedx/core/djangoapps/credit/tests/test_api.py
@@ -651,7 +651,7 @@ class CreditRequirementApiTests(CreditApiTestBase):
         api.set_credit_requirements(self.course_key, requirements)
 
         # Satisfy one of the requirements, but not the other
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(11):
             api.set_credit_requirement_status(
                 user,
                 self.course_key,
@@ -663,7 +663,7 @@ class CreditRequirementApiTests(CreditApiTestBase):
         self.assertFalse(api.is_user_eligible_for_credit(user.username, self.course_key))
 
         # Satisfy the other requirement
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(22):
             api.set_credit_requirement_status(
                 user,
                 self.course_key,
@@ -717,7 +717,7 @@ class CreditRequirementApiTests(CreditApiTestBase):
         # Delete the eligibility entries and satisfy the user's eligibility
         # requirement again to trigger eligibility notification
         CreditEligibility.objects.all().delete()
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(15):
             api.set_credit_requirement_status(
                 user,
                 self.course_key,
@@ -1048,15 +1048,13 @@ class CreditProviderIntegrationApiTests(CreditApiTestBase):
         # - 1 query: Look up the user's enrollment date in the course.
         # - 2 query: Look up the user's completion date in the course.
         # - 1 query: Update the request.
-        # - 2 queries: Update the history table for the request.
         # - 4 Django savepoints
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(14):
             request = api.create_credit_request(self.course_key, self.PROVIDER_ID, self.USER_INFO['username'])
 
         # - 2 queries: Retrieve and update the request
-        # - 1 query: Update the history table for the request.
         uuid = request["parameters"]["request_uuid"]
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             api.update_credit_request_status(uuid, self.PROVIDER_ID, "approved")
 
         with self.assertNumQueries(1):

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -28,7 +28,6 @@ django-pipeline-forgiving==1.0.0
 django-pyfs==1.0.7
 django-sekizai>=0.10
 django-ses==0.7.1
-django-simple-history==1.6.3
 django-statici18n==1.4.0
 django-storages==1.4.1
 django-method-override==0.1.0


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-1755

This module would need to be upgraded for Django 1.11 compatibility. There's currently a history table which records every CourseEnrollment in the common/djangoapps/student Django application. That table has now grown to be 47 million rows - and the most recent version of django-simple-history adds a field to the table - and all HistoricalRecords.

After some asking around, we've found that the data in these history tables is not used - instead we use tracking events at edx.org. So this PR removes the module and all its historical logging. All data will be removed by mgmt commands added in a subsequent PR.