### PR TITLE
PLAT-1555 Stop using deprecated TEST_* DB setting keys

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -75,18 +75,22 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': TEST_ROOT / "db" / "test_edx.db",
-        'TEST_NAME': TEST_ROOT / "db" / "test_edx.db",
         'OPTIONS': {
             'timeout': 30,
         },
         'ATOMIC_REQUESTS': True,
+        'TEST': {
+            'NAME': TEST_ROOT / "db" / "test_edx.db",
+        },
     },
     'student_module_history': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': TEST_ROOT / "db" / "test_student_module_history.db",
-        'TEST_NAME': TEST_ROOT / "db" / "test_student_module_history.db",
         'OPTIONS': {
             'timeout': 30,
+        },
+        'TEST': {
+            'NAME': TEST_ROOT / "db" / "test_student_module_history.db",
         },
     }
 }

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -67,18 +67,22 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': TEST_ROOT / "db" / "test_edx.db",
-        'TEST_NAME': TEST_ROOT / "db" / "test_edx.db",
         'OPTIONS': {
             'timeout': 30,
         },
         'ATOMIC_REQUESTS': True,
+        'TEST': {
+            'NAME': TEST_ROOT / "db" / "test_edx.db",
+        },
     },
     'student_module_history': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': TEST_ROOT / "db" / "test_student_module_history.db",
-        'TEST_NAME': TEST_ROOT / "db" / "test_student_module_history.db",
         'OPTIONS': {
             'timeout': 30,
+        },
+        'TEST': {
+            'NAME': TEST_ROOT / "db" / "test_student_module_history.db",
         },
     }
 }


### PR DESCRIPTION
These are the only uses of this deprecated settings pattern that I could find in the repository.