### PR TITLE
extended parameters of non-language-specific custom certificate templates

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -513,12 +513,12 @@ def get_language_specific_template_or_default(language, templates):
     Returns default templates If no language matches, or language passed is None
     """
     two_letter_language = _get_two_letter_language_code(language)
-    language_or_default_templates = list(templates.filter(Q(language=two_letter_language) | Q(language=None)))
-    language_specific_template = get_language_specific_template(language, language_or_default_templates)
+    language_or_default_templates = list(templates.filter(Q(language=two_letter_language) | Q(language=None) | Q(language='')))
+    language_specific_template = get_language_specific_template(two_letter_language, language_or_default_templates)
     if language_specific_template:
         return language_specific_template
     else:
-        return language_or_default_templates[0] if language_or_default_templates else None
+        return get_all_languages_or_default_template(language_or_default_templates)
 
 
 def get_language_specific_template(language, templates):
@@ -526,6 +526,13 @@ def get_language_specific_template(language, templates):
         if template.language == language:
             return template
     return None
+
+
+def get_all_languages_or_default_template(templates):
+    for template in templates:
+        if template.language == '':
+            return template
+    return templates[0] if templates else None
 
 
 def _get_two_letter_language_code(language_code):

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -1074,6 +1074,13 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'course name: test_null_lang_template')
 
+        #create an org_mode_and_coursekey template language=''
+        self._create_custom_named_template('test_all_languages_template', org_id=1, mode='honor', course_key=unicode(self.course.id), language='')
+        #verify returns null lang template
+        response = self.client.get(test_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'course name: test_all_languages_template')
+
         #create a org_mode_and_coursekey template language=lang
         self._create_custom_named_template('test_right_lang_template', org_id=1, mode='honor', course_key=unicode(self.course.id), language=right_language)
         # verify return right_language template
@@ -1119,6 +1126,13 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'course name: test_null_lang_template')
 
+        #create an org and mode template language=''
+        self._create_custom_named_template('test_all_languages_template', org_id=1, mode='honor', language='')
+        #verify returns All Languages template
+        response = self.client.get(test_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'course name: test_all_languages_template')
+
         #create a org and mode template language=lang
         self._create_custom_named_template('test_right_lang_template', org_id=1, mode='honor', language=right_language)
         # verify return right_language template
@@ -1161,6 +1175,13 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         response = self.client.get(test_url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'course name: test_null_lang_template')
+
+        #create an org template language=''
+        self._create_custom_named_template('test_all_languages_template', org_id=1, language='')
+        #verify returns All Languages template
+        response = self.client.get(test_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'course name: test_all_languages_template')
 
         #create a org template language=lang
         self._create_custom_named_template('test_right_lang_template', org_id=1, language=right_language)
@@ -1206,6 +1227,13 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'course name: test_null_lang_template')
 
+        #create a mode template language=''
+        self._create_custom_named_template('test_all_languages_template', mode='honor', language='')
+        #verify returns All Languages template
+        response = self.client.get(test_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'course name: test_all_languages_template')
+
         #create a mode template language=lang
         self._create_custom_named_template('test_right_lang_template', mode='honor', language=right_language)
         # verify return right_language template
@@ -1248,6 +1276,13 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         response = self.client.get(test_url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'course name: test_null_lang_template')
+
+        #create a mode template language=''
+        self._create_custom_named_template('test_all_languages_template', org_id=1, mode='honor', language='')
+        #verify returns All Languages template
+        response = self.client.get(test_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'course name: test_all_languages_template')
 
         #create a mode template language=lang
         self._create_custom_named_template('test_right_lang_template', org_id=1, mode='honor', language=right_language)


### PR DESCRIPTION
This is a fix for the bug found in ticket [WL-1218](https://openedx.atlassian.net/browse/WL-1218) where a custom certificate template that was saved with its language set to 'All Languages' was not retrieved by the lookup logic, with the default certificate template being rendered instead.