### PR TITLE
Add flags to tox.ini so paver tests can run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,28 @@
 [tox]
 envlist = py27-django{18,19,110,111}
 
+# This is needed to prevent the lms, cms, and openedx packages inside the "Open
+# edX" package (defined in setup.py) from getting installed into site-packages
+# where they can get imported, which is bad because those won't even contain
+# most of the source code since we don't explicitly add anything to the source
+# distribution.
+skipsdist=True
+
+# The default toxworkdir is in the source tree (as ".tox/"), but `django-admin
+# compilemessages` unconditionally walks the entire directory tree under the
+# source root and cannot handle encountering the toxworkdir.  So, we un-break
+# compilemessages by moving the toxworkdir to the home directory.
+toxworkdir={homedir}/edxapp_toxenv
+
 [testenv]
+# This ensures "-e ." is installed, so that a link back to the top-level
+# edx-platform source directory is installed in site-packages, making
+# edx-platform source code importable from python subprocesses.  Child
+# processes running python code do not import from the current working
+# directory without hacking sys.path, but they will inherit the tox virtualenv
+# and look in site-packages.
+usedevelop=True
+
 setenv =
     PYTHONHASHSEED = 0
 passenv =


### PR DESCRIPTION
See conversations in https://github.com/edx/edx-platform/pull/16737

The other PR merges this code into `bmedx/tmp_django111_tests`, so that enough tests would start under Django 1.11 to make test output revealing.  This PR merges the exact same change into master.

PLAT-1802