### PR TITLE
Delete old recurring_nudge_schedules_for_hour task

### DIFF
--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -69,31 +69,6 @@ class RecurringNudge(ScheduleMessageType):
         self.name = "recurringnudge_day{}".format(day)
 
 
-# TODO: delete once recurring_nudge_schedule_bin is fully rolled out
-@task(ignore_result=True, routing_key=ROUTING_KEY)
-def recurring_nudge_schedule_hour(
-    site_id, day, target_hour_str, org_list, exclude_orgs=False, override_recipient_email=None,
-):
-    target_hour = deserialize(target_hour_str)
-    msg_type = RecurringNudge(day)
-
-    for (user, language, context) in _recurring_nudge_schedules_for_hour(
-        Site.objects.get(id=site_id),
-        target_hour,
-        org_list,
-        exclude_orgs
-    ):
-        msg = msg_type.personalize(
-            Recipient(
-                user.username,
-                override_recipient_email or user.email,
-            ),
-            language,
-            context,
-        )
-        _recurring_nudge_schedule_send.apply_async((site_id, str(msg)), retry=False)
-
-
 @task(ignore_result=True, routing_key=ROUTING_KEY)
 def _recurring_nudge_schedule_send(site_id, msg_str):
     site = Site.objects.get(pk=site_id)
@@ -104,80 +79,6 @@ def _recurring_nudge_schedule_send(site_id, msg_str):
     msg = Message.from_string(msg_str)
     LOG.debug('Recurring Nudge: Sending message = %s', msg_str)
     ace.send(msg)
-
-
-# TODO: delete once _recurring_nudge_schedules_for_bin is fully rolled out
-def _recurring_nudge_schedules_for_hour(site, target_hour, org_list, exclude_orgs=False):
-    users, schedules = _gather_users_and_schedules_for_target_hour(target_hour, org_list, exclude_orgs)
-
-    dashboard_relative_url = reverse('dashboard')
-    for (user, user_schedules) in groupby(schedules, lambda s: s.enrollment.user):
-        user_schedules = list(user_schedules)
-        course_id_strs = [str(schedule.enrollment.course_id) for schedule in user_schedules]
-
-        first_schedule = user_schedules[0]
-
-        template_context = {
-            'student_name': user.profile.name,
-
-            'course_name': first_schedule.enrollment.course.display_name,
-            'course_url': absolute_url(site, reverse('course_root', args=[str(first_schedule.enrollment.course_id)])),
-
-            # This is used by the bulk email optout policy
-            'course_ids': course_id_strs,
-            # Platform information
-            'homepage_url': encode_url(marketing_link('ROOT')),
-            'dashboard_url': absolute_url(site, dashboard_relative_url),
-            'template_revision': settings.EDX_PLATFORM_REVISION,
-            'platform_name': settings.PLATFORM_NAME,
-            'contact_mailing_address': settings.CONTACT_MAILING_ADDRESS,
-            'social_media_urls': encode_urls_in_dict(getattr(settings, 'SOCIAL_MEDIA_FOOTER_URLS', {})),
-            'mobile_store_urls': encode_urls_in_dict(getattr(settings, 'MOBILE_STORE_URLS', {})),
-        }
-
-        # Information for including upsell messaging in template.
-        _add_upsell_button_information_to_template_context(user, first_schedule, template_context)
-
-        yield (user, first_schedule.enrollment.course.language, template_context)
-
-
-def _gather_users_and_schedules_for_target_hour(target_hour, org_list, exclude_orgs):
-    beginning_of_day = target_hour.replace(hour=0, minute=0, second=0)
-    users = User.objects.filter(
-        courseenrollment__schedule__start__gte=beginning_of_day,
-        courseenrollment__schedule__start__lt=beginning_of_day + datetime.timedelta(days=1),
-        courseenrollment__is_active=True,
-    ).annotate(
-        first_schedule=Min('courseenrollment__schedule__start')
-    ).filter(
-        first_schedule__gte=target_hour,
-        first_schedule__lt=target_hour + datetime.timedelta(minutes=60)
-    )
-
-    schedules = Schedule.objects.select_related(
-        'enrollment__user__profile',
-        'enrollment__course',
-    ).prefetch_related(
-        'enrollment__course__modes'
-    ).filter(
-        enrollment__user__in=users,
-        start__gte=beginning_of_day,
-        start__lt=beginning_of_day + datetime.timedelta(days=1),
-        enrollment__is_active=True,
-    ).order_by('enrollment__user__id')
-
-    if org_list is not None:
-        if exclude_orgs:
-            schedules = schedules.exclude(enrollment__course__org__in=org_list)
-        else:
-            schedules = schedules.filter(enrollment__course__org__in=org_list)
-
-    if "read_replica" in settings.DATABASES:
-        schedules = schedules.using("read_replica")
-
-    LOG.debug('Scheduled Nudge: Query = %r', schedules.query.sql_with_params())
-
-    return users, schedules
 
 
 @task(ignore_result=True, routing_key=ROUTING_KEY)


### PR DESCRIPTION
Because of our blue-green deploys, I had to split this out into a separate PR. The code that added and started using the new task (`recurring_nudge_schedules_for_bin`) is now deployed to production.