### PR TITLE
Schedule-based Highlights email update

### DIFF
--- a/openedx/core/djangoapps/schedules/content_highlights.py
+++ b/openedx/core/djangoapps/schedules/content_highlights.py
@@ -27,6 +27,9 @@ def course_has_highlights(course_key):
 def get_week_highlights(user, course_key, week_num):
     """
     Get highlights (list of unicode strings) for a given week.
+    week_num starts at 1.
+    Raises CourseUpdateDoesNotExist if highlights do not exist for
+    the requested week_num.
     """
     if not COURSE_UPDATE_WAFFLE_FLAG.is_enabled(course_key):
         raise CourseUpdateDoesNotExist(
@@ -75,12 +78,12 @@ def _get_sections_with_highlights(course_module):
 def _get_highlights_for_week(sections, week_num, course_key):
     # assume each provided section maps to a single week
     num_sections = len(sections)
-    if not (0 <= week_num < num_sections):
+    if not (1 <= week_num <= num_sections):
         raise CourseUpdateDoesNotExist(
             "Requested week {} but {} has only {} sections.".format(
-                week_num + 1, course_key, num_sections
+                week_num, course_key, num_sections
             )
         )
 
-    section = sections[week_num]
+    section = sections[week_num - 1]
     return section.highlights

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/common/upsell_cta.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/common/upsell_cta.txt
@@ -1,5 +1,4 @@
 {% load i18n %}
-
 {% if show_upsell %}
 {% blocktrans trimmed %}
     Don't miss the opportunity to highlight your new knowledge and skills by earning a verified

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.html
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.html
@@ -4,7 +4,7 @@
 
 {% block preview_text %}
     {% blocktrans trimmed %}
-        Welcome to week {{ week_num }} of our {{ course_name }} course!
+        Welcome to week {{ week_num }} of {{ course_name }}!
     {% endblocktrans %}
 {% endblock %}
 
@@ -14,18 +14,21 @@
         <td>
             <p>
                 {% blocktrans trimmed %}
-                    Welcome to week {{ week_num }} of <strong>{{ course_name }}</strong>!
+                    We hope you're enjoying <strong>{{ course_name }}</strong>!
+                    We want to let you know what you can look forward to in week {{ week_num }}:
                 {% endblocktrans %}
+                <ul>
+                    {% for highlight in week_highlights %}
+                        <li>{{ highlight }}</li>
+                    {% endfor %}
+                </ul>
             </p>
             <p>
                 {% blocktrans trimmed %}
-                    Here is what you can look forward to learning this week:
+                    With self-paced courses, you learn on your own schedule.
+                    We encourage you to spend time with the course each week.
+                    Your focused attention will pay off in the end!
                 {% endblocktrans %}
-                    <ul>
-                        {% for highlight in week_highlights %}
-                            <li>{{ highlight }}</li>
-                        {% endfor %}
-                    </ul>
             </p>
 
             {% trans "Resume your course now" as course_cta_text %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.txt
@@ -1,14 +1,16 @@
 {% load i18n %}
 
 {% blocktrans trimmed %}
-Welcome to week {{ week_num }} of our {{ course_name }} course!
-
-Here is what you can look forward to learning this week:
+We hope you're enjoying {{ course_name }}!
+We want to let you know what you can look forward to in week {{ week_num }}:
 {% endblocktrans %}
 
 {% for highlight in week_highlights %}
   * {{ highlight }}
 {% endfor %}
 
-
+{% blocktrans trimmed %}
+With self-paced courses, you learn on your own schedule. We encourage you to spend time with the course each week.
+Your focused attention will pay off in the end!
+{% endblocktrans %}
 {% include "schedules/edx_ace/common/upsell_cta.txt"%}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/subject.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans %}{{ course_name }} - Welcome to Week {{ week_num }} {% endblocktrans %}
+{% blocktrans %}Welcome to week {{ week_num }} {% endblocktrans %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/body.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/body.txt
@@ -12,5 +12,4 @@
     {% endblocktrans %}
     {% trans "Keep learning" %} <{{course_url}}>
 {% endif %}
-
 {% include "schedules/edx_ace/common/upsell_cta.txt"%}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.txt
@@ -15,5 +15,4 @@
 
 {% trans "Start learning now" %} <{{ course_url }}>
 {% endif %}
-
 {% include "schedules/edx_ace/common/upsell_cta.txt"%}

--- a/openedx/core/djangoapps/schedules/tests/test_content_highlights.py
+++ b/openedx/core/djangoapps/schedules/tests/test_content_highlights.py
@@ -39,12 +39,12 @@ class TestContentHighlights(ModuleStoreTestCase):
     def test_non_existent_course_raises_exception(self):
         nonexistent_course_key = self.course_key.replace(run='no_such_run')
         with self.assertRaises(CourseUpdateDoesNotExist):
-            get_week_highlights(self.user, nonexistent_course_key, 0)
+            get_week_highlights(self.user, nonexistent_course_key, week_num=1)
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     def test_empty_course_raises_exception(self):
         with self.assertRaises(CourseUpdateDoesNotExist):
-            get_week_highlights(self.user, self.course_key, 0)
+            get_week_highlights(self.user, self.course_key, week_num=1)
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, False)
     def test_flag_disabled(self):
@@ -53,7 +53,7 @@ class TestContentHighlights(ModuleStoreTestCase):
 
         self.assertFalse(course_has_highlights(self.course_key))
         with self.assertRaises(CourseUpdateDoesNotExist):
-            get_week_highlights(self.user, self.course_key, week_num=0)
+            get_week_highlights(self.user, self.course_key, week_num=1)
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     def test_flag_enabled(self):
@@ -62,7 +62,7 @@ class TestContentHighlights(ModuleStoreTestCase):
             self._create_chapter(highlights=highlights)
         self.assertTrue(course_has_highlights(self.course_key))
         self.assertEqual(
-            get_week_highlights(self.user, self.course_key, week_num=0),
+            get_week_highlights(self.user, self.course_key, week_num=1),
             highlights,
         )
 
@@ -77,7 +77,7 @@ class TestContentHighlights(ModuleStoreTestCase):
 
         self.assertFalse(course_has_highlights(self.course_key))
         with self.assertRaises(CourseUpdateDoesNotExist):
-            get_week_highlights(self.user, self.course_key, week_num=0)
+            get_week_highlights(self.user, self.course_key, week_num=1)
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     def test_course_with_highlights(self):
@@ -89,15 +89,15 @@ class TestContentHighlights(ModuleStoreTestCase):
         self.assertTrue(course_has_highlights(self.course_key))
 
         self.assertEqual(
-            get_week_highlights(self.user, self.course_key, week_num=0),
+            get_week_highlights(self.user, self.course_key, week_num=1),
             [u'a', u'b', u'á'],
         )
         self.assertEqual(
-            get_week_highlights(self.user, self.course_key, week_num=1),
+            get_week_highlights(self.user, self.course_key, week_num=2),
             [u'skipped a week'],
         )
         with self.assertRaises(CourseUpdateDoesNotExist):
-            get_week_highlights(self.user, self.course_key, week_num=2)
+            get_week_highlights(self.user, self.course_key, week_num=3)
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     def test_staff_only(self):
@@ -109,4 +109,4 @@ class TestContentHighlights(ModuleStoreTestCase):
 
         self.assertTrue(course_has_highlights(self.course_key))
         with self.assertRaises(CourseUpdateDoesNotExist):
-            get_week_highlights(self.user, self.course_key, week_num=0)
+            get_week_highlights(self.user, self.course_key, week_num=1)


### PR DESCRIPTION
FYI @edx/rapid-experiments-team @shamck @srpearce 

Here is the output using the FileEmail channel:

<img width="596" alt="screen shot 2017-11-06 at 2 13 55 pm" src="https://user-images.githubusercontent.com/6772826/32459227-ed9c36dc-c2fc-11e7-8d2a-866326116a17.png">

