### PR TITLE
Ability to set content of static pages via Site Configuration

### DIFF
--- a/lms/djangoapps/static_template_view/tests/test_views.py
+++ b/lms/djangoapps/static_template_view/tests/test_views.py
@@ -5,11 +5,16 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
+
 
 class MarketingSiteViewTests(TestCase):
     """ Tests for the marketing site views """
 
     def _test_view(self, view_name, mimetype):
+        """
+        Gets a view and tests that it exists.
+        """
         resp = self.client.get(reverse(view_name))
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp['Content-Type'], mimetype)
@@ -25,6 +30,36 @@ class MarketingSiteViewTests(TestCase):
         Test the about view
         """
         self._test_view('about', 'text/html')
+
+    def test_about_with_site_configuration(self):
+        """
+        Test the about view with the header and content set in SiteConfiguration.
+        """
+        test_header = u"Very Unique Test Header"
+        test_content = u"Very Unique Test Content"
+        test_header_key = u'static_template_about_header'
+        test_content_key = u'static_template_about_content'
+        response = None
+        configuration = {test_header_key: test_header, test_content_key: test_content}
+        with with_site_configuration_context(configuration=configuration):
+            response = self.client.get(reverse("about"))
+        self.assertIn(test_header.encode('utf-8'), response.content)
+        self.assertIn(test_content.encode('utf-8'), response.content)
+
+    def test_about_with_site_configuration_and_html(self):
+        """
+        Test the about view with html in the header.
+        """
+        test_header = u"<i>Very Unique Test Header</i>"
+        test_content = u"<i>Very Unique Test Content</i>"
+        test_header_key = u'static_template_about_header'
+        test_content_key = u'static_template_about_content'
+        response = None
+        configuration = {test_header_key: test_header, test_content_key: test_content}
+        with with_site_configuration_context(configuration=configuration):
+            response = self.client.get(reverse("about"))
+        self.assertIn(test_header.encode('utf-8'), response.content)
+        self.assertIn(test_content.encode('utf-8'), response.content)
 
     def test_404(self):
         """

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -10,11 +10,21 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="outside-app">
-    <h1>${_("Page not found")}</h1>
-    <p>${Text(_('The page that you were looking for was not found. Go back to the {link_start}homepage{link_end} or let us know about any pages that may have been moved at {email}.')).format(
-        link_start=HTML('<a href="/">'),
-        link_end=HTML('</a>'),
-        email=HTML('<a href="mailto:{email}">{email}</a>').format(email=Text(static.get_tech_support_email_address()))
-      )}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("Page not found")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">
+                % if page_content:
+                    ${page_content}
+                % else:
+                    ${Text(_('The page that you were looking for was not found. Go back to the {link_start}homepage{link_end} or let us know about any pages that may have been moved at {email}.')).format(
+                    link_start=HTML('<a href="/">'),
+                    link_end=HTML('</a>'),
+                    email=HTML('<a href="mailto:{email}">{email}</a>').format(email=Text(static.get_tech_support_email_address()))
+                    )}
+                % endif
+            </%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/about.html
+++ b/lms/templates/static_templates/about.html
@@ -6,7 +6,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("About")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("About")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/blog.html
+++ b/lms/templates/static_templates/blog.html
@@ -6,7 +6,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("Blog")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("Blog")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -6,7 +6,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("Contact")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("Contact")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/donate.html
+++ b/lms/templates/static_templates/donate.html
@@ -6,7 +6,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("Donate")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("Donate")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/embargo.html
+++ b/lms/templates/static_templates/embargo.html
@@ -9,14 +9,20 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="outside-app">
-    <p>
-    ${Text(_("Our system indicates that you are trying to access this {platform_name} "
-        "course from a country or region currently subject to U.S. economic and trade sanctions." 
-        "Unfortunately, because {platform_name} is required to comply with export controls," 
-        "we cannot allow you to access this course at this time."
-      )).format(
-        platform_name=Text(settings.PLATFORM_NAME),
-      )}
-    </p>
+      % if page_header:
+         <h1>
+            <%block name="pageheader">${page_header}</%block>
+        </h1>
+      % endif
+        <p>
+            <%block name="pagecontent">${page_content or Text(_("Our system indicates that you are trying to access this {platform_name} "
+                    "course from a country or region currently subject to U.S. economic and trade sanctions."
+                    "Unfortunately, because {platform_name} is required to comply with export controls,"
+                    "we cannot allow you to access this course at this time."
+                    )).format(
+                    platform_name=Text(settings.PLATFORM_NAME),
+                    )}}
+        </%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/faq.html
+++ b/lms/templates/static_templates/faq.html
@@ -6,7 +6,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("FAQ")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("FAQ")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/help.html
+++ b/lms/templates/static_templates/help.html
@@ -6,7 +6,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("Help")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("Help")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/honor.html
+++ b/lms/templates/static_templates/honor.html
@@ -6,7 +6,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("Honor Code")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("Honor Code")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/jobs.html
+++ b/lms/templates/static_templates/jobs.html
@@ -6,7 +6,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("Jobs")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("Jobs")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/media-kit.html
+++ b/lms/templates/static_templates/media-kit.html
@@ -6,7 +6,11 @@
 
 <main id="main" aria-label="Cntent" tabindex="-1">
     <section class="container about">
-        <h1>${_("Media Kit")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("Media Kit")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/news.html
+++ b/lms/templates/static_templates/news.html
@@ -7,7 +7,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("In the Press")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("In the Press")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/press.html
+++ b/lms/templates/static_templates/press.html
@@ -7,7 +7,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("In the Press")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("In the Press")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/privacy.html
+++ b/lms/templates/static_templates/privacy.html
@@ -7,7 +7,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("Privacy Policy")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("Privacy Policy")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/server-down.html
+++ b/lms/templates/static_templates/server-down.html
@@ -8,15 +8,28 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="outside-app">
-      <h1>
-        ${Text(_("Currently the {platform_name} servers are down")).format(
-            platform_name=HTML(u"<em>{}</em>").format(Text(static.get_platform_name()))
-        )}
-      </h1>
-      <p>
-        ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
-        "Please email us at {tech_support_email} to report any problems or downtime.")).format(
-            tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(Text(static.get_tech_support_email_address()))
-        )}</p>
+        <h1>
+            <%block name="pageheader">
+                % if page_header:
+                    ${page_header}
+                % else:
+                    ${Text(_("Currently the {platform_name} servers are down")).format(
+                    platform_name=HTML(u"<em>{}</em>").format(Text(static.get_platform_name()))
+                    )}
+                % endif
+            </%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">
+                % if page_content:
+                    ${page_content}
+                % else:
+                    ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
+                    "Please email us at {tech_support_email} to report any problems or downtime.")).format(
+                    tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(Text(static.get_tech_support_email_address()))
+                    )}
+                % endif
+            </%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/server-error.html
+++ b/lms/templates/static_templates/server-error.html
@@ -8,17 +8,29 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="outside-app">
-      <h1>
-        ${Text(_(u"There has been a 500 error on the {platform_name} servers")).format(
-            platform_name=HTML("<em>{platform_name}</em>").format(platform_name=Text(static.get_platform_name()))
-        )}
-      </h1>
-      <p>
-        ${Text(_('Please wait a few seconds and then reload the page. If the problem persists, please email us at {email}.')).format(
-            email=HTML('<a href="mailto:{email}">{email}</a>').format(
-                email=Text(static.get_tech_support_email_address())
-            )
-        )}
-      </p>
+        <h1>
+            <%block name="pageheader">
+                % if page_header:
+                    ${page_header}
+                % else:
+                    ${Text(_(u"There has been a 500 error on the {platform_name} servers")).format(
+                    platform_name=HTML("<em>{platform_name}</em>").format(platform_name=Text(static.get_platform_name()))
+                    )}
+                % endif
+            </%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">
+                % if page_content:
+                    ${page_content}
+                % else:
+                    ${Text(_('Please wait a few seconds and then reload the page. If the problem persists, please email us at {email}.')).format(
+                    email=HTML('<a href="mailto:{email}">{email}</a>').format(
+                    email=Text(static.get_tech_support_email_address())
+                    )
+                    )}
+                % endif
+            </%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/server-overloaded.html
+++ b/lms/templates/static_templates/server-overloaded.html
@@ -8,16 +8,28 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="outside-app">
-      <h1>
-        ${Text(_("Currently the {platform_name} servers are overloaded")).format(
-            platform_name=HTML("<em>{}</em>").format(platform_name=Text(static.get_platform_name()))
-        )}
-      </h1>
-      <p>
-        ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
-        "Please email us at {tech_support_email} to report any problems or downtime.")).format(
-            tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(tech_support_email=Text(static.get_tech_support_email_address()))
-        )}
-      </p>
+        <h1>
+            <%block name="pageheader">
+                % if page_header:
+                    ${page_header}
+                % else:
+                    ${Text(_("Currently the {platform_name} servers are overloaded")).format(
+                    platform_name=HTML("<em>{}</em>").format(platform_name=Text(static.get_platform_name()))
+                    )}
+                % endif
+            </%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">
+                % if page_content:
+                    ${page_content}
+                % else:
+                    ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
+                    "Please email us at {tech_support_email} to report any problems or downtime.")).format(
+                    tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(tech_support_email=Text(static.get_tech_support_email_address()))
+                    )}
+                % endif
+            </%block>
+        </p>
     </section>
 </main>

--- a/lms/templates/static_templates/tos.html
+++ b/lms/templates/static_templates/tos.html
@@ -6,7 +6,11 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>${_("Terms of Service")}</h1>
-        <p>${_("This page left intentionally blank. Feel free to add your own content.")}</p>
+        <h1>
+            <%block name="pageheader">${page_header or _("Terms of Service")}</%block>
+        </h1>
+        <p>
+            <%block name="pagecontent">${page_content or _("This page left intentionally blank. Feel free to add your own content.")}</%block>
+        </p>
     </section>
 </main>


### PR DESCRIPTION
This PR allows the ability to set the header `<h1>` and content sections of the static template pages in two different ways.
1. Using the pageheader and pagecontent block names as a site wide template.
2. Setting SiteConfiguration settings for the header and/or the content for each page.

**Dependencies**: None

**Screenshots**:
![screenshot](https://user-images.githubusercontent.com/2694231/31840315-6c421d86-b5aa-11e7-8ad5-ecf3bb428fa9.jpg)


**Sandbox URL**: https://pr16297.sandbox.opencraft.hosting

**Merge deadline**: "None" 

**Testing instructions**:
1. Open the django admin for https://pr16297.sandbox.opencraft.hosting
2. Login with the typical staff credentials.
3. Add a new SiteConfiguration model.
4. Select the relevant site (could be example.com)
5. For the value insert the following:
`{"static_template_about_header":"Unique About Header", "static_template_about_content":"The content of the about page."}`
6. Navigate to https://pr16297.sandbox.opencraft.hosting/about
7. Ensure that the header and content have changed as expected.

**Author notes and concerns**:
1. The format for modifying the SiteConfiguration is as follows.
For the header: `static_template_htmlpagename_header`
For the content: `static_template_htmlpagename_content`
If the page contains a dash '-' it is converted to an underscore '_'.
The ".html" is also removed as well.
Example: `static_template_server_error_content`
2. The content allows html so that a more complex content section can be provided such as `<p>` for separating out paragraphs or `<img>` for images.

**Reviewers**
- [ ] smarnach
- [ ] edX reviewer[s] TBD

OpenCraft ticket: OC-3225