### PR TITLE
Order program instructors based on new program field

### DIFF
--- a/openedx/core/djangoapps/catalog/tests/factories.py
+++ b/openedx/core/djangoapps/catalog/tests/factories.py
@@ -189,6 +189,7 @@ class ProgramFactory(DictFactoryBase):
     expected_learning_items = factory.LazyFunction(partial(generate_instances, CourseFactory))
     faq = factory.LazyFunction(partial(generate_instances, FAQFactory))
     hidden = False
+    instructor_ordering = factory.LazyFunction(partial(generate_instances, PersonFactory))
     is_program_eligible_for_one_click_purchase = True
     job_outlook_items = factory.LazyFunction(partial(generate_instances, JobOutlookItemFactory))
     marketing_slug = factory.Faker('slug')

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -698,7 +698,27 @@ class ProgramMarketingDataExtender(ProgramDataExtender):
             program_instructors = self.instructors
             cache.set(cache_key, program_instructors, 3600)
 
-        self.data['instructors'] = program_instructors
+        if 'instructor_ordering' not in self.data:
+            # If no instructor ordering is set in discovery, it doesn't populate this key
+            self.data['instructor_ordering'] = []
+
+        sorted_instructor_names = [
+            ' '.join(filter(None, (instructor['given_name'], instructor['family_name'])))
+            for instructor in self.data['instructor_ordering']
+        ]
+        instructors_to_be_sorted = [
+            instructor for instructor in program_instructors
+            if instructor['name'] in sorted_instructor_names
+        ]
+        instructors_to_not_be_sorted = [
+            instructor for instructor in program_instructors
+            if instructor['name'] not in sorted_instructor_names
+        ]
+        sorted_instructors = sorted(
+            instructors_to_be_sorted,
+            key=lambda item: sorted_instructor_names.index(item['name'])
+        )
+        self.data['instructors'] = sorted_instructors + instructors_to_not_be_sorted
 
     def extend(self):
         """Execute extension handlers, returning the extended data."""


### PR DESCRIPTION
This collects the instructors from the courses in the program like before. There is now a field in the program model in discovery that allows you to list instructors for the program.

This CANNOT be merged until this PR has landed: https://github.com/edx/course-discovery/pull/1244