### PR TITLE
PLAT-1801 Preserve new user login behavior under Django 1.10+

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta
 import ddt
 import freezegun
 import httpretty
-import pytest
 import pytz
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -69,7 +68,6 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         (False, None, False, False),
     )
     @ddt.unpack
-    @pytest.mark.django111_expected_failure
     def test_redirect_to_dashboard(self, is_active, enrollment_mode, redirect, has_started):
         # Configure whether course has started
         # If it has go to course home instead of dashboard

--- a/common/djangoapps/edxmako/makoloader.py
+++ b/common/djangoapps/edxmako/makoloader.py
@@ -2,8 +2,7 @@ import logging
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.template import Engine, engines
-from django.template.base import TemplateDoesNotExist
+from django.template import Engine, engines, TemplateDoesNotExist
 from django.template.loaders.app_directories import Loader as AppDirectoriesLoader
 from django.template.loaders.filesystem import Loader as FilesystemLoader
 
@@ -22,6 +21,7 @@ class MakoLoader(object):
     """
 
     is_usable = False
+    supports_recursion = False
 
     def __init__(self, base_loader):
         # base_loader is an instance of a BaseLoader subclass

--- a/common/djangoapps/student/urls.py
+++ b/common/djangoapps/student/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
     url(r'^login_ajax$', student.views.login_user, name="login"),
     url(r'^login_ajax/(?P<error>[^/]*)$', student.views.login_user),
 
-    url(r'^email_confirm/(?P<key>[^/]*)$', student.views.confirm_email_change),
+    url(r'^email_confirm/(?P<key>[^/]*)$', student.views.confirm_email_change, name='confirm_email_change'),
 
     url(r'^create_account$', student.views.create_account, name='create_account'),
     url(r'^activate/(?P<key>[^/]*)$', student.views.activate_account, name="activate"),

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -157,7 +157,6 @@ class PreRequisiteCourseCatalog(ModuleStoreTestCase, LoginEnrollmentTestCase, Mi
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
     """
     Test for Index page course cards sorting
@@ -208,7 +207,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
         self.assertNotIn('Search for a course', response.content)
 
         # check the /courses view
-        response = self.client.get(reverse('branding.views.courses'))
+        response = self.client.get(reverse('courses'))
         self.assertEqual(response.status_code, 200)
 
         # assert that the course discovery UI is not present
@@ -232,7 +231,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
         self.assertIn('Search for a course', response.content)
 
         # check the /courses view
-        response = self.client.get(reverse('branding.views.courses'))
+        response = self.client.get(reverse('courses'))
         self.assertEqual(response.status_code, 200)
 
         # assert that the course discovery UI is present
@@ -255,7 +254,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
         self.assertEqual(context['courses'][2].id, self.course_with_default_start_date.id)
 
         # check the /courses view
-        response = self.client.get(reverse('branding.views.courses'))
+        response = self.client.get(reverse('courses'))
         self.assertEqual(response.status_code, 200)
         ((template, context), _) = RENDER_MOCK.call_args  # pylint: disable=unpacking-non-sequence
         self.assertEqual(template, 'courseware/courses.html')
@@ -281,7 +280,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
         self.assertEqual(context['courses'][2].id, self.course_with_default_start_date.id)
 
         # check the /courses view as well
-        response = self.client.get(reverse('branding.views.courses'))
+        response = self.client.get(reverse('courses'))
         self.assertEqual(response.status_code, 200)
         ((template, context), _) = RENDER_MOCK.call_args  # pylint: disable=unpacking-non-sequence
         self.assertEqual(template, 'courseware/courses.html')
@@ -301,7 +300,7 @@ class IndexPageProgramsTests(SiteMixin, ModuleStoreTestCase):
     def test_get_programs_with_type_called(self):
         views = [
             (reverse('root'), 'student.views.get_programs_with_type'),
-            (reverse('branding.views.courses'), 'courseware.views.views.get_programs_with_type'),
+            (reverse('courses'), 'courseware.views.views.get_programs_with_type'),
         ]
         for url, dotted_path in views:
             with patch(dotted_path) as mock_get_programs_with_type:

--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -44,7 +44,7 @@ class BlockSerializer(serializers.Serializer):  # pylint: disable=abstract-metho
                 request=self.context['request'],
             ),
             'student_view_url': reverse(
-                'courseware.views.views.render_xblock',
+                'render_xblock',
                 kwargs={'usage_key_string': unicode(block_key)},
                 request=self.context['request'],
             ),

--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -2,7 +2,6 @@
 Tests for wiki middleware.
 """
 
-import pytest
 from django.test.client import Client
 from nose.plugins.attrib import attr
 from wiki.models import URLPath
@@ -14,7 +13,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestWikiAccessMiddleware(ModuleStoreTestCase):
     """Tests for WikiAccessMiddleware."""
 

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -3,7 +3,6 @@ Test the about xblock
 """
 import datetime
 
-import pytest
 import pytz
 from ccx_keys.locator import CCXLocator
 from django.conf import settings
@@ -39,7 +38,6 @@ SHIB_ERROR_STR = "The currently logged-in user account does not have permission 
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTrackingTestCase, MilestonesTestCaseMixin):
     """
     Tests about xblock.
@@ -194,7 +192,6 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for the course about page
@@ -243,7 +240,6 @@ class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
     This test case will check the About page when a course has a capped enrollment
@@ -291,7 +287,6 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleSt
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class AboutWithInvitationOnly(SharedModuleStoreTestCase):
     """
     This test case will check the About page when a course is invitation only.
@@ -339,7 +334,6 @@ class AboutWithInvitationOnly(SharedModuleStoreTestCase):
 
 @attr(shard=1)
 @patch.dict(settings.FEATURES, {'RESTRICT_ENROLL_BY_REG_METHOD': True})
-@pytest.mark.django111_expected_failure
 class AboutTestCaseShibCourse(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
     Test cases covering about page behavior for courses that use shib enrollment domain ("shib courses")
@@ -380,7 +374,6 @@ class AboutTestCaseShibCourse(LoginEnrollmentTestCase, SharedModuleStoreTestCase
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class AboutWithClosedEnrollment(ModuleStoreTestCase):
     """
     This test case will check the About page for a course that has enrollment start/end
@@ -426,7 +419,6 @@ class AboutWithClosedEnrollment(ModuleStoreTestCase):
 @attr(shard=1)
 @patch.dict(settings.FEATURES, {'ENABLE_SHOPPING_CART': True})
 @patch.dict(settings.FEATURES, {'ENABLE_PAID_COURSE_REGISTRATION': True})
-@pytest.mark.django111_expected_failure
 class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
     This test class runs through a suite of verifications regarding

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -6,7 +6,6 @@ import datetime
 import itertools
 
 import ddt
-import pytest
 import pytz
 from ccx_keys.locator import CCXLocator
 from django.contrib.auth.models import User
@@ -159,7 +158,6 @@ class CoachAccessTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
 
 @attr(shard=1)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Tests for the various access controls on the student dashboard
@@ -633,7 +631,6 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         self.assertEqual(bool(access._has_access_course(self.staff, 'load_mobile', descriptor)), staff_expected)
 
     @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True, 'MILESTONES_APP': True})
-    @pytest.mark.django111_expected_failure
     def test_courseware_page_unfulfilled_prereqs(self):
         """
         Test courseware access when a course has pre-requisite course yet to be completed

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -3,7 +3,6 @@
 Test the course_info xblock
 """
 import mock
-import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import QueryDict
@@ -35,7 +34,6 @@ QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class CourseInfoTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
     Tests for the Course Info page
@@ -145,7 +143,6 @@ class CourseInfoTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCase,
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class CourseInfoLastAccessedTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests of the CourseInfo last accessed link.
@@ -304,7 +301,6 @@ class CourseInfoTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class CourseInfoTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for the Course Info page for an XML course
@@ -354,7 +350,6 @@ class CourseInfoTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
 
 @attr(shard=1)
 @override_settings(FEATURES=dict(settings.FEATURES, EMBARGO=False))
-@pytest.mark.django111_expected_failure
 class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
     Tests for the info page of self-paced courses.

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -5,7 +5,6 @@ Python tests for the Survey workflows
 from collections import OrderedDict
 from copy import deepcopy
 
-import pytest
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from nose.plugins.attrib import attr
@@ -18,7 +17,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class SurveyViewsTests(LoginEnrollmentTestCase, SharedModuleStoreTestCase, XssTestMixin):
     """
     All tests for the views.py file

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -3,7 +3,6 @@
 from datetime import datetime, timedelta
 
 import ddt
-import pytest
 import waffle
 from django.contrib.messages.middleware import MessageMiddleware
 from django.core.urlresolvers import reverse
@@ -46,7 +45,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 @attr(shard=1)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class CourseDateSummaryTest(SharedModuleStoreTestCase):
     """Tests for course date summary blocks."""
 

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -1,7 +1,6 @@
 """
 Tests use cases related to LMS Entrance Exam behavior, such as gated content access (TOC)
 """
-import pytest
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from mock import Mock, patch
@@ -39,7 +38,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 @attr(shard=2)
 @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})
-@pytest.mark.django111_expected_failure
 class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Check that content is properly gated.

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -5,7 +5,6 @@ import json
 import pickle
 from datetime import datetime
 
-import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -174,7 +173,6 @@ class NormalStudentVisibilityTest(MasqueradeTestCase):
         return UserFactory()
 
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    @pytest.mark.django111_expected_failure
     def test_staff_debug_not_visible(self):
         """
         Tests that staff debug control is not present for a student.
@@ -224,7 +222,6 @@ class TestStaffMasqueradeAsStudent(StaffMasqueradeTestCase):
     Check for staff being able to masquerade as student.
     """
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    @pytest.mark.django111_expected_failure
     def test_staff_debug_with_masquerade(self):
         """
         Tests that staff debug control is not visible when masquerading as a student.
@@ -314,7 +311,6 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         )
 
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    @pytest.mark.django111_expected_failure
     def test_masquerade_as_specific_user_on_self_paced(self):
         """
         Test masquerading as a specific user for course info page when self paced configuration
@@ -339,7 +335,6 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         self.assertIn("OOGIE BLOOGIE", content)
 
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    @pytest.mark.django111_expected_failure
     def test_masquerade_as_specific_student(self):
         """
         Test masquerading as a specific user.

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -692,7 +692,6 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
             BlockCompletion.objects.get(block_key=block.scope_ids.usage_id)
 
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_XBLOCK_VIEW_ENDPOINT': True})
-    @pytest.mark.django111_expected_failure
     def test_xblock_view_handler(self):
         args = [
             'edX/toy/2012_Fall',
@@ -826,7 +825,6 @@ class TestTOC(ModuleStoreTestCase):
 @attr(shard=1)
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
-@pytest.mark.django111_expected_failure
 class TestProctoringRendering(SharedModuleStoreTestCase):
     @classmethod
     def setUpClass(cls):
@@ -1242,7 +1240,6 @@ class TestGatedSubsectionRendering(SharedModuleStoreTestCase, MilestonesTestCase
 
 @attr(shard=1)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class TestHtmlModifiers(ModuleStoreTestCase):
     """
     Tests to verify that standard modifications to the output of XModule/XBlock
@@ -1407,7 +1404,6 @@ class XBlockWithJsonInitData(XBlock):
 
 @attr(shard=1)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class JsonInitDataTest(ModuleStoreTestCase):
     """Tests for JSON data injected into the JS init function."""
 
@@ -1492,7 +1488,6 @@ class ViewInStudioTest(ModuleStoreTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class MongoViewInStudioTest(ViewInStudioTest):
     """Test the 'View in Studio' link visibility in a mongo backed course."""
 
@@ -1522,7 +1517,6 @@ class MongoViewInStudioTest(ViewInStudioTest):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class MixedViewInStudioTest(ViewInStudioTest):
     """Test the 'View in Studio' link visibility in a mixed mongo backed course."""
 
@@ -1557,7 +1551,6 @@ class DetachedXBlock(XBlock):
 @attr(shard=1)
 @patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': True, 'DISPLAY_HISTOGRAMS_TO_STAFF': True})
 @patch('courseware.module_render.has_access', Mock(return_value=True, autospec=True))
-@pytest.mark.django111_expected_failure
 class TestStaffDebugInfo(SharedModuleStoreTestCase):
     """Tests to verify that Staff Debug Info panel and histograms are displayed to staff."""
 
@@ -1905,7 +1898,6 @@ class TestModuleTrackingContext(SharedModuleStoreTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestXmoduleRuntimeEvent(TestSubmittingProblems):
     """
     Inherit from TestSubmittingProblems to get functionality that set up a course and problems structure
@@ -1975,7 +1967,6 @@ class TestXmoduleRuntimeEvent(TestSubmittingProblems):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestRebindModule(TestSubmittingProblems):
     """
     Tests to verify the functionality of rebinding a module.

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -3,7 +3,6 @@ This test file will run through some LMS test scenarios regarding access and nav
 """
 import time
 
-import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
@@ -21,7 +20,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that navigation state is saved properly.

--- a/lms/djangoapps/courseware/tests/test_password_history.py
+++ b/lms/djangoapps/courseware/tests/test_password_history.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from uuid import uuid4
 
 import ddt
-import pytest
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.core.urlresolvers import reverse
@@ -24,7 +23,6 @@ from student.models import PasswordHistory
 @attr(shard=1)
 @patch.dict("django.conf.settings.FEATURES", {'ADVANCED_SECURITY': True})
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class TestPasswordHistory(LoginEnrollmentTestCase):
     """
     Go through some of the PasswordHistory use cases

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -1,7 +1,6 @@
 """
 Test for split test XModule
 """
-import pytest
 from django.core.urlresolvers import reverse
 from mock import MagicMock
 from nose.plugins.attrib import attr
@@ -143,7 +142,6 @@ class SplitTestBase(SharedModuleStoreTestCase):
             self.assertIn(visible, content)
 
 
-@pytest.mark.django111_expected_failure
 class TestSplitTestVert(SplitTestBase):
     """
     Tests a sequential whose top-level vertical is determined by a split test.
@@ -212,7 +210,6 @@ class TestSplitTestVert(SplitTestBase):
         ]
 
 
-@pytest.mark.django111_expected_failure
 class TestVertSplitTestVert(SplitTestBase):
     """
     Tests a sequential whose top-level vertical contains a split test determining content within that vertical.

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -10,7 +10,6 @@ import os
 from textwrap import dedent
 
 import ddt
-import pytest
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
@@ -337,7 +336,6 @@ class TestCourseGrades(TestSubmittingProblems):
 
 @attr(shard=3)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class TestCourseGrader(TestSubmittingProblems):
     """
     Suite of tests for the course grader.
@@ -781,7 +779,6 @@ class ProblemWithUploadedFilesTest(TestSubmittingProblems):
         # re-fetch the course from the database so the object is up to date
         self.refresh_course()
 
-    @pytest.mark.django111_expected_failure
     def test_three_files(self):
         # Open the test files, and arrange to close them later.
         filenames = "prog1.py prog2.py prog3.py"
@@ -810,7 +807,6 @@ class ProblemWithUploadedFilesTest(TestSubmittingProblems):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestPythonGradedResponse(TestSubmittingProblems):
     """
     Check that we can submit a schematic and custom response, and it answers properly.
@@ -1178,7 +1174,6 @@ class TestConditionalContent(TestSubmittingProblems):
         # Submit answers for problem in Section 1, which is visible to all students.
         self.submit_question_answer('H1P1', {'2_1': 'Correct', '2_2': 'Incorrect'})
 
-    @pytest.mark.django111_expected_failure
     def test_split_different_problems_group_0(self):
         """
         Tests that users who see different problems in a split_test module instance are graded correctly.
@@ -1198,7 +1193,6 @@ class TestConditionalContent(TestSubmittingProblems):
         homework_2_score = (1.0 + 2.0) / 4
         self.check_grade_percent(round((homework_1_score + homework_2_score) / 2, 2))
 
-    @pytest.mark.django111_expected_failure
     def test_split_different_problems_group_1(self):
         """
         Tests that users who see different problems in a split_test module instance are graded correctly.
@@ -1235,7 +1229,6 @@ class TestConditionalContent(TestSubmittingProblems):
 
         self.submit_question_answer('H1P1', {'2_1': 'Correct'})
 
-    @pytest.mark.django111_expected_failure
     def test_split_one_group_no_problems_group_0(self):
         """
         Tests what happens when a given group has no problems in it (students receive 0 for that section).
@@ -1251,7 +1244,6 @@ class TestConditionalContent(TestSubmittingProblems):
         homework_2_score = 0.0
         self.check_grade_percent(round((homework_1_score + homework_2_score) / 2, 2))
 
-    @pytest.mark.django111_expected_failure
     def test_split_one_group_no_problems_group_1(self):
         """
         Verifies students in the group that DOES have a problem receive a score for their problem.

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -246,7 +246,6 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
         cls.course.tabs.append(xmodule_tabs.CourseTab.load('static_tab', name='New Tab', url_slug='new_tab'))
         cls.course.save()
 
-    @pytest.mark.django111_expected_failure
     def test_logged_in(self):
         self.setup_user()
         url = reverse('static_tab', args=[self.course.id.to_deprecated_string(), 'new_tab'])
@@ -260,14 +259,12 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("OOGIE BLOOGIE", resp.content)
 
-    @pytest.mark.django111_expected_failure
     def test_invalid_course_key(self):
         self.setup_user()
         request = get_mock_request(self.user)
         with self.assertRaises(Http404):
             StaticCourseTabView().get(request, course_id='edX/toy', tab_slug='new_tab')
 
-    @pytest.mark.django111_expected_failure
     def test_get_static_tab_fragment(self):
         self.setup_user()
         course = get_course_by_id(self.course.id)
@@ -323,7 +320,6 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.xml_url = "8e4cce2b4aaf4ba28b1220804619e41f"
 
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    @pytest.mark.django111_expected_failure
     def test_logged_in_xml(self):
         self.setup_user()
         url = reverse('static_tab', args=[self.xml_course_key.to_deprecated_string(), self.xml_url])
@@ -341,7 +337,6 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
 
 @attr(shard=1)
 @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})
-@pytest.mark.django111_expected_failure
 class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Validate tab behavior when dealing with Entrance Exams
@@ -449,7 +444,6 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TextBookCourseViewsTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
     Validate tab behavior when dealing with textbooks.

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -1,7 +1,6 @@
 import datetime
 
 import pytz
-import pytest
 from django.core.urlresolvers import reverse
 from mock import patch
 from nose.plugins.attrib import attr
@@ -164,7 +163,6 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
         self.org_staff_user = OrgStaffFactory(course_key=self.course.id)
         self.org_instructor_user = OrgInstructorFactory(course_key=self.course.id)
 
-    @pytest.mark.django111_expected_failure
     def test_redirection_unenrolled(self):
         """
         Verify unenrolled student is redirected to the 'about' section of the chapter
@@ -181,7 +179,6 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
             )
         )
 
-    @pytest.mark.django111_expected_failure
     def test_redirection_enrolled(self):
         """
         Verify enrolled student is redirected to the 'Welcome' section of
@@ -305,7 +302,6 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
             self.assert_request_status_code(200, url)
 
     @patch.dict('courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
-    @pytest.mark.django111_expected_failure
     def test_dark_launch_enrolled_student(self):
         """
         Make sure that before course start, students can't access course
@@ -333,7 +329,6 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
         self._check_non_staff_dark(self.test_course)
 
     @patch.dict('courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
-    @pytest.mark.django111_expected_failure
     def test_dark_launch_instructor(self):
         """
         Make sure that before course start instructors can access the
@@ -357,7 +352,6 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
         self._check_non_staff_dark(self.test_course)
 
     @patch.dict('courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
-    @pytest.mark.django111_expected_failure
     def test_dark_launch_global_staff(self):
         """
         Make sure that before course start staff can access

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -210,7 +210,6 @@ class TestJumpTo(ModuleStoreTestCase):
 
 @attr(shard=2)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class IndexQueryTestCase(ModuleStoreTestCase):
     """
     Tests for query count.
@@ -253,7 +252,6 @@ class IndexQueryTestCase(ModuleStoreTestCase):
 
 @attr(shard=2)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class ViewsTestCase(ModuleStoreTestCase):
     """
     Tests for views.py methods.
@@ -1117,7 +1115,6 @@ class TestProgressDueDate(BaseDueDateTests):
 
 
 # TODO: LEARNER-71: Delete entire TestAccordionDueDate class
-@pytest.mark.django111_expected_failure
 class TestAccordionDueDate(BaseDueDateTests):
     """
     Test that the accordion page displays due dates correctly
@@ -1190,7 +1187,6 @@ class StartDateTests(ModuleStoreTestCase):
     @patch('util.date_utils.ugettext', fake_ugettext(translations={
         "SHORT_DATE_FORMAT": "%Y-%b-%d",
     }))
-    @pytest.mark.django111_expected_failure
     def test_format_localized_in_studio_course(self):
         course = self.set_up_course()
         response = self.get_about_response(course.id)
@@ -2198,7 +2194,6 @@ class ViewCheckerBlock(XBlock):
 
 @attr(shard=1)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class TestIndexView(ModuleStoreTestCase):
     """
     Tests of the courseware.views.index view.
@@ -2536,7 +2531,6 @@ class TestIndexViewCrawlerStudentStateWrites(SharedModuleStoreTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCase):
     """
     Ensure that the Enterprise Data Consent redirects are in place only when consent is required.

--- a/lms/djangoapps/courseware/tests/tests.py
+++ b/lms/djangoapps/courseware/tests/tests.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 from unittest import TestCase
 
 import mock
-import pytest
 from django.core.urlresolvers import reverse
 from nose.plugins.attrib import attr
 from opaque_keys.edx.keys import CourseKey
@@ -19,7 +18,6 @@ from xmodule.modulestore.tests.factories import ToyCourseFactory
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class ActivateLoginTest(LoginEnrollmentTestCase):
     """
     Test logging in and logging out.
@@ -124,7 +122,6 @@ class PageLoaderTestCase(LoginEnrollmentTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestMongoCoursesLoad(ModuleStoreTestCase, PageLoaderTestCase):
     """
     Check that all pages in test courses load properly from Mongo.

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2376,7 +2376,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         """
         enroll user using a registration code
         """
-        redeem_url = reverse('shoppingcart.views.register_code_redemption', args=[code], is_dashboard_endpoint=False)
+        redeem_url = reverse('register_code_redemption', args=[code], is_dashboard_endpoint=False)
         self.client.login(username=user.username, password='test')
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
@@ -2871,7 +2871,6 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         decorated_func(request, self.course.id.to_deprecated_string())
         self.assertTrue(func.called)
 
-    @pytest.mark.django111_expected_failure
     def test_enrollment_report_features_csv(self):
         """
         test to generate enrollment report.
@@ -2912,7 +2911,6 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         response = self.client.post(url, {})
         self.assertIn('The detailed enrollment report is being created.', response.content)
 
-    @pytest.mark.django111_expected_failure
     def test_bulk_purchase_detailed_report(self):
         """
         test to generate detailed enrollment report.
@@ -2968,7 +2966,6 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         response = self.client.post(url, {})
         self.assertIn('The detailed enrollment report is being created.', response.content)
 
-    @pytest.mark.django111_expected_failure
     def test_create_registration_code_without_invoice_and_order(self):
         """
         test generate detailed enrollment report,
@@ -2991,7 +2988,6 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         response = self.client.post(url, {})
         self.assertIn('The detailed enrollment report is being created.', response.content)
 
-    @pytest.mark.django111_expected_failure
     def test_invoice_payment_is_still_pending_for_registration_codes(self):
         """
         test generate enrollment report

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -4,7 +4,6 @@ Unit tests for instructor_dashboard.py.
 import datetime
 
 import ddt
-import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
@@ -321,7 +320,6 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         # Max number of student per page is one.  Patched setting MAX_STUDENTS_PER_PAGE_GRADE_BOOK = 1
         self.assertEqual(len(response.mako_context['students']), 1)  # pylint: disable=no-member
 
-    @pytest.mark.django111_expected_failure
     def test_open_response_assessment_page(self):
         """
         Test that Open Responses is available only if course contains at least one ORA block
@@ -341,7 +339,6 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
         self.assertIn(ora_section, response.content)
 
-    @pytest.mark.django111_expected_failure
     def test_open_response_assessment_page_orphan(self):
         """
         Tests that the open responses tab loads if the course contains an

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -11,7 +11,6 @@ import textwrap
 from collections import namedtuple
 
 import ddt
-import pytest
 from celery.states import FAILURE, SUCCESS
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
@@ -68,7 +67,6 @@ class TestIntegrationTask(InstructorTaskModuleTestCase):
 
 @attr(shard=3)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class TestRescoringTask(TestIntegrationTask):
     """
     Integration-style tests for rescoring problems in a background task.

--- a/lms/templates/registration/password_reset_email.html
+++ b/lms/templates/registration/password_reset_email.html
@@ -3,7 +3,7 @@
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-{{ protocol }}://{{ site_name }}{% url 'student.views.password_reset_confirm_wrapper' uidb36=uid token=token %}
+{{ protocol }}://{{ site_name }}{% url 'password_reset_confirm' uidb36=uid token=token %}
 {% endblock %}
 
 {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." %}

--- a/openedx/core/djangoapps/theming/template_loaders.py
+++ b/openedx/core/djangoapps/theming/template_loaders.py
@@ -41,13 +41,7 @@ class ThemeFilesystemLoader(FilesystemLoader):
         if isinstance(theme_dirs, list):
             template_dirs = theme_dirs + template_dirs
 
-        for template_dir in template_dirs:
-            try:
-                yield safe_join(template_dir, template_name)
-            except SuspiciousFileOperation:
-                # The joined path was located outside of this template_dir
-                # (it might be inside another one, so this isn't fatal).
-                pass
+        return list(super(ThemeFilesystemLoader, self).get_template_sources(template_name, template_dirs))
 
     @staticmethod
     def get_theme_template_sources():

--- a/openedx/core/djangoapps/theming/templatetags/optional_include.py
+++ b/openedx/core/djangoapps/theming/templatetags/optional_include.py
@@ -9,8 +9,9 @@ except for making it optional.
 # possible, we should disable pylint so it doesn't complain about the violations
 # that are already in that file
 # pylint: skip-file
+from django.template import Library, TemplateDoesNotExist
 from django.template.base import (
-    TemplateSyntaxError, Library, token_kwargs, TemplateDoesNotExist
+    TemplateSyntaxError, token_kwargs
 )
 from django.template.loader_tags import IncludeNode
 

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -409,7 +409,6 @@ class AccountCreationActivationAndPasswordChangeTest(TestCase):
         activate_account(u'invalid')
 
     @skip_unless_lms
-    @pytest.mark.django111_expected_failure
     def test_request_password_change(self):
         # Create and activate an account
         activation_key = create_account(self.USERNAME, self.PASSWORD, self.EMAIL)
@@ -428,7 +427,6 @@ class AccountCreationActivationAndPasswordChangeTest(TestCase):
         self.assertIsNot(result, None)
 
     @skip_unless_lms
-    @pytest.mark.django111_expected_failure
     def test_request_password_change_invalid_user(self):
         with self.assertRaises(UserNotFound):
             request_password_change(self.EMAIL, self.IS_SECURE)

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -640,7 +640,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         self.assertEqual(1, len(pending_change))
         activation_key = pending_change[0].activation_key
         confirm_change_url = reverse(
-            "student.views.confirm_email_change", kwargs={'key': activation_key}
+            "confirm_email_change", kwargs={'key': activation_key}
         )
         response = self.client.post(confirm_change_url)
         self.assertEqual(200, response.status_code)

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -4,7 +4,6 @@ Test scenarios for the crowdsource hinter xblock.
 import json
 import unittest
 
-import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from nose.plugins.attrib import attr
@@ -136,7 +135,6 @@ class TestCrowdsourceHinter(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestHinterFunctions(TestCrowdsourceHinter):
     """
     Check that the essential functions of the hinter work as expected.

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -9,7 +9,6 @@ import StringIO
 import unittest
 from copy import deepcopy
 
-import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
@@ -197,7 +196,6 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestRecommenderCreateFromEmpty(TestRecommender):
     """
     Check whether we can add resources to an empty database correctly
@@ -258,7 +256,6 @@ class TestRecommenderResourceBase(TestRecommender):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestRecommenderWithResources(TestRecommenderResourceBase):
     """
     Check whether we can add/edit/flag/export resources correctly
@@ -425,7 +422,6 @@ class TestRecommenderWithResources(TestRecommenderResourceBase):
 
 @attr(shard=1)
 @ddt
-@pytest.mark.django111_expected_failure
 class TestRecommenderVoteWithResources(TestRecommenderResourceBase):
     """
     Check whether we can vote resources correctly
@@ -540,7 +536,6 @@ class TestRecommenderVoteWithResources(TestRecommenderResourceBase):
 
 @attr(shard=1)
 @ddt
-@pytest.mark.django111_expected_failure
 class TestRecommenderStaffFeedbackWithResources(TestRecommenderResourceBase):
     """
     Check whether we can remove/endorse resources correctly
@@ -636,7 +631,6 @@ class TestRecommenderStaffFeedbackWithResources(TestRecommenderResourceBase):
 
 @attr(shard=1)
 @ddt
-@pytest.mark.django111_expected_failure
 class TestRecommenderFileUploading(TestRecommender):
     """
     Check whether we can handle file uploading correctly


### PR DESCRIPTION
The `ModelBackend` authentication backend changes in Django 1.10 to no longer allow inactive users to log in.  We decided in [PLAT-1365](https://openedx.atlassian.net/browse/PLAT-1365) that this is basically ok, but missed that we do currently allow new, still-inactive users to log in (only when the user is first created).  I changed this flow to use a specific auth backend for this first login which normally isn't available for authentication:

* `ModelBackend` in Django 1.9 and earlier, which is what our main `RateLimitBackend` inherits from (we don't currently apply rate limiting to these new user logins anyway).
* `AllowAllUsersModelBackend` in Django 1.10, which behaves the same as `ModelBackend` in earlier versions.

I also went through and unmarked all the now-passing tests that had failed due to this, fixing a few other minor issues along the way:

* Fixed some URL lookups that were still using the Python path for the view function
* Fixed some problems with template loading, especially where themes are involved; some of the classes we were importing moved in 1.9 (but are available from `django.template` in all relevant versions), and the behavior of `get_template_sources()` changed a little in 1.10.