### PR TITLE
Updated the permissions to all non staff users to get their entitlements

### DIFF
--- a/common/djangoapps/entitlements/api/v1/permissions.py
+++ b/common/djangoapps/entitlements/api/v1/permissions.py
@@ -1,0 +1,19 @@
+"""
+This module provides a custom DRF Permission class for supporting SAFE_METHODS to Authenticated Users, but
+requiring Superuser access for all other Request types on an API endpoint.
+"""
+
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+
+class IsAdminOrAuthenticatedReadOnly(BasePermission):
+    """
+    Method that will require staff access for all methods not
+    in the SAFE_METHODS list.  For example GET requests will not
+    require a Staff or Admin user.
+    """
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS:
+            return request.user.is_authenticated
+        else:
+            return request.user.is_staff

--- a/common/djangoapps/entitlements/tests/factories.py
+++ b/common/djangoapps/entitlements/tests/factories.py
@@ -1,18 +1,20 @@
 import string
-import uuid
+from uuid import uuid4
 
 import factory
 from factory.fuzzy import FuzzyChoice, FuzzyText
 
 from entitlements.models import CourseEntitlement
 from student.tests.factories import UserFactory
+from course_modes.helpers import CourseMode
 
 
 class CourseEntitlementFactory(factory.django.DjangoModelFactory):
     class Meta(object):
         model = CourseEntitlement
 
-    course_uuid = uuid.uuid4()
-    mode = FuzzyChoice(['verified', 'profesional'])
+    uuid = factory.LazyFunction(uuid4)
+    course_uuid = factory.LazyFunction(uuid4)
+    mode = FuzzyChoice([CourseMode.VERIFIED, CourseMode.PROFESSIONAL])
     user = factory.SubFactory(UserFactory)
     order_number = FuzzyText(prefix='TEXTX', chars=string.digits)


### PR DESCRIPTION
[LEARNER-3084]

Change to allow Users without staff permissions for GET their entitlements, but not allow them to POST, or DELETE to the entitlement API.

