### PR TITLE
Remove collection of JS bundles for themes.

### DIFF
--- a/openedx/core/djangoapps/theming/storage.py
+++ b/openedx/core/djangoapps/theming/storage.py
@@ -251,22 +251,14 @@ class ThemePipelineMixin(PipelineMixin):
 
         for theme in themes:
             css_packages = self.get_themed_packages(theme.theme_dir_name, settings.PIPELINE_CSS)
-            js_packages = self.get_themed_packages(theme.theme_dir_name, settings.PIPELINE_JS)
 
             from pipeline.packager import Packager
-            packager = Packager(storage=self, css_packages=css_packages, js_packages=js_packages)
+            packager = Packager(storage=self, css_packages=css_packages)
             for package_name in packager.packages['css']:
                 package = packager.package_for('css', package_name)
                 output_file = package.output_filename
                 if self.packing:
                     packager.pack_stylesheets(package)
-                paths[output_file] = (self, output_file)
-                yield output_file, output_file, True
-            for package_name in packager.packages['js']:
-                package = packager.package_for('js', package_name)
-                output_file = package.output_filename
-                if self.packing:
-                    packager.pack_javascripts(package)
                 paths[output_file] = (self, output_file)
                 yield output_file, output_file, True
 


### PR DESCRIPTION
Remove duplication of bundles JS assets (e.g. lms-modules.js) across themes.

From the commit message:

```
Comprehensive themes used to allow you to override JS within one of the
bundles created for Studio and LMS (specified in the common.py env
files). So for instance, the bundle that becomes lms-base-application.js
is defined like this:

base_application_js = [
    'js/src/utility.js',
    'js/src/logger.js',
    'js/user_dropdown_v1.js',
    'js/dialog_tab_controls.js',
    'js/src/string_utils.js',
    'js/form.ext.js',
    'js/src/ie_shim.js',
    'js/src/accessibility_tools.js',
    'js/toggle_login_modal.js',
    'js/src/lang_edx.js',
]

You could not add a custom file to this list in your theme, but if you
created a themes/mytheme/lms/static/js/dialog_tab_controls.js, then your
theme's version of that file would be wrapped into the bundle, which
would be created at {staticfiles}/mytheme/js/lms-base-application.js

It doesn't appear that this functionality has seen much use in practice,
and it adds minutes to the compile time for sites compiling multiple
themes, so this commit removes this capability. It is still possible to
create and invoke custom JavaScript that is theme specific, and will
compile out to {staticfiles}/mytheme/js -- it's just not possible to
override a file that becomes part of the standard Studio/LMS bundles.
```

FYI: @arizzitano, @fredsmith, @feanil 