### PR TITLE
Fix keyboard navigation in course outline

### DIFF
--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -14,25 +14,19 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <main role="main" class="course-outline" id="main" tabindex="-1">
     % if blocks.get('children'):
-        <ol class="block-tree" role="tree">
+        <ol class="block-tree">
             % for section in blocks.get('children'):
                 <li
-                    aria-expanded="true"
                     class="outline-item focusable section"
                     id="${ section['id'] }"
-                    role="treeitem"
-                    tabindex="0"
                 >
                     <div class="section-name">
                         <h3 class="section-title">${ section['display_name'] }</h3>
                     </div>
-                    <ol class="outline-item focusable" role="group" tabindex="0">
+                    <ol class="outline-item focusable">
                         % for subsection in section.get('children', []):
                             <li
                                 class="subsection ${ 'current' if subsection['last_accessed'] else '' }"
-                                role="treeitem"
-                                tabindex="-1"
-                                aria-expanded="true"
                             >
                                 <a
                                     class="outline-item focusable"
@@ -107,7 +101,6 @@ from openedx.core.djangolib.markup import HTML, Text
                                     <div class="subsection-actions">
                                         ## Resume button (if last visited section)
                                         % if subsection['last_accessed']:
-                                            <span class="sr-only">${ _("This is your last visited course section.") }</span>
                                             <span class="resume-right">
                                                 <b>${ _("Resume Course") }</b>
                                                 <span class="icon fa fa-arrow-circle-right" aria-hidden="true"></span>


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-2893

Remove some obsolete and broken a11y markup that was causing keyboard navigation in the main course outline to focus elements that shouldn't be focused.  See jira bug above for context.

The python tests shouldn't be affected -- they still use static html fragments that are a little bit more out of date with this change (they were already out of date).  I figured fixing those didn't need to happen here.

The bokchoy tests shouldn't be affected -- they use css classes as selectors, and those haven't changed.  We'll see once the full test suite runs here.

I considered adding a new bokchoy test (making sure that tabbing through the outline was sensible).  But there didn't seem to be any similar tests like that, so I figured it was too low-level of a thing to check.  But I can go back and add one if you reviewers like. 