### PR TITLE
Move bookmarks/course_overviews startup to AppConfig ready.

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -503,7 +503,7 @@ JWT_AUTH.update(ENV_TOKENS.get('JWT_AUTH', {}))
 
 ######################## CUSTOM COURSES for EDX CONNECTOR ######################
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-    INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon')
+    INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig')
 
 # Partner support link for CMS footer
 PARTNER_SUPPORT_EMAIL = ENV_TOKENS.get('PARTNER_SUPPORT_EMAIL', PARTNER_SUPPORT_EMAIL)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -939,7 +939,7 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.service_status',
 
     # Bookmarks
-    'openedx.core.djangoapps.bookmarks',
+    'openedx.core.djangoapps.bookmarks.apps.BookmarksConfig',
 
     # Video module configs (This will be moved to Video once it becomes an XBlock)
     'openedx.core.djangoapps.video_config',

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1015,7 +1015,7 @@ INSTALLED_APPS = [
     # Additional problem types
     'edx_jsme',    # Molecular Structure
 
-    'openedx.core.djangoapps.content.course_overviews',
+    'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig',
     'openedx.core.djangoapps.content.course_structures.apps.CourseStructuresConfig',
     'openedx.core.djangoapps.content.block_structure.apps.BlockStructureConfig',
 
@@ -1188,19 +1188,19 @@ MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = 15 * 60
 # that this app should be inserted *before*. A None here means it should be appended to the list.
 OPTIONAL_APPS = (
     ('mentoring', None),
-    ('problem_builder', 'openedx.core.djangoapps.content.course_overviews'),
+    ('problem_builder', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('edx_sga', None),
 
     # edx-ora2
-    ('submissions', 'openedx.core.djangoapps.content.course_overviews'),
-    ('openassessment', 'openedx.core.djangoapps.content.course_overviews'),
-    ('openassessment.assessment', 'openedx.core.djangoapps.content.course_overviews'),
-    ('openassessment.fileupload', 'openedx.core.djangoapps.content.course_overviews'),
-    ('openassessment.workflow', 'openedx.core.djangoapps.content.course_overviews'),
-    ('openassessment.xblock', 'openedx.core.djangoapps.content.course_overviews'),
+    ('submissions', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment.assessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment.fileupload', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment.workflow', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment.xblock', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
 
     # edxval
-    ('edxval', 'openedx.core.djangoapps.content.course_overviews'),
+    ('edxval', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
 
     # Organizations App (http://github.com/edx/edx-organizations)
     ('organizations', None),

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -331,7 +331,7 @@ FEATURES['ENABLE_TEAMS'] = True
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
 
 ######### custom courses #########
-INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon')
+INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig')
 FEATURES['CUSTOM_COURSES_EDX'] = True
 
 # API access management -- needed for simple-history to run.

--- a/cms/envs/yaml_config.py
+++ b/cms/envs/yaml_config.py
@@ -259,7 +259,7 @@ BROKER_USE_SSL = ENV_TOKENS.get('CELERY_BROKER_USE_SSL', False)
 
 ######################## CUSTOM COURSES for EDX CONNECTOR ######################
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-    INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon')
+    INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig')
 
 ########################## Extra middleware classes  #######################
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -823,7 +823,7 @@ ECOMMERCE_SERVICE_WORKER_USERNAME = ENV_TOKENS.get(
 
 ##### Custom Courses for EdX #####
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-    INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon']
+    INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig']
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
         'lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider',
     )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2221,7 +2221,7 @@ INSTALLED_APPS = [
     'lms.djangoapps.lms_xblock',
 
     # Course data caching
-    'openedx.core.djangoapps.content.course_overviews',
+    'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig',
     'openedx.core.djangoapps.content.course_structures.apps.CourseStructuresConfig',
     'openedx.core.djangoapps.content.block_structure.apps.BlockStructureConfig',
     'lms.djangoapps.course_blocks',
@@ -2883,19 +2883,19 @@ ALL_LANGUAGES = [
 # that this app should be inserted *before*. A None here means it should be appended to the list.
 OPTIONAL_APPS = [
     ('mentoring', None),
-    ('problem_builder', 'openedx.core.djangoapps.content.course_overviews'),
+    ('problem_builder', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('edx_sga', None),
 
     # edx-ora2
-    ('submissions', 'openedx.core.djangoapps.content.course_overviews'),
-    ('openassessment', 'openedx.core.djangoapps.content.course_overviews'),
-    ('openassessment.assessment', 'openedx.core.djangoapps.content.course_overviews'),
-    ('openassessment.fileupload', 'openedx.core.djangoapps.content.course_overviews'),
-    ('openassessment.workflow', 'openedx.core.djangoapps.content.course_overviews'),
-    ('openassessment.xblock', 'openedx.core.djangoapps.content.course_overviews'),
+    ('submissions', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment.assessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment.fileupload', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment.workflow', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
+    ('openassessment.xblock', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
 
     # edxval
-    ('edxval', 'openedx.core.djangoapps.content.course_overviews'),
+    ('edxval', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
 
     # edX Proctoring
     ('edx_proctoring', None),

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2076,7 +2076,7 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.video_config',
 
     # Bookmarks
-    'openedx.core.djangoapps.bookmarks',
+    'openedx.core.djangoapps.bookmarks.apps.BookmarksConfig',
 
     # Our courseware
     'courseware',

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -552,7 +552,7 @@ FACEBOOK_APP_ID = "Test"
 FACEBOOK_API_VERSION = "v2.8"
 
 ######### custom courses #########
-INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon']
+INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig']
 FEATURES['CUSTOM_COURSES_EDX'] = True
 
 # Set dummy values for profile image settings.

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -306,7 +306,7 @@ GRADES_DOWNLOAD_ROUTING_KEY = HIGH_MEM_QUEUE
 
 ##### Custom Courses for EdX #####
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-    INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon']
+    INSTALLED_APPS += ['lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig']
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS += (
         'lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider',
     )

--- a/openedx/core/djangoapps/bookmarks/apps.py
+++ b/openedx/core/djangoapps/bookmarks/apps.py
@@ -1,0 +1,16 @@
+"""
+Configuration for bookmarks Django app
+"""
+from django.apps import AppConfig
+
+
+class BookmarksConfig(AppConfig):
+    """
+    Configuration class for bookmarks Django app
+    """
+    name = 'openedx.core.djangoapps.bookmarks'
+    verbose_name = "Bookmarks"
+
+    def ready(self):
+        # Register the signals handled by bookmarks.
+        from . import signals

--- a/openedx/core/djangoapps/bookmarks/startup.py
+++ b/openedx/core/djangoapps/bookmarks/startup.py
@@ -1,5 +1,0 @@
-"""
-Setup the signals on startup.
-"""
-
-from . import signals  # pylint: disable=unused-import

--- a/openedx/core/djangoapps/ccxcon/__init__.py
+++ b/openedx/core/djangoapps/ccxcon/__init__.py
@@ -6,5 +6,3 @@ that is used to interact with the CCX and their master courses.
 The ccxcon app needs to be placed in `openedx.core.djangoapps`
 because it will be used both in CMS and LMS.
 """
-
-default_app_config = 'openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig'

--- a/openedx/core/djangoapps/content/course_overviews/apps.py
+++ b/openedx/core/djangoapps/content/course_overviews/apps.py
@@ -1,0 +1,17 @@
+"""
+Configuration for course_overviews Django app
+"""
+from django.apps import AppConfig
+
+
+class CourseOverviewsConfig(AppConfig):
+    """
+    Configuration class for course_overviews Django app
+    """
+    name = 'openedx.core.djangoapps.content.course_overviews'
+    verbose_name = "Course Overviews"
+
+    def ready(self):
+        # Import signals to activate signal handler which invalidates
+        # the CourseOverview cache every time a course is published.
+        from . import signals  # pylint: disable=unused-import

--- a/openedx/core/djangoapps/content/course_overviews/startup.py
+++ b/openedx/core/djangoapps/content/course_overviews/startup.py
@@ -1,5 +1,0 @@
-"""Code run at server start up to initialize the course_overviews app."""
-
-# Importing signals is necessary to activate signal handler, which invalidates
-# the CourseOverview cache every time a course is published.
-import openedx.core.djangoapps.content.course_overviews.signals  # pylint: disable=unused-import


### PR DESCRIPTION
Covers these django apps:
```
openedx.core.djangoapps.bookmarks
openedx.core.djangoapps.content.course_overviews
```
Also, went back and removed the `default_app_label` from `ccxcon`.