### PR TITLE
Fix instructors ordering on program marketing page

### DIFF
--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -605,8 +605,8 @@ class ProgramMarketingDataExtender(ProgramDataExtender):
     def __init__(self, program_data, user):
         super(ProgramMarketingDataExtender, self).__init__(program_data, user)
 
-        # Aggregate dict of instructors for the program keyed by name
-        self.instructors = {}
+        # Aggregate list of instructors for the program
+        self.instructors = []
 
         # Values for programs' price calculation.
         self.data['avg_price_per_course'] = 0.0
@@ -628,7 +628,7 @@ class ProgramMarketingDataExtender(ProgramDataExtender):
 
         if not program_instructors:
             # We cache the program instructors list to avoid repeated modulestore queries
-            program_instructors = self.instructors.values()
+            program_instructors = self.instructors
             cache.set(cache_key, program_instructors, 3600)
 
         self.data['instructors'] = program_instructors
@@ -688,6 +688,7 @@ class ProgramMarketingDataExtender(ProgramDataExtender):
             course_instructors = getattr(course_descriptor, 'instructor_info', {})
 
             # Deduplicate program instructors using instructor name
-            self.instructors.update(
-                {instructor.get('name', '').strip(): instructor for instructor in course_instructors.get('instructors', [])}
-            )
+            curr_instructors_names = [instructor.get('name', '').strip() for instructor in self.instructors]
+            for instructor in course_instructors.get('instructors', []):
+                if instructor.get('name', '').strip() not in curr_instructors_names:
+                    self.instructors.append(instructor)


### PR DESCRIPTION
Changed to hold the instructors in a list instead of a dict because a dict does not keep ordering.