### PR TITLE
LEARNER-2819: Fix caching of course_outline_root_block.

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -5,11 +5,11 @@ from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.course_api.blocks.api import get_blocks
 from lms.djangoapps.course_blocks.utils import get_student_module_as_dict
-from openedx.core.lib.cache_utils import memoized
+from request_cache.middleware import request_cached
 from xmodule.modulestore.django import modulestore
 
 
-@memoized
+@request_cached
 def get_course_outline_block_tree(request, course_id):
     """
     Returns the root block of the course outline, with children as blocks.


### PR DESCRIPTION
Replaces use of @memoized decorator for request caching to fix possible memory leak.

FYI: @jmbowman: You had mentioned this a while ago and I thought memoized was request scoped.  But in case it isn't and this causes a leak, it is now more explicit.  Thanks.

FYI: @andy-armstrong 