### PR TITLE
fix malformed template variable

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_upgrade_reminder.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_upgrade_reminder.py
@@ -302,6 +302,8 @@ class TestUpgradeReminder(FilteredQueryCountMixin, CacheIsolationTestCase):
             for (_name, (_msg, email), _kwargs) in mock_channel.deliver.mock_calls:
                 for template in attr.astuple(email):
                     self.assertNotIn("TEMPLATE WARNING", template)
+                    self.assertNotIn("{{", template)
+                    self.assertNotIn("}}", template)
 
     def _get_template_overrides(self):
         templates_override = deepcopy(settings.TEMPLATES)

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.html
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.html
@@ -34,14 +34,14 @@
                 {% if course_ids|length > 1 %}
                     {% blocktrans trimmed %}
                         We hope you are enjoying learning with us so far on <strong>{{ platform_name }}</strong>! A
-                        verified certificate allows you to highlight your new knowledge and skills. An {{ platform_name
-                        }} certificate is official and easily shareable.
+                        verified certificate allows you to highlight your new knowledge and skills. An
+                        {{ platform_name }} certificate is official and easily shareable.
                     {% endblocktrans %}
                 {% else %}
                     {% blocktrans trimmed %}
                         We hope you are enjoying learning with us so far in <strong>{{ first_course_name }}</strong>! A
-                        verified certificate allows you to highlight your new knowledge and skills. An {{ platform_name
-                        }} certificate is official and easily shareable.
+                        verified certificate allows you to highlight your new knowledge and skills. An
+                        {{ platform_name }} certificate is official and easily shareable.
                     {% endblocktrans %}
                 {% endif %}
             </p>


### PR DESCRIPTION
This variable was wrapped across two lines which prevented the template engine from processing it.