### PR TITLE
PLAT-1774 Move x_module monkey-patching

### DIFF
--- a/cms/djangoapps/xblock_config/apps.py
+++ b/cms/djangoapps/xblock_config/apps.py
@@ -1,0 +1,26 @@
+"""
+xblock_config Application Configuration
+"""
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+import cms.lib.xblock.runtime
+import xmodule.x_module
+from openedx.core.lib.xblock_utils import xblock_local_resource_url
+
+
+class XBlockConfig(AppConfig):
+    """
+    Default configuration for the "xblock_config" Django application.
+    """
+    name = u'xblock_config'
+    verbose_name = u'XBlock Configuration'
+
+    def ready(self):
+        # In order to allow descriptors to use a handler url, we need to
+        # monkey-patch the x_module library.
+        # TODO: Remove this code when Runtimes are no longer created by modulestores
+        # https://openedx.atlassian.net/wiki/display/PLAT/Convert+from+Storage-centric+runtimes+to+Application-centric+runtimes
+        xmodule.x_module.descriptor_global_handler_url = cms.lib.xblock.runtime.handler_url
+        xmodule.x_module.descriptor_global_local_resource_url = xblock_local_resource_url

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -955,7 +955,7 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.external_auth',
     'student',  # misleading name due to sharing with lms
     'openedx.core.djangoapps.course_groups',  # not used in cms (yet), but tests run
-    'xblock_config',
+    'xblock_config.apps.XBlockConfig',
 
     # Maintenance tools
     'maintenance',

--- a/cms/startup.py
+++ b/cms/startup.py
@@ -5,16 +5,12 @@ Module with code executed during Studio startup
 import django
 from django.conf import settings
 
-import cms.lib.xblock.runtime
-import xmodule.x_module
 from openedx.core.djangoapps.monkey_patch import django_db_models_options
 from openedx.core.lib.django_startup import autostartup
 
 # Force settings to run so that the python path is modified
 
 settings.INSTALLED_APPS  # pylint: disable=pointless-statement
-
-from openedx.core.lib.xblock_utils import xblock_local_resource_url
 
 
 def run():
@@ -31,13 +27,6 @@ def run():
     autostartup()
 
     add_mimetypes()
-
-    # In order to allow descriptors to use a handler url, we need to
-    # monkey-patch the x_module library.
-    # TODO: Remove this code when Runtimes are no longer created by modulestores
-    # https://openedx.atlassian.net/wiki/display/PLAT/Convert+from+Storage-centric+runtimes+to+Application-centric+runtimes
-    xmodule.x_module.descriptor_global_handler_url = cms.lib.xblock.runtime.handler_url
-    xmodule.x_module.descriptor_global_local_resource_url = xblock_local_resource_url
 
 
 def add_mimetypes():

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1270,7 +1270,7 @@ class ConfigurableFragmentWrapper(object):
 # the Runtime part of its interface. This function mostly matches the
 # Runtime.handler_url interface.
 #
-# The monkey-patching happens in (lms|cms)/startup.py
+# The monkey-patching happens in cms/djangoapps/xblock_config/apps.py and lms/djangoapps/lms_xblock/apps.py
 def descriptor_global_handler_url(block, handler_name, suffix='', query='', thirdparty=False):  # pylint: disable=unused-argument
     """
     See :meth:`xblock.runtime.Runtime.handler_url`.
@@ -1282,7 +1282,7 @@ def descriptor_global_handler_url(block, handler_name, suffix='', query='', thir
 # we can refactor modulestore to split out the FieldData half of its interface from
 # the Runtime part of its interface. This function matches the Runtime.local_resource_url interface
 #
-# The monkey-patching happens in (lms|cms)/startup.py
+# The monkey-patching happens in cms/djangoapps/xblock_config/apps.py and lms/djangoapps/lms_xblock/apps.py
 def descriptor_global_local_resource_url(block, uri):  # pylint: disable=invalid-name, unused-argument
     """
     See :meth:`xblock.runtime.Runtime.local_resource_url`.

--- a/lms/djangoapps/lms_xblock/apps.py
+++ b/lms/djangoapps/lms_xblock/apps.py
@@ -1,0 +1,25 @@
+"""
+lms_xblock Application Configuration
+"""
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+import xmodule.x_module
+from .runtime import handler_url, local_resource_url
+
+
+class LMSXBlockConfig(AppConfig):
+    """
+    Default configuration for the "lms.djangoapps.lms_xblock" Django application.
+    """
+    name = u'lms.djangoapps.lms_xblock'
+    verbose_name = u'LMS XBlock'
+
+    def ready(self):
+        # In order to allow modules to use a handler url, we need to
+        # monkey-patch the x_module library.
+        # TODO: Remove this code when Runtimes are no longer created by modulestores
+        # https://openedx.atlassian.net/wiki/display/PLAT/Convert+from+Storage-centric+runtimes+to+Application-centric+runtimes
+        xmodule.x_module.descriptor_global_handler_url = handler_url
+        xmodule.x_module.descriptor_global_local_resource_url = local_resource_url

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2218,7 +2218,7 @@ INSTALLED_APPS = [
     # Surveys
     'survey',
 
-    'lms.djangoapps.lms_xblock',
+    'lms.djangoapps.lms_xblock.apps.LMSXBlockConfig',
 
     # Course data caching
     'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig',

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -15,9 +15,6 @@ from openedx.core.lib.django_startup import autostartup
 
 from openedx.core.djangoapps.monkey_patch import django_db_models_options
 
-import xmodule.x_module
-import lms_xblock.runtime
-
 log = logging.getLogger(__name__)
 
 
@@ -35,13 +32,6 @@ def run():
     autostartup()
 
     add_mimetypes()
-
-    # In order to allow modules to use a handler url, we need to
-    # monkey-patch the x_module library.
-    # TODO: Remove this code when Runtimes are no longer created by modulestores
-    # https://openedx.atlassian.net/wiki/display/PLAT/Convert+from+Storage-centric+runtimes+to+Application-centric+runtimes
-    xmodule.x_module.descriptor_global_handler_url = lms_xblock.runtime.handler_url
-    xmodule.x_module.descriptor_global_local_resource_url = lms_xblock.runtime.local_resource_url
 
 
 def add_mimetypes():


### PR DESCRIPTION
Moving the currently required monkey-patching of two x_module functions from the deprecated `startup.py` modules to the initialization of appropriate Django apps.