### PR TITLE
WIP Course Updates email task: bin by course

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
@@ -35,6 +35,7 @@ class TestSendCourseUpdate(ScheduleUpsellTestMixin, ScheduleSendEmailTestBase):
     experience_type = ScheduleExperience.EXPERIENCES.course_updates
 
     queries_deadline_for_each_course = True
+    bin_by = 'course'
 
     def setUp(self):
         super(TestSendCourseUpdate, self).setUp()

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_upgrade_reminder.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_upgrade_reminder.py
@@ -49,7 +49,7 @@ class TestUpgradeReminder(ScheduleSendEmailTestBase):
 
         self.task.apply(kwargs=dict(
             site_id=self.site_config.site.id, target_day_str=serialize(target_day), day_offset=offset,
-            bin_num=self._calculate_bin_for_user(schedule.enrollment.user),
+            bin_num=self._calculate_bin(schedule.enrollment.user, unicode(schedule.enrollment.course.id)),
         ))
 
         self.assertEqual(mock_ace.send.called, not is_verified)
@@ -73,7 +73,7 @@ class TestUpgradeReminder(ScheduleSendEmailTestBase):
 
             self.task.apply(kwargs=dict(
                 site_id=self.site_config.site.id, target_day_str=serialize(target_day), day_offset=offset,
-                bin_num=self._calculate_bin_for_user(user),
+                bin_num=self._calculate_bin(user, 'edX/toy/Course0'),
             ))
 
             messages = [Message.from_string(m) for m in sent_messages]
@@ -92,7 +92,7 @@ class TestUpgradeReminder(ScheduleSendEmailTestBase):
 
         self.task.apply(kwargs=dict(
             site_id=self.site_config.site.id, target_day_str=serialize(target_day), day_offset=offset,
-            bin_num=self._calculate_bin_for_user(schedule.enrollment.user),
+            bin_num=self._calculate_bin(schedule.enrollment.user, unicode(schedule.enrollment.course.id)),
         ))
         self.assertEqual(mock_ace.send.called, False)
 

--- a/openedx/core/djangoapps/schedules/management/commands/tests/upsell_base.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/upsell_base.py
@@ -42,7 +42,7 @@ class ScheduleUpsellTestMixin(object):
             mock_schedule_send.apply_async = lambda args, *_a, **_kw: sent_messages.append(args[1])
             self.task.apply(kwargs=dict(
                 site_id=self.site_config.site.id, target_day_str=serialize(target_day), day_offset=offset,
-                bin_num=self._calculate_bin_for_user(schedule.enrollment.user),
+                bin_num=self._calculate_bin(schedule.enrollment.user, unicode(schedule.enrollment.course.id)),
             ))
         self.assertEqual(len(sent_messages), 1)
 


### PR DESCRIPTION
Here's the initial implementation of binning by course instead of binning by user. The tests are currently failing because they use SQLite and SQLite does not support the CRC32 function.

We are going to hold off finishing this PR until we see the performance of binning by user in production. If it is "good enough" we may just close this PR, but it we see problems, we will put more effort into this and try to resolve the test failures.

FYI: @edx/rapid-experiments-team 