### PR TITLE
Handle Unicode chars with AlreadyRunningError exception

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -252,6 +252,14 @@ def view_alreadyrunningerror(request):  # pylint: disable=unused-argument
 
 
 @common_exceptions_400
+def view_alreadyrunningerror_unicode(request):  # pylint: disable=unused-argument
+    """
+    A dummy view that raises an AlreadyRunningError exception with unicode message
+    """
+    raise AlreadyRunningError(u'Text with unicode chárácters')
+
+
+@common_exceptions_400
 def view_queue_connection_error(request):  # pylint: disable=unused-argument
     """
     A dummy view that raises a QueueConnectionError exception.
@@ -287,17 +295,19 @@ class TestCommonExceptions400(TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertIn("User does not exist", resp.content)
 
-    def test_alreadyrunningerror(self):
-        self.request.is_ajax.return_value = False
+    @ddt.data(True, False)
+    def test_alreadyrunningerror(self, is_ajax):
+        self.request.is_ajax.return_value = is_ajax
         resp = view_alreadyrunningerror(self.request)  # pylint: disable=assignment-from-no-return
         self.assertEqual(resp.status_code, 400)
         self.assertIn("Requested task is already running", resp.content)
 
-    def test_alreadyrunningerror_ajax(self):
-        self.request.is_ajax.return_value = True
-        resp = view_alreadyrunningerror(self.request)  # pylint: disable=assignment-from-no-return
+    @ddt.data(True, False)
+    def test_alreadyrunningerror_with_unicode(self, is_ajax):
+        self.request.is_ajax.return_value = is_ajax
+        resp = view_alreadyrunningerror_unicode(self.request)  # pylint: disable=assignment-from-no-return
         self.assertEqual(resp.status_code, 400)
-        self.assertIn("Requested task is already running", resp.content)
+        self.assertIn('Text with unicode chárácters', resp.content)
 
     @ddt.data(True, False)
     def test_queue_connection_error(self, is_ajax):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -150,7 +150,7 @@ def common_exceptions_400(func):
         except User.DoesNotExist:
             message = _('User does not exist.')
         except (AlreadyRunningError, QueueConnectionError) as err:
-            message = str(err)
+            message = unicode(err)
 
         if use_json:
             return JsonResponseBadRequest(message)


### PR DESCRIPTION
When `AlreadyRunningError` exception raises with a language other than English, the text might contain the Unicode characters. When we handle that exception we should expect the code to have Unicode.

[EDUCATOR-1730](https://openedx.atlassian.net/browse/EDUCATOR-1730)


## To Reproduce
1. Change account setting and set the language to Spanish
2. Open `Instructor Dashboard`  & try to create problem grade report (or any instructor task) by hitting the button twice to get `AlreadyRunningError`. 
3. Make sure there is **no** 500 error. 