### PR TITLE
Add edx-private and sandbox req files to tox env.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,10 @@ deps =
     -rrequirements/edx/paver.txt
     -rrequirements/edx/testing.txt
     -rrequirements/edx/post.txt
+    -rrequirements/edx/edx-private.txt
+    -rrequirements/edx-sandbox/base.txt
+    -rrequirements/edx-sandbox/local.txt
+    -rrequirements/edx-sandbox/post.txt
 
 commands =
     pytest {posargs}


### PR DESCRIPTION
I missed a few requirements files for the tox environment. I've added them based on the Ansible code I found here:
https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/tasks/deploy.yml#L132-L211
These missing requirements files are causing differences in tests in the Docker devstack vs. tox environments.