### PR TITLE
Re-render XBlockOutlineView on highlights change

### DIFF
--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -635,6 +635,7 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'common/j
                     saveHighlights();
 
                     expectServerHandshakeWithHighlights(updatedHighlights);
+                    expectHighlightLinkNumberToBe(updatedHighlights.length);
 
                     openHighlights();
                     expectHighlightsToBe(updatedHighlights);

--- a/cms/static/js/views/xblock_outline.js
+++ b/cms/static/js/views/xblock_outline.js
@@ -224,7 +224,11 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
             },
 
             onSync: function(event) {
-                if (ViewUtils.hasChangedAttributes(this.model, ['visibility_state', 'child_info', 'display_name'])) {
+                var hasChangedAttributes = ViewUtils.hasChangedAttributes(
+                    this.model,
+                    ['visibility_state', 'child_info', 'display_name', 'highlights']
+                );
+                if (hasChangedAttributes) {
                     this.onXBlockChange();
                 }
             },


### PR DESCRIPTION
FYI: @edx/rapid-experiments-team 

There is a function that checks whether a XBlockOutlineView should re-render based on whether a certain set of attributes on the model changed or not. That set of attributes did not include `highlights`.

I think the reason why sections with children (subsections) were correctly getting re-rendered is that `child_info` was already getting checked, and somehow (still not exactly sure how) that array is getting replaced on every save with the subsections so that backbone always reports that the `child_info` field has changed. This isn't really ideal, but I don't think there is much negative performance impact with this needless re-rendering since it only happens once when the modal is saved.

Hmm... if only we were using a JavaScript library that explicitly defined what data a view relies on and re-renders it for us when that data changes...