### PR TITLE
TE-2320 - paver command to consolidate bokchoy db cache creation

### DIFF
--- a/pavelib/__init__.py
+++ b/pavelib/__init__.py
@@ -1,4 +1,7 @@
 """
 paver commands
 """
-from . import assets, servers, docs, prereqs, quality, tests, js_test, i18n, bok_choy, acceptance_test
+from . import (
+    assets, servers, docs, prereqs, quality, tests, js_test, i18n, bok_choy,
+    acceptance_test, database
+)

--- a/pavelib/database.py
+++ b/pavelib/database.py
@@ -1,0 +1,45 @@
+"""
+tasks for controlling the databases used in tests
+"""
+from __future__ import print_function
+import os
+
+from paver.easy import sh, needs
+
+from pavelib.utils.passthrough_opts import PassthroughTask
+from pavelib.utils.timer import timed
+from pavelib.utils.envs import Env
+
+
+@needs('pavelib.prereqs.install_prereqs')
+@PassthroughTask
+@timed
+def update_bokchoy_db_cache():
+    """
+    Update and cache the MYSQL database for bokchoy testing. This command
+    will remove any previously cached database files and apply migrations
+    on a fresh db.
+
+    You can commit the resulting files in common/test/db_cache into
+    git to speed up test runs
+    """
+    bokchoy_db_files = [
+        'bok_choy_data_default.json',
+        'bok_choy_data_student_module_history.json',
+        'bok_choy_migrations_data_default.sql',
+        'bok_choy_migrations_data_student_module_history.sql',
+        'bok_choy_schema_default.sql',
+        'bok_choy_schema_student_module_history.sql'
+    ]
+    print('Removing cached db files for bokchoy tests')
+    for db_file in bokchoy_db_files:
+        try:
+            db_file_path = os.path.join(
+                '{}/common/test/db_cache'.format(Env.REPO_ROOT), db_file
+            )
+            os.remove(db_file_path)
+            print('\tRemoved {}'.format(db_file_path))
+        except OSError:
+            continue
+
+    sh('{}/scripts/reset-test-db.sh'.format(Env.REPO_ROOT))


### PR DESCRIPTION
The paver command 'update_bokchoy_db_cache' consolidates the steps mentioned here: https://openedx.atlassian.net/wiki/spaces/~zoldak/pages/34734636/How+to+do+common+administrative+stuff

My intention is to add the lettuce db caching function to 'database.py', as well as any other code needed to push/pull db files from s3