### PR TITLE
Follow up to #16473

### DIFF
--- a/lms/static/sass/discussion/_mixins.scss
+++ b/lms/static/sass/discussion/_mixins.scss
@@ -77,7 +77,7 @@
   }
 
   svg {
-    max-width: 100%;
+    max-width: 100% !important;
   }
 }
 


### PR DESCRIPTION
This rule needs an `!important` in order to override the inline style

@yro would you mind reviewing? I should have included this in https://github.com/edx/edx-platform/pull/16473

Example of current behavior: 
<img width="1435" alt="screen shot 2017-11-16 at 1 09 30 pm" src="https://user-images.githubusercontent.com/7373924/32907866-a9ceaf22-cacf-11e7-9579-38671f378e5b.png">

With `!important`: 
<img width="1438" alt="screen shot 2017-11-16 at 1 12 15 pm" src="https://user-images.githubusercontent.com/7373924/32907893-cd3ff3bc-cacf-11e7-821e-ecc0f46a5c3e.png">
