### PR TITLE
No unicode in "from" value on Bulk Emails

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -416,6 +416,13 @@ def _get_source_address(course_id, course_title, course_language, truncate=True)
     if len(escaped_encoded_from_addr) >= 320 and truncate:
         from_addr = format_address(course_name)
 
+    # EDUCATOR-1773: Courses with unicode in the title are not handled by django-ses logging
+    # remove this block once https://github.com/django-ses/django-ses/issues/137 is resolved and released
+    try:
+        dummy_var = "not a unicode string {}".format(from_addr)
+    except UnicodeEncodeError:
+        from_addr = format_address(course_name)
+
     return from_addr
 
 

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -4,7 +4,7 @@ Unit tests for sending course email
 """
 import json
 import os
-from unittest import skipIf
+from unittest import skip, skipIf
 
 import ddt
 from django.conf import settings
@@ -267,10 +267,20 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
         self.assertEqual(len(mail.outbox[0].to), 1)
         self.assertEquals(mail.outbox[0].to[0], self.instructor.email)
         self.assertEquals(mail.outbox[0].subject, 'test subject for myself')
+        """
+        TODO - uncomment this assertion and delete the following alternate once django-ses is fixed. EDUCATOR-1773
         self.assertEquals(
             mail.outbox[0].from_email,
             u'"{course_display_name}" Course Staff <{course_name}-no-reply@example.com>'.format(
                 course_display_name=self.course.display_name,
+                course_name=self.course.id.course
+            )
+        )
+        """  # pylint: disable=pointless-string-statement
+        self.assertEquals(
+            mail.outbox[0].from_email,
+            u'"{course_display_name}" Course Staff <{course_name}-no-reply@example.com>'.format(
+                course_display_name=self.course.number,
                 course_name=self.course.id.course
             )
         )
@@ -499,6 +509,7 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
             [self.instructor.email] + [s.email for s in self.staff] + [s.email for s in self.students]
         )
 
+    @skip("Unicode course names are broken, see EDUCATOR-1773 for details. Un-skip after django-ses is fixed.")
     @override_settings(BULK_EMAIL_DEFAULT_FROM_EMAIL="no-reply@courseupdates.edx.org")
     def test_long_course_display_name(self):
         """


### PR DESCRIPTION
Until https://github.com/django-ses/django-ses/issues/137 is resolved, we need
to proactively search for and prevent unicode values in from_addr.

EDUCATOR-1773