### PR TITLE
[ENT-749] Fix logistration page issues in Enterprise context (plus a color fix to validation)

### DIFF
--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -399,7 +399,7 @@
       }
 
       &.success {
-        border-color: $success-color-hover;
+        border-color: theme-color("success");
       }
     }
 
@@ -410,7 +410,7 @@
       }
 
       &.success {
-        outline-color: $success-color-hover;
+        outline-color: theme-color("success");
       }
     }
 
@@ -438,7 +438,7 @@
       }
 
       &.success {
-        color: $success-color-hover;
+        color: theme-color("success");
       }
     }
 

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -10,16 +10,18 @@
     height: 100%;
     padding-left: $baseline;
     padding-right: $baseline;
+    margin-left: auto;
   }
 
   .login-register.border-left {
     border-left: 1px solid #d9d9d9;
     padding-left: ($baseline*1.5);
     padding-right: $baseline;
+    margin-left: 0;
   }
 }
 
-@media (max-width: 767px) {
+@include media-breakpoint-down(md) {
   .enterprise-content {
     margin: auto auto;
     display: block;


### PR DESCRIPTION
[ENT-749](https://openedx.atlassian.net/browse/ENT-749)

Since the LMS is now responsive, some changes were made that broke how things looked on the logistration page in an Enterprise context.

Additionally, the `$success-color-hover` variable was changed and produced a very dark green color that, at least to me, looked basically black. We now use the success color defined for the theme.

The fix looks like this (don't mind the missing logo):

![selection_003](https://user-images.githubusercontent.com/10018065/32556095-4bcedc4a-c4c0-11e7-82c1-42f851a464ce.jpg)
