### PR TITLE
Install chem nltk from edX fork.

### DIFF
--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -10,4 +10,7 @@ setup(
         "scipy==0.14.0",
         "nltk==2.0.6",
     ],
+    dependency_links=[
+        "git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6",
+    ],
 )


### PR DESCRIPTION
nltk==2.0.6 does not exist (at least as of right now) and is preventing sandboxes from provisioning.