### PR TITLE
PLAT-1542 No callable queryset method arguments

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -22,7 +22,7 @@ from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from pytz import UTC
 from django.utils.translation import ugettext as _
-from mock import Mock, patch
+from mock import Mock, NonCallableMock, patch
 from nose.plugins.attrib import attr
 from nose.tools import raises
 from opaque_keys.edx.keys import CourseKey
@@ -485,7 +485,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
 
         msg: message to display if assertion fails.
         """
-        mock_problem_key = Mock(return_value=u'')
+        mock_problem_key = NonCallableMock(return_value=u'')
         mock_problem_key.course_key = self.course.id
         with patch.object(UsageKey, 'from_string') as patched_method:
             patched_method.return_value = mock_problem_key


### PR DESCRIPTION
Looking through Splunk logs, we had exactly one test which was triggering deprecation warnings about a queryset method receiving a callable argument (because it was a `Mock` object, which is callable by default).  Switched it to a `NonCallableMock` to get around this (the original `UsageKey` object being mocked isn't callable, so this is more accurate anyway).