### PR TITLE
PLAT-1773 Delegate edx-proctoring service registration to app ready

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1028,7 +1028,7 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.coursegraph.apps.CoursegraphConfig',
 
     # Credit courses
-    'openedx.core.djangoapps.credit',
+    'openedx.core.djangoapps.credit.apps.CreditConfig',
 
     'xblock_django',
 

--- a/lms/djangoapps/grades/apps.py
+++ b/lms/djangoapps/grades/apps.py
@@ -5,6 +5,8 @@ Signal handlers are connected here.
 """
 
 from django.apps import AppConfig
+from django.conf import settings
+from edx_proctoring.runtime import set_runtime_service
 
 
 class GradesConfig(AppConfig):
@@ -20,3 +22,6 @@ class GradesConfig(AppConfig):
         # Can't import models at module level in AppConfigs, and models get
         # included from the signal handlers
         from .signals import handlers  # pylint: disable=unused-variable
+        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+            from .services import GradesService
+            set_runtime_service('grades', GradesService())

--- a/lms/djangoapps/instructor/apps.py
+++ b/lms/djangoapps/instructor/apps.py
@@ -1,0 +1,19 @@
+"""
+Instructor Application Configuration
+"""
+
+from django.apps import AppConfig
+from django.conf import settings
+from edx_proctoring.runtime import set_runtime_service
+
+
+class InstructorConfig(AppConfig):
+    """
+    Default configuration for the "lms.djangoapps.instructor" Django application.
+    """
+    name = u'lms.djangoapps.instructor'
+
+    def ready(self):
+        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+            from .services import InstructorService
+            set_runtime_service('instructor', InstructorService())

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2074,7 +2074,7 @@ INSTALLED_APPS = [
     'util',
     'certificates.apps.CertificatesConfig',
     'dashboard',
-    'lms.djangoapps.instructor',
+    'lms.djangoapps.instructor.apps.InstructorConfig',
     'lms.djangoapps.instructor_task',
     'openedx.core.djangoapps.course_groups',
     'bulk_email',
@@ -2228,7 +2228,7 @@ INSTALLED_APPS = [
     'commerce',
 
     # Credit courses
-    'openedx.core.djangoapps.credit',
+    'openedx.core.djangoapps.credit.apps.CreditConfig',
 
     # Course teams
     'lms.djangoapps.teams',

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -49,23 +49,6 @@ def run():
     # Mako requires the directories to be added after the django setup.
     microsite.enable_microsites(log)
 
-    # register any dependency injections that we need to support in edx_proctoring
-    # right now edx_proctoring is dependent on the openedx.core.djangoapps.credit and
-    # lms.djangoapps.grades
-    if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
-        # Import these here to avoid circular dependencies of the form:
-        # edx-platform app --> DRF --> django translation --> edx-platform app
-        from edx_proctoring.runtime import set_runtime_service
-        from lms.djangoapps.instructor.services import InstructorService
-        from openedx.core.djangoapps.credit.services import CreditService
-        from lms.djangoapps.grades.services import GradesService
-        set_runtime_service('credit', CreditService())
-
-        # register InstructorService (for deleting student attempts and user staff access roles)
-        set_runtime_service('instructor', InstructorService())
-
-        set_runtime_service('grades', GradesService())
-
     # In order to allow modules to use a handler url, we need to
     # monkey-patch the x_module library.
     # TODO: Remove this code when Runtimes are no longer created by modulestores

--- a/openedx/core/djangoapps/credit/apps.py
+++ b/openedx/core/djangoapps/credit/apps.py
@@ -1,0 +1,19 @@
+"""
+Credit Application Configuration
+"""
+
+from django.apps import AppConfig
+from django.conf import settings
+from edx_proctoring.runtime import set_runtime_service
+
+
+class CreditConfig(AppConfig):
+    """
+    Default configuration for the "openedx.core.djangoapps.credit" Django application.
+    """
+    name = u'openedx.core.djangoapps.credit'
+
+    def ready(self):
+        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+            from .services import CreditService
+            set_runtime_service('credit', CreditService())


### PR DESCRIPTION
Moves the registration of services for edx-proctoring into the initialization of the apps in which those services are defined.

Also, it looks like we're struggling to come up with meaningful separate docstrings for an `apps.py` module, the `AppConfig` subclass in it, and that class's `ready()` method.  pylint won't complain if we omit the latter, because it's just an override of a base class method.  For the class docstrings, we can at least point out that it's the default configuration (although it still seems pretty redundant).