### PR TITLE
Bump studio-frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "^0.4.1",
     "@edx/paragon": "^0.2.0",
-    "@edx/studio-frontend": "^0.4.0",
+    "@edx/studio-frontend": "^0.5.0",
     "babel-core": "^6.23.0",
     "babel-loader": "^6.4.0",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
SFE is now at [0.5.0](https://www.npmjs.com/package/@edx/studio-frontend).

@edx/educator-dahlia 