### PR TITLE
[ENT-671] Show the Enterprise tagline on the logistration page.

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -267,7 +267,8 @@ def enterprise_sidebar_context(request):
 
     platform_name = configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
 
-    logo_url = enterprise_customer.get('branding_configuration', {}).get('logo', '')
+    branding_configuration = enterprise_customer.get('branding_configuration', {})
+    logo_url = branding_configuration.get('logo', '') if isinstance(branding_configuration, dict) else ''
 
     branded_welcome_template = configuration_helpers.get_value(
         'ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE',

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -32,6 +32,22 @@
   }
 }
 
+.enterprise-tagline {
+  width: 300px;
+  font-size: 14px;
+  text-align: left;
+  display: inline-block;
+  vertical-align: middle;
+  line-height: normal;
+  margin-left: -30px;
+}
+
+@media (max-width: $bp-screen-sm) {
+  .enterprise-tagline {
+    width: 200px
+  }
+}
+
 .window-wrap {
   background: $white;
 }

--- a/lms/templates/header/brand.html
+++ b/lms/templates/header/brand.html
@@ -7,6 +7,7 @@
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # App that handles subdomain specific branding
 from branding import api as branding_api
@@ -18,6 +19,12 @@ from branding import api as branding_api
       <img class="logo-image" src="${static.url("images/logo.png")}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}" itemprop="logo" />
     </a>
   </div>
+  % if enable_enterprise_sidebar:
+    <span class="enterprise-tagline">
+      <% tagline = configuration_helpers.get_value('ENTERPRISE_TAGLINE', settings.ENTERPRISE_TAGLINE) %>
+      ${tagline}
+    </span>
+  % endif
   % if course and not disable_courseware_header:
     <div class="course-header">
       <span class="provider">${course.display_org_with_default}:</span>

--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -7,6 +7,7 @@
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from lms.djangoapps.ccx.overrides import get_current_ccx
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # App that handles subdomain specific branding
 from branding import api as branding_api
@@ -18,6 +19,12 @@ from branding import api as branding_api
     <img  class="logo" src="${branding_api.get_logo_url(is_secure)}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
     </%block>
   </a>
+  % if enable_enterprise_sidebar:
+    <span class="enterprise-tagline">
+      <% tagline = configuration_helpers.get_value('ENTERPRISE_TAGLINE', settings.ENTERPRISE_TAGLINE) %>
+      ${tagline}
+    </span>
+  % endif
   % if course:
     <div class="course-header">
       <span class="provider">${course.display_org_with_default}:</span>

--- a/lms/templates/navigation/navbar-logo-header.html
+++ b/lms/templates/navigation/navbar-logo-header.html
@@ -7,6 +7,7 @@
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from lms.djangoapps.ccx.overrides import get_current_ccx
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # App that handles subdomain specific branding
 from branding import api as branding_api
@@ -20,6 +21,12 @@ from branding import api as branding_api
       </%block>
     </a>
   </div>
+  % if enable_enterprise_sidebar:
+    <span class="enterprise-tagline">
+      <% tagline = configuration_helpers.get_value('ENTERPRISE_TAGLINE', settings.ENTERPRISE_TAGLINE) %>
+      ${tagline}
+    </span>
+  % endif
   % if course:
     <div class="course-header">
       <span class="provider">${course.display_org_with_default}:</span>


### PR DESCRIPTION
This makes sure the enterprise tagline renders on the logistration page as well. Previously it was rendering only on the course/program enrollment landing pages and the DSC page, but those are on separate code bases, so we needed a separate PR for the logistration page.

**JIRA tickets**: [ENT-671](https://openedx.atlassian.net/browse/ENT-671)

**Dependencies**: None

**Screenshots**: TBD

**Merge deadline**: End of sprint.

**Testing instructions**:

1. Go into incognito.
1. Attempt to go to the course enrollment landing page for some enterprise customer for whom the registration page still shows up (Aviato/Pied Piper?).
1. When redirected to the registration page with the enterprise sidebar, ensure you also see the enterprise tagline at the top next to the logo.
1. Make your browser's screen size smaller and smaller and ensure the tagline renders well with the logo at all possible screen sizes, including mobile-level.

**Settings**
```yaml
ENTERPRISE_TAGLINE: 'Yes, this is the tagline.'
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```