### PR TITLE
Switch to using a signal to manage pending enrollments when a user is activated or changes their email address

### DIFF
--- a/common/djangoapps/student/migrations/0014_courseenrollmentallowed_user.py
+++ b/common/djangoapps/student/migrations/0014_courseenrollmentallowed_user.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('student', '0013_delete_historical_enrollment_records'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseenrollmentallowed',
+            name='user',
+            field=models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, help_text="First user which enrolled in the specified course through the specified e-mail. Once set, it won't change.", null=True),
+        ),
+    ]

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -12,9 +12,9 @@ from nose.plugins.attrib import attr
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
 from openedx.core.djangoapps.embargo.test_utils import restrict_course
-from student.models import CourseEnrollment, CourseFullError
+from student.models import CourseEnrollment, CourseEnrollmentAllowed, CourseFullError, EnrollmentClosedError
 from student.roles import CourseInstructorRole, CourseStaffRole
-from student.tests.factories import UserFactory
+from student.tests.factories import CourseEnrollmentAllowedFactory, UserFactory
 from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -280,3 +280,63 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
             params['email_opt_in'] = email_opt_in
 
         return self.client.post(reverse('change_enrollment'), params)
+
+    def test_cea_enrolls_only_one_user(self):
+        """
+        Tests that a CourseEnrollmentAllowed can be used by just one user.
+        If the user changes e-mail and then a second user tries to enroll with the same accepted e-mail,
+        the second enrollment should fail.
+        However, the original user can reuse the CEA many times.
+        """
+
+        cea = CourseEnrollmentAllowedFactory(
+            email='allowed@edx.org',
+            course_id=self.course.id,
+            auto_enroll=False,
+        )
+        # Still unlinked
+        self.assertIsNone(cea.user)
+
+        user1 = UserFactory.create(username="tester1", email="tester1@e.com", password="test")
+        user2 = UserFactory.create(username="tester2", email="tester2@e.com", password="test")
+
+        self.assertFalse(
+            CourseEnrollment.objects.filter(course_id=self.course.id, user=user1).exists()
+        )
+
+        user1.email = 'allowed@edx.org'
+        user1.save()
+
+        CourseEnrollment.enroll(user1, self.course.id, check_access=True)
+
+        self.assertTrue(
+            CourseEnrollment.objects.filter(course_id=self.course.id, user=user1).exists()
+        )
+
+        # The CEA is now linked
+        cea.refresh_from_db()
+        self.assertEqual(cea.user, user1)
+
+        # user2 wants to enroll too, (ab)using the same allowed e-mail, but cannot
+        user1.email = 'my_other_email@edx.org'
+        user1.save()
+        user2.email = 'allowed@edx.org'
+        user2.save()
+        with self.assertRaises(EnrollmentClosedError):
+            CourseEnrollment.enroll(user2, self.course.id, check_access=True)
+
+        # CEA still linked to user1. Also after unenrolling
+        cea.refresh_from_db()
+        self.assertEqual(cea.user, user1)
+
+        CourseEnrollment.unenroll(user1, self.course.id)
+
+        cea.refresh_from_db()
+        self.assertEqual(cea.user, user1)
+
+        # Enroll user1 again. Because it's the original owner of the CEA, the enrollment is allowed
+        CourseEnrollment.enroll(user1, self.course.id, check_access=True)
+
+        # Still same
+        cea.refresh_from_db()
+        self.assertEqual(cea.user, user1)

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -7,8 +7,8 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 from django_countries.fields import Country
 
-from student.models import PasswordHistory
-from student.tests.factories import UserFactory
+from student.models import CourseEnrollmentAllowed, PasswordHistory
+from student.tests.factories import UserFactory, CourseEnrollmentAllowedFactory
 from student.tests.tests import UserSettingsEventTestMixin
 
 
@@ -154,3 +154,25 @@ class TestUserEvents(UserSettingsEventTestMixin, TestCase):
         self.user.last_name = "Duck"
         self.user.save()
         self.assert_no_events_were_emitted()
+
+    def test_enrolled_after_email_change(self):
+        """
+        Test that when a user's email changes, the user is enrolled in pending courses.
+        """
+        pending_enrollment = CourseEnrollmentAllowedFactory(auto_enroll=True)
+
+        # the e-mail will change to test@edx.org (from something else)
+        self.assertNotEquals(self.user.email, 'test@edx.org')
+
+        # there's a CEA for the new e-mail
+        self.assertEquals(CourseEnrollmentAllowed.objects.count(), 1)
+        self.assertEquals(CourseEnrollmentAllowed.objects.filter(email='test@edx.org').count(), 1)
+
+        # Changing the e-mail to the enrollment-allowed e-mail should enroll
+        self.user.email = 'test@edx.org'
+        self.user.save()
+        self.assert_user_enrollment_occurred('edX/toy/2012_Fall')
+
+        # CEAs shouldn't have been affected
+        self.assertEquals(CourseEnrollmentAllowed.objects.count(), 1)
+        self.assertEquals(CourseEnrollmentAllowed.objects.filter(email='test@edx.org').count(), 1)

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -699,6 +699,12 @@ class UserSettingsEventTestMixin(EventTestMixin):
             **kwargs
         )
 
+    def assert_user_enrollment_occurred(self, course_key):
+        """
+        Helper method to assert that the user is enrolled in the given course.
+        """
+        self.assertTrue(CourseEnrollment.is_enrolled(self.user, CourseKey.from_string(course_key)))
+
 
 class EnrollmentEventTestMixin(EventTestMixin):
     """ Mixin with assertions for validating enrollment events. """

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -51,11 +51,12 @@ class EmailEnrollmentState(object):
             # is_active is `None` if the user is not enrolled in the course
             exists_ce = is_active is not None and is_active
             full_name = user.profile.name
+            ceas = CourseEnrollmentAllowed.for_user(user).filter(course_id=course_id).all()
         else:
             mode = None
             exists_ce = False
             full_name = None
-        ceas = CourseEnrollmentAllowed.objects.filter(course_id=course_id, email=email).all()
+            ceas = CourseEnrollmentAllowed.objects.filter(email=email, course_id=course_id).all()
         exists_allowed = ceas.exists()
         state_auto_enroll = exists_allowed and ceas[0].auto_enroll
 


### PR DESCRIPTION
This pull request ensures that whenever a user is activated or has their email address changed, either by following the standard process, or by an administrator using the Django admin panel, pending enrollments are processed to allow the user to access courses that they've been enrolled in by a course instructor.

**Dependencies**: None

**Screenshots**: N/A; no UI changes

**Sandbox URL**: https://pr16267.sandbox.opencraft.hosting/

**Testing instructions**:

1. As a course instructor, proxy-enroll a non-existent user in a course by email address.
2. As a standard user, create an account with a matching email address.
3. As a standard user, verify that you've been enrolled in the given course once you activate your account (if applicable).
4. As a course instructor, proxy-enroll another non-existent user in a course by email address.
5. As a standard user, create an account with a different email address.
6. As a standard user, activate your account (if necessary).
7. As a standard user, change your email address to match the proxy-enrollment record.
8. As a standard user, verify that you don't immediately see the course you were proxy-enrolled in.
9. As a standard user, click the verification link to effect the account email address change.
10. As a standard user, verify that you now see the course you were proxy-enrolled in.
11. As a course instructor, proxy enroll a third non-existent user in a course by email address.
12. As a standard user, create a third account with an email address that does not match the proxy-enrollment record.
13. As a standard user, activate your account (if necessary).
14. As a standard user, verify that you are not enrolled in the course.
15. As a system administrator, use the Django admin to manually change the email address for the newly-registered user to match the proxy enrollment email address you used.
16. As a standard user, verify both that your email address was changed, and that you were enrolled in the course.

**Author notes and concerns**:

1. We switch from using a method called from the relevant views to a signal that's called whenever a User object is modified and either the activity state of the user or its email address is changed. The exact desired criteria may be different.

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```