### PR TITLE
Change default article name to be course name instead of slug

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -709,10 +709,8 @@ class HighLevelTabTest(UniqueCourseTest):
         self.assertTrue(self.tab_nav.is_on_tab('Wiki'))
 
         # Assert that a default wiki is created
-        expected_article_name = "{org}.{course_number}.{course_run}".format(
-            org=self.course_info['org'],
-            course_number=self.course_info['number'],
-            course_run=self.course_info['run']
+        expected_article_name = "{course_name}".format(
+            course_name=self.course_info['display_name']
         )
         self.assertEqual(expected_article_name, course_wiki.article_name)
 

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -104,6 +104,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         self.assertEquals(resp.status_code, 200)
 
         self.has_course_navigator(resp)
+        self.assertContains(resp, '<h3 class="entry-title">{}</h3>'.format(course.display_name_with_default))
 
     def has_course_navigator(self, resp):
         """

--- a/lms/djangoapps/course_wiki/views.py
+++ b/lms/djangoapps/course_wiki/views.py
@@ -83,7 +83,7 @@ def course_wiki_redirect(request, course_id, wiki_path=""):  # pylint: disable=u
         urlpath = URLPath.create_article(
             root,
             course_slug,
-            title=course_slug,
+            title=course.display_name_with_default,
             content=content,
             user_message=_("Course page automatically created."),
             user=None,


### PR DESCRIPTION
[OSPR-2021 ](https://openedx.atlassian.net/browse/OSPR-2021 )

Change the default name of an article to use the ```course name``` instead of the ```course slug```

Sandbox:

* LMS: https://pr16670.sandbox.opencraft.hosting/
* Studio: https://studio-pr16670.sandbox.opencraft.hosting/

Reviewers:
- [x] Code review: @iloveagent57

cc @pomegranited 

(distracting "it's true, it's on wikipedia" gif removed..)