### PR TITLE
Sync course language: Discovery -> LMS Course Overview

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -17,6 +17,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from config_models.models import ConfigurationModel
 from lms.djangoapps import django_comment_client
+from openedx.core.djangoapps.catalog.models import CatalogIntegration
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from static_replace.models import AssetBaseUrlConfig
 from xmodule import course_metadata_utils, block_metadata_utils
@@ -194,7 +195,8 @@ class CourseOverview(TimeStampedModel):
         course_overview.course_video_url = CourseDetails.fetch_video_url(course.id)
         course_overview.self_paced = course.self_paced
 
-        course_overview.language = course.language
+        if not CatalogIntegration.is_enabled():
+            course_overview.language = course.language
 
         return course_overview
 

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from PIL import Image
 
 from lms.djangoapps.certificates.api import get_active_web_certificate
+from openedx.core.djangoapps.catalog.tests.mixins import CatalogIntegrationMixin
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.lib.courses import course_image_url
 from static_replace.models import AssetBaseUrlConfig
@@ -40,7 +41,7 @@ from ..models import CourseOverview, CourseOverviewImageSet, CourseOverviewImage
 
 @attr(shard=3)
 @ddt.ddt
-class CourseOverviewTestCase(ModuleStoreTestCase):
+class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase):
     """
     Tests for CourseOverview model.
     """
@@ -269,6 +270,24 @@ class CourseOverviewTestCase(ModuleStoreTestCase):
         # other test functions don't specify a run but work fine).
         course = CourseFactory.create(default_store=modulestore_type, run="TestRun", **kwargs)
         self.check_course_overview_against_course(course)
+
+    @ddt.data(True, False)
+    def test_language_field(self, catalog_integration_enabled):
+        """
+        Test that the language field is not updated from the modulestore
+        when catalog integration is enabled. In that case, it gets updated
+        by the sync_course_runs management command, which synchronizes with
+        the Catalog service.
+        """
+        self.create_catalog_integration(enabled=catalog_integration_enabled)
+
+        course = CourseFactory.create(language='en')
+        course_overview = CourseOverview.get_from_id(course.id)
+
+        if catalog_integration_enabled:
+            self.assertNotEqual(course_overview.language, course.language)
+        else:
+            self.assertEqual(course_overview.language, course.language)
 
     @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
     def test_get_non_existent_course(self, modulestore_type):


### PR DESCRIPTION
This PR updates the `sync_course_runs` management command to pull a course's `content_language` setting from the Catalog/Discovery service to the `CourseOverview` table in the LMS.

If the Catalog/Discovery service integration is enabled in the LMS, the `language` setting is no pulled from the modulestore when the course is published.

FYI @edx/rapid-experiments-team, @schenedx 