### PR TITLE
Add more ssencrypt tests

### DIFF
--- a/lms/djangoapps/verify_student/ssencrypt.py
+++ b/lms/djangoapps/verify_student/ssencrypt.py
@@ -123,6 +123,10 @@ def rsa_decrypt(data, rsa_priv_key_bytes):
     """
     When given some `data` and an RSA private key, decrypt the data
     """
+    if isinstance(data, text_type):
+        data = data.encode('utf-8')
+    if isinstance(rsa_priv_key_bytes, text_type):
+        rsa_priv_key_bytes = rsa_priv_key_bytes.encode('utf-8')
     if rsa_priv_key_bytes.startswith(b'-----'):
         key = serialization.load_pem_private_key(rsa_priv_key_bytes, password=None, backend=default_backend())
     else:


### PR DESCRIPTION
We got tripped up in production because the actual code sent a Unicode string instead of bytes as the public string, despite documentation to the contrary and having no tests covering that case.  pycrypto silently guessed how to convert that to bytes, cryptography forces you to be explicit about how to get the bytes to be encrypted.  Added code to check both the data and keys for RSA encryption/decryption for Unicode values, and explicitly convert them to bytes if necessary.  Also added test cases to make sure this works.