### PR TITLE
Bump edx-enterprise to 0.54.1.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -47,7 +47,7 @@ edx-lint==0.4.3
 astroid==1.3.8
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.54.0
+edx-enterprise==0.54.1
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 edx-organizations==0.4.8


### PR DESCRIPTION
This updates `edx-enterprise` to 0.54.1 to include font size change on the enterprise data sharing consent page.

**JIRA Ticket**: [ENT-764](https://openedx.atlassian.net/browse/ENT-764)

**Testing Instructions**: See https://github.com/edx/edx-enterprise/pull/250.