### PR TITLE
[ENT-750] Bump edx-enterprise to 0.53.17.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -47,7 +47,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.53.16
+edx-enterprise==0.53.17
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.8


### PR DESCRIPTION
This bumps edx-enterprise to use https://github.com/edx/edx-enterprise/pull/248.

**JIRA tickets**: [ENT-750](https://openedx.atlassian.net/browse/ENT-750)

**Testing instructions**:

1. See https://github.com/edx/edx-enterprise/pull/248

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```