### PR TITLE
[ENT-759] Add a TPA pipeline step to take forced sync into account.

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0013_sync_learner_profile_data.py
+++ b/common/djangoapps/third_party_auth/migrations/0013_sync_learner_profile_data.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0012_auto_20170626_1135'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='sync_learner_profile_data',
+            field=models.BooleanField(default=False, help_text='Synchronize user profile data received from the identity provider with the edX user account on each SSO login. The user will be notified if the email address associated with their account is changed as a part of this synchronization.'),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='sync_learner_profile_data',
+            field=models.BooleanField(default=False, help_text='Synchronize user profile data received from the identity provider with the edX user account on each SSO login. The user will be notified if the email address associated with their account is changed as a part of this synchronization.'),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='sync_learner_profile_data',
+            field=models.BooleanField(default=False, help_text='Synchronize user profile data received from the identity provider with the edX user account on each SSO login. The user will be notified if the email address associated with their account is changed as a part of this synchronization.'),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -181,6 +181,14 @@ class ProviderConfig(ConfigurationModel):
             "immediately after authenticating with the third party instead of the login page."
         ),
     )
+    sync_learner_profile_data = models.BooleanField(
+        default=False,
+        help_text=_(
+            "Synchronize user profile data received from the identity provider with the edX user "
+            "account on each SSO login. The user will be notified if the email address associated "
+            "with their account is changed as a part of this synchronization."
+        )
+    )
     prefix = None  # used for provider_id. Set to a string value in subclass
     backend_name = None  # Set to a field or fixed value in subclass
     accepts_logins = True  # Whether to display a sign-in button when the provider is enabled

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -57,6 +57,7 @@ def apply_settings(django_settings):
         'social_core.pipeline.social_auth.associate_user',
         'social_core.pipeline.social_auth.load_extra_data',
         'social_core.pipeline.user.user_details',
+        'third_party_auth.pipeline.user_details_force_sync',
         'third_party_auth.pipeline.set_logged_in_cookies',
         'third_party_auth.pipeline.login_analytics',
     ]

--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -6,8 +6,10 @@ import mock
 import ddt
 from django import test
 from django.contrib.auth import models
+from django.core import mail
 from social_django import models as social_models
 
+from student.tests.factories import UserFactory
 from third_party_auth import pipeline, provider
 from third_party_auth.tests import testutil
 
@@ -303,9 +305,6 @@ class TestPipelineUtilityFunctions(TestCase, test.TestCase):
 class EnsureUserInformationTestCase(testutil.TestCase, test.TestCase):
     """Tests ensuring that we have the necessary user information to proceed with the pipeline."""
 
-    def setUp(self):
-        super(EnsureUserInformationTestCase, self).setUp()
-
     @ddt.data(
         (True, '/register'),
         (False, '/login')
@@ -335,3 +334,105 @@ class EnsureUserInformationTestCase(testutil.TestCase, test.TestCase):
                 )
                 assert response.status_code == 302
                 assert response.url == expected_redirect_url
+
+
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+class UserDetailsForceSyncTestCase(testutil.TestCase, test.TestCase):
+    """Tests to ensure learner profile data is properly synced if the provider requires it."""
+
+    def setUp(self):
+        super(UserDetailsForceSyncTestCase, self).setUp()
+        # pylint: disable=attribute-defined-outside-init
+        self.user = UserFactory.create()
+        self.old_email = self.user.email
+        self.old_username = self.user.username
+        self.old_fullname = self.user.profile.name
+        self.details = {
+            'email': 'new+{}'.format(self.user.email),
+            'username': 'new_{}'.format(self.user.username),
+            'fullname': 'Grown Up {}'.format(self.user.profile.name),
+            'country': 'PK',
+            'non_existing_field': 'value',
+        }
+
+        # Mocks
+        self.strategy = mock.MagicMock()
+        self.strategy.storage.user.changed.side_effect = lambda user: user.save()
+
+        get_from_pipeline = mock.patch('third_party_auth.pipeline.provider.Registry.get_from_pipeline')
+        self.get_from_pipeline = get_from_pipeline.start()
+        self.get_from_pipeline.return_value = mock.MagicMock(sync_learner_profile_data=True)
+        self.addCleanup(get_from_pipeline.stop)
+
+    def test_user_details_force_sync(self):
+        """
+        The user details are synced properly and an email is sent when the email is changed.
+        """
+        # Begin the pipeline.
+        pipeline.user_details_force_sync(
+            auth_entry=pipeline.AUTH_ENTRY_LOGIN,
+            strategy=self.strategy,
+            details=self.details,
+            user=self.user,
+        )
+
+        # User now has updated information in the DB.
+        user = User.objects.get()
+        assert user.email == 'new+{}'.format(self.old_email)
+        assert user.username == 'new_{}'.format(self.old_username)
+        assert user.profile.name == 'Grown Up {}'.format(self.old_fullname)
+        assert user.profile.country == 'PK'
+
+        assert len(mail.outbox) == 1
+
+    def test_user_details_force_sync_email_conflict(self):
+        """
+        The user details were attempted to be synced but the incoming email already exists for another account.
+        """
+        # Create a user with an email that conflicts with the incoming value.
+        UserFactory.create(email='new+{}'.format(self.old_email))
+
+        # Begin the pipeline.
+        pipeline.user_details_force_sync(
+            auth_entry=pipeline.AUTH_ENTRY_LOGIN,
+            strategy=self.strategy,
+            details=self.details,
+            user=self.user,
+        )
+
+        # The email is not changed, but everything else is.
+        user = User.objects.get(pk=self.user.pk)
+        assert user.email == self.old_email
+        assert user.username == 'new_{}'.format(self.old_username)
+        assert user.profile.name == 'Grown Up {}'.format(self.old_fullname)
+        assert user.profile.country == 'PK'
+
+        # No email should be sent for an email change.
+        assert len(mail.outbox) == 0
+
+    def test_user_details_force_sync_username_conflict(self):
+        """
+        The user details were attempted to be synced but the incoming username already exists for another account.
+
+        An email should still be sent in this case.
+        """
+        # Create a user with an email that conflicts with the incoming value.
+        UserFactory.create(username='new_{}'.format(self.old_username))
+
+        # Begin the pipeline.
+        pipeline.user_details_force_sync(
+            auth_entry=pipeline.AUTH_ENTRY_LOGIN,
+            strategy=self.strategy,
+            details=self.details,
+            user=self.user,
+        )
+
+        # The username is not changed, but everything else is.
+        user = User.objects.get(pk=self.user.pk)
+        assert user.email == 'new+{}'.format(self.old_email)
+        assert user.username == self.old_username
+        assert user.profile.name == 'Grown Up {}'.format(self.old_fullname)
+        assert user.profile.country == 'PK'
+
+        # An email should still be sent because the email changed.
+        assert len(mail.outbox) == 1

--- a/common/templates/emails/sync_learner_profile_data_email_change_body.txt
+++ b/common/templates/emails/sync_learner_profile_data_email_change_body.txt
@@ -1,0 +1,25 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
+
+<p>
+${_("The email associated with your {platform_name} account has changed from {old_email} to {new_email}.").format(
+    platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+    old_email=old_email,
+    new_email=new_email,
+)}
+</p>
+
+
+<p>${_("No action is needed on your part.")}</p>
+
+<p>
+${_("If this change is not correct, contact {link_start}{platform_name} Support{link_end} "
+    "or your administrator.").format(
+        platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+        link_start=u"<a href='{support_link}'>".format(
+            support_link=configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK),
+        ),
+        link_end=u"</a>",
+    )
+}
+</p>

--- a/common/templates/emails/sync_learner_profile_data_email_change_subject.txt
+++ b/common/templates/emails/sync_learner_profile_data_email_change_subject.txt
@@ -1,0 +1,6 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
+
+${_("Your {platform_name} account email has been updated").format(
+    platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+)}


### PR DESCRIPTION
Some Enterprise Customers would like to be able to force synchronization of data such as the username and email each time a user performs SSO through the customer's IdP. Normally, this already happens as a pipeline step through `python-social-auth`'s `social_core.pipeline.user.user_details` function, but that step protects some fields without a configuration to remove that protection, notably for the `username` and `email` fields, among others.

Since we can't configure it to remove protected fields (we can only add), we add a new pipeline step that behaves similarly to the upstream step but takes into account our use case. Additionally, our use case calls for sending an email to the old and new emails each time the email changes during SSO, alerting the user to this change in case they'd like to use the email to login directly to their edX account without SSO.

This should be a configurable option, most preferably on the provider itself to keep it generic, so a new field is added for that purpose.

**JIRA tickets**: [ENT-759](https://openedx.atlassian.net/browse/ENT-759)

**Merge deadline**: Within a week.

**Testing instructions**:

1. Set up an IdP like SAPSF/Facebook (any IdP that sends back a username or email, at least), and an Enterprise Customer connected to it (or not, it's optional for this feature which is actually generic but can be utilized by an Enterprise Customer). You can just use the currently setup Degreed IdP on the business sandbox.
1. Perform SSO (i.e. through [this link](https://business.sandbox.edx.org/enterprise/58152f7f-6d0e-41cf-862d-0a27c6fad72c/course/course-v1:edX+DemoX+Demo_Course/enroll/) for Degreed).
1. Change your username/email on the IdP's side (i.e. for Degreed, click the top right portrait, and go to 'Settings' -> 'Email', then change the 'edX' email to something *you* can verify).
1. Perform SSO again the same way (preferably in incognito), and notice that even the username/email fields are now changed for the edX profile.
1. If you had changed your email, too, ensure you receive an email to *both* the new and old emails.

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```