### PR TITLE
Remove use of non-relational fields in select_related queries

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1871,7 +1871,7 @@ class CourseEnrollment(models.Model):
         # remove previously cached entries to keep memory usage low.
         request_cache.clear_cache(cls.MODE_CACHE_NAMESPACE)
 
-        records = cls.objects.filter(user__in=users, course_id=course_key).select_related('user__id')
+        records = cls.objects.filter(user__in=users, course_id=course_key).select_related('user')
         cache = cls._get_mode_active_request_cache()
         for record in records:
             enrollment_state = CourseEnrollmentState(record.mode, record.is_active)

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -44,7 +44,7 @@ class BulkRoleCache(object):
         roles_by_user = defaultdict(set)
         get_cache(cls.CACHE_NAMESPACE)[cls.CACHE_KEY] = roles_by_user
 
-        for role in CourseAccessRole.objects.filter(user__in=users).select_related('user__id'):
+        for role in CourseAccessRole.objects.filter(user__in=users).select_related('user'):
             roles_by_user[role.user.id].add(role)
 
         users_without_roles = filter(lambda u: u.id not in roles_by_user, users)

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -170,7 +170,7 @@ class _EnrollmentBulkContext(object):
         CourseEnrollment.bulk_fetch_enrollment_states(users, context.course_id)
         self.verified_users = [
             verified.user.id for verified in
-            SoftwareSecurePhotoVerification.verified_query().filter(user__in=users).select_related('user__id')
+            SoftwareSecurePhotoVerification.verified_query().filter(user__in=users).select_related('user')
         ]
 
 
@@ -295,7 +295,7 @@ class CourseGradeReport(object):
             return izip_longest(*args, fillvalue=fillvalue)
 
         users = CourseEnrollment.objects.users_enrolled_in(context.course_id, include_inactive=True)
-        users = users.select_related('profile__allow_certificate')
+        users = users.select_related('profile')
         return grouper(users)
 
     def _user_grades(self, course_grade, context):

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -182,7 +182,7 @@ def bulk_cache_cohorts(course_key, users):
         cohorts_by_user = {
             membership.user: membership
             for membership in
-            CohortMembership.objects.filter(user__in=users, course_id=course_key).select_related('user__id')
+            CohortMembership.objects.filter(user__in=users, course_id=course_key).select_related('user')
         }
         for user, membership in cohorts_by_user.iteritems():
             cache[_cohort_cache_key(user.id, course_key)] = membership.course_user_group

--- a/openedx/core/djangoapps/user_api/course_tag/api.py
+++ b/openedx/core/djangoapps/user_api/course_tag/api.py
@@ -36,7 +36,7 @@ class BulkCourseTags(object):
                 and the secondary key is the course tag's key
         """
         course_tags = defaultdict(dict)
-        for tag in UserCourseTag.objects.filter(user__in=users, course_id=course_id).select_related('user__id'):
+        for tag in UserCourseTag.objects.filter(user__in=users, course_id=course_id).select_related('user'):
             course_tags[tag.user.id][tag.key] = tag.value
         get_cache(cls.CACHE_NAMESPACE)[cls._cache_key(course_id)] = course_tags
 


### PR DESCRIPTION
Using select_related with non-relational fields will throw errors in Django 1.11, so I am removing them. I have verified that these changes do not modify the actual queries performed.