### PR TITLE
Revert removing CREATE_SCHEDULE_WAFFLE_FLAG "Merge pull request #16728"

### DIFF
--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -15,12 +15,12 @@ from course_modes.tests.factories import CourseModeFactory
 from courseware.course_tools import VerifiedUpgradeTool
 from courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.schedules.config import CREATE_SCHEDULE_WAFFLE_FLAG
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-from openedx.core.djangoapps.schedules.tests.factories import ScheduleConfigFactory
 
 
 @attr(shard=3)
@@ -40,6 +40,7 @@ class VerifiedUpgradeToolTest(SharedModuleStoreTestCase):
         )
         cls.course_overview = CourseOverview.get_from_id(cls.course.id)
 
+    @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, True)
     def setUp(self):
         super(VerifiedUpgradeToolTest, self).setUp()
 
@@ -55,11 +56,6 @@ class VerifiedUpgradeToolTest(SharedModuleStoreTestCase):
         mock_get_current_site.return_value = SiteFactory.create()
 
         DynamicUpgradeDeadlineConfiguration.objects.create(enabled=True)
-
-        ScheduleConfigFactory.create(
-            site=mock_get_current_site.return_value,
-            create_schedules=True
-        )
 
         self.enrollment = CourseEnrollmentFactory(
             course_id=self.course.id,

--- a/openedx/core/djangoapps/schedules/config.py
+++ b/openedx/core/djangoapps/schedules/config.py
@@ -3,6 +3,12 @@ from openedx.core.djangoapps.waffle_utils import WaffleFlagNamespace, CourseWaff
 
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=u'schedules')
 
+CREATE_SCHEDULE_WAFFLE_FLAG = CourseWaffleFlag(
+    waffle_namespace=WAFFLE_FLAG_NAMESPACE,
+    flag_name=u'create_schedules_for_course',
+    flag_undefined_default=False
+)
+
 COURSE_UPDATE_WAFFLE_FLAG = CourseWaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
     flag_name=u'send_updates_for_course',

--- a/openedx/core/djangoapps/schedules/docs/README.rst
+++ b/openedx/core/djangoapps/schedules/docs/README.rst
@@ -250,6 +250,14 @@ and link it to the Site. Make sure to enable all of the settings:
 -  ``hold_back_ratio``: ratio of all new Course Enrollments that should
    NOT have a Schedule created.
 
+Roll-out Waffle Flag
+^^^^^^^^^^^^^^^^^^^^
+
+There is one roll-out related course waffle flag that we plan to delete
+called ``schedules.create_schedules_for_course``, which, if the
+``ScheduleConfig.create_schedules`` is disabled, will enable schedule
+creation on a per-course basis.
+
 Self-paced Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/openedx/core/djangoapps/schedules/signals.py
+++ b/openedx/core/djangoapps/schedules/signals.py
@@ -18,6 +18,7 @@ from openedx.core.djangoapps.schedules.content_highlights import course_has_high
 from openedx.core.djangoapps.signals.signals import COURSE_START_DATE_CHANGED
 from openedx.core.djangoapps.theming.helpers import get_current_site
 from student.models import CourseEnrollment
+from .config import CREATE_SCHEDULE_WAFFLE_FLAG
 from .models import Schedule, ScheduleConfig
 from .tasks import update_course_schedules
 
@@ -38,7 +39,10 @@ def create_schedule(sender, **kwargs):
 
     enrollment = kwargs['instance']
     schedule_config = ScheduleConfig.current(current_site)
-    if not schedule_config.create_schedules:
+    if (
+        not schedule_config.create_schedules
+        and not CREATE_SCHEDULE_WAFFLE_FLAG.is_enabled(enrollment.course_id)
+    ):
         log.debug('Schedules: Creation not enabled for this course or for this site')
         return
 

--- a/openedx/core/djangoapps/schedules/tests/test_signals.py
+++ b/openedx/core/djangoapps/schedules/tests/test_signals.py
@@ -7,6 +7,7 @@ from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
 from courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.schedules.models import ScheduleExperience
+from openedx.core.djangoapps.schedules.signals import CREATE_SCHEDULE_WAFFLE_FLAG
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -43,28 +44,40 @@ class CreateScheduleTests(SharedModuleStoreTestCase):
         with self.assertRaises(Schedule.DoesNotExist):
             enrollment.schedule
 
+    @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, True)
     def test_create_schedule(self, mock_get_current_site):
         site = SiteFactory.create()
         mock_get_current_site.return_value = site
         ScheduleConfigFactory.create(site=site)
         self.assert_schedule_created()
 
+    @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, True)
     def test_no_current_site(self, mock_get_current_site):
         mock_get_current_site.return_value = None
         self.assert_schedule_not_created()
 
-    def test_schedule_config_enabled(self, mock_get_current_site):
+    @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, True)
+    def test_schedule_config_disabled_waffle_enabled(self, mock_get_current_site):
+        site = SiteFactory.create()
+        mock_get_current_site.return_value = site
+        ScheduleConfigFactory.create(site=site, create_schedules=False)
+        self.assert_schedule_created()
+
+    @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, False)
+    def test_schedule_config_enabled_waffle_disabled(self, mock_get_current_site):
         site = SiteFactory.create()
         mock_get_current_site.return_value = site
         ScheduleConfigFactory.create(site=site, create_schedules=True)
         self.assert_schedule_created()
 
-    def test_schedule_config_disabled(self, mock_get_current_site):
+    @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, False)
+    def test_schedule_config_disabled_waffle_disabled(self, mock_get_current_site):
         site = SiteFactory.create()
         mock_get_current_site.return_value = site
         ScheduleConfigFactory.create(site=site, create_schedules=False)
         self.assert_schedule_not_created()
 
+    @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, True)
     def test_schedule_config_creation_enabled_instructor_paced(self, mock_get_current_site):
         site = SiteFactory.create()
         mock_get_current_site.return_value = site
@@ -74,14 +87,15 @@ class CreateScheduleTests(SharedModuleStoreTestCase):
         with self.assertRaises(Schedule.DoesNotExist):
             enrollment.schedule
 
+    @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, True)
     @patch('openedx.core.djangoapps.schedules.signals.course_has_highlights')
     def test_create_schedule_course_updates_experience(self, mock_course_has_highlights, mock_get_current_site):
         site = SiteFactory.create()
-        ScheduleConfigFactory.create(site=site, enabled=True, create_schedules=True)
         mock_course_has_highlights.return_value = True
         mock_get_current_site.return_value = site
         self.assert_schedule_created(experience_type=ScheduleExperience.EXPERIENCES.course_updates)
 
+    @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, True)
     @patch('analytics.track')
     @patch('random.random')
     @ddt.data(


### PR DESCRIPTION
We've decided to keep this waffle flag around a while longer - while we continue to popularize, develop and test the dynamic pacing features.

This reverts commit 8b652ad35263476e1198af3ffa46e07479134b45, reversing
changes made to b212af2488a154e7bd76e9e32779b31333984e4d.

FYI @edx/rapid-experiments-team 