### PR TITLE
Delete hard coded npm registry setting to accelerate installation

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -14,7 +14,6 @@ from .utils.envs import Env
 from .utils.timer import timed
 
 PREREQS_STATE_DIR = os.getenv('PREREQ_CACHE_DIR', Env.REPO_ROOT / '.prereqs_cache')
-NPM_REGISTRY = "https://registry.npmjs.org/"
 NO_PREREQ_MESSAGE = "NO_PREREQ_INSTALL is set, not installing prereqs"
 NO_PYTHON_UNINSTALL_MESSAGE = 'NO_PYTHON_UNINSTALL is set. No attempts will be made to uninstall old Python libs.'
 COVERAGE_REQ_FILE = 'requirements/edx/coverage.txt'
@@ -134,9 +133,6 @@ def node_prereqs_installation():
     Configures npm and installs Node prerequisites
     """
     cb_error_text = "Subprocess return code: 1"
-    sh("test `npm config get registry` = \"{reg}\" || "
-       "(echo setting registry; npm config set registry"
-       " {reg})".format(reg=NPM_REGISTRY))
 
     # Error handling around a race condition that produces "cb() never called" error. This
     # evinces itself as `cb_error_text` and it ought to disappear when we upgrade


### PR DESCRIPTION
to accelerate installation, people usually set npm registry to a faster mirror by running 'npm config set registry BLAH_BLAH'
and even if the customized config not available, by default it is 'NPM_REGISTRY = "https://registry.npmjs.org/"', so delete these lines always works.