### PR TITLE
Convert mongo read_preference setting at a lower level.

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -24,7 +24,6 @@ import django.dispatch
 import django.utils
 from django.utils.translation import get_language, to_locale
 
-from pymongo import ReadPreference
 from xmodule.contentstore.django import contentstore
 from xmodule.modulestore.draft_and_published import BranchSettingMixin
 from xmodule.modulestore.mixed import MixedModuleStore
@@ -277,9 +276,6 @@ def create_modulestore_instance(
         xb_user_service = DjangoXBlockUserService(get_current_user())
     else:
         xb_user_service = None
-
-    if 'read_preference' in doc_store_config:
-        doc_store_config['read_preference'] = getattr(ReadPreference, doc_store_config['read_preference'])
 
     xblock_field_data_wrappers = [load_function(path) for path in settings.XBLOCK_FIELD_DATA_WRAPPERS]
 

--- a/common/lib/xmodule/xmodule/mongo_utils.py
+++ b/common/lib/xmodule/xmodule/mongo_utils.py
@@ -4,6 +4,7 @@ Common MongoDB connection functions.
 import logging
 
 import pymongo
+from pymongo import ReadPreference
 from mongodb_proxy import MongoProxy
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -32,6 +33,13 @@ def connect_to_mongodb(
     else:
         # No 'replicaSet' in kwargs - so no secondary reads.
         mongo_client_class = pymongo.MongoClient
+
+    # If read_preference is given as a name of a valid ReadPreference.<NAME> constant
+    # such as "SECONDARY_PREFERRED", convert it. Otherwise pass it through unchanged.
+    if 'read_preference' in kwargs:
+        read_preference = getattr(ReadPreference, kwargs['read_preference'], None)
+        if read_preference is not None:
+            kwargs['read_preference'] = read_preference
 
     mongo_conn = pymongo.database.Database(
         mongo_client_class(

--- a/common/lib/xmodule/xmodule/tests/test_mongo_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_mongo_utils.py
@@ -1,0 +1,28 @@
+"""Tests for methods defined in mongo_utils.py"""
+import os
+from unittest import TestCase
+from uuid import uuid4
+
+from pymongo import ReadPreference
+
+from django.conf import settings
+
+from xmodule.mongo_utils import connect_to_mongodb
+
+
+class MongoUtilsTests(TestCase):
+    """
+    Tests for methods exposed in mongo_utils
+    """
+    def test_connect_to_mongo_read_preference(self):
+        """
+        Test that read_preference parameter gets converted to a valid pymongo read preference.
+        """
+        host = 'edx.devstack.mongo' if 'BOK_CHOY_HOSTNAME' in os.environ else 'localhost'
+        db = 'test_read_preference_%s' % uuid4().hex
+        # Support for read_preference given in constant name form (ie. PRIMARY, SECONDARY_PREFERRED)
+        connection = connect_to_mongodb(db, host, read_preference='SECONDARY_PREFERRED')
+        self.assertEqual(connection.client.read_preference, ReadPreference.SECONDARY_PREFERRED)
+        # Support for read_preference given as mongos name.
+        connection = connect_to_mongodb(db, host, read_preference='secondaryPreferred')
+        self.assertEqual(connection.client.read_preference, ReadPreference.SECONDARY_PREFERRED)

--- a/common/lib/xmodule/xmodule/tests/test_mongo_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_mongo_utils.py
@@ -1,4 +1,7 @@
-"""Tests for methods defined in mongo_utils.py"""
+"""
+Tests for methods defined in mongo_utils.py
+"""
+import ddt
 import os
 from unittest import TestCase
 from uuid import uuid4
@@ -10,19 +13,26 @@ from django.conf import settings
 from xmodule.mongo_utils import connect_to_mongodb
 
 
+@ddt.ddt
 class MongoUtilsTests(TestCase):
     """
     Tests for methods exposed in mongo_utils
     """
-    def test_connect_to_mongo_read_preference(self):
+    @ddt.data(
+        ('PRIMARY', 'primary', ReadPreference.PRIMARY),
+        ('SECONDARY_PREFERRED', 'secondaryPreferred', ReadPreference.SECONDARY_PREFERRED),
+        ('NEAREST', 'nearest', ReadPreference.NEAREST),
+    )
+    @ddt.unpack
+    def test_connect_to_mongo_read_preference(self, enum_name, mongos_name, expected_read_preference):
         """
         Test that read_preference parameter gets converted to a valid pymongo read preference.
         """
         host = 'edx.devstack.mongo' if 'BOK_CHOY_HOSTNAME' in os.environ else 'localhost'
         db = 'test_read_preference_%s' % uuid4().hex
         # Support for read_preference given in constant name form (ie. PRIMARY, SECONDARY_PREFERRED)
-        connection = connect_to_mongodb(db, host, read_preference='SECONDARY_PREFERRED')
-        self.assertEqual(connection.client.read_preference, ReadPreference.SECONDARY_PREFERRED)
+        connection = connect_to_mongodb(db, host, read_preference=enum_name)
+        self.assertEqual(connection.client.read_preference, expected_read_preference)
         # Support for read_preference given as mongos name.
-        connection = connect_to_mongodb(db, host, read_preference='secondaryPreferred')
-        self.assertEqual(connection.client.read_preference, ReadPreference.SECONDARY_PREFERRED)
+        connection = connect_to_mongodb(db, host, read_preference=mongos_name)
+        self.assertEqual(connection.client.read_preference, expected_read_preference)


### PR DESCRIPTION
Convert mongo read_preference setting at a lower level.

Doing it at the modulestore level does not cover all usages of mongo, for example when connecting to the contentstore.

This became a problem after https://github.com/edx/configuration/pull/4196 was merged. Our sandbox builds started failing with `pymongo.errors.ConfigurationError: Not a valid read preference` because the new default `read_reference` (`"SECONDARY_PREFERRED"`) was not getting converted to `ReadPreference.SECONDARY_PREFERRED` constant for all mongo connections.

Note that the mongo client allows the `read_preference` parameter to be given either as a `ReadPreference.SECONDARY_PREFERRED` constant, or a string of the form `"secondaryPreferred"`, but not `"SECONDARY_PREFERRED"`, which is why the conversion is necessary.

This patch moves the conversion from `"SECONDARY_PREFERRED"` to `ReadPreference.SECONDARY_PREFERRED`, while also allowing other forms of `read_preference` parameters, such as `"secondaryPreferred"` for backwards compatibility.

**JIRA**: https://openedx.atlassian.net/browse/OSPR-2012

**Sandbox URL**:

- LMS: https://pr16540.sandbox.opencraft.hosting/
- Studio: https://studio-pr16540.sandbox.opencraft.hosting/

**Merge deadline**: ~~This is breaking edx_sandbox.yml builds, so would like to merge ASAP.~~ https://github.com/edx/configuration/pull/4196 was reverted, so this is no longer critical.

**Testing instructions**:

1. Without this patch, using the default value of `EDXAPP_MONGO_READ_PREFERENCE` (`"SECONDARY_PREFERRED")` from https://github.com/edx/configuration/pull/4196, try to spawn a new sandbox using the edx_sandbox.yml playbook. Observe that it fails with the `pymongo.errors.ConfigurationError: Not a valid read preference` error at the `[demo : import demo course]` step.
2. Try to build a sandbox with this patch, observe that it succeeds.

**Reviewers**
- [ ] @UmanShahzad 
- [ ] edX reviewer[s] TBD