### PR TITLE
Add highlights_enabled_for_messaging course field

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1190,8 +1190,9 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             })
         elif xblock.category == 'chapter':
             xblock_info.update({
-                'highlights': getattr(xblock, 'highlights', []),
+                'highlights': xblock.highlights,
                 'highlights_enabled': highlights_setting.is_enabled(),
+                'highlights_enabled_for_messaging': course.highlights_enabled_for_messaging,
                 'highlights_preview_only': not COURSE_UPDATE_WAFFLE_FLAG.is_enabled(course.id),
                 'highlights_doc_url': HelpUrlExpert.the_one().url_for_token('content_highlights'),
             })

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -2573,7 +2573,9 @@ class TestXBlockInfo(ItemTest):
             self.assertEqual(xblock_info['start'], DEFAULT_START_DATE.strftime('%Y-%m-%dT%H:%M:%SZ'))
 
     def test_highlights_enabled(self):
-        chapter = modulestore().get_item(self.chapter.location)
+        self.course.highlights_enabled_for_messaging = True
+        self.store.update_item(self.course, None)
+        chapter = self.store.get_item(self.chapter.location)
         with highlights_setting.override():
             xblock_info = create_xblock_info(chapter)
             self.assertTrue(xblock_info['highlights_enabled'])
@@ -2606,6 +2608,7 @@ class TestXBlockInfo(ItemTest):
         self.assertEqual(xblock_info['format'], None)
         self.assertEqual(xblock_info['highlights'], self.chapter.highlights)
         self.assertFalse(xblock_info['highlights_enabled'])
+        self.assertFalse(xblock_info['highlights_enabled_for_messaging'])
 
         # Finally, validate the entire response for consistency
         self.validate_xblock_info_consistency(xblock_info, has_child_info=has_child_info)

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -28,6 +28,7 @@ class CourseMetadata(object):
         'end',
         'enrollment_start',
         'enrollment_end',
+        'certificate_available_date',
         'tabs',
         'graceperiod',
         'show_timezone',
@@ -59,6 +60,7 @@ class CourseMetadata(object):
         'show_correctness',
         'chrome',
         'default_tab',
+        'highlights_enabled_for_messaging',
     ]
 
     @classmethod
@@ -107,13 +109,6 @@ class CourseMetadata(object):
         # display the "Allow Unsupported XBlocks" setting.
         if not XBlockStudioConfigurationFlag.is_enabled():
             filtered_list.append('allow_unsupported_xblocks')
-
-        # TODO: https://openedx.atlassian.net/browse/EDUCATOR-736
-        # Before we roll out the auto-certs feature, move this to a good, shared
-        # place such that we're not repeating code found in LMS.
-        switches = WaffleSwitchNamespace(name=u'certificates', log_prefix=u'Certificates: ')
-        if not switches.is_enabled(u'instructor_paced_only'):
-            filtered_list.append('certificate_available_date')
 
         return filtered_list
 

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -869,6 +869,14 @@ class CourseFields(object):
         ),
         scope=Scope.settings, default=False
     )
+    highlights_enabled_for_messaging = Boolean(
+        display_name=_("Highlights Enabled for Messaging"),
+        help=_(
+            "Enter true or false. If true, any highlights associated with content in the course will be messaged "
+            "to learners at their scheduled time."
+        ),
+        scope=Scope.settings, default=False
+    )
 
 
 class CourseModule(CourseFields, SequenceModule):  # pylint: disable=abstract-method


### PR DESCRIPTION
This PR adds an additional course field for indicating whether content highlights are ready to be messaged to Learners.

FYI @edx/rapid-experiments-team 