### PR TITLE
(WIP) LEARNER-2653 Add Owner to openedx.yml

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -3,5 +3,6 @@
 
 nick: edx
 oeps: {}
+owner: edx/learner
 openedx-release: {ref: release, requirements: requirements/edx/github.txt}
 track-pulls: true


### PR DESCRIPTION
edX-platform push translation job responsible for pushing translations created in 
https://github.com/edx-ops/ecom-secure/pull/23
is failing because transifex script from ecommerce-scripts checks for repo owner from openedx.yml and edx-platform has no owner so job fails. 
Not sure who is the actual owner of edx-platform . using edx/learner for the time being for testing purposes 