### PR TITLE
Fix edX logo links to home page instead of dashboard.

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -17,6 +17,7 @@ import urlparse
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from branding.models import BrandingApiConfig
@@ -418,3 +419,16 @@ def get_about_url():
     Lookup and return About page url
     """
     return get_url("ABOUT")
+
+
+def get_home_url():
+    """
+    Lookup and return home page url, lookup is performed in the following order
+
+    1. return marketing root URL, If marketing is enabled
+    2. Otherwise return dashboard URL.
+    """
+    if settings.FEATURES.get('ENABLE_MKTG_SITE', False):
+        return marketing_link('ROOT')
+
+    return reverse('dashboard')

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -3,10 +3,12 @@
 from __future__ import unicode_literals
 
 import mock
+from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from branding.api import get_footer, get_logo_url
+from branding.api import get_footer, get_home_url, get_logo_url
+from edxmako.shortcuts import marketing_link
 
 
 class TestHeader(TestCase):
@@ -23,6 +25,18 @@ class TestHeader(TestCase):
             logo_url = get_logo_url()
 
         self.assertEqual(logo_url, cdn_url)
+
+    def test_home_url_with_mktg_disabled(self):
+        expected_url = get_home_url()
+        self.assertEqual(reverse('dashboard'), expected_url)
+
+    @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True})
+    @mock.patch.dict('django.conf.settings.MKTG_URLS', {
+        "ROOT": "https://edx.org",
+    })
+    def test_home_url_with_mktg_enabled(self):
+        expected_url = get_home_url()
+        self.assertEqual(marketing_link('ROOT'), expected_url)
 
 
 class TestFooter(TestCase):

--- a/lms/templates/header/brand.html
+++ b/lms/templates/header/brand.html
@@ -14,7 +14,7 @@ from branding import api as branding_api
 
 <h1 class="hd logo-header navbar-brand">
   <div class="logo">
-    <a class="navbar-brand" href="${reverse('dashboard')}" itemprop="url">
+    <a class="navbar-brand" href="${branding_api.get_home_url()}" itemprop="url">
       <img class="logo-image" src="${static.url("images/logo.png")}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}" itemprop="logo" />
     </a>
   </div>

--- a/lms/templates/navigation/navbar-logo-header.html
+++ b/lms/templates/navigation/navbar-logo-header.html
@@ -14,7 +14,7 @@ from branding import api as branding_api
 
 <h1 class="hd logo-header">
   <div class="logo">
-    <a href="${reverse('dashboard')}">
+    <a href="${branding_api.get_home_url()}">
       <%block name="navigation_logo">
       <img src="${branding_api.get_logo_url(is_secure)}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
       </%block>


### PR DESCRIPTION
When you are on the Dashboard, or on any page in courseware, the logo in the Header links to dashboard and the logo in the footer links to edX home page.

LEARNER-2881