### PR TITLE
ACE writes to a file by default

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3308,7 +3308,7 @@ COURSEGRAPH_JOB_QUEUE = LOW_PRIORITY_QUEUE
 
 ############## Settings for ACE ####################################
 ACE_ENABLED_CHANNELS = [
-    'sailthru_email'
+    'file_email'
 ]
 ACE_ENABLED_POLICIES = [
     'bulk_email_optout'

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -36,7 +36,7 @@ django-user-tasks==0.1.5
 django-waffle==0.12.0
 djangorestframework-jwt==1.11.0
 enum34==1.1.6
-edx-ace==0.1.5
+edx-ace==0.1.6
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.6
 edx-drf-extensions==1.2.3


### PR DESCRIPTION
Instead of sending to Sailthru by default, instead write emails to files on local disk. This seems like a much more sane default for devstacks.