### PR TITLE
Upgrade django-ses for Django 1.11 support

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -27,7 +27,7 @@ django-oauth-toolkit==0.12.0
 django-pipeline-forgiving==1.0.0
 django-pyfs==1.0.7
 django-sekizai>=0.10
-django-ses==0.7.1
+django-ses==0.8.3.1
 django-simple-history==1.9.0
 django-statici18n==1.4.0
 django-storages==1.4.1


### PR DESCRIPTION
This is another Django-using dependency which we missed because it doesn't explicitly depend on Django in `setup.py`.  I spotted it when looking through `site-packages` for management commands that still use `optparse`.  The changes in the new releases look pretty minor except for newer Django version support and adding an initial migration for its one table; we don't even include the app in `INSTALLED_APPS`, so we don't currently have that table and shouldn't end up running this migration either.