### PR TITLE
Program Details Page one-click purchase button with entitlements

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -136,10 +136,10 @@ class CourseMode(models.Model):
 
     HONOR = 'honor'
     PROFESSIONAL = 'professional'
-    VERIFIED = "verified"
-    AUDIT = "audit"
-    NO_ID_PROFESSIONAL_MODE = "no-id-professional"
-    CREDIT_MODE = "credit"
+    VERIFIED = 'verified'
+    AUDIT = 'audit'
+    NO_ID_PROFESSIONAL_MODE = 'no-id-professional'
+    CREDIT_MODE = 'credit'
 
     DEFAULT_MODE = Mode(
         settings.COURSE_MODE_DEFAULTS['slug'],

--- a/common/djangoapps/entitlements/models.py
+++ b/common/djangoapps/entitlements/models.py
@@ -24,3 +24,10 @@ class CourseEntitlement(TimeStampedModel):
         help_text='The current Course enrollment for this entitlement. If NULL the Learner has not enrolled.'
     )
     order_number = models.CharField(max_length=128, null=True)
+
+    @property
+    def expired_at_datetime(self):
+        """
+        Getter to be used instead of expired_at because of the conditional check and update
+        """
+        return self.expired_at

--- a/openedx/core/djangoapps/catalog/tests/factories.py
+++ b/openedx/core/djangoapps/catalog/tests/factories.py
@@ -8,6 +8,7 @@ from faker import Faker
 
 
 fake = Faker()
+VERIFIED_MODE = 'verified'
 
 
 def generate_instances(factory_class, count=3):
@@ -103,8 +104,16 @@ class SeatFactory(DictFactoryBase):
     currency = 'USD'
     price = factory.Faker('random_int')
     sku = factory.LazyFunction(generate_seat_sku)
-    type = 'verified'
+    type = VERIFIED_MODE
     upgrade_deadline = factory.LazyFunction(generate_zulu_datetime)
+
+
+class EntitlementFactory(DictFactoryBase):
+    currency = 'USD'
+    price = factory.Faker('random_int')
+    sku = factory.LazyFunction(generate_seat_sku)
+    mode = VERIFIED_MODE
+    expires = None
 
 
 class CourseRunFactory(DictFactoryBase):
@@ -121,7 +130,7 @@ class CourseRunFactory(DictFactoryBase):
     start = factory.LazyFunction(generate_zulu_datetime)
     status = 'published'
     title = factory.Faker('catch_phrase')
-    type = 'verified'
+    type = VERIFIED_MODE
     uuid = factory.Faker('uuid4')
     content_language = 'en'
     max_effort = 4
@@ -130,6 +139,7 @@ class CourseRunFactory(DictFactoryBase):
 
 class CourseFactory(DictFactoryBase):
     course_runs = factory.LazyFunction(partial(generate_instances, CourseRunFactory))
+    entitlements = factory.LazyFunction(partial(generate_instances, EntitlementFactory))
     image = ImageFactory()
     key = factory.LazyFunction(generate_course_key)
     owners = factory.LazyFunction(partial(generate_instances, OrganizationFactory, count=1))


### PR DESCRIPTION
Update one-click purchase eligibility for programs to consider user's entitlements in addition to their enrollments and compile the appropriate sku list for remaining unpurchased using entitlement products first, when available.

[LEARNER-3082](https://openedx.atlassian.net/browse/LEARNER-3082)