### PR TITLE
Make the Section Highlights in outline a button

### DIFF
--- a/cms/static/js/views/course_outline.js
+++ b/cms/static/js/views/course_outline.js
@@ -220,9 +220,11 @@ define(['jquery', 'underscore', 'js/views/xblock_outline', 'common/js/components
                     event.preventDefault();
                     this.publishXBlock();
                 }.bind(this));
-                element.find('.highlights-button').click(function(event) {
-                    event.preventDefault();
-                    this.highlightsXBlock();
+                element.find('.highlights-button').on('click keydown', function(event) {
+                    if (event.type === 'click' || event.which === 13 || event.which === 32) {
+                        event.preventDefault();
+                        this.highlightsXBlock();
+                    }
                 }.bind(this));
             },
 

--- a/cms/static/sass/views/_outline.scss
+++ b/cms/static/sass/views/_outline.scss
@@ -638,6 +638,12 @@
   .highlights-button {
     cursor: pointer;
     color: theme-color("primary");
+
+    // remove button styling
+    border: none;
+    background: none;
+    padding: 0;
+    font-weight: 600;
   }
 
   .number-highlights {

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -203,10 +203,10 @@ if (is_proctored_exam) {
             <% if (xblockInfo.get('highlights_enabled') && course.get('self_paced') && xblockInfo.isChapter()) { %>
                 <div class="block-highlights">
                     <% var number_of_highlights = (xblockInfo.get('highlights') || []).length; %>
-                        <span class="block-highlights-value highlights-button action-button">
+                        <button class="block-highlights-value highlights-button action-button">
                             <span class="number-highlights"><%- number_of_highlights %></span>
                             <%- gettext('Section Highlights') %>
-                        </span>
+                        </button>
                 </div>
             <% } %>
             <% if (xblockInfo.get('is_time_limited')) { %>


### PR DESCRIPTION
The "# Section Highlights" text should look and behave exactly as it did before, but now it is a `<button>` in the DOM, focusable using the tab key, and pressing the enter key opens it in addition to clicking it.

![screenshot-20171101174457-1197x286](https://user-images.githubusercontent.com/1505923/32299693-e6053a64-bf2c-11e7-8672-d79d7ffc4a77.png)

FYI @edx/rapid-experiments-team 
