### PR TITLE
Schedules: absolute_url returns given URL if already absolute

### DIFF
--- a/openedx/core/djangoapps/schedules/template_context.py
+++ b/openedx/core/djangoapps/schedules/template_context.py
@@ -31,6 +31,13 @@ def encode_url(url):
 
 
 def absolute_url(site, relative_path):
+    """Add site.domain to the beginning of the given relative path.
+
+    If the given URL is already absolute (has a netloc part), then it is just returned.
+    """
+    if bool(urlparse(relative_path).netloc):
+        # Given URL is already absolute
+        return relative_path
     root = site.domain.rstrip('/')
     relative_path = relative_path.lstrip('/')
     return encode_url(u'https://{root}/{path}'.format(root=root, path=relative_path))

--- a/openedx/core/djangoapps/schedules/template_context.py
+++ b/openedx/core/djangoapps/schedules/template_context.py
@@ -31,7 +31,8 @@ def encode_url(url):
 
 
 def absolute_url(site, relative_path):
-    """Add site.domain to the beginning of the given relative path.
+    """
+    Add site.domain to the beginning of the given relative path.
 
     If the given URL is already absolute (has a netloc part), then it is just returned.
     """

--- a/openedx/core/djangoapps/schedules/tests/test_template_context.py
+++ b/openedx/core/djangoapps/schedules/tests/test_template_context.py
@@ -1,0 +1,23 @@
+from openedx.core.djangoapps.schedules.template_context import absolute_url
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
+
+
+@skip_unless_lms
+class TestTemplateContext(CacheIsolationTestCase):
+    def setUp(self):
+        self.site = SiteFactory.create()
+        self.site.domain = 'example.com'
+
+    def test_absolute_url(self):
+        absolute = absolute_url(self.site, '/foo/bar')
+        self.assertEqual(absolute, 'https://example.com/foo/bar')
+
+    def test_absolute_url_domain_lstrip(self):
+        self.site.domain = 'example.com/'
+        absolute = absolute_url(self.site, 'foo/bar')
+        self.assertEqual(absolute, 'https://example.com/foo/bar')
+
+    def test_absolute_url_already_absolute(self):
+        absolute = absolute_url(self.site, 'https://some-cdn.com/foo/bar')
+        self.assertEqual(absolute, 'https://some-cdn.com/foo/bar')


### PR DESCRIPTION
Fixes a bug that @mulby saw with the upgrade_reminder emails.

FYI @edx/rapid-experiments-team 