### PR TITLE
Small fixes to support Okta SSO.

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -150,7 +150,7 @@ logger = getLogger(__name__)
 
 
 class AuthEntryError(AuthException):
-    """Raised when auth_entry is missing or invalid on URLs.
+    """Raised when auth_entry is invalid on URLs.
 
     auth_entry tells us whether the auth flow was initiated to register a new
     user (in which case it has the value of AUTH_ENTRY_REGISTER) or log in an
@@ -459,10 +459,11 @@ def running(request):
 
 def parse_query_params(strategy, response, *args, **kwargs):
     """Reads whitelisted query params, transforms them into pipeline args."""
-    auth_entry = strategy.request.session.get(AUTH_ENTRY_KEY)
-    if not (auth_entry and auth_entry in _AUTH_ENTRY_CHOICES):
-        raise AuthEntryError(strategy.request.backend, 'auth_entry missing or invalid')
-
+    # If auth_entry is not in the session, we got here by a non-standard workflow.
+    # We simply assume 'login' in that case.
+    auth_entry = strategy.request.session.get(AUTH_ENTRY_KEY, AUTH_ENTRY_LOGIN)
+    if auth_entry not in _AUTH_ENTRY_CHOICES:
+        raise AuthEntryError(strategy.request.backend, 'auth_entry invalid')
     return {'auth_entry': auth_entry}
 
 

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -929,11 +929,10 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         with self.assertRaises(pipeline.AuthEntryError):
             strategy.request.backend.auth_complete = mock.MagicMock(return_value=self.fake_auth_complete(strategy))
 
-    def test_pipeline_raises_auth_entry_error_if_auth_entry_missing(self):
+    def test_pipeline_assumes_login_if_auth_entry_missing(self):
         _, strategy = self.get_request_and_strategy(auth_entry=None, redirect_uri='social:complete')
-
-        with self.assertRaises(pipeline.AuthEntryError):
-            strategy.request.backend.auth_complete = mock.MagicMock(return_value=self.fake_auth_complete(strategy))
+        response = self.fake_auth_complete(strategy)
+        self.assertEqual(response.url, reverse('signin_user'))
 
 
 # pylint: disable=test-inherits-tests, abstract-method

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -95,7 +95,7 @@
 
                     if (this.autoSubmit) {
                         $(this.el).hide();
-                        $('#register-honor_code').prop('checked', true);
+                        $('#register-honor_code, #register-terms_of_service').prop('checked', true);
                         this.submitForm();
                     }
 


### PR DESCRIPTION
This PR contains two small independent SSO fixes.

1. Automatically accept the Terms of Service when auto-filling the registration form.  The old code only accepts the Honour Code automatially when an SSO provider is configured to skip the registration form.  If and Open edX instance is configured to also/only require accepting the Terms of Service, the user will be shown the form with an authentication error.  With this PR applied, the Terms of Service are also accepted.

2. Assume `auth_entry = login` if the pipeline is entered in the complete stage.  This helps with Okta SSO (and possibly other SSO providers where the user starts on the Okta page, logs in there and then is forwarded to an URL configured in Okta.  With this fix applied we can use an URL of the form `/auth/complete/<provider-type>/`, and everything will work correctly.  Without this fix, the pipeline would throw an exception becaus `auth_entry` is not set.

**JIRA tickets**: None

**Discussions**: None

**Dependencies**: None

**Screenshots**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

Will be provided once the sandbox is ready.

**Author notes and concerns**: None

**Reviewers**
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```