### PR TITLE
Org-level schedule upgrade deadline opt-out

### DIFF
--- a/lms/djangoapps/courseware/admin.py
+++ b/lms/djangoapps/courseware/admin.py
@@ -8,4 +8,5 @@ admin.site.register(models.DynamicUpgradeDeadlineConfiguration, ConfigurationMod
 admin.site.register(models.OfflineComputedGrade)
 admin.site.register(models.OfflineComputedGradeLog)
 admin.site.register(models.CourseDynamicUpgradeDeadlineConfiguration, KeyedConfigurationModelAdmin)
+admin.site.register(models.OrgDynamicUpgradeDeadlineConfiguration, KeyedConfigurationModelAdmin)
 admin.site.register(models.StudentModule)

--- a/lms/djangoapps/courseware/migrations/0005_orgdynamicupgradedeadlineconfiguration.py
+++ b/lms/djangoapps/courseware/migrations/0005_orgdynamicupgradedeadlineconfiguration.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.db.models.deletion
 from django.conf import settings
+import courseware.models
 
 
 class Migration(migrations.Migration):
@@ -25,5 +26,14 @@ class Migration(migrations.Migration):
                 ('opt_out', models.BooleanField(default=False, help_text='Disable the dynamic upgrade deadline for this organization.')),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
             ],
+            options={
+                'ordering': ('-change_date',),
+                'abstract': False,
+            },
+            bases=(courseware.models.OptOutDynamicUpgradeDeadlineMixin, models.Model),
+        ),
+        migrations.AlterModelOptions(
+            name='coursedynamicupgradedeadlineconfiguration',
+            options={'ordering': ('-change_date',)},
         ),
     ]

--- a/lms/djangoapps/courseware/migrations/0005_orgdynamicupgradedeadlineconfiguration.py
+++ b/lms/djangoapps/courseware/migrations/0005_orgdynamicupgradedeadlineconfiguration.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('courseware', '0004_auto_20171010_1639'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='OrgDynamicUpgradeDeadlineConfiguration',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
+                ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
+                ('org_id', models.CharField(max_length=255, db_index=True)),
+                ('deadline_days', models.PositiveSmallIntegerField(default=21, help_text='Number of days a learner has to upgrade after content is made available')),
+                ('opt_out', models.BooleanField(default=False, help_text='Disable the dynamic upgrade deadline for this organization.')),
+                ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
+            ],
+        ),
+    ]

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -379,27 +379,21 @@ class DynamicUpgradeDeadlineConfiguration(ConfigurationModel):
     )
 
 
-class OptOutDynamicUpgradeDeadlineConfiguration(DynamicUpgradeDeadlineConfiguration):
-    """ Dynamic upgrade deadline configuration with opt-out switch.
-
-    This is an abstract model that both CourseDynamicUpgradeDeadlineConfiguration and
-    OrgDynamicUpgradeDeadlineConfiguration inherit.
+class OptOutDynamicUpgradeDeadlineMixin(object):
     """
-    opt_out = models.BooleanField(
-        default=False,
-        help_text=_('Disable the dynamic upgrade deadline for this course run.')
-    )
+    Provides convenience methods for interpreting the enabled and opt out status.
+    """
 
     def opted_in(self):
-        """Convienence function that returns True if this config model is both enabled and opt_out is False"""
+        """Convenience function that returns True if this config model is both enabled and opt_out is False"""
         return self.enabled and not self.opt_out
 
     def opted_out(self):
-        """Convienence function that returns True if this config model is both enabled and opt_out is True"""
+        """Convenience function that returns True if this config model is both enabled and opt_out is True"""
         return self.enabled and self.opt_out
 
 
-class CourseDynamicUpgradeDeadlineConfiguration(OptOutDynamicUpgradeDeadlineConfiguration):
+class CourseDynamicUpgradeDeadlineConfiguration(OptOutDynamicUpgradeDeadlineMixin, ConfigurationModel):
     """
     Per-course run configuration for dynamic upgrade deadlines.
 
@@ -410,8 +404,18 @@ class CourseDynamicUpgradeDeadlineConfiguration(OptOutDynamicUpgradeDeadlineConf
 
     course_id = CourseKeyField(max_length=255, db_index=True)
 
+    deadline_days = models.PositiveSmallIntegerField(
+        default=21,
+        help_text=_('Number of days a learner has to upgrade after content is made available')
+    )
 
-class OrgDynamicUpgradeDeadlineConfiguration(OptOutDynamicUpgradeDeadlineConfiguration):
+    opt_out = models.BooleanField(
+        default=False,
+        help_text=_('Disable the dynamic upgrade deadline for this course run.')
+    )
+
+
+class OrgDynamicUpgradeDeadlineConfiguration(OptOutDynamicUpgradeDeadlineMixin, ConfigurationModel):
     """
     Per-org configuration for dynamic upgrade deadlines.
 
@@ -421,3 +425,13 @@ class OrgDynamicUpgradeDeadlineConfiguration(OptOutDynamicUpgradeDeadlineConfigu
     KEY_FIELDS = ('org_id',)
 
     org_id = models.CharField(max_length=255, db_index=True)
+
+    deadline_days = models.PositiveSmallIntegerField(
+        default=21,
+        help_text=_('Number of days a learner has to upgrade after content is made available')
+    )
+
+    opt_out = models.BooleanField(
+        default=False,
+        help_text=_('Disable the dynamic upgrade deadline for this organization.')
+    )

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -379,47 +379,45 @@ class DynamicUpgradeDeadlineConfiguration(ConfigurationModel):
     )
 
 
-class CourseDynamicUpgradeDeadlineConfiguration(ConfigurationModel):
+class OptOutDynamicUpgradeDeadlineConfiguration(DynamicUpgradeDeadlineConfiguration):
+    """ Dynamic upgrade deadline configuration with opt-out switch.
+
+    This is an abstract model that both CourseDynamicUpgradeDeadlineConfiguration and
+    OrgDynamicUpgradeDeadlineConfiguration inherit.
+    """
+    opt_out = models.BooleanField(
+        default=False,
+        help_text=_('Disable the dynamic upgrade deadline for this course run.')
+    )
+
+    def opted_in(self):
+        """Convienence function that returns True if this config model is both enabled and opt_out is False"""
+        return self.enabled and not self.opt_out
+
+    def opted_out(self):
+        """Convienence function that returns True if this config model is both enabled and opt_out is True"""
+        return self.enabled and self.opt_out
+
+
+class CourseDynamicUpgradeDeadlineConfiguration(OptOutDynamicUpgradeDeadlineConfiguration):
     """
     Per-course run configuration for dynamic upgrade deadlines.
 
     This model controls dynamic upgrade deadlines on a per-course run level, allowing course runs to
     have different deadlines or opt out of the functionality altogether.
     """
-    class Meta(object):
-        app_label = 'courseware'
-
     KEY_FIELDS = ('course_id',)
 
     course_id = CourseKeyField(max_length=255, db_index=True)
-    deadline_days = models.PositiveSmallIntegerField(
-        default=21,
-        help_text=_('Number of days a learner has to upgrade after content is made available')
-    )
-    opt_out = models.BooleanField(
-        default=False,
-        help_text=_('Disable the dynamic upgrade deadline for this course run.')
-    )
 
 
-class OrgDynamicUpgradeDeadlineConfiguration(ConfigurationModel):
+class OrgDynamicUpgradeDeadlineConfiguration(OptOutDynamicUpgradeDeadlineConfiguration):
     """
     Per-org configuration for dynamic upgrade deadlines.
 
     This model controls dynamic upgrade deadlines on a per-org level, allowing organizations to
     have different deadlines or opt out of the functionality altogether.
     """
-    class Meta(object):
-        app_label = 'courseware'
-
     KEY_FIELDS = ('org_id',)
 
     org_id = models.CharField(max_length=255, db_index=True)
-    deadline_days = models.PositiveSmallIntegerField(
-        default=21,
-        help_text=_('Number of days a learner has to upgrade after content is made available')
-    )
-    opt_out = models.BooleanField(
-        default=False,
-        help_text=_('Disable the dynamic upgrade deadline for this organization.')
-    )

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -400,3 +400,26 @@ class CourseDynamicUpgradeDeadlineConfiguration(ConfigurationModel):
         default=False,
         help_text=_('Disable the dynamic upgrade deadline for this course run.')
     )
+
+
+class OrgDynamicUpgradeDeadlineConfiguration(ConfigurationModel):
+    """
+    Per-org configuration for dynamic upgrade deadlines.
+
+    This model controls dynamic upgrade deadlines on a per-org level, allowing organizations to
+    have different deadlines or opt out of the functionality altogether.
+    """
+    class Meta(object):
+        app_label = 'courseware'
+
+    KEY_FIELDS = ('org_id',)
+
+    org_id = models.CharField(max_length=255, db_index=True)
+    deadline_days = models.PositiveSmallIntegerField(
+        default=21,
+        help_text=_('Number of days a learner has to upgrade after content is made available')
+    )
+    opt_out = models.BooleanField(
+        default=False,
+        help_text=_('Disable the dynamic upgrade deadline for this organization.')
+    )

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -24,10 +24,15 @@ from courseware.date_summary import (
     VerifiedUpgradeDeadlineDate,
     CertificateAvailableDate
 )
-from courseware.models import DynamicUpgradeDeadlineConfiguration, CourseDynamicUpgradeDeadlineConfiguration
+from courseware.models import (
+    CourseDynamicUpgradeDeadlineConfiguration,
+    DynamicUpgradeDeadlineConfiguration,
+    OrgDynamicUpgradeDeadlineConfiguration
+)
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.schedules.signals import CREATE_SCHEDULE_WAFFLE_FLAG
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
@@ -562,6 +567,7 @@ class TestDateAlerts(SharedModuleStoreTestCase):
                 self.assertEqual(len(messages), 0)
 
 
+@ddt.ddt
 @attr(shard=1)
 class TestScheduleOverrides(SharedModuleStoreTestCase):
 
@@ -599,15 +605,28 @@ class TestScheduleOverrides(SharedModuleStoreTestCase):
     @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, True)
     def test_date_with_self_paced_with_enrollment_after_course_start(self):
         """ Enrolling after a course begins should result in the upgrade deadline being set relative to the
-        enrollment date. """
+        enrollment date.
+
+        Additionally, OrgDynamicUpgradeDeadlineConfiguration should override the number of days until the deadline,
+        and CourseDynamicUpgradeDeadlineConfiguration should override the org-level override.
+        """
         global_config = DynamicUpgradeDeadlineConfiguration.objects.create(enabled=True)
-        course = create_self_paced_course_run(days_till_start=-1)
+        course = create_self_paced_course_run(days_till_start=-1, org_id='TestOrg')
         enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT)
         block = VerifiedUpgradeDeadlineDate(course, enrollment.user)
         expected = enrollment.created + timedelta(days=global_config.deadline_days)
         self.assertEqual(block.date, expected)
 
-        # Courses should be able to override the deadline
+        # Orgs should be able to override the deadline
+        org_config = OrgDynamicUpgradeDeadlineConfiguration.objects.create(
+            enabled=True, org_id=course.org, deadline_days=4
+        )
+        enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT)
+        block = VerifiedUpgradeDeadlineDate(course, enrollment.user)
+        expected = enrollment.created + timedelta(days=org_config.deadline_days)
+        self.assertEqual(block.date, expected)
+
+        # Courses should be able to override the deadline (and the org-level override)
         course_config = CourseDynamicUpgradeDeadlineConfiguration.objects.create(
             enabled=True, course_id=course.id, deadline_days=3
         )
@@ -649,6 +668,68 @@ class TestScheduleOverrides(SharedModuleStoreTestCase):
 
         block = VerifiedUpgradeDeadlineDate(course, enrollment.user)
         self.assertEqual(block.date, expected)
+
+    @ddt.data(
+        # (enroll before configs, org enabled, org opt-out, course enabled, course opt-out, expected dynamic deadline)
+        (False, False, False, False, False, True),
+        (False, False, False, False, True, True),
+        (False, False, False, True, False, True),
+        (False, False, False, True, True, False),
+        (False, False, True, False, False, True),
+        (False, False, True, False, True, True),
+        (False, False, True, True, False, True),
+        (False, False, True, True, True, False),
+        (False, True, False, False, False, True),
+        (False, True, False, False, True, True),
+        (False, True, False, True, False, True),
+        (False, True, False, True, True, False),  # course-level overrides org-level
+        (False, True, True, False, False, False),
+        (False, True, True, False, True, False),
+        (False, True, True, True, False, True),  # course-level overrides org-level
+        (False, True, True, True, True, False),
+
+        (True, False, False, False, False, True),
+        (True, False, False, False, True, True),
+        (True, False, False, True, False, True),
+        (True, False, False, True, True, False),
+        (True, False, True, False, False, True),
+        (True, False, True, False, True, True),
+        (True, False, True, True, False, True),
+        (True, False, True, True, True, False),
+        (True, True, False, False, False, True),
+        (True, True, False, False, True, True),
+        (True, True, False, True, False, True),
+        (True, True, False, True, True, False),  # course-level overrides org-level
+        (True, True, True, False, False, False),
+        (True, True, True, False, True, False),
+        (True, True, True, True, False, True),  # course-level overrides org-level
+        (True, True, True, True, True, False),
+    )
+    @ddt.unpack
+    @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, True)
+    def test_date_with_org_and_course_config_overrides(self, enroll_first, org_config_enabled, org_config_opt_out,
+                                                       course_config_enabled, course_config_opt_out,
+                                                       expected_dynamic_deadline):
+        """ Runs through every combination of org-level plus course-level DynamicUpgradeDeadlineConfiguration enabled
+        and opt-out states to verify that course-level overrides the org-level config. """
+        course = create_self_paced_course_run(days_till_start=-1, org_id='TestOrg')
+        DynamicUpgradeDeadlineConfiguration.objects.create(enabled=True)
+        if enroll_first:
+            enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT, course__self_paced=True)
+        OrgDynamicUpgradeDeadlineConfiguration.objects.create(
+            enabled=org_config_enabled, opt_out=org_config_opt_out, org_id=course.id.org
+        )
+        CourseDynamicUpgradeDeadlineConfiguration.objects.create(
+            enabled=course_config_enabled, opt_out=course_config_opt_out, course_id=course.id
+        )
+        if not enroll_first:
+            enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT, course__self_paced=True)
+
+        # The enrollment has a schedule, and the upgrade_deadline is set when expected_dynamic_deadline is True
+        if not enroll_first:
+            self.assertEqual(enrollment.schedule.upgrade_deadline is not None, expected_dynamic_deadline)
+        # The CourseEnrollment.upgrade_deadline property method is checking the configs
+        self.assertEqual(enrollment.dynamic_upgrade_deadline is not None, expected_dynamic_deadline)
 
 
 def create_user(verification_status=None):
@@ -705,7 +786,7 @@ def create_course_run(
     return course
 
 
-def create_self_paced_course_run(days_till_start=1):
+def create_self_paced_course_run(days_till_start=1, org_id=None):
     """ Create a new course run and course modes.
 
     All date-related arguments are relative to the current date-time (now) unless otherwise specified.
@@ -714,9 +795,11 @@ def create_self_paced_course_run(days_till_start=1):
 
     Arguments:
         days_till_start (int): Number of days until the course starts.
+        org_id (string): String org id to assign the course to (default: None; use CourseFactory default)
     """
     now = datetime.now(utc)
-    course = CourseFactory.create(start=now + timedelta(days=days_till_start), self_paced=True)
+    course = CourseFactory.create(start=now + timedelta(days=days_till_start), self_paced=True,
+                                  org=org_id if org_id else 'TestedX')
 
     CourseModeFactory(
         course_id=course.id,


### PR DESCRIPTION
Similar to the existing `CourseDynamicUpgradeDeadlineConfiguration`, I made a `CourseDynamicUpgradeDeadlineConfiguration` that will:

1. Prevent filling schedules' upgrade_deadline field at course enrollment time.
2. Force the `CourseEnrollment.dynamic_upgrade_deadline` property to return `None` (in-case the org was opted-out after schedules with upgrade_deadlines were already created).

The course-level config should always override the org-level config as long as it is enabled.

FYI: @edx/rapid-experiments-team 