### PR TITLE
PLAT-1413 Remove TEMPLATE_DEBUG setting

### DIFF
--- a/cms/envs/dev.py
+++ b/cms/envs/dev.py
@@ -13,7 +13,6 @@ from openedx.core.lib.logsettings import get_logger_config
 from lms.envs.dev import (WIKI_ENABLED)
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 HTTPS = 'off'
 
 LOGGING = get_logger_config(ENV_ROOT / "log",

--- a/cms/envs/yaml_config.py
+++ b/cms/envs/yaml_config.py
@@ -60,7 +60,6 @@ CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
 #
 
 DEBUG = False
-TEMPLATE_DEBUG = False
 
 EMAIL_BACKEND = 'django_ses.SESBackend'
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'

--- a/lms/envs/content.py
+++ b/lms/envs/content.py
@@ -10,7 +10,6 @@ between dev machines and AWS machines.
 from .aws import *
 
 DEBUG = True
-TEMPLATE_DEBUG = True
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 

--- a/lms/envs/dev.py
+++ b/lms/envs/dev.py
@@ -16,7 +16,6 @@ from .common import *
 from openedx.core.lib.derived import derive_settings
 
 DEBUG = True
-TEMPLATE_DEBUG = True
 
 HTTPS = 'off'
 FEATURES['DISABLE_START_DATES'] = False

--- a/lms/envs/yaml_config.py
+++ b/lms/envs/yaml_config.py
@@ -59,7 +59,6 @@ CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
 #
 
 DEBUG = False
-TEMPLATE_DEBUG = False
 
 EMAIL_BACKEND = 'django_ses.SESBackend'
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'


### PR DESCRIPTION
This is the only one of the removed settings from the ticket which was still in use, and all we ever did was set it to its default value (the same as `DEBUG`).  Removed.

I did find some uses of these in the `edx-val` and `xblock` repos, but only for their own tests (and those tests render no templates, so the settings aren't even used; they were just auto-generated by Django way back when).  I'll submit PRs for those after looking to see if any other fixes need to be made, but they aren't holding back the edx-platform changes.