### PR TITLE
Remove pragmas to disable mako-missing-default

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -1,6 +1,5 @@
-## xss-lint: disable=mako-missing-default
-
 ## coding=utf-8
+## mako
 
 ## Pages currently use v1 styling by default. Once the Pattern Library
 ## rollout has been completed, this default can be switched to v2.

--- a/cms/templates/ux/reference/fragments/course-settings.html
+++ b/cms/templates/ux/reference/fragments/course-settings.html
@@ -1,5 +1,5 @@
+<%page expression_filter="h"/>
 <script>
-    ## xss-lint: disable=mako-missing-default
 </script>
 <div class="wrapper-mast wrapper">
   <header class="mast has-subtitle">

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -1,5 +1,3 @@
-## xss-lint: disable=mako-missing-default
-
 ## coding=utf-8
 
 ## This is the main Mako template that all page templates should include.

--- a/lms/templates/ux/reference/fragments/unit-fragment.html
+++ b/lms/templates/ux/reference/fragments/unit-fragment.html
@@ -1,6 +1,6 @@
 ## mako
+<%page expression_filter="h"/>
 <script>
-    ## xss-lint: disable=mako-missing-default
 </script>
 
 <section class="main-container">


### PR DESCRIPTION
@andy-armstrong: I'm not clear on why these pragmas were needed.  Additionally, if any are in fact needed, I think we should include an additional comment to detail why so that this doesn't become a common practice.  Thanks. :)

FYI: @fysheets 