### PR TITLE
Scope base build to footer only.

### DIFF
--- a/lms/static/sass/_build-footer-edx.scss
+++ b/lms/static/sass/_build-footer-edx.scss
@@ -1,21 +1,18 @@
 // ----------------------------------------
 // LMS edx.org Footer: Shared Build Compile
-
-// Base build
-@import 'base/build';
+@import 'lms/theme/variables';
+@import 'bootstrap/variables';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/mixins/breakpoints';
+@import '../variables';
+@import 'lms/theme/variables-v1';
+@import 'base/mixins';
 
 footer#footer-edx-v3 {
   @import 'base/extends';
-
-  // base - starter
   @import 'base/base';
 }
 
-// base - elements
 @import 'elements/typography';
-
-// shared - platform
 @import 'shared/footer-edx';
-
-// Extra theme-specific rules
 @import 'lms/theme/extras';


### PR DESCRIPTION
@edx/learner-spartans @bderusha @marcotuts @AlasdairSwan 

I haven't fully tested this, but it seems to make sense to scope all these rules to the footer only.

The only confusion comes with the concept of the v3 footer. Are there any other footers already in the platform that do not use the v3? If so, we need to add those selectors to the scoping class.

Please feel free to add any code and force push if you find any changes.