### PR TITLE
EDUCATOR-1773 resolution

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -416,13 +416,6 @@ def _get_source_address(course_id, course_title, course_language, truncate=True)
     if len(escaped_encoded_from_addr) >= 320 and truncate:
         from_addr = format_address(course_name)
 
-    # EDUCATOR-1773: Courses with unicode in the title are not handled by django-ses logging
-    # remove this block once https://github.com/django-ses/django-ses/issues/137 is resolved and released
-    try:
-        dummy_var = "not a unicode string {}".format(from_addr)
-    except UnicodeEncodeError:
-        from_addr = format_address(course_name)
-
     return from_addr
 
 

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -4,7 +4,7 @@ Unit tests for sending course email
 """
 import json
 import os
-from unittest import skip, skipIf
+from unittest import skipIf
 
 import ddt
 from django.conf import settings
@@ -267,20 +267,10 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
         self.assertEqual(len(mail.outbox[0].to), 1)
         self.assertEquals(mail.outbox[0].to[0], self.instructor.email)
         self.assertEquals(mail.outbox[0].subject, 'test subject for myself')
-        """
-        TODO - uncomment this assertion and delete the following alternate once django-ses is fixed. EDUCATOR-1773
         self.assertEquals(
             mail.outbox[0].from_email,
             u'"{course_display_name}" Course Staff <{course_name}-no-reply@example.com>'.format(
                 course_display_name=self.course.display_name,
-                course_name=self.course.id.course
-            )
-        )
-        """  # pylint: disable=pointless-string-statement
-        self.assertEquals(
-            mail.outbox[0].from_email,
-            u'"{course_display_name}" Course Staff <{course_name}-no-reply@example.com>'.format(
-                course_display_name=self.course.number,
                 course_name=self.course.id.course
             )
         )
@@ -509,7 +499,6 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
             [self.instructor.email] + [s.email for s in self.staff] + [s.email for s in self.students]
         )
 
-    @skip("Unicode course names are broken, see EDUCATOR-1773 for details. Un-skip after django-ses is fixed.")
     @override_settings(BULK_EMAIL_DEFAULT_FROM_EMAIL="no-reply@courseupdates.edx.org")
     def test_long_course_display_name(self):
         """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -27,7 +27,7 @@ django-oauth-toolkit==0.12.0
 django-pipeline-forgiving==1.0.0
 django-pyfs==1.0.7
 django-sekizai>=0.10
-django-ses==0.8.3.1
+django-ses==0.8.4
 django-simple-history==1.9.0
 django-statici18n==1.4.0
 django-storages==1.4.1


### PR DESCRIPTION
This reverts commit 3e9e97e6d866b23d9a51602bc1ee8f24128b932f, reversing
changes made to 0d931107aa86598c070eaba7df223cc46e240fb1.

As mentioned in https://github.com/edx/edx-platform/pull/16635, this change is only intended to be temporary while we wait to fix the issue properly in the upstream django-ses library. I anticipate this PR will include the relevant bump to get the latest version of django-ses included as well.

EDUCATOR-1773