### PR TITLE
Customize course info title

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -373,6 +373,27 @@ def course_info(request, course_id):
         # Get the course tools enabled for this user and course
         course_tools = CourseToolsPluginManager.get_enabled_course_tools(request, course_key)
 
+        course_homepage_invert_title =\
+            configuration_helpers.get_value(
+                'COURSE_HOMEPAGE_INVERT_TITLE',
+                False
+            )
+
+        course_homepage_show_subtitle =\
+            configuration_helpers.get_value(
+                'COURSE_HOMEPAGE_SHOW_SUBTITLE',
+                True
+            )
+
+        course_homepage_show_org =\
+            configuration_helpers.get_value('COURSE_HOMEPAGE_SHOW_ORG', True)
+
+        course_title = course.display_number_with_default
+        course_subtitle = course.display_name_with_default
+        if course_homepage_invert_title:
+            course_title = course.display_name_with_default
+            course_subtitle = course.display_number_with_default
+
         context = {
             'request': request,
             'masquerade_user': user,
@@ -380,6 +401,10 @@ def course_info(request, course_id):
             'url_to_enroll': CourseTabView.url_to_enroll(course_key),
             'cache': None,
             'course': course,
+            'course_title': course_title,
+            'course_subtitle': course_subtitle,
+            'show_subtitle': course_homepage_show_subtitle,
+            'show_org': course_homepage_show_org,
             'staff_access': staff_access,
             'masquerade': masquerade,
             'supports_preview_menu': True,

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -58,8 +58,15 @@ from openedx.core.djangolib.markup import HTML, Text
     >
       <div class="home">
         <div class="page-header-main">
-            <h2 class="hd hd-2 page-title">${_("Welcome to {org}'s {course_name}!").format(org=course.display_org_with_default, course_name=course.display_number_with_default)}
-              <div class="page-subtitle">${course.display_name_with_default}</div>
+            <h2 class="hd hd-2 page-title">
+              % if show_org:
+                ${_("Welcome to {org}'s {course_title}!").format(org=course.display_org_with_default, course_title=course_title)}
+              % else:
+                ${_("Welcome to {course_title}!").format(course_title=course_title)}
+              % endif
+              % if show_subtitle:
+                <div class="page-subtitle">${course_subtitle}</div>
+              % endif
             </h2>
         </div>
         % if resume_course_url and user_is_enrolled:


### PR DESCRIPTION
[OSPR-2022 ](https://openedx.atlassian.net/browse/OSPR-2022 )

Adding this 3 variables in ```site_configuration```: ```COURSE_HOMEPAGE_INVERT_TITLE```, ```COURSE_HOMEPAGE_SHOW_SUBTITLE``` and ```COURSE_HOMEPAGE_SHOW_ORG``` makes the course info page title and subtitle to be configurable. 

You can swap between ```course title``` and ```course number```, show or hide the ```organization``` and show or hide the ```subtitle```.

Sandbox:

* LMS: https://pr16671.sandbox.opencraft.hosting/
* Studio: https://studio-pr16671.sandbox.opencraft.hosting/

`staff@example.com` user has super user access to Django Admin.

Screenshots:

* Default behavior is unchanged:
  ![default course info title](https://user-images.githubusercontent.com/7556571/33299556-1463ccee-d43c-11e7-9c54-9fb6c93fc22a.png)
* Using example site configuration: 
  ```json
  { 
       "COURSE_HOMEPAGE_INVERT_TITLE":true,
       "COURSE_HOMEPAGE_SHOW_SUBTITLE":false,
       "COURSE_HOMEPAGE_SHOW_ORG":false
  }
  ```
  ![invert title hide org and subtitle](https://user-images.githubusercontent.com/7556571/33299574-2b52dc56-d43c-11e7-9cfe-51e1da1fc5e6.png)

Reviewers:
- [ ] Code review: ¯_(ツ)_/¯

cc @pomegranited 