### PR TITLE
Allow escaping out of Studio CourseOutlineXBlockModals

### DIFF
--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -21,7 +21,8 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
 
     CourseOutlineXBlockModal = BaseModal.extend({
         events: _.extend({}, BaseModal.prototype.events, {
-            'click .action-save': 'save'
+            'click .action-save': 'save',
+            keydown: 'keyHandler'
         }),
 
         options: $.extend({}, BaseModal.prototype.options, {
@@ -102,6 +103,12 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             });
 
             return $.extend.apply(this, [true, {}].concat(requestData));
+        },
+
+        keyHandler: function(event) {
+            if (event.which === 27) {  // escape key
+                this.hide();
+            }
         }
     });
 


### PR DESCRIPTION
For accessibility, pressing escape while a modal is open should close the modal.

This affects the settings, publish, and the new section highlights modals on the course outline page of Studio.

FYI @edx/rapid-experiments-team 