### PR TITLE
LMS urls cleanup for Django 1.11 part 3

### DIFF
--- a/lms/djangoapps/grades/api/urls.py
+++ b/lms/djangoapps/grades/api/urls.py
@@ -1,11 +1,13 @@
-""" Grades API URLs. """
+"""
+Grades API URLs.
+"""
+
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from lms.djangoapps.grades.api import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         r'^v0/course_grade/{course_id}/users/$'.format(
             course_id=settings.COURSE_ID_PATTERN,
@@ -18,4 +20,4 @@ urlpatterns = patterns(
         ),
         views.CourseGradingPolicy.as_view(), name='course_grading_policy'
     ),
-)
+]

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -2,173 +2,92 @@
 Instructor API endpoint urls.
 """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    '',
+from lms.djangoapps.instructor.views import api, gradebook_api
 
-    url(r'^students_update_enrollment$',
-        'lms.djangoapps.instructor.views.api.students_update_enrollment', name="students_update_enrollment"),
-    url(r'^register_and_enroll_students$',
-        'lms.djangoapps.instructor.views.api.register_and_enroll_students', name="register_and_enroll_students"),
-    url(r'^list_course_role_members$',
-        'lms.djangoapps.instructor.views.api.list_course_role_members', name="list_course_role_members"),
-    url(r'^modify_access$',
-        'lms.djangoapps.instructor.views.api.modify_access', name="modify_access"),
-    url(r'^bulk_beta_modify_access$',
-        'lms.djangoapps.instructor.views.api.bulk_beta_modify_access', name="bulk_beta_modify_access"),
-    url(r'^get_problem_responses$',
-        'lms.djangoapps.instructor.views.api.get_problem_responses', name="get_problem_responses"),
-    url(r'^get_grading_config$',
-        'lms.djangoapps.instructor.views.api.get_grading_config', name="get_grading_config"),
-    url(r'^get_students_features(?P<csv>/csv)?$',
-        'lms.djangoapps.instructor.views.api.get_students_features', name="get_students_features"),
-    url(r'^get_issued_certificates/$',
-        'lms.djangoapps.instructor.views.api.get_issued_certificates', name="get_issued_certificates"),
-    url(r'^get_students_who_may_enroll$',
-        'lms.djangoapps.instructor.views.api.get_students_who_may_enroll', name="get_students_who_may_enroll"),
-    url(r'^get_user_invoice_preference$',
-        'lms.djangoapps.instructor.views.api.get_user_invoice_preference', name="get_user_invoice_preference"),
-    url(r'^get_sale_records(?P<csv>/csv)?$',
-        'lms.djangoapps.instructor.views.api.get_sale_records', name="get_sale_records"),
-    url(r'^get_sale_order_records$',
-        'lms.djangoapps.instructor.views.api.get_sale_order_records', name="get_sale_order_records"),
-    url(r'^sale_validation_url$',
-        'lms.djangoapps.instructor.views.api.sale_validation', name="sale_validation"),
-    url(r'^get_anon_ids$',
-        'lms.djangoapps.instructor.views.api.get_anon_ids', name="get_anon_ids"),
-    url(r'^get_student_progress_url$',
-        'lms.djangoapps.instructor.views.api.get_student_progress_url', name="get_student_progress_url"),
-    url(r'^reset_student_attempts$',
-        'lms.djangoapps.instructor.views.api.reset_student_attempts', name="reset_student_attempts"),
-    url(
-        r'^rescore_problem$',
-        'lms.djangoapps.instructor.views.api.rescore_problem',
-        name="rescore_problem"
-    ), url(
-        r'^override_problem_score$',
-        'lms.djangoapps.instructor.views.api.override_problem_score',
-        name="override_problem_score"
-    ), url(
-        r'^reset_student_attempts_for_entrance_exam$',
-        'lms.djangoapps.instructor.views.api.reset_student_attempts_for_entrance_exam',
-        name="reset_student_attempts_for_entrance_exam"
-    ), url(
-        r'^rescore_entrance_exam$',
-        'lms.djangoapps.instructor.views.api.rescore_entrance_exam',
-        name="rescore_entrance_exam"
-    ), url(
-        r'^list_entrance_exam_instructor_tasks',
-        'lms.djangoapps.instructor.views.api.list_entrance_exam_instructor_tasks',
-        name="list_entrance_exam_instructor_tasks"
-    ), url(
-        r'^mark_student_can_skip_entrance_exam',
-        'lms.djangoapps.instructor.views.api.mark_student_can_skip_entrance_exam',
-        name="mark_student_can_skip_entrance_exam"
-    ),
-
-    url(r'^list_instructor_tasks$',
-        'lms.djangoapps.instructor.views.api.list_instructor_tasks', name="list_instructor_tasks"),
-    url(r'^list_background_email_tasks$',
-        'lms.djangoapps.instructor.views.api.list_background_email_tasks', name="list_background_email_tasks"),
-    url(r'^list_email_content$',
-        'lms.djangoapps.instructor.views.api.list_email_content', name="list_email_content"),
-    url(r'^list_forum_members$',
-        'lms.djangoapps.instructor.views.api.list_forum_members', name="list_forum_members"),
-    url(r'^update_forum_role_membership$',
-        'lms.djangoapps.instructor.views.api.update_forum_role_membership', name="update_forum_role_membership"),
-    url(r'^send_email$',
-        'lms.djangoapps.instructor.views.api.send_email', name="send_email"),
-    url(r'^change_due_date$', 'lms.djangoapps.instructor.views.api.change_due_date',
-        name='change_due_date'),
-    url(r'^reset_due_date$', 'lms.djangoapps.instructor.views.api.reset_due_date',
-        name='reset_due_date'),
-    url(r'^show_unit_extensions$', 'lms.djangoapps.instructor.views.api.show_unit_extensions',
-        name='show_unit_extensions'),
-    url(r'^show_student_extensions$', 'lms.djangoapps.instructor.views.api.show_student_extensions',
-        name='show_student_extensions'),
+urlpatterns = [
+    url(r'^students_update_enrollment$', api.students_update_enrollment, name='students_update_enrollment'),
+    url(r'^register_and_enroll_students$', api.register_and_enroll_students, name='register_and_enroll_students'),
+    url(r'^list_course_role_members$', api.list_course_role_members, name='list_course_role_members'),
+    url(r'^modify_access$', api.modify_access, name='modify_access'),
+    url(r'^bulk_beta_modify_access$', api.bulk_beta_modify_access, name='bulk_beta_modify_access'),
+    url(r'^get_problem_responses$', api.get_problem_responses, name='get_problem_responses'),
+    url(r'^get_grading_config$', api.get_grading_config, name='get_grading_config'),
+    url(r'^get_students_features(?P<csv>/csv)?$', api.get_students_features, name='get_students_features'),
+    url(r'^get_issued_certificates/$', api.get_issued_certificates, name='get_issued_certificates'),
+    url(r'^get_students_who_may_enroll$', api.get_students_who_may_enroll, name='get_students_who_may_enroll'),
+    url(r'^get_user_invoice_preference$', api.get_user_invoice_preference, name='get_user_invoice_preference'),
+    url(r'^get_sale_records(?P<csv>/csv)?$', api.get_sale_records, name='get_sale_records'),
+    url(r'^get_sale_order_records$', api.get_sale_order_records, name='get_sale_order_records'),
+    url(r'^sale_validation_url$', api.sale_validation, name='sale_validation'),
+    url(r'^get_anon_ids$', api.get_anon_ids, name='get_anon_ids'),
+    url(r'^get_student_progress_url$', api.get_student_progress_url, name='get_student_progress_url'),
+    url(r'^reset_student_attempts$', api.reset_student_attempts, name='reset_student_attempts'),
+    url(r'^rescore_problem$', api.rescore_problem, name='rescore_problem'),
+    url(r'^override_problem_score$', api.override_problem_score, name='override_problem_score'),
+    url(r'^reset_student_attempts_for_entrance_exam$', api.reset_student_attempts_for_entrance_exam,
+        name='reset_student_attempts_for_entrance_exam'),
+    url(r'^rescore_entrance_exam$', api.rescore_entrance_exam, name='rescore_entrance_exam'),
+    url(r'^list_entrance_exam_instructor_tasks', api.list_entrance_exam_instructor_tasks,
+        name='list_entrance_exam_instructor_tasks'),
+    url(r'^mark_student_can_skip_entrance_exam', api.mark_student_can_skip_entrance_exam,
+        name='mark_student_can_skip_entrance_exam'),
+    url(r'^list_instructor_tasks$', api.list_instructor_tasks, name='list_instructor_tasks'),
+    url(r'^list_background_email_tasks$', api.list_background_email_tasks, name='list_background_email_tasks'),
+    url(r'^list_email_content$', api.list_email_content, name='list_email_content'),
+    url(r'^list_forum_members$', api.list_forum_members, name='list_forum_members'),
+    url(r'^update_forum_role_membership$', api.update_forum_role_membership, name='update_forum_role_membership'),
+    url(r'^send_email$', api.send_email, name='send_email'),
+    url(r'^change_due_date$', api.change_due_date, name='change_due_date'),
+    url(r'^reset_due_date$', api.reset_due_date, name='reset_due_date'),
+    url(r'^show_unit_extensions$', api.show_unit_extensions, name='show_unit_extensions'),
+    url(r'^show_student_extensions$', api.show_student_extensions, name='show_student_extensions'),
 
     # proctored exam downloads...
-    url(r'^get_proctored_exam_results$',
-        'lms.djangoapps.instructor.views.api.get_proctored_exam_results', name="get_proctored_exam_results"),
+    url(r'^get_proctored_exam_results$', api.get_proctored_exam_results, name='get_proctored_exam_results'),
 
     # Grade downloads...
-    url(r'^list_report_downloads$',
-        'lms.djangoapps.instructor.views.api.list_report_downloads', name="list_report_downloads"),
-    url(r'calculate_grades_csv$',
-        'lms.djangoapps.instructor.views.api.calculate_grades_csv', name="calculate_grades_csv"),
-    url(r'problem_grade_report$',
-        'lms.djangoapps.instructor.views.api.problem_grade_report', name="problem_grade_report"),
+    url(r'^list_report_downloads$', api.list_report_downloads, name='list_report_downloads'),
+    url(r'calculate_grades_csv$', api.calculate_grades_csv, name='calculate_grades_csv'),
+    url(r'problem_grade_report$', api.problem_grade_report, name='problem_grade_report'),
 
     # Financial Report downloads..
-    url(r'^list_financial_report_downloads$',
-        'lms.djangoapps.instructor.views.api.list_financial_report_downloads', name="list_financial_report_downloads"),
+    url(r'^list_financial_report_downloads$', api.list_financial_report_downloads,
+        name='list_financial_report_downloads'),
 
     # Registration Codes..
-    url(r'get_registration_codes$',
-        'lms.djangoapps.instructor.views.api.get_registration_codes', name="get_registration_codes"),
-    url(r'generate_registration_codes$',
-        'lms.djangoapps.instructor.views.api.generate_registration_codes', name="generate_registration_codes"),
-    url(r'active_registration_codes$',
-        'lms.djangoapps.instructor.views.api.active_registration_codes', name="active_registration_codes"),
-    url(r'spent_registration_codes$',
-        'lms.djangoapps.instructor.views.api.spent_registration_codes', name="spent_registration_codes"),
+    url(r'get_registration_codes$', api.get_registration_codes, name='get_registration_codes'),
+    url(r'generate_registration_codes$', api.generate_registration_codes, name='generate_registration_codes'),
+    url(r'active_registration_codes$', api.active_registration_codes, name='active_registration_codes'),
+    url(r'spent_registration_codes$', api.spent_registration_codes, name='spent_registration_codes'),
 
     # Reports..
-    url(r'get_enrollment_report$',
-        'lms.djangoapps.instructor.views.api.get_enrollment_report', name="get_enrollment_report"),
-    url(r'get_exec_summary_report$',
-        'lms.djangoapps.instructor.views.api.get_exec_summary_report', name="get_exec_summary_report"),
-    url(r'get_course_survey_results$',
-        'lms.djangoapps.instructor.views.api.get_course_survey_results', name="get_course_survey_results"),
-    url(r'export_ora2_data',
-        'lms.djangoapps.instructor.views.api.export_ora2_data', name="export_ora2_data"),
+    url(r'get_enrollment_report$', api.get_enrollment_report, name='get_enrollment_report'),
+    url(r'get_exec_summary_report$', api.get_exec_summary_report, name='get_exec_summary_report'),
+    url(r'get_course_survey_results$', api.get_course_survey_results, name='get_course_survey_results'),
+    url(r'export_ora2_data', api.export_ora2_data, name='export_ora2_data'),
 
     # Coupon Codes..
-    url(r'get_coupon_codes',
-        'lms.djangoapps.instructor.views.api.get_coupon_codes', name="get_coupon_codes"),
+    url(r'get_coupon_codes', api.get_coupon_codes, name='get_coupon_codes'),
 
     # spoc gradebook
-    url(r'^gradebook$',
-        'lms.djangoapps.instructor.views.gradebook_api.spoc_gradebook', name='spoc_gradebook'),
+    url(r'^gradebook$', gradebook_api.spoc_gradebook, name='spoc_gradebook'),
 
-    url(r'^gradebook/(?P<offset>[0-9]+)$',
-        'lms.djangoapps.instructor.views.gradebook_api.spoc_gradebook', name='spoc_gradebook'),
+    url(r'^gradebook/(?P<offset>[0-9]+)$', gradebook_api.spoc_gradebook, name='spoc_gradebook'),
 
     # Cohort management
-    url(r'add_users_to_cohorts$',
-        'lms.djangoapps.instructor.views.api.add_users_to_cohorts', name="add_users_to_cohorts"),
+    url(r'add_users_to_cohorts$', api.add_users_to_cohorts, name='add_users_to_cohorts'),
 
     # Certificates
-    url(r'^generate_example_certificates$',
-        'lms.djangoapps.instructor.views.api.generate_example_certificates',
-        name='generate_example_certificates'),
-
-    url(r'^enable_certificate_generation$',
-        'lms.djangoapps.instructor.views.api.enable_certificate_generation',
-        name='enable_certificate_generation'),
-
-    url(r'^start_certificate_generation',
-        'lms.djangoapps.instructor.views.api.start_certificate_generation',
-        name='start_certificate_generation'),
-
-    url(r'^start_certificate_regeneration',
-        'lms.djangoapps.instructor.views.api.start_certificate_regeneration',
-        name='start_certificate_regeneration'),
-
-    url(r'^certificate_exception_view/$',
-        'lms.djangoapps.instructor.views.api.certificate_exception_view',
-        name='certificate_exception_view'),
-
-    url(r'^generate_certificate_exceptions/(?P<generate_for>[^/]*)',
-        'lms.djangoapps.instructor.views.api.generate_certificate_exceptions',
+    url(r'^generate_example_certificates$', api.generate_example_certificates, name='generate_example_certificates'),
+    url(r'^enable_certificate_generation$', api.enable_certificate_generation, name='enable_certificate_generation'),
+    url(r'^start_certificate_generation', api.start_certificate_generation, name='start_certificate_generation'),
+    url(r'^start_certificate_regeneration', api.start_certificate_regeneration, name='start_certificate_regeneration'),
+    url(r'^certificate_exception_view/$', api.certificate_exception_view, name='certificate_exception_view'),
+    url(r'^generate_certificate_exceptions/(?P<generate_for>[^/]*)', api.generate_certificate_exceptions,
         name='generate_certificate_exceptions'),
-
-    url(r'^generate_bulk_certificate_exceptions',
-        'lms.djangoapps.instructor.views.api.generate_bulk_certificate_exceptions',
+    url(r'^generate_bulk_certificate_exceptions', api.generate_bulk_certificate_exceptions,
         name='generate_bulk_certificate_exceptions'),
-
-    url(r'^certificate_invalidation_view/$',
-        'lms.djangoapps.instructor.views.api.certificate_invalidation_view',
-        name='certificate_invalidation_view'),
-)
+    url(r'^certificate_invalidation_view/$', api.certificate_invalidation_view, name='certificate_invalidation_view'),
+]

--- a/lms/djangoapps/lti_provider/urls.py
+++ b/lms/djangoapps/lti_provider/urls.py
@@ -3,15 +3,15 @@ LTI Provider API endpoint urls.
 """
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    '',
+from lti_provider import views
 
+urlpatterns = [
     url(
         r'^courses/{course_id}/{usage_id}$'.format(
             course_id=settings.COURSE_ID_PATTERN,
             usage_id=settings.USAGE_ID_PATTERN
         ),
-        'lti_provider.views.lti_launch', name="lti_provider_launch"),
-)
+        views.lti_launch, name="lti_provider_launch"),
+]

--- a/lms/djangoapps/mobile_api/course_info/urls.py
+++ b/lms/djangoapps/mobile_api/course_info/urls.py
@@ -1,13 +1,13 @@
 """
 URLs for course_info API
 """
+
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import CourseHandoutsList, CourseUpdatesList
 
-urlpatterns = patterns(
-    'mobile_api.course_info.views',
+urlpatterns = [
     url(
         r'^{}/handouts$'.format(settings.COURSE_ID_PATTERN),
         CourseHandoutsList.as_view(),
@@ -18,4 +18,4 @@ urlpatterns = patterns(
         CourseUpdatesList.as_view(),
         name='course-updates-list'
     ),
-)
+]

--- a/lms/djangoapps/mobile_api/urls.py
+++ b/lms/djangoapps/mobile_api/urls.py
@@ -1,14 +1,14 @@
 """
 URLs for mobile API
 """
-from django.conf.urls import include, patterns, url
+
+from django.conf.urls import include, url
 
 from .users.views import my_user_info
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^users/', include('mobile_api.users.urls')),
     url(r'^my_user_info', my_user_info),
     url(r'^video_outlines/', include('mobile_api.video_outlines.urls')),
     url(r'^course_info/', include('mobile_api.course_info.urls')),
-)
+]

--- a/lms/djangoapps/mobile_api/users/urls.py
+++ b/lms/djangoapps/mobile_api/users/urls.py
@@ -1,13 +1,13 @@
 """
 URLs for user API
 """
+
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import UserCourseEnrollmentsList, UserCourseStatus, UserDetail
 
-urlpatterns = patterns(
-    'mobile_api.users.views',
+urlpatterns = [
     url('^' + settings.USERNAME_PATTERN + '$', UserDetail.as_view(), name='user-detail'),
     url(
         '^' + settings.USERNAME_PATTERN + '/course_enrollments/$',
@@ -17,4 +17,4 @@ urlpatterns = patterns(
     url('^{}/course_status_info/{}'.format(settings.USERNAME_PATTERN, settings.COURSE_ID_PATTERN),
         UserCourseStatus.as_view(),
         name='user-course-status')
-)
+]

--- a/lms/djangoapps/mobile_api/video_outlines/urls.py
+++ b/lms/djangoapps/mobile_api/video_outlines/urls.py
@@ -1,13 +1,13 @@
 """
 URLs for video outline API
 """
+
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import VideoSummaryList, VideoTranscripts
 
-urlpatterns = patterns(
-    'mobile_api.video_outlines.views',
+urlpatterns = [
     url(
         r'^courses/{}$'.format(settings.COURSE_ID_PATTERN),
         VideoSummaryList.as_view(),
@@ -18,4 +18,4 @@ urlpatterns = patterns(
         VideoTranscripts.as_view(),
         name='video-transcripts-detail'
     ),
-)
+]

--- a/lms/djangoapps/notes/urls.py
+++ b/lms/djangoapps/notes/urls.py
@@ -1,9 +1,15 @@
-from django.conf.urls import patterns, url
+"""
+URL definitions for the notes app
+"""
+
+from django.conf.urls import url
+
+from notes.api import api_request
 
 id_regex = r"(?P<note_id>[0-9A-Fa-f]+)"
-urlpatterns = patterns('notes.api',
-                       url(r'^api$', 'api_request', {'resource': 'root'}, name='notes_api_root'),
-                       url(r'^api/annotations$', 'api_request', {'resource': 'notes'}, name='notes_api_notes'),
-                       url(r'^api/annotations/' + id_regex + r'$', 'api_request', {'resource': 'note'}, name='notes_api_note'),
-                       url(r'^api/search', 'api_request', {'resource': 'search'}, name='notes_api_search')
-                       )
+urlpatterns = [
+    url(r'^api$', api_request, {'resource': 'root'}, name='notes_api_root'),
+    url(r'^api/annotations$', api_request, {'resource': 'notes'}, name='notes_api_notes'),
+    url(r'^api/annotations/' + id_regex + r'$', api_request, {'resource': 'note'}, name='notes_api_note'),
+    url(r'^api/search', api_request, {'resource': 'search'}, name='notes_api_search')
+]

--- a/lms/djangoapps/notifier_api/urls.py
+++ b/lms/djangoapps/notifier_api/urls.py
@@ -1,11 +1,15 @@
-from django.conf.urls import include, patterns, url
+"""
+URLs for the notifier api app
+"""
+
+from django.conf.urls import include, url
 from rest_framework import routers
 
 from notifier_api.views import NotifierUsersViewSet
 
 notifier_api_router = routers.DefaultRouter()
 notifier_api_router.register(r'users', NotifierUsersViewSet, base_name="notifier_users")
-urlpatterns = patterns(
-    '',
+
+urlpatterns = [
     url(r'^v1/', include(notifier_api_router.urls)),
-)
+]

--- a/lms/djangoapps/rss_proxy/urls.py
+++ b/lms/djangoapps/rss_proxy/urls.py
@@ -3,6 +3,8 @@ URLs for the rss_proxy djangoapp.
 """
 from django.conf.urls import url
 
+from rss_proxy.views import proxy
+
 urlpatterns = [
-    url(r"^$", "rss_proxy.views.proxy", name="proxy"),
+    url(r'^$', proxy, name='proxy'),
 ]

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -1383,7 +1383,7 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
         self._assert_404(reverse('shoppingcart.views.use_code', args=[]), use_post=True)
         self._assert_404(reverse('shoppingcart.views.update_user_cart', args=[]))
         self._assert_404(reverse('shoppingcart.views.reset_code_redemption', args=[]), use_post=True)
-        self._assert_404(reverse('shoppingcart.views.billing_details', args=[]))
+        self._assert_404(reverse('billing_details', args=[]))
 
     def test_upgrade_postpay_callback_emits_ga_event(self):
         # Enroll as honor in the course with the current user.
@@ -1693,7 +1693,7 @@ class ShoppingcartViewsClosedEnrollment(ModuleStoreTestCase):
         self.testing_course.enrollment_end = self.nextday
         self.testing_course = self.update_course(self.testing_course, self.user.id)
 
-        resp = self.client.post(reverse('shoppingcart.views.billing_details'))
+        resp = self.client.post(reverse('billing_details'))
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(json.loads(resp.content)['is_course_enrollment_closed'])
 

--- a/lms/djangoapps/shoppingcart/urls.py
+++ b/lms/djangoapps/shoppingcart/urls.py
@@ -1,29 +1,36 @@
+"""
+Defines the shoppingcart URLs
+"""
+
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    'shoppingcart.views',
+from shoppingcart import views
 
-    url(r'^postpay_callback/$', 'postpay_callback'),  # Both the ~accept and ~reject callback pages are handled here
-    url(r'^receipt/(?P<ordernum>[0-9]*)/$', 'show_receipt'),
-    url(r'^donation/$', 'donate', name='donation'),
-    url(r'^csv_report/$', 'csv_report', name='payment_csv_report'),
+urlpatterns = [
+    # Both the ~accept and ~reject callback pages are handled here
+    url(r'^postpay_callback/$', views.postpay_callback, name='shoppingcart.views.postpay_callback'),
+
+    url(r'^receipt/(?P<ordernum>[0-9]*)/$', views.show_receipt, name='shoppingcart.views.show_receipt'),
+    url(r'^donation/$', views.donate, name='donation'),
+    url(r'^csv_report/$', views.csv_report, name='payment_csv_report'),
+
     # These following URLs are only valid if the ENABLE_SHOPPING_CART feature flag is set
-    url(r'^$', 'show_cart'),
-    url(r'^clear/$', 'clear_cart'),
-    url(r'^remove_item/$', 'remove_item'),
-    url(r'^add/course/{}/$'.format(settings.COURSE_ID_PATTERN), 'add_course_to_cart', name='add_course_to_cart'),
-    url(r'^register/redeem/(?P<registration_code>[0-9A-Za-z]+)/$', 'register_code_redemption', name='register_code_redemption'),
-    url(r'^use_code/$', 'use_code'),
-    url(r'^update_user_cart/$', 'update_user_cart'),
-    url(r'^reset_code_redemption/$', 'reset_code_redemption'),
-    url(r'^billing_details/$', 'billing_details', name='billing_details'),
-    url(r'^verify_cart/$', 'verify_cart'),
-)
+    url(r'^$', views.show_cart, name='shoppingcart.views.show_cart'),
+    url(r'^clear/$', views.clear_cart, name='shoppingcart.views.clear_cart'),
+    url(r'^remove_item/$', views.remove_item, name='shoppingcart.views.remove_item'),
+    url(r'^add/course/{}/$'.format(settings.COURSE_ID_PATTERN), views.add_course_to_cart, name='add_course_to_cart'),
+    url(r'^register/redeem/(?P<registration_code>[0-9A-Za-z]+)/$',
+        views.register_code_redemption, name='register_code_redemption'),
+    url(r'^use_code/$', views.use_code, name='shoppingcart.views.use_code'),
+    url(r'^update_user_cart/$', views.update_user_cart, name='shoppingcart.views.update_user_cart'),
+    url(r'^reset_code_redemption/$', views.reset_code_redemption, name='shoppingcart.views.reset_code_redemption'),
+    url(r'^billing_details/$', views.billing_details, name='billing_details'),
+    url(r'^verify_cart/$', views.verify_cart, name='shoppingcart.views.verify_cart'),
+]
 
 if settings.FEATURES.get('ENABLE_PAYMENT_FAKE'):
     from shoppingcart.tests.payment_fake import PaymentFakeView
-    urlpatterns += patterns(
-        'shoppingcart.tests.payment_fake',
-        url(r'^payment_fake', PaymentFakeView.as_view()),
-    )
+    urlpatterns += [
+        url(r'^payment_fake', PaymentFakeView.as_view(), name='shoppingcart.views.payment_fake'),
+    ]

--- a/lms/djangoapps/static_template_view/urls.py
+++ b/lms/djangoapps/static_template_view/urls.py
@@ -3,34 +3,31 @@ URLs for static_template_view app
 """
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = (
-    'static_template_view.views',
+from static_template_view import views
 
-    # TODO: Is this used anymore? What is STATIC_GRAB?
-    url(r'^t/(?P<template>[^/]*)$', 'index'),
-
+urlpatterns = [
     # Semi-static views (these need to be rendered and have the login bar, but don't change)
-    url(r'^404$', 'render', {'template': '404.html'}, name="404"),
+    url(r'^404$', views.render, {'template': '404.html'}, name="404"),
     # display error page templates, for testing purposes
-    url(r'^404$', 'render_404'),  # Can this be deleted? Test test_404_microsites fails with this.
-    url(r'^500$', 'render_500'),
+    url(r'^404$', views.render_404),  # Can this be deleted? Test test_404_microsites fails with this.
+    url(r'^500$', views.render_500),
 
-    url(r'^blog$', 'render', {'template': 'blog.html'}, name="blog"),
-    url(r'^contact$', 'render', {'template': 'contact.html'}, name="contact"),
-    url(r'^donate$', 'render', {'template': 'donate.html'}, name="donate"),
-    url(r'^faq$', 'render', {'template': 'faq.html'}, name="faq"),
-    url(r'^help$', 'render', {'template': 'help.html'}, name="help_edx"),
-    url(r'^jobs$', 'render', {'template': 'jobs.html'}, name="jobs"),
-    url(r'^news$', 'render', {'template': 'news.html'}, name="news"),
-    url(r'^press$', 'render', {'template': 'press.html'}, name="press"),
-    url(r'^media-kit$', 'render', {'template': 'media-kit.html'}, name="media-kit"),
-    url(r'^copyright$', 'render', {'template': 'copyright.html'}, name="copyright"),
+    url(r'^blog$', views.render, {'template': 'blog.html'}, name="blog"),
+    url(r'^contact$', views.render, {'template': 'contact.html'}, name="contact"),
+    url(r'^donate$', views.render, {'template': 'donate.html'}, name="donate"),
+    url(r'^faq$', views.render, {'template': 'faq.html'}, name="faq"),
+    url(r'^help$', views.render, {'template': 'help.html'}, name="help_edx"),
+    url(r'^jobs$', views.render, {'template': 'jobs.html'}, name="jobs"),
+    url(r'^news$', views.render, {'template': 'news.html'}, name="news"),
+    url(r'^press$', views.render, {'template': 'press.html'}, name="press"),
+    url(r'^media-kit$', views.render, {'template': 'media-kit.html'}, name="media-kit"),
+    url(r'^copyright$', views.render, {'template': 'copyright.html'}, name="copyright"),
 
     # Press releases
-    url(r'^press/([_a-zA-Z0-9-]+)$', 'render_press_release', name='press_release'),
-)
+    url(r'^press/([_a-zA-Z0-9-]+)$', views.render_press_release, name='press_release'),
+]
 
 # Only enable URLs for those marketing links actually enabled in the
 # settings. Disable URLs by marking them as None.
@@ -52,6 +49,4 @@ for key, value in settings.MKTG_URL_LINK_MAP.items():
 
     # Make the assumption that the URL we want is the lowercased
     # version of the map key
-    urlpatterns += (url(r'^%s$' % key.lower(), 'render', {'template': template}, name=value),)
-
-urlpatterns = patterns(*urlpatterns)
+    urlpatterns.append(url(r'^%s$' % key.lower(), views.render, {'template': template}, name=value))

--- a/lms/djangoapps/student_account/urls.py
+++ b/lms/djangoapps/student_account/urls.py
@@ -1,16 +1,14 @@
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = []
+from student_account import views
+
+urlpatterns = [
+    url(r'^finish_auth$', views.finish_auth, name='finish_auth'),
+    url(r'^settings$', views.account_settings, name='account_settings'),
+]
 
 if settings.FEATURES.get('ENABLE_COMBINED_LOGIN_REGISTRATION'):
-    urlpatterns += patterns(
-        'student_account.views',
-        url(r'^password$', 'password_change_request_handler', name='password_change_request'),
-    )
-
-urlpatterns += patterns(
-    'student_account.views',
-    url(r'^finish_auth$', 'finish_auth', name='finish_auth'),
-    url(r'^settings$', 'account_settings', name='account_settings'),
-)
+    urlpatterns += [
+        url(r'^password$', views.password_change_request_handler, name='password_change_request'),
+    ]

--- a/lms/djangoapps/support/urls.py
+++ b/lms/djangoapps/support/urls.py
@@ -1,14 +1,13 @@
 """
 URLs for the student support app.
 """
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from support import views
 
 from lms.djangoapps.support.views.contact_us import ContactUsView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', views.index, name="index"),
     url(r'^certificates/?$', views.CertificatesSupportView.as_view(), name="certificates"),
     url(r'^refund/?$', views.RefundSupportView.as_view(), name="refund"),
@@ -19,4 +18,4 @@ urlpatterns = patterns(
         views.EnrollmentSupportListView.as_view(),
         name="enrollment_list"
     ),
-)
+]

--- a/lms/djangoapps/survey/urls.py
+++ b/lms/djangoapps/survey/urls.py
@@ -2,11 +2,11 @@
 URL mappings for the Survey feature
 """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    'survey.views',
+from survey import views
 
-    url(r'^(?P<survey_name>[0-9A-Za-z]+)/$', 'view_survey', name='view_survey'),
-    url(r'^(?P<survey_name>[0-9A-Za-z]+)/answers/$', 'submit_answers', name='submit_answers'),
-)
+urlpatterns = [
+    url(r'^(?P<survey_name>[0-9A-Za-z]+)/$', views.view_survey, name='view_survey'),
+    url(r'^(?P<survey_name>[0-9A-Za-z]+)/answers/$', views.submit_answers, name='submit_answers'),
+]

--- a/lms/djangoapps/teams/api_urls.py
+++ b/lms/djangoapps/teams/api_urls.py
@@ -1,7 +1,9 @@
-"""Defines the URL routes for the Team API."""
+"""
+Defines the URL routes for the Team API.
+"""
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import (
     MembershipDetailView,
@@ -15,8 +17,7 @@ from .views import (
 TEAM_ID_PATTERN = r'(?P<team_id>[a-z\d_-]+)'
 TOPIC_ID_PATTERN = r'(?P<topic_id>[A-Za-z\d_.-]+)'
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         r'^v0/teams/$',
         TeamsListView.as_view(),
@@ -55,4 +56,4 @@ urlpatterns = patterns(
         MembershipDetailView.as_view(),
         name="team_membership_detail"
     )
-)
+]

--- a/lms/djangoapps/teams/urls.py
+++ b/lms/djangoapps/teams/urls.py
@@ -1,11 +1,12 @@
-"""Defines the URL routes for this app."""
+"""
+Defines the URL routes for this app.
+"""
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
 from .views import TeamsDashboardView
 
-urlpatterns = patterns(
-    'teams.views',
+urlpatterns = [
     url(r"^/$", login_required(TeamsDashboardView.as_view()), name="teams_dashboard")
-)
+]

--- a/lms/djangoapps/verify_student/urls.py
+++ b/lms/djangoapps/verify_student/urls.py
@@ -1,13 +1,13 @@
-""" URL definitions for the verify_student app. """
+"""
+URL definitions for the verify_student app.
+"""
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from lms.djangoapps.verify_student import views
 
-urlpatterns = patterns(
-    '',
-
+urlpatterns = [
     # The user is starting the verification / payment process,
     # most likely after enrolling in a course and selecting
     # a "verified" track.
@@ -104,12 +104,11 @@ urlpatterns = patterns(
         views.ReverifyView.as_view(),
         name="verify_student_reverify"
     ),
-)
+]
 
 # Fake response page for incourse reverification ( software secure )
 if settings.FEATURES.get('ENABLE_SOFTWARE_SECURE_FAKE'):
     from lms.djangoapps.verify_student.tests.fake_software_secure import SoftwareSecureFakeView
-    urlpatterns += patterns(
-        'verify_student.tests.fake_software_secure',
+    urlpatterns += [
         url(r'^software-secure-fake-response', SoftwareSecureFakeView.as_view()),
-    )
+    ]

--- a/lms/templates/shoppingcart/shopping_cart.html
+++ b/lms/templates/shoppingcart/shopping_cart.html
@@ -297,7 +297,7 @@ from openedx.core.lib.courses import course_image_url
           return false;
        }
        event.preventDefault();
-       location.href = "${reverse('shoppingcart.views.billing_details')}";
+       location.href = "${reverse('billing_details')}";
    });
 
 


### PR DESCRIPTION
- Remove usage of django.urls.patterns
- Change urls tuples to lists
- Make all string view names callables
- This is the third urls update for LMS