### PR TITLE
Remove flaky rate limiting test.

### DIFF
--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -548,32 +548,6 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             expected_status = status.HTTP_429_TOO_MANY_REQUESTS if attempt >= self.rate_limit else status.HTTP_200_OK
             self.assert_enrollment_status(expected_status=expected_status)
 
-    def test_enrollment_throttle_for_staff_user(self):
-        """ Make sure throttle rate is higher for staff users """
-        self.rate_limit_config.enabled = True
-        self.rate_limit_config.save()
-        self.client.logout()
-        staff_user = UserFactory.create(password=self.PASSWORD, is_staff=True)
-        self.client.login(username=staff_user.username, password=self.PASSWORD)
-
-        CourseModeFactory(
-            course_id=self.course.id,
-            mode_slug=CourseMode.DEFAULT_MODE_SLUG,
-            mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
-        )
-
-        throttle = EnrollmentUserThrottle()
-        throttle.scope = 'staff'
-        rate_limit, __ = throttle.parse_rate(throttle.get_rate())
-
-        # Make enough requests to reach the rate limit
-        for attempt in xrange(rate_limit):
-            self.assert_enrollment_status(username=staff_user.username, expected_status=status.HTTP_200_OK)
-
-        # Once the limit is reached, subsequent requests should fail
-        for attempt in xrange(rate_limit + 50):
-            self.assert_enrollment_status(username=staff_user.username, expected_status=status. HTTP_429_TOO_MANY_REQUESTS)
-
     def test_enrollment_throttle_for_service(self):
         """Make sure a service can call the enrollment API as many times as needed. """
         self.rate_limit_config.enabled = True


### PR DESCRIPTION
Appears that this test is flaky - failing every so often. Here's an example:

https://build.testeng.edx.org/job/edx-platform-python-unittests-pr/42112/testReport/junit/common.djangoapps.enrollment.tests.test_views/EnrollmentTest/test_enrollment_throttle_for_staff_user/

And here's a Splunk query showing several failures:

https://splunk.edx.org/en-US/app/search/search?q=search%20index%3Dtesteng%20sourcetype%3Djunit%20test_enrollment_throttle_for_staff_user%20source%3D%22%2Fvar%2Flib%2Fjenkins%2Fjobs%2Fedx-platform-python*%2Fbuilds%2F*%2FjunitResult.xml%22%20NOT%20%22case.failedSince%22%3D0%20%22case.skipped%22%3Dfalse%20AssertionError&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=&latest=&sid=1508174499.422820

Also of concern, it seems from the Splunk query above that the test takes ~60 seconds to run each time? (unless I'm mis-reading ms as seconds...).