### PR TITLE
Update minimum version for edx-bootstrap in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "edx",
   "version": "0.1.0",
   "dependencies": {
-    "@edx/edx-bootstrap": "^0.4.1",
+    "@edx/edx-bootstrap": "^0.4.2",
     "@edx/paragon": "^0.2.0",
     "@edx/studio-frontend": "^0.3.0",
     "babel-core": "^6.23.0",


### PR DESCRIPTION
### Discussion

Reflect updated `edx-bootstrap` version from [edx-bootstrap#22](https://github.com/edx/edx-bootstrap/pull/22). This `edx-bootstrap` change involved adding previously unmet peer dependencies to the `edx-bootstrap` `package.json` file.

### Sandbox
https://tools-edx-jenkins.edx.org/job/sandboxes/job/CreateSandbox/6357/