### PR TITLE
Changed AlreadyRunningError to be able to throw unicode error message…

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -249,6 +249,10 @@ def view_alreadyrunningerror(request):  # pylint: disable=unused-argument
     "A dummy view that raises an AlreadyRunningError exception"
     raise AlreadyRunningError()
 
+@common_exceptions_400
+def view_alreadyrunningerror_unicode(request):  # pylint: disable=unused-argument
+    "A dummy view that raises an AlreadyRunningError exception"
+    raise AlreadyRunningError(u'Dummy unicode text ☺')
 
 @common_exceptions_400
 def view_queue_connection_error(request):  # pylint: disable=unused-argument
@@ -291,12 +295,18 @@ class TestCommonExceptions400(TestCase):
         resp = view_alreadyrunningerror(self.request)  # pylint: disable=assignment-from-no-return
         self.assertEqual(resp.status_code, 400)
         self.assertIn("Requested task is already running", resp.content)
+        resp_unicode = view_alreadyrunningerror_unicode(self.request)  # pylint: disable=assignment-from-no-return
+        self.assertEqual(resp_unicode.status_code, 400)
+        self.assertIn("Dummy unicode text ☺", resp_unicode.content)
 
     def test_alreadyrunningerror_ajax(self):
         self.request.is_ajax.return_value = True
         resp = view_alreadyrunningerror(self.request)  # pylint: disable=assignment-from-no-return
         self.assertEqual(resp.status_code, 400)
         self.assertIn("Requested task is already running", resp.content)
+        resp_unicode = view_alreadyrunningerror_unicode(self.request)  # pylint: disable=assignment-from-no-return
+        self.assertEqual(resp_unicode.status_code, 400)
+        self.assertIn("Dummy unicode text ☺", resp_unicode.content)
 
     @ddt.data(True, False)
     def test_queue_connection_error(self, is_ajax):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -150,7 +150,7 @@ def common_exceptions_400(func):
         except User.DoesNotExist:
             message = _('User does not exist.')
         except (AlreadyRunningError, QueueConnectionError) as err:
-            message = str(err)
+            message = unicode(err)
 
         if use_json:
             return JsonResponseBadRequest(message)


### PR DESCRIPTION
…, in case of accented characters resulted from language translation