### PR TITLE
Fix for tex2jax \tag{} width issue

### DIFF
--- a/lms/static/sass/discussion/_mixins.scss
+++ b/lms/static/sass/discussion/_mixins.scss
@@ -75,6 +75,10 @@
     @include padding-left($baseline*2);
     @include padding-right(0);
   }
+
+  svg {
+    max-width: 100%;
+  }
 }
 
 @-webkit-keyframes fadeIn {


### PR DESCRIPTION
# [EDUCATOR-1685](https://openedx.atlassian.net/browse/EDUCATOR-1685)

This prevents the library from applying an inline style that is much
too wide and breaks everything.

### Before fix:
<img width="1440" alt="screen shot 2017-11-06 at 4 44 40 pm" src="https://user-images.githubusercontent.com/7373924/32465687-4edc1f24-c312-11e7-945c-1683ecefc7be.png">

### After fix:
<img width="1327" alt="screen shot 2017-11-06 at 4 44 09 pm" src="https://user-images.githubusercontent.com/7373924/32465703-57bc08b6-c312-11e7-95d2-28d2eee62d4b.png">
