### PR TITLE
Fix breadcrumb tooltips in IE

### DIFF
--- a/common/lib/xmodule/xmodule/css/sequence/display.scss
+++ b/common/lib/xmodule/xmodule/css/sequence/display.scss
@@ -117,6 +117,7 @@ $seq-nav-height: 50px;
         border-width: 1px;
         border-bottom-style: solid;
         box-sizing: border-box;
+        overflow: visible; // for tooltip - IE11 uses 'hidden' by default if width/height is specified
 
         .icon {
           display: block;


### PR DESCRIPTION
IE11 is not using 'overflow: visible' as the default overflow,
so set that manually. This allows our tooltips on the course nav
buttons to appear on hover or focus.

https://openedx.atlassian.net/browse/LEARNER-3125