### PR TITLE
Fix regex in video xmodule to check for HTML5 video urls which contain parameters

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -286,7 +286,7 @@ function(VideoPlayer, i18n, moment, _) {
      */
     function extractHLSVideoSources(state) {
         return _.filter(state.config.sources, function(source) {
-            return /\.m3u8$/.test(source);
+            return /\.m3u8(\?.*)?$/.test(source);
         });
     }
 


### PR DESCRIPTION
This PR allows video components to use HTML5 videos which contain URL parameters, which were previously ignored due to a regex which expects video URLs to end with ".m3u8".

**Dependencies**: None

**Sandbox URL**: https://pr16193.sandbox.opencraft.hosting/

**Merge deadline**: None

**Screenshot**:

![image](https://user-images.githubusercontent.com/249196/31462921-8b88033c-aece-11e7-94e8-1d27e92a8c77.png)

**Testing instructions**:

1. Check that the HTML5 video from Vimeo displays correctly at https://studio-pr16193.sandbox.opencraft.hosting/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@1822e8f0fc964a3d816d54fc3ea3455a
2. Check that the video URL contains the previously unusable URL: https://player.vimeo.com/external/225003478.m3u8?s=6438b130458bd0eb38f7625ffa26623caee8ff7c

**Author notes and concerns**:
1. Another possible regex would be to remove the end of line marker: `/\.m3u8/` instead of `/\.m3u8\??.*$/`
This would match any string with .m3u8 anywhere in it however. So I chose add a match for the parameters instead.
2. I can't imagine greediness being an issue here, but perhaps I am mistaken.

**Reviewers**
- [ ] (smarnach)
- [ ] edX reviewer[s] TBD