### PR TITLE
LEARNER-2653 Updated translations make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ clean:
 
 extract_translations:
 	# Extract localizable strings from sources
-	paver i18n_extract
+	i18n_tool extract -vv
 
 push_translations:
 	# Push source strings to Transifex for translation
-	paver i18n_transifex_push
+	i18n_tool transifex push


### PR DESCRIPTION
LEARNER-2653
Paver commands were causing requirement problems
running on jenkins so changed to i18n_tools commands

Now jenkins jobs wont be pushing translations for coffee scripts so for coffee scripts translation change. The person will have to manually run the push command to push translations. (takes 1 min). 