### PR TITLE
PLAT-1762 Remove obsolete mentoring XBlock

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1194,7 +1194,6 @@ MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = 15 * 60
 # The order of INSTALLED_APPS matters, so this tuple is the app name and the item in INSTALLED_APPS
 # that this app should be inserted *before*. A None here means it should be appended to the list.
 OPTIONAL_APPS = (
-    ('mentoring', None),
     ('problem_builder', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('edx_sga', None),
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2878,7 +2878,6 @@ ALL_LANGUAGES = [
 # The order of INSTALLED_APPS matters, so this tuple is the app name and the item in INSTALLED_APPS
 # that this app should be inserted *before*. A None here means it should be appended to the list.
 OPTIONAL_APPS = [
-    ('mentoring', None),
     ('problem_builder', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
     ('edx_sga', None),
 

--- a/requirements/edx/edx-private.txt
+++ b/requirements/edx/edx-private.txt
@@ -7,7 +7,6 @@
 
 
 # For Harvard courses:
--e git+https://github.com/gsehub/xblock-mentoring.git@4d1cce78dc232d5da6ffd73817b5c490e87a6eee#egg=xblock-mentoring
 git+https://github.com/open-craft/problem-builder.git@v2.7.7#egg=xblock-problem-builder==2.7.7
 
 # Oppia XBlock


### PR DESCRIPTION
All of the remaining mentoring XBlocks on stage and production have been upgraded to Problem Builder XBlocks, so we can finally remove this dependency.