### PR TITLE
Pin sorl-thumbnail to 12.3

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -99,7 +99,7 @@ scipy==0.14.0
 Shapely==1.2.16
 singledispatch==3.4.0.2
 six>=1.10.0,<2.0.0
-sorl-thumbnail>=12.3,<13
+sorl-thumbnail==12.3
 sortedcontainers==0.9.2
 stevedore==1.10.0
 sure==1.2.3


### PR DESCRIPTION
Pin sorl-thumbnail to 12.3 to avoid migrations sneaking in to the platform.