### PR TITLE
Change template's deprecated '=' comparison to '=='.

### DIFF
--- a/lms/templates/wiki/plugins/attachments/index.html
+++ b/lms/templates/wiki/plugins/attachments/index.html
@@ -87,7 +87,7 @@
               <td class="attachment-actions">
                 {% if attachment|can_write:user %}
                   {% if not attachment.current_revision.deleted %}
-                {% if 'attachment.article = article' %}
+                {% if attachment.article == article %}
                       <a href="{% url 'wiki:attachments_delete' path=urlpath.path article_id=article.id attachment_id=attachment.id %}" class="btn btn-danger">{% trans "Delete" %}</a>
                     {% else %}
                       <a href="{% url 'wiki:attachments_delete' path=urlpath.path article_id=article.id attachment_id=attachment.id %}" class="btn">{% trans "Detach" %}</a>


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-1431

I searched all files with this regex: `'{%[ ]*if'` and looked over all the results. The change is the only single quote comparison I found.