### PR TITLE
Memoize common lookups during request

### DIFF
--- a/common/djangoapps/edxmako/paths.py
+++ b/common/djangoapps/edxmako/paths.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from mako.exceptions import TopLevelLookupException
 from mako.lookup import TemplateLookup
 
+from request_cache.middleware import request_cached
 from openedx.core.djangoapps.theming.helpers import get_template as themed_template
 from openedx.core.djangoapps.theming.helpers import get_template_path_with_theme, strip_site_theme_templates_path
 
@@ -107,6 +108,7 @@ def add_lookup(namespace, directory, package=None, prepend=False):
     templates.add_directory(directory, prepend=prepend)
 
 
+@request_cached
 def lookup_template(namespace, name):
     """
     Look up a Mako template by namespace and name.

--- a/openedx/core/djangoapps/theming/helpers.py
+++ b/openedx/core/djangoapps/theming/helpers.py
@@ -19,14 +19,17 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
     get_theme_dirs,
     get_themes_unchecked
 )
-from request_cache.middleware import RequestCache
+from request_cache.middleware import RequestCache, request_cached
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 
 
+@request_cached
 def get_template_path(relative_path, **kwargs):
     """
     This is a proxy function to hide microsite_configuration behind comprehensive theming.
+
+    The calculated value is cached for the lifetime of the current request.
     """
     # We need to give priority to theming over microsites
     # So, we apply microsite override only if there is no associated site theme

--- a/openedx/core/djangoapps/theming/tests/test_helpers.py
+++ b/openedx/core/djangoapps/theming/tests/test_helpers.py
@@ -12,6 +12,7 @@ from openedx.core.djangoapps.theming import helpers as theming_helpers
 from openedx.core.djangoapps.theming.helpers import get_template_path_with_theme, strip_site_theme_templates_path, \
     get_themes, Theme, get_theme_base_dir
 from openedx.core.djangolib.testing.utils import skip_unless_cms, skip_unless_lms
+from request_cache.middleware import RequestCache
 
 
 class TestHelpers(TestCase):
@@ -188,6 +189,8 @@ class TestHelpers(TestCase):
                 with patch("microsite_configuration.microsite.TEMPLATES_BACKEND") as mock_microsite_backend:
                     mock_microsite_backend.get_template = Mock(return_value="/microsite/about.html")
                     self.assertEqual(theming_helpers.get_template_path("about.html"), "about.html")
+
+        RequestCache.clear_request_cache()
 
         # if the current site does not have associated SiteTheme then get_template_path should return microsite override
         with patch(


### PR DESCRIPTION
# [EDUCATOR-1731](https://openedx.atlassian.net/browse/EDUCATOR-1731)

Prevents repeated memcached lookups on functions whose values should
remain static for the lifetime of a request.

See [this comment](https://openedx.atlassian.net/browse/EDUCATOR-1731?focusedCommentId=294703&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-294703) for how and why I chose these methods.

FYI @sanfordstudent @feanil 