### PR TITLE
ENT-735: Enterprise version upgrade to 0.53.5

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -48,7 +48,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.53.4
+edx-enterprise==0.53.5
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.7


### PR DESCRIPTION
This edx-enterprise version upgrade adds a fix for 429 error for SAP learner data transmission.