### PR TITLE
Make messages available in DOM

### DIFF
--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -57,8 +57,8 @@
         <div class="content-primary">
             % if waffle_flag_enabled:
                 <div id="root"></div>
+                <%static:sfeTranslate locale="fr"></%static:sfeTranslate>
                 <%static:webpack entry="AssetsPage"></%static:webpack>
-                <%static:ericfischer locale="fr"></%static:ericfischer>
             % else:
                 <div class="wrapper-assets"></div>
             % endif

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -58,6 +58,7 @@
             % if waffle_flag_enabled:
                 <div id="root"></div>
                 <%static:webpack entry="AssetsPage"></%static:webpack>
+                <%static:ericfischer locale="fr"></%static:ericfischer>
             % else:
                 <div class="wrapper-assets"></div>
             % endif

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -86,27 +86,34 @@ engine = Engine(dirs=settings.DEFAULT_TEMPLATE_ENGINE['DIRS'])
 source, template_path = Loader(engine).load_template_source(path)
 %>${source | n, decode.utf8}</%def>
 
-<%def name="ericfischer(locale)">
+<%def name="sfeTranslate(locale)">
     <%
         from django.conf import settings
+        from django.contrib.staticfiles.storage import staticfiles_storage
         from django.template import Template, Context
         from webpack_loader.exceptions import WebpackLoaderBadStatsError
 
-        path = "{base}/bundles/studio-frontend/locale_messages/{locale}.json".format(
+        messages = ""
+        messages_path = "{base}/bundles/studio-frontend/locale_messages/{locale}.json".format(
             base=settings.STATIC_ROOT,
             locale=locale
         )
+        with open(messages_path) as inputfile:
+            messages = inputfile.read()
 
-        messages = ""
-        with open(path) as input:
-            messages = input.read()
+        localeScriptUrl = staticfiles_storage.url(
+            "bundles/studio-frontend/locale_scripts/{locale}.js".format(locale=locale)
+        )
 
         return Template("""
-            <div id=studio-frontend-messages style="display: none;">
+            <script type="text/javascript" src={{ localeScriptUrl }}></script>
+            <div id=studio-frontend-messages style="display: none;" data-locale={{locale}}>
                 {{ messages }}
             </div>
         """).render(Context({
+            'localeScriptUrl': localeScriptUrl,
             'messages': messages,
+            'locale': locale
         }))
     %>
 </%def>

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -86,6 +86,31 @@ engine = Engine(dirs=settings.DEFAULT_TEMPLATE_ENGINE['DIRS'])
 source, template_path = Loader(engine).load_template_source(path)
 %>${source | n, decode.utf8}</%def>
 
+<%def name="ericfischer(locale)">
+    <%
+        from django.conf import settings
+        from django.template import Template, Context
+        from webpack_loader.exceptions import WebpackLoaderBadStatsError
+
+        path = "{base}/bundles/studio-frontend/locale_messages/{locale}.json".format(
+            base=settings.STATIC_ROOT,
+            locale=locale
+        )
+
+        messages = ""
+        with open(path) as input:
+            messages = input.read()
+
+        return Template("""
+            <div id=studio-frontend-messages style="display: none;">
+                {{ messages }}
+            </div>
+        """).render(Context({
+            'messages': messages,
+        }))
+    %>
+</%def>
+
 <%def name="webpack(entry)">
     <%doc>
         Loads Javascript onto your page from a Webpack-generated bundle.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,6 +123,7 @@ var wpconfig = {
                     /studio-frontend/,
                     /paragon/
                 ],
+                exclude: /studio-frontend\/src\/locale_scripts/,
                 use: 'babel-loader'
             },
             {
@@ -133,6 +134,17 @@ var wpconfig = {
                     options: {
                         name: '[name].[ext]',
                         outputPath: 'studio-frontend/locale_messages/'
+                    }
+                }
+            },
+            {
+                test: /\.jsx$/,
+                include: /studio-frontend\/src\/locale_scripts/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        name: '[name].[ext]',
+                        outputPath: 'studio-frontend/locale_scripts/'
                     }
                 }
             },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -126,6 +126,17 @@ var wpconfig = {
                 use: 'babel-loader'
             },
             {
+                test: /\.json$/,
+                include: /studio-frontend\/i18n\/locales/,
+                use: {
+                    loader: 'file-loader',
+                    options: {
+                        name: '[name].[ext]',
+                        outputPath: 'studio-frontend/locale_messages/'
+                    }
+                }
+            },
+            {
                 test: /(.scss|.css)$/,
                 include: [
                     /studio-frontend/,


### PR DESCRIPTION
Branched from https://github.com/edx/edx-platform/pull/16111, pairs with https://github.com/edx/studio-frontend/pull/39

As this code currently stands, I am able to embed the relevant messages into the DOM in a hidden div, so studio-frontend can look for and use them.

Example:
<img width="638" alt="screen shot 2017-10-19 at 3 22 04 pm" src="https://user-images.githubusercontent.com/7373924/31789882-904c7dd0-b4e1-11e7-9f1d-396f4d8a79a1.png">

I have yet to do any work to get studio-frontend to use this.

FYI @edx/educator-dahlia 