### PR TITLE
PLAT-1749 Support Django 1.10+ CSRF tokens

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -442,7 +442,7 @@ MIDDLEWARE_CLASSES = [
     'openedx.core.djangoapps.header_control.middleware.HeaderControlMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    'birdcage.v1_11.csrf.CsrfViewMiddleware',
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
 
     # Instead of SessionMiddleware, we use a more secure version

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1268,7 +1268,7 @@ MIDDLEWARE_CLASSES = [
     'corsheaders.middleware.CorsMiddleware',
     'openedx.core.djangoapps.cors_csrf.middleware.CorsCSRFMiddleware',
     'openedx.core.djangoapps.cors_csrf.middleware.CsrfCrossDomainCookieMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    'birdcage.v1_11.csrf.CsrfViewMiddleware',
 
     'splash.middleware.SplashMiddleware',
 

--- a/lms/envs/load_test.py
+++ b/lms/envs/load_test.py
@@ -11,7 +11,7 @@ from .aws import *
 # Disable CSRF for load testing
 EXCLUDE_CSRF = lambda elem: elem not in [
     'django.template.context_processors.csrf',
-    'django.middleware.csrf.CsrfViewMiddleware'
+    'birdcage.v1_11.csrf.CsrfViewMiddleware'
 ]
 DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] = filter(
     EXCLUDE_CSRF, DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors']

--- a/openedx/core/djangoapps/cors_csrf/middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/middleware.py
@@ -46,7 +46,7 @@ import logging
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
-from django.middleware.csrf import CsrfViewMiddleware
+from birdcage.v1_11.csrf import CsrfViewMiddleware
 
 from .helpers import is_cross_domain_request_allowed, skip_cross_domain_referer_check
 

--- a/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.core.exceptions import MiddlewareNotUsed, ImproperlyConfigured
 from django.http import HttpResponse
-from django.middleware.csrf import CsrfViewMiddleware
+from birdcage.v1_11.csrf import CsrfViewMiddleware
 
 from ..middleware import CorsCSRFMiddleware, CsrfCrossDomainCookieMiddleware
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -17,6 +17,7 @@ dealer==2.0.4
 defusedxml==0.4.1
 django-babel-underscore==0.5.2
 markey==0.8  # From django-babel-underscore
+django-birdcage==1.0.0
 django-config-models==0.1.8
 django-countries==4.6.1
 django-filter==1.0.4


### PR DESCRIPTION
Integrate an external package (created by Russell Keith-Magee, a Django core developer) to support reading CSRF tokens created by Django 1.10+ even with earlier versions of Django.  This should help avoid problems during the upgrade to 1.11 where a user might have a request hit the old site after an earlier request hit the new one and upgraded the CSRF token.