### PR TITLE
Add an lms_initialization app

### DIFF
--- a/lms/djangoapps/lms_initialization/__init__.py
+++ b/lms/djangoapps/lms_initialization/__init__.py
@@ -1,0 +1,3 @@
+"""
+Initialization app for the LMS
+"""

--- a/lms/djangoapps/lms_initialization/apps.py
+++ b/lms/djangoapps/lms_initialization/apps.py
@@ -1,0 +1,25 @@
+"""
+Initialization app for the LMS
+
+This app consists solely of a ready method in its AppConfig, and should be
+included early in the INSTALLED_APPS list.
+"""
+
+import analytics
+from django.apps import AppConfig
+from django.conf import settings
+
+
+class LMSInitializationConfig(AppConfig):
+    """
+    Application Configuration for lms_initialization.
+    """
+    name = 'lms_initialization'
+    verbose_name = 'LMS Initialization'
+
+    def ready(self):
+        """
+        Global LMS initialization methods are called here.  This runs after
+        settings have loaded, but before most other djangoapp initializations.
+        """
+        pass

--- a/lms/djangoapps/lms_initialization/apps.py
+++ b/lms/djangoapps/lms_initialization/apps.py
@@ -22,4 +22,11 @@ class LMSInitializationConfig(AppConfig):
         Global LMS initialization methods are called here.  This runs after
         settings have loaded, but before most other djangoapp initializations.
         """
-        pass
+        self._initialize_analytics()
+
+    def _initialize_analytics(self):
+        """
+        Initialize Segment analytics module by setting the write_key.
+        """
+        if settings.LMS_SEGMENT_KEY:
+            analytics.write_key = settings.LMS_SEGMENT_KEY

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1988,6 +1988,9 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'djcelery',
 
+    # Initialization
+    'lms_initialization.apps.LMSInitializationConfig',
+
     # Common views
     'openedx.core.djangoapps.common_views',
 

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -13,7 +13,6 @@ settings.INSTALLED_APPS  # pylint: disable=pointless-statement
 
 from openedx.core.lib.django_startup import autostartup
 from openedx.core.release import doc_version
-import analytics
 
 from openedx.core.djangoapps.monkey_patch import django_db_models_options
 
@@ -56,10 +55,6 @@ def run():
 
     # Mako requires the directories to be added after the django setup.
     microsite.enable_microsites(log)
-
-    # Initialize Segment analytics module by setting the write_key.
-    if settings.LMS_SEGMENT_KEY:
-        analytics.write_key = settings.LMS_SEGMENT_KEY
 
     # register any dependency injections that we need to support in edx_proctoring
     # right now edx_proctoring is dependent on the openedx.core.djangoapps.credit and


### PR DESCRIPTION
In two commits, create an lms_initialization app to take the place of lms.startup.run(), and migrate `analytics` initialization to that new app.