### PR TITLE
Fix Django Wiki Links Issue

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -48,7 +48,7 @@
 
 # Third-party:
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
-git+https://github.com/edx/django-wiki.git@v0.0.14#egg=django-wiki==0.0.14
+-e git+https://github.com/edx/django-wiki.git@b2d3c9392504c7ed21e0979ee5a39d061328df77#egg=django-wiki
 git+https://github.com/edx/django-openid-auth.git@0.14#egg=django-openid-auth==0.14
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
This PR is to update Django-Wiki in edX Platform, I am adding commit temporary to create a sandbox with the branch and see if things are working smootly. 

Django-Wiki removes characters like `:` or `@` in the url because `safe_mode` is set to `replace`. I have updated it to remove it because in edX we mostly support these in the url patterns. 


Django-Wiki PR: https://github.com/edx/django-wiki/pull/28
Docs: https://pythonhosted.org/Markdown/release-2.6.html#safe_mode-deprecated

[EDUCATOR-1655](https://openedx.atlassian.net/browse/EDUCATOR-1655)