### PR TITLE
Only convert price to local currency after document is ready

### DIFF
--- a/openedx/features/course_experience/static/course_experience/js/currency.js
+++ b/openedx/features/course_experience/static/course_experience/js/currency.js
@@ -66,9 +66,16 @@ export class Currency {  // eslint-disable-line import/prefer-default-export
     this.setPrice();
   }
 
+  getCountryCaller(position) {
+    const caller = function callerFunction() {
+      this.getCountry(position);
+    }.bind(this);
+    $(document).ready(caller);
+  }
+
   getUserLocation() {
     // Get user location from browser
-    navigator.geolocation.getCurrentPosition(this.getCountry.bind(this));
+    navigator.geolocation.getCurrentPosition(this.getCountryCaller.bind(this));
   }
 
   constructor(skipInitialize) {


### PR DESCRIPTION
Depending on whether location is being spoofed by chrome extension or is loading from browser there is race condition that may cause this code not to work