### PR TITLE
Changing error message to begin deprecation process.

### DIFF
--- a/common/static/js/vendor/ova/annotator-full.js
+++ b/common/static/js/vendor/ova/annotator-full.js
@@ -2504,9 +2504,8 @@ Annotator.Plugin.Store = (function(_super) {
   };
 
   Store.prototype._onError = function(xhr) {
-    var action, message;
-    action = xhr._action;
-    Annotator._t("Note: Your annotations will NOT be saved once you leave this page and will not be visible to anyone.");
+    var message;
+    message = Annotator._t("Note: Your annotations will NOT be saved once you leave this page and will not be visible to anyone.");
     Annotator.showNotification(message, Annotator.Notification.ERROR);
     return console.error(Annotator._t("API request failed:") + (" '" + xhr.status + "'"));
   };

--- a/common/static/js/vendor/ova/annotator-full.js
+++ b/common/static/js/vendor/ova/annotator-full.js
@@ -2506,22 +2506,7 @@ Annotator.Plugin.Store = (function(_super) {
   Store.prototype._onError = function(xhr) {
     var action, message;
     action = xhr._action;
-    message = Annotator._t("Sorry, our server seems to be down. We could not ") + action + Annotator._t(" this annotation");
-    if (xhr._action === 'search') {
-      message = Annotator._t("Sorry, the Annotations service is down. Contact your instructor and try again later.");
-    } else if (xhr._action === 'read' && !xhr._id) {
-      message = Annotator._t("Sorry, our server seems to be down. We could not ") + action + Annotator._t(" the annotation(s).");
-    }
-    switch (xhr.status) {
-      case 401:
-        message = Annotator._t("Sorry, you are not allowed to ") + action + Annotator._t(" this annotation");
-        break;
-      case 404:
-        message = Annotator._t("Sorry, we could not connect to the annotations database.");
-        break;
-      case 500:
-        message = Annotator._t("Sorry, our server is down. Contact your instructor and try again later.");
-    }
+    Annotator._t("Note: Your annotations will NOT be saved once you leave this page and will not be visible to anyone.");
     Annotator.showNotification(message, Annotator.Notification.ERROR);
     return console.error(Annotator._t("API request failed:") + (" '" + xhr.status + "'"));
   };


### PR DESCRIPTION
**Background:** We are beginning the process of deprecating the three versions of HarvardX's annotation tool xmodule (text, image, and video). In order to start preparing for this, we would like to reset the error message to a more definite (yet vague) message to say that the annotation will not be saved at all rather than contacting someone or trying again later.

**Studio Updates:** None.
**LMS Updates:** Message will now read "Note: Your annotations will NOT be saved once you leave this page and will not be visible to anyone."