### PR TITLE
Adds all HTML5 sources to the returned video API data

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -977,6 +977,11 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
 
         encoded_videos = {}
         val_video_data = {}
+        all_sources = self.html5_sources or []
+
+        # `source` is a deprecated field, but we include it for backwards compatibility.
+        if self.source:
+            all_sources.append(self.source)
 
         # Check in VAL data first if edx_video_id exists
         if self.edx_video_id:
@@ -1008,10 +1013,9 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
 
         # Fall back to other video URLs in the video module if not found in VAL
         if not encoded_videos:
-            video_url = self.html5_sources[0] if self.html5_sources else self.source
-            if video_url:
+            if all_sources:
                 encoded_videos["fallback"] = {
-                    "url": video_url,
+                    "url": all_sources[0],
                     "file_size": 0,  # File size is unknown for fallback URLs
                 }
 
@@ -1036,4 +1040,5 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
             "duration": val_video_data.get('duration', None),
             "transcripts": transcripts,
             "encoded_videos": encoded_videos,
+            "all_sources": all_sources,
         }

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1366,6 +1366,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
                     "fallback": {"url": self.TEST_SOURCE_URL, "file_size": 0},
                     "youtube": {"url": self.TEST_YOUTUBE_EXPECTED_URL, "file_size": 0}
                 },
+                "all_sources": [self.TEST_SOURCE_URL],
             }
         )
 
@@ -1380,6 +1381,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
                 "duration": None,
                 "transcripts": {self.TEST_LANGUAGE: self.transcript_url},
                 "encoded_videos": {"youtube": {"url": self.TEST_YOUTUBE_EXPECTED_URL, "file_size": 0}},
+                "all_sources": [],
             }
         )
 
@@ -1397,6 +1399,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
                 "only_on_web": False,
                 "duration": self.TEST_DURATION,
                 "transcripts": {self.TEST_LANGUAGE: self.transcript_url},
+                'all_sources': [self.TEST_SOURCE_URL],
             }
         )
 

--- a/lms/djangoapps/mobile_api/video_outlines/serializers.py
+++ b/lms/djangoapps/mobile_api/video_outlines/serializers.py
@@ -172,6 +172,8 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
         "only_on_web": video_descriptor.only_on_web,
     }
 
+    all_sources = []
+
     if video_descriptor.only_on_web:
         ret = {
             "video_url": None,
@@ -180,6 +182,7 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
             "size": 0,
             "transcripts": {},
             "language": None,
+            "all_sources": all_sources,
         }
         ret.update(always_available_data)
         return ret
@@ -201,8 +204,12 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
     # Then fall back to VideoDescriptor fields for video URLs
     elif video_descriptor.html5_sources:
         video_url = video_descriptor.html5_sources[0]
+        all_sources = video_descriptor.html5_sources
     else:
         video_url = video_descriptor.source
+
+    if video_descriptor.source:
+        all_sources.append(video_descriptor.source)
 
     # Get duration/size, else default
     duration = video_data.get('duration', None)
@@ -236,7 +243,8 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
         "size": size,
         "transcripts": transcripts,
         "language": video_descriptor.get_default_transcript_language(transcripts_info),
-        "encoded_videos": video_data.get('profiles')
+        "encoded_videos": video_data.get('profiles'),
+        "all_sources": all_sources,
     }
     ret.update(always_available_data)
     return ret


### PR DESCRIPTION
Returns the full list of HTML5 video sources from the Course Blocks API and the Mobile Video API, so that the mobile app can choose a downloadable video type from all available video sources.

**JIRA tickets**: [OSPR-2020](https://openedx.atlassian.net/browse/OSPR-2020)

**Dependencies**:

Related to, but not required by https://github.com/edx/edx-app-ios/pull/1033

**Sandbox URL**:

* LMS: https://pr16590.sandbox.opencraft.hosting/
* Studio: https://studio-pr16590.sandbox.opencraft.hosting/

**Merge deadline**: Would like to have merged prior to next edx-app-ios release.

**Setup instructions**

Import the [video_test_course.tar.gz](https://github.com/edx/edx-platform/files/1485484/video_test_course.Dl2Kjh.tar.gz), or use the sandbox server above.

**Testing instructions**

1. Login to the LMS, and enrol in the video test course.
   The sandbox has the standard `honor`, `audit`, and `verified` users, all enrolled in the test course.
1. Visit the Mobile Video API link for the course, e.g.,
    https://pr16590.sandbox.opencraft.hosting/api/mobile/v0.5/video_outlines/courses/course-v1:OpenCraft+OC-3313+2017_01
1. Visit the Course Blocks API for the course, e.g.,
    https://pr16590.sandbox.opencraft.hosting/api/courses/v1/blocks/?course_id=course-v1%3aOpenCraft%2bOC-3313%2b2017_01&all_blocks=true&depth=all&student_view_data=video

Note that the `all_sources` list provided by each API reflects the full list of non-YouTube video URLs for each unit in the course.

**Author notes and concerns**:

1. The `edx-app-ios` currently uses the Course Blocks API to decide whether a block contains downloadable or streamable video content.  However, it uses the Mobile Video API to decide which URLs to use for downloading.  I wasn't able to untangle this, so updated both APIs.
1. This change does not affect courses which use the Video Pipeline employed by edx.org.
1. Because this change alters the return value of `student_view_data` for video modules, you'll need to rebuild any existing course blocks data to see the change.  On devstacks, the command to do this is:
   ```bash
   ./manage.py lms generate_course_blocks --all_courses --force --settings=devstack
   ```

**Reviewers**

- [ ] @bradenmacdonald 
- [ ] edX TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_MOBILE_REST_API: true
```