### PR TITLE
ENT-673: Hide braces when ENTERPRISE_TAGLINE is not set.

### DIFF
--- a/lms/templates/header/brand.html
+++ b/lms/templates/header/brand.html
@@ -22,7 +22,9 @@ from branding import api as branding_api
   % if enable_enterprise_sidebar:
     <span class="enterprise-tagline">
       <% tagline = configuration_helpers.get_value('ENTERPRISE_TAGLINE', settings.ENTERPRISE_TAGLINE) %>
-      ${tagline}
+      % if tagline:
+        ${tagline}
+      % endif
     </span>
   % endif
   % if course and not disable_courseware_header:

--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -22,7 +22,9 @@ from branding import api as branding_api
   % if enable_enterprise_sidebar:
     <span class="enterprise-tagline">
       <% tagline = configuration_helpers.get_value('ENTERPRISE_TAGLINE', settings.ENTERPRISE_TAGLINE) %>
-      ${tagline}
+      % if tagline:
+        ${tagline}
+      % endif
     </span>
   % endif
   % if course:

--- a/lms/templates/navigation/navbar-logo-header.html
+++ b/lms/templates/navigation/navbar-logo-header.html
@@ -24,7 +24,9 @@ from branding import api as branding_api
   % if enable_enterprise_sidebar:
     <span class="enterprise-tagline">
       <% tagline = configuration_helpers.get_value('ENTERPRISE_TAGLINE', settings.ENTERPRISE_TAGLINE) %>
-      ${tagline}
+      % if tagline:
+        ${tagline}
+      % endif
     </span>
   % endif
   % if course:


### PR DESCRIPTION
__Description:__

This PR fixes the issue where empty braces `{}` appear on registration pages when `ENTERPRISE_TAGLINE`.
