### PR TITLE
Fixes Discussion Posts Not Showing in IE11 Browsers

### DIFF
--- a/lms/static/js/ie11_find_array.js
+++ b/lms/static/js/ie11_find_array.js
@@ -1,0 +1,45 @@
+// Polyfill for patching IE11 Browsers
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Polyfill
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+     // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      var k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return kValue.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return kValue;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return undefined.
+      return undefined;
+    }
+  });
+}

--- a/lms/static/js/ie11_find_array.js
+++ b/lms/static/js/ie11_find_array.js
@@ -1,28 +1,32 @@
 // Polyfill for patching IE11 Browsers
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Polyfill
+"use strict";
+
 if (!Array.prototype.find) {
-  Object.defineProperty(Array.prototype, 'find', {
-    value: function(predicate) {
-     // 1. Let O be ? ToObject(this value).
-      if (this == null) {
-        throw new TypeError('"this" is null or not defined');
-      }
+    Object.defineProperty(Array.prototype, 'find', { // eslint-disable-line no-extend-native
+      value: function(predicate) {
+        var o, len, thisArg, k, kValue;
 
-      var o = Object(this);
+        // 1. Let O be ? ToObject(this value).
+        if (this == null) {
+          throw new TypeError('"this" is null or not defined');
+        }
 
-      // 2. Let len be ? ToLength(? Get(O, "length")).
-      var len = o.length >>> 0;
+        o = Object(this);
 
-      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-      if (typeof predicate !== 'function') {
-        throw new TypeError('predicate must be a function');
+        // 2. Let len be ? ToLength(? Get(O, "length")).
+        len = o.length >>> 0;
+
+        // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+        if (typeof predicate !== 'function') {
+          throw new TypeError('predicate must be a function');
       }
 
       // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-      var thisArg = arguments[1];
+      thisArg = arguments[1];
 
       // 5. Let k be 0.
-      var k = 0;
+      k = 0;
 
       // 6. Repeat, while k < len
       while (k < len) {
@@ -30,7 +34,7 @@ if (!Array.prototype.find) {
         // b. Let kValue be ? Get(O, Pk).
         // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
         // d. If testResult is true, return kValue.
-        var kValue = o[k];
+        kValue = o[k];
         if (predicate.call(thisArg, kValue, k, o)) {
           return kValue;
         }

--- a/lms/static/js/ie11_find_array.js
+++ b/lms/static/js/ie11_find_array.js
@@ -19,7 +19,7 @@ if (!Array.prototype.find) {
 
             // 3. If IsCallable(predicate) is false, throw a TypeError exception.
             if (typeof predicate !== 'function') {
-              throw new TypeError('predicate must be a function');
+                throw new TypeError('predicate must be a function');
             }
 
             // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.

--- a/lms/static/js/ie11_find_array.js
+++ b/lms/static/js/ie11_find_array.js
@@ -4,46 +4,46 @@
 if (!Array.prototype.find) {
     Object.defineProperty(Array.prototype, 'find', { // eslint-disable-line no-extend-native
         value: function(predicate) {
-          'use strict';
-          var o, len, thisArg, k, kValue;
+            'use strict';
+            var o, len, thisArg, k, kValue;
 
-          // 1. Let O be ? ToObject(this value).
-          if (this == null) {
-            throw new TypeError('"this" is null or not defined');
-          }
+            // 1. Let O be ? ToObject(this value).
+            if (this == null) {
+                throw new TypeError('"this" is null or not defined');
+            }
 
-          o = Object(this);
+            o = Object(this);
 
-          // 2. Let len be ? ToLength(? Get(O, "length")).
-          len = o.length >>> 0;
+            // 2. Let len be ? ToLength(? Get(O, "length")).
+            len = o.length >>> 0;
 
-          // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-          if (typeof predicate !== 'function') {
-            throw new TypeError('predicate must be a function');
+            // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+            if (typeof predicate !== 'function') {
+              throw new TypeError('predicate must be a function');
+            }
+
+            // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+            thisArg = arguments[1];
+
+            // 5. Let k be 0.
+            k = 0;
+
+            // 6. Repeat, while k < len
+            while (k < len) {
+                // a. Let Pk be ! ToString(k).
+                // b. Let kValue be ? Get(O, Pk).
+                // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+                // d. If testResult is true, return kValue.
+                kValue = o[k];
+                if (predicate.call(thisArg, kValue, k, o)) {
+                    return kValue;
+                }
+                // e. Increase k by 1.
+                k++;
+            }
+
+            // 7. Return undefined.
+            return undefined;
         }
-
-        // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-        thisArg = arguments[1];
-
-        // 5. Let k be 0.
-        k = 0;
-
-        // 6. Repeat, while k < len
-        while (k < len) {
-          // a. Let Pk be ! ToString(k).
-          // b. Let kValue be ? Get(O, Pk).
-          // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-          // d. If testResult is true, return kValue.
-          kValue = o[k];
-          if (predicate.call(thisArg, kValue, k, o)) {
-            return kValue;
-          }
-          // e. Increase k by 1.
-          k++;
-        }
-
-        // 7. Return undefined.
-        return undefined;
-      }
     });
 }

--- a/lms/static/js/ie11_find_array.js
+++ b/lms/static/js/ie11_find_array.js
@@ -1,49 +1,49 @@
 // Polyfill for patching IE11 Browsers
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Polyfill
-"use strict";
 
 if (!Array.prototype.find) {
     Object.defineProperty(Array.prototype, 'find', { // eslint-disable-line no-extend-native
-      value: function(predicate) {
-        var o, len, thisArg, k, kValue;
+        value: function(predicate) {
+          'use strict';
+          var o, len, thisArg, k, kValue;
 
-        // 1. Let O be ? ToObject(this value).
-        if (this == null) {
-          throw new TypeError('"this" is null or not defined');
+          // 1. Let O be ? ToObject(this value).
+          if (this == null) {
+            throw new TypeError('"this" is null or not defined');
+          }
+
+          o = Object(this);
+
+          // 2. Let len be ? ToLength(? Get(O, "length")).
+          len = o.length >>> 0;
+
+          // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+          if (typeof predicate !== 'function') {
+            throw new TypeError('predicate must be a function');
         }
 
-        o = Object(this);
+        // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+        thisArg = arguments[1];
 
-        // 2. Let len be ? ToLength(? Get(O, "length")).
-        len = o.length >>> 0;
+        // 5. Let k be 0.
+        k = 0;
 
-        // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-        if (typeof predicate !== 'function') {
-          throw new TypeError('predicate must be a function');
-      }
-
-      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-      thisArg = arguments[1];
-
-      // 5. Let k be 0.
-      k = 0;
-
-      // 6. Repeat, while k < len
-      while (k < len) {
-        // a. Let Pk be ! ToString(k).
-        // b. Let kValue be ? Get(O, Pk).
-        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-        // d. If testResult is true, return kValue.
-        kValue = o[k];
-        if (predicate.call(thisArg, kValue, k, o)) {
-          return kValue;
+        // 6. Repeat, while k < len
+        while (k < len) {
+          // a. Let Pk be ! ToString(k).
+          // b. Let kValue be ? Get(O, Pk).
+          // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+          // d. If testResult is true, return kValue.
+          kValue = o[k];
+          if (predicate.call(thisArg, kValue, k, o)) {
+            return kValue;
+          }
+          // e. Increase k by 1.
+          k++;
         }
-        // e. Increase k by 1.
-        k++;
-      }
 
-      // 7. Return undefined.
-      return undefined;
-    }
-  });
+        // 7. Return undefined.
+        return undefined;
+      }
+    });
 }

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -56,9 +56,11 @@ from pipeline_mako import render_require_js_path_overrides
 
   <%
     jsi18n_path = "js/i18n/{language}/djangojs.js".format(language=LANGUAGE_CODE)
+    ie11_fix_path = "js/ie11_find_array.js"
   %>
 
   <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+  <script type="text/javascript" src="${static.url(ie11_fix_path)}"></script>
 
   <link rel="icon" type="image/x-icon" href="${static.url(static.get_value('favicon_path', settings.FAVICON_PATH))}" />
 


### PR DESCRIPTION
Fixes a bug that makes discussion posts unable to be viewed by IE11 browsers. The recently introduced bug uses a JavaScript method that does not exist in IE11. The bug shows up when cohorts with divided discussions are used, and causes the discussion JS scripts to crash.
In order to see the bug [Cohorts](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohort_config.html#enabling-cohorts-in-your-course) must be enabled and [Divided Discussions](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/manage_discussions/set_up_divided_discussions.html#setting-up-divided-discussions) setup.

The bug was introduced with this line: https://github.com/edx/edx-platform/pull/15490/files#diff-4f2b6d91600f0c3fd67b46b47d35f2dcR121

**JIRA**: [OSPR-2015](https://openedx.atlassian.net/browse/OSPR-2015)

**Sandbox URL**:

* LMS: https://pr16571.sandbox.opencraft.hosting/
* Studio: https://studio-pr16571.sandbox.opencraft.hosting/

**Testing instructions**:
1. Using **IE11** Create an account on LMS
2. Sign up for the demonstration course.
3. View the discussions page. 
4. Create a new discussion.
5. Should be able to see posts on the right hand side of the screen.

**Reviewers**
- [x] @pomegranited 
- [ ] TBD

