### PR TITLE
Move third_party_auth settings code to ready method.

### DIFF
--- a/cms/startup.py
+++ b/cms/startup.py
@@ -23,6 +23,9 @@ settings.INSTALLED_APPS  # pylint: disable=pointless-statement
 def run():
     """
     Executed during django startup
+
+    NOTE: DO **NOT** add additional code to this method or this file! The Platform Team
+          is moving all startup code to more standard locations using Django best practices.
     """
     django_db_models_options.patch()
 

--- a/common/djangoapps/third_party_auth/__init__.py
+++ b/common/djangoapps/third_party_auth/__init__.py
@@ -3,6 +3,9 @@
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
+default_app_config = 'third_party_auth.apps.ThirdPartyAuthConfig'
+
+
 def is_enabled():
     """Check whether third party authentication has been enabled. """
 

--- a/common/djangoapps/third_party_auth/apps.py
+++ b/common/djangoapps/third_party_auth/apps.py
@@ -1,0 +1,22 @@
+
+from django.apps import AppConfig
+from django.conf import settings
+
+
+class ThirdPartyAuthConfig(AppConfig):
+    name = 'third_party_auth'
+    verbose_name = "Third-party authentication"
+
+    def ready(self):
+        # To override the settings before loading social_django.
+        if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
+            self._enable_third_party_auth()
+
+    def _enable_third_party_auth(self):
+        """
+        Enable the use of third_party_auth, which allows users to sign in to edX
+        using other identity providers. For configuration details, see
+        common/djangoapps/third_party_auth/settings.py.
+        """
+        from third_party_auth import settings as auth_settings
+        auth_settings.apply_settings(settings)

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -35,10 +35,6 @@ def run():
     """
     django_db_models_options.patch()
 
-    # To override the settings before executing the autostartup() for python-social-auth
-    if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
-        enable_third_party_auth()
-
     # Comprehensive theming needs to be set up before django startup,
     # because modifying django template paths after startup has no effect.
     if is_comprehensive_theming_enabled():
@@ -114,14 +110,3 @@ def enable_microsites():
     Here for backwards compatibility
     """
     microsite.enable_microsites(log)
-
-
-def enable_third_party_auth():
-    """
-    Enable the use of third_party_auth, which allows users to sign in to edX
-    using other identity providers. For configuration details, see
-    common/djangoapps/third_party_auth/settings.py.
-    """
-
-    from third_party_auth import settings as auth_settings
-    auth_settings.apply_settings(settings)

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -32,6 +32,9 @@ log = logging.getLogger(__name__)
 def run():
     """
     Executed during django startup
+
+    NOTE: DO **NOT** add additional code to this method or this file! The Platform Team
+          is moving all startup code to more standard locations using Django best practices.
     """
     django_db_models_options.patch()
 


### PR DESCRIPTION
Move the third_party_auth settings tweak code out of startup.py. `third_party_auth` is before `social_django` in INSTALLED_APPS - so all *should* be well.