### PR TITLE
Move back to upstream edx-sga requirement.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -104,7 +104,6 @@ git+https://github.com/edx/edx-proctoring.git@1.3.0#egg=edx-proctoring==1.3.0
 
 # Third Party XBlocks
 
-# Move the edx-sga xblock requirement back to base.txt and onto the upstream version after these changes are merged upstream.
-git+https://github.com/doctoryes/edx-sga.git@c20a8a8e259ef7d5da6394d9f67549200bbb46ee#egg=edx-sga==0.0
+git+https://github.com/mitodl/edx-sga.git@d019b8a050c056db535e3ff13c93096145a932de#egg=edx-sga==0.7.1
 git+https://github.com/open-craft/xblock-poll@7ba819b968fe8faddb78bb22e1fe7637005eb414#egg=xblock-poll==1.2.7
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.18#egg=xblock-drag-and-drop-v2==2.0.18


### PR DESCRIPTION
@edx/platform-team This PR moves edx-platform back to the upstream edx-sga XBlock. If additional changes are required for Django 1.11, we'll deal with that later.

I rebased my branch yesterday on top of upstream, which broke this requirement version.