### PR TITLE
Remove unreachable return in contentstore course listing

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -558,8 +558,6 @@ def course_listing(request):
         u'optimization_enabled': optimization_enabled
     })
 
-    return response
-
 
 def _get_rerun_link_for_item(course_key):
     """ Returns the rerun link for the given course key. """


### PR DESCRIPTION
I noticed an extra return statement returning an undefined variable from within the course listing view defined in `cms/djangoapps/contentstore/views/course.py`.

This is a very small patch to remove that unreachable return.