### PR TITLE
Bump version of user-state-client module.

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -98,7 +98,7 @@ git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd3
 git+https://github.com/edx/edx-milestones.git@v0.1.11#egg=edx-milestones==0.1.11
 git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
+git+https://github.com/edx/edx-user-state-client.git@1.0.2#egg=edx-user-state-client==1.0.2
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.6#egg=lti_consumer-xblock==1.1.6
 git+https://github.com/edx/edx-proctoring.git@1.3.1#egg=edx-proctoring==1.3.1
 # This is here because all of the other XBlocks are located here. However, it is published to PyPI and will be installed that way


### PR DESCRIPTION
The user-state-client was pinning the XBlock requirement to 1.0.0 unnecessarily. This pinning caused problems sometimes when building tox environments.

The diff:
https://github.com/edx/edx-user-state-client/compare/1.0.1...1.0.2