### PR TITLE
PLAT-1382 Populate ALLOWED_HOSTS for tests

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -40,6 +40,15 @@ from lms.envs.test import (
     REGISTRATION_EXTRA_FIELDS,
 )
 
+# Add some host names used in assorted tests
+ALLOWED_HOSTS = [
+    'localhost',
+    'logistration.testserver',
+    '.testserver.fake',
+    'test-site.testserver',
+    'testserver.fakeother',
+]
+
 # mongo connection settings
 MONGO_PORT_NUM = int(os.environ.get('EDXAPP_TEST_MONGO_PORT', '27017'))
 MONGO_HOST = os.environ.get('EDXAPP_TEST_MONGO_HOST', 'localhost')

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -3,7 +3,6 @@ Tests for branding page
 """
 import datetime
 
-import pytest
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse
@@ -292,7 +291,6 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class IndexPageProgramsTests(SiteMixin, ModuleStoreTestCase):
     """
     Tests for Programs List in Marketing Pages.

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 
 import ddt
 import datetime
-import pytest
 from django.conf import settings
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
@@ -261,7 +260,6 @@ class MicrositeCertificatesViewsTests(ModuleStoreTestCase):
         self.store.update_item(self.course, self.user.id)
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
-    @pytest.mark.django111_expected_failure
     def test_html_view_for_microsite(self):
         test_configuration_string = """{
             "default": {
@@ -311,7 +309,6 @@ class MicrositeCertificatesViewsTests(ModuleStoreTestCase):
         self.assertIn('Microsite title', response.content)
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
-    @pytest.mark.django111_expected_failure
     def test_html_view_microsite_configuration_missing(self):
         test_configuration_string = """{
             "default": {

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 from urllib import urlencode
 from uuid import uuid4
 
-import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.client import Client, RequestFactory
@@ -243,7 +242,6 @@ class CommonCertificatesTestCase(ModuleStoreTestCase):
 
 @attr(shard=1)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class CertificatesViewsTests(CommonCertificatesTestCase):
     """
     Tests for the certificates web/html views

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -19,7 +19,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestSites(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     This is testing of the Site Configuration feature
@@ -136,6 +135,7 @@ class TestSites(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertNotContains(resp, 'This is a Test Site footer')
 
     @override_settings(SITE_NAME=settings.MICROSITE_TEST_HOSTNAME)
+    @pytest.mark.django111_expected_failure
     def test_site_homepage_course_max(self):
         """
         Verify that the number of courses displayed on the homepage honors

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -11,7 +11,6 @@ import shutil
 import tempfile
 
 import ddt
-import pytest
 from boto.exception import BotoServerError
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -3641,7 +3640,6 @@ class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginE
 
 @attr(shard=1)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
-@pytest.mark.django111_expected_failure
 class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Checks that only instructors have access to email endpoints, and that
@@ -4527,7 +4525,6 @@ class TestCourseIssuedCertificatesData(SharedModuleStoreTestCase):
 
 @attr(shard=1)
 @override_settings(REGISTRATION_CODE_LENGTH=8)
-@pytest.mark.django111_expected_failure
 class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
     """
     Test data dumps for E-commerce Course Registration Codes.

--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -4,7 +4,6 @@ Unit tests for Ecommerce feature flag in new instructor dashboard.
 
 import datetime
 
-import pytest
 import pytz
 from django.core.urlresolvers import reverse
 from nose.plugins.attrib import attr
@@ -19,7 +18,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
     """
     Check for E-commerce view on the new instructor dashboard

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -8,7 +8,6 @@ from decimal import Decimal
 from urlparse import urlparse
 
 import ddt
-import pytest
 import pytz
 from django.conf import settings
 from django.contrib.admin.sites import AdminSite
@@ -476,7 +475,6 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
         self.assertIn("Cart item quantity should not be greater than 1 when applying activation code", resp.content)
 
     @ddt.data(True, False)
-    @pytest.mark.django111_expected_failure
     def test_reg_code_uses_associated_mode(self, expired_mode):
         """Tests the use of reg codes on verified courses, expired or active. """
         course_key = self.course_key.to_deprecated_string()
@@ -489,7 +487,6 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
         self.assertIn(self.course.display_name.encode('utf-8'), resp.content)
 
     @ddt.data(True, False)
-    @pytest.mark.django111_expected_failure
     def test_reg_code_uses_unknown_mode(self, expired_mode):
         """Tests the use of reg codes on verified courses, expired or active. """
         course_key = self.course_key.to_deprecated_string()
@@ -1443,7 +1440,6 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
             }
         )
 
-    @pytest.mark.django111_expected_failure
     def test_shopping_cart_navigation_link_not_in_microsite(self):
         """
         Tests shopping cart link is available in navigation header if request is not from a microsite.
@@ -1478,7 +1474,6 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
             self.assertEqual(resp.status_code, 200)
             self.assertIn('<a class="shopping-cart"', resp.content)
 
-    @pytest.mark.django111_expected_failure
     def test_shopping_cart_navigation_link_in_microsite_courseware_page(self):
         """
         Tests shopping cart link is not available in navigation header if request is from a microsite

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -588,7 +588,6 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         self.assertEqual(enterprise_cookie.value, '')
 
     @override_settings(SITE_NAME=settings.MICROSITE_TEST_HOSTNAME)
-    @pytest.mark.django111_expected_failure
     def test_microsite_uses_old_login_page(self):
         # Retrieve the login page from a microsite domain
         # and verify that we're served the old page.
@@ -599,7 +598,6 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         self.assertContains(resp, "Log into your Test Site Account")
         self.assertContains(resp, "login-form")
 
-    @pytest.mark.django111_expected_failure
     def test_microsite_uses_old_register_page(self):
         # Retrieve the register page from a microsite domain
         # and verify that we're served the old page.

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -34,6 +34,15 @@ from util.testing import patch_testcase, patch_sessions
 patch_testcase()
 patch_sessions()
 
+# Add some host names used in assorted tests
+ALLOWED_HOSTS = [
+    'localhost',
+    'logistration.testserver',
+    '.testserver.fake',
+    'test-site.testserver',
+    'testserver.fakeother',
+]
+
 # Silence noisy logs to make troubleshooting easier when tests fail.
 import logging
 LOG_OVERRIDES = [

--- a/openedx/core/djangoapps/site_configuration/tests/factories.py
+++ b/openedx/core/djangoapps/site_configuration/tests/factories.py
@@ -16,7 +16,7 @@ class SiteFactory(DjangoModelFactory):
         model = Site
         django_get_or_create = ('domain',)
 
-    domain = Sequence('testserver.fake.{}'.format)
+    domain = Sequence('{}.testserver.fake'.format)
     name = SelfAttribute('domain')
 
 

--- a/openedx/core/djangoapps/theming/urls.py
+++ b/openedx/core/djangoapps/theming/urls.py
@@ -16,3 +16,5 @@ if is_comprehensive_theming_enabled():
             name='openedx.theming.update_theme_fragment_view',
         ),
     ]
+else:
+    urlpatterns = []


### PR DESCRIPTION
Django 1.11 stops skipping `ALLOWED_HOSTS` for test runs, so we now need to populate it with all the host names we make up for various tests.  Other minor tweaks I had to make:

* Renamed the generated "testserver.fake.{integer}" host names to "{integer}.testserver.fake" so they can all be caught by a subdomain entry in `ALLOWED_HOSTS`.
* Made sure that `urls.py` in the `theming` app always defines a `urlpatterns` variable (by 1.11, Django gets unhappy if you try to import patterns from a module that doesn't have any).