### PR TITLE
Pin moment dependency to 2.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jquery": "~2.2.0",
     "jquery-migrate": "^1.4.1",
     "jquery.scrollto": "~2.1.2",
-    "moment": "^2.15.1",
+    "moment": "2.18.1",
     "moment-timezone": "~0.5.5",
     "picturefill": "~3.0.2",
     "popper.js": "~1.12.5",


### PR DESCRIPTION
A new version was pushed this morning that broke a number of bok choy tests.