### PR TITLE
Exclude .tox directory from quality checks

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -53,7 +53,7 @@
 #
 # ------------------------------
 [MASTER]
-ignore = ,.git,migrations,node_modules,.pycharm_helpers
+ignore = ,.git,.tox,migrations,node_modules,.pycharm_helpers
 persistent = yes
 load-plugins = edx_lint.pylint,pylint_django,pylint_celery
 
@@ -180,4 +180,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 42ec1461de97fc01d7191c1c5f2fd5ec67671a61
+# 5c46ef5d76dd14aadf0311325da7f519a2241646

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -1,6 +1,6 @@
 # pylintrc tweaks for use with edx_lint.
 [MASTER]
-ignore+ = ,.git,migrations,node_modules,.pycharm_helpers
+ignore+ = ,.git,.tox,migrations,node_modules,.pycharm_helpers
 
 [BASIC]
 attr-rgx = [a-z_][a-z0-9_]{2,40}$

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py
 #   It's a little unusual, but we have good reasons for doing so, so we disable
 #   this rule.
 ignore=E501,E265,W602
-exclude=migrations,.git,.pycharm_helpers,test_root/staticfiles,node_modules
+exclude=migrations,.git,.pycharm_helpers,.tox,test_root/staticfiles,node_modules
 
 [isort]
 indent='    '


### PR DESCRIPTION
`.tox` is a local-only folder with copies of the main repo and installations of 3rd-party packages; no need to run static code analysis on files in it.