### PR TITLE
EDUCATOR-1542 give access to Special Exam tab to the course team

### DIFF
--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -2,12 +2,13 @@
 Unit tests for Edx Proctoring feature flag in new instructor dashboard.
 """
 
+import ddt
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from mock import patch
 from nose.plugins.attrib import attr
 
-from student.roles import CourseFinanceAdminRole
+from student.roles import CourseStaffRole, CourseInstructorRole
 from student.tests.factories import AdminFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -15,6 +16,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 @attr(shard=1)
 @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': True})
+@ddt.ddt
 class TestProctoringDashboardViews(SharedModuleStoreTestCase):
     """
     Check for Proctoring view on the new instructor dashboard
@@ -22,10 +24,6 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestProctoringDashboardViews, cls).setUpClass()
-        cls.course = CourseFactory.create(enable_proctored_exams=True)
-
-        # URL for instructor dash
-        cls.url = reverse('instructor_dashboard', kwargs={'course_id': cls.course.id.to_deprecated_string()})
         button = '<button type="button" class="btn-link special_exams" data-section="special_exams">Special Exams</button>'
         cls.proctoring_link = button
 
@@ -36,24 +34,74 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
         self.instructor = AdminFactory.create()
         self.client.login(username=self.instructor.username, password="test")
 
-        CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
+    def setup_course_url(self, course):
+        """
+        Create URL for instructor dashboard
+        """
+        self.url = reverse('instructor_dashboard', kwargs={'course_id': course.id.to_deprecated_string()})
 
-    def test_pass_proctoring_tab_in_instructor_dashboard(self):
+    def setup_course(self, enable_proctored_exams, enable_timed_exams):
         """
-        Test Pass Proctoring Tab is in the Instructor Dashboard
+        Create course based on proctored exams and timed exams values
         """
+        self.course = CourseFactory.create(enable_proctored_exams=enable_proctored_exams,
+                                           enable_timed_exams=enable_timed_exams)
+        self.setup_course_url(self.course)
+
+    @ddt.data(
+        (True, False),
+        (False, True)
+    )
+    @ddt.unpack
+    def test_proctoring_tab_visible_for_global_staff(self, enable_proctored_exams, enable_timed_exams):
+        """
+        Test Proctoring Tab is visible in the Instructor Dashboard
+        for global staff
+        """
+        self.setup_course(enable_proctored_exams, enable_timed_exams)
+
         self.instructor.is_staff = True
         self.instructor.save()
 
-        response = self.client.get(self.url)
-        self.assertIn(self.proctoring_link, response.content)
-        self.assertIn('Allowance Section', response.content)
+        # verify that proctoring tab is visible for global staff
+        self._assert_proctoring_tab_is_available()
 
-    def test_no_tab_non_global_staff(self):
+    @ddt.data(
+        (True, False),
+        (False, True)
+    )
+    @ddt.unpack
+    def test_proctoring_tab_visible_for_course_staff_and_admin(self, enable_proctored_exams, enable_timed_exams):
         """
-        Test Pass Proctoring Tab is not in the Instructor Dashboard
-        for non global staff users
+        Test Proctoring Tab is visible in the Instructor Dashboard
+        for course staff(role of STAFF or ADMIN)
         """
+        self.setup_course(enable_proctored_exams, enable_timed_exams)
+
+        self.instructor.is_staff = False
+        self.instructor.save()
+
+        # verify that proctoring tab is visible for course staff
+        CourseStaffRole(self.course.id).add_users(self.instructor)
+        self._assert_proctoring_tab_is_available()
+
+        # verify that proctoring tab is visible for course instructor
+        CourseStaffRole(self.course.id).remove_users(self.instructor)
+        CourseInstructorRole(self.course.id).add_users(self.instructor)
+        self._assert_proctoring_tab_is_available()
+
+    @ddt.data(
+        (True, False),
+        (False, True)
+    )
+    @ddt.unpack
+    def test_no_proctoring_tab_non_global_staff(self, enable_proctored_exams, enable_timed_exams):
+        """
+        Test Proctoring Tab is not visible in the Instructor Dashboard
+        for course team other than role of staff or admin
+        """
+        self.setup_course(enable_proctored_exams, enable_timed_exams)
+
         self.instructor.is_staff = False
         self.instructor.save()
 
@@ -62,14 +110,29 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
         self.assertNotIn('Allowance Section', response.content)
 
     @patch.dict(settings.FEATURES, {'ENABLE_SPECIAL_EXAMS': False})
-    def test_no_tab_flag_unset(self):
+    @ddt.data(
+        (True, False),
+        (False, True)
+    )
+    @ddt.unpack
+    def test_no_tab_flag_unset(self, enable_proctored_exams, enable_timed_exams):
         """
-        Special Exams tab will not be visible if
-        the user is not a staff member.
+        Special Exams tab will not be visible if special exams settings are not enabled inspite of
+        proctored exams or timed exams is enabled
         """
+        self.setup_course(enable_proctored_exams, enable_timed_exams)
+
         self.instructor.is_staff = True
         self.instructor.save()
 
         response = self.client.get(self.url)
         self.assertNotIn(self.proctoring_link, response.content)
         self.assertNotIn('Allowance Section', response.content)
+
+    def _assert_proctoring_tab_is_available(self):
+        """
+        Asserts that proctoring tab is available for logged in user.
+        """
+        response = self.client.get(self.url)
+        self.assertIn(self.proctoring_link, response.content)
+        self.assertIn('Allowance Section', response.content)


### PR DESCRIPTION
# [Course team has no Permissions to access view-special_exams - EDUCATOR-1542](https://openedx.atlassian.net/browse/EDUCATOR-1542)

### Description
This PR allows course teams (role of STAFF or ADMIN) to access the special exams tab if either Enable Timed Exams is TRUE OR Enable proctored Exams is TRUE.

### How to Test?

**Stage** 

1. Login into stage https://courses.stage.edx.org/login
2. Go to the link https://courses.stage.edx.org/courses/course-v1:abcd+TESTING.ENGL.01.x+2016_T1/instructor#view-membership.
3. See user `c_staff` is added as `Course Staff` but not able to see the view-special_exam tab.

**Sandbox**
1. Login into sandbox https://educator-1542.sandbox.edx.org/login
2. Go to the link https://educator-1542.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-membership
3. See user `audit` is added as `Course Staff` and able to see the view-special_exam tab.

**Screenshots**
before fix
<img width="1221" alt="screen shot 2017-10-26 at 6 22 53 pm" src="https://user-images.githubusercontent.com/13939335/32055389-17fbb7fc-ba7b-11e7-99c2-5591b69e9af4.png">

after fix
<img width="1219" alt="screen shot 2017-10-26 at 6 22 41 pm" src="https://user-images.githubusercontent.com/13939335/32055431-3ae3d52e-ba7b-11e7-9a86-1a4509ba931a.png">

### Testing
- [x] Unit test


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @attiyaIshaque 
- [x] Code review: @noraiz-anwar 
- [x] Code review: @awaisdar001 

### Post-review
- [x] Rebase and squash commits

