### PR TITLE
Enable Auth Source to use a different db for auth for Mongo

### DIFF
--- a/common/lib/xmodule/xmodule/mongo_utils.py
+++ b/common/lib/xmodule/xmodule/mongo_utils.py
@@ -50,9 +50,15 @@ def connect_to_mongodb(
             wait_time=retry_wait_time
         )
 
+    # default the authSource to be whatever db we are connecting to (for backwards compatiblity)
+    authSource=db
+    if kwargs.get('authSource'):
+      # override if configured to use a different db for auth (e.g. Mongodb Atlas)
+      authSource=kwargs.get('authSource')
+
     # If credentials were provided, authenticate the user.
     if user is not None and password is not None:
-        mongo_conn.authenticate(user, password)
+        mongo_conn.authenticate(user, password, authSource)
 
     return mongo_conn
 


### PR DESCRIPTION
By default if no auth source is passed, the client will use the database the user is connecting too.

For some cloud providers (like Mongo Atlas), the user must be authenticated against 'admin' database even though they are accessing some other db.

The goal is to have a backwards compatible setting such that if the current users don't have this setting, it will continue to work.

Despite having the authSource=admin property in the URI, the authenticate call seems to ignore that. Open to ideas if there is a better way to achieve this :)

There are a couple of other PRs related to this:
https://github.com/edx/cs_comments_service/pull/250
https://github.com/edx/configuration/pull/4131