### PR TITLE
Makes regen_user fn respect ENABLE_OPENBADGES

### DIFF
--- a/lms/djangoapps/certificates/management/commands/regenerate_user.py
+++ b/lms/djangoapps/certificates/management/commands/regenerate_user.py
@@ -9,6 +9,7 @@ from django.core.management.base import BaseCommand, CommandError
 from opaque_keys.edx.keys import CourseKey
 
 from badges.events.course_complete import get_completion_badge
+from badges.utils import badges_enabled
 from certificates.api import regenerate_user_certificates
 from xmodule.modulestore.django import modulestore
 
@@ -100,7 +101,7 @@ class Command(BaseCommand):
                 course_id
             )
 
-            if course.issue_badges:
+            if badges_enabled() and course.issue_badges:
                 badge_class = get_completion_badge(course_id, student)
                 badge = badge_class.get_for_user(student)
 

--- a/lms/djangoapps/certificates/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/tests/test_cert_management.py
@@ -169,6 +169,7 @@ class RegenerateCertificatesTest(CertificateManagementTest):
 
     @ddt.data(True, False)
     @override_settings(CERT_QUEUE='test-queue')
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_OPENBADGES': True})
     @patch('certificates.api.XQueueCertInterface', spec=True)
     def test_clear_badge(self, issue_badges, xqueue):
         """


### PR DESCRIPTION
The `regenerate_user` function currently doesn't check to see if the `ENABLE_OPENBADGES` setting is turned on before running badges code. That is not good, so in the PR I fix that.

---

- uses pre-existing function to check if badging is enabled