### PR TITLE
Update course run data fields to retrieve from Catalog for Certificates

### DIFF
--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -247,8 +247,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         super(CertificatesViewsTests, self).setUp()
         self.mock_course_run_details = {
             'content_language': 'en',
-            'start': '2013-02-05T05:00:00Z',
-            'end': '2013-03-05T05:00:00Z',
+            'weeks_to_complete': '4',
             'max_effort': '10'
         }
 
@@ -1361,7 +1360,6 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         CertificateGenerationCourseSetting.objects.update_or_create(
             course_key=self.course.id,
             defaults={
-                'language_specific_templates_enabled': include_effort,
                 'include_hours_of_effort': include_effort
             }
         )

--- a/openedx/core/djangoapps/catalog/tests/factories.py
+++ b/openedx/core/djangoapps/catalog/tests/factories.py
@@ -119,7 +119,8 @@ class CourseRunFactory(DictFactoryBase):
     type = 'verified'
     uuid = factory.Faker('uuid4')
     content_language = 'en'
-    max_effort = 5
+    max_effort = 4
+    weeks_to_complete = 10
 
 
 class CourseFactory(DictFactoryBase):

--- a/openedx/core/djangoapps/catalog/tests/test_utils.py
+++ b/openedx/core/djangoapps/catalog/tests/test_utils.py
@@ -349,11 +349,10 @@ class TestGetCourseRunDetails(CatalogIntegrationMixin, TestCase):
         course_run = CourseRunFactory()
         course_run_details = {
             'content_language': course_run['content_language'],
-            'start': course_run['start'],
-            'end': course_run['end'],
+            'weeks_to_complete': course_run['weeks_to_complete'],
             'max_effort': course_run['max_effort']
         }
         mock_get_edx_api_data.return_value = course_run_details
-        data = get_course_run_details(course_run['key'], ['content_language', 'start', 'end', 'max_effort'])
+        data = get_course_run_details(course_run['key'], ['content_language', 'weeks_to_complete', 'max_effort'])
         self.assertTrue(mock_get_edx_api_data.called)
         self.assertEqual(data, course_run_details)


### PR DESCRIPTION
Updating the context gathered from Catalog for rendering Course Certificates

This is a fix for the bug where self-paced course runs were appearing to have several hundred hours of effort