### PR TITLE
Fix watch_assets call from paver update_assets.

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -962,6 +962,6 @@ def update_assets(args):
                 'background': not args.debug,
                 'theme_dirs': args.theme_dirs,
                 'themes': args.themes,
-                'wait': float(args.wait)
+                'wait': [float(args.wait)]
             },
         )


### PR DESCRIPTION
Tiny fix so `paver update_assets` doesn't break when calling `watch_assets`.