### PR TITLE
EDUCATOR-1590 | Message context usernames should come from django models

### DIFF
--- a/lms/djangoapps/discussion/signals/handlers.py
+++ b/lms/djangoapps/discussion/signals/handlers.py
@@ -54,11 +54,9 @@ def send_message(comment, site):
         'comment_id': comment.id,
         'comment_body': comment.body,
         'comment_author_id': comment.user_id,
-        'comment_username': comment.username,
         'comment_created_at': comment.created_at,  # comment_client models dates are already serialized
         'thread_id': thread.id,
         'thread_title': thread.title,
-        'thread_username': thread.username,
         'thread_author_id': thread.user_id,
         'thread_created_at': thread.created_at,  # comment_client models dates are already serialized
         'thread_commentable_id': thread.commentable_id,

--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -100,15 +100,17 @@ def _get_course_language(course_id):
 
 def _build_message_context(context):
     message_context = get_base_template_context(context['site'])
-    message_context.update(_deserialize_context_dates(context))
-    message_context['post_link'] = _get_thread_url(context)
+    message_context.update(context)
+    thread_author = User.objects.get(id=context['thread_author_id'])
+    comment_author = User.objects.get(id=context['comment_author_id'])
+    message_context.update({
+        'thread_username': thread_author.username,
+        'comment_username': comment_author.username,
+        'post_link': _get_thread_url(context),
+        'comment_created_at': date.deserialize(context['comment_created_at']),
+        'thread_created_at': date.deserialize(context['thread_created_at'])
+    })
     return message_context
-
-
-def _deserialize_context_dates(context):
-    context['comment_created_at'] = date.deserialize(context['comment_created_at'])
-    context['thread_created_at'] = date.deserialize(context['thread_created_at'])
-    return context
 
 
 def _get_thread_url(context):


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-1590