### PR TITLE
PLAT-1418 Remove obsolete can_import_settings attribute

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/reindex_course.py
+++ b/cms/djangoapps/contentstore/management/commands/reindex_course.py
@@ -26,7 +26,6 @@ class Command(BaseCommand):
         ./manage.py reindex_course --setup - reindexes all courses for devstack setup
     """
     help = dedent(__doc__)
-    can_import_settings = True
     CONFIRMATION_PROMPT = u"Re-indexing all courses might be a time consuming operation. Do you want to continue?"
 
     def add_arguments(self, parser):

--- a/cms/djangoapps/contentstore/management/commands/reindex_library.py
+++ b/cms/djangoapps/contentstore/management/commands/reindex_library.py
@@ -22,7 +22,6 @@ class Command(BaseCommand):
         ./manage.py reindex_library --all - reindexes all available libraries
     """
     help = dedent(__doc__)
-    can_import_settings = True
     CONFIRMATION_PROMPT = u"Reindexing all libraries might be a time consuming operation. Do you want to continue?"
 
     def add_arguments(self, parser):


### PR DESCRIPTION
We only had 2 management commands declaring this attribute which is removed in Django 1.11, and it seems to have no effect even in 1.8.