### PR TITLE
Turn on deprecation warnings in Django 1.11

### DIFF
--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -41,6 +41,7 @@ class TestPaverBokChoyCmd(unittest.TestCase):
             "SELENIUM_DRIVER_LOG_DIR='{}/test_root/log{}'".format(REPO_DIR, shard_str),
             "VERIFY_XSS='{}'".format(verify_xss),
             "python",
+            "-Wd",
             "-m",
             "pytest",
             "{}/common/test/acceptance/{}".format(REPO_DIR, name),

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -341,7 +341,8 @@ class BokChoyTestSuite(TestSuite):
             cmd.append("--rcfile={}".format(self.coveragerc))
         else:
             cmd += [
-                "python"
+                "python",
+                "-Wd",
             ]
         cmd += [
             "-m",

--- a/pavelib/utils/test/suites/pytest_suite.py
+++ b/pavelib/utils/test/suites/pytest_suite.py
@@ -134,7 +134,7 @@ class SystemTestSuite(PytestSuite):
         if self.django_toxenv:
             cmd = ['tox', '-e', self.django_toxenv, '--']
         else:
-            cmd = ['pytest']
+            cmd = ['python', '-Wd', '-m', 'pytest']
         cmd.extend([
             '--ds={}'.format('{}.envs.{}'.format(self.root, self.settings)),
             "--junitxml={}".format(self.xunit_report),
@@ -223,7 +223,7 @@ class LibTestSuite(PytestSuite):
         if self.django_toxenv:
             cmd = ['tox', '-e', self.django_toxenv, '--']
         else:
-            cmd = ['pytest']
+            cmd = ['python', '-Wd', '-m', 'pytest']
         cmd.extend([
             "-p",
             "no:randomly",

--- a/tox.ini
+++ b/tox.ini
@@ -48,4 +48,4 @@ deps =
     -rrequirements/edx-sandbox/post.txt
 
 commands =
-    pytest {posargs}
+    python -Wd -m pytest {posargs}


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-1350

Invoke pytest with `python -Wd -m pytest` in order to turn deprecation warnings on even though they are off by default in Django 1.11.