### PR TITLE
Fixes to mgmt cmds which delete django-simple-history data.

### DIFF
--- a/common/djangoapps/microsite_configuration/management/commands/delete_historical_microsite_data.py
+++ b/common/djangoapps/microsite_configuration/management/commands/delete_historical_microsite_data.py
@@ -5,7 +5,7 @@ microsite_configuration_historicalmicrositetemplate
 """
 
 import logging
-from common.djangoapps.microsite_configuration.models import MicrositeOrganizationMapping, MicrositeTemplate
+from microsite_configuration.models import MicrositeOrganizationMapping, MicrositeTemplate
 from openedx.core.djangoapps.util.row_delete import delete_rows, BaseDeletionCommand
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/verify_student/management/commands/delete_historical_verify_student_data.py
+++ b/lms/djangoapps/verify_student/management/commands/delete_historical_verify_student_data.py
@@ -3,7 +3,7 @@ Command to delete all rows from the verify_student_historicalverificationdeadlin
 """
 
 import logging
-from verify_student.models import VerificationDeadline
+from lms.djangoapps.verify_student.models import VerificationDeadline
 from openedx.core.djangoapps.util.row_delete import delete_rows, BaseDeletionCommand
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Follow-on PR to this PR: https://github.com/edx/edx-platform/pull/16220

THIS is what happens when you don't test software - it doesn't work properly. After merging, I ran each command and found the problems that are fixed in this PR.