### PR TITLE
LEARNER-717 Added logs for discovery

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides.py
@@ -3,16 +3,20 @@ Classes that override default django-oauth-toolkit behavior
 """
 from __future__ import unicode_literals
 
+import logging
 from datetime import datetime
 
 from django.contrib.auth import authenticate, get_user_model
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
-from oauth2_provider.models import AccessToken
-from oauth2_provider.oauth2_validators import OAuth2Validator
 from pytz import utc
 
+from oauth2_provider.models import AccessToken
+from oauth2_provider.oauth2_validators import OAuth2Validator
+
 from .models import RestrictedApplication
+
+log = logging.getLogger(__name__)
 
 
 @receiver(pre_save, sender=AccessToken)
@@ -73,6 +77,9 @@ class EdxOAuth2Validator(OAuth2Validator):
         grant_type = request.grant_type
         user = request.user
 
+        _token_prefix = token['access_token'][:3]
+        log.info('Saving bearer token with prefix [%s] for user [%d]', _token_prefix, user.id)
+
         if grant_type == 'client_credentials':
             # Temporarily remove the grant type to avoid triggering the super method's code that removes request.user.
             request.grant_type = None
@@ -99,6 +106,8 @@ class EdxOAuth2Validator(OAuth2Validator):
             assert expires_in < 0
 
             token['expires_in'] = expires_in
+
+        log.info('Finished bearer token with prefix [%s] for user [%d]', _token_prefix, user.id)
 
         # Restore the original request attributes
         request.grant_type = grant_type

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
@@ -63,10 +63,10 @@ class ClientCredentialsTest(mixins.AccessTokenMixin, TestCase):
             'client_id': application.client_id,
             'client_secret': application.client_secret,
             'scope': ' '.join(scopes),
-            'token_type': 'jwt'
+            'token_type': 'jwt',
         }
 
-        response = self.client.post(reverse('access_token'), data)
+        response = self.client.post(reverse('access_token'), data, user=self.user)
         self.assertEqual(response.status_code, 200)
 
         content = json.loads(response.content)


### PR DESCRIPTION
*[LEARNER-717](https://openedx.atlassian.net/browse/LEARNER-717)*

*Description:*
save_bearer_token causing a lot of deadlock issues on prod. Added those logs to get more discovery on the underling issue. Those logs will evaluate our hypothesis that multiple requests are being sent also they will tell user id that way we will be able to track other user logs during that time to get a batter idea how student ended up in that state. 