### PR TITLE
PLAT-1766 Upgrade django-cas for Django 1.11 compatibility

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -55,7 +55,7 @@ git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
-git+https://github.com/mitodl/django-cas.git@47cfef16cbbf305f943cceb8c0b02514194eb9fa#egg=django-cas==2.1.1
+git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 # Master pyfs has a bug working with VPC auth. This is a fix. We should switch
 # back to master when and if this fix is merged back.


### PR DESCRIPTION
Upgrade to the latest commit on django-cas master which added some compatibility fixes for Django 1.9 through 1.11.