### PR TITLE
set django version in paver args

### DIFF
--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -68,7 +68,12 @@ function emptyxunit {
 END
 
 }
-PAVER_ARGS="-v"
+
+if [[ $DJANGO_VERSION == '1.11' ]]; then
+    PAVER_ARGS="-v --django_version=1.11"
+else
+    PAVER_ARGS="-v"
+fi
 PARALLEL="--processes=-1"
 export SUBSET_JOB=$JOB_NAME
 case "$TEST_SUITE" in


### PR DESCRIPTION
Jenkins jobs will now contain an environment variable stating which version of Django a test should be run with. For more information, see https://github.com/edx/testeng-ci/pull/110