### PR TITLE
Revert "Allow theme template block override"

### DIFF
--- a/common/djangoapps/edxmako/paths.py
+++ b/common/djangoapps/edxmako/paths.py
@@ -70,11 +70,6 @@ class DynamicTemplateLookup(TemplateLookup):
             try:
                 # Try to find themed template, i.e. see if current theme overrides the template
                 template = super(DynamicTemplateLookup, self).get_template(get_template_path_with_theme(uri))
-                # For an overriding template, the uri is the path to the same template, so the lookup always
-                # finds the same overriding template. If that's the case, route to exception so that the
-                # uri can be stripped of the path and the parent template can be found.
-                if template == super(DynamicTemplateLookup, self).get_template(uri):
-                    raise TopLevelLookupException()
             except TopLevelLookupException:
                 # strip off the prefix path to theme and look in default template dirs
                 template = super(DynamicTemplateLookup, self).get_template(strip_site_theme_templates_path(uri))

--- a/common/test/test-theme/lms/templates/dashboard.html
+++ b/common/test/test-theme/lms/templates/dashboard.html
@@ -1,4 +1,0 @@
-<%inherit file="dashboard.html" />
-<%block name="pagetitle">Overridden Title!</%block>
-${parent.body()}
-<%block name="bodyextra">Overriden Body Extra!</%block>

--- a/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
+++ b/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
@@ -64,30 +64,6 @@ class TestComprehensiveThemeLMS(TestCase):
         result = staticfiles.finders.find('test-theme/images/logo.png')
         self.assertEqual(result, settings.TEST_THEME / 'lms/static/images/logo.png')
 
-    @with_comprehensive_theme("test-theme")
-    def test_override_block_in_parent(self):
-        """
-        Test that theme title is used instead of parent title.
-        """
-        self._login()
-        dashboard_url = reverse('dashboard')
-        resp = self.client.get(dashboard_url)
-        self.assertEqual(resp.status_code, 200)
-        # This string comes from the 'pagetitle' block of the overriding theme.
-        self.assertContains(resp, "Overridden Title!")
-
-    @with_comprehensive_theme("test-theme")
-    def test_override_block_in_grandparent(self):
-        """
-        Test that theme title is used instead of parent's parent's title.
-        """
-        self._login()
-        dashboard_url = reverse('dashboard')
-        resp = self.client.get(dashboard_url)
-        self.assertEqual(resp.status_code, 200)
-        # This string comes from the 'bodyextra' block of the overriding theme.
-        self.assertContains(resp, "Overriden Body Extra!")
-
 
 @skip_unless_cms
 class TestComprehensiveThemeCMS(TestCase):


### PR DESCRIPTION
Reverts edx/edx-platform#15947. It pushed us over the limit for xsslint violations, and master is now failing the quality build. 

Please either quickly fix forward, or we should merge in this revert PR.
@bderusha @UmanShahzad 