### PR TITLE
Fix header logo link to MKTG root.

### DIFF
--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -14,7 +14,7 @@ from branding import api as branding_api
 %>
 
 <h1 class="header-logo">
-  <a href="${reverse('dashboard')}">
+  <a href="${branding_api.get_home_url()}">
     <%block name="navigation_logo">
     <img  class="logo" src="${branding_api.get_logo_url(is_secure)}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
     </%block>


### PR DESCRIPTION
In courseware, banner Logo links to Dashboard, footer logo
links to home page.

LEARNER-2881