### PR TITLE
EDUCATOR-1729 | Control forum notifications with SiteConfiguration, too.

### DIFF
--- a/lms/djangoapps/discussion/signals/handlers.py
+++ b/lms/djangoapps/discussion/signals/handlers.py
@@ -9,10 +9,14 @@ from opaque_keys.edx.keys import CourseKey
 from django_comment_common import signals
 from lms.djangoapps.discussion.config.waffle import waffle, FORUM_RESPONSE_NOTIFICATIONS, SEND_NOTIFICATIONS_FOR_COURSE
 from lms.djangoapps.discussion import tasks
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.theming.helpers import get_current_site
 
 
 log = logging.getLogger(__name__)
+
+
+ENABLE_FORUM_NOTIFICATIONS_FOR_SITE_KEY = 'enable_forum_notifications'
 
 
 @receiver(signals.comment_created)
@@ -22,12 +26,22 @@ def send_discussion_email_notification(sender, user, post, **kwargs):
         return
 
     if not SEND_NOTIFICATIONS_FOR_COURSE.is_enabled(CourseKey.from_string(post.thread.course_id)):
-        log.debug('Discussion: Response notifications not enabled for this course')
+        log.debug('Discussion: Response notifications not enabled for course: %s.', post.thread.course_id)
         return
 
     current_site = get_current_site()
     if current_site is None:
-        log.debug('Discussion: No current site, not sending notification')
+        log.info('Discussion: No current site, not sending notification about post: %s.', post.id)
+        return
+
+    try:
+        if not current_site.configuration.get_value(ENABLE_FORUM_NOTIFICATIONS_FOR_SITE_KEY, False):
+            log_message = 'Discussion: notifications not enabled for site: %s. Not sending message about post: %s.'
+            log.info(log_message, current_site, post.id)
+            return
+    except SiteConfiguration.DoesNotExist:
+        log_message = 'Discussion: No SiteConfiguration for site %s. Not sending message about post: %s.'
+        log.info(log_message, current_site, post.id)
         return
 
     send_message(post, current_site)

--- a/lms/djangoapps/discussion/tests/test_signals.py
+++ b/lms/djangoapps/discussion/tests/test_signals.py
@@ -5,6 +5,8 @@ from opaque_keys.edx.keys import CourseKey
 
 from django_comment_common import signals
 from lms.djangoapps.discussion.config.waffle import waffle, FORUM_RESPONSE_NOTIFICATIONS, SEND_NOTIFICATIONS_FOR_COURSE
+from lms.djangoapps.discussion.signals.handlers import ENABLE_FORUM_NOTIFICATIONS_FOR_SITE_KEY
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory, SiteConfigurationFactory
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 
 
@@ -15,10 +17,16 @@ class SendMessageHandlerTestCase(TestCase):
         self.post = mock.Mock()
         self.post.thread.course_id = 'course-v1:edX+DemoX+Demo_Course'
 
+        self.site = SiteFactory.create()
+
     @mock.patch('lms.djangoapps.discussion.signals.handlers.get_current_site')
     @mock.patch('lms.djangoapps.discussion.signals.handlers.send_message')
     @override_waffle_flag(SEND_NOTIFICATIONS_FOR_COURSE, True)
     def test_comment_created_signal_sends_message(self, mock_send_message, mock_get_current_site):
+        site_config = SiteConfigurationFactory.create(site=self.site)
+        site_config.values[ENABLE_FORUM_NOTIFICATIONS_FOR_SITE_KEY] = True
+        site_config.save()
+        mock_get_current_site.return_value = self.site
         with waffle().override(FORUM_RESPONSE_NOTIFICATIONS):
             signals.comment_created.send(sender=self.sender, user=self.user, post=self.post)
 
@@ -44,6 +52,31 @@ class SendMessageHandlerTestCase(TestCase):
     @override_waffle_flag(SEND_NOTIFICATIONS_FOR_COURSE, True)
     def test_comment_created_signal_message_not_sent_without_site(self, mock_send_message, mock_get_current_site):
         with waffle().override(FORUM_RESPONSE_NOTIFICATIONS, active=True):
+            signals.comment_created.send(sender=self.sender, user=self.user, post=self.post)
+
+            self.assertFalse(mock_send_message.called)
+
+    @mock.patch('lms.djangoapps.discussion.signals.handlers.get_current_site')
+    @mock.patch('lms.djangoapps.discussion.signals.handlers.send_message')
+    @override_waffle_flag(SEND_NOTIFICATIONS_FOR_COURSE, True)
+    def test_comment_created_signal_msg_not_sent_without_site_config(self, mock_send_message, mock_get_current_site):
+        mock_get_current_site.return_value = self.site
+        with waffle().override(FORUM_RESPONSE_NOTIFICATIONS):
+            signals.comment_created.send(sender=self.sender, user=self.user, post=self.post)
+
+            self.assertFalse(mock_send_message.called)
+
+    @mock.patch('lms.djangoapps.discussion.signals.handlers.get_current_site')
+    @mock.patch('lms.djangoapps.discussion.signals.handlers.send_message')
+    @override_waffle_flag(SEND_NOTIFICATIONS_FOR_COURSE, True)
+    def test_comment_created_signal_msg_not_sent_with_site_config_disabled(
+            self, mock_send_message, mock_get_current_site
+    ):
+        site_config = SiteConfigurationFactory.create(site=self.site)
+        site_config.values[ENABLE_FORUM_NOTIFICATIONS_FOR_SITE_KEY] = False
+        site_config.save()
+        mock_get_current_site.return_value = self.site
+        with waffle().override(FORUM_RESPONSE_NOTIFICATIONS):
             signals.comment_created.send(sender=self.sender, user=self.user, post=self.post)
 
             self.assertFalse(mock_send_message.called)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-1729

We want to control whether notifications of forum activity are sent to thread authors on a per-Site basis.  This change includes a check in the `SiteConfiguration` for a key indicating that this feature is enabled.

@bderusha is this an appropriate use of `SiteConfiguration` for keeping this featuring implicitly disabled on white label sites?