### PR TITLE
Exclude bumper from VAL handling the transcripts

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -225,7 +225,8 @@ class VideoStudentViewHandlers(object):
                     For 'en' check if SJSON exists. For non-`en` check if SRT file exists.
         """
         is_bumper = request.GET.get('is_bumper', False)
-        feature_enabled = is_val_transcript_feature_enabled_for_course(self.course_id)
+        # Currently, we don't handle video pre-load/bumper transcripts in edx-val.
+        feature_enabled = is_val_transcript_feature_enabled_for_course(self.course_id) and not is_bumper
         transcripts = self.get_transcripts_info(is_bumper, include_val_transcripts=feature_enabled)
         if dispatch.startswith('translation'):
             language = dispatch.replace('translation', '').strip('/')


### PR DESCRIPTION
## [EDUCATOR-1382](https://openedx.atlassian.net/browse/EDUCATOR-1382)

For video component, bumper/pre-load transcripts need to be handled only in transcript dispatches. Video bumper flow remains the same as previously. So, if request to the dispatches is a bumper transcript request, then val transcripts will not get included (even if val transcripts feature is enabled).

Relevant tests has been added for all three dispatches in the presence of val transcripts.

### sandbox
- [x] [video-bumper-transcripts.sandbox.edx.org](https://studio-video-bumper-transcripts.sandbox.edx.org/container/block-v1:uet+cs101+2015_LT+type@vertical+block@2edc87c035574859a616a0c753427905)

