### PR TITLE
Mark boundary of modal dialog better

### DIFF
--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -19,7 +19,7 @@ from xmodule.tabs import CourseTabList
 </div>
 
 <div id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-modal="true" tabindex="-1" aria-labelledby="support-platform-name">
-  <div class="inner-wrapper">
+   <div class="inner-wrapper" role="group" aria-label="dialog">
     ## TODO: find a way to refactor this
     <button class="btn-link close-modal" tabindex="0">
       <span class="icon fa fa-remove" aria-hidden="true"></span>


### PR DESCRIPTION
We already mark the Support help modal dialog for screen readers
per recommendations. But some screen readers need a little extra
help. So mark the boundary of internal dialog contents with a group
role as well.

https://openedx.atlassian.net/browse/LEARNER-2888