### PR TITLE
add option to disable capturing stderr in pytest

### DIFF
--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -50,6 +50,10 @@ __test__ = False  # do not collect
     make_option("-q", "--quiet", action="store_const", const=0, dest="verbosity"),
     make_option("-v", "--verbosity", action="count", dest="verbosity", default=1),
     make_option(
+        "--disable_capture", action="store_true", dest="disable_capture",
+        help="Disable capturing of stdout/stderr"
+    ),
+    make_option(
         '--disable-migrations',
         action='store_true',
         dest='disable_migrations',
@@ -132,6 +136,10 @@ def test_system(options, passthrough_options):
     make_option("--verbose", action="store_const", const=2, dest="verbosity"),
     make_option("-q", "--quiet", action="store_const", const=0, dest="verbosity"),
     make_option("-v", "--verbosity", action="count", dest="verbosity", default=1),
+    make_option(
+        "--disable_capture", action="store_true", dest="disable_capture",
+        help="Disable capturing of stdout/stderr"
+    ),
 ], share_with=['pavelib.utils.test.utils.clean_reports_dir'])
 @PassthroughTask
 @timed

--- a/pavelib/utils/test/suites/pytest_suite.py
+++ b/pavelib/utils/test/suites/pytest_suite.py
@@ -32,6 +32,7 @@ class PytestSuite(TestSuite):
             self.django_toxenv = 'py27-django111'
         else:
             self.django_toxenv = 'py27-django18'
+        self.disable_capture = kwargs.get('disable_capture', None)
         self.report_dir = Env.REPORT_DIR / self.root
 
         # If set, put reports for run in "unique" directories.
@@ -144,6 +145,9 @@ class SystemTestSuite(PytestSuite):
         elif self.verbosity > 1:
             cmd.append("--verbose")
 
+        if self.disable_capture:
+            cmd.append("-s")
+
         if self.processes == -1:
             cmd.append('-n auto')
             cmd.append('--dist=loadscope')
@@ -230,6 +234,8 @@ class LibTestSuite(PytestSuite):
             cmd.append("--quiet")
         elif self.verbosity > 1:
             cmd.append("--verbose")
+        if self.disable_capture:
+            cmd.append("-s")
         cmd.append(self.test_id)
 
         return self._under_coverage_cmd(cmd)

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -111,13 +111,13 @@ case "$TEST_SUITE" in
     "lms-unit")
         case "$SHARD" in
             "all")
-                paver test_system -s lms $PAVER_ARGS $PARALLEL 2> lms-tests.log
+                paver test_system -s lms --disable_capture $PAVER_ARGS $PARALLEL 2> lms-tests.log
                 ;;
             [1-3])
-                paver test_system -s lms --eval-attr="shard==$SHARD" $PAVER_ARGS $PARALLEL 2> lms-tests.$SHARD.log
+                paver test_system -s lms --disable_capture --eval-attr="shard==$SHARD" $PAVER_ARGS $PARALLEL 2> lms-tests.$SHARD.log
                 ;;
             4|"noshard")
-                paver test_system -s lms --eval-attr='not shard' $PAVER_ARGS $PARALLEL 2> lms-tests.4.log
+                paver test_system -s lms --disable_capture --eval-attr='not shard' $PAVER_ARGS $PARALLEL 2> lms-tests.4.log
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
@@ -131,11 +131,11 @@ case "$TEST_SUITE" in
         ;;
 
     "cms-unit")
-        paver test_system -s cms $PAVER_ARGS 2> cms-tests.log
+        paver test_system -s cms --disable_capture $PAVER_ARGS 2> cms-tests.log
         ;;
 
     "commonlib-unit")
-        paver test_lib $PAVER_ARGS 2> common-tests.log
+        paver test_lib --disable_capture $PAVER_ARGS 2> common-tests.log
         ;;
 
     "js-unit")


### PR DESCRIPTION
Lately python unit test builds have been producing extremely large build artifacts on Jenkins. The default behavior of pytest is capture everything written to stdout/stderr into file descriptors (see https://docs.pytest.org/en/latest/capture.html). These get pulled into our report artifacts, so that a user can view stderr loggin for each individual test. This PR will reduce the size of the junit xml report by disabling additional capture of stderr/stdout logging. NOTE: You can still see failures/test results in the console log and test result artifact.

For reference:
Python build from today (using default pytest capture method):
* Link: https://build.testeng.edx.org/job/edx-platform-python-unittests-pr/43126/
* Disk Usage:
```bash
du --human-readable --max-depth=1 edx-platform-python-unittests-pr/builds/43126
243M	43126/archive
129M	43126/coveragepy
242M	43126/htmlreports
12K	43126/timestamper
715M	43126

ls -lh edx-platform-python-unittests-pr/builds/43126/junitResult.xml 
-rw-r--r-- 1 jenkins jenkins 102M Oct 31 17:23 edx-platform-python-unittests-pr/builds/43126/junitResult.xml
```

This PR:
* Link to build: https://build.testeng.edx.org/job/edx-platform-python-unittests-pr/43171/
* Disk Usage:
```bash
du --human-readable --max-depth=1 edx-platform-python-unittests-pr/builds/43171
224M	43171/archive
129M	43171/coveragepy
146M	43171/htmlreports
12K	43171/timestamper
505M	43171

ls -lh edx-platform-python-unittests-pr/builds/43171/junitResult.xml 
-rw-r--r-- 1 jenkins jenkins 6.2M Oct 31 21:31 edx-platform-python-unittests-pr/builds/43171/junitResult.xml

```

In case you are curious about the effects of this on logging errors, here is a link to a build of this PR that failed https://build.testeng.edx.org/job/edx-platform-python-unittests-pr/43164/

I don't know if this is the right path forward. Perhaps users really want to see extra logging in the test result. However, we didn't have this while running tests via nosetest. Example:
* individual test result based before the move to pytest: https://build.testeng.edx.org/job/edx-platform-python-unittests-pr/43089/testReport/cms.djangoapps.contentstore.tests.test_courseware_index/GroupConfigurationSearchMongo/test_content_group_gets_indexed/
* individual test result from the PR from today (referenced above): https://build.testeng.edx.org/job/edx-platform-python-unittests-pr/43126/testReport/cms.djangoapps.contentstore.tests.test_courseware_index/GroupConfigurationSearchMongo/test_content_group_gets_indexed/

