### PR TITLE
PLAT-1540 Upgrade django-extensions for better Django 1.9+ support

### DIFF
--- a/lms/envs/bok_choy.auth.json
+++ b/lms/envs/bok_choy.auth.json
@@ -35,6 +35,9 @@
             "ENGINE": "django.db.backends.mysql",
             "HOST": "localhost",
             "NAME": "edxtest",
+            "OPTIONS": {
+                "init_command": "SET foreign_key_checks = 0;"
+            },
             "PASSWORD": "",
             "PORT": "3306",
             "USER": "root"

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -19,7 +19,7 @@ django-babel-underscore==0.5.2
 markey==0.8  # From django-babel-underscore
 django-config-models==0.1.8
 django-countries==4.6.1
-django-extensions==1.5.9
+django-extensions==1.6.2
 django-filter==1.0.4
 django-ipware==1.1.0
 django-model-utils==3.0.0


### PR DESCRIPTION
django-extensions is our only dependency which was still using `django.core.cache.get_cache()`.  I don't think we were actually using that part of it, but this upgrade includes fixes for that and many other parts of it under Django 1.9+, and doesn't seem to make major changes to the parts we currently use.