### PR TITLE
Subsections with prereqs now visible in outline

### DIFF
--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -344,11 +344,14 @@ def add_course_content_milestone(course_id, content_id, relationship, milestone)
     return milestones_api.add_course_content_milestone(course_id, content_id, relationship, milestone)
 
 
-def get_course_content_milestones(course_id, content_id, relationship, user_id=None):
+def get_course_content_milestones(course_id, content_id=None, relationship='requires', user_id=None):
     """
     Client API operation adapter/wrapper
     Uses the request cache to store all of a user's
     milestones
+
+    Returns all content blocks in a course if content_id is None, otherwise it just returns that
+    specific content block.
     """
     if not settings.FEATURES.get('MILESTONES_APP'):
         return []
@@ -366,6 +369,9 @@ def get_course_content_milestones(course_id, content_id, relationship, user_id=N
             relationship=relationship,
             user={"id": user_id}
         )
+
+    if content_id is None:
+        return request_cache_dict[user_id][relationship]
 
     return [m for m in request_cache_dict[user_id][relationship] if m['content_id'] == unicode(content_id)]
 

--- a/common/test/acceptance/pages/lms/course_home.py
+++ b/common/test/acceptance/pages/lms/course_home.py
@@ -83,7 +83,7 @@ class CourseOutlinePage(PageObject):
     SECTION_SELECTOR = '.outline-item.section:nth-of-type({0})'
     SECTION_TITLES_SELECTOR = '.section-name h3'
     SUBSECTION_SELECTOR = SECTION_SELECTOR + ' .subsection:nth-of-type({1}) .outline-item'
-    SUBSECTION_TITLES_SELECTOR = SECTION_SELECTOR + ' .subsection .subsection-title'
+    SUBSECTION_TITLES_SELECTOR = SECTION_SELECTOR + ' .subsection .subsection-title .subsection-title-name'
     OUTLINE_RESUME_COURSE_SELECTOR = '.outline-item .resume-right'
 
     def __init__(self, browser, parent_page):

--- a/common/test/acceptance/tests/lms/test_lms_gating.py
+++ b/common/test/acceptance/tests/lms/test_lms_gating.py
@@ -150,9 +150,13 @@ class GatingTest(UniqueCourseTest):
         """
         Given that I am a student
         When I visit the LMS Courseware
-        Then I cannot see a gated subsection
+        Then I can see a gated subsection
+TODO:            The gated subsection should have a lock icon
+TODO:            and be in the format: "<Subsection Title> (Prerequisite Required)"
         When I fulfill the gating Prerequisite
         Then I can see the gated subsection
+TODO:            Now the gated subsection should have an unlock icon
+TODO:            and screen readers should read the section as: "<Subsection Title> Unlocked"
         """
         self._setup_prereq()
         self._setup_gated_subsection()
@@ -160,7 +164,7 @@ class GatingTest(UniqueCourseTest):
         self._auto_auth(self.STUDENT_USERNAME, self.STUDENT_EMAIL, False)
 
         self.course_home_page.visit()
-        self.assertEqual(self.course_home_page.outline.num_subsections, 1)
+        self.assertEqual(self.course_home_page.outline.num_subsections, 2)
 
         # Fulfill prerequisite and verify that gated subsection is shown
         self.courseware_page.visit()
@@ -175,7 +179,9 @@ class GatingTest(UniqueCourseTest):
         Then I can see all gated subsections
         Displayed along with notification banners
         Then if I masquerade as a student
-        Then I cannot see a gated subsection
+        Then I can see a gated subsection
+TODO:            The gated subsection should have a lock icon
+TODO:            and be in the format: "<Subsection Title> (Prerequisite Required)"
         When I fufill the gating prerequisite
         Then I can see the gated subsection (without a banner)
         """
@@ -204,7 +210,7 @@ class GatingTest(UniqueCourseTest):
 
         self.course_home_page.visit()
         self.course_home_page.preview.set_staff_view_mode('Learner')
-        self.assertEqual(self.course_home_page.outline.num_subsections, 1)
+        self.assertEqual(self.course_home_page.outline.num_subsections, 2)
         self.course_home_page.outline.go_to_section('Test Section 1', 'Test Subsection 1')
         self.courseware_page.wait_for_page()
         self.assertFalse(self.courseware_page.has_banner())

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -146,7 +146,7 @@ class TestGetBlocksQueryCounts(SharedModuleStoreTestCase):
             self._get_blocks(
                 course,
                 expected_mongo_queries=0,
-                expected_sql_queries=6 if with_storage_backing else 5,
+                expected_sql_queries=5 if with_storage_backing else 4,
             )
 
     @ddt.data(
@@ -164,5 +164,5 @@ class TestGetBlocksQueryCounts(SharedModuleStoreTestCase):
             self._get_blocks(
                 course,
                 expected_mongo_queries,
-                expected_sql_queries=14 if with_storage_backing else 6,
+                expected_sql_queries=13 if with_storage_backing else 5,
             )

--- a/lms/djangoapps/course_api/blocks/transformers/milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/milestones.py
@@ -66,8 +66,6 @@ class MilestonesAndSpecialExamsTransformer(BlockStructureTransformer):
 
             if usage_info.has_staff_access:
                 return False
-            elif self.has_pending_milestones_for_user(block_key, usage_info):
-                return True
             elif self.gated_by_required_content(block_key, block_structure, required_content):
                 return True
             elif (settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
@@ -137,18 +137,21 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
         (
             'H',
             'A',
-            ('course', 'A', 'B', 'C',)
+            ('course', 'A', 'B', 'C', 'H', 'I')
         ),
         (
             'H',
             'ProctoredExam',
-            ('course', 'A', 'B', 'C'),
+            ('course', 'A', 'B', 'C', 'H', 'I'),
         ),
     )
     @ddt.unpack
     def test_gated(self, gated_block_ref, gating_block_ref, expected_blocks_before_completion):
         """
-        First, checks that a student cannot see the gated block when it is gated by the gating block and no
+        Students should be able to see gated content blocks before and after they have completed the
+        prerequisite for it.
+
+        First, checks that a student can see the gated block when it is gated by the gating block and no
         attempt has been made to complete the gating block.
         Then, checks that the student can see the gated block after the gating block has been completed.
 
@@ -160,7 +163,7 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
         self.course.enable_subsection_gating = True
         self.setup_gated_section(self.blocks[gated_block_ref], self.blocks[gating_block_ref])
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(6):
             self.get_blocks_and_check_against_expected(self.user, expected_blocks_before_completion)
 
         # clear the request cache to simulate a new request
@@ -174,7 +177,7 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
                 self.user,
             )
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(6):
             self.get_blocks_and_check_against_expected(self.user, self.ALL_BLOCKS_EXCEPT_SPECIAL)
 
     def test_staff_access(self):
@@ -195,7 +198,7 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
         self.course.enable_subsection_gating = True
         self.setup_gated_section(self.blocks['H'], self.blocks['A'])
         expected_blocks = (
-            'course', 'A', 'B', 'C', 'ProctoredExam', 'D', 'E', 'PracticeExam', 'F', 'G', 'TimedExam', 'J', 'K'
+            'course', 'A', 'B', 'C', 'ProctoredExam', 'D', 'E', 'PracticeExam', 'F', 'G', 'TimedExam', 'J', 'K', 'H', 'I'
         )
         self.get_blocks_and_check_against_expected(self.user, expected_blocks)
         # clear the request cache to simulate a new request

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -35,9 +35,34 @@ from openedx.core.djangolib.markup import HTML, Text
                                 >
                                     <div class="subsection-text">
                                         ## Subsection title
-                                        <span class="subsection-title">${ subsection['display_name'] }</span>
-
+                                        <span class="subsection-title">
+                                            % if subsection['id'] in milestones:
+                                                % if milestones[subsection['id']]['completed_prereqs']:
+                                                    <span class="menu-icon icon fa fa-unlock"
+                                                        aria-hidden="true">
+                                                    </span>
+                                                    <span class="subsection-title-name">
+                                                        ${ subsection['display_name'] }
+                                                    </span>
+                                                    <span class="sr">&nbsp;${_("Unlocked")}</span>
+                                                % else:
+                                                    <span class="menu-icon icon fa fa-lock" 
+                                                    aria-hidden="true">
+                                                    </span>
+                                                    <span class="subsection-title-name">
+                                                        ${ subsection['display_name'] }
+                                                    </span>
+                                                    <span class="details">
+                                                        ${ _("(Prerequisite required)") }
+                                                    </span>
+                                                % endif
+                                            % else:
+                                                <span class="subsection-title-name">
+                                                    ${ subsection['display_name'] }
+                                                </span>
+                                            % endif
                                         <div class="details">
+
                                             ## There are behavior differences between rendering of subsections which have
                                             ## exams (timed, graded, etc) and those that do not.
                                             ##
@@ -91,7 +116,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                             class="menu-icon icon fa fa-pencil-square-o"
                                                             aria-hidden="true"
                                                         ></span>
-                                                        <span class="sr">${_("This content is graded")}</span>
+                                                        <span class="sr">&nbsp;${_("This content is graded")}</span>
                                                     % endif
                                                 % endif
                                             </span>

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -176,7 +176,7 @@ class TestCourseHomePage(CourseHomePageTestCase):
         course_home_url(self.course)
 
         # Fetch the view and verify the query counts
-        with self.assertNumQueries(49, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(50, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_home_url(self.course)
                 self.client.get(url)

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -6,17 +6,23 @@ import json
 
 from django.core.urlresolvers import reverse
 from pyquery import PyQuery as pq
+from gating import api as lms_gating_api
+from mock import patch, Mock
 
 from courseware.tests.factories import StaffFactory
+from openedx.core.lib.gating import api as gating_api
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from milestones.tests.utils import MilestonesTestCaseMixin
+from lms.djangoapps.course_api.blocks.transformers.milestones import MilestonesAndSpecialExamsTransformer
 
 from .test_course_home import course_home_url
 
 TEST_PASSWORD = 'test'
+GATING_NAMESPACE_QUALIFIER = '.gating'
 
 
 class TestCourseOutlinePage(SharedModuleStoreTestCase):
@@ -105,6 +111,138 @@ class TestCourseOutlinePage(SharedModuleStoreTestCase):
                     self.assertTrue(sequential.children)
                     for vertical in sequential.children:
                         self.assertNotIn(vertical.display_name, response_content)
+
+
+class TestCourseOutlinePageWithPrerequisites(SharedModuleStoreTestCase, MilestonesTestCaseMixin):
+    """
+    Test the course outline view with prerequisites.
+    """
+    TRANSFORMER_CLASS_TO_TEST = MilestonesAndSpecialExamsTransformer
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Creates a test course that can be used for non-destructive tests
+        """
+
+        cls.PREREQ_REQUIRED = '(Prerequisite required)'
+        cls.UNLOCKED = 'Unlocked'
+
+        with super(TestCourseOutlinePageWithPrerequisites, cls).setUpClassAndTestData():
+            cls.course, cls.course_blocks = cls.create_test_course()
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up and enroll our fake user in the course."""
+        cls.user = UserFactory(password=TEST_PASSWORD)
+        CourseEnrollment.enroll(cls.user, cls.course.id)
+
+    @classmethod
+    def create_test_course(cls):
+        """Creates a test course."""
+
+        course = CourseFactory.create()
+        course.enable_subsection_gating = True
+        course_blocks = {}
+        with cls.store.bulk_operations(course.id):
+            course_blocks['chapter'] = ItemFactory.create(category='chapter', parent_location=course.location)
+            course_blocks['prerequisite'] = ItemFactory.create(category='sequential', parent_location=course_blocks['chapter'].location, display_name='Prerequisite Exam')
+            course_blocks['gated_content'] = ItemFactory.create(category='sequential', parent_location=course_blocks['chapter'].location, display_name='Gated Content')
+            course_blocks['prerequisite_vertical'] = ItemFactory.create(category='vertical', parent_location=course_blocks['prerequisite'].location)
+            course_blocks['gated_content_vertical'] = ItemFactory.create(category='vertical', parent_location=course_blocks['gated_content'].location)
+        course.children = [course_blocks['chapter']]
+        course_blocks['chapter'].children = [course_blocks['prerequisite'], course_blocks['gated_content']]
+        course_blocks['prerequisite'].children = [course_blocks['prerequisite_vertical']]
+        course_blocks['gated_content'].children = [course_blocks['gated_content_vertical']]
+        if hasattr(cls, 'user'):
+            CourseEnrollment.enroll(cls.user, course.id)
+        return course, course_blocks
+
+    def setUp(self):
+        """
+        Set up for the tests.
+        """
+        super(TestCourseOutlinePageWithPrerequisites, self).setUp()
+        self.client.login(username=self.user.username, password=TEST_PASSWORD)
+
+    def setup_gated_section(self, gated_block, gating_block):
+        """
+        Test helper to create a gating requirement
+        Args:
+            gated_block: The block the that learner will not have access to until they complete the gating block
+            gating_block: (The prerequisite) The block that must be completed to get access to the gated block
+        """
+
+        gating_api.add_prerequisite(self.course.id, unicode(gating_block.location))
+        gating_api.set_required_content(self.course.id, gated_block.location, gating_block.location, 100)
+
+    def test_content_locked(self):
+        """
+        Test that a sequntial/subsection with unmet prereqs correctly indicated that its content is locked
+        """
+        course = self.course
+        self.setup_gated_section(self.course_blocks['gated_content'], self.course_blocks['prerequisite'])
+
+        response = self.client.get(course_home_url(course))
+        self.assertEqual(response.status_code, 200)
+
+        response_content = pq(response.content)
+
+        # check lock icon is present
+        lock_icon = response_content('.fa-lock')
+        self.assertTrue(lock_icon, "lock icon is not present, but should be")
+
+        subsection = lock_icon.parents('.subsection-title')
+
+        # check that subsection-title-name is the display name
+        gated_subsection_title = self.course_blocks['gated_content'].display_name
+        self.assertIn(gated_subsection_title, subsection.children('.subsection-title-name').html())
+
+        # check that it says prerequisite required
+        self.assertIn(self.PREREQ_REQUIRED, subsection.children('.details').html())
+
+        # check that there is not a screen reader message
+        self.assertFalse(subsection.children('.sr'))
+
+    def test_content_unlocked(self):
+        """
+        Test that a sequntial/subsection with unmet prereqs correctly indicated that its content is locked
+        """
+        course = self.course
+        self.setup_gated_section(self.course_blocks['gated_content'], self.course_blocks['prerequisite'])
+
+        # complete the prerequiste to unlock the gated content
+        # this call triggers reevaluation of prerequisites fulfilled by the gating block.
+        with patch('gating.api._get_subsection_percentage', Mock(return_value=100)):
+            lms_gating_api.evaluate_prerequisite(
+                self.course,
+                Mock(location=self.course_blocks['prerequisite'].location),
+                self.user,
+            )
+
+        response = self.client.get(course_home_url(course))
+        self.assertEqual(response.status_code, 200)
+
+        response_content = pq(response.content)
+
+        # check unlock icon is present
+        unlock_icon = response_content('.fa-unlock')
+        self.assertTrue(unlock_icon, "unlock icon is not present, but should be")
+
+        subsection = unlock_icon.parents('.subsection-title')
+
+        # check that subsection-title-name is the display name of gated content section
+        gated_subsection_title = self.course_blocks['gated_content'].display_name
+        self.assertIn(gated_subsection_title, subsection.children('.subsection-title-name').html())
+
+        # check that it doesn't say prerequisite required
+        self.assertNotIn(self.PREREQ_REQUIRED, subsection.children('.subsection-title-name').html())
+
+        # check that there is a screen reader message
+        self.assertTrue(subsection.children('.sr'))
+
+        # check that the screen reader message is correct
+        self.assertIn(self.UNLOCKED, subsection.children('.sr').html())
 
 
 class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase):

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -10,6 +10,8 @@ from courseware.courses import get_course_overview_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 
 from ..utils import get_course_outline_block_tree
+from util.milestones_helpers import get_course_content_milestones
+from xmodule.modulestore.django import modulestore
 
 
 class CourseOutlineFragmentView(EdxFragmentView):
@@ -28,10 +30,34 @@ class CourseOutlineFragmentView(EdxFragmentView):
         if not course_block_tree:
             return None
 
+        content_milestones = self.get_content_milestones(request, course_key)
+
         context = {
             'csrf': csrf(request)['csrf_token'],
             'course': course_overview,
             'blocks': course_block_tree,
+            'milestones': content_milestones
         }
         html = render_to_string('course_experience/course-outline-fragment.html', context)
         return Fragment(html)
+
+    def get_content_milestones(self, request, course_key):
+        """
+        Returns dict of subsections with prerequisites and whether the prerequisite has been completed or not
+        """
+
+        all_course_prereqs = get_course_content_milestones(course_key)
+
+        content_ids_of_unfulfilled_prereqs = [
+            milestone['content_id']
+            for milestone in get_course_content_milestones(course_key, user_id=request.user.id)
+        ]
+
+        course_content_milestones = {
+            milestone['content_id']: {
+                'completed_prereqs': milestone['content_id'] not in content_ids_of_unfulfilled_prereqs
+            }
+            for milestone in all_course_prereqs
+        }
+
+        return course_content_milestones


### PR DESCRIPTION
WL-1317

Previously, the course outline would only show subsections that had
prerequisites if the prerequisite was already met.  It would give no
indication that the subsection existed before the prequisite was met.
The course outline will now show subsections with indications that that
section (a) has prerequisites and (b) whether the prerequisite has been
met.