### PR TITLE
fix dashboard error on edx.org theme

### DIFF
--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -125,7 +125,8 @@ from openedx.core.djangoapps.theming import helpers as theming_helpers
         <% course_verification_status = verification_status_by_course.get(enrollment.course_id, {}) %>
         <% course_requirements = courses_requirements_not_met.get(enrollment.course_id) %>
         <% related_programs = inverted_programs.get(unicode(enrollment.course_id)) %>
-        <%include file = 'dashboard/_dashboard_course_listing.html' args="course_overview=enrollment.course_overview, enrollment=enrollment, show_courseware_link=show_courseware_link, cert_status=cert_status, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, is_course_blocked=is_course_blocked, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs" />
+        <% show_consent_link = (enrollment.course_id in consent_required_courses) %>
+        <%include file = 'dashboard/_dashboard_course_listing.html' args='course_overview=enrollment.course_overview, enrollment=enrollment, show_courseware_link=show_courseware_link, cert_status=cert_status, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, is_course_blocked=is_course_blocked, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name' />
       % endfor
 
       </ul>


### PR DESCRIPTION
Fix the dashboard on edx.org theme to correctly pass the new view consent parameters to the included _dashboard_course_listing.html page.