### PR TITLE
Update enterprise version to `0.53.4`

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.53.1
+edx-enterprise==0.53.4
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.7


### PR DESCRIPTION
ENT-731
@asadiqbal08 @saleem-latif @douglashall 

**Here is the list of changes for enterprise:**
* [PLAT-1780] Remove dependency on django-extensions 
* Improve Theming of Enterprise Pages
* [ENT-731] Preseve catalog querystring on declining DSC 

Here is the commits list from version `0.53.1` to `0.53.4`:https://github.com/edx/edx-enterprise/compare/0.53.1...0.53.4