### PR TITLE
WIP Fixed issue where git logs aren't functioning

### DIFF
--- a/lms/djangoapps/dashboard/git_import.py
+++ b/lms/djangoapps/dashboard/git_import.py
@@ -15,6 +15,7 @@ from django.core import management
 from django.core.management.base import CommandError
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from opaque_keys.edx.locator import CourseLocator
 from opaque_keys.edx.keys import CourseKey
 
 from dashboard.models import CourseImportLog
@@ -294,6 +295,11 @@ def add_repo(repo, rdir_in, branch=None):
     if match:
         course_id = match.group(1)
         course_key = CourseKey.from_string(course_id)
+        course_key = CourseLocator(
+            org=course_key.org,
+            course=course_key.course,
+            run=course_key.run
+        )
         cdir = '{0}/{1}'.format(git_repo_dir, course_key.course)
         log.debug('Studio course dir = %s', cdir)
 

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -28,6 +28,7 @@ from django.views.decorators.http import condition
 from django.views.generic.base import TemplateView
 from opaque_keys.edx.keys import CourseKey
 from path import Path as path
+from opaque_keys.edx.locator import CourseLocator
 
 import dashboard.git_import as git_import
 import track.views
@@ -621,6 +622,11 @@ class GitLogs(TemplateView):
                 raise Http404
             cilset = CourseImportLog.objects.order_by('-created')
         else:
+            course_id = CourseLocator(
+                org=course_id.org,
+                course=course_id.course,
+                run=course_id.run
+            )
             try:
                 course = get_course_by_id(course_id)
             except Exception:


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/312

#### What's this PR do?
- It fixes `Course ID` links on git logs  table.
- ` GIT LOGS` is a  [tab](http://0.0.0.0:8000/sysadmin/gitlogs) inside `SYSADMIN` dashboard.
- Issue appears when
   - a course key of an imported course is saved as `opaque_keys.edx.keys.CourseKey` object in edx system
   - And same course key is saved in CourseImportLog model as `opaque_keys.edx.locations.SlashSeparatedCourseKey` object. Due to course id sent in apis as slash key
    - Issue appears when user call this [api](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/dashboard/sysadmin_urls.py#L15) with a old slash course key
like `course/mitx/80.02`. The code is [here](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/dashboard/sysadmin.py#L586)

#### How should this be manually tested?
Use slashed key in course (u can export course from studio and add slash key in its xml content)

##### how to turn on the sysadmin dashboard:
- go to `lms.env.json` file and set FEATURE flag `ENABLE_SYSADMIN_DASHBOARD": true` save and start server `paver run_all_servers`
- you can find `lms.env.json` on devstack doing these steps
  - vagrant up
  - vagrant ssh
  - sudo su edxapp
  - cd ..
  - vi lms.env.json
- Once you do the above steps then login into LMS. you will see `SYSADMIN` link in header.
  - <img width="906" alt="screen shot 2017-10-24 at 3 49 18 pm" src="https://user-images.githubusercontent.com/10431250/31939231-271a20ba-b8d3-11e7-9b50-4f4733d0f13f.png">

##### how to load a course from git, using /sysadmin/courses:
- On `SYSADMIN` go to [`courses`](http://0.0.0.0:8000/sysadmin/courses) tab. Add your git repo url. By default it loads course from master branch.
  - <img width="1228" alt="screen shot 2017-10-24 at 3 54 14 pm" src="https://user-images.githubusercontent.com/10431250/31939462-ecd3ed36-b8d3-11e7-9fba-0a053c392139.png">
- Sample git url is https://github.com/amir-qayyum-khan/test_edx_course

##### Does testing this require multiple module stores? Or is it enough to just test with split mongo?
- The issue can be reproduce on default settings of devstack for modules

@pdpinch 
<img width="1249" alt="screen shot 2017-08-28 at 7 04 21 pm" src="https://user-images.githubusercontent.com/10431250/29776942-bd5b1f20-8c23-11e7-83c4-a726f8c1e52b.png">
