### PR TITLE
[Transcript Retrieval] Move contentstore to fallback

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -977,7 +977,7 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
         '''
 
         descriptor = instantiate_descriptor(data=xml_data_transcripts)
-        translations = descriptor.available_translations(descriptor.get_transcripts_info())
+        translations = descriptor.available_translations(descriptor.get_transcripts_info(include_val_transcripts=False))
         self.assertEqual(translations, ['hr', 'ge'])
 
     def test_video_with_no_transcripts_translation_retrieval(self):
@@ -987,13 +987,17 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
         does not throw an exception.
         """
         descriptor = instantiate_descriptor(data=None)
-        translations_with_fallback = descriptor.available_translations(descriptor.get_transcripts_info())
+        translations_with_fallback = descriptor.available_translations(
+            descriptor.get_transcripts_info(include_val_transcripts=False)
+        )
         self.assertEqual(translations_with_fallback, ['en'])
 
         with patch.dict(settings.FEATURES, FALLBACK_TO_ENGLISH_TRANSCRIPTS=False):
             # Some organizations don't have English transcripts for all videos
             # This feature makes it configurable
-            translations_no_fallback = descriptor.available_translations(descriptor.get_transcripts_info())
+            translations_no_fallback = descriptor.available_translations(
+                descriptor.get_transcripts_info(include_val_transcripts=False)
+            )
             self.assertEqual(translations_no_fallback, [])
 
     @override_settings(ALL_LANGUAGES=ALL_LANGUAGES)
@@ -1017,7 +1021,11 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
             </video>
         '''
         descriptor = instantiate_descriptor(data=xml_data_transcripts)
-        translations = descriptor.available_translations(descriptor.get_transcripts_info(), verify_assets=False)
+        translations = descriptor.available_translations(
+            descriptor.get_transcripts_info(include_val_transcripts=False),
+            include_val_transcripts=False,
+            verify_assets=False
+        )
         self.assertNotEqual(translations, ['ur'])
 
     def assert_validation_message(self, validation, expected_msg):
@@ -1073,6 +1081,6 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
         """
         descriptor = instantiate_descriptor(data=None)
         descriptor.transcripts = None
-        response = descriptor.get_transcripts_info()
+        response = descriptor.get_transcripts_info(include_val_transcripts=False)
         expected = {'transcripts': {}, 'sub': ''}
         self.assertEquals(expected, response)

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -977,7 +977,10 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
         '''
 
         descriptor = instantiate_descriptor(data=xml_data_transcripts)
-        translations = descriptor.available_translations(descriptor.get_transcripts_info(include_val_transcripts=False))
+        translations = descriptor.available_translations(
+            descriptor.get_transcripts_info(include_val_transcripts=False),
+            include_val_transcripts=False
+        )
         self.assertEqual(translations, ['hr', 'ge'])
 
     def test_video_with_no_transcripts_translation_retrieval(self):
@@ -988,7 +991,8 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
         """
         descriptor = instantiate_descriptor(data=None)
         translations_with_fallback = descriptor.available_translations(
-            descriptor.get_transcripts_info(include_val_transcripts=False)
+            descriptor.get_transcripts_info(include_val_transcripts=False),
+            include_val_transcripts=False,
         )
         self.assertEqual(translations_with_fallback, ['en'])
 
@@ -996,7 +1000,8 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
             # Some organizations don't have English transcripts for all videos
             # This feature makes it configurable
             translations_no_fallback = descriptor.available_translations(
-                descriptor.get_transcripts_info(include_val_transcripts=False)
+                descriptor.get_transcripts_info(include_val_transcripts=False),
+                include_val_transcripts=False,
             )
             self.assertEqual(translations_no_fallback, [])
 

--- a/common/lib/xmodule/xmodule/video_module/bumper_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/bumper_utils.py
@@ -121,7 +121,7 @@ def bumper_metadata(video, sources):
     """
     Generate bumper metadata.
     """
-    transcripts = video.get_transcripts_info(is_bumper=True)
+    transcripts = video.get_transcripts_info(is_bumper=True, include_val_transcripts=False)
     unused_track_url, bumper_transcript_language, bumper_languages = video.get_transcripts_for_student(transcripts)
 
     metadata = OrderedDict({

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -770,12 +770,16 @@ class VideoTranscriptsMixin(object):
             transcript_language = u'en'
         return transcript_language
 
-    def get_transcripts_info(self, is_bumper=False):
+    def get_transcripts_info(self, is_bumper=False, include_val_transcripts=True):
         """
         Returns a transcript dictionary for the video.
 
         Arguments:
             is_bumper(bool): If True, the request is for the bumper transcripts
+            include_val_transcripts(bool): If True, val transcripts will also get included
+
+        Note: Do not include VAL transcripts into the transcripts metadata if the request is for bumper transcripts.
+        Currently, we don't handle video pre-load/bumper transcripts in edx-val.
         """
         if is_bumper:
             transcripts = copy.deepcopy(get_bumper_settings(self).get('transcripts', {}))
@@ -790,10 +794,7 @@ class VideoTranscriptsMixin(object):
             for language_code, transcript_file in transcripts.items() if transcript_file != ''
         }
 
-        # Do not include VAL transcripts into the transcripts metadata
-        # if the request is for bumper transcripts. Currently, we don't
-        # handle video pre-load/bumper transcripts in edx-val.
-        if not is_bumper:
+        if include_val_transcripts:
             transcript_languages = get_available_transcript_languages(
                 edx_video_id=self.edx_video_id,
                 youtube_id_1_0=self.youtube_id_1_0,

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -226,7 +226,7 @@ class VideoStudentViewHandlers(object):
         is_bumper = request.GET.get('is_bumper', False)
         # Currently, we don't handle video pre-load/bumper transcripts in edx-val.
         include_val_transcripts = not is_bumper
-        transcripts = self.get_transcripts_info(is_bumper)
+        transcripts = self.get_transcripts_info(is_bumper, include_val_transcripts=include_val_transcripts)
         if dispatch.startswith('translation'):
             language = dispatch.replace('translation', '').strip('/')
 

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -922,7 +922,8 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
         def _update_transcript_for_index(language=None):
             """ Find video transcript - if not found, don't update index """
             try:
-                transcripts = self.get_transcripts_info()
+                # This is to index contentstore transcripts so, do not include VAL transcripts.
+                transcripts = self.get_transcripts_info(include_val_transcripts=False)
                 transcript = self.get_transcript(
                     transcripts, transcript_format='txt', lang=language
                 )[0].replace("\n", " ")

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -44,7 +44,6 @@ from .bumper_utils import bumperize
 from .transcripts_utils import (
     get_html5_ids,
     get_video_ids_info,
-    is_val_transcript_feature_enabled_for_course,
     Transcript,
     VideoTranscriptsMixin,
 )
@@ -289,8 +288,7 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
             if download_video_link and download_video_link.endswith('.m3u8'):
                 download_video_link = None
 
-        feature_enabled = is_val_transcript_feature_enabled_for_course(self.course_id)
-        transcripts = self.get_transcripts_info(include_val_transcripts=feature_enabled)
+        transcripts = self.get_transcripts_info()
         track_url, transcript_language, sorted_languages = self.get_transcripts_for_student(transcripts=transcripts)
 
         # CDN_VIDEO_URLS is only to be used here and will be deleted
@@ -1023,9 +1021,8 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
                     "file_size": 0,  # File size is not relevant for external link
                 }
 
-        feature_enabled = is_val_transcript_feature_enabled_for_course(self.runtime.course_id.for_branch(None))
-        transcripts_info = self.get_transcripts_info(include_val_transcripts=feature_enabled)
-        available_translations = self.available_translations(transcripts_info, include_val_transcripts=feature_enabled)
+        transcripts_info = self.get_transcripts_info()
+        available_translations = self.available_translations(transcripts_info)
         transcripts = {
             lang: self.runtime.handler_url(self, 'transcript', 'download', query="lang=" + lang, thirdparty=True)
             for lang in available_translations

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1467,33 +1467,17 @@ class TestVideoDescriptorStudentViewJson(TestCase):
         ({'uk': 1, 'de': 1}, 'en-subs', ['de', 'en'], ['en', 'uk', 'de']),
     )
     @ddt.unpack
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages')
-    def test_student_view_with_val_transcripts_enabled(self, transcripts, english_sub, val_transcripts,
-                                                       expected_transcripts, mock_get_transcript_languages):
+    def test_student_view_with_val_transcripts(self, transcripts, english_sub, val_transcripts,
+                                               expected_transcripts, mock_get_transcript_languages):
         """
-        Test `student_view_data` with edx-val transcripts enabled.
+        Test that `student_view_data` works as expected with edx-val transcripts.
         """
         mock_get_transcript_languages.return_value = val_transcripts
         self.video.transcripts = transcripts
         self.video.sub = english_sub
         student_view_response = self.get_result()
         self.assertItemsEqual(student_view_response['transcripts'].keys(), expected_transcripts)
-
-    @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
-        Mock(return_value=False),
-    )
-    @patch(
-        'xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages',
-        Mock(return_value=['ro', 'es']),
-    )
-    def test_student_view_with_val_transcripts_disabled(self):
-        """
-        Test `student_view_data` with edx-val transcripts disabled.
-        """
-        student_view_response = self.get_result()
-        self.assertDictEqual(student_view_response['transcripts'], {self.TEST_LANGUAGE: self.transcript_url})
 
 
 @attr(shard=1)

--- a/lms/djangoapps/mobile_api/video_outlines/serializers.py
+++ b/lms/djangoapps/mobile_api/video_outlines/serializers.py
@@ -11,7 +11,6 @@ from courseware.module_render import get_module_for_descriptor
 from util.module_utils import get_dynamic_descriptor_children
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.mongo.base import BLOCK_TYPES_WITH_CHILDREN
-from xmodule.video_module.transcripts_utils import is_val_transcript_feature_enabled_for_course
 
 
 class BlockOutline(object):
@@ -209,12 +208,8 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
     size = default_encoded_video.get('file_size', 0)
 
     # Transcripts...
-    feature_enabled = is_val_transcript_feature_enabled_for_course(course_id)
-    transcripts_info = video_descriptor.get_transcripts_info(include_val_transcripts=feature_enabled)
-    transcript_langs = video_descriptor.available_translations(
-        transcripts=transcripts_info,
-        include_val_transcripts=feature_enabled
-    )
+    transcripts_info = video_descriptor.get_transcripts_info()
+    transcript_langs = video_descriptor.available_translations(transcripts=transcripts_info)
 
     transcripts = {
         lang: reverse(

--- a/lms/djangoapps/mobile_api/video_outlines/tests.py
+++ b/lms/djangoapps/mobile_api/video_outlines/tests.py
@@ -889,7 +889,7 @@ class TestVideoSummaryList(TestVideoAPITestCase, MobileAuthTestMixin, MobileCour
     @ddt.unpack
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages')
     def test_val_transcript_languages(self, transcripts, english_sub, val_transcripts,
-                                                  expected_transcripts, mock_get_transcript_languages):
+                                      expected_transcripts, mock_get_transcript_languages):
         """
         Tests that serialized course outline includes the VAL transcripts/translations languages as well.
         """

--- a/lms/djangoapps/mobile_api/video_outlines/tests.py
+++ b/lms/djangoapps/mobile_api/video_outlines/tests.py
@@ -887,10 +887,12 @@ class TestVideoSummaryList(TestVideoAPITestCase, MobileAuthTestMixin, MobileCour
         ({'uk': 1, 'de': 1}, 'en-subs', ['de', 'en'], ['en', 'uk', 'de']),
     )
     @ddt.unpack
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages')
-    def test_val_transcripts_with_feature_enabled(self, transcripts, english_sub, val_transcripts,
+    def test_val_transcript_languages(self, transcripts, english_sub, val_transcripts,
                                                   expected_transcripts, mock_get_transcript_languages):
+        """
+        Tests that serialized course outline includes the VAL transcripts/translations languages as well.
+        """
         self.login_and_enroll()
         video = ItemFactory.create(
             parent=self.nameless_unit,
@@ -939,10 +941,6 @@ class TestTranscriptsDetail(TestVideoAPITestCase, MobileAuthTestMixin, MobileCou
         self.api_response(expected_response_code=200, lang='en')
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
-        Mock(return_value=True),
-    )
-    @patch(
         'xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages',
         Mock(return_value=['uk']),
     )
@@ -974,20 +972,3 @@ class TestTranscriptsDetail(TestVideoAPITestCase, MobileAuthTestMixin, MobileCou
         self.assertEqual(response.content, expected_content)
         for attribute, value in expected_headers.iteritems():
             self.assertEqual(response.get(attribute), value)
-
-    @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
-        Mock(return_value=False),
-    )
-    @patch(
-        'xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages',
-        Mock(return_value=['uk']),
-    )
-    def test_val_transcript_feature_disabled(self):
-        """
-        Tests transcript retrieval view with val transcripts when
-        the corresponding feature is disabled.
-        """
-        self.login_and_enroll()
-        # request to retrieval endpoint will result in 404 as val transcripts are disabled.
-        self.api_response(expected_response_code=404, lang='uk')


### PR DESCRIPTION
## [EDUCATOR-1757](https://openedx.atlassian.net/browse/EDUCATOR-1757)

### Description
This moves contentstore to fallback for:
- Download and Translation dispatches
- Mobile-only Transcript Retrieval View

This also removes the transcript course-rollout feature flag from Video Handlers, Mobile Views. Consequently, VAL transcripts will always get included with video component ones but there is one exception though, which is "Bumper transcripts". Those are not included in edx-val for number of reasons and bumper also uses the same `translation/{lang}/` and `available_translations/` dispatches. In bumper case, this PR makes sure that we don't include VAL transcripts – `i.e.` in `translation/{lang}/` and `available_translations/` dispatches. 

