### PR TITLE
Add OrgWaffleFlag to waffle_utils

### DIFF
--- a/openedx/core/djangoapps/waffle_utils/admin.py
+++ b/openedx/core/djangoapps/waffle_utils/admin.py
@@ -3,11 +3,11 @@ Django admin page for waffle utils models
 """
 from django.contrib import admin
 
-from config_models.admin import ConfigurationModelAdmin, KeyedConfigurationModelAdmin
+from config_models.admin import KeyedConfigurationModelAdmin
 
 
-from .forms import WaffleFlagCourseOverrideAdminForm
-from .models import WaffleFlagCourseOverrideModel
+from .forms import WaffleFlagCourseOverrideAdminForm, WaffleFlagOrgOverrideAdminForm
+from .models import WaffleFlagCourseOverrideModel, WaffleFlagOrgOverrideModel
 
 
 class WaffleFlagCourseOverrideAdmin(KeyedConfigurationModelAdmin):
@@ -26,4 +26,23 @@ class WaffleFlagCourseOverrideAdmin(KeyedConfigurationModelAdmin):
         }),
     )
 
+
+class WaffleFlagOrgOverrideAdmin(KeyedConfigurationModelAdmin):
+    """
+    Admin for course override of waffle flags.
+
+    Includes search by org_id and waffle_flag.
+
+    """
+    form = WaffleFlagOrgOverrideAdminForm
+    search_fields = ['waffle_flag', 'org_id']
+    fieldsets = (
+        (None, {
+            'fields': ('waffle_flag', 'org_id', 'override_choice', 'enabled'),
+            'description': 'Enter a valid org id and an existing waffle flag. The waffle flag name is not validated.'
+        }),
+    )
+
+
 admin.site.register(WaffleFlagCourseOverrideModel, WaffleFlagCourseOverrideAdmin)
+admin.site.register(WaffleFlagOrgOverrideModel, WaffleFlagOrgOverrideAdmin)

--- a/openedx/core/djangoapps/waffle_utils/forms.py
+++ b/openedx/core/djangoapps/waffle_utils/forms.py
@@ -5,7 +5,7 @@ from django import forms
 
 from openedx.core.lib.courses import clean_course_id
 
-from .models import WaffleFlagCourseOverrideModel
+from .models import WaffleFlagCourseOverrideModel, WaffleFlagOrgOverrideModel
 
 
 class WaffleFlagCourseOverrideAdminForm(forms.ModelForm):
@@ -21,6 +21,27 @@ class WaffleFlagCourseOverrideAdminForm(forms.ModelForm):
         Validate the course id
         """
         return clean_course_id(self)
+
+    def clean_waffle_flag(self):
+        """
+        Validate the waffle flag is an existing flag.
+        """
+        cleaned_flag = self.cleaned_data['waffle_flag']
+
+        if not cleaned_flag:
+            msg = u'Waffle flag must be supplied.'
+            raise forms.ValidationError(msg)
+
+        return cleaned_flag.strip()
+
+
+class WaffleFlagOrgOverrideAdminForm(forms.ModelForm):
+    """
+    Input form for org override of waffle flags, allowing us to verify data.
+    """
+    class Meta(object):
+        model = WaffleFlagOrgOverrideModel
+        fields = '__all__'
 
     def clean_waffle_flag(self):
         """

--- a/openedx/core/djangoapps/waffle_utils/migrations/0002_waffleflagorgoverridemodel.py
+++ b/openedx/core/djangoapps/waffle_utils/migrations/0002_waffleflagorgoverridemodel.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('waffle_utils', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='WaffleFlagOrgOverrideModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
+                ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
+                ('waffle_flag', models.CharField(max_length=255, db_index=True)),
+                ('org_id', models.CharField(max_length=255, db_index=True)),
+                ('override_choice', models.CharField(default=b'on', max_length=3, choices=[(b'on', 'Force On'), (b'off', 'Force Off')])),
+                ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
+            ],
+            options={
+                'verbose_name': 'Waffle flag org override',
+                'verbose_name_plural': 'Waffle flag org overrides',
+            },
+        ),
+    ]

--- a/openedx/core/djangoapps/waffle_utils/tests/test_init.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_init.py
@@ -8,8 +8,8 @@ from opaque_keys.edx.keys import CourseKey
 from request_cache.middleware import RequestCache
 from waffle.testutils import override_flag
 
-from .. import CourseWaffleFlag, WaffleFlagNamespace
-from ..models import WaffleFlagCourseOverrideModel
+from .. import CourseWaffleFlag, OrgWaffleFlag, WaffleFlagNamespace
+from ..models import WaffleFlagCourseOverrideModel, WaffleFlagOrgOverrideModel
 
 
 @ddt.ddt
@@ -90,4 +90,85 @@ class TestCourseWaffleFlag(TestCase):
             WaffleFlagCourseOverrideModel.override_value.assert_called_once_with(
                 self.NAMESPACED_FLAG_NAME,
                 self.TEST_COURSE_KEY
+            )
+
+
+@ddt.ddt
+class TestOrgWaffleFlag(TestCase):
+    """
+    Tests the OrgWaffleFlag.
+    """
+
+    NAMESPACE_NAME = 'test_namespace'
+    FLAG_NAME = 'test_flag'
+    NAMESPACED_FLAG_NAME = NAMESPACE_NAME + '.' + FLAG_NAME
+
+    TEST_ORG_KEY = 'edX'
+    TEST_ORG_2_KEY = 'edX2'
+    TEST_NAMESPACE = WaffleFlagNamespace(NAMESPACE_NAME)
+    TEST_ORG_FLAG = OrgWaffleFlag(TEST_NAMESPACE, FLAG_NAME)
+
+    @ddt.data(
+        {'org_override': WaffleFlagOrgOverrideModel.ALL_CHOICES.on, 'waffle_enabled': False, 'result': True},
+        {'org_override': WaffleFlagOrgOverrideModel.ALL_CHOICES.off, 'waffle_enabled': True, 'result': False},
+        {'org_override': WaffleFlagOrgOverrideModel.ALL_CHOICES.unset, 'waffle_enabled': True, 'result': True},
+        {'org_override': WaffleFlagOrgOverrideModel.ALL_CHOICES.unset, 'waffle_enabled': False, 'result': False},
+    )
+    def test_org_waffle_flag(self, data):
+        """
+        Tests various combinations of a flag being set in waffle and overridden
+        for an organization.
+        """
+        RequestCache.clear_request_cache()
+
+        with patch.object(WaffleFlagOrgOverrideModel, 'override_value', return_value=data['org_override']):
+            with override_flag(self.NAMESPACED_FLAG_NAME, active=data['waffle_enabled']):
+                # check twice to test that the result is properly cached
+                self.assertEqual(self.TEST_ORG_FLAG.is_enabled(self.TEST_ORG_KEY), data['result'])
+                self.assertEqual(self.TEST_ORG_FLAG.is_enabled(self.TEST_ORG_KEY), data['result'])
+                # result is cached, so override check should happen once
+                WaffleFlagOrgOverrideModel.override_value.assert_called_once_with(
+                    self.NAMESPACED_FLAG_NAME,
+                    self.TEST_ORG_KEY
+                )
+
+        # check flag for a second org
+        if data['org_override'] == WaffleFlagOrgOverrideModel.ALL_CHOICES.unset:
+            # When org override wasn't set for the first org, the second org will get the same
+            # cached value from waffle.
+            self.assertEqual(self.TEST_ORG_FLAG.is_enabled(self.TEST_ORG_2_KEY), data['waffle_enabled'])
+        else:
+            # When org override was set for the first org, it should not apply to the second
+            # org which should get the default value of False.
+            self.assertEqual(self.TEST_ORG_FLAG.is_enabled(self.TEST_ORG_2_KEY), False)
+
+    @ddt.data(
+        {'flag_undefined_default': None, 'result': False},
+        {'flag_undefined_default': False, 'result': False},
+        {'flag_undefined_default': True, 'result': True},
+    )
+    def test_undefined_waffle_flag(self, data):
+        """
+        Test flag with various defaults provided for undefined waffle flags.
+        """
+        RequestCache.clear_request_cache()
+
+        test_org_flag = OrgWaffleFlag(
+            self.TEST_NAMESPACE,
+            self.FLAG_NAME,
+            flag_undefined_default=data['flag_undefined_default']
+        )
+
+        with patch.object(
+            WaffleFlagOrgOverrideModel,
+            'override_value',
+            return_value=WaffleFlagOrgOverrideModel.ALL_CHOICES.unset
+        ):
+            # check twice to test that the result is properly cached
+            self.assertEqual(test_org_flag.is_enabled(self.TEST_ORG_KEY), data['result'])
+            self.assertEqual(test_org_flag.is_enabled(self.TEST_ORG_KEY), data['result'])
+            # result is cached, so override check should happen once
+            WaffleFlagOrgOverrideModel.override_value.assert_called_once_with(
+                self.NAMESPACED_FLAG_NAME,
+                self.TEST_ORG_KEY
             )

--- a/openedx/core/djangoapps/waffle_utils/testutils.py
+++ b/openedx/core/djangoapps/waffle_utils/testutils.py
@@ -10,7 +10,8 @@ from waffle.testutils import override_flag
 # waffle tables. For example:
 #   QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 #   with self.assertNumQueries(6, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
-WAFFLE_TABLES = ['waffle_utils_waffleflagcourseoverridemodel', 'waffle_flag', 'waffle_switch', 'waffle_sample']
+WAFFLE_TABLES = ['waffle_utils_waffleflagcourseoverridemodel', 'waffle_utils_waffleflagorgoverridemodel', 'waffle_flag',
+                 'waffle_switch', 'waffle_sample']
 
 
 def override_waffle_flag(flag, active):


### PR DESCRIPTION
We have a CourseWaffleFlag that can override a generic WaffleFlag on a per-course basis. This adds an OrgWaffleFlag that can override a flag per organization.

Unlike CourseWaffleFlag which validates the input and internally stores a CourseKey object, OrgWaffleFlag just stores a string since we don't have a concept of an OrgKey.

I ended up not using this for the feature I'm working on, but I think it could still be useful in the future.

FYI @edx/ret 