### PR TITLE
Course dates web fragment for mobile apps.

### DIFF
--- a/openedx/features/course_experience/tests/views/test_course_dates.py
+++ b/openedx/features/course_experience/tests/views/test_course_dates.py
@@ -1,0 +1,47 @@
+"""
+Tests for course dates fragment.
+"""
+from datetime import timedelta, datetime
+from django.core.urlresolvers import reverse
+
+from student.tests.factories import UserFactory
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+
+
+TEST_PASSWORD = 'test'
+
+
+class TestCourseDatesFragmentView(ModuleStoreTestCase):
+    """Tests for the course dates fragment view."""
+
+    def setUp(self):
+        super(TestCourseDatesFragmentView, self).setUp()
+        with self.store.default_store(ModuleStoreEnum.Type.split):
+            self.course = CourseFactory.create(
+                org='edX',
+                number='test',
+                display_name='Test Course',
+                start=datetime.now() - timedelta(days=30),
+                end=datetime.now() + timedelta(days=30),
+            )
+        self.user = UserFactory(password=TEST_PASSWORD)
+        self.client.login(username=self.user.username, password=TEST_PASSWORD)
+
+        self.dates_fragment_url = reverse(
+            'openedx.course_experience.mobile_dates_fragment_view',
+            kwargs={
+                'course_id': unicode(self.course.id)
+            }
+        )
+
+    def test_course_dates_fragment(self):
+        response = self.client.get(self.dates_fragment_url)
+        self.assertContains(response, 'Important Course Dates')
+        self.assertContains(response, 'Today is')
+        self.assertContains(response, 'Course End')
+
+        self.client.logout()
+        response = self.client.get(self.dates_fragment_url)
+        self.assertEqual(response.status_code, 404)

--- a/openedx/features/course_experience/urls.py
+++ b/openedx/features/course_experience/urls.py
@@ -4,6 +4,7 @@ Defines URLs for the course experience.
 
 from django.conf.urls import url
 
+from views.course_dates import CourseDatesFragmentMobileView
 from views.course_home import CourseHomeFragmentView, CourseHomeView
 from views.course_outline import CourseOutlineFragmentView
 from views.course_reviews import CourseReviewsView
@@ -62,5 +63,10 @@ urlpatterns = [
         r'^dismiss_welcome_message$',
         dismiss_welcome_message,
         name='openedx.course_experience.dismiss_welcome_message',
+    ),
+    url(
+        r'^mobile_dates_fragment',
+        CourseDatesFragmentMobileView.as_view(),
+        name='openedx.course_experience.mobile_dates_fragment_view',
     ),
 ]

--- a/openedx/features/course_experience/views/course_dates.py
+++ b/openedx/features/course_experience/views/course_dates.py
@@ -1,6 +1,7 @@
 """
 Fragment for rendering the course dates sidebar.
 """
+from django.http import Http404
 from django.template.loader import render_to_string
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
@@ -26,3 +27,20 @@ class CourseDatesFragmentView(EdxFragmentView):
         }
         html = render_to_string('course_experience/course-dates-fragment.html', context)
         return Fragment(html)
+
+
+class CourseDatesFragmentMobileView(CourseDatesFragmentView):
+    """
+    A course dates fragment to show dates on mobile apps.
+
+    Mobile apps uses WebKit mobile client to create and maintain a session with
+    the server for authenticated requests, and it hasn't exposed any way to find
+    out either session was created with the server or not so mobile app uses a
+    mechanism to automatically create/recreate session with the server for all
+    authenticated requests if the server returns 404.
+    """
+    def get(self, request, *args, **kwargs):
+        if not request.user.is_authenticated():
+            raise Http404
+
+        return super(CourseDatesFragmentMobileView, self).get(request, *args, **kwargs)


### PR DESCRIPTION
Implement a course dates fragment as a web view, currently we are using the course info page to get the course dates section by parsing the whole html page.

Implemented a seperate view to handle unauthenticated users, original view was rendering some dates even if user was not authenticated.

LEARNER-2769

**Sandbox:**

1. Web view: https://dates-fragment.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/mobile_dates_fragment
2. JSON: https://dates-fragment.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/mobile_dates_fragment?format=json