### PR TITLE
Enterprise- Version bumped to 0.51.5

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -47,7 +47,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.51.3
+edx-enterprise==0.51.5
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.7


### PR DESCRIPTION
@douglashall @saleem-latif @zubair-arbi FYI
The version, 0.51.5, contains enabled_course_modes JSONField to EnterpriseCustomerCatalog model.