### PR TITLE
Tag LMS Unit 3 tests that fail in Django 1.11

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import ddt
 import freezegun
 import httpretty
+import pytest
 import pytz
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -68,6 +69,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         (False, None, False, False),
     )
     @ddt.unpack
+    @pytest.mark.django111_expected_failure
     def test_redirect_to_dashboard(self, is_active, enrollment_mode, redirect, has_started):
         # Configure whether course has started
         # If it has go to course home instead of dashboard

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -10,6 +10,7 @@ import os
 from textwrap import dedent
 
 import ddt
+import pytest
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
@@ -336,6 +337,7 @@ class TestCourseGrades(TestSubmittingProblems):
 
 @attr(shard=3)
 @ddt.ddt
+@pytest.mark.django111_expected_failure
 class TestCourseGrader(TestSubmittingProblems):
     """
     Suite of tests for the course grader.

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -4,6 +4,7 @@ Unit tests for instructor_dashboard.py.
 import datetime
 
 import ddt
+import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
@@ -320,6 +321,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         # Max number of student per page is one.  Patched setting MAX_STUDENTS_PER_PAGE_GRADE_BOOK = 1
         self.assertEqual(len(response.mako_context['students']), 1)  # pylint: disable=no-member
 
+    @pytest.mark.django111_expected_failure
     def test_open_response_assessment_page(self):
         """
         Test that Open Responses is available only if course contains at least one ORA block
@@ -339,6 +341,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
         self.assertIn(ora_section, response.content)
 
+    @pytest.mark.django111_expected_failure
     def test_open_response_assessment_page_orphan(self):
         """
         Tests that the open responses tab loads if the course contains an

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -11,6 +11,7 @@ import textwrap
 from collections import namedtuple
 
 import ddt
+import pytest
 from celery.states import FAILURE, SUCCESS
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
@@ -67,6 +68,7 @@ class TestIntegrationTask(InstructorTaskModuleTestCase):
 
 @attr(shard=3)
 @ddt.ddt
+@pytest.mark.django111_expected_failure
 class TestRescoringTask(TestIntegrationTask):
     """
     Integration-style tests for rescoring problems in a background task.

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -2,6 +2,7 @@
 Tests for the LTI provider views
 """
 
+import pytest
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -163,6 +164,7 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
 
 
 @attr(shard=3)
+@pytest.mark.django111_expected_failure
 class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCase):
     """
     Tests for the rendering returned by lti_launch view.

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -8,6 +8,7 @@ from urllib import urlencode
 
 import ddt
 import mock
+import pytest
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
@@ -470,6 +471,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         ('register_user', 'register'),
     )
     @ddt.unpack
+    @pytest.mark.django111_expected_failure
     def test_hinted_login_dialog_disabled(self, url_name, auth_entry):
         """Test that the dialog doesn't show up for hinted logins when disabled. """
         self.google_provider.skip_hinted_login_dialog = True
@@ -513,6 +515,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         ('register_user', 'register'),
     )
     @ddt.unpack
+    @pytest.mark.django111_expected_failure
     def test_settings_tpa_hinted_login_dialog_disabled(self, url_name, auth_entry):
         """Test that the dialog doesn't show up for hinted logins when disabled via settings.THIRD_PARTY_AUTH_HINT. """
         self.google_provider.skip_hinted_login_dialog = True
@@ -585,6 +588,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         self.assertEqual(enterprise_cookie.value, '')
 
     @override_settings(SITE_NAME=settings.MICROSITE_TEST_HOSTNAME)
+    @pytest.mark.django111_expected_failure
     def test_microsite_uses_old_login_page(self):
         # Retrieve the login page from a microsite domain
         # and verify that we're served the old page.
@@ -595,6 +599,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         self.assertContains(resp, "Log into your Test Site Account")
         self.assertContains(resp, "login-form")
 
+    @pytest.mark.django111_expected_failure
     def test_microsite_uses_old_register_page(self):
         # Retrieve the register page from a microsite domain
         # and verify that we're served the old page.

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -9,6 +9,7 @@ import re
 from datetime import datetime, timedelta
 
 import ddt
+import pytest
 from django.core.urlresolvers import reverse
 from django.db.models import signals
 from nose.plugins.attrib import attr
@@ -66,6 +67,7 @@ class SupportViewAccessTests(SupportViewTestCase):
         ))
     ))
     @ddt.unpack
+    @pytest.mark.django111_expected_failure
     def test_access(self, url_name, role, has_access):
         if role is not None:
             role().add_users(self.user)

--- a/openedx/core/djangoapps/external_auth/tests/test_shib.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_shib.py
@@ -5,7 +5,10 @@ Tests for Shibboleth Authentication
 @jbau
 """
 import unittest
+from importlib import import_module
+from urllib import urlencode
 
+import pytest
 from ddt import ddt, data
 from django.conf import settings
 from django.http import HttpResponseRedirect
@@ -14,14 +17,12 @@ from django.test.client import RequestFactory, Client as DjangoTestClient
 from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import AnonymousUser, User
-from importlib import import_module
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
 from openedx.core.djangoapps.external_auth.views import (
     shib_login, course_specific_login, course_specific_register, _flatten_to_ascii
 )
 from mock import patch
 from nose.plugins.attrib import attr
-from urllib import urlencode
 
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from student.views import change_enrollment
@@ -297,6 +298,7 @@ class ShibSPTest(CacheIsolationTestCase):
 
     @unittest.skipUnless(settings.FEATURES.get('AUTH_USE_SHIB'), "AUTH_USE_SHIB not set")
     @data(*gen_all_identities())
+    @pytest.mark.django111_expected_failure
     def test_registration_form_submit(self, identity):
         """
         Tests user creation after the registration form that pops is submitted.  If there is no shib


### PR DESCRIPTION
Fixed some url reverse errors instead of marking since they were trivial