### PR TITLE
ed-1590 Templates for email forum notifications

### DIFF
--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -18,7 +18,6 @@ from edx_ace.utils import date
 from edx_ace.message import MessageType
 from edx_ace.recipient import Recipient
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.site_configuration.helpers import get_value
 from lms.djangoapps.django_comment_client.utils import permalink
 import lms.lib.comment_client as cc
 

--- a/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/email/body.html
+++ b/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/email/body.html
@@ -2,33 +2,29 @@
 
 {% load i18n %}
 {% load static %}
-
-{% block preview_text %}
-    {% blocktrans trimmed %}
-        {{ comment_username }} replied to your thread.
-    {% endblocktrans %}
-{% endblock %}
-
 {% block content %}
 <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
         <td>
-            {% blocktrans trimmed %}
-                <p>
-                    Hi {{ thread_username }},
-                </p>
+            <p>
+                {% blocktrans trimmed %}
+                    {{ comment_username }} replied to your <b>{{ thread_title }}</b> post
+                {% endblocktrans %}
+            </p>
 
-                <p>
-                    {{ comment_username }} made the following reply to {{ thread_title }} at {{ comment_created_at }}.
-                </p>
+            <div style="border: 1px solid white;
+                        padding: 15px 15px 15px 20px;
+                        box-shadow: 0 0px 2px rgba(0, 0, 0, 0.55);
+                        margin: 30px 70px 40px 0px;">
+                {{ comment_body }}
+            </div>
 
-                <p>
-                    {{ comment_body }}
-                </p>
-            {% endblocktrans %}
-
-            {% trans "View the discussion" as course_cta_text %}
+            {% trans "View discussion" as course_cta_text %}
             {% include "schedules/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=post_link%}
+
+            {% block google_analytics_pixel %}
+                <img src="{{ ga_tracking_pixel_url }}" alt="" role="presentation" aria-hidden="true" style="display: block;"/>
+            {% endblock %}
         </td>
     </tr>
 </table>

--- a/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/email/body.txt
+++ b/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/email/body.txt
@@ -1,5 +1,15 @@
 {% load i18n %}
 
+{% block content %}
 {% blocktrans trimmed %}
-    This is the reply to your thread:
+    {{ comment_username }} replied to your <b>{{ thread_title }}</b> post
 {% endblocktrans %}
+
+{{ comment_body }}
+
+<a href="{{ post_link }}"> {% trans "View discussion" %} </a>
+{% endblock %}
+
+{% block google_analytics_pixel %}
+<img src="{{ ga_tracking_pixel_url }}" alt="" role="presentation" aria-hidden="true" style="display: block;"/>
+{% endblock %}

--- a/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/email/subject.txt
+++ b/lms/djangoapps/discussion/templates/discussion/edx_ace/responsenotification/email/subject.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
 
-{% blocktrans %}
-Someone replied to your thread on {{ platform_name }}
+{% blocktrans trimmed %}
+    Response to your {{ thread_title }} post
 {% endblocktrans %}


### PR DESCRIPTION
Make the forum notification email content pretty.

We ended up getting rid of the "Reply to discussion" and "Unfollow discussion" links - there is no way to link to the comment textarea because of the way we load the page, and creating an extra "unfollow discussion" page is out of scope for this sprint.

<img width="621" alt="screen shot 2017-11-16 at 2 46 39 pm" src="https://user-images.githubusercontent.com/6182097/32914193-bb595504-cae2-11e7-8d36-c1317d29a704.png">
