### PR TITLE
Fix lang mapping for zh_HANS

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -2,7 +2,7 @@
 
 # This will copy each source language to a new directory at the end of the i18n generate step
 # which allows us to migrate to a new locale code without re-creating the Transifex project.
-edx-lang-map:
+edx_lang_map:
     zh_CN: zh_HANS
 
 locales:


### PR DESCRIPTION
Fixing an underscore / dash mismatch in config.yaml to allow zh_HANS translations to be generated.