### PR TITLE
addresses issue where branch information was not being stripped from …

### DIFF
--- a/openedx/core/djangoapps/coursegraph/tasks.py
+++ b/openedx/core/djangoapps/coursegraph/tasks.py
@@ -144,6 +144,16 @@ def get_course_last_published(course_key):
     return course_last_published_date
 
 
+def strip_branch_and_version(location):
+    """
+    Removes the branch and version information from a location.
+    Args:
+        location: an xblock's location.
+    Returns: that xblock's location without branch and version information.
+    """
+    return location.for_branch(None)
+
+
 def serialize_course(course_id):
     """
     Serializes a course into py2neo Nodes and Relationships
@@ -170,15 +180,15 @@ def serialize_course(course_id):
             fields[field_name] = coerce_types(value)
 
         node = Node(block_type, 'item', **fields)
-        location_to_node[item.location.version_agnostic()] = node
+        location_to_node[strip_branch_and_version(item.location)] = node
 
     # create relationships
     relationships = []
     for item in items:
         previous_child_node = None
         for index, child in enumerate(item.get_children()):
-            parent_node = location_to_node.get(item.location.version_agnostic())
-            child_node = location_to_node.get(child.location.version_agnostic())
+            parent_node = location_to_node.get(strip_branch_and_version(item.location))
+            child_node = location_to_node.get(strip_branch_and_version(child.location))
 
             if parent_node is not None and child_node is not None:
                 child_node["index"] = index


### PR DESCRIPTION
…child blocks when serializing courses (PLAT-1794)

The core thing that the dump_to_neo4j script does is gather all the items in a course, determine which ones follow another or descend from another, and translates that information into nodes and relationships in a graph, which it then exports to neo4j.

In [PLAT-1794](https://openedx.atlassian.net/browse/PLAT-1794), we saw an issue with the code that determines parent-child relationships. Parent-child relationships are determined by doing the following passthrough on the items in a course:

1. Iterate once through all the items in a course, turn them into Node objects, and cache them by the item's location attribute
2. Iterate again through all the items in a course. For each iteration, iterate over that item's children. Use the item's and child's locations to retrieve their cached Node objects and create a Relationship object between the two.

The bug was that item locations are stripped of branch and version information, but their children are not. In a previous PR (https://github.com/edx/edx-platform/pull/16133), we removed the version information, but not the branch information. This PR now removes both both.

@macdiesel and/or @fredsmith , looking to one of you for a review please! I'll merge after 1 thumbs up.



