### PR TITLE
Fix polls 404 on disabled completion.

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -481,10 +481,13 @@ def get_module_system_for_user(
         Returns None if no special processing is required.
         """
         handlers = {
-            'completion': handle_completion_event,
             'grade': handle_grade_event,
-            'progress': handle_deprecated_progress_event,
         }
+        if completion_waffle.waffle().is_enabled(completion_waffle.ENABLE_COMPLETION_TRACKING):
+            handlers.update({
+                'completion': handle_completion_event,
+                'progress': handle_deprecated_progress_event,
+            })
         return handlers.get(event_type)
 
     def publish(block, event_type, event):

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -624,7 +624,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
                 content_type='application/json',
             )
             request.user = self.mock_user
-            with self.assertRaises(Http404):
+            with patch('lms.djangoapps.completion.models.BlockCompletionManager.submit_completion') as mock_complete:
                 render.handle_xblock_callback(
                     request,
                     unicode(course.id),
@@ -632,6 +632,8 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
                     signal,
                     '',
                 )
+                mock_complete.assert_not_called()
+            self.assertFalse(BlockCompletion.objects.filter(block_key=block.scope_ids.usage_id).exists())
 
     @ddt.data(
         ('complete', {'completion': 0.625}, 0.625),


### PR DESCRIPTION
Calling `runtime.handle('progress', ...)` was causing a 404 error due to
the handle_deprecated_progress_event function.  It should be okay for xblocks to submit a
completion or progress event; they just shouldn't have it treated
specially.

The fix is to avoid calling the special handler for `'progress'` events (and completion events) if the waffle switch is disabled, rather than causing an error.  In general, blocks are allowed to send arbitrary events.  Normally they just get logged, rather than being handled specially, so disabling the special handling should fall back to the logging that was already happening, rather than causing a new, unexpected error.

[EDUCATOR-1642](https://openedx.atlassian.net/browse/EDUCATOR-1642)

## Reviewers 

- [x] @bradenmacdonald 
- [x] @yro 

## Test instructions

1. In a devstack studio, Create a course, or modify an existing course to have a poll block.
    * Add "poll" to the list of custom modules in advanced settings
    * Add a new unit of "Advanced -> Poll" type.
2. In the lms, on the master branch, submit an answer for the poll.  
   Without this fix, a 404 happens inside `/courses/course-v1:edX+DemoX+Demo_Course/xblock/block-v1:edX+DemoX+Demo_Course+type@poll+block@...`/handler/vote (which calls `runtime.publish('progress', {})`).  The "submit" button will be disabled, but refreshing the page will re-enable it.
3. Update the lms to this branch.  Refresh the page, and submit an answer to the poll.  
4. Verify that with this fix, the poll submits as expected, and no object is created in `lms.djangoapps.completion.BlockCompletion`.