### PR TITLE
Allow "<%= edx.HtmlUtils" in xss_linter

### DIFF
--- a/scripts/tests/test_xss_linter.py
+++ b/scripts/tests/test_xss_linter.py
@@ -1072,6 +1072,7 @@ class TestUnderscoreTemplateLinter(TestLinter):
 
     @data(
         {'template': '<%= HtmlUtils.ensureHtml(message) %>'},
+        {'template': '<%= edx.HtmlUtils.ensureHtml(message) %>'},
         {'template': '<%= _.escape(message) %>'},
     )
     def test_check_underscore_no_escape_allowed(self, data):

--- a/scripts/xss_linter.py
+++ b/scripts/xss_linter.py
@@ -998,6 +998,7 @@ class UnderscoreTemplateLinter(BaseLinter):
         Safe examples::
 
             <%= HtmlUtils.ensureHtml(message) %>
+            <%= edx.HtmlUtils.ensureHtml(message) %>
             <%= _.escape(message) %>
 
         Arguments:
@@ -1008,6 +1009,8 @@ class UnderscoreTemplateLinter(BaseLinter):
 
         """
         if expression.expression_inner.startswith('HtmlUtils.'):
+            return True
+        if expression.expression_inner.startswith('edx.HtmlUtils.'):
             return True
         if expression.expression_inner.startswith('_.escape('):
             return True

--- a/scripts/xsslint_thresholds.json
+++ b/scripts/xsslint_thresholds.json
@@ -25,7 +25,7 @@
         "python-interpolate-html": 64,
         "python-parse-error": 0,
         "python-requires-html-or-text": 0,
-        "python-wrap-html": 226,
+        "python-wrap-html": 228,
         "underscore-not-escaped": 507
     },
     "total": 1770


### PR DESCRIPTION
The underscore templates do not have access to `HtmlUtils` unless we [pass a reference to it in the template context](https://github.com/edx/edx-platform/blob/master/cms/static/js/views/partition_group_details.js#L45). I feel like adding that to every template context that needs it seems boilerplate-y. A lot of underscore templates instead access `HtmlUtils` through the global variable `edx`: `edx.HtmlUtils`. However, the xss-linter does not recognize using `edx.HtmlUtils` inside of a `<%= %>` block as an allowable exception. This PR adds the exception.

I noticed that we are also allowing `edx.HtmlUtils` in [other checks](https://github.com/edx/edx-platform/blob/master/scripts/xss_linter.py#L1232), so I figured this would also be okay.

FYI: @edx/rapid-experiments-team 