### PR TITLE
Cherry-pick: Pin Jasmine version to avoid failing js tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-config-edx": "^3.0.0",
     "eslint-config-edx-es5": "^2.0.0",
     "eslint-import-resolver-webpack": "^0.8.1",
-    "jasmine-core": "^2.6.4",
+    "jasmine-core": "2.6.4",
     "jasmine-jquery": "^2.1.1",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.3",


### PR DESCRIPTION
Jasmine was pinned to 2.6.4 on master a few months ago, as 2.7.0 was causing all js builds to fail. As pointed out by @Nelapa , this should be added to ginkgo in order to get js builds passing.