### PR TITLE
Fix the systems parsing code for pylint.

### DIFF
--- a/pavelib/paver_tests/test_paver_quality.py
+++ b/pavelib/paver_tests/test_paver_quality.py
@@ -8,7 +8,7 @@ import unittest
 
 import paver.easy
 import paver.tasks
-from ddt import ddt, file_data
+from ddt import ddt, file_data, data, unpack
 from mock import MagicMock, mock_open, patch
 from path import Path as path
 from paver.easy import BuildFailure
@@ -58,6 +58,34 @@ class TestPaverQualityViolations(unittest.TestCase):
             f.write("hello\nhithere")
         num, _violations = pavelib.quality._pep8_violations(f.name)  # pylint: disable=protected-access
         self.assertEqual(num, 2)
+
+
+@ddt
+class TestPaverQualityOptions(unittest.TestCase):
+    """
+    Tests the paver pylint command-line options parsing.
+    """
+    @data(
+        ({'limit': '5500'}, (-1, 5500, False, pavelib.quality.ALL_SYSTEMS.split(','))),
+        ({'limit': '1000:5500'}, (1000, 5500, False, pavelib.quality.ALL_SYSTEMS.split(','))),
+        ({'limit': '1:2:3:4:5'}, (1, 2, False, pavelib.quality.ALL_SYSTEMS.split(','))),
+        ({'system': 'lms,cms'}, (-1, -1, False, ['lms', 'cms'])),
+        (
+            {'limit': '2000:5000', 'errors': True, 'system': 'lms,cms,openedx'},
+            (2000, 5000, True, ['lms', 'cms', 'openedx'])
+        ),
+    )
+    @unpack
+    def test_pylint_parser_other_string(self, options, expected_values):
+        class PaverOptions(object):
+            """
+            Simple options class to mimick paver's Namespace object.
+            """
+            def __init__(self, d):
+                self.__dict__ = d
+        paver_options = PaverOptions(options)
+        returned_values = pavelib.quality._parse_pylint_options(paver_options)  # pylint: disable=protected-access
+        self.assertEqual(returned_values, expected_values)
 
 
 class TestPaverReportViolationsCounts(unittest.TestCase):

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -11,7 +11,8 @@ set -e
 ###############################################################################
 
 # Violations thresholds for failing the build
-export PYLINT_THRESHOLD=3600
+export LOWER_PYLINT_THRESHOLD=1000
+export UPPER_PYLINT_THRESHOLD=5335
 export ESLINT_THRESHOLD=9134
 export STYLELINT_THRESHOLD=973
 

--- a/scripts/circle-ci-tests.sh
+++ b/scripts/circle-ci-tests.sh
@@ -57,7 +57,7 @@ else
             echo "Finding pylint violations and storing in report..."
             # HACK: we need to print something to the console, otherwise circleci
             # fails and aborts the job because nothing is displayed for > 10 minutes.
-            paver run_pylint -l $PYLINT_THRESHOLD | tee pylint.log || EXIT=1
+            paver run_pylint -l $LOWER_PYLINT_THRESHOLD:$UPPER_PYLINT_THRESHOLD | tee pylint.log || EXIT=1
 
             mkdir -p reports
             PATH=$PATH:node_modules/.bin

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -84,7 +84,7 @@ case "$TEST_SUITE" in
         echo "Finding pep8 violations and storing report..."
         paver run_pep8 > pep8.log || { cat pep8.log; EXIT=1; }
         echo "Finding pylint violations and storing in report..."
-        paver run_pylint -l $PYLINT_THRESHOLD > pylint.log || { echo 'Too many pylint violations. You can view them in pylint.log'; EXIT=1; }
+        paver run_pylint -l $LOWER_PYLINT_THRESHOLD:$UPPER_PYLINT_THRESHOLD > pylint.log || { echo 'Too many pylint violations. You can view them in pylint.log'; EXIT=1; }
 
         mkdir -p reports
 


### PR DESCRIPTION
Pylint testing for PRs was mistakenly disabled in this March 2017 PR:
https://github.com/edx/edx-platform/pull/14643
These changes re-enable pylint testing. Our pylint errors in the meantime have increased from 3600 to 5322. Also, adds a lower limit to guard against this situation in the future. And raises the upper limit.