### PR TITLE
PLAT-1427 Adapt to build_attrs change in Django 1.11

### DIFF
--- a/lms/djangoapps/course_wiki/editors.py
+++ b/lms/djangoapps/course_wiki/editors.py
@@ -1,3 +1,8 @@
+"""
+Support for using the CodeMirror code editor as a wiki content editor.
+"""
+
+import django
 from django import forms
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string
@@ -9,6 +14,9 @@ from wiki.editors.markitup import MarkItUpAdminWidget
 
 
 class CodeMirrorWidget(forms.Widget):
+    """
+    Use CodeMirror as a Django form widget (like a textarea).
+    """
     def __init__(self, attrs=None):
         # The 'rows' and 'cols' attributes are required for HTML correctness.
         default_attrs = {
@@ -25,7 +33,14 @@ class CodeMirrorWidget(forms.Widget):
         if value is None:
             value = ''
 
-        final_attrs = self.build_attrs(attrs, name=name)
+        # TODO: Remove Django 1.11 upgrade shim
+        # SHIM: Compensate for build_attrs() implementation change in 1.11
+        if django.VERSION < (1, 11):
+            final_attrs = self.build_attrs(attrs, name=name)
+        else:
+            extra_attrs = attrs.copy()
+            extra_attrs['name'] = name
+            final_attrs = self.build_attrs(self.attrs, extra_attrs=extra_attrs)  # pylint: disable=redundant-keyword-arg
 
         # TODO use the help_text field of edit form instead of rendering a template
 
@@ -36,6 +51,9 @@ class CodeMirrorWidget(forms.Widget):
 
 
 class CodeMirror(BaseEditor):
+    """
+    Wiki content editor using CodeMirror.
+    """
     editor_id = 'codemirror'
 
     def get_admin_widget(self, instance=None):

--- a/openedx/core/djangoapps/api_admin/widgets.py
+++ b/openedx/core/djangoapps/api_admin/widgets.py
@@ -1,5 +1,6 @@
 """ Form widget classes """
 
+import django
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.forms.utils import flatatt
@@ -15,7 +16,15 @@ class TermsOfServiceCheckboxInput(CheckboxInput):
     """ Renders a checkbox with a label linking to the terms of service. """
 
     def render(self, name, value, attrs=None):
-        final_attrs = self.build_attrs(attrs, type='checkbox', name=name)
+        # TODO: Remove Django 1.11 upgrade shim
+        # SHIM: Compensate for behavior change of default authentication backend in 1.10
+        if django.VERSION < (1, 11):
+            final_attrs = self.build_attrs(attrs, type='checkbox', name=name)
+        else:
+            extra_attrs = attrs.copy()
+            extra_attrs.update({'type': 'checkbox', 'name': name})
+            final_attrs = self.build_attrs(self.attrs, extra_attrs=extra_attrs)  # pylint: disable=redundant-keyword-arg
+
         if self.check_test(value):
             final_attrs['checked'] = 'checked'
         if not (value is True or value is False or value is None or value == ''):


### PR DESCRIPTION
This internal method changed in 1.11 to facilitate template-based widget rendering.  These changes make sure the same set of attributes is passed along regardless of which Django version we're using.  Only one of our dependencies (`django-filters`) was using `build_attrs()` directly, and it already has similar code to adapt to the change.