### PR TITLE
Move hint before content it refers to

### DIFF
--- a/lms/templates/wiki/includes/editor_widget.html
+++ b/lms/templates/wiki/includes/editor_widget.html
@@ -1,7 +1,7 @@
 {% load i18n %}
-<textarea {{ attrs }}>{{ content }}</textarea>
 <p id="hint_id_content" class="help-block">
     {% blocktrans with start_link="<a id='cheatsheetLink' href='#cheatsheetModal' rel='leanModal'>" end_link="</a>" %}
         Markdown syntax is allowed. See the {{ start_link }}cheatsheet{{ end_link }} for help.
     {% endblocktrans %}
 </p>
+<textarea {{ attrs }}>{{ content }}</textarea>


### PR DESCRIPTION
# [EDUCATOR-1557](https://openedx.atlassian.net/browse/EDUCATOR-1557)

## Before:
<img width="1075" alt="screen shot 2017-11-08 at 4 12 41 pm" src="https://user-images.githubusercontent.com/7373924/32574664-db7610b4-c49f-11e7-8989-b08603f9fb19.png">

## After:
<img width="1075" alt="screen shot 2017-11-08 at 4 12 27 pm" src="https://user-images.githubusercontent.com/7373924/32574679-e52d3b96-c49f-11e7-860c-55fddcc08e21.png">
