### PR TITLE
Show current tab even in high contrast mode

### DIFF
--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -102,12 +102,12 @@
             font-weight: $font-weight-normal;
             display: inline-block;
             margin-bottom: -1*$baseline/2;
-            border-bottom: 4px solid transparent;
+            border-bottom: 4px hidden theme-color("dark");
             cursor: pointer;
 
             &.active,
             &:hover {
-              border-bottom-color: theme-color("dark");
+              border-bottom-style: solid;
             }
 
             &:hover {

--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -52,13 +52,13 @@
         display: block;
         text-align: center;
         text-decoration: none;
-        border-bottom: 4px solid transparent;
+        border-bottom: 4px hidden theme-color("primary");
 
         &:hover,
         &:focus,
         &.active {
           color: theme-color("primary");
-          border-bottom-color: theme-color("primary");
+          border-bottom-style: solid;
           background-color: transparent;
         }
       }


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-3219

In the dashboard header and the course navigation bar, the current tab is supposed to be the only one with a bottom border.  But in high contrast mode in Windows, all of them were assigned a bottom border color.

So instead of toggling the color when active, toggle the border style, since Windows overrides our color choice anyway.  I'm not a CSS expert, so I'd appreciate feedback on whether that pattern change makes sense.

Mark worried in the jira task that this approach might affect box height, but it does not seem to.

Here's an example of old rendering:
![highcontrastold](https://user-images.githubusercontent.com/1196901/32917376-f8216652-caec-11e7-8952-205356e5ae06.png)

And here's the fixed version:
![highcontrastnew](https://user-images.githubusercontent.com/1196901/32917429-296d3ca4-caed-11e7-8548-aff99fd64a58.png)

Screenshots don't present hover behavior, but it is the same as it used to be (hovering over a tab shows a border).