### PR TITLE
Make FAQ responses allow HTML and fix banner image sizing.

### DIFF
--- a/lms/static/sass/views/_program-marketing-page.scss
+++ b/lms/static/sass/views/_program-marketing-page.scss
@@ -7,7 +7,7 @@
   .main-banner {
     color: $white;
     margin-bottom: 1px;
-    background-size:100% 100% !important;
+    background-size:cover !important;
     background-repeat:no-repeat !important;
 
     .authoring-org-logo {

--- a/lms/templates/courseware/program_marketing.html
+++ b/lms/templates/courseware/program_marketing.html
@@ -341,7 +341,7 @@ endorser_org = endorser_position.get('organization_name') or corporate_endorseme
             ${faq['question']}
           </div>
           <div class="answer">
-            ${faq['answer']}
+            ${HTML(faq['answer'])}
           </div>
         </div>
       % endfor


### PR DESCRIPTION
Small changes to fix program marketing page. FAQ answers can be HTML now and the banner image doesn't disproportionately stretch.