### PR TITLE
Add oauth_provider to Studio INSTALLED_APPS

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1050,6 +1050,7 @@ INSTALLED_APPS = [
     # These are apps that aren't strictly needed by Studio, but are imported by
     # other apps that are.  Django 1.8 wants to have imported models supported
     # by installed apps.
+    'oauth_provider',
     'courseware',
     'survey',
     'lms.djangoapps.verify_student.apps.VerifyStudentConfig',


### PR DESCRIPTION
This should fix the last of the warnings we've been getting in production about things that will break under Django 1.9 (other than the in-progress Chinese locale change).  Something in Studio imports the oauth_provider models on startup; since the app doesn't have any auto-initialization code, adding this should be mostly harmless.