### PR TITLE
Remove unused nose settings and plugin

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -46,21 +46,6 @@ MONGO_HOST = os.environ.get('EDXAPP_TEST_MONGO_HOST', 'localhost')
 
 THIS_UUID = uuid4().hex[:5]
 
-_SYSTEM = 'cms'
-
-_REPORT_DIR = REPO_ROOT / 'reports' / _SYSTEM
-_REPORT_DIR.makedirs_p()
-_NOSEID_DIR = REPO_ROOT / '.testids' / _SYSTEM
-_NOSEID_DIR.makedirs_p()
-
-NOSE_ARGS = [
-    '--id-file', _NOSEID_DIR / 'noseids',
-]
-
-NOSE_PLUGINS = [
-    'openedx.core.djangolib.testing.utils.NoseDatabaseIsolation'
-]
-
 TEST_ROOT = path('test_root')
 
 # Want static files in the same dir for running on jenkins.

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -89,21 +89,6 @@ WIKI_ENABLED = True
 # Enable a parental consent age limit for testing
 PARENTAL_CONSENT_AGE_LIMIT = 13
 
-_SYSTEM = 'lms'
-
-_REPORT_DIR = REPO_ROOT / 'reports' / _SYSTEM
-_REPORT_DIR.makedirs_p()
-_NOSEID_DIR = REPO_ROOT / '.testids' / _SYSTEM
-_NOSEID_DIR.makedirs_p()
-
-NOSE_ARGS = [
-    '--id-file', _NOSEID_DIR / 'noseids',
-]
-
-NOSE_PLUGINS = [
-    'openedx.core.djangolib.testing.utils.NoseDatabaseIsolation'
-]
-
 # Local Directories
 TEST_ROOT = path("test_root")
 # Want static files in the same dir for running on jenkins.

--- a/openedx/core/djangolib/testing/utils.py
+++ b/openedx/core/djangolib/testing/utils.py
@@ -13,14 +13,12 @@ import re
 from unittest import skipUnless
 
 import crum
-from django import db
 from django.conf import settings
 from django.contrib import sites
 from django.core.cache import caches
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.test import RequestFactory, TestCase, override_settings
 from django.test.utils import CaptureQueriesContext
-from nose.plugins import Plugin
 from request_cache.middleware import RequestCache
 
 
@@ -220,23 +218,6 @@ class FilteredQueryCountMixin(object):
 
         with context:
             func(*args, **kwargs)
-
-
-class NoseDatabaseIsolation(Plugin):
-    """
-    nosetest plugin that resets django databases before any tests begin.
-
-    Used to make sure that tests running in multi processes aren't sharing
-    a database connection.
-    """
-    name = "database-isolation"
-
-    def begin(self):
-        """
-        Before any tests start, reset all django database connections.
-        """
-        for db_ in db.connections.all():
-            db_.close()
 
 
 def get_mock_request(user=None):


### PR DESCRIPTION
I just stumbled across a note I'd left myself while working on the pytest switch to rip this out when done.  None of this should be needed anymore.