### PR TITLE
Fixes for common/lib tests in Django 1.9+

### DIFF
--- a/common/lib/conftest.py
+++ b/common/lib/conftest.py
@@ -1,8 +1,0 @@
-from django.conf import settings
-
-
-def pytest_configure():
-    """
-    Use Django's default settings for tests in common/lib.
-    """
-    settings.configure()

--- a/common/lib/pytest.ini
+++ b/common/lib/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+DJANGO_SETTINGS_MODULE = openedx.tests.settings
 addopts = --nomigrations --reuse-db --durations=20
 norecursedirs = .cache
 python_classes =

--- a/common/lib/xmodule/xmodule/tests/test_services.py
+++ b/common/lib/xmodule/xmodule/tests/test_services.py
@@ -23,7 +23,8 @@ class DummyConfig(ConfigurationModel):
     """
     Dummy Configuration
     """
-    pass
+    class Meta:
+        app_label = 'xmoduletestservices'
 
 
 class DummyUnexpected(object):

--- a/openedx/tests/settings.py
+++ b/openedx/tests/settings.py
@@ -1,0 +1,33 @@
+"""
+Minimal Django settings for tests of common/lib.
+Required in Django 1.9+ due to imports of models in stock Django apps.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import tempfile
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'default.db',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    }
+}
+
+INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'openedx.core.djangoapps.video_config',
+    'edxval',
+)
+
+MEDIA_ROOT = tempfile.mkdtemp()
+
+SECRET_KEY = 'insecure-secret-key'
+
+USE_TZ = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django{18,111}
+envlist = py27-django{18,19,110,111}
 
 [testenv]
 setenv =
@@ -9,6 +9,8 @@ passenv =
     EDXAPP_TEST_MONGO_HOST
 deps =
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2
     -rrequirements/edx/pre.txt
     -rrequirements/edx/github.txt


### PR DESCRIPTION
Some configuration updates to get nearly all common/lib tests passing on Django 1.9 through 1.11.  Also updated the tox configuration to make it easier to run tests for 1.9 and 1.10 in order to check for relevant deprecation warnings.