### PR TITLE
bump enterprise version from 0.52.4 to 0.52.10

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -47,7 +47,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.52.4
+edx-enterprise==0.52.10
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.7


### PR DESCRIPTION
ENT-675

**Here is the list of changes for enterprise:**

- Add `EnterpriseCustomerCatalog` UUID as query parameter "catalog" in enterprise course and program enrollment URL's.
- Update course enrollment view for enabled course mode in enterprise catalogs
- Update `EnterpriseApiClient.get_enterprise_courses` to account for `EnterpriseCustomerCatalogs`
- Updated the call level to enrollment URLs
- Fix migration issue for `enabled-course-modes` field of EnterpriseCustomerCatalog

Here is the commits list from version `0.52.4` to `0.52.10`: https://github.com/edx/edx-enterprise/compare/0.52.4...0.52.10