### PR TITLE
Fix request to currency endpoint

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -3,6 +3,7 @@ Views for the course_mode module
 """
 
 import decimal
+import json
 import urllib
 
 import waffle
@@ -190,8 +191,11 @@ class ChooseModeView(View):
         context['currency_data'] = []
         if waffle.switch_is_active('local_currency'):
             if 'edx-price-l10n' not in request.COOKIES:
-                context['currency_data'] = get_currency_data()
-
+                currency_data = get_currency_data()
+                try:
+                    context['currency_data'] = json.dumps(currency_data)
+                except TypeError:
+                    pass
         return render_to_response("course_modes/choose.html", context)
 
     @method_decorator(tpa_hint_ends_existing_session)

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -136,7 +136,7 @@ def get_currency_data():
         api = create_catalog_api_client(user)
         cache_key = '{base}.currency'.format(base=catalog_integration.CACHE_KEY)
 
-        return get_edx_api_data(catalog_integration, 'currency', api=api,
+        return get_edx_api_data(catalog_integration, 'currency', api=api, traverse_pagination=False,
                                 cache_key=cache_key if catalog_integration.is_cache_enabled else None)
     else:
         return []


### PR DESCRIPTION
Data from this request should almost never be necessary since cookie will be set on marketing site.
However, this fixes two issues with requesting the data so that it will be properly available to the javascript.