### PR TITLE
PLAT-1779 Fix CMS INSTALLED_APPS/model imports mismatch

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1050,7 +1050,10 @@ INSTALLED_APPS = [
     # These are apps that aren't strictly needed by Studio, but are imported by
     # other apps that are.  Django 1.8 wants to have imported models supported
     # by installed apps.
+    'courseware',
+    'survey',
     'lms.djangoapps.verify_student.apps.VerifyStudentConfig',
+    'lms.djangoapps.completion.apps.CompletionAppConfig',
 
     # Microsite configuration application
     'microsite_configuration',


### PR DESCRIPTION
I discussed a number of options for fixing this with @nasthagiri , and we concluded that just adding them to Studio's `INSTALLED_APPS` should be "mostly harmless".  Rather than maintaining a strict separation between which apps are running in LMS and which are running in Studio, we'd rather focus on making it harmless to run them in either service and start moving the modules at the bottom of the import chain into separately installable packages.