### PR TITLE
Fix focus loss when bookmarking a page in IE

### DIFF
--- a/openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmark_button.js
+++ b/openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmark_button.js
@@ -58,6 +58,7 @@
                         },
                         complete: function() {
                             view.$el.prop('disabled', false);
+                            view.$el.focus();
                         }
                     });
                 },
@@ -78,6 +79,7 @@
                         },
                         complete: function() {
                             view.$el.prop('disabled', false);
+                            view.$el.focus();
                         }
                     });
                 },
@@ -105,7 +107,7 @@
                     }
                     this.messageView.showMessage(errorMsg);
 
-                // Hide message automatically after some interval
+                    // Hide message automatically after some interval
                     setTimeout(_.bind(function() {
                         this.messageView.hideMessage();
                     }, this), this.showBannerInterval);


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-2896

In IE, when a user presses the bookmark/remove-bookmark button, the focus was lost on that button because we set disabled=true while we do the operation. Set the focus back when we are done.

(And fix an indentation issue while I was there.)