### PR TITLE
Fix onload tabindex focus for wiki edits

### DIFF
--- a/lms/templates/wiki/includes/editor.html
+++ b/lms/templates/wiki/includes/editor.html
@@ -6,6 +6,7 @@
 <script language="javascript">
   $(document).ready(function() {
     $("#id_revision").val('{{ article.current_revision.id }}');
+    $("#div_id_title > .controls").attr('tabindex', -1).focus();
   });
 </script>
 </div>


### PR DESCRIPTION
## [EDUCATOR-1556](https://openedx.atlassian.net/browse/EDUCATOR-1556)

### Description
Fix tab focus on wiki edit pages.

### Testing
- [x] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 @cptvitamin 

FYI: @edx/educator-neem

### Post-review
- [x] Rebase and squash commits

