### PR TITLE
Remove uneccessary aria labels in the student dashboard

### DIFF
--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -371,7 +371,8 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         # Verify that the correct banner color is rendered
         self.assertContains(
             response,
-            "<article class=\"course {}\">".format(self.MODE_CLASSES[status])
+            "<div class=\"course {}\" aria-labelledby=\"course-title-{}\">".format(
+                self.MODE_CLASSES[status], self.course.id)
         )
 
         # Verify that the correct copy is rendered on the dashboard

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -59,10 +59,9 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
           lang="${course_overview.language}"
         % endif
       >
-<article class="course${mode_class}">
+<div class="course${mode_class}" aria-labelledby="course-title-${enrollment.course_id}">
   <% course_target = reverse(course_home_url_name(course_overview.id), args=[unicode(course_overview.id)]) %>
-  <section class="details" aria-labelledby="details-heading-${course_overview.number}">
-      <h2 class="hd hd-2 sr" id="details-heading-${course_overview.number}">${_('Course details')}</h2>
+  <div class="details">
     <div class="wrapper-course-image" aria-hidden="true">
       % if show_courseware_link:
         % if not is_course_blocked:
@@ -90,7 +89,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
       % endif
     </div>
       <div class="wrapper-course-details">
-        <h3 class="course-title">
+        <h3 class="course-title" id="course-title-${enrollment.course_id}">
           % if show_courseware_link:
             % if not is_course_blocked:
               <a data-course-key="${enrollment.course_id}" href="${course_target}">${course_overview.display_name_with_default}</a>
@@ -264,7 +263,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
           </div>
         </div>
       </div>
-  </section>
+  </div>
   <footer class="wrapper-messages-primary">
     <div class="messages-list">
       % if related_programs:
@@ -411,7 +410,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
         % endif
     </div>
   </footer>
-</article>
+</div>
 </div>
 </li>
 <script>

--- a/lms/templates/learner_dashboard/_dashboard_navigation_courses.html
+++ b/lms/templates/learner_dashboard/_dashboard_navigation_courses.html
@@ -6,5 +6,3 @@ from django.utils.translation import ugettext as _
 <header class="wrapper-header-courses">
   <h2 class="header-courses">${_("My Courses")}</h2>
 </header>
-
-<h2 class="hd hd-2 sr" id="courses-tab">${_('My Courses')}</h2>


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-2891

From ticket:

> There is some additional cleanup that needs to be performed here. There is an aria-labelledby element on the section elements that references the heading that is slated to be removed by this ticket. 
> 1) this shouldn't be a section element (div is fine), and it shouldn't have an aria-labelledby. 
> 2) The parent article element should be a section element and it should have an aria-labelledby that references the h3 that is the course name (which will need an IDref now).

Testing:

https://benjilee.sandbox.edx.org/ (should be built by 11am EST)

Go to the course dashboard and use your favorite screenreader
- Navigation by header should not be showing "Course Details". It should be showing the name of the course instead. 
