### PR TITLE
Avoid a django breaking change: set_language response code

### DIFF
--- a/lms/static/js/spec/student_account/account_settings_fields_spec.js
+++ b/lms/static/js/spec/student_account/account_settings_fields_spec.js
@@ -142,8 +142,13 @@ define(['backbone',
                     requests,
                     'POST',
                     '/i18n/setlang/',
-                    'language=' + data[fieldData.valueAttribute]
+                    $.param({
+                        language: data[fieldData.valueAttribute],
+                        next: window.location.href
+                    })
                 );
+                // Django will actually respond with a 302 redirect, but that would cause a page load during these
+                // unittests.  204 should work fine for testing.
                 AjaxHelpers.respondWithNoContent(requests);
                 FieldViewsSpecHelpers.expectMessageContains(view, 'Your changes have been saved.');
 
@@ -157,7 +162,10 @@ define(['backbone',
                     requests,
                     'POST',
                     '/i18n/setlang/',
-                    'language=' + data[fieldData.valueAttribute]
+                    $.param({
+                        language: data[fieldData.valueAttribute],
+                        next: window.location.href
+                    })
                 );
                 AjaxHelpers.respondWithError(requests, 500);
                 FieldViewsSpecHelpers.expectMessageContains(

--- a/lms/static/js/student_account/views/account_settings_fields.js
+++ b/lms/static/js/student_account/views/account_settings_fields.js
@@ -52,7 +52,8 @@
                 fieldTemplate: field_dropdown_account_template,
                 saveSucceeded: function() {
                     var data = {
-                        language: this.modelValue()
+                        language: this.modelValue(),
+                        next: window.location.href
                     };
 
                     var view = this;


### PR DESCRIPTION
This addresses the following breaking change introduced in Django 1.10 by ~~forcing a reload via javascript rather than relying on a 302 from the lms~~ ensuring the response remains a 302 redirect.

> * set_language() now returns a 204 status code (No Content) for AJAX requests when there is no next parameter in POST or GET.
 
PLAT-1353