### PR TITLE
django_comment_client management command cleanup for Django 1.11

### DIFF
--- a/lms/djangoapps/django_comment_client/management/commands/assign_role.py
+++ b/lms/djangoapps/django_comment_client/management/commands/assign_role.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
-
 from django_comment_common.models import Role
 
 

--- a/lms/djangoapps/django_comment_client/management/commands/assign_role.py
+++ b/lms/djangoapps/django_comment_client/management/commands/assign_role.py
@@ -1,28 +1,29 @@
-from optparse import make_option
+from __future__ import print_function
 
 from django.contrib.auth.models import User
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from django_comment_common.models import Role
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--remove',
-                    action='store_true',
-                    dest='remove',
-                    default=False,
-                    help='Remove the role instead of adding it'),
-    )
+    help = 'Assign a discussion forum role to a user.'
 
-    args = '<user|email> <role> <course_id>'
-    help = 'Assign a discussion forum role to a user '
+    def add_arguments(self, parser):
+        parser.add_argument('name_or_email',
+                            help='username or email address of the user to assign a role')
+        parser.add_argument('role',
+                            help='the role to which the user will be assigned')
+        parser.add_argument('course_id',
+                            help='the edx course_id')
+        parser.add_argument('--remove',
+                            action='store_true',
+                            help='remove the role instead of adding/assigning it')
 
     def handle(self, *args, **options):
-        if len(args) != 3:
-            raise CommandError('Usage is assign_role {0}'.format(self.args))
-
-        name_or_email, role, course_id = args
+        name_or_email = options['name_or_email']
+        role = options['role']
+        course_id = options['course_id']
 
         role = Role.objects.get(name=role, course_id=course_id)
 
@@ -36,4 +37,4 @@ class Command(BaseCommand):
         else:
             user.roles.add(role)
 
-        print 'Success!'
+        print('Success!')

--- a/lms/djangoapps/django_comment_client/management/commands/assign_roles_for_course.py
+++ b/lms/djangoapps/django_comment_client/management/commands/assign_roles_for_course.py
@@ -7,7 +7,6 @@ Enrollments.
 from __future__ import print_function
 
 from django.core.management.base import BaseCommand
-
 from django_comment_common.models import assign_default_role_on_enrollment
 from student.models import CourseEnrollment
 

--- a/lms/djangoapps/django_comment_client/management/commands/assign_roles_for_course.py
+++ b/lms/djangoapps/django_comment_client/management/commands/assign_roles_for_course.py
@@ -4,26 +4,27 @@ This must be run only after seed_permissions_roles.py!
 Creates default roles for all users in the provided course. Just runs through
 Enrollments.
 """
-from django.core.management.base import BaseCommand, CommandError
+from __future__ import print_function
+
+from django.core.management.base import BaseCommand
 
 from django_comment_common.models import assign_default_role_on_enrollment
 from student.models import CourseEnrollment
 
 
 class Command(BaseCommand):
-    args = 'course_id'
-    help = 'Add roles for all users in a course'
+    help = 'Add roles for all users in a course.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('course_id',
+                            help='the edx course_id')
 
     def handle(self, *args, **options):
-        if len(args) == 0:
-            raise CommandError("Please provide a course id")
-        if len(args) > 1:
-            raise CommandError("Too many arguments")
-        course_id = args[0]
+        course_id = options['course_id']
 
-        print "Updated roles for ",
+        print('Updated roles for ', end=' ')
         for i, enrollment in enumerate(CourseEnrollment.objects.filter(course_id=course_id, is_active=1), start=1):
             assign_default_role_on_enrollment(None, enrollment)
             if i % 1000 == 0:
-                print "{0}...".format(i),
-        print
+                print('{0}...'.format(i), end=' ')
+        print()

--- a/lms/djangoapps/django_comment_client/management/commands/create_roles_for_existing.py
+++ b/lms/djangoapps/django_comment_client/management/commands/create_roles_for_existing.py
@@ -4,23 +4,21 @@ This must be run only after seed_permissions_roles.py!
 Creates default roles for all users currently in the database. Just runs through
 Enrollments.
 """
-from django.core.management.base import BaseCommand, CommandError
+from __future__ import print_function
+
+from django.core.management.base import BaseCommand
 
 from django_comment_common.models import assign_default_role_on_enrollment
 from student.models import CourseEnrollment
 
 
 class Command(BaseCommand):
-    args = 'course_id'
-    help = 'Seed default permisssions and roles'
+    help = 'Seed default permisssions and roles.'
 
     def handle(self, *args, **options):
-        if len(args) != 0:
-            raise CommandError("This Command takes no arguments")
-
-        print "Updated roles for ",
+        print("Updated roles for ", end=' ')
         for i, enrollment in enumerate(CourseEnrollment.objects.filter(is_active=1), start=1):
             assign_default_role_on_enrollment(None, enrollment)
             if i % 1000 == 0:
-                print "{0}...".format(i),
-        print
+                print('{0}...'.format(i), end=' ')
+        print()

--- a/lms/djangoapps/django_comment_client/management/commands/create_roles_for_existing.py
+++ b/lms/djangoapps/django_comment_client/management/commands/create_roles_for_existing.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
     help = 'Seed default permisssions and roles.'
 
     def handle(self, *args, **options):
-        print("Updated roles for ", end=' ')
+        print('Updated roles for ', end=' ')
         for i, enrollment in enumerate(CourseEnrollment.objects.filter(is_active=1), start=1):
             assign_default_role_on_enrollment(None, enrollment)
             if i % 1000 == 0:

--- a/lms/djangoapps/django_comment_client/management/commands/create_roles_for_existing.py
+++ b/lms/djangoapps/django_comment_client/management/commands/create_roles_for_existing.py
@@ -7,7 +7,6 @@ Enrollments.
 from __future__ import print_function
 
 from django.core.management.base import BaseCommand
-
 from django_comment_common.models import assign_default_role_on_enrollment
 from student.models import CourseEnrollment
 

--- a/lms/djangoapps/django_comment_client/management/commands/get_discussion_link.py
+++ b/lms/djangoapps/django_comment_client/management/commands/get_discussion_link.py
@@ -5,14 +5,14 @@ from courseware.courses import get_course
 
 
 class Command(BaseCommand):
-    args = "<course_id>"
+    help = "Write a discussion link for a given course on standard output."
+
+    def add_arguments(self, parser):
+        parser.add_argument('course_id',
+                            help='course for which to write a discussion link')
 
     def handle(self, *args, **options):
-        if not args:
-            raise CommandError("Course id not specified")
-        if len(args) > 1:
-            raise CommandError("Only one course id may be specifiied")
-        course_id = args[0]
+        course_id = options['course_id']
 
         course_key = CourseKey.from_string(course_id)
 

--- a/lms/djangoapps/django_comment_client/management/commands/get_discussion_link.py
+++ b/lms/djangoapps/django_comment_client/management/commands/get_discussion_link.py
@@ -5,7 +5,7 @@ from courseware.courses import get_course
 
 
 class Command(BaseCommand):
-    help = "Write a discussion link for a given course on standard output."
+    help = 'Write a discussion link for a given course on standard output.'
 
     def add_arguments(self, parser):
         parser.add_argument('course_id',
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
         course = get_course(course_key)
         if not course:
-            raise CommandError("Invalid course id: {}".format(course_id))
+            raise CommandError('Invalid course id: {}'.format(course_id))
 
         if course.discussion_link:
             self.stdout.write(course.discussion_link)

--- a/lms/djangoapps/django_comment_client/management/commands/get_discussion_link.py
+++ b/lms/djangoapps/django_comment_client/management/commands/get_discussion_link.py
@@ -1,7 +1,6 @@
+from courseware.courses import get_course
 from django.core.management.base import BaseCommand, CommandError
 from opaque_keys.edx.keys import CourseKey
-
-from courseware.courses import get_course
 
 
 class Command(BaseCommand):

--- a/lms/djangoapps/django_comment_client/management/commands/reload_forum_users.py
+++ b/lms/djangoapps/django_comment_client/management/commands/reload_forum_users.py
@@ -1,6 +1,8 @@
 """
 Reload forum (comment client) users from existing users.
 """
+from __future__ import print_function
+
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 
@@ -8,21 +10,27 @@ import lms.lib.comment_client as cc
 
 
 class Command(BaseCommand):
-    help = 'Reload forum (comment client) users from existing users'
+    help = 'Reload forum (comment client) users from existing users.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('usernames',
+                            nargs='*',
+                            metavar='username',
+                            help='zero or more usernames (zero implies all users)')
 
     def adduser(self, user):
-        print user
+        print(user)
         try:
             cc_user = cc.User.from_django_user(user)
             cc_user.save()
         except Exception as err:
-            print "update user info to discussion failed for user with id: %s, error=%s" % (user, str(err))
+            print('update user info to discussion failed for user with id: {}, error={}'.format(user, str(err)))
 
     def handle(self, *args, **options):
-        if len(args) != 0:
-            uset = [User.objects.get(username=x) for x in args]
+        if len(options['usernames']) >= 1:
+            user_list = User.objects.filter(username__in=options['usernames'])
         else:
-            uset = User.objects.all()
+            user_list = User.objects.all()
 
-        for user in uset:
+        for user in user_list:
             self.adduser(user)

--- a/lms/djangoapps/django_comment_client/management/commands/reload_forum_users.py
+++ b/lms/djangoapps/django_comment_client/management/commands/reload_forum_users.py
@@ -3,10 +3,9 @@ Reload forum (comment client) users from existing users.
 """
 from __future__ import print_function
 
+import lms.lib.comment_client as cc
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
-
-import lms.lib.comment_client as cc
 
 
 class Command(BaseCommand):

--- a/lms/djangoapps/django_comment_client/management/commands/seed_permissions_roles.py
+++ b/lms/djangoapps/django_comment_client/management/commands/seed_permissions_roles.py
@@ -2,9 +2,8 @@
 Management command to seed default permissions and roles.
 """
 from django.core.management.base import BaseCommand
-from opaque_keys.edx.keys import CourseKey
-
 from django_comment_common.utils import seed_permissions_roles
+from opaque_keys.edx.keys import CourseKey
 
 
 class Command(BaseCommand):

--- a/lms/djangoapps/django_comment_client/management/commands/seed_permissions_roles.py
+++ b/lms/djangoapps/django_comment_client/management/commands/seed_permissions_roles.py
@@ -1,21 +1,21 @@
 """
 Management command to seed default permissions and roles.
 """
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from opaque_keys.edx.keys import CourseKey
 
 from django_comment_common.utils import seed_permissions_roles
 
 
 class Command(BaseCommand):
-    args = 'course_id'
-    help = 'Seed default permisssions and roles'
+    help = 'Seed default permisssions and roles.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('course_id',
+                            help='the edx course_id')
 
     def handle(self, *args, **options):
-        if len(args) == 0:
-            raise CommandError("Please provide a course id")
-        if len(args) > 1:
-            raise CommandError("Too many arguments")
-        course_id = CourseKey.from_string(args[0])
+        course_id = options['course_id']
 
-        seed_permissions_roles(course_id)
+        course_key = CourseKey.from_string(course_id)
+        seed_permissions_roles(course_key)

--- a/lms/djangoapps/django_comment_client/management/commands/show_permissions.py
+++ b/lms/djangoapps/django_comment_client/management/commands/show_permissions.py
@@ -1,31 +1,34 @@
+from __future__ import print_function
+
 from django.contrib.auth.models import User
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    args = 'user'
-    help = "Show a user's roles and permissions"
+    help = "Show a user's roles and permissions."
+
+    def add_arguments(self, parser):
+        parser.add_argument('email_or_username',
+                            help='the email or username of the user')
 
     def handle(self, *args, **options):
-        print args
-        if len(args) != 1:
-            raise CommandError("The number of arguments does not match. ")
+        email_or_username = options['email_or_username']
         try:
-            if '@' in args[0]:
-                user = User.objects.get(email=args[0])
+            if '@' in email_or_username:
+                user = User.objects.get(email=email_or_username)
             else:
-                user = User.objects.get(username=args[0])
+                user = User.objects.get(username=email_or_username)
         except User.DoesNotExist:
-            print "User %s does not exist. " % args[0]
-            print "Available users: "
-            print User.objects.all()
+            print('User {} does not exist. '.format(email_or_username))
+            print('Available users: ')
+            print(User.objects.all())
             return
 
         roles = user.roles.all()
-        print "%s has %d roles:" % (user, len(roles))
+        print('{} has %d roles:'.format(user, len(roles)))
         for role in roles:
-            print "\t%s" % role
+            print('\t{}'.format(role))
 
         for role in roles:
-            print "%s has permissions: " % role
-            print role.permissions.all()
+            print('{} has permissions: '.format(role))
+            print(role.permissions.all())

--- a/lms/djangoapps/django_comment_client/management/commands/sync_user_info.py
+++ b/lms/djangoapps/django_comment_client/management/commands/sync_user_info.py
@@ -3,10 +3,9 @@ One-off script to sync all user information to the
 discussion service (later info will be synced automatically)
 """
 
+import lms.lib.comment_client as cc
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
-
-import lms.lib.comment_client as cc
 
 
 class Command(BaseCommand):

--- a/lms/djangoapps/django_comment_client/management/commands/sync_user_info.py
+++ b/lms/djangoapps/django_comment_client/management/commands/sync_user_info.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     """
     Management command for adding all users to the discussion service.
     """
-    help = 'Sync all user ids, usernames, and emails to the discussion service'
+    help = 'Sync all user ids, usernames, and emails to the discussion service.'
 
     def handle(self, *args, **options):
         for user in User.objects.all().iterator():


### PR DESCRIPTION
* optparse -> argparse
* python3 style print()
* consistent usage of QuerySets in `reload_forum_users.py`
* consistent punctuation in command description and help text