### PR TITLE
CMS urls cleanup for Django 1.11

### DIFF
--- a/cms/djangoapps/contentstore/api/urls.py
+++ b/cms/djangoapps/contentstore/api/urls.py
@@ -1,18 +1,10 @@
 """ Course Import API URLs. """
 from django.conf import settings
-from django.conf.urls import (
-    patterns,
-    url,
-)
+from django.conf.urls import url
 
 from cms.djangoapps.contentstore.api import views
 
-urlpatterns = patterns(
-    '',
-    url(
-        r'^v0/import/{course_id}/$'.format(
-            course_id=settings.COURSE_ID_PATTERN,
-        ),
-        views.CourseImportView.as_view(), name='course_import'
-    ),
-)
+urlpatterns = [
+    url(r'^v0/import/{course_id}/$'.format(course_id=settings.COURSE_ID_PATTERN,),
+        views.CourseImportView.as_view(), name='course_import'),
+]

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -274,7 +274,7 @@ def reverse_url(handler_name, key_name=None, key_value=None, kwargs=None):
     kwargs_for_reverse = {key_name: unicode(key_value)} if key_name else None
     if kwargs:
         kwargs_for_reverse.update(kwargs)
-    return reverse('contentstore.views.' + handler_name, kwargs=kwargs_for_reverse)
+    return reverse(handler_name, kwargs=kwargs_for_reverse)
 
 
 def reverse_course_url(handler_name, course_key, kwargs=None):

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -368,11 +368,11 @@ def certificates_list_handler(request, course_key_string):
             return JsonResponse({"error": msg}, status=403)
 
         if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
-            certificate_url = reverse_course_url('certificates.certificates_list_handler', course_key)
+            certificate_url = reverse_course_url('certificates_list_handler', course_key)
             course_outline_url = reverse_course_url('course_handler', course_key)
             upload_asset_url = reverse_course_url('assets_handler', course_key)
             activation_handler_url = reverse_course_url(
-                handler_name='certificates.certificate_activation_handler',
+                handler_name='certificate_activation_handler',
                 course_key=course_key
             )
             course_modes = [
@@ -429,7 +429,7 @@ def certificates_list_handler(request, course_key_string):
                 course.certificates['certificates'].append(new_certificate.certificate_data)
                 response = JsonResponse(CertificateManager.serialize_certificate(new_certificate), status=201)
                 response["Location"] = reverse_course_url(
-                    'certificates.certificates_detail_handler',
+                    'certificates_detail_handler',
                     course.id,
                     kwargs={'certificate_id': new_certificate.id}
                 )

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -264,7 +264,7 @@ def course_handler(request, course_key_string=None):
                 return HttpResponseBadRequest()
         elif request.method == 'GET':  # assume html
             if course_key_string is None:
-                return redirect(reverse("home"))
+                return redirect(reverse('home'))
             else:
                 return course_index(request, CourseKey.from_string(course_key_string))
         else:
@@ -572,7 +572,7 @@ def course_listing(request):
             u'libraries': [format_library_for_view(lib) for lib in libraries],
             u'show_new_library_button': get_library_creator_status(user),
             u'user': user,
-            u'request_course_creator_url': reverse(u'contentstore.views.request_course_creator'),
+            u'request_course_creator_url': reverse('request_course_creator'),
             u'course_creator_status': _get_course_creator_status(user),
             u'rerun_creator_status': GlobalStaff().has_user(user),
             u'allow_unicode_course_id': settings.FEATURES.get(u'ALLOW_UNICODE_COURSE_ID', False),

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -210,7 +210,7 @@ class CertificatesListHandlerTestCase(
         """
         Return url for the handler.
         """
-        return reverse_course_url('certificates.certificates_list_handler', self.course.id)
+        return reverse_course_url('certificates_list_handler', self.course.id)
 
     def test_can_create_certificate(self):
         """
@@ -441,7 +441,7 @@ class CertificatesDetailHandlerTestCase(
         """
         cid = cid if cid > 0 else self._id
         return reverse_course_url(
-            'certificates.certificates_detail_handler',
+            'certificates_detail_handler',
             self.course.id,
             kwargs={'certificate_id': cid},
         )
@@ -764,7 +764,7 @@ class CertificatesDetailHandlerTestCase(
         """
         Activate and Deactivate the course certificate
         """
-        test_url = reverse_course_url('certificates.certificate_activation_handler', self.course.id)
+        test_url = reverse_course_url('certificate_activation_handler', self.course.id)
         self._add_course_certificates(count=1, signatory_count=2, asset_path_format=signatory_path)
 
         is_active = True
@@ -795,7 +795,7 @@ class CertificatesDetailHandlerTestCase(
         Tests certificate Activate and Deactivate should not be allowed if user
         does not have write permissions on course.
         """
-        test_url = reverse_course_url('certificates.certificate_activation_handler', self.course.id)
+        test_url = reverse_course_url('certificate_activation_handler', self.course.id)
         self._add_course_certificates(count=1, signatory_count=2, asset_path_format=signatory_path)
         user = UserFactory()
         self.client.login(username=user.username, password='test')
@@ -814,7 +814,7 @@ class CertificatesDetailHandlerTestCase(
         Certificate activation should fail when user has not read access to course then permission denied exception
         should raised.
         """
-        test_url = reverse_course_url('certificates.certificate_activation_handler', self.course.id)
+        test_url = reverse_course_url('certificate_activation_handler', self.course.id)
         test_user_client, test_user = self.create_non_staff_authed_user_client()
         CourseEnrollment.enroll(test_user, self.course.id)
         self._add_course_certificates(count=1, signatory_count=2, asset_path_format=signatory_path)

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -112,7 +112,7 @@ class ItemTest(CourseTestCase):
             data['display_name'] = display_name
         if boilerplate is not None:
             data['boilerplate'] = boilerplate
-        return self.client.ajax_post(reverse('contentstore.views.xblock_handler'), json.dumps(data))
+        return self.client.ajax_post(reverse('xblock_handler'), json.dumps(data))
 
     def _create_vertical(self, parent_usage_key=None):
         """
@@ -653,7 +653,7 @@ class DuplicateHelper(object):
         if display_name is not None:
             data['display_name'] = display_name
 
-        resp = self.client.ajax_post(reverse('contentstore.views.xblock_handler'), json.dumps(data))
+        resp = self.client.ajax_post(reverse('xblock_handler'), json.dumps(data))
         return self.response_usage_key(resp)
 
 
@@ -864,7 +864,7 @@ class TestMoveItem(ItemTest):
             data['target_index'] = target_index
 
         return self.client.patch(
-            reverse('contentstore.views.xblock_handler'),
+            reverse('xblock_handler'),
             json.dumps(data),
             content_type='application/json'
         )
@@ -1147,7 +1147,7 @@ class TestMoveItem(ItemTest):
         data = {'move_source_locator': unicode(self.html_usage_key)}
         with self.assertRaises(InvalidKeyError):
             self.client.patch(
-                reverse('contentstore.views.xblock_handler'),
+                reverse('xblock_handler'),
                 json.dumps(data),
                 content_type='application/json'
             )
@@ -1157,7 +1157,7 @@ class TestMoveItem(ItemTest):
         Test patch request without providing a move source locator.
         """
         response = self.client.patch(
-            reverse('contentstore.views.xblock_handler')
+            reverse('xblock_handler')
         )
         self.assertEqual(response.status_code, 400)
         response = json.loads(response.content)
@@ -1308,7 +1308,7 @@ class TestMoveItem(ItemTest):
         }
         with self.assertRaises(ItemNotFoundError):
             self.client.patch(
-                reverse('contentstore.views.xblock_handler'),
+                reverse('xblock_handler'),
                 json.dumps(data),
                 content_type='application/json'
             )

--- a/cms/djangoapps/maintenance/urls.py
+++ b/cms/djangoapps/maintenance/urls.py
@@ -1,12 +1,11 @@
 """
 URLs for the maintenance app.
 """
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import ForcePublishCourseView, MaintenanceIndexView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', MaintenanceIndexView.as_view(), name='maintenance_index'),
     url(r'^force_publish_course/?$', ForcePublishCourseView.as_view(), name='force_publish_course'),
-)
+]

--- a/cms/djangoapps/pipeline_js/urls.py
+++ b/cms/djangoapps/pipeline_js/urls.py
@@ -1,11 +1,10 @@
 """
 URL patterns for Javascript files used to load all of the XModule JS in one wad.
 """
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+from pipeline_js.views import xmodule_js_files, requirejs_xmodule
 
-urlpatterns = patterns(
-    'pipeline_js.views',
-
-    url(r'^files\.json$', 'xmodule_js_files', name='xmodule_js_files'),
-    url(r'^xmodule\.js$', 'requirejs_xmodule', name='requirejs_xmodule'),
-)
+urlpatterns = [
+    url(r'^files\.json$', xmodule_js_files, name='xmodule_js_files'),
+    url(r'^xmodule\.js$', requirejs_xmodule, name='requirejs_xmodule'),
+]

--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -21,7 +21,7 @@
 
 <%block name="requirejs">
     require(["js/factories/edit_tabs"], function (EditTabsFactory) {
-        EditTabsFactory("${context_course.location | n, js_escaped_string}", "${reverse('contentstore.views.tabs_handler', kwargs={'course_key_string': context_course.id})}");
+        EditTabsFactory("${context_course.location | n, js_escaped_string}", "${reverse('tabs_handler', kwargs={'course_key_string': context_course.id})}");
     });
 </%block>
 

--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -119,7 +119,7 @@ from openedx.core.djangolib.js_utils import (
       ManageCourseUsersFactory(
         "${context_course.display_name_with_default | h}",
         ${users | n, dump_js_escaped_json},
-        "${reverse('contentstore.views.course_team_handler', kwargs={'course_key_string': unicode(context_course.id), 'email': '@@EMAIL@@'}) | n, js_escaped_string}",
+        "${reverse('course_team_handler', kwargs={'course_key_string': unicode(context_course.id), 'email': '@@EMAIL@@'}) | n, js_escaped_string}",
         ${request.user.id | n, dump_js_escaped_json},
         ${allow_actions | n, dump_js_escaped_json}
       );

--- a/cms/templates/manage_users_lib.html
+++ b/cms/templates/manage_users_lib.html
@@ -112,7 +112,7 @@ from openedx.core.djangolib.js_utils import (
       ManageLibraryUsersFactory(
         "${context_library.display_name_with_default | h}",
         ${users | n, dump_js_escaped_json},
-        "${reverse('contentstore.views.course_team_handler', kwargs={'course_key_string': library_key, 'email': '@@EMAIL@@'}) | n, js_escaped_string}",
+        "${reverse('course_team_handler', kwargs={'course_key_string': library_key, 'email': '@@EMAIL@@'}) | n, js_escaped_string}",
         ${request.user.id | n, dump_js_escaped_json},
         ${allow_actions | n, dump_js_escaped_json}
       );

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -19,21 +19,21 @@
       % if context_course:
       <%
             course_key = context_course.id
-            index_url = reverse('contentstore.views.course_handler', kwargs={'course_key_string': unicode(course_key)})
-            course_team_url = reverse('contentstore.views.course_team_handler', kwargs={'course_key_string': unicode(course_key)})
-            assets_url = reverse('contentstore.views.assets_handler', kwargs={'course_key_string': unicode(course_key)})
-            textbooks_url = reverse('contentstore.views.textbooks_list_handler', kwargs={'course_key_string': unicode(course_key)})
-            videos_url = reverse('contentstore.views.videos_handler', kwargs={'course_key_string': unicode(course_key)})
-            import_url = reverse('contentstore.views.import_handler', kwargs={'course_key_string': unicode(course_key)})
-            course_info_url = reverse('contentstore.views.course_info_handler', kwargs={'course_key_string': unicode(course_key)})
-            export_url = reverse('contentstore.views.export_handler', kwargs={'course_key_string': unicode(course_key)})
-            settings_url = reverse('contentstore.views.settings_handler', kwargs={'course_key_string': unicode(course_key)})
-            grading_url = reverse('contentstore.views.grading_handler', kwargs={'course_key_string': unicode(course_key)})
-            advanced_settings_url = reverse('contentstore.views.advanced_settings_handler', kwargs={'course_key_string': unicode(course_key)})
-            tabs_url = reverse('contentstore.views.tabs_handler', kwargs={'course_key_string': unicode(course_key)})
+            index_url = reverse('course_handler', kwargs={'course_key_string': unicode(course_key)})
+            course_team_url = reverse('course_team_handler', kwargs={'course_key_string': unicode(course_key)})
+            assets_url = reverse('assets_handler', kwargs={'course_key_string': unicode(course_key)})
+            textbooks_url = reverse('textbooks_list_handler', kwargs={'course_key_string': unicode(course_key)})
+            videos_url = reverse('videos_handler', kwargs={'course_key_string': unicode(course_key)})
+            import_url = reverse('import_handler', kwargs={'course_key_string': unicode(course_key)})
+            course_info_url = reverse('course_info_handler', kwargs={'course_key_string': unicode(course_key)})
+            export_url = reverse('export_handler', kwargs={'course_key_string': unicode(course_key)})
+            settings_url = reverse('settings_handler', kwargs={'course_key_string': unicode(course_key)})
+            grading_url = reverse('grading_handler', kwargs={'course_key_string': unicode(course_key)})
+            advanced_settings_url = reverse('advanced_settings_handler', kwargs={'course_key_string': unicode(course_key)})
+            tabs_url = reverse('tabs_handler', kwargs={'course_key_string': unicode(course_key)})
             certificates_url = ''
             if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
-                certificates_url = reverse('contentstore.views.certificates.certificates_list_handler', kwargs={'course_key_string': unicode(course_key)})
+                certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': unicode(course_key)})
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>
@@ -93,7 +93,7 @@
                     <a href="${course_team_url}">${_("Course Team")}</a>
                   </li>
                   <li class="nav-item nav-course-settings-group-configurations">
-                    <a href="${reverse('contentstore.views.group_configurations_list_handler', kwargs={'course_key_string': unicode(course_key)})}">${_("Group Configurations")}</a>
+                    <a href="${reverse('group_configurations_list_handler', kwargs={'course_key_string': unicode(course_key)})}">${_("Group Configurations")}</a>
                   </li>
                   <li class="nav-item nav-course-settings-advanced">
                     <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
@@ -133,10 +133,10 @@
       % elif context_library:
        <%
             library_key = context_library.location.course_key
-            index_url = reverse('contentstore.views.library_handler', kwargs={'library_key_string': unicode(library_key)})
-            import_url = reverse('contentstore.views.import_handler', kwargs={'course_key_string': unicode(library_key)})
-            lib_users_url = reverse('contentstore.views.manage_library_users', kwargs={'library_key_string': unicode(library_key)})
-            export_url = reverse('contentstore.views.export_handler', kwargs={'course_key_string': unicode(library_key)})
+            index_url = reverse('library_handler', kwargs={'library_key_string': unicode(library_key)})
+            import_url = reverse('import_handler', kwargs={'course_key_string': unicode(library_key)})
+            lib_users_url = reverse('manage_library_users', kwargs={'library_key_string': unicode(library_key)})
+            export_url = reverse('export_handler', kwargs={'course_key_string': unicode(library_key)})
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Library:")}</span>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -1,12 +1,17 @@
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib.admin import autodiscover as django_autodiscover
 from django.utils.translation import ugettext_lazy as _
-from ratelimitbackend import admin
 
+import contentstore.views
+import django_cas.views
+import openedx.core.djangoapps.common_views.xblock
+import openedx.core.djangoapps.debug.views
+import openedx.core.djangoapps.external_auth.views
+import openedx.core.djangoapps.lang_pref.views
 from cms.djangoapps.contentstore.views.organization import OrganizationListView
-
+from ratelimitbackend import admin
 
 django_autodiscover()
 admin.site.site_header = _('Studio Administration')
@@ -20,51 +25,40 @@ COURSELIKE_KEY_PATTERN = r'(?P<course_key_string>({}|{}))'.format(
 # Pattern to match a library key only
 LIBRARY_KEY_PATTERN = r'(?P<library_key_string>library-v1:[^/+]+\+[^/+]+)'
 
-urlpatterns = patterns(
-    '',
-
+urlpatterns = [
     url(r'', include('student.urls')),
-
-    url(r'^transcripts/upload$', 'contentstore.views.upload_transcripts', name='upload_transcripts'),
-    url(r'^transcripts/download$', 'contentstore.views.download_transcripts', name='download_transcripts'),
-    url(r'^transcripts/check$', 'contentstore.views.check_transcripts', name='check_transcripts'),
-    url(r'^transcripts/choose$', 'contentstore.views.choose_transcripts', name='choose_transcripts'),
-    url(r'^transcripts/replace$', 'contentstore.views.replace_transcripts', name='replace_transcripts'),
-    url(r'^transcripts/rename$', 'contentstore.views.rename_transcripts', name='rename_transcripts'),
-    url(r'^transcripts/save$', 'contentstore.views.save_transcripts', name='save_transcripts'),
-
+    url(r'^transcripts/upload$', contentstore.views.upload_transcripts, name='upload_transcripts'),
+    url(r'^transcripts/download$', contentstore.views.download_transcripts, name='download_transcripts'),
+    url(r'^transcripts/check$', contentstore.views.check_transcripts, name='check_transcripts'),
+    url(r'^transcripts/choose$', contentstore.views.choose_transcripts, name='choose_transcripts'),
+    url(r'^transcripts/replace$', contentstore.views.replace_transcripts, name='replace_transcripts'),
+    url(r'^transcripts/rename$', contentstore.views.rename_transcripts, name='rename_transcripts'),
+    url(r'^transcripts/save$', contentstore.views.save_transcripts, name='save_transcripts'),
     url(r'^preview/xblock/(?P<usage_key_string>.*?)/handler/(?P<handler>[^/]*)(?:/(?P<suffix>.*))?$',
-        'contentstore.views.preview_handler', name='preview_handler'),
-
+        contentstore.views.preview_handler, name='preview_handler'),
     url(r'^xblock/(?P<usage_key_string>.*?)/handler/(?P<handler>[^/]*)(?:/(?P<suffix>.*))?$',
-        'contentstore.views.component_handler', name='component_handler'),
-
+        contentstore.views.component_handler, name='component_handler'),
     url(r'^xblock/resource/(?P<block_type>[^/]*)/(?P<uri>.*)$',
-        'openedx.core.djangoapps.common_views.xblock.xblock_resource', name='xblock_resource_url'),
-
-    url(r'^not_found$', 'contentstore.views.not_found', name='not_found'),
-    url(r'^server_error$', 'contentstore.views.server_error', name='server_error'),
+        openedx.core.djangoapps.common_views.xblock.xblock_resource, name='xblock_resource_url'),
+    url(r'^not_found$', contentstore.views.not_found, name='not_found'),
+    url(r'^server_error$', contentstore.views.server_error, name='server_error'),
     url(r'^organizations$', OrganizationListView.as_view(), name='organizations'),
 
     # noop to squelch ajax errors
-    url(r'^event$', 'contentstore.views.event', name='event'),
-
+    url(r'^event$', contentstore.views.event, name='event'),
     url(r'^xmodule/', include('pipeline_js.urls')),
     url(r'^heartbeat$', include('openedx.core.djangoapps.heartbeat.urls')),
-
     url(r'^user_api/', include('openedx.core.djangoapps.user_api.legacy_urls')),
-
     url(r'^i18n/', include('django.conf.urls.i18n')),
 
     # User API endpoints
     url(r'^api/user/', include('openedx.core.djangoapps.user_api.urls')),
 
     # Update session view
-    url(
-        r'^lang_pref/session_language',
-        'openedx.core.djangoapps.lang_pref.views.update_session_language',
+    url(r'^lang_pref/session_language',
+        openedx.core.djangoapps.lang_pref.views.update_session_language,
         name='session_language'
-    ),
+        ),
 
     # Darklang View to change the preview language (or dark language)
     url(r'^update_lang/', include('openedx.core.djangoapps.dark_lang.urls', namespace='dark_lang')),
@@ -75,67 +69,89 @@ urlpatterns = patterns(
     # For redirecting to help pages.
     url(r'^help_token/', include('help_tokens.urls')),
     url(r'^api/', include('cms.djangoapps.api.urls', namespace='api')),
-)
 
-# restful api
-urlpatterns += patterns(
-    'contentstore.views',
-
-    url(r'^$', 'howitworks', name='homepage'),
-    url(r'^howitworks$', 'howitworks'),
-    url(r'^signup$', 'signup', name='signup'),
-    url(r'^signin$', 'login_page', name='login'),
-    url(r'^request_course_creator$', 'request_course_creator', name='request_course_creator'),
-
-    url(r'^course_team/{}(?:/(?P<email>.+))?$'.format(COURSELIKE_KEY_PATTERN), 'course_team_handler'),
-    url(r'^course_info/{}$'.format(settings.COURSE_KEY_PATTERN), 'course_info_handler'),
-    url(
-        r'^course_info_update/{}/(?P<provided_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
-        'course_info_update_handler'
-    ),
-    url(r'^home/?$', 'course_listing', name='home'),
-    url(
-        r'^course/{}/search_reindex?$'.format(settings.COURSE_KEY_PATTERN),
-        'course_search_index_handler',
+    # restful api
+    url(r'^$', contentstore.views.howitworks, name='homepage'),
+    url(r'^howitworks$', contentstore.views.howitworks, name='howitworks'),
+    url(r'^signup$', contentstore.views.signup, name='signup'),
+    url(r'^signin$', contentstore.views.login_page, name='login'),
+    url(r'^request_course_creator$', contentstore.views.request_course_creator, name='request_course_creator'),
+    url(r'^course_team/{}(?:/(?P<email>.+))?$'.format(COURSELIKE_KEY_PATTERN),
+        contentstore.views.course_team_handler, name='course_team_handler'),
+    url(r'^course_info/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.course_info_handler,
+        name='course_info_handler'),
+    url(r'^course_info_update/{}/(?P<provided_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
+        contentstore.views.course_info_update_handler, name='course_info_update_handler'
+        ),
+    url(r'^home/?$', contentstore.views.course_listing, name='home'),
+    url(r'^course/{}/search_reindex?$'.format(settings.COURSE_KEY_PATTERN),
+        contentstore.views.course_search_index_handler,
         name='course_search_index_handler'
-    ),
-    url(r'^course/{}?$'.format(settings.COURSE_KEY_PATTERN), 'course_handler', name='course_handler'),
+        ),
+    url(r'^course/{}?$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.course_handler, name='course_handler'),
     url(r'^course_notifications/{}/(?P<action_state_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
-        'course_notifications_handler'),
-    url(r'^course_rerun/{}$'.format(settings.COURSE_KEY_PATTERN), 'course_rerun_handler', name='course_rerun_handler'),
-    url(r'^container/{}$'.format(settings.USAGE_KEY_PATTERN), 'container_handler'),
-    url(r'^orphan/{}$'.format(settings.COURSE_KEY_PATTERN), 'orphan_handler'),
-    url(r'^assets/{}/{}?$'.format(settings.COURSE_KEY_PATTERN, settings.ASSET_KEY_PATTERN), 'assets_handler'),
-    url(r'^import/{}$'.format(COURSELIKE_KEY_PATTERN), 'import_handler'),
-    url(r'^import_status/{}/(?P<filename>.+)$'.format(COURSELIKE_KEY_PATTERN), 'import_status_handler'),
+        contentstore.views.course_notifications_handler,
+        name='course_notifications_handler'),
+    url(r'^course_rerun/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.course_rerun_handler,
+        name='course_rerun_handler'),
+    url(r'^container/{}$'.format(settings.USAGE_KEY_PATTERN), contentstore.views.container_handler,
+        name='container_handler'),
+    url(r'^orphan/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.orphan_handler,
+        name='orphan_handler'),
+    url(r'^assets/{}/{}?$'.format(settings.COURSE_KEY_PATTERN, settings.ASSET_KEY_PATTERN),
+        contentstore.views.assets_handler,
+        name='assets_handler'),
+    url(r'^import/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore.views.import_handler,
+        name='import_handler'),
+    url(r'^import_status/{}/(?P<filename>.+)$'.format(COURSELIKE_KEY_PATTERN),
+        contentstore.views.import_status_handler, name='import_status_handler'),
     # rest api for course import/export
-    url(
-        r'^api/courses/',
+    url(r'^api/courses/',
         include('cms.djangoapps.contentstore.api.urls', namespace='courses_api')
-    ),
-    url(r'^export/{}$'.format(COURSELIKE_KEY_PATTERN), 'export_handler'),
-    url(r'^export_output/{}$'.format(COURSELIKE_KEY_PATTERN), 'export_output_handler'),
-    url(r'^export_status/{}$'.format(COURSELIKE_KEY_PATTERN), 'export_status_handler'),
-    url(r'^xblock/outline/{}$'.format(settings.USAGE_KEY_PATTERN), 'xblock_outline_handler'),
-    url(r'^xblock/container/{}$'.format(settings.USAGE_KEY_PATTERN), 'xblock_container_handler'),
-    url(r'^xblock/{}/(?P<view_name>[^/]+)$'.format(settings.USAGE_KEY_PATTERN), 'xblock_view_handler'),
-    url(r'^xblock/{}?$'.format(settings.USAGE_KEY_PATTERN), 'xblock_handler'),
-    url(r'^tabs/{}$'.format(settings.COURSE_KEY_PATTERN), 'tabs_handler'),
-    url(r'^settings/details/{}$'.format(settings.COURSE_KEY_PATTERN), 'settings_handler'),
-    url(r'^settings/grading/{}(/)?(?P<grader_index>\d+)?$'.format(settings.COURSE_KEY_PATTERN), 'grading_handler'),
-    url(r'^settings/advanced/{}$'.format(settings.COURSE_KEY_PATTERN), 'advanced_settings_handler'),
-    url(r'^textbooks/{}$'.format(settings.COURSE_KEY_PATTERN), 'textbooks_list_handler'),
-    url(r'^textbooks/{}/(?P<textbook_id>\d[^/]*)$'.format(settings.COURSE_KEY_PATTERN), 'textbooks_detail_handler'),
-    url(r'^videos/{}(?:/(?P<edx_video_id>[-\w]+))?$'.format(settings.COURSE_KEY_PATTERN), 'videos_handler'),
-    url(r'^video_images/{}(?:/(?P<edx_video_id>[-\w]+))?$'.format(settings.COURSE_KEY_PATTERN), 'video_images_handler'),
-    url(r'^transcript_preferences/{}$'.format(settings.COURSE_KEY_PATTERN), 'transcript_preferences_handler'),
-    url(r'^video_encodings_download/{}$'.format(settings.COURSE_KEY_PATTERN), 'video_encodings_download'),
-    url(r'^group_configurations/{}$'.format(settings.COURSE_KEY_PATTERN), 'group_configurations_list_handler'),
+        ),
+    url(r'^export/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore.views.export_handler,
+        name='export_handler'),
+    url(r'^export_output/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore.views.export_output_handler,
+        name='export_output_handler'),
+    url(r'^export_status/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore.views.export_status_handler,
+        name='export_status_handler'),
+    url(r'^xblock/outline/{}$'.format(settings.USAGE_KEY_PATTERN), contentstore.views.xblock_outline_handler,
+        name='xblock_outline_handler'),
+    url(r'^xblock/container/{}$'.format(settings.USAGE_KEY_PATTERN), contentstore.views.xblock_container_handler,
+        name='xblock_container_handler'),
+    url(r'^xblock/{}/(?P<view_name>[^/]+)$'.format(settings.USAGE_KEY_PATTERN), contentstore.views.xblock_view_handler,
+        name='xblock_view_handler'),
+    url(r'^xblock/{}?$'.format(settings.USAGE_KEY_PATTERN), contentstore.views.xblock_handler,
+        name='xblock_handler'),
+    url(r'^tabs/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.tabs_handler,
+        name='tabs_handler'),
+    url(r'^settings/details/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.settings_handler,
+        name='settings_handler'),
+    url(r'^settings/grading/{}(/)?(?P<grader_index>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
+        contentstore.views.grading_handler, name='grading_handler'),
+    url(r'^settings/advanced/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.advanced_settings_handler,
+        name='advanced_settings_handler'),
+    url(r'^textbooks/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.textbooks_list_handler,
+        name='textbooks_list_handler'),
+    url(r'^textbooks/{}/(?P<textbook_id>\d[^/]*)$'.format(settings.COURSE_KEY_PATTERN),
+        contentstore.views.textbooks_detail_handler, name='textbooks_detail_handler'),
+    url(r'^videos/{}(?:/(?P<edx_video_id>[-\w]+))?$'.format(settings.COURSE_KEY_PATTERN),
+        contentstore.views.videos_handler, name='videos_handler'),
+    url(r'^video_images/{}(?:/(?P<edx_video_id>[-\w]+))?$'.format(settings.COURSE_KEY_PATTERN),
+        contentstore.views.video_images_handler, name='video_images_handler'),
+    url(r'^transcript_preferences/{}$'.format(settings.COURSE_KEY_PATTERN),
+        contentstore.views.transcript_preferences_handler, name='transcript_preferences_handler'),
+    url(r'^video_encodings_download/{}$'.format(settings.COURSE_KEY_PATTERN),
+        contentstore.views.video_encodings_download, name='video_encodings_download'),
+    url(r'^group_configurations/{}$'.format(settings.COURSE_KEY_PATTERN),
+        contentstore.views.group_configurations_list_handler,
+        name='group_configurations_list_handler'),
     url(r'^group_configurations/{}/(?P<group_configuration_id>\d+)(/)?(?P<group_id>\d+)?$'.format(
-        settings.COURSE_KEY_PATTERN), 'group_configurations_detail_handler'),
+        settings.COURSE_KEY_PATTERN), contentstore.views.group_configurations_detail_handler,
+        name='group_configurations_detail_handler'),
     url(r'^api/val/v0/', include('edxval.urls')),
     url(r'^api/tasks/v0/', include('user_tasks.urls')),
-)
+]
 
 JS_INFO_DICT = {
     'domain': 'djangojs',
@@ -144,60 +160,59 @@ JS_INFO_DICT = {
 }
 
 if settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES'):
-    urlpatterns += (
+    urlpatterns += [
         url(r'^library/{}?$'.format(LIBRARY_KEY_PATTERN),
-            'contentstore.views.library_handler', name='library_handler'),
+            contentstore.views.library_handler, name='library_handler'),
         url(r'^library/{}/team/$'.format(LIBRARY_KEY_PATTERN),
-            'contentstore.views.manage_library_users', name='manage_library_users'),
-    )
+            contentstore.views.manage_library_users, name='manage_library_users'),
+    ]
 
 if settings.FEATURES.get('ENABLE_EXPORT_GIT'):
-    urlpatterns += (url(
-        r'^export_git/{}$'.format(
-            settings.COURSE_KEY_PATTERN,
-        ),
-        'contentstore.views.export_git',
-        name='export_git',
-    ),)
+    urlpatterns += [
+        url(r'^export_git/{}$'.format(settings.COURSE_KEY_PATTERN),
+            contentstore.views.export_git,
+            name='export_git')
+    ]
 
 if settings.FEATURES.get('ENABLE_SERVICE_STATUS'):
-    urlpatterns += patterns(
-        '',
-        url(r'^status/', include('openedx.core.djangoapps.service_status.urls')),
-    )
+    urlpatterns.append(url(r'^status/', include('openedx.core.djangoapps.service_status.urls')))
 
 if settings.FEATURES.get('AUTH_USE_CAS'):
-    urlpatterns += (
-        url(r'^cas-auth/login/$', 'openedx.core.djangoapps.external_auth.views.cas_login', name="cas-login"),
-        url(r'^cas-auth/logout/$', 'django_cas.views.logout', {'next_page': '/'}, name="cas-logout"),
-    )
+    urlpatterns += [
+        url(r'^cas-auth/login/$', openedx.core.djangoapps.external_auth.views.cas_login, name="cas-login"),
+        url(r'^cas-auth/logout/$', django_cas.views.logout, {'next_page': '/'}, name="cas-logout"),
+    ]
 
-urlpatterns += patterns('', url(r'^admin/', include(admin.site.urls)),)
+urlpatterns.append(url(r'^admin/', include(admin.site.urls)))
 
 # enable entrance exams
 if settings.FEATURES.get('ENTRANCE_EXAMS'):
-    urlpatterns += (
-        url(r'^course/{}/entrance_exam/?$'.format(settings.COURSE_KEY_PATTERN), 'contentstore.views.entrance_exam'),
-    )
+    urlpatterns.append(url(r'^course/{}/entrance_exam/?$'.format(settings.COURSE_KEY_PATTERN),
+                       contentstore.views.entrance_exam))
 
 # Enable Web/HTML Certificates
 if settings.FEATURES.get('CERTIFICATES_HTML_VIEW'):
-    urlpatterns += (
-        url(r'^certificates/activation/{}/'.format(settings.COURSE_KEY_PATTERN),
-            'contentstore.views.certificates.certificate_activation_handler'),
-        url(r'^certificates/{}/(?P<certificate_id>\d+)/signatories/(?P<signatory_id>\d+)?$'.format(
-            settings.COURSE_KEY_PATTERN), 'contentstore.views.certificates.signatory_detail_handler'),
-        url(r'^certificates/{}/(?P<certificate_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
-            'contentstore.views.certificates.certificates_detail_handler'),
-        url(r'^certificates/{}$'.format(settings.COURSE_KEY_PATTERN),
-            'contentstore.views.certificates.certificates_list_handler')
+    from contentstore.views.certificates import (
+        certificate_activation_handler,
+        signatory_detail_handler,
+        certificates_detail_handler,
+        certificates_list_handler
     )
 
+    urlpatterns += [
+        url(r'^certificates/activation/{}/'.format(settings.COURSE_KEY_PATTERN),
+            certificate_activation_handler,
+            name='certificate_activation_handler'),
+        url(r'^certificates/{}/(?P<certificate_id>\d+)/signatories/(?P<signatory_id>\d+)?$'.format(
+            settings.COURSE_KEY_PATTERN), signatory_detail_handler, name='signatory_detail_handler'),
+        url(r'^certificates/{}/(?P<certificate_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
+            certificates_detail_handler, name='certificates_detail_handler'),
+        url(r'^certificates/{}$'.format(settings.COURSE_KEY_PATTERN),
+            certificates_list_handler, name='certificates_list_handler')
+    ]
+
 # Maintenance Dashboard
-urlpatterns += patterns(
-    '',
-    url(r'^maintenance/', include('maintenance.urls', namespace='maintenance')),
-)
+urlpatterns.append(url(r'^maintenance/', include('maintenance.urls', namespace='maintenance')))
 
 if settings.DEBUG:
     try:
@@ -218,24 +233,20 @@ if settings.DEBUG:
 
 if 'debug_toolbar' in settings.INSTALLED_APPS:
     import debug_toolbar
-    urlpatterns += (
-        url(r'^__debug__/', include(debug_toolbar.urls)),
-    )
+    urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
 
 # UX reference templates
-urlpatterns += patterns(
-    '',
-    url(r'^template/(?P<template>.+)$', 'openedx.core.djangoapps.debug.views.show_reference_template'),
-)
+urlpatterns.append(url(r'^template/(?P<template>.+)$', openedx.core.djangoapps.debug.views.show_reference_template,
+                       name='openedx.core.djangoapps.debug.views.show_reference_template'))
 
 # Custom error pages
 # These are used by Django to render these error codes. Do not remove.
 # pylint: disable=invalid-name
-handler404 = 'contentstore.views.render_404'
-handler500 = 'contentstore.views.render_500'
+handler404 = contentstore.views.render_404
+handler500 = contentstore.views.render_500
 
 # display error page templates, for testing purposes
-urlpatterns += (
+urlpatterns += [
     url(r'^404$', handler404),
     url(r'^500$', handler500),
-)
+]

--- a/openedx/core/djangoapps/external_auth/tests/test_ssl.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_ssl.py
@@ -110,7 +110,7 @@ class SSLClientTest(ModuleStoreTestCase):
         redirects them to the signup page on CMS.
         """
         self.client.get(
-            reverse('contentstore.views.login_page'),
+            reverse('login'),
             SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL)
         )
 
@@ -152,7 +152,7 @@ class SSLClientTest(ModuleStoreTestCase):
         """
 
         response = self.client.get(
-            reverse('contentstore.views.login_page'),
+            reverse('login'),
             SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL)
         )
         self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
- Remove usage of django.urls.patterns
- Change urls tuples to lists
- Make all string view names callables
- Give contentstore views names to match their function name where they didn't have them, change code and templates where necessary to use the name instead of dotted Python path