### PR TITLE
Update clear_collectstatic_cache management command to Django 1.11 spec

### DIFF
--- a/common/djangoapps/static_replace/management/commands/clear_collectstatic_cache.py
+++ b/common/djangoapps/static_replace/management/commands/clear_collectstatic_cache.py
@@ -1,14 +1,21 @@
-###
-### Script for importing courseware from XML format
-###
+"""
+Django management command to clear the 'staticfiles' Django cache
+"""
 
-from django.core.management.base import NoArgsCommand
+from __future__ import print_function
+
+from django.core.management.base import BaseCommand
 from django.core.cache import caches
 
 
-class Command(NoArgsCommand):
-    help = 'Import the specified data directory into the default ModuleStore'
+class Command(BaseCommand):
+    """
+    Implementation of the management command
+    """
 
-    def handle_noargs(self, **options):
+    help = 'Empties the Django caches["staticfiles"] cache.'
+
+    def handle(self, *args, **_):
         staticfiles_cache = caches['staticfiles']
         staticfiles_cache.clear()
+        print("Cache cleared.")


### PR DESCRIPTION
This command inherited from the deprecated Django NoArgsCommand and needed to be updated. See [PLAT-1407](https://openedx.atlassian.net/browse/PLAT-1407) for details. No other usages of NoArgsCommand were found.