### PR TITLE
Move library creator checks to POST-only

### DIFF
--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -58,7 +58,7 @@ def get_library_creator_status(user):
     elif settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
         return get_course_creator_status(user) == 'granted'
     else:
-        return True
+        return not settings.FEATURES.get('DISABLE_COURSE_CREATION', False)
 
 
 @login_required

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -72,21 +72,20 @@ def library_handler(request, library_key_string=None):
         log.exception("Attempted to use the content library API when the libraries feature is disabled.")
         raise Http404  # Should never happen because we test the feature in urls.py also
 
-    if not get_library_creator_status(request.user):
-        if not request.user.is_staff:
+    if request.method == 'POST':
+        if not get_library_creator_status(request.user):
             return HttpResponseForbidden()
 
-    if library_key_string is not None and request.method == 'POST':
-        return HttpResponseNotAllowed(("POST",))
+        if library_key_string is not None:
+            return HttpResponseNotAllowed(("POST",))
 
-    if request.method == 'POST':
         return _create_library(request)
 
-    # request method is get, since only GET and POST are allowed by @require_http_methods(('GET', 'POST'))
-    if library_key_string:
-        return _display_library(library_key_string, request)
+    else:
+        if library_key_string:
+            return _display_library(library_key_string, request)
 
-    return _list_libraries(request)
+        return _list_libraries(request)
 
 
 def _display_library(library_key_string, request):

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -72,8 +72,14 @@ class UnitTestLibraries(CourseTestCase):
         """
         nostaff_client, nostaff_user = self.create_non_staff_authed_user_client()
         self.assertFalse(get_library_creator_status(nostaff_user))
-        response = nostaff_client.get_json(LIBRARY_REST_URL)
-        self.assertEqual(response.status_code, 200)
+
+        # To be explicit, this user can GET, but not POST
+        get_response = nostaff_client.get_json(LIBRARY_REST_URL)
+        post_response = nostaff_client.ajax_post(LIBRARY_REST_URL, {
+            'org': 'org', 'library': 'lib', 'display_name': "New Library",
+        })
+        self.assertEqual(get_response.status_code, 200)
+        self.assertEqual(post_response.status_code, 403)
 
     @patch("contentstore.views.library.LIBRARIES_ENABLED", False)
     def test_with_libraries_disabled(self):

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -28,6 +28,7 @@ def make_url_for_lib(key):
 
 
 @ddt.ddt
+@mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': False})
 class UnitTestLibraries(CourseTestCase):
     """
     Unit tests for library views
@@ -62,6 +63,17 @@ class UnitTestLibraries(CourseTestCase):
     def test_library_creator_status_with_no_course_creator_role(self):
         _, nostaff_user = self.create_non_staff_authed_user_client()
         self.assertEqual(get_library_creator_status(nostaff_user), True)
+
+    @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': True})
+    @mock.patch("contentstore.views.library.LIBRARIES_ENABLED", True)
+    def test_library_creator_status_with_no_course_creator_role_and_disabled_nonstaff_course_creation(self):
+        """
+        Ensure that `DISABLE_COURSE_CREATION` feature works with libraries as well.
+        """
+        nostaff_client, nostaff_user = self.create_non_staff_authed_user_client()
+        self.assertFalse(get_library_creator_status(nostaff_user))
+        response = nostaff_client.get_json(LIBRARY_REST_URL)
+        self.assertEqual(response.status_code, 200)
 
     @patch("contentstore.views.library.LIBRARIES_ENABLED", False)
     def test_with_libraries_disabled(self):


### PR DESCRIPTION
Getting this started on jenkins in case we decide we want it.

Review will be easiest if you open the new file - I essentially reorganized everything insinde `library_handler` to treat POST vs GET as the primary logic concern.