### PR TITLE
Allow Waffle flags to work when outside a request context

### DIFF
--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -1,3 +1,8 @@
+"""
+Unit tests for course tools.
+"""
+
+import crum
 import datetime
 
 from mock import patch
@@ -59,6 +64,7 @@ class VerifiedUpgradeToolTest(SharedModuleStoreTestCase):
         )
         self.request = RequestFactory().request()
         self.request.user = self.enrollment.user
+        crum.set_current_request(self.request)
 
     def test_tool_visible(self):
         self.assertTrue(VerifiedUpgradeTool().is_enabled(self.request, self.course.id))

--- a/openedx/core/djangoapps/waffle_utils/tests/test_testutils.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_testutils.py
@@ -1,7 +1,11 @@
 """
 Tests for waffle utils test utilities.
 """
+
+import crum
+
 from django.test import TestCase
+from django.test.client import RequestFactory
 from opaque_keys.edx.keys import CourseKey
 
 from request_cache.middleware import RequestCache
@@ -25,6 +29,8 @@ class OverrideWaffleFlagTests(TestCase):
 
     def setUp(self):
         super(OverrideWaffleFlagTests, self).setUp()
+        request = RequestFactory().request()
+        crum.set_current_request(request)
         RequestCache.clear_request_cache()
 
     @override_waffle_flag(TEST_COURSE_FLAG, True)


### PR DESCRIPTION
This fix ensures that our Waffle utilities will work when called outside of a request context. In such a situation, the default value is returned but not cached, so that other callers will get the correct value.

I started to investigate why the 404 page is rendered without a request context, but I didn't get very far. I think this change is still necessary because there could be other scenarios where we accidentally access Waffle in this way.

I put logging in so that we can get a sense of how often this is happening, and whether some of the situations need to be improved upon. Let me know if you think this will be too aggressive.

FYI @ormsbee @robrap @feanil @HarryRein 