### PR TITLE
Course Week Highlights (Studio): adding Google Analytics tracking

### DIFF
--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -296,8 +296,8 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/j
             });
 
             afterEach(function() {
-                EditHelpers.removeMockAnalytics();
                 EditHelpers.cancelModalIfShowing();
+                EditHelpers.removeMockAnalytics();
                 // Clean up after the $.datepicker
                 $('#start_date').datepicker('destroy');
                 $('#due_date').datepicker('destroy');

--- a/cms/static/js/views/course_outline.js
+++ b/cms/static/js/views/course_outline.js
@@ -206,6 +206,7 @@ define(['jquery', 'underscore', 'js/views/xblock_outline', 'common/js/components
                 });
 
                 if (modal) {
+                    window.analytics.track('edx.bi.highlights.modal_open');
                     modal.show();
                 }
             },

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -215,6 +215,12 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
     });
 
     HighlightsXBlockModal = CourseOutlineXBlockModal.extend({
+
+        events: _.extend({}, CourseOutlineXBlockModal.prototype.events, {
+            'click .action-save': 'callAnalytics',
+            'click .action-cancel': 'callAnalytics'
+        }),
+
         initialize: function() {
             CourseOutlineXBlockModal.prototype.initialize.call(this);
             if (this.options.xblockType) {
@@ -236,6 +242,12 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                   'this section (250 character limit).'
                 )
             );
+        },
+
+        callAnalytics: function(event) {
+            event.preventDefault();
+            window.analytics.track('edx.bi.highlights.' + event.target.innerText.toLowerCase());
+            this.save(event);
         },
 
         addActionButtons: function() {


### PR DESCRIPTION
Work will add tracking to the Modal's "Save" and "Cancel" buttons, as well as the "Enter Sections Highlights" link that opens the modal.