### PR TITLE
Use singular getter function where only one requirement is expected

### DIFF
--- a/openedx/core/djangoapps/credit/api/eligibility.py
+++ b/openedx/core/djangoapps/credit/api/eligibility.py
@@ -297,7 +297,7 @@ def remove_credit_requirement_status(username, course_key, req_namespace, req_na
     """
 
     # Find the requirement we're trying to remove
-    req_to_remove = CreditRequirement.get_course_requirements(course_key, namespace=req_namespace, name=req_name)
+    req_to_remove = CreditRequirement.get_course_requirement(course_key, req_namespace, req_name)
 
     # If we can't find the requirement, then the most likely explanation
     # is that there was a lag removing the credit requirements after the course

--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -385,7 +385,7 @@ class CreditRequirement(TimeStampedModel):
             name(str): Name of credit course requirement
 
         Returns:
-            CreditRequirement object if exists
+            CreditRequirement object if exists, None otherwise.
 
         """
         try:


### PR DESCRIPTION
This avoids a fatal error in Django 1.9+ in most scenarios, where this
code (before this commit) will no longer result in an implicit __in
query.  This commit should be a no-op functionally for Django 1.8.

More info: https://code.djangoproject.com/ticket/25284

PLAT-1525

---

This was tested by monkey patching django.db.models.sql.query.Query.build_filter to raise an error where the implicit __in bug is expected to occur.  https://github.com/edx/edx-platform/pull/16216