### PR TITLE
Add django-simple-history back to edx-platform as a requirement.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -912,6 +912,9 @@ INSTALLED_APPS = [
     # Common views
     'openedx.core.djangoapps.common_views',
 
+    # History tables
+    'simple_history',
+
     # Database-backed configuration
     'config_models',
     'waffle',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1988,6 +1988,9 @@ INSTALLED_APPS = [
     # Common views
     'openedx.core.djangoapps.common_views',
 
+    # History tables
+    'simple_history',
+
     # Database-backed configuration
     'config_models',
     'waffle',

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -28,6 +28,7 @@ django-pipeline-forgiving==1.0.0
 django-pyfs==1.0.7
 django-sekizai>=0.10
 django-ses==0.7.1
+django-simple-history==1.6.3
 django-statici18n==1.4.0
 django-storages==1.4.1
 django-method-override==0.1.0


### PR DESCRIPTION
The module is still used by (at least) edx-enterprise. It was removed recently in this PR:
https://github.com/edx/edx-platform/pull/16188

@edx/devops FYI: Until this PR is merged (or hotfixed onto the current RC), the current release on stage *CANNOT* be advanced to production.