### PR TITLE
Remove zendesk access token from support view.

### DIFF
--- a/lms/djangoapps/support/views/contact_us.py
+++ b/lms/djangoapps/support/views/contact_us.py
@@ -19,7 +19,7 @@ class ContactUsView(View):
         context = {
             'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
             'zendesk_api_host': settings.ZENDESK_URL,
-            'access_token': settings.ZENDESK_OAUTH_ACCESS_TOKEN,
+            'access_token': 'DUMMY_ACCESS_TOKEN',  # LEARNER-3450
             'custom_fields': settings.ZENDESK_CUSTOM_FIELDS
         }
 


### PR DESCRIPTION
The zendesk oauth access token is being exposed to the frontend (and inspectors) by providing it to the template context, which [passes it to the form](https://github.com/edx/edx-platform/blob/master/lms/templates/support/contact_us.html#L37).

As part of [EDUCATOR-1793](https://openedx.atlassian.net/browse/EDUCATOR-1793), we need this access token both hidden and then rotated.

The intent of this PR is to *hide* the access token, and as we understand, there is ongoing work to revamp the logic of this form to use the proxy zendesk endpoint that @edx/educator-dahlia is building out.

@efischer19 @bderusha @tasawernawaz @feanil @fredsmith 