### PR TITLE
Learner-3399 fix for certificates

### DIFF
--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -658,7 +658,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         self.assertIn("We cannot find a certificate with this URL or ID number.", response.content)
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
-    def test_html_view_for_non_viewable_certificate(self):
+    def test_html_view_for_non_viewable_certificate_and_for_student_user(self):
         """
         Tests that Certificate HTML Web View returns "Cannot Find Certificate" if certificate is not viewable yet.
         """

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -350,7 +350,7 @@ def _get_user_certificate(request, user, course_key, course, preview_mode=None):
                 verify_uuid=unicode(uuid4().hex),
                 modified_date=modified_date
             )
-    else:
+    elif certificates_viewable_for_course(course):
         # certificate is being viewed by learner or public
         try:
             user_certificate = GeneratedCertificate.eligible_certificates.get(
@@ -514,13 +514,6 @@ def render_html_view(request, user_id, course_id):
             "%d. Specific error: %s"
         )
         log.info(error_str, course_id, user_id, str(exception))
-        return _render_invalid_certificate(course_id, platform_name, configuration)
-
-    if not certificates_viewable_for_course(course):
-        log.info(
-            "Invalid cert: Certificate for %s is not viewable yet.",
-            course_id,
-        )
         return _render_invalid_certificate(course_id, platform_name, configuration)
 
     # Kick the user back to the "Invalid" screen if the feature is disabled for the course


### PR DESCRIPTION
[LEARNER-3399](https://openedx.atlassian.net/browse/LEARNER-3399)

**Description:**
This is a follow up pr to issue created by https://github.com/edx/edx-platform/pull/16620.
Which disabled the certificate preview for staff users in studio.