### PR TITLE
Schedules: more info logging and add exception logging

### DIFF
--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -66,18 +66,28 @@ class ScheduleMessageBaseTask(Task):
 
     @classmethod
     def log_debug(cls, message, *args, **kwargs):
+        """
+        Wrapper around LOG.debug that prefixes the message.
+        """
         LOG.debug(cls.log_prefix + ': ' + message, *args, **kwargs)
+
+    @classmethod
+    def log_info(cls, message, *args, **kwargs):
+        """
+        Wrapper around LOG.info that prefixes the message.
+        """
+        LOG.info(cls.log_prefix + ': ' + message, *args, **kwargs)
 
     @classmethod
     def enqueue(cls, site, current_date, day_offset, override_recipient_email=None):
         current_date = resolvers._get_datetime_beginning_of_day(current_date)
 
         if not cls.is_enqueue_enabled(site):
-            cls.log_debug('Message queuing disabled for site %s', site.domain)
+            cls.log_info('Message queuing disabled for site %s', site.domain)
             return
 
         target_date = current_date + datetime.timedelta(days=day_offset)
-        cls.log_debug('Target date = %s', target_date.isoformat())
+        cls.log_info('Target date = %s', target_date.isoformat())
         for bin in range(cls.num_bins):
             task_args = (
                 site.id,
@@ -86,7 +96,7 @@ class ScheduleMessageBaseTask(Task):
                 bin,
                 override_recipient_email,
             )
-            cls.log_debug('Launching task with args = %r', task_args)
+            cls.log_info('Launching task with args = %r', task_args)
             cls.apply_async(
                 task_args,
                 retry=False,
@@ -228,7 +238,7 @@ def _is_delivery_enabled(site, delivery_config_var, log_prefix):
     if getattr(ScheduleConfig.current(site), delivery_config_var, False):
         return True
     else:
-        LOG.debug('%s: Message delivery disabled for site %s', log_prefix, site.domain)
+        LOG.info('%s: Message delivery disabled for site %s', log_prefix, site.domain)
 
 
 def _annotate_for_monitoring(message_type, site, bin_num, target_day_str, day_offset):

--- a/openedx/core/djangoapps/schedules/tests/test_tasks.py
+++ b/openedx/core/djangoapps/schedules/tests/test_tasks.py
@@ -29,7 +29,7 @@ class TestScheduleMessageBaseTask(CacheIsolationTestCase):
         with patch.multiple(
             self.basetask,
             is_enqueue_enabled=Mock(return_value=False),
-            log_debug=DEFAULT,
+            log_info=DEFAULT,
             run=send,
         ) as patches:
             self.basetask.enqueue(
@@ -37,7 +37,7 @@ class TestScheduleMessageBaseTask(CacheIsolationTestCase):
                 current_date=datetime.datetime.now(),
                 day_offset=2
             )
-            patches['log_debug'].assert_called_once_with(
+            patches['log_info'].assert_called_once_with(
                 'Message queuing disabled for site %s', self.site.domain)
             send.apply_async.assert_not_called()
 
@@ -48,7 +48,7 @@ class TestScheduleMessageBaseTask(CacheIsolationTestCase):
         with patch.multiple(
             self.basetask,
             is_enqueue_enabled=Mock(return_value=True),
-            log_debug=DEFAULT,
+            log_info=DEFAULT,
             run=send,
         ) as patches:
             self.basetask.enqueue(
@@ -58,8 +58,7 @@ class TestScheduleMessageBaseTask(CacheIsolationTestCase):
             )
             target_date = current_date.replace(hour=0, minute=0, second=0, microsecond=0) + \
                 datetime.timedelta(day_offset)
-            print(patches['log_debug'].mock_calls)
-            patches['log_debug'].assert_any_call(
+            patches['log_info'].assert_any_call(
                 'Target date = %s', target_date.isoformat())
             assert send.call_count == DEFAULT_NUM_BINS
 

--- a/openedx/core/djangoapps/schedules/utils.py
+++ b/openedx/core/djangoapps/schedules/utils.py
@@ -14,4 +14,13 @@ class PrefixedDebugLoggerMixin(object):
             self.log_prefix = self.__class__.__name__
 
     def log_debug(self, message, *args, **kwargs):
+        """
+        Wrapper around LOG.debug that prefixes the message.
+        """
         LOG.debug(self.log_prefix + ': ' + message, *args, **kwargs)
+
+    def log_info(self, message, *args, **kwargs):
+        """
+        Wrapper around LOG.info that prefixes the message.
+        """
+        LOG.info(self.log_prefix + ': ' + message, *args, **kwargs)


### PR DESCRIPTION
We are trying to debug why emails are not getting sent in production. Most of our existing logging is set to the debug level which is not logged in production. This makes them info logs instead. I also added a exception log around the part of the code that we suspect might be preventing the emails from being sent.