### PR TITLE
[MCKIN-5899] Create model to track aggregate completion

### DIFF
--- a/lms/djangoapps/completion/migrations/0002_aggregate_completion.py
+++ b/lms/djangoapps/completion/migrations/0002_aggregate_completion.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import lms.djangoapps.completion.models
+import django.utils.timezone
+from django.conf import settings
+import model_utils.fields
+import openedx.core.djangoapps.xmodule_django.models
+import openedx.core.djangolib.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('completion', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AggregateCompletion',
+            fields=[
+                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
+                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
+                ('id', openedx.core.djangolib.fields.BigAutoField(serialize=False, primary_key=True)),
+                ('course_key', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255)),
+                ('aggregation_name', models.CharField(max_length=255)),
+                ('block_key', openedx.core.djangoapps.xmodule_django.models.UsageKeyField(max_length=255)),
+                ('earned', models.FloatField(validators=[lms.djangoapps.completion.models.validate_positive_float])),
+                ('possible', models.FloatField(validators=[lms.djangoapps.completion.models.validate_positive_float])),
+                ('percent', models.FloatField(validators=[lms.djangoapps.completion.models.validate_percent])),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='aggregatecompletion',
+            unique_together=set([('course_key', 'block_key', 'user', 'aggregation_name')]),
+        ),
+        migrations.AlterIndexTogether(
+            name='aggregatecompletion',
+            index_together=set([('course_key', 'aggregation_name', 'block_key', 'percent'), ('user', 'aggregation_name', 'course_key', 'block_key')]),
+        ),
+    ]

--- a/lms/djangoapps/completion/models.py
+++ b/lms/djangoapps/completion/models.py
@@ -7,9 +7,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models.signals import pre_save
 from django.utils.translation import ugettext as _
 from model_utils.models import TimeStampedModel
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, UsageKeyField
 from . import waffle
@@ -30,7 +31,60 @@ def validate_percent(value):
         raise ValidationError(_('{value} must be between 0.0 and 1.0').format(value=value))
 
 
-class BlockCompletionManager(models.Manager):
+def validate_positive_float(value):
+    """
+    Verifies that the passed in value is greater than 0.
+    """
+    if value < 0.0:
+        raise ValidationError(_('{value} must be larger than 0.').format(value=value))
+
+
+class CompletionManager(models.Manager):
+    """
+    A completion manager
+    """
+
+    def validate(self, user, course_key, block_key):
+        """
+        Performs validation
+
+        Parameters:
+            * user (django.contrib.auth.models.User):
+            * course_key (opaque_keys.edx.keys.CourseKey):
+            * block_key (opaque_keys.edx.keys.UsageKey):
+
+        Raises:
+            TypeError:
+                If the wrong type is passed for the parameters.
+        """
+        if not isinstance(course_key, CourseKey):
+            raise TypeError(
+                _("course_key must be an instance of `opaque_keys.edx.keys.CourseKey`.  Got {}".format(
+                    type(course_key)
+                ))
+            )
+        if not isinstance(block_key, UsageKey):
+            raise TypeError(
+                _("block_key must be an instance of `opaque_keys.edx.keys.UsageKey`.  Got {}".format(
+                    type(block_key)
+                ))
+            )
+        try:
+            block_type = block_key.block_type
+        except AttributeError:
+            raise TypeError(
+                _("block_key must be an instance of `opaque_keys.edx.keys.UsageKey`.  Got {}".format(type(block_key)))
+            )
+
+    @staticmethod
+    def pre_save(sender, instance, **kwargs):
+        """
+        Validate all fields before saving to database.
+        """
+        instance.full_clean()
+
+
+class BlockCompletionManager(CompletionManager):
     """
     Custom manager for BlockCompletion model.
 
@@ -57,12 +111,14 @@ class BlockCompletionManager(models.Manager):
             object was newly created by this call.
 
         Raises:
+             TypeError:
+                If the wrong type is passed for the parameters.
 
-            ValueError:
-                If the wrong type is passed for one of the parameters.
+            RuntimeError:
+                If waffle.ENABLE_COMPLETION_TRACKING is not enabled.
 
             django.core.exceptions.ValidationError:
-                If a float is passed that is not between 0.0 and 1.0.
+                If the completion parameter is not between 0.0 and 1.0.
 
             django.db.DatabaseError:
                 If there was a problem getting, creating, or updating the
@@ -73,37 +129,103 @@ class BlockCompletionManager(models.Manager):
                 IntegrityError and OperationalError are relatively common
                 subclasses.
         """
-
-        # Raise ValueError to match normal django semantics for wrong type of field.
-        if not isinstance(course_key, CourseKey):
-            raise ValueError(
-                "course_key must be an instance of `opaque_keys.edx.keys.CourseKey`.  Got {}".format(type(course_key))
-            )
-        try:
-            block_type = block_key.block_type
-        except AttributeError:
-            raise ValueError(
-                "block_key must be an instance of `opaque_keys.edx.keys.UsageKey`.  Got {}".format(type(block_key))
-            )
-
-        if waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING):
-            obj, isnew = self.get_or_create(
-                user=user,
-                course_key=course_key,
-                block_type=block_type,
-                block_key=block_key,
-                defaults={'completion': completion},
-            )
-            if not isnew and obj.completion != completion:
-                obj.completion = completion
-                obj.full_clean()
-                obj.save()
-        else:
-            # If the feature is not enabled, this method should not be called.  Error out with a RuntimeError.
+        if not waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING):
             raise RuntimeError(
-                "BlockCompletion.objects.submit_completion should not be called when the feature is disabled."
+                _("BlockCompletionManager.submit_completion should not be called when the feature is disabled.")
             )
-        return obj, isnew
+        self.validate(user, course_key, block_key)
+
+        obj, is_new = self.get_or_create(
+            user=user,
+            course_key=course_key,
+            block_type=block_key.block_type,
+            block_key=block_key,
+            defaults={'completion': completion},
+        )
+        if not is_new and obj.completion != completion:
+            obj.completion = completion
+            obj.full_clean()
+            obj.save()
+        return obj, is_new
+
+
+class AggregateCompletionManager(CompletionManager):
+    """
+    Custom manager for AggregateCompletion model.
+    """
+
+    def submit_completion(self, user, course_key, block_key, aggregation_name, earned, possible):
+        """
+        Inserts and Updates the completion AggregateCompletion for the specified record.
+
+        Parameters:
+            * user (django.contrib.auth.models.User): The user for whom the
+              completion is being submitted.
+            * course_key (opaque_keys.edx.keys.CourseKey): The course in
+              which the submitted block is found.
+            * block_key (opaque_keys.edx.keys.UsageKey): The block that has had
+              its completion changed.
+            * aggregation_name (string): The name of the aggregated blocks.
+              This is set by the level that the aggregation
+              is occurring. Possible values are "course", "chapter", "sequential", "vertical"
+            * earned (float): The positive sum of the fractional completions of all descendant blocks up
+              to the value of possible.
+            * possible (float): The total sum of the possible completion values of all descendant
+              blocks that are visible to the user. This should be a positive integer.
+
+        Return Value:
+            (BlockCompletion, bool): A tuple comprising the created or updated
+            BlockCompletion object and a boolean value indicating whether the
+            object was newly created by this call.
+
+        Raises:
+            TypeError:
+                If the wrong type is passed for the parameters.
+
+            ValueError:
+                If the value of earned is greater than possible.
+
+            django.core.exceptions.ValidationError:
+                If earned / possible results in a number that is less than 0 or greater than 1 or any float is
+                less than zero.
+
+            RuntimeError:
+                If waffle.ENABLE_COMPLETION_AGGREGATION is not enabled.
+
+            django.db.DatabaseError:
+                If there was a problem getting, creating, or updating the
+                BlockCompletion record in the database.
+
+                This will also be a more specific error, as described here:
+                https://docs.djangoproject.com/en/1.11/ref/exceptions/#database-exceptions.
+                IntegrityError and OperationalError are relatively common
+                subclasses.
+        """
+        if not waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_AGGREGATION):
+            raise RuntimeError(
+                _("AggregateCompletionManager.submit_completion should "
+                  "not be called when the aggregation feature is disabled.")
+            )
+        self.validate(user, course_key, block_key)
+        if earned > possible:
+            raise ValueError(_('Earned cannot be greater than the possible value.'))
+        if possible > 0.0:
+            percent = earned / possible
+        else:
+            percent = 0.0
+
+        obj, is_new = self.update_or_create(
+            user=user,
+            course_key=course_key,
+            aggregation_name=aggregation_name,
+            block_key=block_key,
+            defaults={
+                'percent': percent,
+                'possible': possible,
+                'earned': earned,
+            },
+        )
+        return obj, is_new
 
 
 class BlockCompletion(TimeStampedModel, models.Model):
@@ -147,3 +269,45 @@ class BlockCompletion(TimeStampedModel, models.Model):
             block_key=self.block_key,
             completion=self.completion,
         )
+
+
+class AggregateCompletion(TimeStampedModel):
+    """
+    Aggregators are blocks that contain other blocks, are not themselves completable,
+    and are considered complete when all descendant blocks are complete.
+    """
+    id = BigAutoField(primary_key=True)  # pylint: disable=invalid-name
+    user = models.ForeignKey(User)
+    course_key = CourseKeyField(max_length=255)
+    aggregation_name = models.CharField(max_length=255)
+    block_key = UsageKeyField(max_length=255)
+    earned = models.FloatField(validators=[validate_positive_float])
+    possible = models.FloatField(validators=[validate_positive_float])
+    percent = models.FloatField(validators=[validate_percent])
+
+    objects = AggregateCompletionManager()
+
+    class Meta(object):
+        index_together = [
+            ('user', 'aggregation_name', 'course_key', 'block_key'),
+            ('course_key', 'aggregation_name', 'block_key', 'percent'),
+        ]
+
+        unique_together = [
+            ('course_key', 'block_key', 'user', 'aggregation_name')
+        ]
+
+    def __unicode__(self):
+        return 'AggregationCompletion: {username}, {course_key}, {block_key}: {percent}'.format(
+            username=self.user.username,
+            course_key=self.course_key,
+            block_key=self.block_key,
+            percent=self.percent,
+        )
+
+
+pre_save.connect(
+    AggregateCompletionManager.pre_save,
+    AggregateCompletion,
+    dispatch_uid="completion.models.AggregateCompletion"
+)

--- a/lms/djangoapps/completion/models.py
+++ b/lms/djangoapps/completion/models.py
@@ -212,7 +212,7 @@ class AggregateCompletionManager(CompletionManager):
         if possible > 0.0:
             percent = earned / possible
         else:
-            percent = 0.0
+            percent = 1.0
 
         obj, is_new = self.update_or_create(
             user=user,

--- a/lms/djangoapps/completion/tests/test_models.py
+++ b/lms/djangoapps/completion/tests/test_models.py
@@ -4,6 +4,8 @@ Test models, managers, and validators.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import ddt
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from opaque_keys.edx.keys import UsageKey
@@ -142,3 +144,178 @@ class CompletionDisabledTestCase(CompletionSetUpMixin, TestCase):
                 completion=0.9,
             )
         self.assertEqual(models.BlockCompletion.objects.count(), 1)
+
+
+@ddt.ddt
+class AggregateCompletionTestCase(TestCase):
+    BLOCK_KEY = u'block-v1:edx+test+run+type@video+block@doggos'
+    BLOCK_KEY_OBJ = UsageKey.from_string(BLOCK_KEY)
+    COURSE_KEY_OBJ = UsageKey.from_string(BLOCK_KEY).course_key
+
+    def setUp(self):
+        super(AggregateCompletionTestCase, self).setUp()
+        self.user = UserFactory()
+
+        # Enable completion tracking
+        overrider = waffle.waffle().override(waffle.ENABLE_COMPLETION_AGGREGATION, True)
+        overrider.__enter__()
+        self.addCleanup(overrider.__exit__, None, None, None)
+
+    @ddt.data(
+        # Valid arguments
+        (BLOCK_KEY_OBJ, 'course', 0.5, 1, 0.5),
+    )
+    @ddt.unpack
+    def test_submit_completion_with_valid_data(self, block_key_obj, aggregate_name, earned, possible, expected_percent):
+        obj, is_new = models.AggregateCompletion.objects.submit_completion(
+            user=self.user,
+            course_key=block_key_obj.course_key,
+            block_key=block_key_obj,
+            aggregation_name=aggregate_name,
+            earned=earned,
+            possible=possible
+        )
+        self.assertTrue(is_new)
+        self.assertEqual(len(models.AggregateCompletion.objects.all()), 1)
+        self.assertEqual(obj.earned, earned)
+        self.assertEqual(obj.possible, possible)
+        self.assertEqual(obj.percent, expected_percent)
+
+    @ddt.data(
+        # Earned greater than possible
+        (BLOCK_KEY_OBJ, COURSE_KEY_OBJ, 'course', 1.1, 1,
+         ValueError, "The earned cannot be larger than the possible value."),
+        # Earned is less than zero.
+        (BLOCK_KEY_OBJ, COURSE_KEY_OBJ, 'course', -0.5, 1,
+         ValidationError, "{'percent': [u'-0.5 must be between 0.0 and 1.0'],"
+                          " 'earned': [u'-0.5 must be larger than 0.']}"),
+        # Possible is less than zero.
+        (BLOCK_KEY_OBJ, COURSE_KEY_OBJ, 'course', -1.5, -1,
+         ValidationError, "{'percent': [u'1.5 must be between 0.0 and 1.0'],"
+                          " 'possible': [u'-1.0 must be larger than 0.'],"
+                          " 'earned': [u'-1.5 must be larger than 0.']}"),
+        # TypeError for Block Key
+        (BLOCK_KEY, COURSE_KEY_OBJ, 'course', 0.5, 1,
+         TypeError, "{'percent': [u'1.5 must be between 0.0 and 1.0'],"
+                    " 'possible': [u'-1.0 must be larger than 0.'],"
+                    " 'earned': [u'-1.5 must be larger than 0.']}"),
+        # TypeError for Course Key
+        (BLOCK_KEY_OBJ, str(COURSE_KEY_OBJ), 'course', 0.5, 1,
+         TypeError, "{'percent': [u'1.5 must be between 0.0 and 1.0'],"
+                    " 'possible': [u'-1.0 must be larger than 0.'],"
+                    " 'earned': [u'-1.5 must be larger than 0.']}"),
+    )
+    @ddt.unpack
+    def test_submit_completion_with_exception(self, block_key, course_key, aggregate_name,
+                                              earned, possible, exception_type, exception_message):
+        with self.assertRaises(exception_type) as context_manager:
+            models.AggregateCompletion.objects.submit_completion(
+                user=self.user,
+                course_key=course_key,
+                block_key=block_key,
+                aggregation_name=aggregate_name,
+                earned=earned,
+                possible=possible)
+
+            self.assertEqual(exception_message, str(context_manager.exception))
+
+    @ddt.data(
+        (
+            BLOCK_KEY_OBJ, 'course', 0.5, 1, 0.5,
+        )
+    )
+    @ddt.unpack
+    def test_aggregate_completion_string(self, block_key_obj, aggregate_name,
+                                         earned, possible, expected_percent):
+        obj, is_new = models.AggregateCompletion.objects.submit_completion(
+            user=self.user,
+            course_key=block_key_obj.course_key,
+            block_key=block_key_obj,
+            aggregation_name=aggregate_name,
+            earned=earned,
+            possible=possible
+        )
+        expected_string = 'AggregationCompletion: {username}, course-v1:edx+test+run, ' \
+                          'block-v1:edx+test+run+type@video+block@doggos: 0.5'.format(username=self.user.username)
+        self.assertEqual(str(obj), expected_string)
+
+    @ddt.data(
+        # Changes the value of earned. This does not create a new object.
+        (
+            BLOCK_KEY_OBJ, 'course', 0.5, 1, 0.5,
+            BLOCK_KEY_OBJ, 'course', 0.7, 1, 0.7, False
+        ),
+        # Changes the value of possible. This does not create a new object.
+        (
+            BLOCK_KEY_OBJ, 'course', 0.5, 1, 0.5,
+            BLOCK_KEY_OBJ, 'course', 0.5, 2, 0.25, False
+        ),
+        # Changes the value of aggregate_name. This creates a new object.
+        (
+            BLOCK_KEY_OBJ, 'course', 0.5, 1, 0.5,
+            BLOCK_KEY_OBJ, 'chapter', 0.5, 1, 0.5, True
+        ),
+        # Changes the block_key. This creates a new object.
+        (
+            BLOCK_KEY_OBJ, 'course', 0.5, 1, 0.5,
+            UsageKey.from_string(u'block-v1:edX+DemoX+Demo_Course+type@sequential+block@workflow'),
+            'course', 0.5, 1, 0.5, True
+        ),
+    )
+    @ddt.unpack
+    def test_submit_completion_twice_with_changes(self, block_key_obj, aggregate_name, earned, possible,
+                                                  expected_percent, new_block_key_obj, new_aggregate_name, new_earned,
+                                                  new_possible, new_percent, is_second_obj_new):
+        obj, is_new = models.AggregateCompletion.objects.submit_completion(
+            user=self.user,
+            course_key=block_key_obj.course_key,
+            block_key=block_key_obj,
+            aggregation_name=aggregate_name,
+            earned=earned,
+            possible=possible
+        )
+        self.assertEqual(obj.percent, expected_percent)
+        self.assertTrue(is_new)
+
+        new_obj, is_new = models.AggregateCompletion.objects.submit_completion(
+            user=self.user,
+            course_key=new_block_key_obj.course_key,
+            block_key=new_block_key_obj,
+            aggregation_name=new_aggregate_name,
+            earned=new_earned,
+            possible=new_possible
+        )
+        self.assertEqual(new_obj.percent, new_percent)
+        self.assertEqual(is_new, is_second_obj_new)
+        if is_second_obj_new:
+            self.assertNotEqual(obj.id, new_obj.id)
+
+
+@ddt.ddt
+class AggregateCompletionDisabledTestCase(TestCase):
+
+    def setUp(self):
+        super(AggregateCompletionDisabledTestCase, self).setUp()
+        # Disable completion tracking
+        overrider = waffle.waffle().override(waffle.ENABLE_COMPLETION_AGGREGATION, False)
+        overrider.__enter__()
+        self.addCleanup(overrider.__exit__, None, None, None)
+
+    @ddt.data(
+        (RuntimeError, "AggregateCompletion.submit_completion should not be "
+                       "called when the aggregation feature is disabled.")
+    )
+    @ddt.unpack
+    def test_cannot_call_submit_completion(self, exception_type, exception_message):
+        self.assertEqual(models.AggregateCompletion.objects.count(), 0)
+        with self.assertRaises(exception_type) as context_manager:
+            models.AggregateCompletion.objects.submit_completion(
+                user=None,
+                course_key=None,
+                block_key=None,
+                aggregation_name='course',
+                earned=0.5,
+                possible=1.0,
+            )
+            self.assertEqual(exception_message, str(context_manager.exception))
+        self.assertEqual(models.AggregateCompletion.objects.count(), 0)

--- a/lms/djangoapps/completion/waffle.py
+++ b/lms/djangoapps/completion/waffle.py
@@ -18,6 +18,11 @@ WAFFLE_NAMESPACE = 'completion'
 # xblocks.
 ENABLE_COMPLETION_TRACKING = 'enable_completion_tracking'
 
+# Full name: completion.enable_completion_aggregation
+# Indicates whether or not to track completion of aggregate blocks.  Keeping
+# this disabled will prevent creation of AggregateCompletion objects in the database
+ENABLE_COMPLETION_AGGREGATION = 'enable_completion_aggregation'
+
 
 def waffle():
     """


### PR DESCRIPTION
Creates an Aggregate completion model for the completion API.

The AggregateCompletion model inherits from TimeStampedModel and has the following fields:
```
id = BigAutoField(primary_key=True)  # pylint: disable=invalid-name
user = models.ForeignKey(User)
course_key = CourseKeyField(max_length=255)
aggregation_name = models.CharField(max_length=255)
block_key = UsageKeyField(max_length=255)
earned = models.FloatField(validators=[validate_positive_float])
possible = models.FloatField(validators=[validate_positive_float])
percent = models.FloatField(validators=[validate_percent])
```
**JIRA tickets**: MCKIN-5899

**Sandbox URL**:
- LMS: https://pr16715.sandbox.opencraft.hosting
- Studio: https://studio-pr16715.sandbox.opencraft.hosting

**Merge deadline**: None

**Testing instructions**:
1. Enable completion aggregation feature using waffle switch: 
   ```bash
   ./manage.py lms waffle_switch completion.enable_completion_aggregation on --create --settings=devstack
   ```
2. Run lms shell
3. Make sure the database has been migrated.
```
python manage.py lms migrate --settings=devstack
```
3. Start a python shell.
```python manage.py lms shell --settings=devstack```

4. Run the following python commands to create a new AggregateCompletion object.
```
from lms.djangoapps.completion.models import AggregateCompletion;
from opaque_keys.edx.keys import UsageKey;
from django.contrib.auth import get_user_model
user = get_user_model().objects.get(username='audit')
block_key_obj = UsageKey.from_string(u'block-v1:edx+test+run+type@video+block@doggos');
AggregateCompletion.objects.submit_completion(user, block_key_obj.course_key, block_key_obj, "course", 0.5, 1);
```
5. Result should be the following:
```
(<AggregateCompletion: AggregationCompletion: audit, course-v1:edx+test+run, block-v1:edx+test+run+type@video+block@doggos: 0.5>, True)
```

**Reviewers**
- [ ] @pomegranited 
- [ ] edX reviewer[s] TBD