### PR TITLE
Fix Show Answer button display for the value "Answered" in studio

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -906,7 +906,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         elif self.showanswer == SHOWANSWER.ANSWERED:
             # NOTE: this is slightly different from 'attempted' -- resetting the problems
             # makes lcp.done False, but leaves attempts unchanged.
-            return self.lcp.done
+            return self.is_correct()
         elif self.showanswer == SHOWANSWER.CLOSED:
             return self.closed()
         elif self.showanswer == SHOWANSWER.FINISHED:

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -459,6 +459,11 @@ class CapaModuleTest(unittest.TestCase):
         self.assertTrue(still_in_grace.answer_available())
 
     def test_showanswer_answered(self):
+        """
+        Tests that with showanswer="answered" should show answer after the problem is correctly answered.
+        It should *NOT* show answer if the answer is incorrect.
+        """
+        # Can not see "Show Answer" when student answer is wrong
         answer_wrong = CapaFactory.create(
             showanswer=SHOWANSWER.ANSWERED,
             max_attempts="1",
@@ -468,7 +473,7 @@ class CapaModuleTest(unittest.TestCase):
         )
         self.assertFalse(answer_wrong.answer_available())
 
-
+        # Expect to see "Show Answer" when answer is correct
         answer_correct = CapaFactory.create(
             showanswer=SHOWANSWER.ANSWERED,
             max_attempts="1",
@@ -477,7 +482,6 @@ class CapaModuleTest(unittest.TestCase):
             correct=True
         )
         self.assertTrue(answer_correct.answer_available())
-
 
     @ddt.data('', 'other-value')
     def test_show_correctness_other(self, show_correctness):

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -35,7 +35,7 @@ from xblock.scorable import Score
 from . import get_test_system
 from pytz import UTC
 from capa.correctmap import CorrectMap
-from ..capa_base_constants import RANDOMIZATION
+from ..capa_base_constants import RANDOMIZATION, SHOWANSWER
 
 
 class CapaFactory(object):
@@ -457,6 +457,27 @@ class CapaModuleTest(unittest.TestCase):
                                             due=self.yesterday_str,
                                             graceperiod=self.two_day_delta_str)
         self.assertTrue(still_in_grace.answer_available())
+
+    def test_showanswer_answered(self):
+        answer_wrong = CapaFactory.create(
+            showanswer=SHOWANSWER.ANSWERED,
+            max_attempts="1",
+            attempts="0",
+            due=self.tomorrow_str,
+            correct=False
+        )
+        self.assertFalse(answer_wrong.answer_available())
+
+
+        answer_correct = CapaFactory.create(
+            showanswer=SHOWANSWER.ANSWERED,
+            max_attempts="1",
+            attempts="0",
+            due=self.tomorrow_str,
+            correct=True
+        )
+        self.assertTrue(answer_correct.answer_available())
+
 
     @ddt.data('', 'other-value')
     def test_show_correctness_other(self, show_correctness):


### PR DESCRIPTION
[EDUCATOR-1563](https://openedx.atlassian.net/browse/EDUCATOR-1563)

### Description
In [docs](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_components/create_problem.html#show-answer), it is explained that we should show "Show Answer" button for "Answered" value when the user has correctly submitted the answer. The current behavior is such, even if the learner has answered the question wrong, the "Show Answer" button would be available.


### Sandbox
[awaisdar001.sandbox.edx.org](https://awaisdar001.sandbox.edx.org/)
