### PR TITLE
Hide the create library for non-staff users when DISABLE_COURSE_CREATION

### DIFF
--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -58,7 +58,7 @@ def get_library_creator_status(user):
     elif settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
         return get_course_creator_status(user) == 'granted'
     else:
-        return True
+        return not settings.FEATURES.get('DISABLE_COURSE_CREATION', False)
 
 
 @login_required

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -28,6 +28,7 @@ def make_url_for_lib(key):
 
 
 @ddt.ddt
+@mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': False})
 class UnitTestLibraries(CourseTestCase):
     """
     Unit tests for library views
@@ -62,6 +63,15 @@ class UnitTestLibraries(CourseTestCase):
     def test_library_creator_status_with_no_course_creator_role(self):
         _, nostaff_user = self.create_non_staff_authed_user_client()
         self.assertEqual(get_library_creator_status(nostaff_user), True)
+
+    @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': True})
+    @mock.patch("contentstore.views.library.LIBRARIES_ENABLED", True)
+    def test_library_creator_status_with_no_course_creator_role_and_disabled_nonstaff_course_creation(self):
+        """
+        Ensure that `DISABLE_COURSE_CREATION` feature works with libraries as well.
+        """
+        _, nostaff_user = self.create_non_staff_authed_user_client()
+        self.assertFalse(get_library_creator_status(nostaff_user))
 
     @patch("contentstore.views.library.LIBRARIES_ENABLED", False)
     def test_with_libraries_disabled(self):


### PR DESCRIPTION
This is a tiny bug that has been [reported](https://groups.google.com/d/msg/openedx-ops/YzTHBlyfX38/IDXnZGuLAgAJ) a while ago:

> Is there a setting similar to 'DISABLE_COURSE_CREATION': True
> 
> That I can add to my CMS settings or cms/envs/common.py, to disable the library creation for non staff in cypress? I can't find it in the docs.
> 
> Thanks!
> 

