### PR TITLE
Fix warnings/errors in Django 1.10

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -46,7 +46,7 @@ urlpatterns = [
     # noop to squelch ajax errors
     url(r'^event$', contentstore.views.event, name='event'),
     url(r'^xmodule/', include('pipeline_js.urls')),
-    url(r'^heartbeat$', include('openedx.core.djangoapps.heartbeat.urls')),
+    url(r'^heartbeat', include('openedx.core.djangoapps.heartbeat.urls')),
     url(r'^user_api/', include('openedx.core.djangoapps.user_api.legacy_urls')),
     url(r'^i18n/', include('django.conf.urls.i18n')),
 

--- a/common/djangoapps/course_modes/migrations/0010_archived_suggested_prices_to_charfield.py
+++ b/common/djangoapps/course_modes/migrations/0010_archived_suggested_prices_to_charfield.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import re
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_modes', '0009_suggested_prices_to_charfield'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='coursemodesarchive',
+            name='suggested_prices',
+            field=models.CharField(default=b'', max_length=255, blank=True, validators=[django.core.validators.RegexValidator(re.compile('^[\\d,]+\\Z'), 'Enter only digits separated by commas.', 'invalid')]),
+        ),
+    ]

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -810,7 +810,8 @@ class CourseModesArchive(models.Model):
     min_price = models.IntegerField(default=0)
 
     # the suggested prices for this mode
-    suggested_prices = models.CommaSeparatedIntegerField(max_length=255, blank=True, default='')
+    suggested_prices = models.CharField(max_length=255, blank=True, default='',
+                                        validators=[validate_comma_separated_integer_list])
 
     # the currency these prices are in, using lower case ISO currency codes
     currency = models.CharField(default="usd", max_length=8)

--- a/lms/djangoapps/edxnotes/urls.py
+++ b/lms/djangoapps/edxnotes/urls.py
@@ -7,8 +7,8 @@ from edxnotes import views
 
 # Additionally, we include login URLs for the browseable API.
 urlpatterns = [
-    url(r"^/$", views.edxnotes, name="edxnotes"),
-    url(r"^/notes/$", views.notes, name="notes"),
-    url(r"^/token/$", views.get_token, name="get_token"),
-    url(r"^/visibility/$", views.edxnotes_visibility, name="edxnotes_visibility"),
+    url(r"^$", views.edxnotes, name="edxnotes"),
+    url(r"^notes/$", views.notes, name="notes"),
+    url(r"^token/$", views.get_token, name="get_token"),
+    url(r"^visibility/$", views.edxnotes_visibility, name="edxnotes_visibility"),
 ]

--- a/lms/djangoapps/teams/urls.py
+++ b/lms/djangoapps/teams/urls.py
@@ -8,5 +8,5 @@ from django.contrib.auth.decorators import login_required
 from .views import TeamsDashboardView
 
 urlpatterns = [
-    url(r"^/$", login_required(TeamsDashboardView.as_view()), name="teams_dashboard")
+    url(r"^$", login_required(TeamsDashboardView.as_view()), name="teams_dashboard")
 ]

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -72,7 +72,7 @@ urlpatterns = [
     # Static template view endpoints like blog, faq, etc.
     url(r'', include('static_template_view.urls')),
 
-    url(r'^heartbeat$', include('openedx.core.djangoapps.heartbeat.urls')),
+    url(r'^heartbeat', include('openedx.core.djangoapps.heartbeat.urls')),
 
     # Note: these are older versions of the User API that will eventually be
     # subsumed by api/user listed below.
@@ -634,7 +634,7 @@ urlpatterns += [
 
     # Student Notes
     url(
-        r'^courses/{}/edxnotes'.format(
+        r'^courses/{}/edxnotes/'.format(
             settings.COURSE_ID_PATTERN,
         ),
         include('edxnotes.urls'),
@@ -686,7 +686,7 @@ if settings.FEATURES['ENABLE_TEAMS']:
             include('lms.djangoapps.teams.api_urls')
         ),
         url(
-            r'^courses/{}/teams'.format(
+            r'^courses/{}/teams/'.format(
                 settings.COURSE_ID_PATTERN,
             ),
             include('lms.djangoapps.teams.urls'),


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-1356

These changes remove these warnings seen when running `makemigrations` in Django 1.10:
```
?: (urls.W001) Your URL pattern '^heartbeat$' uses include with a regex ending with a '$'. Remove the dollar from the regex to avoid problems including URLs.
?: (urls.W002) Your URL pattern '^/$' [name='edxnotes'] has a regex beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
?: (urls.W002) Your URL pattern '^/$' [name='teams_dashboard'] has a regex beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
course_modes.CourseModesArchive.suggested_prices: (fields.W901) CommaSeparatedIntegerField has been deprecated. Support for it (except in historical migrations) will be removed in Django 2.0.
    HINT: Use CharField(validators=[validate_comma_separated_integer_list]) instead.
```
and also one error due to a urls.py file with no `urlpatterns` defined.