### PR TITLE
Exposing course run license via Course API

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -74,6 +74,7 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     mobile_available = serializers.BooleanField()
     hidden = serializers.SerializerMethodField()
     invitation_only = serializers.BooleanField()
+    license = serializers.CharField()
 
     # 'course_id' is a deprecated field, please use 'id' instead.
     course_id = serializers.CharField(source='id', read_only=True)

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -17,9 +17,10 @@ from openedx.core.djangoapps.models.course_details import CourseDetails
 from xmodule.course_module import DEFAULT_START_DATE
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import check_mongo_calls
-
-from ..serializers import CourseDetailSerializer, CourseSerializer
 from .mixins import CourseApiFactoryMixin
+from ..serializers import CourseDetailSerializer, CourseSerializer
+
+LICENSE = 'all-rights-reserved'
 
 
 @attr(shard=3)
@@ -73,10 +74,19 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
             'mobile_available': False,
             'hidden': False,
             'invitation_only': False,
+            'license': LICENSE,
 
             # 'course_id' is a deprecated field, please use 'id' instead.
             'course_id': u'edX/toy/2012_Fall',
         }
+
+    @staticmethod
+    def create_course(**kwargs):
+        combined_kwargs = {
+            'license': LICENSE,
+        }
+        combined_kwargs.update(kwargs)
+        return CourseApiFactoryMixin.create_course(**combined_kwargs)
 
     def _get_request(self, user=None):
         """

--- a/openedx/core/djangoapps/content/course_overviews/migrations/0015_courseoverview_license.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0015_courseoverview_license.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_overviews', '0014_courseoverview_certificate_available_date'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseoverview',
+            name='license',
+            field=models.CharField(max_length=255, blank=True),
+        ),
+    ]

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -44,7 +44,7 @@ class CourseOverview(TimeStampedModel):
         app_label = 'course_overviews'
 
     # IMPORTANT: Bump this whenever you modify this model and/or add a migration.
-    VERSION = 6
+    VERSION = 7
 
     # Cache entry versioning.
     version = IntegerField()
@@ -103,6 +103,7 @@ class CourseOverview(TimeStampedModel):
     eligible_for_financial_aid = BooleanField(default=True)
 
     language = TextField(null=True)
+    license = models.CharField(max_length=255, blank=True)
 
     @classmethod
     def _create_or_update(cls, course):
@@ -195,6 +196,7 @@ class CourseOverview(TimeStampedModel):
         course_overview.self_paced = course.self_paced
 
         course_overview.language = course.language
+        course_overview.license = course.license or ''
 
         return course_overview
 

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -508,6 +508,17 @@ class CourseOverviewTestCase(ModuleStoreTestCase):
         self.assertEqual(len(course_ids_to_overviews), 1)
         self.assertIn(course_with_overview_1.id, course_ids_to_overviews)
 
+    @ddt.data(
+        ('', '',),
+        (None, '',),
+        ('all-rights-reserved', 'all-rights-reserved',),
+    )
+    @ddt.unpack
+    def test_license(self, license, expected_value):
+        course = CourseFactory.create(emit_signals=True, license=license)
+        course_overview = CourseOverview.get_from_id(course.id)
+        self.assertEqual(course_overview.license, expected_value)
+
 
 @attr(shard=3)
 @ddt.ddt


### PR DESCRIPTION
The license for course run content is now stored on the CourseOverviews model and exposed via the Course API.

LEARNER-2791