### PR TITLE
LEARNER-717 Add Refresh Token Expiration time

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -510,6 +510,7 @@ OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS = 30
 
 OAUTH2_PROVIDER = {
     'OAUTH2_VALIDATOR_CLASS': 'openedx.core.djangoapps.oauth_dispatch.dot_overrides.EdxOAuth2Validator',
+    'REFRESH_TOKEN_EXPIRE_SECONDS': 20160,
     'SCOPES': {
         'read': 'Read scope',
         'write': 'Write scope',


### PR DESCRIPTION
Added Refresh Token Expiration Time = 2 weeks. Managment Command will clean all those tokens which have expired after two weeks. 

Tested the command locally working :+1: 
Will update the commit message in final rebase. 