### PR TITLE
Updates to the API Endpoint to remove the Staff users ability to get all

### DIFF
--- a/common/djangoapps/entitlements/api/v1/tests/test_views.py
+++ b/common/djangoapps/entitlements/api/v1/tests/test_views.py
@@ -120,8 +120,9 @@ class EntitlementViewSetTest(ModuleStoreTestCase):
         results = response.data.get('results', [])  # pylint: disable=no-member
         assert results == CourseEntitlementSerializer([entitlement], many=True).data
 
-    def test_staff_get_all_entitlements(self):
-        entitlements = CourseEntitlementFactory.create_batch(2)
+    def test_staff_not_get_all_entitlements(self):
+        CourseEntitlementFactory.create_batch(2)
+        entitlement = CourseEntitlementFactory.create(user=self.user)
 
         response = self.client.get(
             self.entitlements_list_url,
@@ -130,7 +131,7 @@ class EntitlementViewSetTest(ModuleStoreTestCase):
         assert response.status_code == 200
 
         results = response.data.get('results', [])
-        assert results == CourseEntitlementSerializer(entitlements, many=True).data
+        assert results == CourseEntitlementSerializer([entitlement], many=True).data
 
     def test_get_user_entitlements(self):
         user2 = UserFactory()


### PR DESCRIPTION
Entitlements

Small PR to remove Staff User's ability to retrieve ALL entitlements from the Entitlement API. This PR will still allow the Staff user to query for user entitlements.

Future work is planned to refactor this Endpoint to simplify and remove inconsistencies.