### PR TITLE
bump enterprise version from 0.53.7 to 0.53.9

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -47,7 +47,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.53.7
+edx-enterprise==0.53.9
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.7


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @douglashall 

* ENT-711: Show generic info message on enterprise course enrollment page.
* ENT-687: Apply appropriate content filtering to the `EnterpriseCustomerCatalog` detail endpoints.

Here is the commits list from version `0.53.7` to `0.53.9`: https://github.com/edx/edx-enterprise/compare/0.53.7...0.53.9