### PR TITLE
Move ccxcon, credit, and programs Django apps to AppConfig standard.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2251,7 +2251,7 @@ INSTALLED_APPS = [
     'xblock_django',
 
     # programs support
-    'openedx.core.djangoapps.programs',
+    'openedx.core.djangoapps.programs.apps.ProgramsConfig',
 
     # Catalog integration
     'openedx.core.djangoapps.catalog',

--- a/openedx/core/djangoapps/ccxcon/apps.py
+++ b/openedx/core/djangoapps/ccxcon/apps.py
@@ -10,4 +10,4 @@ class CCXConnectorConfig(AppConfig):
     verbose_name = "CCX Connector"
 
     def ready(self):
-        import openedx.core.djangoapps.ccxcon.signals
+        from . import signals

--- a/openedx/core/djangoapps/credit/__init__.py
+++ b/openedx/core/djangoapps/credit/__init__.py
@@ -1,3 +1,0 @@
-""" Register signal handlers """
-
-from . import signals

--- a/openedx/core/djangoapps/credit/apps.py
+++ b/openedx/core/djangoapps/credit/apps.py
@@ -14,6 +14,7 @@ class CreditConfig(AppConfig):
     name = u'openedx.core.djangoapps.credit'
 
     def ready(self):
+        from . import signals
         if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
             from .services import CreditService
             set_runtime_service('credit', CreditService())

--- a/openedx/core/djangoapps/programs/__init__.py
+++ b/openedx/core/djangoapps/programs/__init__.py
@@ -8,6 +8,3 @@ if and only if the service is deployed in the Open edX installation.
 To ensure maximum separation of concerns, and a minimum of interdependencies,
 this package should be kept small, thin, and stateless.
 """
-
-# Register signal handlers
-from . import signals

--- a/openedx/core/djangoapps/programs/apps.py
+++ b/openedx/core/djangoapps/programs/apps.py
@@ -1,0 +1,14 @@
+"""
+Programs Configuration
+"""
+from django.apps import AppConfig
+
+
+class ProgramsConfig(AppConfig):
+    """
+    Default configuration for the "openedx.core.djangoapps.programs" Django application.
+    """
+    name = u'openedx.core.djangoapps.programs'
+
+    def ready(self):
+        from . import signals


### PR DESCRIPTION
Minor PR - none of these changes are blocking Django 1.11. But these changes will remove anti-patterns.