### PR TITLE
PLAT-1775 Move help tokens configuration from startup to settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -133,6 +133,7 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
 )
 from openedx.core.lib.license import LicenseMixin
 from openedx.core.lib.derived import derived, derived_dict_entry
+from openedx.core.release import doc_version
 
 ############################ FEATURE CONFIGURATION #############################
 
@@ -1382,6 +1383,9 @@ AFFILIATE_COOKIE_NAME = 'affiliate_id'
 ############## Settings for Studio Context Sensitive Help ##############
 
 HELP_TOKENS_INI_FILE = REPO_ROOT / "cms" / "envs" / "help_tokens.ini"
+HELP_TOKENS_LANGUAGE_CODE = lambda settings: settings.LANGUAGE_CODE
+HELP_TOKENS_VERSION = lambda settings: doc_version()
+derived('HELP_TOKENS_LANGUAGE_CODE', 'HELP_TOKENS_VERSION')
 
 # This is required for the migrations in oauth_dispatch.models
 # otherwise it fails saying this attribute is not present in Settings

--- a/cms/startup.py
+++ b/cms/startup.py
@@ -15,7 +15,6 @@ from openedx.core.lib.django_startup import autostartup
 settings.INSTALLED_APPS  # pylint: disable=pointless-statement
 
 from openedx.core.lib.xblock_utils import xblock_local_resource_url
-from openedx.core.release import doc_version
 from startup_configurations.validate_config import validate_cms_config
 
 
@@ -40,10 +39,6 @@ def run():
     # https://openedx.atlassian.net/wiki/display/PLAT/Convert+from+Storage-centric+runtimes+to+Application-centric+runtimes
     xmodule.x_module.descriptor_global_handler_url = cms.lib.xblock.runtime.handler_url
     xmodule.x_module.descriptor_global_local_resource_url = xblock_local_resource_url
-
-    # Set the version of docs that help-tokens will go to.
-    settings.HELP_TOKENS_LANGUAGE_CODE = settings.LANGUAGE_CODE
-    settings.HELP_TOKENS_VERSION = doc_version()
 
     # validate configurations on startup
     validate_cms_config(settings)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -44,6 +44,7 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
     get_theme_base_dirs_from_settings
 )
 from openedx.core.lib.derived import derived, derived_dict_entry
+from openedx.core.release import doc_version
 from xmodule.modulestore.modulestore_settings import update_module_store_settings
 from xmodule.modulestore.edit_info import EditInfoMixin
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
@@ -3295,10 +3296,13 @@ REDIRECT_CACHE_KEY_PREFIX = 'redirects'
 ############## Settings for LMS Context Sensitive Help ##############
 
 HELP_TOKENS_INI_FILE = REPO_ROOT / "lms" / "envs" / "help_tokens.ini"
+HELP_TOKENS_LANGUAGE_CODE = lambda settings: settings.LANGUAGE_CODE
+HELP_TOKENS_VERSION = lambda settings: doc_version()
 HELP_TOKENS_BOOKS = {
     'learner': 'http://edx.readthedocs.io/projects/open-edx-learner-guide',
     'course_author': 'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course',
 }
+derived('HELP_TOKENS_LANGUAGE_CODE', 'HELP_TOKENS_VERSION')
 
 ############## OPEN EDX ENTERPRISE SERVICE CONFIGURATION ######################
 # The Open edX Enterprise service is currently hosted via the LMS container/process.

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -12,7 +12,6 @@ from django.conf import settings
 settings.INSTALLED_APPS  # pylint: disable=pointless-statement
 
 from openedx.core.lib.django_startup import autostartup
-from openedx.core.release import doc_version
 
 from openedx.core.djangoapps.monkey_patch import django_db_models_options
 
@@ -72,10 +71,6 @@ def run():
     # https://openedx.atlassian.net/wiki/display/PLAT/Convert+from+Storage-centric+runtimes+to+Application-centric+runtimes
     xmodule.x_module.descriptor_global_handler_url = lms_xblock.runtime.handler_url
     xmodule.x_module.descriptor_global_local_resource_url = lms_xblock.runtime.local_resource_url
-
-    # Set the version of docs that help-tokens will go to.
-    settings.HELP_TOKENS_LANGUAGE_CODE = settings.LANGUAGE_CODE
-    settings.HELP_TOKENS_VERSION = doc_version()
 
     # validate configurations on startup
     validate_lms_config(settings)


### PR DESCRIPTION
This seems to fit pretty nicely as derived settings.  We're already importing the `doc_version` function from the bok_choy settings files, so that seems safe enough.