### PR TITLE
Fix i18n for the page title in course tabs

### DIFF
--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -1,7 +1,9 @@
 ## mako
 
 <%page expression_filter="h"/>
+
 <%!
+from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML
 %>
 
@@ -20,7 +22,7 @@ ${HTML(fragment.head_html())}
 ${HTML(fragment.foot_html())}
 </%block>
 
-<%block name="pagetitle">${tab['name']} | ${course.display_number_with_default}</%block>
+<%block name="pagetitle">${_(tab['name'])} | ${course.display_number_with_default}</%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page=active_page" />
 

--- a/lms/templates/courseware/tab-view-v2.html
+++ b/lms/templates/courseware/tab-view-v2.html
@@ -1,9 +1,11 @@
 ## mako
 
+<%page expression_filter="h"/>
+
 <%! main_css = "style-main-v2" %>
 
-<%page expression_filter="h"/>
 <%!
+from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML
 %>
 
@@ -14,7 +16,7 @@ from openedx.core.djangolib.markup import HTML
 
 <%def name="online_help_token()"><% return "${tab['online_help_token']}" %></%def>
 
-<%block name="pagetitle">${tab['name']} | ${course.display_number_with_default}</%block>
+<%block name="pagetitle">${_(tab['name'])} | ${course.display_number_with_default}</%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page=active_page" />
 

--- a/lms/templates/courseware/tab-view.html
+++ b/lms/templates/courseware/tab-view.html
@@ -5,6 +5,11 @@
 ## Override the default styles_version to use Bootstrap
 <%! main_css = "css/bootstrap/lms-main.css" %>
 
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML
+%>
+
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
 
@@ -12,13 +17,9 @@
 
 <%def name="online_help_token()"><% return "${tab['online_help_token']}" %></%def>
 
-<%block name="pagetitle">${tab['name']} | ${course.display_number_with_default}</%block>
+<%block name="pagetitle">${_(tab['name'])} | ${course.display_number_with_default}</%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page=active_page" />
-
-<%!
-from openedx.core.djangolib.markup import HTML
-%>
 
 <%block name="head_extra">
 ${HTML(fragment.head_html())}


### PR DESCRIPTION
Make sure that tab names are localized when being shown in page titles. This bug was reported by `@sambapete` in Slack.

Note: this change should be patched back to Ginkgo too. FYI @nedbat.