### PR TITLE
Add trim to instructor deduplicator

### DIFF
--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -679,5 +679,5 @@ class ProgramMarketingDataExtender(ProgramDataExtender):
 
             # Deduplicate program instructors using instructor name
             self.instructors.update(
-                {instructor.get('name'): instructor for instructor in course_instructors.get('instructors', [])}
+                {instructor.get('name', '').strip(): instructor for instructor in course_instructors.get('instructors', [])}
             )


### PR DESCRIPTION
Current instructor list on program marketing page has duplicate
professors because they are manually entered and some have trailing
spaces. This fixes that.