### PR TITLE
Fixes to common/openedx tests that reference apps CMS doesn't use

### DIFF
--- a/common/djangoapps/entitlements/api/v1/tests/test_serializers.py
+++ b/common/djangoapps/entitlements/api/v1/tests/test_serializers.py
@@ -2,10 +2,13 @@ import unittest
 
 from django.conf import settings
 from django.test import RequestFactory
+
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
-from entitlements.api.v1.serializers import CourseEntitlementSerializer
-from entitlements.tests.factories import CourseEntitlementFactory
+# Entitlements is not in CMS' INSTALLED_APPS so these imports will error during test collection
+if settings.ROOT_URLCONF == 'lms.urls':
+    from entitlements.api.v1.serializers import CourseEntitlementSerializer
+    from entitlements.tests.factories import CourseEntitlementFactory
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')

--- a/common/djangoapps/entitlements/api/v1/tests/test_views.py
+++ b/common/djangoapps/entitlements/api/v1/tests/test_views.py
@@ -6,11 +6,13 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-
-from entitlements.tests.factories import CourseEntitlementFactory
-from entitlements.models import CourseEntitlement
-from entitlements.api.v1.serializers import CourseEntitlementSerializer
 from student.tests.factories import CourseEnrollmentFactory, UserFactory, TEST_PASSWORD
+
+# Entitlements is not in CMS' INSTALLED_APPS so these imports will error during test collection
+if settings.ROOT_URLCONF == 'lms.urls':
+    from entitlements.tests.factories import CourseEntitlementFactory
+    from entitlements.models import CourseEntitlement
+    from entitlements.api.v1.serializers import CourseEntitlementSerializer
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')

--- a/common/djangoapps/status/tests.py
+++ b/common/djangoapps/status/tests.py
@@ -8,8 +8,10 @@ from django.core.cache import cache
 from django.test import TestCase
 from opaque_keys.edx.locations import CourseLocator
 
-from .models import CourseMessage, GlobalStatusMessage
-from .status import get_site_status_msg
+# Status is not in CMS' INSTALLED_APPS so these imports will error during test collection
+if settings.ROOT_URLCONF == 'lms.urls':
+    from .models import CourseMessage, GlobalStatusMessage
+    from .status import get_site_status_msg
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/cors_csrf/tests/test_views.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_views.py
@@ -1,16 +1,21 @@
 """Tests for cross-domain request views. """
 
-import ddt
 import json
+import unittest
 
+from django.conf import settings
+from django.core.urlresolvers import NoReverseMatch, reverse
 from django.test import TestCase
-from django.core.urlresolvers import reverse, NoReverseMatch
 
+import ddt
 from config_models.models import cache
 
-from ..models import XDomainProxyConfiguration
+# cors_csrf is not in CMS' INSTALLED_APPS so these imports will error during test collection
+if settings.ROOT_URLCONF == 'lms.urls':
+    from ..models import XDomainProxyConfiguration
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @ddt.ddt
 class XDomainProxyTest(TestCase):
     """Tests for the xdomain proxy end-point. """

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_adapter.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_adapter.py
@@ -2,20 +2,22 @@
 Tests for DOT Adapter
 """
 
+import unittest
 from datetime import timedelta
 
-import ddt
 from django.conf import settings
 from django.test import TestCase
 from django.utils.timezone import now
-from oauth2_provider import models
-import unittest
 
+import ddt
+from oauth2_provider import models
 from student.tests.factories import UserFactory
 
-from ..adapters import DOTAdapter
-from .constants import DUMMY_REDIRECT_URL, DUMMY_REDIRECT_URL2
-from ..models import RestrictedApplication
+# oauth_dispatch is not in CMS' INSTALLED_APPS so these imports will error during test collection
+if settings.FEATURES.get("ENABLE_OAUTH2_PROVIDER"):
+    from ..adapters import DOTAdapter
+    from .constants import DUMMY_REDIRECT_URL, DUMMY_REDIRECT_URL2
+    from ..models import RestrictedApplication
 
 
 @ddt.ddt
@@ -24,11 +26,9 @@ class DOTAdapterTestCase(TestCase):
     """
     Test class for DOTAdapter.
     """
-
-    adapter = DOTAdapter()
-
     def setUp(self):
         super(DOTAdapterTestCase, self).setUp()
+        self.adapter = DOTAdapter()
         self.user = UserFactory()
         self.public_client = self.adapter.create_public_client(
             name='public app',

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -3,12 +3,18 @@ Test of custom django-oauth-toolkit behavior
 """
 
 # pylint: disable=protected-access
+import unittest
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase, RequestFactory
-from ..dot_overrides import EdxOAuth2Validator
+
+# oauth_dispatch is not in CMS' INSTALLED_APPS so these imports will error during test collection
+if settings.ROOT_URLCONF == 'lms.urls':
+    from ..dot_overrides import EdxOAuth2Validator
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class AuthenticateTestCase(TestCase):
     """
     Test that users can authenticate with either username or email
@@ -38,6 +44,7 @@ class AuthenticateTestCase(TestCase):
         )
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class CustomValidationTestCase(TestCase):
     """
     Test custom user validation works.

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -12,22 +12,26 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory, TestCase, override_settings
 from oauth2_provider import models as dot_models
-from provider import constants
 
+from provider import constants
 from student.tests.factories import UserFactory
 from third_party_auth.tests.utils import ThirdPartyOAuthTestMixin, ThirdPartyOAuthTestMixinGoogle
 from . import mixins
-from .constants import DUMMY_REDIRECT_URL
-from .. import adapters
-from .. import models
 
 # NOTE (CCB): We use this feature flag in a roundabout way to determine if the oauth_dispatch app is installed
 # in the current service--LMS or Studio. Normally we would check if settings.ROOT_URLCONF == 'lms.urls'; however,
 # simply importing the views will results in an error due to the requisite apps not being installed (in Studio). Thus,
 # we are left with this hack, of checking the feature flag which will never be True for Studio.
+#
+# NOTE (BJM): As of Django 1.9 we also can't import models for apps which aren't in INSTALLED_APPS, so making all of
+# these imports conditional except mixins, which doesn't currently import forbidden models, and is needed at test
+# discovery time.
 OAUTH_PROVIDER_ENABLED = settings.FEATURES.get('ENABLE_OAUTH2_PROVIDER')
 
 if OAUTH_PROVIDER_ENABLED:
+    from .constants import DUMMY_REDIRECT_URL
+    from .. import adapters
+    from .. import models
     from .. import views
 
 
@@ -75,11 +79,10 @@ class _DispatchingViewTestCase(TestCase):
 
     Subclasses need to define self.url.
     """
-    dop_adapter = adapters.DOPAdapter()
-    dot_adapter = adapters.DOTAdapter()
-
     def setUp(self):
         super(_DispatchingViewTestCase, self).setUp()
+        self.dop_adapter = adapters.DOPAdapter()
+        self.dot_adapter = adapters.DOTAdapter()
         self.user = UserFactory()
         self.dot_app = self.dot_adapter.create_public_client(
             name='test dot application',
@@ -270,10 +273,9 @@ class TestAuthorizationView(_DispatchingViewTestCase):
     Test class for AuthorizationView
     """
 
-    dop_adapter = adapters.DOPAdapter()
-
     def setUp(self):
         super(TestAuthorizationView, self).setUp()
+        self.dop_adapter = adapters.DOPAdapter()
         self.user = UserFactory()
         self.dot_app = self.dot_adapter.create_confidential_client(
             name='test dot application',
@@ -399,11 +401,10 @@ class TestViewDispatch(TestCase):
     Test that the DispatchingView dispatches the right way.
     """
 
-    dop_adapter = adapters.DOPAdapter()
-    dot_adapter = adapters.DOTAdapter()
-
     def setUp(self):
         super(TestViewDispatch, self).setUp()
+        self.dop_adapter = adapters.DOPAdapter()
+        self.dot_adapter = adapters.DOTAdapter()
         self.user = UserFactory()
         self.view = views._DispatchingView()  # pylint: disable=protected-access
         self.dop_adapter.create_public_client(


### PR DESCRIPTION
CMS tests that use models from apps that are not included in CMS' INSTALLED_APPS will error at test collection. This PR scopes those imports so that tests will run or skip as appropriate.