### PR TITLE
Create program detail fragment for mobile app

### DIFF
--- a/lms/djangoapps/learner_dashboard/programs.py
+++ b/lms/djangoapps/learner_dashboard/programs.py
@@ -4,14 +4,21 @@ Fragments for rendering programs.
 from django.http import Http404
 from django.template.loader import render_to_string
 from django.utils.translation import get_language_bidi
+from django.core.urlresolvers import reverse
+
 from web_fragments.fragment import Fragment
 
+from lms.djangoapps.commerce.utils import EcommerceService
+from lms.djangoapps.learner_dashboard.utils import FAKE_COURSE_KEY, strip_course_id
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.programs.utils import (
+    ProgramDataExtender,
     ProgramProgressMeter,
+    get_certificates,
     get_program_marketing_url
 )
+from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 
 
 class ProgramsFragmentView(EdxFragmentView):
@@ -39,6 +46,66 @@ class ProgramsFragmentView(EdxFragmentView):
         self.add_fragment_resource_urls(programs_fragment)
 
         return programs_fragment
+
+    def css_dependencies(self):
+        """
+        Returns list of CSS files that this view depends on.
+
+        The helper function that it uses to obtain the list of CSS files
+        works in conjunction with the Django pipeline to ensure that in development mode
+        the files are loaded individually, but in production just the single bundle is loaded.
+        """
+        if get_language_bidi():
+            return self.get_css_dependencies('style-learner-dashboard-rtl')
+        else:
+            return self.get_css_dependencies('style-learner-dashboard')
+
+
+class ProgramDetailsFragmentView(EdxFragmentView):
+    """
+    Render the program details fragment.
+    """
+    def render_to_fragment(self, request, program_uuid, **kwargs):
+        """View details about a specific program."""
+        programs_config = kwargs.get('programs_config') or ProgramsApiConfig.current()
+        if not programs_config.enabled or not request.user.is_authenticated():
+            raise Http404
+
+        meter = ProgramProgressMeter(request.site, request.user, uuid=program_uuid)
+        program_data = meter.programs[0]
+
+        if not program_data:
+            raise Http404
+
+        program_data = ProgramDataExtender(program_data, request.user).extend()
+        course_data = meter.progress(programs=[program_data], count_only=False)[0]
+        certificate_data = get_certificates(request.user, program_data)
+
+        program_data.pop('courses')
+        skus = program_data.get('skus')
+        ecommerce_service = EcommerceService()
+
+        urls = {
+            'program_listing_url': reverse('program_listing_view'),
+            'track_selection_url': strip_course_id(
+                reverse('course_modes_choose', kwargs={'course_id': FAKE_COURSE_KEY})
+            ),
+            'commerce_api_url': reverse('commerce_api:v0:baskets:create'),
+            'buy_button_url': ecommerce_service.get_checkout_page_url(*skus)
+        }
+
+        context = {
+            'urls': urls,
+            'user_preferences': get_user_preferences(request.user),
+            'program_data': program_data,
+            'course_data': course_data,
+            'certificate_data': certificate_data
+        }
+
+        html = render_to_string('learner_dashboard/program_details_fragment.html', context)
+        program_details_fragment = Fragment(html)
+        self.add_fragment_resource_urls(program_details_fragment)
+        return program_details_fragment
 
     def css_dependencies(self):
         """

--- a/lms/djangoapps/learner_dashboard/urls.py
+++ b/lms/djangoapps/learner_dashboard/urls.py
@@ -7,4 +7,6 @@ urlpatterns = [
     url(r'^programs/$', views.program_listing, name='program_listing_view'),
     url(r'^programs/(?P<program_uuid>[0-9a-f-]+)/$', views.program_details, name='program_details_view'),
     url(r'^programs_fragment/$', programs.ProgramsFragmentView.as_view(), name='program_listing_fragment_view'),
+    url(r'^programs/(?P<program_uuid>[0-9a-f-]+)/details_fragment/$', programs.ProgramDetailsFragmentView.as_view(),
+        name='program_details_fragment_view'),
 ]

--- a/lms/djangoapps/learner_dashboard/views.py
+++ b/lms/djangoapps/learner_dashboard/views.py
@@ -1,22 +1,11 @@
 """Learner dashboard views"""
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
-from django.http import Http404
 from django.views.decorators.http import require_GET
 
 from edxmako.shortcuts import render_to_response
-from lms.djangoapps.commerce.utils import EcommerceService
 
-from lms.djangoapps.learner_dashboard.programs import ProgramsFragmentView
-from lms.djangoapps.learner_dashboard.utils import FAKE_COURSE_KEY, strip_course_id
+from lms.djangoapps.learner_dashboard.programs import ProgramsFragmentView, ProgramDetailsFragmentView
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
-from openedx.core.djangoapps.programs.utils import (
-    ProgramDataExtender,
-    ProgramProgressMeter,
-    get_certificates,
-    get_program_marketing_url
-)
-from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 
 
 @login_required
@@ -43,43 +32,17 @@ def program_listing(request):
 def program_details(request, program_uuid):
     """View details about a specific program."""
     programs_config = ProgramsApiConfig.current()
-    if not programs_config.enabled:
-        raise Http404
-
-    meter = ProgramProgressMeter(request.site, request.user, uuid=program_uuid)
-    program_data = meter.programs[0]
-
-    if not program_data:
-        raise Http404
-
-    program_data = ProgramDataExtender(program_data, request.user).extend()
-    course_data = meter.progress(programs=[program_data], count_only=False)[0]
-    certificate_data = get_certificates(request.user, program_data)
-
-    program_data.pop('courses')
-    skus = program_data.get('skus')
-    ecommerce_service = EcommerceService()
-
-    urls = {
-        'program_listing_url': reverse('program_listing_view'),
-        'track_selection_url': strip_course_id(
-            reverse('course_modes_choose', kwargs={'course_id': FAKE_COURSE_KEY})
-        ),
-        'commerce_api_url': reverse('commerce_api:v0:baskets:create'),
-        'buy_button_url': ecommerce_service.get_checkout_page_url(*skus)
-    }
+    program_fragment = ProgramDetailsFragmentView().render_to_fragment(
+        request, program_uuid, programs_config=programs_config
+    )
 
     context = {
-        'urls': urls,
+        'program_fragment': program_fragment,
         'show_program_listing': programs_config.enabled,
         'show_dashboard_tabs': True,
         'nav_hidden': True,
         'disable_courseware_js': True,
         'uses_pattern_library': True,
-        'user_preferences': get_user_preferences(request.user),
-        'program_data': program_data,
-        'course_data': course_data,
-        'certificate_data': certificate_data
     }
 
     return render_to_response('learner_dashboard/program_details.html', context)

--- a/lms/templates/learner_dashboard/program_details.html
+++ b/lms/templates/learner_dashboard/program_details.html
@@ -3,29 +3,14 @@
 
 <%page expression_filter="h"/>
 <%inherit file="../main.html" />
-<%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.js_utils import (
-    dump_js_escaped_json, js_escaped_string
-)
+from openedx.core.djangolib.markup import HTML
 %>
-
-<%block name="js_extra">
-<%static:require_module module_name="js/learner_dashboard/program_details_factory" class_name="ProgramDetailsFactory">
-ProgramDetailsFactory({
-    programData: ${program_data | n, dump_js_escaped_json},
-    courseData: ${course_data | n, dump_js_escaped_json},
-    certificateData: ${certificate_data | n, dump_js_escaped_json},
-    urls: ${urls | n, dump_js_escaped_json},
-    userPreferences: ${user_preferences | n, dump_js_escaped_json},
-});
-</%static:require_module>
-</%block>
 
 <%block name="pagetitle">${_("Program Details")}</%block>
 <%block name="bodyclass">program-details</%block>
 
 <main id="main" aria-label="Content" tabindex="-1">
-    <div class="js-program-details-wrapper program-details-wrapper"></div>
+    ${HTML(program_fragment.body_html())}
 </main>

--- a/lms/templates/learner_dashboard/program_details_fragment.html
+++ b/lms/templates/learner_dashboard/program_details_fragment.html
@@ -1,0 +1,23 @@
+## mako
+
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+from openedx.core.djangolib.js_utils import (
+    dump_js_escaped_json, js_escaped_string
+)
+%>
+
+<%block name="js_extra">
+<%static:require_module module_name="js/learner_dashboard/program_details_factory" class_name="ProgramDetailsFactory">
+ProgramDetailsFactory({
+    programData: ${program_data | n, dump_js_escaped_json},
+    courseData: ${course_data | n, dump_js_escaped_json},
+    certificateData: ${certificate_data | n, dump_js_escaped_json},
+    urls: ${urls | n, dump_js_escaped_json},
+    userPreferences: ${user_preferences | n, dump_js_escaped_json},
+});
+</%static:require_module>
+</%block>
+
+<div class="js-program-details-wrapper program-details-wrapper"></div>


### PR DESCRIPTION
To extract the program detail information edX mobile team has to
parse all the un-necassary details which takes time that ultimately
slows down app.To avoid it,a detail fragment is created that will
be used in the mobile app as well as on the web.

**Sandbox:** https://programs-fragment.sandbox.edx.org/dashboard/programs/1008a443-5f1c-4e7d-ad8d-14dd47e988f0/details_fragment/

**User:**
email: edx@example.com
password: edx

LEARNER-2981