### PR TITLE
Schedules: turn off HTML escaping for email text fields

### DIFF
--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 {% load i18n %}
 
 {% blocktrans trimmed %}
@@ -14,3 +15,4 @@ With self-paced courses, you learn on your own schedule. We encourage you to spe
 Your focused attention will pay off in the end!
 {% endblocktrans %}
 {% include "schedules/edx_ace/common/upsell_cta.txt"%}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/from_name.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/from_name.txt
@@ -1,1 +1,3 @@
+{% autoescape off %}
 {{ course_name }}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/subject.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/subject.txt
@@ -1,3 +1,5 @@
+{% autoescape off %}
 {% load i18n %}
 
 {% blocktrans %}Welcome to week {{ week_num }} {% endblocktrans %}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/body.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/body.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 {% load i18n %}
 {% load ace %}
 {% if course_ids|length > 1 %}
@@ -14,3 +15,4 @@
     {% trans "Keep learning" %} <{% with_link_tracking course_url %}>
 {% endif %}
 {% include "schedules/edx_ace/common/upsell_cta.txt"%}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/from_name.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/from_name.txt
@@ -1,5 +1,7 @@
+{% autoescape off %}
 {% if course_ids|length > 1 %}
 {{ platform_name }}
 {% else %}
 {{ course_name }}
 {% endif %}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/subject.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/subject.txt
@@ -1,2 +1,4 @@
+{% autoescape off %}
 {% load i18n %}
 {% trans "Keep up the momentum!" %}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 {% load i18n %}
 {% load ace %}
 {% if course_ids|length > 1 %}
@@ -16,3 +17,4 @@
 {% trans "Start learning now" %} <{% with_link_tracking course_url %}>
 {% endif %}
 {% include "schedules/edx_ace/common/upsell_cta.txt"%}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/from_name.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/from_name.txt
@@ -1,5 +1,7 @@
+{% autoescape off %}
 {% if course_ids|length > 1 %}
 {{ platform_name }}
 {% else %}
 {{ course_name }}
 {% endif %}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/subject.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/subject.txt
@@ -1,6 +1,8 @@
+{% autoescape off %}
 {% load i18n %}
 {% if course_ids|length > 1 %}
 {% blocktrans %}Keep learning on {{ platform_name }}{% endblocktrans %}
 {% else %}
 {% blocktrans %}Keep learning in {{course_name}}{% endblocktrans %}
 {% endif %}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 {% load i18n %}
 {% load ace %}
 {% if course_ids|length > 1 %}
@@ -27,3 +28,4 @@ Upgrade by {{ user_schedule_upgrade_deadline_time }}.
 
 {% trans "Upgrade now at" %} <{% with_link_tracking upsell_link %}>
 {% endif %}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/from_name.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/from_name.txt
@@ -1,5 +1,7 @@
+{% autoescape off %}
 {% if course_ids|length > 1 %}
 {{ platform_name }}
 {% else %}
 {{ first_course_name }}
 {% endif %}
+{% endautoescape %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/subject.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/subject.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 {% load i18n %}
 
 {% if course_ids|length > 1 %}
@@ -5,3 +6,4 @@
 {% else %}
 {% blocktrans %}Upgrade to earn a verified certificate in {{ first_course_name }}{% endblocktrans %}
 {% endif %}
+{% endautoescape %}


### PR DESCRIPTION
@adampalay let us know that he was getting some weird HTML escaped characters in his email subject lines from this feature.

By default, Django HTML escapes all variables. We have to explicitly disable escaping on the templates that are plain text (those that end in `*.txt`: `subject.txt`, `from_name.txt`, and `body.txt`).

To test this I locally created a course in Studio called "Cat's & "Dog's"", sent the recurring nudge and saw that the text remained unescaped in the plain-text email:

**Before:**
```
To: edx@example.com
From: Cat&#39;s &amp; &quot;Dog&#39;s&quot;
Subject: Keep learning in Cat&#39;s &amp; &quot;Dog&#39;s&quot;
Body:
Remember when you enrolled in Cat&#39;s &amp; &quot;Dog&#39;s&quot; on Your Platform Name Here? We do, and we’re glad to have you! Come see what everyone is learning.

Start learning now <URL>
```
**After:**
```
To: edx@example.com
From: Cat's & "Dog's"
Subject: Keep learning in Cat's & "Dog's"
Body:
Remember when you enrolled in Cat's & "Dog's" on Your Platform Name Here? We do, and we’re glad to have you! Come see what everyone is learning.

Start learning now <URL>
```