### PR TITLE
Discussion Add Post - Add Explicit Labeling of Discussion Checkboxes

### DIFF
--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -48,21 +48,21 @@
         <div class="js-post-body editor" aria-describedby="new-post-editor-description" name="body"></div>
     </div>
     <div class="post-options">
-        <label class="field-label label-inline">
-            <input type="checkbox" name="follow" class="field-input input-checkbox" checked>
+        <label for= "follow" class="field-label label-inline">
+            <input id="follow" type="checkbox" name="follow" class="field-input input-checkbox" checked>
             <span class="field-input-label">
                 <span class="icon fa fa-star" aria-hidden="true"></span><%- gettext("follow this post") %>
             </span>
         </label>
         <% if (allow_anonymous) { %>
-        <label class="field-label label-inline">
-            <input type="checkbox" name="anonymous" class="field-input input-checkbox">
+        <label for="anonymous" class="field-label label-inline">
+            <input id="anonymous" type="checkbox" name="anonymous" class="field-input input-checkbox">
             <span class="field-input-label"><%- gettext("post anonymously") %></span>
         </label>
         <% } %>
         <% if (allow_anonymous_to_peers) { %>
-        <label class="field-label label-inline">
-            <input type="checkbox" name="anonymous_to_peers" class="field-input input-checkbox">
+        <label for="anonymous_to_peers" class="field-label label-inline">
+            <input id="anonymous_to_peers" type="checkbox" name="anonymous_to_peers" class="field-input input-checkbox">
             <span class="field-input-label"><%- gettext("post anonymously to classmates") %></span>
         </div>
         <% } %>


### PR DESCRIPTION
### [EDUCATOR-1559](https://openedx.atlassian.net/browse/EDUCATOR-1559)

A11y fix for explicit labeling of the checkboxes when adding a new discussion post.

cc @sanfordstudent @cptvitamin 