### PR TITLE
Add flags to tox.ini so paver tests can run (2)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,28 @@
 [tox]
 envlist = py27-django{18,19,110,111}
 
+# This is needed to prevent the lms, cms, and openedx packages inside the "Open
+# edX" package (defined in setup.py) from getting installed into site-packages
+# where they can get imported, which is bad because those won't even contain
+# most of the source code since we don't explicitly add anything to the source
+# distribution.
+skipsdist=True
+
+# The default toxworkdir is in the source tree (as ".tox/"), but `django-admin
+# compilemessages` unconditionally walks the entire directory tree under the
+# source root and cannot handle encountering the toxworkdir.  So, we un-break
+# compilemessages by moving the toxworkdir to the home directory.
+toxworkdir={homedir}/edxapp_toxenv
+
 [testenv]
+# This ensures "-e ." is installed, so that a link back to the top-level
+# edx-platform source directory is installed in site-packages, making
+# edx-platform source code importable from python subprocesses.  Child
+# processes running python code do not import from the current working
+# directory without hacking sys.path, but they will inherit the tox virtualenv
+# and look in site-packages.
+usedevelop=True
+
 setenv =
     PYTHONHASHSEED = 0
 passenv =


### PR DESCRIPTION
This changes tox configuration, see comments above each added line for explanation.

Before this commit, either all or some paver tests wouldn't even start under the django 1.11 tox environment due to an import error caused by a mostly empty openedx module in site-packages.

Moving .tox from the source tree to the home dir was done to fix another unrelated issue where the new version of the `compilemessages` django core management command would erroneously parse the .tox directory. Introduced in 1.9: https://github.com/django/django/commit/40f0a84cb151669313faadf857aaddd18d39aaeb