### PR TITLE
Schedules: course language -> closest released language

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -40,7 +40,7 @@ from courseware.courses import get_course_by_id
 from edxmako.shortcuts import render_to_response
 from edxmako.template import Template
 from openedx.core.djangoapps.catalog.utils import get_course_run_details
-from openedx.core.djangoapps.lang_pref.api import released_languages
+from openedx.core.djangoapps.lang_pref.api import get_closest_released_language
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.courses import course_image_url
 from openedx.core.djangoapps.certificates.api import display_date_for_certificate, certificates_viewable_for_course
@@ -656,7 +656,7 @@ def _get_custom_template_and_language(course_id, course_mode, course_language):
     Return the custom certificate template, if any, that should be rendered for the provided course/mode/language
     combination, along with the language that should be used to render that template.
     """
-    closest_released_language = _get_closest_released_language(course_language) if course_language else None
+    closest_released_language = get_closest_released_language(course_language) if course_language else None
     template = get_certificate_template(course_id, course_mode, closest_released_language)
 
     if template and template.language:
@@ -665,24 +665,6 @@ def _get_custom_template_and_language(course_id, course_mode, course_language):
         return (template, settings.LANGUAGE_CODE)
     else:
         return (None, None)
-
-
-def _get_closest_released_language(target):
-    """
-    Return the language code that most closely matches the target and is fully supported by the LMS, or None
-    if there are no fully supported languages that match the target.
-    """
-    match = None
-    languages = released_languages()
-
-    for language in languages:
-        if language.code == target:
-            match = language.code
-            break
-        elif (match is None) and (language.code[:2] == target[:2]):
-            match = language.code
-
-    return match
 
 
 def _render_invalid_certificate(course_id, platform_name, configuration):

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -17,6 +17,7 @@ from model_utils.models import TimeStampedModel
 from config_models.models import ConfigurationModel
 from lms.djangoapps import django_comment_client
 from openedx.core.djangoapps.catalog.models import CatalogIntegration
+from openedx.core.djangoapps.lang_pref.api import get_closest_released_language
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from static_replace.models import AssetBaseUrlConfig
 from xmodule import course_metadata_utils, block_metadata_utils
@@ -609,6 +610,15 @@ class CourseOverview(TimeStampedModel):
             instructor: Instructor-led courses
         """
         return 'self' if self.self_paced else 'instructor'
+
+    @property
+    def closest_released_language(self):
+        """
+        Returns the language code that most closely matches this course' language and is fully
+        supported by the LMS, or None if there are no fully supported languages that
+        match the target.
+        """
+        return get_closest_released_language(self.language) if self.language else None
 
     def apply_cdn_to_urls(self, image_urls):
         """

--- a/openedx/core/djangoapps/lang_pref/api.py
+++ b/openedx/core/djangoapps/lang_pref/api.py
@@ -73,3 +73,22 @@ def all_languages():
     """
     languages = [(lang[0], _(lang[1])) for lang in settings.ALL_LANGUAGES]  # pylint: disable=translation-of-non-string
     return sorted(languages, key=lambda lang: lang[1])
+
+
+def get_closest_released_language(target_language_code):
+    """
+    Return the language code that most closely matches the target and is fully
+    supported by the LMS, or None if there are no fully supported languages that
+    match the target.
+    """
+    match = None
+    languages = released_languages()
+
+    for language in languages:
+        if language.code == target_language_code:
+            match = language.code
+            break
+        elif (match is None) and (language.code[:2] == target_language_code[:2]):
+            match = language.code
+
+    return match

--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -195,7 +195,7 @@ class BinnedSchedulesBaseResolver(PrefixedDebugLoggerMixin, RecipientResolver):
             except InvalidContextError:
                 continue
 
-            yield (user, first_schedule.enrollment.course.language, template_context)
+            yield (user, first_schedule.enrollment.course.closest_released_language, template_context)
 
     def get_template_context(self, user, user_schedules):
         """
@@ -317,7 +317,7 @@ def _get_upsell_information_for_schedule(user, schedule):
             enrollment.dynamic_upgrade_deadline,
             get_format(
                 'DATE_FORMAT',
-                lang=course.language,
+                lang=course.closest_released_language,
                 use_l10n=True
             )
         )
@@ -370,7 +370,7 @@ class CourseUpdateResolver(BinnedSchedulesBaseResolver):
             })
             template_context.update(_get_upsell_information_for_schedule(user, schedule))
 
-            yield (user, schedule.enrollment.course.language, template_context)
+            yield (user, schedule.enrollment.course.closest_released_language, template_context)
 
 
 def _get_trackable_course_home_url(course_id):


### PR DESCRIPTION
## Problem
A course' language code is set to `es-es` while our transifex translation files for Spanish are only for `es-419`.  `gettext`will find the translation only if the requested language is equal to or a subset of the translation file.  Here's a table to summarize `gettext` behavior:

requested language code | translation (.mo) file language code | translated?
--------------------------|---------------------------------- | -----------
es-419|es|:white_check_mark:
es-es|es|:white_check_mark:
es|es|:white_check_mark:
es-419|es-419|:white_check_mark:
es-es|es-419|:x:
es|es-419|:x:

## Fix
In order to address this issue, we use the same strategy used by other LMS i18n features. We rely on the fact that we maintain an accurate list of LMS released languages in the configuration setting for the `DarkLang` middleware. We use this list to find the closest matching language that corresponds to the requested language code.

For example, we make the following conversions:

- es-es -> es-419
- es -> es-419
- es-419 -> es-419

## Code
This PR makes the following changes to fix the issue.

- Moves the `get_closest_released_language` functionality out of the `certificates` djangoapp into the common `lang_pref` djangoapp.
- Adds a new `closest_released_language` property to the `CourseOverview` model.
- Updates the `schedules` app to use the new `closest_released_language` property instead of the `language` property of the `CourseOverview`.

FYI @amangano-edx @BenjiLee @edx/rapid-experiments-team  