### PR TITLE
Add a proper get_queryset() method to remove _default_manager access.

### DIFF
--- a/lms/djangoapps/shoppingcart/admin.py
+++ b/lms/djangoapps/shoppingcart/admin.py
@@ -21,13 +21,13 @@ class SoftDeleteCouponAdmin(admin.ModelAdmin):
     readonly_fields = ('created_at',)
     actions = ['really_delete_selected']
 
-    def queryset(self, request):
-        """ Returns a QuerySet of all model instances that can be edited by the
-        admin site. This is used by changelist_view. """
-        # Default: qs = self.model._default_manager.get_active_coupons_query_set()
-        # Queryset with all the coupons including the soft-deletes: qs = self.model._default_manager.get_queryset()
-        query_string = self.model._default_manager.get_active_coupons_queryset()  # pylint: disable=protected-access
-        return query_string
+    def get_queryset(self, request):
+        """
+        Returns a QuerySet of all model instances that can be edited by the
+        admin site - used by changelist_view.
+        """
+        qs = super(SoftDeleteCouponAdmin, self).get_queryset(request)
+        return qs.filter(is_active=True)
 
     def get_actions(self, request):
         actions = super(SoftDeleteCouponAdmin, self).get_actions(request)

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -1309,21 +1309,6 @@ class RegistrationCodeRedemption(models.Model):
         return code_redemption
 
 
-class SoftDeleteCouponManager(models.Manager):
-    """ Use this manager to get objects that have a is_active=True """
-    def get_active_coupons_queryset(self):
-        """
-        filter the is_active = True Coupons only
-        """
-        return super(SoftDeleteCouponManager, self).get_queryset().filter(is_active=True)
-
-    def get_queryset(self):
-        """
-        get all the coupon objects
-        """
-        return super(SoftDeleteCouponManager, self).get_queryset()
-
-
 class Coupon(models.Model):
     """
     This table contains coupon codes
@@ -1343,8 +1328,6 @@ class Coupon(models.Model):
 
     def __unicode__(self):
         return "[Coupon] code: {} course: {}".format(self.code, self.course_id)
-
-    objects = SoftDeleteCouponManager()
 
     @property
     def display_expiry_date(self):

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -572,7 +572,7 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
         messages = FallbackStorage(request)
         request._messages = messages        # pylint: disable=protected-access
         coupon_admin = SoftDeleteCouponAdmin(Coupon, AdminSite())
-        test_query_set = coupon_admin.queryset(request)
+        test_query_set = coupon_admin.get_queryset(request)
         test_actions = coupon_admin.get_actions(request)
         self.assertIn('really_delete_selected', test_actions['really_delete_selected'])
         self.assertEqual(get_coupon.is_active, True)
@@ -585,7 +585,7 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
         coupon = Coupon(code='TestCode123', description='testing123', course_id=self.course_key,
                         percentage_discount=22, created_by=self.user, is_active=True)
         coupon.save()
-        test_query_set = coupon_admin.queryset(request)
+        test_query_set = coupon_admin.get_queryset(request)
         coupon_admin.really_delete_selected(request, test_query_set)
         for coupon in test_query_set:
             self.assertEqual(coupon.is_active, False)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-1375
Remove the now-unused custom model manager for coupons.