### PR TITLE
Default middleware_classes in emulate_http_request

### DIFF
--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -6,7 +6,6 @@ import logging
 from urlparse import urljoin
 
 from celery import task
-from crum import CurrentRequestUserMiddleware
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
@@ -22,7 +21,6 @@ import lms.lib.comment_client as cc
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.schedules.template_context import get_base_template_context
-from openedx.core.djangoapps.theming.middleware import CurrentSiteThemeMiddleware
 from openedx.core.lib.celery.task_utils import emulate_http_request
 
 
@@ -44,11 +42,7 @@ def send_ace_message(context):
     if _should_send_message(context):
         context['site'] = Site.objects.get(id=context['site_id'])
         thread_author = User.objects.get(id=context['thread_author_id'])
-        middleware_classes = [
-            CurrentRequestUserMiddleware,
-            CurrentSiteThemeMiddleware,
-        ]
-        with emulate_http_request(site=context['site'], user=thread_author, middleware_classes=middleware_classes):
+        with emulate_http_request(site=context['site'], user=thread_author):
             message_context = _build_message_context(context)
             message = ResponseNotification().personalize(
                 Recipient(thread_author.username, thread_author.email),

--- a/lms/djangoapps/discussion/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/tests/test_tasks.py
@@ -222,12 +222,8 @@ class TaskTestCase(ModuleStoreTestCase):
 
     def _assert_rendered_email(self, message):
         # check that we can actually render the message
-        middleware_classes = [
-            CurrentRequestUserMiddleware,
-            CurrentSiteThemeMiddleware,
-        ]
         with emulate_http_request(
-            site=message.context['site'], user=self.thread_author, middleware_classes=middleware_classes
+            site=message.context['site'], user=self.thread_author
         ):
             rendered_email = EmailRenderer().render(message)
             self.assertTrue(self.comment['body'] in rendered_email.body_html)

--- a/openedx/core/lib/celery/task_utils.py
+++ b/openedx/core/lib/celery/task_utils.py
@@ -1,6 +1,8 @@
 from contextlib import contextmanager
 
+from crum import CurrentRequestUserMiddleware
 from django.http import HttpRequest, HttpResponse
+from openedx.core.djangoapps.theming.middleware import CurrentSiteThemeMiddleware
 
 
 @contextmanager
@@ -20,12 +22,17 @@ def emulate_http_request(site=None, user=None, middleware_classes=None):
         site (Site): The site that this request should emulate. Defaults to None.
         user (User): The user that initiated this fake request. Defaults to None
         middleware_classes (list): A list of classes that implement Django's middleware interface.
+            Defaults to [CurrentRequestUserMiddleware, CurrentSiteThemeMiddleware] if None.
     """
     request = HttpRequest()
     request.user = user
     request.site = site
 
-    middleware_classes = middleware_classes or []
+    # TODO: define the default middleware_classes in settings.py
+    middleware_classes = middleware_classes or [
+        CurrentRequestUserMiddleware,
+        CurrentSiteThemeMiddleware,
+    ]
     middleware_instances = [klass() for klass in middleware_classes]
     response = HttpResponse()
 


### PR DESCRIPTION
To reduce the amount of duplicated code with using the `emulate_http_request` context manager, I made the `middleware_classes` default to the couple middleware that we were only using with existing calls to `emulate_http_request`:

```python
[
    CurrentRequestUserMiddleware,
    CurrentSiteThemeMiddleware,
]
```

I couldn't figure out how to refactor the context manger any more than this since we source the other parameters from different places in each place that the manager is called. Open to suggestions though...

FYI @edx/rapid-experiments-team 