### PR TITLE
Drop underscore usage from openedx/

### DIFF
--- a/common/static/common/js/karma.common.conf.js
+++ b/common/static/common/js/karma.common.conf.js
@@ -297,6 +297,7 @@ function getBaseConfig(config, useRequireJs) {
         frameworks: ['custom'],
 
         plugins: [
+            'karma-babel-preprocessor',
             'karma-jasmine',
             'karma-jasmine-html-reporter',
             'karma-requirejs',

--- a/lms/static/karma_lms.conf.js
+++ b/lms/static/karma_lms.conf.js
@@ -56,7 +56,12 @@ var options = {
         {pattern: 'lms/js/spec/main.js', included: true}
     ],
 
-    preprocessors: {}
+    preprocessors: {
+        'course_bookmarks/**/*.js': ['babel'],
+        'course_experience/**/*.js': ['babel'],
+        'course_search/**/*.js': ['babel'],
+        'learner_profile/**/*.js': ['babel'],
+    },
 };
 
 options.specFiles

--- a/lms/static/karma_lms.conf.js
+++ b/lms/static/karma_lms.conf.js
@@ -60,8 +60,8 @@ var options = {
         'course_bookmarks/**/*.js': ['babel'],
         'course_experience/**/*.js': ['babel'],
         'course_search/**/*.js': ['babel'],
-        'learner_profile/**/*.js': ['babel'],
-    },
+        'learner_profile/**/*.js': ['babel']
+    }
 };
 
 options.specFiles

--- a/openedx/features/course_bookmarks/.eslintrc.js
+++ b/openedx/features/course_bookmarks/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: 'eslint-config-edx',
+  root: true,
+  settings: {
+    'import/resolver': 'webpack',
+  },
+};

--- a/openedx/features/course_bookmarks/static/course_bookmarks/js/spec/bookmark_button_view_spec.js
+++ b/openedx/features/course_bookmarks/static/course_bookmarks/js/spec/bookmark_button_view_spec.js
@@ -1,8 +1,8 @@
 define([
-    'backbone', 'jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
+    'backbone', 'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
     'common/js/spec_helpers/template_helpers', 'course_bookmarks/js/views/bookmark_button'
 ],
-    function(Backbone, $, _, AjaxHelpers, TemplateHelpers, BookmarkButtonView) {
+    function(Backbone, $, AjaxHelpers, TemplateHelpers, BookmarkButtonView) {
         'use strict';
 
         describe('BookmarkButtonView', function() {
@@ -76,7 +76,7 @@ define([
                 var requests = AjaxHelpers.requests(this);
 
                 var bookmarkedData = [[addBookmarkedData, removeBookmarkData], [removeBookmarkData, addBookmarkedData]];
-                _.each(bookmarkedData, function(actionsData) {
+                bookmarkedData.forEach(function(actionsData) {
                     var firstActionData = actionsData[0];
                     var secondActionData = actionsData[1];
 

--- a/openedx/features/course_bookmarks/static/course_bookmarks/js/spec/bookmarks_list_view_spec.js
+++ b/openedx/features/course_bookmarks/static/course_bookmarks/js/spec/bookmarks_list_view_spec.js
@@ -1,7 +1,6 @@
 define([
     'backbone',
     'jquery',
-    'underscore',
     'logger',
     'URI',
     'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
@@ -11,7 +10,7 @@ define([
     'course_bookmarks/js/views/bookmarks_list',
     'course_bookmarks/js/collections/bookmarks'
 ],
-    function(Backbone, $, _, Logger, URI, AjaxHelpers, TemplateHelpers, MessageBannerView,
+    function(Backbone, $, Logger, URI, AjaxHelpers, TemplateHelpers, MessageBannerView,
              BookmarkHelpers, BookmarksListView, BookmarksCollection) {
         'use strict';
 
@@ -56,8 +55,8 @@ define([
 
             verifyRequestParams = function(requests, params) {
                 var urlParams = (new URI(requests[requests.length - 1].url)).query(true);
-                _.each(params, function(value, key) {
-                    expect(urlParams[key]).toBe(value);
+                Object.keys(params).forEach(function(key) {
+                    expect(urlParams[key]).toBe(params[key]);
                 });
             };
 

--- a/openedx/features/course_bookmarks/static/course_bookmarks/js/spec_helpers/bookmark_helpers.js
+++ b/openedx/features/course_bookmarks/static/course_bookmarks/js/spec_helpers/bookmark_helpers.js
@@ -1,9 +1,8 @@
 define(
     [
-        'underscore',
         'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
     ],
-    function(_, AjaxHelpers) {
+    function(AjaxHelpers) {
         'use strict';
 
         var TEST_COURSE_ID = 'course-v1:test-course';
@@ -43,7 +42,7 @@ define(
         };
 
         var breadcrumbTrail = function(path, unitDisplayName) {
-            return _.pluck(path, 'display_name').
+            return path.map(value => value['display_name']).
             concat([unitDisplayName]).
             join(' <span class="icon fa fa-caret-right" aria-hidden="true"></span><span class="sr">-</span> ');
         };

--- a/openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmark_button.js
+++ b/openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmark_button.js
@@ -1,8 +1,8 @@
 (function(define) {
     'use strict';
 
-    define(['gettext', 'jquery', 'underscore', 'backbone', 'js/views/message_banner'],
-        function(gettext, $, _, Backbone, MessageBannerView) {
+    define(['gettext', 'jquery', 'backbone', 'js/views/message_banner'],
+        function(gettext, $, Backbone, MessageBannerView) {
             return Backbone.View.extend({
                 errorMessage: gettext('An error has occurred. Please try again.'),
 
@@ -108,9 +108,9 @@
                     this.messageView.showMessage(errorMsg);
 
                     // Hide message automatically after some interval
-                    setTimeout(_.bind(function() {
+                    setTimeout(() => {
                         this.messageView.hideMessage();
-                    }, this), this.showBannerInterval);
+                    }, this.showBannerInterval);
                 }
             });
         });

--- a/openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmarks_list.js
+++ b/openedx/features/course_bookmarks/static/course_bookmarks/js/views/bookmarks_list.js
@@ -2,11 +2,11 @@
     'use strict';
 
     define([
-        'gettext', 'jquery', 'underscore', 'backbone', 'logger', 'moment', 'edx-ui-toolkit/js/utils/html-utils',
+        'gettext', 'jquery', 'backbone', 'logger', 'moment', 'edx-ui-toolkit/js/utils/html-utils',
         'common/js/components/views/paging_header', 'common/js/components/views/paging_footer',
         'text!course_bookmarks/templates/bookmarks-list.underscore'
     ],
-        function(gettext, $, _, Backbone, Logger, _moment, HtmlUtils,
+        function(gettext, $, Backbone, Logger, _moment, HtmlUtils,
                  PagingHeaderView, PagingFooterView, bookmarksListTemplate) {
             var moment = _moment || window.moment;
 
@@ -36,7 +36,8 @@
                     this.pagingHeaderView = new PagingHeaderView({collection: this.collection});
                     this.pagingFooterView = new PagingFooterView({collection: this.collection});
                     this.listenTo(this.collection, 'page_changed', this.render);
-                    _.bindAll(this, 'render', 'humanFriendlyDate');
+                    this.render = this.render.bind(this);
+                    this.humanFriendlyDate = this.humanFriendlyDate.bind(this);
                 },
 
                 render: function() {

--- a/openedx/features/course_search/static/course_search/js/collections/search_collection.js
+++ b/openedx/features/course_search/static/course_search/js/collections/search_collection.js
@@ -2,10 +2,9 @@
     'use strict';
 
     define([
-        'underscore',
         'backbone',
         'course_search/js/models/search_result'
-    ], function(_, Backbone, SearchResult) {
+    ], function(Backbone, SearchResult) {
         return Backbone.Collection.extend({
 
             model: SearchResult,
@@ -84,7 +83,7 @@
                 this.totalCount = response.total;
                 this.accessDeniedCount += response.access_denied_count;
                 this.totalCount -= this.accessDeniedCount;
-                return _.map(response.results, function(result) {
+                return response.results.map(function(result) {
                     return result.data;
                 });
             },

--- a/openedx/features/course_search/static/course_search/js/course_search_factory.js
+++ b/openedx/features/course_search/static/course_search/js/course_search_factory.js
@@ -2,10 +2,10 @@
     'use strict';
 
     define([
-        'underscore', 'backbone', 'course_search/js/search_router', 'course_search/js/views/search_form',
+        'backbone', 'course_search/js/search_router', 'course_search/js/views/search_form',
         'course_search/js/collections/search_collection', 'course_search/js/views/course_search_results_view'
     ],
-        function(_, Backbone, SearchRouter, CourseSearchForm, SearchCollection, CourseSearchResultsView) {
+        function(Backbone, SearchRouter, CourseSearchForm, SearchCollection, CourseSearchResultsView) {
             return function(options) {
                 var courseId = options.courseId;
                 var requestedQuery = options.query;
@@ -17,7 +17,7 @@
                 });
                 var collection = new SearchCollection([], {courseId: courseId});
                 var results = new CourseSearchResultsView({collection: collection});
-                var dispatcher = _.clone(Backbone.Events);
+                var dispatcher = Object.assign({}, Backbone.Events);
 
                 dispatcher.listenTo(router, 'search', function(query) {
                     form.doSearch(query);

--- a/openedx/features/course_search/static/course_search/js/dashboard_search_factory.js
+++ b/openedx/features/course_search/static/course_search/js/dashboard_search_factory.js
@@ -2,10 +2,10 @@
     'use strict';
 
     define([
-        'underscore', 'backbone', 'course_search/js/search_router', 'course_search/js/views/search_form',
+        'backbone', 'course_search/js/search_router', 'course_search/js/views/search_form',
         'course_search/js/collections/search_collection', 'course_search/js/views/dashboard_search_results_view'
     ],
-        function(_, Backbone, SearchRouter, SearchForm, SearchCollection, DashboardSearchResultsView) {
+        function(Backbone, SearchRouter, SearchForm, SearchCollection, DashboardSearchResultsView) {
             return function() {
                 var router = new SearchRouter();
                 var form = new SearchForm({
@@ -13,7 +13,7 @@
                 });
                 var collection = new SearchCollection([]);
                 var results = new DashboardSearchResultsView({collection: collection});
-                var dispatcher = _.clone(Backbone.Events);
+                var dispatcher = Object.assign({}, Backbone.Events);
 
                 dispatcher.listenTo(router, 'search', function(query) {
                     form.doSearch(query);

--- a/openedx/features/course_search/static/course_search/js/views/search_item_view.js
+++ b/openedx/features/course_search/static/course_search/js/views/search_item_view.js
@@ -3,12 +3,11 @@
 
     define([
         'jquery',
-        'underscore',
         'backbone',
         'gettext',
         'logger',
         'edx-ui-toolkit/js/utils/html-utils'
-    ], function($, _, Backbone, gettext, Logger, HtmlUtils) {
+    ], function($, Backbone, gettext, Logger, HtmlUtils) {
         return Backbone.View.extend({
 
             tagName: 'li',
@@ -27,7 +26,7 @@
             },
 
             render: function() {
-                var data = _.clone(this.model.attributes);
+                var data = Object.assign({}, this.model.attributes);
 
                 // Drop the preview text and result type if the search term is found
                 // in the title/location in the course hierarchy

--- a/openedx/features/course_search/static/course_search/js/views/search_results_view.js
+++ b/openedx/features/course_search/static/course_search/js/views/search_results_view.js
@@ -3,14 +3,13 @@
 
     define([
         'jquery',
-        'underscore',
         'backbone',
         'edx-ui-toolkit/js/utils/html-utils',
         'edx-ui-toolkit/js/utils/string-utils',
         'course_search/js/views/search_item_view',
         'text!course_search/templates/search_loading.underscore',
         'text!course_search/templates/search_error.underscore'
-    ], function($, _, Backbone, HtmlUtils, StringUtils, SearchItemView, searchLoadingTemplate, searchErrorTemplate) {
+    ], function($, Backbone, HtmlUtils, StringUtils, SearchItemView, searchLoadingTemplate, searchErrorTemplate) {
         return Backbone.View.extend({
 
             // these should be defined by subclasses

--- a/openedx/features/learner_profile/static/learner_profile/js/learner_profile_factory.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/learner_profile_factory.js
@@ -4,7 +4,6 @@
     define([
         'gettext',
         'jquery',
-        'underscore',
         'backbone',
         'logger',
         'edx-ui-toolkit/js/utils/string-utils',
@@ -19,7 +18,7 @@
         'js/student_account/views/account_settings_fields',
         'js/views/message_banner',
         'string_utils'
-    ], function(gettext, $, _, Backbone, Logger, StringUtils, PagingCollection, AccountSettingsModel,
+    ], function(gettext, $, Backbone, Logger, StringUtils, PagingCollection, AccountSettingsModel,
                 AccountPreferencesModel, FieldsView, LearnerProfileFieldsView, LearnerProfileView, BadgeModel,
                 BadgeListContainer, AccountSettingsFieldViews, MessageBannerView) {
         return function(options) {
@@ -31,7 +30,7 @@
             });
 
             var accountSettingsModel = new AccountSettingsModel(
-                _.extend(
+                Object.assign(
                     options.account_settings_data,
                     {default_public_account_fields: options.default_public_account_fields}
                 ),

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/learner_profile_factory_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/learner_profile_factory_spec.js
@@ -1,6 +1,6 @@
 define(
     [
-        'backbone', 'jquery', 'underscore', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
+        'backbone', 'jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
         'common/js/spec_helpers/template_helpers',
         'js/spec/student_account/helpers',
         'learner_profile/js/spec_helpers/helpers',
@@ -12,7 +12,7 @@ define(
         'learner_profile/js/learner_profile_factory',
         'js/views/message_banner'
     ],
-    function(Backbone, $, _, AjaxHelpers, TemplateHelpers, Helpers, LearnerProfileHelpers, FieldViews,
+    function(Backbone, $, AjaxHelpers, TemplateHelpers, Helpers, LearnerProfileHelpers, FieldViews,
              UserAccountModel, UserPreferencesModel, LearnerProfileView, LearnerProfileFields, LearnerProfilePage) {
         'use strict';
 

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/badge_list_container_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/badge_list_container_spec.js
@@ -1,14 +1,13 @@
 define([
     'backbone',
     'jquery',
-    'underscore',
     'URI',
     'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
     'edx-ui-toolkit/js/pagination/paging-collection',
     'learner_profile/js/spec_helpers/helpers',
     'learner_profile/js/views/badge_list_container'
 ],
-    function(Backbone, $, _, URI, AjaxHelpers, PagingCollection, LearnerProfileHelpers, BadgeListContainer) {
+    function(Backbone, $, URI, AjaxHelpers, PagingCollection, LearnerProfileHelpers, BadgeListContainer) {
         'use strict';
 
         describe('edx.user.BadgeListContainer', function() {
@@ -26,9 +25,9 @@ define([
                 var request;
                 var path;
                 badgeCollection.url = '/api/badges/v1/assertions/user/staff/';
-                _.each(_.range(badgeListObject.count), function(idx) {
+                for (var idx = 0; idx < badgeListObject.count; idx++) {
                     models.push(LearnerProfileHelpers.makeBadge(idx));
-                });
+                }
                 badgeListObject.results = models; // eslint-disable-line no-param-reassign
                 badgeCollection.setPage(pageNum);
                 request = AjaxHelpers.currentRequest(requests);

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/badge_list_container_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/badge_list_container_spec.js
@@ -25,7 +25,7 @@ define([
                 var request;
                 var path;
                 badgeCollection.url = '/api/badges/v1/assertions/user/staff/';
-                for (var idx = 0; idx < badgeListObject.count; idx++) {
+                for (let idx = 0; idx < badgeListObject.count; idx++) {
                     models.push(LearnerProfileHelpers.makeBadge(idx));
                 }
                 badgeListObject.results = models; // eslint-disable-line no-param-reassign

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/badge_list_view_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/badge_list_view_spec.js
@@ -1,12 +1,11 @@
 define([
     'backbone',
     'jquery',
-    'underscore',
     'edx-ui-toolkit/js/pagination/paging-collection',
     'learner_profile/js/spec_helpers/helpers',
     'learner_profile/js/views/badge_list_view'
 ],
-    function(Backbone, $, _, PagingCollection, LearnerProfileHelpers, BadgeListView) {
+    function(Backbone, $, PagingCollection, LearnerProfileHelpers, BadgeListView) {
         'use strict';
 
         describe('edx.user.BadgeListView', function() {
@@ -17,7 +16,7 @@ define([
                 var models = [];
                 var badgeList;
                 badgeCollection.url = '/api/badges/v1/assertions/user/staff/';
-                _.each(badges, function(element) {
+                badges.forEach(function(element) {
                     models.push(new Backbone.Model(element));
                 });
                 badgeCollection.models = models;
@@ -66,9 +65,9 @@ define([
                 var badges = [];
                 var placeholder;
                 var rows;
-                _.each(_.range(4), function(item) {
-                    badges.push(LearnerProfileHelpers.makeBadge(item));
-                });
+                for (var i = 0; i < 4; i++) {
+                    badges.push(LearnerProfileHelpers.makeBadge(i));
+                }
                 view = createView(badges, 1, 2, true);
                 view.render();
                 placeholder = view.$el.find('span.accomplishment-placeholder');

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/badge_list_view_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/badge_list_view_spec.js
@@ -65,7 +65,7 @@ define([
                 var badges = [];
                 var placeholder;
                 var rows;
-                for (var i = 0; i < 4; i++) {
+                for (let i = 0; i < 4; i++) {
                     badges.push(LearnerProfileHelpers.makeBadge(i));
                 }
                 view = createView(badges, 1, 2, true);

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/badge_view_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/badge_view_spec.js
@@ -1,9 +1,9 @@
 define([
-    'backbone', 'jquery', 'underscore',
+    'backbone', 'jquery',
     'learner_profile/js/spec_helpers/helpers',
     'learner_profile/js/views/badge_view'
 ],
-    function(Backbone, $, _, LearnerProfileHelpers, BadgeView) {
+    function(Backbone, $, LearnerProfileHelpers, BadgeView) {
         'use strict';
 
         describe('edx.user.BadgeView', function() {
@@ -83,7 +83,7 @@ define([
                 badgeDiv = view.$el.find('.badge-name');
                 expect(badgeDiv.length).toBeTruthy();
                 expect(badgeDiv.is(':visible')).toBe(true);
-                expect(_.count(badgeDiv.html(), badge.badge_class.display_name)).toBeTruthy();
+                expect(badgeDiv.html().indexOf(badge.badge_class.display_name)).toBeGreaterThan(-1);
             };
 
             it('test badge name is displayed for own profile', function() {

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/learner_profile_fields_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/learner_profile_fields_spec.js
@@ -2,7 +2,6 @@ define(
     [
         'backbone',
         'jquery',
-        'underscore',
         'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
         'common/js/spec_helpers/template_helpers',
         'js/spec/student_account/helpers',
@@ -10,7 +9,7 @@ define(
         'learner_profile/js/views/learner_profile_fields',
         'js/views/message_banner'
     ],
-    function(Backbone, $, _, AjaxHelpers, TemplateHelpers, Helpers, UserAccountModel, LearnerProfileFields,
+    function(Backbone, $, AjaxHelpers, TemplateHelpers, Helpers, UserAccountModel, LearnerProfileFields,
              MessageBannerView) {
         'use strict';
 
@@ -20,9 +19,9 @@ define(
             var MOCK_IMAGE_MIN_BYTES = 16;
 
             var createImageView = function(options) {
-                var yearOfBirth = _.isUndefined(options.yearOfBirth) ? MOCK_YEAR_OF_BIRTH : options.yearOfBirth;
-                var imageMaxBytes = _.isUndefined(options.imageMaxBytes) ? MOCK_IMAGE_MAX_BYTES : options.imageMaxBytes;
-                var imageMinBytes = _.isUndefined(options.imageMinBytes) ? MOCK_IMAGE_MIN_BYTES : options.imageMinBytes;
+                var yearOfBirth = options.yearOfBirth === undefined ? MOCK_YEAR_OF_BIRTH : options.yearOfBirth;
+                var imageMaxBytes = options.imageMaxBytes === undefined ? MOCK_IMAGE_MAX_BYTES : options.imageMaxBytes;
+                var imageMinBytes = options.imageMinBytes === undefined ? MOCK_IMAGE_MIN_BYTES : options.imageMinBytes;
                 var messageView;
 
                 var imageData = {
@@ -33,7 +32,7 @@ define(
                 var accountSettingsModel = new UserAccountModel();
                 accountSettingsModel.set({profile_image: imageData});
                 accountSettingsModel.set({year_of_birth: yearOfBirth});
-                accountSettingsModel.set({requires_parental_consent: !!_.isEmpty(yearOfBirth)});
+                accountSettingsModel.set({requires_parental_consent: yearOfBirth === ''});
 
                 accountSettingsModel.url = Helpers.USER_ACCOUNTS_API_URL;
 

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/learner_profile_view_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/learner_profile_view_spec.js
@@ -4,7 +4,6 @@ define(
         'gettext',
         'backbone',
         'jquery',
-        'underscore',
         'edx-ui-toolkit/js/pagination/paging-collection',
         'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
         'common/js/spec_helpers/template_helpers',
@@ -19,7 +18,7 @@ define(
         'js/student_account/views/account_settings_fields',
         'js/views/message_banner'
     ],
-    function(gettext, Backbone, $, _, PagingCollection, AjaxHelpers, TemplateHelpers, Helpers, LearnerProfileHelpers,
+    function(gettext, Backbone, $, PagingCollection, AjaxHelpers, TemplateHelpers, Helpers, LearnerProfileHelpers,
               FieldViews, UserAccountModel, AccountPreferencesModel, LearnerProfileFields, LearnerProfileView,
               BadgeListContainer, AccountSettingsFieldViews, MessageBannerView) {
         'use strict';

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/section_two_tab_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/section_two_tab_spec.js
@@ -1,13 +1,13 @@
 /* eslint-disable vars-on-top */
 define(
     [
-        'backbone', 'jquery', 'underscore',
+        'backbone', 'jquery',
         'js/spec/student_account/helpers',
         'learner_profile/js/views/section_two_tab',
         'js/views/fields',
         'js/student_account/models/user_account_model'
     ],
-    function(Backbone, $, _, Helpers, SectionTwoTabView, FieldViews, UserAccountModel) {
+    function(Backbone, $, Helpers, SectionTwoTabView, FieldViews, UserAccountModel) {
         'use strict';
 
         describe('edx.user.SectionTwoTab', function() {
@@ -51,11 +51,11 @@ define(
 
             it('profile field parts are actually rendered for public profile', function() {
                 var view = createSectionTwoView(false, true);
-                _.each(view.options.viewList, function(fieldView) {
+                view.options.viewList.forEach(function(fieldView) {
                     spyOn(fieldView, 'render').and.callThrough();
                 });
                 view.render();
-                _.each(view.options.viewList, function(fieldView) {
+                view.options.viewList.forEach(function(fieldView) {
                     expect(fieldView.render).toHaveBeenCalled();
                 });
             });
@@ -67,7 +67,7 @@ define(
                 expect(bio.length).toBe(0);
                 var msg = view.$el.find('span.profile-private-message');
                 expect(msg.length).toBe(1);
-                expect(_.count(msg.html(), messageString)).toBeTruthy();
+                expect(msg.html().indexOf(messageString)).toBeGreaterThan(-1);
             };
 
             it('no profile when profile is private for other people', function() {
@@ -80,11 +80,11 @@ define(
 
             var testProfilePrivatePartsDoNotRender = function(ownProfile) {
                 var view = createSectionTwoView(ownProfile, false);
-                _.each(view.options.viewList, function(fieldView) {
+                view.options.viewList.forEach(function(fieldView) {
                     spyOn(fieldView, 'render');
                 });
                 view.render();
-                _.each(view.options.viewList, function(fieldView) {
+                view.options.viewList.forEach(function(fieldView) {
                     expect(fieldView.render).not.toHaveBeenCalled();
                 });
             };

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/share_modal_view_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/share_modal_view_spec.js
@@ -1,12 +1,12 @@
 define(
     [
-        'backbone', 'jquery', 'underscore', 'moment',
+        'backbone', 'jquery', 'moment',
         'js/spec/student_account/helpers',
         'learner_profile/js/spec_helpers/helpers',
         'learner_profile/js/views/share_modal_view',
         'jquery.simulate'
     ],
-    function(Backbone, $, _, Moment, Helpers, LearnerProfileHelpers, ShareModalView) {
+    function(Backbone, $, Moment, Helpers, LearnerProfileHelpers, ShareModalView) {
         'use strict';
 
         describe('edx.user.ShareModalView', function() {
@@ -16,7 +16,7 @@ define(
 
             var createModalView = function() {
                 var badge = LearnerProfileHelpers.makeBadge(1);
-                var context = _.extend(badge, {
+                var context = Object.assign(badge, {
                     created: new Moment(badge.created),
                     ownProfile: true,
                     badgeMeta: {}

--- a/openedx/features/learner_profile/static/learner_profile/js/spec_helpers/helpers.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec_helpers/helpers.js
@@ -227,15 +227,15 @@ define(['URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'], function(UR
         };
     }
 
-    for(var i = 0; i < 10; i++) {
+    for (let i = 0; i < 10; i++) {
         firstPageBadges.results.push(makeBadge(i));
     }
 
-    for(var i = 10; i < 20; i++) {
+    for (let i = 10; i < 20; i++) {
         secondPageBadges.results.push(makeBadge(i));
     }
 
-    for(var i = 20; i < 30; i++) {
+    for (let i = 20; i < 30; i++) {
         thirdPageBadges.results.push(makeBadge(i));
     }
 

--- a/openedx/features/learner_profile/static/learner_profile/js/spec_helpers/helpers.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec_helpers/helpers.js
@@ -1,4 +1,4 @@
-define(['underscore', 'URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'], function(_, URI, AjaxHelpers) {
+define(['URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'], function(URI, AjaxHelpers) {
     'use strict';
 
     var expectProfileElementContainsField = function(element, view) {
@@ -12,7 +12,7 @@ define(['underscore', 'URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
         }
 
         fieldTitle = titleElement.text().trim();
-        if (!_.isUndefined(view.options.title) && !_.isUndefined(fieldTitle)) {
+        if (view.options.title !== undefined && fieldTitle !== undefined) {
             expect(fieldTitle).toBe(view.options.title);
         }
 
@@ -56,7 +56,7 @@ define(['underscore', 'URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
         expectProfileElementContainsField(sectionOneFieldElements[1], learnerProfileView.options.usernameFieldView);
         expectProfileElementContainsField(sectionOneFieldElements[2], learnerProfileView.options.nameFieldView);
 
-        _.each(_.rest(sectionOneFieldElements, 3), function(sectionFieldElement, fieldIndex) {
+        sectionOneFieldElements.slice(3).each(function(fieldIndex, sectionFieldElement) {
             expectProfileElementContainsField(
                 sectionFieldElement,
                 learnerProfileView.options.sectionOneFieldViews[fieldIndex]
@@ -70,7 +70,7 @@ define(['underscore', 'URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
 
         expect($sectionTwoFieldElements.length).toBe(learnerProfileView.options.sectionTwoFieldViews.length);
 
-        _.each($sectionTwoFieldElements, function(sectionFieldElement, fieldIndex) {
+        $sectionTwoFieldElements.each(function(fieldIndex, sectionFieldElement) {
             expectProfileElementContainsField(
                 sectionFieldElement,
                 learnerProfileView.options.sectionTwoFieldViews[fieldIndex]
@@ -153,7 +153,7 @@ define(['underscore', 'URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
         expect(index).toBe('Showing ' + (pageData.start + 1) + '-' + (pageData.start + pageData.results.length) +
             ' out of ' + pageData.count + ' total');
         expect($badgeListContainer.find('.current-page').text()).toBe('' + pageData.current_page);
-        _.each(pageData.results, function(badge) {
+        pageData.results.forEach(function(badge) {
             expect($('.badge-display:contains(' + badge.badge_class.display_name + ')').length).toBe(1);
         });
     };
@@ -227,17 +227,17 @@ define(['underscore', 'URI', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
         };
     }
 
-    _.each(_.range(0, 10), function(i) {
+    for(var i = 0; i < 10; i++) {
         firstPageBadges.results.push(makeBadge(i));
-    });
+    }
 
-    _.each(_.range(10, 20), function(i) {
+    for(var i = 10; i < 20; i++) {
         secondPageBadges.results.push(makeBadge(i));
-    });
+    }
 
-    _.each(_.range(20, 30), function(i) {
+    for(var i = 20; i < 30; i++) {
         thirdPageBadges.results.push(makeBadge(i));
-    });
+    }
 
     return {
         expectLimitedProfileSectionsAndFieldsToBeRendered: expectLimitedProfileSectionsAndFieldsToBeRendered,

--- a/openedx/features/learner_profile/static/learner_profile/js/views/badge_list_container.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/badge_list_container.js
@@ -1,14 +1,13 @@
-/* eslint-disable no-underscore-dangle */
 (function(define) {
     'use strict';
 
     define(
         [
-            'gettext', 'jquery', 'underscore', 'common/js/components/views/paginated_view',
+            'gettext', 'common/js/components/views/paginated_view',
             'learner_profile/js/views/badge_view', 'learner_profile/js/views/badge_list_view',
             'text!learner_profile/templates/badge_list.underscore'
         ],
-        function(gettext, $, _, PaginatedView, BadgeView, BadgeListView, BadgeListTemplate) {
+        function(gettext, PaginatedView, BadgeView, BadgeListView, BadgeListTemplate) {
             var BadgeListContainer = PaginatedView.extend({
                 type: 'badge',
 

--- a/openedx/features/learner_profile/static/learner_profile/js/views/badge_list_view.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/badge_list_view.js
@@ -4,13 +4,12 @@
     define([
         'gettext',
         'jquery',
-        'underscore',
         'edx-ui-toolkit/js/utils/html-utils',
         'common/js/components/views/list',
         'learner_profile/js/views/badge_view',
         'text!learner_profile/templates/badge_placeholder.underscore'
     ],
-        function(gettext, $, _, HtmlUtils, ListView, BadgeView, badgePlaceholder) {
+        function(gettext, $, HtmlUtils, ListView, BadgeView, badgePlaceholder) {
             var BadgeListView = ListView.extend({
                 tagName: 'div',
 

--- a/openedx/features/learner_profile/static/learner_profile/js/views/badge_view.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/badge_view.js
@@ -3,15 +3,16 @@
 
     define(
         [
-            'gettext', 'jquery', 'underscore', 'backbone', 'moment',
+            'gettext', 'jquery', 'backbone', 'moment',
+            'edx-ui-toolkit/js/utils/html-utils',
             'text!learner_profile/templates/badge.underscore',
             'learner_profile/js/views/share_modal_view'
         ],
-        function(gettext, $, _, Backbone, Moment, badgeTemplate, ShareModalView) {
+        function(gettext, $, Backbone, Moment, HtmlUtils, badgeTemplate, ShareModalView) {
             var BadgeView = Backbone.View.extend({
                 initialize: function(options) {
-                    this.options = _.extend({}, options);
-                    this.context = _.extend(this.options.model.toJSON(), {
+                    this.options = Object.assign({}, options);
+                    this.context = Object.assign(this.options.model.toJSON(), {
                         created: new Moment(this.options.model.toJSON().created),
                         ownProfile: options.ownProfile,
                         badgeMeta: options.badgeMeta
@@ -20,7 +21,7 @@
                 attributes: {
                     class: 'badge-display'
                 },
-                template: _.template(badgeTemplate),
+                template: HtmlUtils.template(badgeTemplate),
                 events: {
                     'click .share-button': 'createModal'
                 },
@@ -32,10 +33,10 @@
                     modal.$el.hide();
                     modal.render();
                     $('body').append(modal.$el);
-                    modal.$el.fadeIn('short', 'swing', _.bind(modal.ready, modal));
+                    modal.$el.fadeIn('short', 'swing', modal.ready.bind(modal));
                 },
                 render: function() {
-                    this.$el.html(this.template(this.context));
+                    HtmlUtils.setHtml(this.$el, this.template(this.context));
                     this.shareButton = this.$el.find('.share-button');
                     return this;
                 }

--- a/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_fields.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_fields.js
@@ -1,11 +1,9 @@
-/* eslint-disable no-underscore-dangle */
 (function(define) {
     'use strict';
 
     define([
         'gettext',
         'jquery',
-        'underscore',
         'backbone',
         'edx-ui-toolkit/js/utils/string-utils',
         'edx-ui-toolkit/js/utils/html-utils',
@@ -13,7 +11,7 @@
         'js/views/image_field',
         'text!learner_profile/templates/social_icons.underscore',
         'backbone-super'
-    ], function(gettext, $, _, Backbone, StringUtils, HtmlUtils, FieldViews, ImageFieldView, socialIconsTemplate) {
+    ], function(gettext, $, Backbone, StringUtils, HtmlUtils, FieldViews, ImageFieldView, socialIconsTemplate) {
         var LearnerProfileFieldViews = {};
 
         LearnerProfileFieldViews.AccountPrivacyFieldView = FieldViews.DropdownFieldView.extend({
@@ -95,7 +93,7 @@
 
             showImageChangeFailedMessage: function(status, responseText) {
                 var errors;
-                if (_.contains([400, 404], status)) {
+                if ([400, 404].indexOf(status) >= 0) {
                     try {
                         errors = JSON.parse(responseText);
                         this.showErrorMessage(errors.user_message);
@@ -133,7 +131,7 @@
         LearnerProfileFieldViews.SocialLinkIconsView = Backbone.View.extend({
 
             initialize: function(options) {
-                this.options = _.extend({}, options);
+                this.options = Object.assign({}, options);
             },
 
             render: function() {

--- a/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_view.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_view.js
@@ -3,17 +3,20 @@
 
     define(
         [
-            'gettext', 'jquery', 'underscore', 'backbone', 'edx-ui-toolkit/js/utils/html-utils',
+            'gettext', 'jquery', 'backbone', 'edx-ui-toolkit/js/utils/html-utils',
             'common/js/components/views/tabbed_view',
             'learner_profile/js/views/section_two_tab'
         ],
-        function(gettext, $, _, Backbone, HtmlUtils, TabbedView, SectionTwoTab) {
+        function(gettext, $, Backbone, HtmlUtils, TabbedView, SectionTwoTab) {
             var LearnerProfileView = Backbone.View.extend({
 
                 initialize: function(options) {
                     var Router;
-                    this.options = _.extend({}, options);
-                    _.bindAll(this, 'showFullProfile', 'render', 'renderFields', 'showLoadingError');
+                    this.options = Object.assign({}, options);
+                    this.showFullProfile = this.showFullProfile.bind(this);
+                    this.render = this.render.bind(this);
+                    this.renderFields = this.renderFields.bind(this);
+                    this.showLoadingError = this.showLoadingError.bind(this);
                     this.listenTo(this.options.preferencesModel, 'change:account_privacy', this.render);
                     Router = Backbone.Router.extend({
                         routes: {':about_me': 'loadTab', ':accomplishments': 'loadTab'}
@@ -91,7 +94,7 @@
                         this.$el.find('.account-settings-container').append(this.tabbedView.el);
 
                         if (this.firstRender) {
-                            this.router.on('route:loadTab', _.bind(this.setActiveTab, this));
+                            this.router.on('route:loadTab', this.setActiveTab.bind(this));
                             Backbone.history.start();
                             this.firstRender = false;
                             // Load from history.
@@ -138,7 +141,7 @@
                     this.$('.profile-image-field').append(imageView.render().el);
 
                     if (this.showFullProfile()) {
-                        _.each(this.options.sectionOneFieldViews, function(childFieldView) {
+                        this.options.sectionOneFieldViews.forEach(function(childFieldView) {
                             view.$('.profile-section-one-fields').append(childFieldView.render().el);
                         });
                     }

--- a/openedx/features/learner_profile/static/learner_profile/js/views/section_two_tab.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/section_two_tab.js
@@ -3,26 +3,28 @@
 
     define(
         [
-            'gettext', 'jquery', 'underscore', 'backbone', 'text!learner_profile/templates/section_two.underscore'
+            'gettext', 'jquery', 'backbone',
+            'edx-ui-toolkit/js/utils/html-utils',
+            'text!learner_profile/templates/section_two.underscore'
         ],
-        function(gettext, $, _, Backbone, sectionTwoTemplate) {
+        function(gettext, $, Backbone, HtmlUtils, sectionTwoTemplate) {
             var SectionTwoTab = Backbone.View.extend({
                 attributes: {
                     class: 'wrapper-profile-section-two'
                 },
-                template: _.template(sectionTwoTemplate),
+                template: HtmlUtils.template(sectionTwoTemplate),
                 initialize: function(options) {
-                    this.options = _.extend({}, options);
+                    this.options = Object.assign({}, options);
                 },
                 render: function() {
                     var self = this;
                     var showFullProfile = this.options.showFullProfile();
-                    this.$el.html(this.template({
+                    HtmlUtils.setHtml(this.$el, this.template({
                         ownProfile: self.options.ownProfile,
                         showFullProfile: showFullProfile
                     }));
                     if (showFullProfile) {
-                        _.each(this.options.viewList, function(fieldView) {
+                        this.options.viewList.forEach(function(fieldView) {
                             self.$el.find('.field-container').append(fieldView.render().el);
                         });
                     }

--- a/openedx/features/learner_profile/static/learner_profile/js/views/share_modal_view.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/share_modal_view.js
@@ -3,15 +3,16 @@
 
     define(
         [
-            'gettext', 'jquery', 'underscore', 'backbone', 'moment',
+            'gettext', 'jquery', 'backbone', 'moment',
+            'edx-ui-toolkit/js/utils/html-utils',
             'text!learner_profile/templates/share_modal.underscore'
         ],
-        function(gettext, $, _, Backbone, Moment, badgeModalTemplate) {
+        function(gettext, $, Backbone, Moment, HtmlUtils, badgeModalTemplate) {
             var ShareModalView = Backbone.View.extend({
                 attributes: {
                     class: 'badges-overlay'
                 },
-                template: _.template(badgeModalTemplate),
+                template: HtmlUtils.template(badgeModalTemplate),
                 events: {
                     'click .badges-modal': function(event) { event.stopPropagation(); },
                     'click .badges-modal .close': 'close',
@@ -21,7 +22,7 @@
                     'focus .focusguard-end': 'focusGuardEnd'
                 },
                 initialize: function(options) {
-                    this.options = _.extend({}, options);
+                    this.options = Object.assign({}, options);
                 },
                 focusGuardStart: function() {
                     // Should only be selected directly if shift-tabbing from the start, so grab last item.
@@ -31,7 +32,7 @@
                     this.$el.find('.badges-modal').focus();
                 },
                 close: function() {
-                    this.$el.fadeOut('short', 'swing', _.bind(this.remove, this));
+                    this.$el.fadeOut('short', 'swing', this.remove.bind(this));
                     this.options.shareButton.focus();
                 },
                 keyAction: function(event) {
@@ -45,7 +46,7 @@
                     this.$el.find('.badges-modal').focus();
                 },
                 render: function() {
-                    this.$el.html(this.template(this.model.toJSON()));
+                    HtmlUtils.setHtml(this.$el, this.template(this.model.toJSON()));
                     return this;
                 }
             });

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jasmine-core": "2.6.4",
     "jasmine-jquery": "^2.1.1",
     "karma": "^0.13.22",
+    "karma-babel-preprocessor": "^7.0.0",
     "karma-chrome-launcher": "^0.2.3",
     "karma-coverage": "^0.5.5",
     "karma-firefox-launcher": "^0.1.7",


### PR DESCRIPTION
**This branch is not ready to be reviewed yet -- I'm experimenting.**

This branch removes all direct usage of underscore from the openedx/** tree.

Underscore is a deprecated technology for edx (https://openedx.atlassian.net/wiki/spaces/FEDX/pages/159330534/Front+End+Technologies), replaced by direct ES2015 features.  So I've gone through and updated the code where necessary.

The one usage that didn't have an obvious replacement (to me) was _.template() -- I *think* the proper replacement would be a similar client-side templating solution in backbone or react, but I didn't want to take that on as well here.  So I simply called out to HtmlUtils to do that for us (which at least lets us consolidate underscore use a little).