### PR TITLE
mattdrayer/ENT-783: Remove 'city' from SuccessFactors OData API requests

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -144,7 +144,6 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
         'defaultFullName': 'fullname',
         'email': 'email',
         'country': 'country',
-        'city': 'city',
     }
 
     # Define a simple mapping to relate SAPSF values to Open edX-compatible values for


### PR DESCRIPTION
The edX system requests a set of fields from SuccessFactors when performing the OData API callback for learner account auto-registration scenarios.  Previously we were including the 'city' field which is not actually necessary, and so we will no longer collect it by default from SuccessFactors customers.