### PR TITLE
Fix frontend email regex for login page.

### DIFF
--- a/common/static/common/js/utils/edx.utils.validate.js
+++ b/common/static/common/js/utils/edx.utils.validate.js
@@ -103,12 +103,12 @@
                         },
 
                         email: {
-                        // This is the same regex used to validate email addresses in Django 1.4
+                        // This is the same regex used to validate email addresses in Django 1.11
                             regex: new RegExp(
                             [
                                 '(^[-!#$%&\'*+/=?^_`{}|~0-9A-Z]+(\\.[-!#$%&\'*+/=?^_`{}|~0-9A-Z]+)*',
                                 '|^"([\\001-\\010\\013\\014\\016-\\037!#-\\[\\]-\\177]|\\\\[\\001-\\011\\013\\014\\016-\\177])*"', // eslint-disable-line max-len
-                                ')@((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\\.)+[A-Z]{2,6}\\.?$)',
+                                ')@((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\\.)+)(?:[A-Z0-9-]{2,63})',
                                 '|\\[(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}\\]$'
                             ].join(''), 'i'
                         ),


### PR DESCRIPTION
Currently we are using Django 1.4 regex for email validation which does not allow custom domains (e.g. eclo.solutions), fixed it with latest Django 1.11 regex.

LEARNER-2828