### PR TITLE
Pass course name to data sharing consent declined template

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -541,6 +541,7 @@ def get_dashboard_consent_notification(request, user, course_enrollments):
             {
                 'title': title,
                 'message': message,
+                'course_name': enrollment.course_overview.display_name,
             }
         )
     return ''


### PR DESCRIPTION
Pass the course name to the data sharing consent declined template such that it can be accessed by the template.

WL-1279