### PR TITLE
Remove aria-label for fields in Account Settings and Profile

### DIFF
--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -483,7 +483,6 @@
                 if (this.modelValueIsSet() === false) {
                     value = this.options.placeholderValue || '';
                 }
-                this.$('.u-field-value').attr('aria-label', this.options.title);
                 this.$('.u-field-value-readonly').text(value);
 
                 if (this.mode === 'display') {


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-2894

Looks like this aria-label was being added blindly to any class `u-field-value`. The proposed approach would be to find all places this change might affect. 

The only places where this aria-label seems to be applying to is the Profile Page, and the Account Settings. Although not listed in the ticket, the same issue occurs on the Profile Page as it does on the Account page.

Testing:

http://benjilee.sandbox.edx.org/

Check the following area in the screenshots and make sure they are...
* Not repeated twice in JAWS
* Repeated once in Voiceover

![screen shot 2017-11-14 at 10 27 16 am](https://user-images.githubusercontent.com/7101723/32788237-adb85390-c926-11e7-926c-4e6b40942e53.png)

![screen shot 2017-11-14 at 10 34 45 am](https://user-images.githubusercontent.com/7101723/32788558-86823af6-c927-11e7-8ab5-8b9bbf32cf7d.png)
