### PR TITLE
Dynamic pacing: Studio support of Section Highlights

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1182,6 +1182,11 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             xblock_info.update({
                 'hide_after_due': xblock.hide_after_due,
             })
+        elif xblock.category == 'chapter':
+            xblock_info.update({
+                'highlights': xblock.highlights,
+                'highlights_enabled': settings.FEATURES.get('ENABLE_SECTION_HIGHLIGHTS', False),
+            })
 
         # update xblock_info with special exam information if the feature flag is enabled
         if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -2389,7 +2389,8 @@ class TestXBlockInfo(ItemTest):
         super(TestXBlockInfo, self).setUp()
         user_id = self.user.id
         self.chapter = ItemFactory.create(
-            parent_location=self.course.location, category='chapter', display_name="Week 1", user_id=user_id
+            parent_location=self.course.location, category='chapter', display_name="Week 1", user_id=user_id,
+            highlights=['highlight'],
         )
         self.sequential = ItemFactory.create(
             parent_location=self.chapter.location, category='sequential', display_name="Lesson 1", user_id=user_id
@@ -2596,6 +2597,7 @@ class TestXBlockInfo(ItemTest):
         self.assertEqual(xblock_info['graded'], False)
         self.assertEqual(xblock_info['due'], None)
         self.assertEqual(xblock_info['format'], None)
+        self.assertEqual(xblock_info['highlights'], self.chapter.highlights)
 
         # Finally, validate the entire response for consistency
         self.validate_xblock_info_consistency(xblock_info, has_child_info=has_child_info)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -264,7 +264,10 @@ FEATURES = {
 
     # Whether archived courses (courses with end dates in the past) should be
     # shown in Studio in a separate list.
-    'ENABLE_SEPARATE_ARCHIVED_COURSES': True
+    'ENABLE_SEPARATE_ARCHIVED_COURSES': True,
+
+    # Whether section-level highlights are enabled on the platform.
+    'ENABLE_SECTION_HIGHLIGHTS': False,
 }
 
 ENABLE_JASMINE = False

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -326,6 +326,8 @@ SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
 
 FEATURES['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = True
 
+FEATURES['ENABLE_SECTION_HIGHLIGHTS'] = True
+
 ########################## AUTHOR PERMISSION #######################
 FEATURES['ENABLE_CREATOR_GROUP'] = False
 

--- a/cms/static/js/models/xblock_info.js
+++ b/cms/static/js/models/xblock_info.js
@@ -159,7 +159,12 @@ function(Backbone, _, str, ModuleUtils) {
              * some additional fields that are not stored in the course descriptor
              * (for example, which groups are selected for this particular XBlock).
              */
-            user_partitions: null
+            user_partitions: null,
+            /**
+             * This xBlock's Highlights to message to learners.
+             */
+            highlights: null,
+            highlights_enabled: null
         },
 
         initialize: function() {

--- a/cms/static/js/views/course_outline.js
+++ b/cms/static/js/views/course_outline.js
@@ -197,6 +197,19 @@ define(['jquery', 'underscore', 'js/views/xblock_outline', 'common/js/components
                 }
             },
 
+            highlightsXBlock: function() {
+                var modal = CourseOutlineModalsFactory.getModal('highlights', this.model, {
+                    onSave: this.refresh.bind(this),
+                    xblockType: XBlockViewUtils.getXBlockType(
+                        this.model.get('category'), this.parentView.model, true
+                    )
+                });
+
+                if (modal) {
+                    modal.show();
+                }
+            },
+
             addButtonActions: function(element) {
                 XBlockOutlineView.prototype.addButtonActions.apply(this, arguments);
                 element.find('.configure-button').click(function(event) {
@@ -206,6 +219,10 @@ define(['jquery', 'underscore', 'js/views/xblock_outline', 'common/js/components
                 element.find('.publish-button').click(function(event) {
                     event.preventDefault();
                     this.publishXBlock();
+                }.bind(this));
+                element.find('.highlights-button').click(function(event) {
+                    event.preventDefault();
+                    this.highlightsXBlock();
                 }.bind(this));
             },
 

--- a/cms/static/js/views/modals/base_modal.js
+++ b/cms/static/js/views/modals/base_modal.js
@@ -5,7 +5,7 @@
  *
  *   getTitle():
  *     returns the title for the modal.
- *   getHTMLContent():
+ *   getContentHtml():
  *     returns the HTML content to be shown inside the modal.
  *
  * A modal implementation should also provide the following options:

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -13,10 +13,11 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
     $, Backbone, _, gettext, BaseView, BaseModal, date, XBlockViewUtils, DateUtils, HtmlUtils, StringUtils
 ) {
     'use strict';
-    var CourseOutlineXBlockModal, SettingsXBlockModal, PublishXBlockModal, AbstractEditor, BaseDateEditor,
+    var CourseOutlineXBlockModal, SettingsXBlockModal, PublishXBlockModal, HighlightsXBlockModal,
+        AbstractEditor, BaseDateEditor,
         ReleaseDateEditor, DueDateEditor, GradingEditor, PublishEditor, AbstractVisibilityEditor,
         StaffLockEditor, UnitAccessEditor, ContentVisibilityEditor, TimedExaminationPreferenceEditor,
-        AccessEditor, ShowCorrectnessEditor;
+        AccessEditor, ShowCorrectnessEditor, HighlightsEditor;
 
     CourseOutlineXBlockModal = BaseModal.extend({
         events: _.extend({}, BaseModal.prototype.events, {
@@ -202,6 +203,38 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
 
         addActionButtons: function() {
             this.addActionButton('publish', gettext('Publish'), true);
+            this.addActionButton('cancel', gettext('Cancel'));
+        }
+    });
+
+    HighlightsXBlockModal = CourseOutlineXBlockModal.extend({
+        initialize: function() {
+            CourseOutlineXBlockModal.prototype.initialize.call(this);
+            if (this.options.xblockType) {
+                this.options.modalName = 'highlights-' + this.options.xblockType;
+            }
+        },
+
+        getTitle: function() {
+            return StringUtils.interpolate(
+                gettext('Highlights for {display_name}'),
+                {display_name: this.model.get('display_name')}
+            );
+        },
+
+        getIntroductionMessage: function() {
+            return StringUtils.interpolate(
+                gettext(
+                    'The highlights you provide here are messaged (i.e., emailed) to learners. Each {item}\'s ' +
+                    'highlights are emailed at the time that we expect the learner to start working on that {item}. ' +
+                    'At this time, we assume that each {item} will take 1 week to complete.'
+                ),
+                {item: this.options.xblockType}
+            );
+        },
+
+        addActionButtons: function() {
+            this.addActionButton('save', gettext('Save'), true);
             this.addActionButton('cancel', gettext('Cancel'));
         }
     });
@@ -844,12 +877,58 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         }
     });
 
+    HighlightsEditor = AbstractEditor.extend({
+        templateName: 'highlights-editor',
+        className: 'edit-show-highlights',
+
+        currentValue: function() {
+            var highlights = [];
+            $('.highlight-input-text').each(function() {
+                var value = $(this).val();
+                if (value !== '' && value !== null) {
+                    highlights.push(value);
+                }
+            });
+            return highlights;
+        },
+
+        hasChanges: function() {
+            return this.model.get('highlights') !== this.currentValue();
+        },
+
+        getRequestData: function() {
+            if (this.hasChanges()) {
+                return {
+                    publish: 'republish',
+                    metadata: {
+                        highlights: this.currentValue()
+                    }
+                };
+            } else {
+                return {};
+            }
+        },
+        getContext: function() {
+            return $.extend(
+                {},
+                AbstractEditor.prototype.getContext.call(this),
+                {
+                    highlights: this.model.get('highlights') || []
+                }
+            );
+        }
+    });
+
     return {
         getModal: function(type, xblockInfo, options) {
             if (type === 'edit') {
                 return this.getEditModal(xblockInfo, options);
             } else if (type === 'publish') {
                 return this.getPublishModal(xblockInfo, options);
+            } else if (type === 'highlights') {
+                return this.getHighlightsModal(xblockInfo, options);
+            } else {
+                return null;
             }
         },
 
@@ -916,6 +995,13 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         getPublishModal: function(xblockInfo, options) {
             return new PublishXBlockModal($.extend({
                 editors: [PublishEditor],
+                model: xblockInfo
+            }, options));
+        },
+
+        getHighlightsModal: function(xblockInfo, options) {
+            return new HighlightsXBlockModal($.extend({
+                editors: [HighlightsEditor],
                 model: xblockInfo
             }, options));
         }

--- a/cms/static/sass/views/_outline.scss
+++ b/cms/static/sass/views/_outline.scss
@@ -634,6 +634,23 @@
     }
   }
 
+  // outline: highlight settings
+  .highlights-button {
+    cursor: pointer;
+    color: $uxpl-blue-base;
+  }
+
+  .highlight-input-text {
+    width: 100%;
+    margin-bottom: 5px;
+    margin-top: 5px;
+  }
+
+  .highlights-description {
+    font-size: 80%;
+    font-weight: bolder;
+  }
+
   // outline: edit item settings
   .wrapper-modal-window-bulkpublish-section,
   .wrapper-modal-window-bulkpublish-subsection,

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -26,7 +26,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor']:
+% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor']:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -200,6 +200,22 @@ if (is_proctored_exam) {
                 </p>
               </div>
             <% } %>
+            <% if (xblockInfo.get('highlights_enabled') && course.get('self_paced') && xblockInfo.isChapter()) { %>
+              <div class="block-highlights">
+                    <span class="sr block-highlights-label"><%- gettext('Highlights:') %></span>
+                    <% var number_of_highlights = (xblockInfo.get('highlights') || []).length; %>
+                    <% if (number_of_highlights > 0) { %>
+                        <span class="block-highlights-value highlights-button action-button">
+                            <%- edx.StringUtils.interpolate(
+                                gettext('Section Highlights: {number_of_highlights} entered'),
+                                {number_of_highlights: number_of_highlights}
+                            ) %>
+                        </span>
+                    <% } else { %>
+                        <span class="block-highlights-value highlights-button action-button"><%- gettext('Enter Section Highlights') %></span>
+                    <% } %>
+              </div>
+            <% } %>
             <% if (xblockInfo.get('is_time_limited')) { %>
                 <div class="status-timed-proctored-exam">
                     <p>

--- a/cms/templates/js/highlights-editor.underscore
+++ b/cms/templates/js/highlights-editor.underscore
@@ -1,0 +1,27 @@
+<form>
+<h3 class="modal-section-title" id="highlights_label"><%- gettext('Section Highlights') %></h3>
+<div class="modal-section-content block-highlights">
+    <div role="group" class="list-fields" aria-labelledby="highlights_label">
+        <p class='field-message highlights-description' id='highlights_description'>
+            <%- gettext('Please enter 3-5 highlights to be sent as separate bullet points in the message.') %>
+        </p>
+        <%
+            var max_number_of_highlights = 5;
+        %>
+        <% _.each(highlights, function(highlight){ %>
+            <input
+                    class="input input-text highlight-input-text"
+                    type="text" maxlength="250" aria-describedby="highlights_description"
+                    value="<%= _.escape(highlight) %>"
+            />
+        <% }); %>
+        <% for (i = highlights.length; i < max_number_of_highlights; i++) { %>
+            <input
+                    class="input input-text highlight-input-text"
+                    type="text" maxlength="250" aria-describedby="highlights_description"
+                    placeholder="<%- gettext('A highlight to look forward to this week.') %>"
+            />
+        <% } %>
+    </div>
+</div>
+</form>


### PR DESCRIPTION
# Studio Support for Weekly Course Update Reminders
## Design Notes

- Highlights - We use this term to refer to the expected topics covered in that Section.  Eventually, this may tie into "Learning Outcomes".  However, since that relationship is unclear at the moment, we are choosing to keep these concepts decoupled at the moment.
- We assume that each Section with provided Highlights maps to a 1-week-load of work.
- This feature is enabled for only self-paced courses at the moment.
- Further detail is provided at:
  - [Functional spec and notes on Weekly Course Emails](https://openedx.atlassian.net/wiki/spaces/RET/pages/192086189/Weekly+Course+Emails)
  - [Tech plan and design notes on Weekly Course Emails](https://openedx.atlassian.net/wiki/spaces/RET/pages/162665953/Milestone+3+Weekly+Course+Update+Emails)
 
## Implementation Notes

- These Studio FED changes are hidden unless the `ENABLE_SECTION_HIGHLIGHTS` feature flag in django settings is set.
- Highlights are provided as a list of maximum 5 items, each with a maximum of 250 characters. 
- These maximums are currently enforced only in the Studio UI.

## Screenshots
### Link to enter highlights when no other Section-specific information exists. 
<img width="761" alt="screen shot 2017-10-23 at 2 24 39 pm" src="https://user-images.githubusercontent.com/6772826/31906571-6d4708a2-b7ff-11e7-84f4-09671f853341.png">

### Link to enter highlights when Section is staff-only. 
<img width="761" alt="screen shot 2017-10-23 at 2 24 46 pm" src="https://user-images.githubusercontent.com/6772826/31906586-75d44e6c-b7ff-11e7-997b-21965ef486f8.png">

### Link to view and update previously entered highlights. 
<img width="1048" alt="screen shot 2017-10-23 at 2 55 52 pm" src="https://user-images.githubusercontent.com/6772826/31907656-717111ea-b802-11e7-8dc6-822668a78b81.png">

### Highlights edit modal when no highlights are set. 
<img width="651" alt="screen shot 2017-10-23 at 2 25 50 pm" src="https://user-images.githubusercontent.com/6772826/31906585-75c0a7ae-b7ff-11e7-9942-4ab81d8dc681.png">

### Highlights edit modal with some previously entered highlights. 
<img width="701" alt="screen shot 2017-10-23 at 2 29 40 pm" src="https://user-images.githubusercontent.com/6772826/31906584-75b29a24-b7ff-11e7-9764-c7be045c32bd.png">

## Review Notes

- [x] Sandbox: https://studio-highlights.sandbox.edx.org/
- [x] FYI @edx/rapid-experiments-team, @srpearce @roderickmorales @shamck 