### PR TITLE
Wire up a stub signal receiver to handle comment_created signals

### DIFF
--- a/lms/djangoapps/discussion/apps.py
+++ b/lms/djangoapps/discussion/apps.py
@@ -1,0 +1,20 @@
+"""
+Discussion Application Configuration
+
+Signal handlers are connected here.
+"""
+
+from django.apps import AppConfig
+
+
+class DiscussionConfig(AppConfig):
+    """
+    Application Configuration for Grades.
+    """
+    name = u'lms.djangoapps.discussion'
+
+    def ready(self):
+        """
+        Connect handlers to send notifications about discussions.
+        """
+        from .signals import handlers  # pylint: disable=unused-variable

--- a/lms/djangoapps/discussion/signals/handlers.py
+++ b/lms/djangoapps/discussion/signals/handlers.py
@@ -1,0 +1,25 @@
+"""
+Signal handlers related to discussions.
+"""
+import logging
+
+from django.dispatch import receiver
+
+from django_comment_common import signals
+from lms.djangoapps.discussion.config.waffle import waffle, FORUM_RESPONSE_NOTIFICATIONS
+
+
+log = logging.getLogger(__name__)
+
+
+@receiver(signals.comment_created)
+def send_discussion_email_notification(sender, user, post, **kwargs):
+    if waffle().is_enabled(FORUM_RESPONSE_NOTIFICATIONS):
+        send_message(post)
+
+
+def send_message(post):
+    """
+    TODO: https://openedx.atlassian.net/browse/EDUCATOR-1572
+    """
+    log.info('Sending message about thread %s', post.thread_id)

--- a/lms/djangoapps/discussion/tests/test_signals.py
+++ b/lms/djangoapps/discussion/tests/test_signals.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+import mock
+
+from django_comment_common import signals
+from lms.djangoapps.discussion.config.waffle import waffle, FORUM_RESPONSE_NOTIFICATIONS
+
+
+class SendMessageHandlerTestCase(TestCase):
+    @mock.patch('lms.djangoapps.discussion.signals.handlers.send_message')
+    def test_comment_created_signal_sends_message(self, mock_send_message):
+        with waffle().override(FORUM_RESPONSE_NOTIFICATIONS):
+            sender = mock.Mock()
+            user = mock.Mock()
+            post = mock.Mock()
+
+            signals.comment_created.send(sender=sender, user=user, post=post)
+
+            mock_send_message.assert_called_once_with(post)
+
+    @mock.patch('lms.djangoapps.discussion.signals.handlers.send_message')
+    def test_comment_created_signal_message_not_sent_without_waffle_switch(self, mock_send_message):
+        with waffle().override(FORUM_RESPONSE_NOTIFICATIONS, active=False):
+            sender = mock.Mock()
+            user = mock.Mock()
+            post = mock.Mock()
+
+            signals.comment_created.send(sender=sender, user=user, post=post)
+
+            self.assertFalse(mock_send_message.called)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2098,7 +2098,7 @@ INSTALLED_APPS = [
     'django_comment_client',
     'django_comment_common',
     'discussion_api',
-    'lms.djangoapps.discussion',
+    'lms.djangoapps.discussion.apps.DiscussionConfig',
 
     # Notes
     'notes',


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-1570