### PR TITLE
Create blank footer style for responsive theming

### DIFF
--- a/lms/static/sass/_build-lms-v1.scss
+++ b/lms/static/sass/_build-lms-v1.scss
@@ -85,6 +85,9 @@
 @import 'mixins-inherited';
 @import 'elements/system-feedback';
 
+// Responsive Design
+@import 'footer';
+
 // overrides
 @import 'developer'; // used for any developer-created scss that needs further polish/refactoring
 @import 'shame';     // used for any bad-form/orphaned scss

--- a/lms/static/sass/_build-lms-v2.scss
+++ b/lms/static/sass/_build-lms-v2.scss
@@ -36,3 +36,6 @@
 @import 'features/course-search';
 @import 'features/course-sock';
 @import 'features/course-upgrade-message';
+
+// Responsive Design
+@import 'footer'

--- a/lms/static/sass/_footer.scss
+++ b/lms/static/sass/_footer.scss
@@ -1,0 +1,1 @@
+// Purposefully empty. To be overwritten via comprehensive themeing.

--- a/lms/static/sass/bootstrap/lms-main.scss
+++ b/lms/static/sass/bootstrap/lms-main.scss
@@ -30,5 +30,8 @@
 @import 'features/course-sock';
 @import 'features/course-upgrade-message';
 
+// Responsive Design
+@import 'footer';
+
 // Individual Pages
 @import "views/program-marketing-page";


### PR DESCRIPTION
In the push to make pages more responsive, we need to replace the
header and footer in our WL sites to be used with both bootstrap
and non bootstrap pages. Currently, the footer in LMS already
responsive, so this change is only to allow for comprehensive
themed sites to override them. Eventually, if the LMS footer needs
to be rewritten, it may use these files.

Part of [WL-1286]

Based off of Harry's work for the header in PR #16210