### PR TITLE
Grades: Fix ZeroDivisionError

### DIFF
--- a/lms/djangoapps/grades/subsection_grade.py
+++ b/lms/djangoapps/grades/subsection_grade.py
@@ -141,7 +141,10 @@ class NonZeroSubsectionGrade(SubsectionGradeBase):
 
     @property
     def percent_graded(self):
-        return self.graded_total.earned / self.graded_total.possible
+        if self.graded_total.possible > 0:
+            return self.graded_total.earned / self.graded_total.possible
+        else:
+            return 0.0
 
     @staticmethod
     def _compute_block_score(

--- a/lms/djangoapps/grades/tests/test_subsection_grade.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade.py
@@ -36,3 +36,13 @@ class SubsectionGradeTest(GradeTestBase):
             read_grade.all_total.first_attempted = created_grade.all_total.first_attempted = None
             self.assertEqual(created_grade.all_total, read_grade.all_total)
             self.assertEqual(created_grade.percent_graded, 0.5)
+
+    def test_zero(self):
+        with mock_get_score(1, 0):
+            grade = CreateSubsectionGrade(
+                self.sequence,
+                self.course_structure,
+                self.subsection_grade_factory._submissions_scores,
+                self.subsection_grade_factory._csm_scores,
+            )
+            self.assertEqual(grade.percent_graded, 0.0)


### PR DESCRIPTION
I found this issue when trying to create a grade report for the Demo course.  There are other courses that will also run into this issue.  So I'd like to get this fix in ASAP.