### PR TITLE
PLAT-1408 Update reference to Django's context_processors module

### DIFF
--- a/lms/envs/load_test.py
+++ b/lms/envs/load_test.py
@@ -10,7 +10,7 @@ from .aws import *
 
 # Disable CSRF for load testing
 EXCLUDE_CSRF = lambda elem: elem not in [
-    'django.core.context_processors.csrf',
+    'django.template.context_processors.csrf',
     'django.middleware.csrf.CsrfViewMiddleware'
 ]
 DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] = filter(


### PR DESCRIPTION
This was the only reference we still had to the module's old location.  The new one is valid as of 1.8, and everything else already switched over to it.