### PR TITLE
openedx urls cleanup for Django 1.11

### DIFF
--- a/openedx/core/djangoapps/api_admin/api/v1/urls.py
+++ b/openedx/core/djangoapps/api_admin/api/v1/urls.py
@@ -1,11 +1,10 @@
 """
 URL definitions for api access request API v1.
 """
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from openedx.core.djangoapps.api_admin.api.v1 import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^api_access_request/$', views.ApiAccessRequestView.as_view(), name='list_api_access_request'),
-)
+]

--- a/openedx/core/djangoapps/bookmarks/urls.py
+++ b/openedx/core/djangoapps/bookmarks/urls.py
@@ -3,12 +3,11 @@ URL routes for the bookmarks app.
 """
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import BookmarksDetailView, BookmarksListView
 
-urlpatterns = patterns(
-    'bookmarks',
+urlpatterns = [
     url(
         r'^v1/bookmarks/$',
         BookmarksListView.as_view(),
@@ -22,4 +21,4 @@ urlpatterns = patterns(
         BookmarksDetailView.as_view(),
         name='bookmarks_detail'
     ),
-)
+]

--- a/openedx/core/djangoapps/credit/urls.py
+++ b/openedx/core/djangoapps/credit/urls.py
@@ -1,30 +1,27 @@
 """
 URLs for the credit app.
 """
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 from openedx.core.djangoapps.credit import models, routers, views
 
 PROVIDER_ID_PATTERN = r'(?P<provider_id>{})'.format(models.CREDIT_PROVIDER_ID_REGEX)
 
-PROVIDER_URLS = patterns(
-    '',
+PROVIDER_URLS = [
     url(r'^request/$', views.CreditProviderRequestCreateView.as_view(), name='create_request'),
     url(r'^callback/?$', views.CreditProviderCallbackView.as_view(), name='provider_callback'),
-)
+]
 
-V1_URLS = patterns(
-    '',
+V1_URLS = [
     url(r'^providers/{}/'.format(PROVIDER_ID_PATTERN), include(PROVIDER_URLS)),
     url(r'^eligibility/$', views.CreditEligibilityView.as_view(), name='eligibility_details'),
-)
+]
 
 router = routers.SimpleRouter()  # pylint: disable=invalid-name
 router.register(r'courses', views.CreditCourseViewSet)
 router.register(r'providers', views.CreditProviderViewSet)
 V1_URLS += router.urls
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^v1/', include(V1_URLS)),
-)
+]

--- a/openedx/core/djangoapps/dark_lang/urls.py
+++ b/openedx/core/djangoapps/dark_lang/urls.py
@@ -2,11 +2,10 @@
 Contains all the URLs for the Dark Language Support App
 """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from openedx.core.djangoapps.dark_lang import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', views.PreviewLanguageFragmentView.as_view(), name='preview_lang'),
-)
+]

--- a/openedx/core/djangoapps/embargo/urls.py
+++ b/openedx/core/djangoapps/embargo/urls.py
@@ -1,15 +1,14 @@
 """URLs served by the embargo app. """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import CheckCourseAccessView, CourseAccessMessageView
 
-urlpatterns = patterns(
-    'openedx.core.djangoapps.embargo.views',
+urlpatterns = [
     url(
         r'^blocked-message/(?P<access_point>enrollment|courseware)/(?P<message_key>.+)/$',
         CourseAccessMessageView.as_view(),
         name='blocked_message',
     ),
     url(r'^v1/course_access/$', CheckCourseAccessView.as_view(), name='v1_course_access'),
-)
+]

--- a/openedx/core/djangoapps/heartbeat/urls.py
+++ b/openedx/core/djangoapps/heartbeat/urls.py
@@ -1,10 +1,10 @@
 """
 Urls for verifying health (heartbeat) of the app.
 """
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    '',
+from openedx.core.djangoapps.heartbeat.views import heartbeat
 
-    url(r'^$', 'openedx.core.djangoapps.heartbeat.views.heartbeat', name='heartbeat'),
-)
+urlpatterns = [
+    url(r'^$', heartbeat, name='heartbeat'),
+]

--- a/openedx/core/djangoapps/oauth_dispatch/urls.py
+++ b/openedx/core/djangoapps/oauth_dispatch/urls.py
@@ -3,25 +3,24 @@ OAuth2 wrapper urls
 """
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
 
 from . import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^authorize/?$', csrf_exempt(views.AuthorizationView.as_view()), name='authorize'),
     url(r'^access_token/?$', csrf_exempt(views.AccessTokenView.as_view()), name='access_token'),
     url(r'^revoke_token/?$', csrf_exempt(views.RevokeTokenView.as_view()), name='revoke_token'),
     url(r'^\.well-known/openid-configuration/?$', views.ProviderInfoView.as_view(), name='openid-config'),
     url(r'^jwks\.json$', views.JwksView.as_view(), name='jwks')
-)
+]
 
 if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
-    urlpatterns += (
+    urlpatterns += [
         url(
             r'^exchange_access_token/(?P<backend>[^/]+)/$',
             csrf_exempt(views.AccessTokenExchangeView.as_view()),
             name='exchange_access_token',
         ),
-    )
+    ]

--- a/openedx/core/djangoapps/performance/urls.py
+++ b/openedx/core/djangoapps/performance/urls.py
@@ -2,10 +2,10 @@
 URLs for performance app
 """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    'openedx.core.djangoapps.performance.views',
+from openedx.core.djangoapps.performance.views import performance_log
 
-    url(r'^performance$', 'performance_log'),
-)
+urlpatterns = [
+    url(r'^performance$', performance_log),
+]

--- a/openedx/core/djangoapps/profile_images/urls.py
+++ b/openedx/core/djangoapps/profile_images/urls.py
@@ -7,12 +7,11 @@ NOTE: These views are deprecated.  These routes are superseded by
 """
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import ProfileImageRemoveView, ProfileImageUploadView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         r'^v1/' + settings.USERNAME_PATTERN + '/upload$',
         ProfileImageUploadView.as_view(),
@@ -23,4 +22,4 @@ urlpatterns = patterns(
         ProfileImageRemoveView.as_view(),
         name="profile_image_remove"
     ),
-)
+]

--- a/openedx/core/djangoapps/service_status/urls.py
+++ b/openedx/core/djangoapps/service_status/urls.py
@@ -2,13 +2,12 @@
 Django URLs for service status app
 """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    '',
-    url(r'^$', 'openedx.core.djangoapps.service_status.views.index', name='status.service.index'),
-    url(r'^celery/$', 'openedx.core.djangoapps.service_status.views.celery_status',
-        name='status.service.celery.status'),
-    url(r'^celery/ping/$', 'openedx.core.djangoapps.service_status.views.celery_ping',
-        name='status.service.celery.ping'),
-)
+from openedx.core.djangoapps.service_status.views import index, celery_status, celery_ping
+
+urlpatterns = [
+    url(r'^$', index, name='status.service.index'),
+    url(r'^celery/$', celery_status, name='status.service.celery.status'),
+    url(r'^celery/ping/$', celery_ping, name='status.service.celery.ping'),
+]

--- a/openedx/core/djangoapps/user_api/legacy_urls.py
+++ b/openedx/core/djangoapps/user_api/legacy_urls.py
@@ -3,7 +3,7 @@ Defines the URL routes for this app.
 """
 
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from rest_framework import routers
 
 from . import views as user_api_views
@@ -12,8 +12,8 @@ from .models import UserPreference
 USER_API_ROUTER = routers.DefaultRouter()
 USER_API_ROUTER.register(r'users', user_api_views.UserViewSet)
 USER_API_ROUTER.register(r'user_prefs', user_api_views.UserPreferenceViewSet)
-urlpatterns = patterns(
-    '',
+
+urlpatterns = [
     url(r'^v1/', include(USER_API_ROUTER.urls)),
     url(
         r'^v1/preferences/(?P<pref_key>{})/users/$'.format(UserPreference.KEY_REGEX),
@@ -33,15 +33,14 @@ urlpatterns = patterns(
         r'^v1/preferences/time_zones/$',
         user_api_views.CountryTimeZoneListView.as_view(),
     ),
-)
+]
 
 if settings.FEATURES.get('ENABLE_COMBINED_LOGIN_REGISTRATION'):
-    urlpatterns += patterns(
-        '',
+    urlpatterns += [
         url(r'^v1/account/login_session/$', user_api_views.LoginSessionView.as_view(),
             name="user_api_login_session"),
         url(r'^v1/account/registration/$', user_api_views.RegistrationView.as_view(),
             name="user_api_registration"),
         url(r'^v1/account/password_reset/$', user_api_views.PasswordResetView.as_view(),
             name="user_api_password_reset"),
-    )
+    ]

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -3,7 +3,7 @@ Defines the URL routes for this app.
 """
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from ..profile_images.views import ProfileImageView
 from .accounts.views import AccountDeactivationView, AccountViewSet
@@ -24,8 +24,7 @@ ACCOUNT_DETAIL = AccountViewSet.as_view({
     'patch': 'partial_update',
 })
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         r'^v1/me$',
         ME,
@@ -71,4 +70,4 @@ urlpatterns = patterns(
         PreferencesDetailView.as_view(),
         name='preferences_detail_api'
     ),
-)
+]

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 import ddt
 from datetime import datetime, timedelta
 from django.conf import settings
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.test import TestCase
@@ -54,8 +54,7 @@ class OAuth2AuthenticationDebug(authentication.OAuth2AuthenticationAllowInactive
     allow_query_params_token = True
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^oauth2/', include('provider.oauth2.urls', namespace='oauth2')),
     url(
         r'^oauth2-test/$',
@@ -69,7 +68,7 @@ urlpatterns = patterns(
             permission_classes=[permissions.TokenHasReadWriteScope]
         )
     ),
-)
+]
 
 
 @attr(shard=2)


### PR DESCRIPTION
- Remove usage of django.urls.patterns
- Change urls tuples to lists
- Make all string view names callables