### PR TITLE
Make the "about course" page adapt to small screens

### DIFF
--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -2,9 +2,9 @@
   .container {
     padding-bottom: 120px;
 
-    @media screen and (max-width: $bp-screen-md) {
+    @include media-breakpoint-down(md) {
       min-width: auto;
-      padding: 20px;
+      padding: $baseline;
     }
   }
 
@@ -32,8 +32,8 @@
       margin: 0 auto;
       max-width: map-get($container-max-widths, xl);
 
-      @media screen and (min-width: $bp-screen-md) {
-        min-width: $bp-screen-md;
+      @include media-breakpoint-up(md) {
+          min-width: map-get($container-max-widths, md);
       }
 
       position: relative;
@@ -300,7 +300,7 @@
   }
 
   .details {
-    @media screen and (min-width: $bp-screen-md) {
+    @include media-breakpoint-up(md) {
       @include float(left);
       @include margin-right(flex-gutter());
 
@@ -395,7 +395,7 @@
   }
 
   .course-sidebar {
-    @media screen and (min-width: $bp-screen-md) {
+    @include media-breakpoint-up(dm) {
       @include box-sizing(border-box);
       @include float(left);
 

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -1,6 +1,11 @@
 .course-info {
   .container {
     padding-bottom: 120px;
+
+    @media screen and (max-width: $bp-screen-md) {
+      min-width: auto;
+      padding: 20px;
+    }
   }
 
   header.course-profile {
@@ -26,7 +31,11 @@
 
       margin: 0 auto;
       max-width: map-get($container-max-widths, xl);
-      min-width: 760px;
+
+      @media screen and (min-width: $bp-screen-md) {
+        min-width: $bp-screen-md;
+      }
+
       position: relative;
       z-index: 2;
 
@@ -291,10 +300,13 @@
   }
 
   .details {
-    @include float(left);
-    @include margin-right(flex-gutter());
+    @media screen and (min-width: $bp-screen-md) {
+      @include float(left);
+      @include margin-right(flex-gutter());
 
-    width: flex-grid(8);
+      width: flex-grid(8);
+    }
+
     font: normal 1em/1.6em $serif;
 
     h2 {
@@ -383,10 +395,12 @@
   }
 
   .course-sidebar {
-    @include box-sizing(border-box);
-    @include float(left);
+    @media screen and (min-width: $bp-screen-md) {
+      @include box-sizing(border-box);
+      @include float(left);
 
-    width: flex-grid(4);
+      width: flex-grid(4);
+    }
 
     > section {
       box-shadow: inset 0 0 3px 0 rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
This makes the about page (e.g. http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/about) responsive, it adapts to small screens like mobile devices.
It uses  `$bp-screen-md` as breaking point, which is $768px. The patch is made of simple fixes that can easily applied while better solutions are in progress (better solutions like rewriting this page in Bootstrap). 

**JIRA tickets**: None

**Discussions**: TBD
**Dependencies**: None

**Screenshots**:
See it before the changes (it was broken):
![screenshots_of_small_screen_before_changes](https://user-images.githubusercontent.com/132703/33082408-612a74e4-cee5-11e7-97e1-de1a54afb04f.png)

And after the changes (it looks nice):
![screenshots_of_small_screen_after_changes](https://user-images.githubusercontent.com/132703/33082415-678d7c8c-cee5-11e7-9e49-03e10f96b5e3.png)

**Sandbox URL**: https://pr16640.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/about

**Partner information**: None

**Deployment targets**: None

**Merge deadline**: None

**Testing instructions**:

1. Open http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/about
2. Check it with small screen, it should look reasonably good
3. Also with big one

**Author notes and concerns**:

1. The sidebar could look better above the course details but this would require more complex CSS or a change in the HTML elements. I didn't change the HTML element order because the current one is fine for SEO etc.: the important content (course description) comes early in the page.
2. The image to the right of the title (`.hero`) is as wide as the screen allows, this can make it very thin or almost invisible. I find it an appropriate solution when the screen is too small.

**Reviewers**
- [ ] @tomaszgy
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
```
