### PR TITLE
Fix low contrast on Notes page

### DIFF
--- a/lms/static/sass/course/_student-notes.scss
+++ b/lms/static/sass/course/_student-notes.scss
@@ -76,7 +76,7 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
 
           display: block;
           margin-top: ($baseline/4);
-          color: $gray-l1;
+          color: $lightest-base-font-color;
           letter-spacing: 0;
         }
       }
@@ -372,7 +372,7 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
 
         @include padding-right($baseline);
 
-        color: $gray-l2;
+        color: $lightest-base-font-color;
         font-weight: $font-semibold !important; // needed for poor base LMS styling scope
       }
 
@@ -450,6 +450,10 @@ $divider-visual-tertiary: ($baseline/20) solid $gray-l4;
     background: $gray-l5;
     border-top: ($baseline/4) solid $active-color;
     padding: ($baseline*1.5);
+
+    a {
+      color: $blue-d1;
+    }
   }
 
   .placeholder-title {


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-3203

In the edxnotes view, a few bits of text had low contrast (page subtitle, tab label, and a link). Now they are each a little darker.

The two $lightest-base-font-color changes are simple and sensible I think.  For the link change, I considered that it might be nice to have $message-background and $message-link colors (instead of $gray-l5 and $blue-d1), but we don't use this pattern of a gray box very often (I could find no other obvious examples clicking around the courses).  Since this is a one-off thing, I figured I'd simply use a darker blue and be done with it.

Testing isn't easy, since the Notes component isn't common and instructions don't seem to exist for setting it up with docker yet.  But I've set up a sandbox with this branch that has been hard-coded to show the Notes page for comparison purposes.  Hit me up for sandbox testing information.

Once you're on the page, you can use a tool like the aXe Chrome extension to confirm that the old page has a11y issues and the new page doesn't.