### PR TITLE
optimize libraries iter for studio dashboard

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -484,7 +484,7 @@ def _accessible_libraries_iter(user, org=None):
     if org is not None:
         libraries = [] if org == '' else modulestore().get_libraries(org=org)
     else:
-        libraries = modulestore().get_libraries()
+        libraries = modulestore().get_library_summaries()
     # No need to worry about ErrorDescriptors - split's get_libraries() never returns them.
     return (lib for lib in libraries if has_studio_read_access(user, lib.location.library_key))
 
@@ -493,7 +493,7 @@ def _accessible_libraries_iter(user, org=None):
 @ensure_csrf_cookie
 def course_listing(request):
     """
-    List all courses available to the logged in user
+    List all courses and libraries available to the logged in user
     """
 
     optimization_enabled = GlobalStaff().has_user(request.user) and \
@@ -502,7 +502,10 @@ def course_listing(request):
     org = request.GET.get('org', '') if optimization_enabled else None
     courses_iter, in_process_course_actions = get_courses_accessible_to_user(request, org)
     user = request.user
+    # remove this temporary log after getting results
+    start_time = time.time()
     libraries = _accessible_libraries_iter(request.user, org) if LIBRARIES_ENABLED else []
+    log.info("_accessible_libraries_iter completed in [%f]", (time.time() - start_time))
 
     def format_in_process_course_view(uca):
         """
@@ -529,6 +532,7 @@ def course_listing(request):
         """
         Return a dict of the data which the view requires for each library
         """
+
         return {
             u'display_name': library.display_name,
             u'library_key': unicode(library.location.library_key),

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -640,3 +640,39 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
             if field.is_set_on(self):
                 xml_object.set(field_name, unicode(field.read_from(self)))
         return xml_object
+
+
+class LibrarySummary(object):
+    """
+    A library summary object which contains the fields required for library listing on studio.
+    """
+
+    def __init__(self, library_locator, display_name):
+        """
+        Initialize LibrarySummary
+
+        Arguments:
+        library_locator (LibraryLocator):  LibraryLocator object of the library.
+
+        display_name (unicode): display name of the library.
+        """
+        self.display_name = display_name if display_name else _(u"Empty")
+
+        self.id = library_locator  # pylint: disable=invalid-name
+        self.location = library_locator.make_usage_key('library', 'library')
+
+    @property
+    def display_org_with_default(self):
+        """
+        Org display names are not implemented. This just provides API compatibility with CourseDescriptor.
+        Always returns the raw 'org' field from the key.
+        """
+        return self.location.library_key.org
+
+    @property
+    def display_number_with_default(self):
+        """
+        Display numbers are not implemented. This just provides API compatibility with CourseDescriptor.
+        Always returns the raw 'library' field from the key.
+        """
+        return self.location.library_key.library

--- a/common/lib/xmodule/xmodule/modulestore/exceptions.py
+++ b/common/lib/xmodule/xmodule/modulestore/exceptions.py
@@ -18,6 +18,13 @@ class MultipleCourseBlocksFound(Exception):
     pass
 
 
+class MultipleLibraryBlocksFound(Exception):
+    """
+    Raise this exception when Iterating over the library blocks return multiple library blocks.
+    """
+    pass
+
+
 class InsufficientSpecificationError(Exception):
     pass
 

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -322,6 +322,23 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         return courses.values()
 
     @strip_key
+    def get_library_summaries(self, **kwargs):
+        """
+        Returns a list of LibrarySummary objects.
+        Information contains `location`, `display_name`, `locator` of the libraries in this modulestore.
+        """
+        library_summaries = {}
+        for store in self.modulestores:
+            if not hasattr(store, 'get_libraries'):
+                continue
+            # fetch library summaries and filter out any duplicated entry across/within stores
+            for library_summary in store.get_library_summaries(**kwargs):
+                library_id = self._clean_locator_for_mapping(library_summary.location)
+                if library_id not in library_summaries:
+                    library_summaries[library_id] = library_summary
+        return library_summaries.values()
+
+    @strip_key
     def get_libraries(self, **kwargs):
         """
         Returns a list containing the top level XBlock of the libraries (LibraryRoot) in this modulestore.

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -362,20 +362,21 @@ class MongoConnection(object):
             return docs
 
     @autoretry_read()
-    def find_course_blocks_by_id(self, ids, course_context=None):
+    def find_courselike_blocks_by_id(self, ids, block_type, course_context=None):
         """
-        Find all structures that specified in `ids`. Among the blocks only return block whose type is `course`.
+        Find all structures that specified in `ids`. Among the blocks only return block whose type is `block_type`.
 
         Arguments:
             ids (list): A list of structure ids
+            block_type: type of block to return
         """
-        with TIMER.timer("find_course_blocks_by_id", course_context) as tagger:
+        with TIMER.timer("find_courselike_blocks_by_id", course_context) as tagger:
             tagger.measure("requested_ids", len(ids))
             docs = [
                 structure_from_mongo(structure, course_context)
                 for structure in self.structures.find(
                     {'_id': {'$in': ids}},
-                    {'blocks': {'$elemMatch': {'block_type': 'course'}}, 'root': 1}
+                    {'blocks': {'$elemMatch': {'block_type': block_type}}, 'root': 1}
                 )
             ]
             tagger.measure("structures", len(docs))


### PR DESCRIPTION
## [EDUCATOR-1696](https://openedx.atlassian.net/browse/EDUCATOR-1696)
Studio dashboard takes too long to load for non-global staff users. During the investigation, it is found that most of the time is taken by libraries fetching and loading. For each hit to the dashboard, all libraries are loaded and iterated to check for access to logged in user.
  
This PR include following changes in an effort to optimize library work:

- Do not fetch complete library from structure collection but only the blocks containing the required information. 
- Do not load libraries, use lighter weight LibrarySummary objects instead.

I have created this [sandbox](https://studio-library-fix.sandbox.edx.org/home/), which contains 599 libraries accessible by staff and honor.

FYI: @awaisdar001 / @efischer19  / @adampalay 