### PR TITLE
Use edx-ace for the password reset email

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -27,7 +27,8 @@ for pkg_name in ['track.contexts', 'track.middleware', 'dd.dogapi']:
 
 ################################ EMAIL ########################################
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
+EMAIL_FILE_PATH = '/edx/src/ace_messages/'
 
 ################################# LMS INTEGRATION #############################
 

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -10,15 +10,22 @@ from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
+from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
+from django.core.urlresolvers import reverse
+from django.core.validators import RegexValidator, slug_re
 from django.forms import widgets
-from django.template import loader
 from django.utils.http import int_to_base36
 from django.utils.translation import ugettext_lazy as _
-from django.core.validators import RegexValidator, slug_re
 
+from edx_ace import ace
+from edx_ace.recipient import Recipient
+from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
+from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import accounts as accounts_settings
+from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
+from student.message_types import PasswordReset
 from student.models import CourseEnrollmentAllowed
 from util.password_policy_validators import password_max_length, password_min_length, validate_password
 
@@ -47,41 +54,39 @@ class PasswordResetFormNoActive(PasswordResetForm):
             raise forms.ValidationError(self.error_messages['unusable'])
         return email
 
-    def save(
-            self,
-            subject_template_name='emails/password_reset_subject.txt',
-            email_template_name='registration/password_reset_email.html',
-            use_https=False,
-            token_generator=default_token_generator,
-            from_email=configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL),
-            request=None
-    ):
+    def save(self,  # pylint: disable=arguments-differ
+             use_https=False,
+             token_generator=default_token_generator,
+             request=None,
+             **_kwargs):
         """
         Generates a one-use only link for resetting password and sends to the
         user.
         """
-        # This import is here because we are copying and modifying the .save from Django 1.4.5's
-        # django.contrib.auth.forms.PasswordResetForm directly, which has this import in this place.
-        from django.core.mail import send_mail
         for user in self.users_cache:
-            site_name = configuration_helpers.get_value(
-                'SITE_NAME',
-                settings.SITE_NAME
+            site = Site.objects.get_current()
+            message_context = get_base_template_context(site)
+
+            message_context.update({
+                'request': request,  # Used by google_analytics_tracking_pixel
+                # TODO: This overrides `platform_name` from `get_base_template_context` to make the tests passes
+                'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+                'reset_link': '{protocol}://{site}{link}'.format(
+                    protocol='https' if use_https else 'http',
+                    site=configuration_helpers.get_value('SITE_NAME', settings.SITE_NAME),
+                    link=reverse('password_reset_confirm', kwargs={
+                        'uidb36': int_to_base36(user.id),
+                        'token': token_generator.make_token(user),
+                    }),
+                )
+            })
+
+            msg = PasswordReset().personalize(
+                recipient=Recipient(user.username, user.email),
+                language=get_user_preference(user, LANGUAGE_KEY),
+                user_context=message_context,
             )
-            context = {
-                'email': user.email,
-                'site_name': site_name,
-                'uid': int_to_base36(user.id),
-                'user': user,
-                'token': token_generator.make_token(user),
-                'protocol': 'https' if use_https else 'http',
-                'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
-            }
-            subject = loader.render_to_string(subject_template_name, context)
-            # Email subject *must not* contain newlines
-            subject = subject.replace('\n', '')
-            email = loader.render_to_string(email_template_name, context)
-            send_mail(subject, email, from_email, [user.email])
+            ace.send(msg)
 
 
 class TrueCheckbox(widgets.CheckboxInput):

--- a/common/djangoapps/student/message_types.py
+++ b/common/djangoapps/student/message_types.py
@@ -1,0 +1,17 @@
+"""
+ACE message types for the student module.
+"""
+from django.conf import settings
+
+from edx_ace.message import MessageType
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+
+class PasswordReset(MessageType):
+    def __init__(self, *args, **kwargs):
+        super(PasswordReset, self).__init__(*args, **kwargs)
+
+        self.options['transactional'] = True
+        self.options['from_address'] = configuration_helpers.get_value(
+            'email_from_address', settings.DEFAULT_FROM_EMAIL
+        )

--- a/common/djangoapps/student/tests/test_configuration_overrides.py
+++ b/common/djangoapps/student/tests/test_configuration_overrides.py
@@ -15,6 +15,7 @@ FAKE_SITE = {
     "university": "fakeuniversity",
     "course_org_filter": "fakeorg",
     "platform_name": "Fake University",
+    "PLATFORM_NAME": "Fake University",
     "email_from_address": "no-reply@fakeuniversity.com",
     "REGISTRATION_EXTRA_FIELDS": {
         "address1": "required",

--- a/common/templates/student/edx_ace/passwordreset/email/body.html
+++ b/common/templates/student/edx_ace/passwordreset/email/body.html
@@ -1,0 +1,40 @@
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% trans "Password Reset" %}
+            </h1>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ platform_name }}.{% endblocktrans %}
+                <br />
+            </p>
+
+            {% if failed %}
+                <p style="color: rgba(0,0,0,.75);">
+                    {% blocktrans %}However, there is currently no user account associated with your email address: {{ email_address }}.{% endblocktrans %}
+                    <br />
+                </p>
+
+                <p style="color: rgba(0,0,0,.75);">
+                    {% trans "If you did not request this change, you can ignore this email." %}
+                    <br />
+                </p>
+            {% else %}
+                <p style="color: rgba(0,0,0,.75);">
+                    {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." %}
+                    <br />
+                </p>
+
+                {% trans "Change my Password" as course_cta_text %}
+
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
+            {% endif %}
+        </td>
+    </tr>
+</table>
+{% endblock %}

--- a/common/templates/student/edx_ace/passwordreset/email/body.txt
+++ b/common/templates/student/edx_ace/passwordreset/email/body.txt
@@ -7,15 +7,12 @@
 {% trans "If you did not request this change, you can ignore this email." %}
 {% else %}
 {% trans "Please go to the following page and choose a new password:" %}
-{% block reset_link %}
-{{ protocol }}://{{ site_name }}{% url 'password_reset_confirm' uidb36=uid token=token %}
-{% endblock %}
+
+{{ reset_link }}
 
 {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." %}
 
 {% trans "Thanks for using our site!" %}
 {% endif %}
-
 {% blocktrans %}The {{ platform_name }} Team{% endblocktrans %}
-
 {% endautoescape %}

--- a/common/templates/student/edx_ace/passwordreset/email/from_name.txt
+++ b/common/templates/student/edx_ace/passwordreset/email/from_name.txt
@@ -1,0 +1,1 @@
+{{ platform_name }}

--- a/common/templates/student/edx_ace/passwordreset/email/head.html
+++ b/common/templates/student/edx_ace/passwordreset/email/head.html
@@ -1,0 +1,1 @@
+{% extends 'ace_common/edx_ace/common/base_head.html' %}

--- a/common/templates/student/edx_ace/passwordreset/email/subject.txt
+++ b/common/templates/student/edx_ace/passwordreset/email/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Password reset on {{ platform_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -39,7 +39,8 @@ for log_name, log_level in LOG_OVERRIDES:
 
 ################################ EMAIL ########################################
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
+EMAIL_FILE_PATH = '/edx/src/ace_messages/'
 
 ############################ PYFS XBLOCKS SERVICE #############################
 # Set configuration for Django pyfilesystem

--- a/lms/templates/emails/password_reset_subject.txt
+++ b/lms/templates/emails/password_reset_subject.txt
@@ -1,4 +1,0 @@
-{% load i18n %}
-{% autoescape off %}
-{% blocktrans %}Password reset on {{ platform_name }}{% endblocktrans %}
-{% endautoescape %}

--- a/openedx/core/djangoapps/ace_common/apps.py
+++ b/openedx/core/djangoapps/ace_common/apps.py
@@ -19,7 +19,7 @@ class AceCommonConfig(AppConfig):
             ProjectType.LMS: {
                 SettingsType.AWS: {PluginSettings.RELATIVE_PATH: u'settings.aws'},
                 SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: u'settings.common'},
-                SettingsType.DEVSTACK: {PluginSettings.RELATIVE_PATH: u'settings.common'},
+                SettingsType.DEVSTACK: {PluginSettings.RELATIVE_PATH: u'settings.devstack'},
             }
         }
     }

--- a/openedx/core/djangoapps/ace_common/settings/aws.py
+++ b/openedx/core/djangoapps/ace_common/settings/aws.py
@@ -14,3 +14,10 @@ def plugin_settings(settings):
         'ACE_CHANNEL_SAILTHRU_API_SECRET', settings.ACE_CHANNEL_SAILTHRU_API_SECRET,
     )
     settings.ACE_ROUTING_KEY = settings.ENV_TOKENS.get('ACE_ROUTING_KEY', settings.ACE_ROUTING_KEY)
+
+    settings.ACE_CHANNEL_DEFAULT_EMAIL = settings.ENV_TOKENS.get(
+        'ACE_CHANNEL_DEFAULT_EMAIL', settings.ACE_CHANNEL_DEFAULT_EMAIL
+    )
+    settings.ACE_CHANNEL_TRANSACTIONAL_EMAIL = settings.ENV_TOKENS.get(
+        'ACE_CHANNEL_TRANSACTIONAL_EMAIL', settings.ACE_CHANNEL_TRANSACTIONAL_EMAIL
+    )

--- a/openedx/core/djangoapps/ace_common/settings/common.py
+++ b/openedx/core/djangoapps/ace_common/settings/common.py
@@ -1,6 +1,6 @@
 def plugin_settings(settings):
     settings.ACE_ENABLED_CHANNELS = [
-        'file_email'
+        'django_email'
     ]
     settings.ACE_ENABLED_POLICIES = [
         'bulk_email_optout'
@@ -9,6 +9,8 @@ def plugin_settings(settings):
     settings.ACE_CHANNEL_SAILTHRU_TEMPLATE_NAME = 'Automated Communication Engine Email'
     settings.ACE_CHANNEL_SAILTHRU_API_KEY = None
     settings.ACE_CHANNEL_SAILTHRU_API_SECRET = None
+    settings.ACE_CHANNEL_DEFAULT_EMAIL = 'django_email'
+    settings.ACE_CHANNEL_TRANSACTIONAL_EMAIL = 'django_email'
 
     settings.ACE_ROUTING_KEY = 'edx.core.low'
 

--- a/openedx/core/djangoapps/ace_common/settings/devstack.py
+++ b/openedx/core/djangoapps/ace_common/settings/devstack.py
@@ -1,0 +1,19 @@
+"""
+Settings for edX ACE on devstack.
+"""
+
+from openedx.core.djangoapps.ace_common.settings import common
+
+
+def plugin_settings(settings):
+    """
+    Override common settings and use `file_email` for better debugging.
+    """
+    common.plugin_settings(settings)
+
+    settings.ACE_ENABLED_CHANNELS = [
+        'file_email'
+    ]
+
+    settings.ACE_CHANNEL_DEFAULT_EMAIL = 'file_email'
+    settings.ACE_CHANNEL_TRANSACTIONAL_EMAIL = 'file_email'

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -20,9 +20,9 @@
     {% block preview_text %}{% endblock %}
 </div>
 
-{# Note {beacon_src} is not a template variable that is evaluated by the Django template engine. It is evaluated by #}
-{# Sailthru when the email is sent. Other email providers would need to replace this variable in the HTML as well. #}
-<img src="{beacon_src}" alt="" role="presentation" aria-hidden="true" />
+{% for image_src in channel.tracker_image_sources %}
+    <img src="{image_src}" alt="" role="presentation" aria-hidden="true" />
+{% endfor %}
 
 {% google_analytics_tracking_pixel %}
 
@@ -157,17 +157,13 @@
                     <tr>
                         <!-- Actions -->
                         <td style="padding-bottom: 20px;">
-                            {# Note that these variables are evaluated by Sailthru, not the Django template engine #}
-                            <p>
-                                <a href="{view_url}" style="color: #005686">
-                                    <font color="#005686"><b>{% trans "View on Web" %}</b></font>
-                                </a>
-                            </p>
-                            <p>
-                                <a href="{optout_confirm_url}" style="color: #005686">
-                                    <font color="#005686"><b>{% trans "Unsubscribe from this list" %}</b></font>
-                                </a>
-                            </p>
+                            {% for action_link_url, action_link_text in channel.action_links %}
+                                <p>
+                                    <a href="{{ action_link_url }}" style="color: #005686">
+                                        <font color="#005686"><b>{{ action_link_text }}</b></font>
+                                    </a>
+                                </p>
+                            {% endfor %}
                         </td>
                     </tr>
                     <tr>

--- a/openedx/core/djangoapps/schedules/management/commands/tests/send_email_base.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/send_email_base.py
@@ -7,8 +7,8 @@ import attr
 import ddt
 import pytz
 from django.conf import settings
-from edx_ace.channel import ChannelType
-from edx_ace.test_utils import StubPolicy, patch_channels, patch_policies
+from edx_ace.channel import ChannelMap, ChannelType
+from edx_ace.test_utils import StubPolicy, patch_policies
 from edx_ace.utils.date import serialize
 from freezegun import freeze_time
 from mock import Mock, patch
@@ -383,11 +383,16 @@ class ScheduleSendEmailTestMixin(FilteredQueryCountMixin):
             )
 
         patch_policies(self, [StubPolicy([ChannelType.PUSH])])
+
         mock_channel = Mock(
-            name='test_channel',
-            channel_type=ChannelType.EMAIL
+            channel_type=ChannelType.EMAIL,
+            action_links=[],
+            tracker_image_sources=[],
         )
-        patch_channels(self, [mock_channel])
+
+        channel_map = ChannelMap([
+            ['sailthru', mock_channel],
+        ])
 
         sent_messages = []
         with self.settings(TEMPLATES=self._get_template_overrides()):
@@ -411,8 +416,9 @@ class ScheduleSendEmailTestMixin(FilteredQueryCountMixin):
 
             with self.assertNumQueries(NUM_QUERIES_PER_MESSAGE_DELIVERY):
                 with patch('analytics.track') as mock_analytics_track:
-                    self.deliver_task(*sent_messages[0])
-                    self.assertEqual(mock_analytics_track.call_count, 1)
+                    with patch('edx_ace.channel.channels', return_value=channel_map):
+                        self.deliver_task(*sent_messages[0])
+                        self.assertEqual(mock_analytics_track.call_count, 1)
 
             self.assertEqual(mock_channel.deliver.call_count, 1)
             for (_name, (_msg, email), _kwargs) in mock_channel.deliver.mock_calls:

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 from django.core.validators import validate_email, ValidationError
 from django.http import HttpResponseForbidden
+from openedx.core.djangoapps.theming.helpers import get_current_request
 from six import text_type
 
 from student.models import User, UserProfile, Registration
@@ -432,7 +433,8 @@ def request_password_change(email, is_secure):
         # and email it to the user.
         form.save(
             from_email=configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL),
-            use_https=is_secure
+            use_https=is_secure,
+            request=get_current_request(),
         )
     else:
         # No user with the provided email address exists.

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -19,6 +19,7 @@ from nose.plugins.attrib import attr
 from nose.tools import raises
 from six import iteritems
 
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.user_api.accounts import PRIVATE_VISIBILITY, USERNAME_MAX_LENGTH
 from openedx.core.djangoapps.user_api.accounts.api import (
     activate_account,
@@ -431,8 +432,13 @@ class AccountCreationActivationAndPasswordChangeTest(TestCase):
         activation_key = create_account(self.USERNAME, self.PASSWORD, self.EMAIL)
         activate_account(activation_key)
 
-        # Request a password change
-        request_password_change(self.EMAIL, self.IS_SECURE)
+        request = RequestFactory().post('/password')
+        request.user = Mock()
+        request.site = SiteFactory()
+
+        with patch('crum.get_current_request', return_value=request):
+            # Request a password change
+            request_password_change(self.EMAIL, self.IS_SECURE)
 
         # Verify that one email message has been sent
         self.assertEqual(len(mail.outbox), 1)
@@ -456,7 +462,12 @@ class AccountCreationActivationAndPasswordChangeTest(TestCase):
         # Create an account, but do not activate it
         create_account(self.USERNAME, self.PASSWORD, self.EMAIL)
 
-        request_password_change(self.EMAIL, self.IS_SECURE)
+        request = RequestFactory().post('/password')
+        request.user = Mock()
+        request.site = SiteFactory()
+
+        with patch('crum.get_current_request', return_value=request):
+            request_password_change(self.EMAIL, self.IS_SECURE)
 
         # Verify that the activation email was still sent
         self.assertEqual(len(mail.outbox), 1)

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -63,7 +63,7 @@ django-waffle==0.12.0
 django-webpack-loader==0.4.1
 djangorestframework-jwt
 dogapi==1.2.1                       # Python bindings to Datadog's API, for metrics gathering
-edx-ace==0.1.6
+edx-ace==0.1.7
 edx-analytics-data-api-client
 edx-ccx-keys
 edx-celeryutils

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -106,7 +106,7 @@ dm.xmlsec.binding==1.3.3  # via python-saml
 docopt==0.6.2
 docutils==0.14            # via botocore
 dogapi==1.2.1
-edx-ace==0.1.6
+edx-ace==0.1.7
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -125,7 +125,7 @@ dm.xmlsec.binding==1.3.3
 docopt==0.6.2
 docutils==0.14
 dogapi==1.2.1
-edx-ace==0.1.6
+edx-ace==0.1.7
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
@@ -290,7 +290,7 @@ s3transfer==0.1.13
 sailthru-client==2.2.3
 scipy==0.14.0
 scrapy==1.1.2
-selenium==3.11.0
+selenium==3.12.0
 service-identity==17.0.0
 shapely==1.2.16
 shortuuid==0.5.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -120,7 +120,7 @@ dm.xmlsec.binding==1.3.3
 docopt==0.6.2
 docutils==0.14
 dogapi==1.2.1
-edx-ace==0.1.6
+edx-ace==0.1.7
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
@@ -279,7 +279,7 @@ s3transfer==0.1.13
 sailthru-client==2.2.3
 scipy==0.14.0
 scrapy==1.1.2             # via pa11ycrawler
-selenium==3.11.0
+selenium==3.12.0
 service-identity==17.0.0  # via scrapy
 shapely==1.2.16
 shortuuid==0.5.0

--- a/themes/red-theme/lms/templates/ace_common/edx_ace/common/base_body.html
+++ b/themes/red-theme/lms/templates/ace_common/edx_ace/common/base_body.html
@@ -22,9 +22,9 @@
 
 <!-- TEST RED THEME MARKER: Do not remove this comment, it is used by the tests to tell if this theme was used -->
 
-{# Note {beacon_src} is not a template variable that is evaluated by the Django template engine. It is evaluated by #}
-{# Sailthru when the email is sent. Other email providers would need to replace this variable in the HTML as well. #}
-<img src="{beacon_src}" alt="" role="presentation" aria-hidden="true" />
+{% for image_src in channel.tracker_image_sources %}
+    <img src="{image_src}" alt="" role="presentation" aria-hidden="true" />
+{% endfor %}
 
 {% google_analytics_tracking_pixel %}
 
@@ -159,17 +159,13 @@
                     <tr>
                         <!-- Actions -->
                         <td style="padding-bottom: 20px;">
-                            {# Note that these variables are evaluated by Sailthru, not the Django template engine #}
-                            <p>
-                                <a href="{view_url}" style="color: #960909">
-                                    <font color="#960909"><b>{% trans "View on Web" %}</b></font>
-                                </a>
-                            </p>
-                            <p>
-                                <a href="{optout_confirm_url}" style="color: #960909">
-                                    <font color="#960909"><b>{% trans "Unsubscribe from this list" %}</b></font>
-                                </a>
-                            </p>
+                            {% for action_link_url, action_link_text in channel.action_links %}
+                                <p>
+                                    <a href="{{ action_link_url }}" style="color: #960909">
+                                        <font color="#960909"><b>{{ action_link_text }}</b></font>
+                                    </a>
+                                </p>
+                            {% endfor %}
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
I've pivoted to use edX ACE instead of manually rendering the HTML.

<kbd><img width="450" src="https://user-images.githubusercontent.com/645156/35188664-952aa728-fe42-11e7-82ac-acc9abf4dd46.png" /></kbd>

### TODO
 - [x] Get the Django email channel PR merged: https://github.com/edx/edx-ace/pull/25
    - [x] Bump the versions to include `edx-ace==0.1.7`
 - [x] Test if locally one more time before it's merged.
 - [x] Nimisha to check if `site.domain` usage is correct.
 - [x] Nimisha to check if the `platform_name` override is correct.
 - [x] Spice up the HTML template for password reset.

### Reviewers
 - [x] A review from @nasthagiri 
 - [ ] Get it reviewed @grozdanowski for theming and Microsite friendliness

 ----

## Too Long Don't Read :point_down: 

> This is a leap of faith! I'm trying to get this merged after being on hold for a while!
> 
> ### Description
> Add in support for multipart emails (html) in the automatic messages that respond to user actions e.g: account creation, password change and password reset.
> 
> This PR:
> 
>  - Adds all the required templates to render the html messages (the base template is the one from the bulk_email app which ultimately is the one from the mailchimp templates)
>  - Overrides the save method in class PasswordResetFormNoActive to have HTML template.
> The bulk of this work was completed by @felipemontoya in #3374, and Sarina's #6681. 
> 
> I am taking over from them, to add in generic branding, get tests passing, and finish code review.
> 
 
