### PR TITLE
Upgrade django-cors-headers for Django 1.11 support

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -141,7 +141,7 @@ transifex-client==0.12.1
 ipaddr==2.1.11
 
 # Used to allow to configure CORS headers for cross-domain requests
-django-cors-headers==1.1.0
+django-cors-headers==2.1.0
 
 # Debug toolbar
 django_debug_toolbar==1.8


### PR DESCRIPTION
We apparently missed this one in our earlier round of dependency upgrades; it doesn't explicitly declare a dependency on Django.  This upgrade should get us to 1.11 support, and I didn't see anything too scary in the [changelog](https://github.com/ottoyiu/django-cors-headers/blob/master/HISTORY.rst); we don't seem to be using the `CorsModel` that got removed.