### PR TITLE
Fix video transcript model import before Django initialization occurs.

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_transcripts.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcripts.py
@@ -526,7 +526,7 @@ class TestDownloadTranscripts(BaseTranscripts):
 
         self.assertEqual(resp.status_code, 404)
 
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
+    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
     def test_download_fallback_transcript(self, mock_get_video_transcript_data):
         """
@@ -567,7 +567,7 @@ class TestDownloadTranscripts(BaseTranscripts):
             self.assertEqual(response.get(attribute), value)
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
+        'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled',
         Mock(return_value=False),
     )
     def test_download_fallback_transcript_feature_disabled(self):
@@ -829,7 +829,7 @@ class TestCheckTranscripts(BaseTranscripts):
         (False, 'not_found')
     )
     @ddt.unpack
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled')
+    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled')
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data', Mock(return_value=True))
     def test_command_for_fallback_transcript(self, feature_enabled, expected_command, video_transcript_feature):
         """

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -33,12 +33,14 @@ from xmodule.video_module.transcripts_utils import (
     get_video_transcript_content,
     generate_subs_from_source,
     get_transcripts_from_youtube,
-    is_val_transcript_feature_enabled_for_course,
     manage_video_subtitles_save,
     remove_subs_from_store,
     Transcript,
     TranscriptsRequestValidationException,
     youtube_video_transcript_name,
+)
+from xmodule.video_module.transcripts_model_utils import (
+    is_val_transcript_feature_enabled_for_course
 )
 
 __all__ = [

--- a/common/lib/xmodule/xmodule/video_module/__init__.py
+++ b/common/lib/xmodule/xmodule/video_module/__init__.py
@@ -1,8 +1,7 @@
 """
-Container for video module and it's utils.
+Container for video module and its utils.
 """
 
-# Disable wildcard-import warnings.
 # pylint: disable=wildcard-import
 
 from .transcripts_utils import *

--- a/common/lib/xmodule/xmodule/video_module/transcripts_model_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_model_utils.py
@@ -1,0 +1,14 @@
+"""
+Utility functions for transcripts dealing with Django models.
+"""
+from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
+
+
+def is_val_transcript_feature_enabled_for_course(course_id):
+    """
+    Get edx-val transcript feature flag
+
+    Arguments:
+        course_id(CourseKey): Course key identifying a course whose feature flag is being inspected.
+    """
+    return VideoTranscriptEnabledFlag.feature_enabled(course_id=course_id)

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -12,7 +12,6 @@ from pysrt import SubRipTime, SubRipItem, SubRipFile
 from lxml import etree
 from HTMLParser import HTMLParser
 
-from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
 from xmodule.exceptions import NotFoundError
 from xmodule.contentstore.content import StaticContent
 from xmodule.contentstore.django import contentstore
@@ -498,16 +497,6 @@ def get_video_ids_info(edx_video_id, youtube_id_1_0, html5_sources):
     video_ids = filter(lambda item: bool(clean(item)), video_ids)
 
     return external, video_ids
-
-
-def is_val_transcript_feature_enabled_for_course(course_id):
-    """
-    Get edx-val transcript feature flag
-
-    Arguments:
-        course_id(CourseKey): Course key identifying a course whose feature flag is being inspected.
-    """
-    return VideoTranscriptEnabledFlag.feature_enabled(course_id=course_id)
 
 
 def get_video_transcript_content(language_code, edx_video_id, youtube_id_1_0, html5_sources):

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -22,7 +22,6 @@ from .transcripts_utils import (
     get_or_create_sjson,
     generate_sjson_for_all_speeds,
     get_video_transcript_content,
-    is_val_transcript_feature_enabled_for_course,
     save_to_store,
     subs_filename,
     Transcript,
@@ -30,7 +29,9 @@ from .transcripts_utils import (
     TranscriptsGenerationException,
     youtube_speed_dict,
 )
-
+from .transcripts_model_utils import (
+    is_val_transcript_feature_enabled_for_course
+)
 
 log = logging.getLogger(__name__)
 

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -44,9 +44,11 @@ from .bumper_utils import bumperize
 from .transcripts_utils import (
     get_html5_ids,
     get_video_ids_info,
-    is_val_transcript_feature_enabled_for_course,
     Transcript,
     VideoTranscriptsMixin,
+)
+from .transcripts_model_utils import (
+    is_val_transcript_feature_enabled_for_course
 )
 from .video_handlers import VideoStudentViewHandlers, VideoStudioViewHandlers
 from .video_utils import create_youtube_string, format_xml_exception_message, get_poster, rewrite_video_url

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -248,7 +248,7 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):
         response = self.item.transcript(request=request, dispatch='available_translations')
         self.assertEqual(json.loads(response.body), ['en', 'uk'])
 
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
+    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
     @patch('xmodule.video_module.transcripts_utils.get_available_transcript_languages')
     @ddt.data(
         (
@@ -309,7 +309,7 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):
         self.assertItemsEqual(json.loads(response.body), result)
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
+        'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled',
         Mock(return_value=False),
     )
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages')
@@ -365,7 +365,7 @@ class TestTranscriptAvailableTranslationsBumperDispatch(TestVideo):
 
     @ddt.data(True, False)
     @patch('xmodule.video_module.transcripts_utils.get_available_transcript_languages')
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled')
+    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled')
     def test_multiple_available_translations(self, feature_enabled,
                                              mock_val_video_transcript_feature, mock_get_transcript_languages):
         """
@@ -459,7 +459,7 @@ class TestTranscriptDownloadDispatch(TestVideo):
         self.assertEqual(response.headers['Content-Disposition'], 'attachment; filename="塞.srt"')
 
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
+    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
     @patch('xmodule.video_module.VideoModule.get_transcript', Mock(side_effect=NotFoundError))
     def test_download_fallback_transcript(self, mock_get_video_transcript_data):
         """
@@ -493,7 +493,7 @@ class TestTranscriptDownloadDispatch(TestVideo):
             self.assertEqual(response.headers[attribute], value)
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
+        'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled',
         Mock(return_value=False),
     )
     @patch('xmodule.video_module.VideoModule.get_transcript', Mock(side_effect=NotFoundError))
@@ -740,7 +740,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
             store.update_item(self.course, self.user.id)
 
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
+    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
     @patch('xmodule.video_module.VideoModule.translation', Mock(side_effect=NotFoundError))
     @patch('xmodule.video_module.VideoModule.get_static_transcript', Mock(return_value=Response(status=404)))
     def test_translation_fallback_transcript(self, mock_get_video_transcript_data):
@@ -774,7 +774,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
             self.assertEqual(response.headers[attribute], value)
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
+        'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled',
         Mock(return_value=False),
     )
     @patch('xmodule.video_module.VideoModule.translation', Mock(side_effect=NotFoundError))
@@ -790,7 +790,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
 
     @ddt.data(True, False)
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_video_transcript_data')
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled')
+    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled')
     def test_translations_bumper_transcript(self, feature_enabled,
                                             mock_val_video_transcript_feature, mock_get_video_transcript_data):
         """

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1467,7 +1467,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
         ({'uk': 1, 'de': 1}, 'en-subs', ['de', 'en'], ['en', 'uk', 'de']),
     )
     @ddt.unpack
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
+    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages')
     def test_student_view_with_val_transcripts_enabled(self, transcripts, english_sub, val_transcripts,
                                                        expected_transcripts, mock_get_transcript_languages):
@@ -1481,7 +1481,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
         self.assertItemsEqual(student_view_response['transcripts'].keys(), expected_transcripts)
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
+        'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled',
         Mock(return_value=False),
     )
     @patch(

--- a/lms/djangoapps/mobile_api/video_outlines/serializers.py
+++ b/lms/djangoapps/mobile_api/video_outlines/serializers.py
@@ -11,7 +11,7 @@ from courseware.module_render import get_module_for_descriptor
 from util.module_utils import get_dynamic_descriptor_children
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.mongo.base import BLOCK_TYPES_WITH_CHILDREN
-from xmodule.video_module.transcripts_utils import is_val_transcript_feature_enabled_for_course
+from xmodule.video_module.transcripts_model_utils import is_val_transcript_feature_enabled_for_course
 
 
 class BlockOutline(object):

--- a/lms/djangoapps/mobile_api/video_outlines/tests.py
+++ b/lms/djangoapps/mobile_api/video_outlines/tests.py
@@ -887,7 +887,7 @@ class TestVideoSummaryList(TestVideoAPITestCase, MobileAuthTestMixin, MobileCour
         ({'uk': 1, 'de': 1}, 'en-subs', ['de', 'en'], ['en', 'uk', 'de']),
     )
     @ddt.unpack
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
+    @patch('openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled', Mock(return_value=True))
     @patch('xmodule.video_module.transcripts_utils.edxval_api.get_available_transcript_languages')
     def test_val_transcripts_with_feature_enabled(self, transcripts, english_sub, val_transcripts,
                                                   expected_transcripts, mock_get_transcript_languages):
@@ -939,7 +939,7 @@ class TestTranscriptsDetail(TestVideoAPITestCase, MobileAuthTestMixin, MobileCou
         self.api_response(expected_response_code=200, lang='en')
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
+        'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled',
         Mock(return_value=True),
     )
     @patch(
@@ -976,7 +976,7 @@ class TestTranscriptsDetail(TestVideoAPITestCase, MobileAuthTestMixin, MobileCou
             self.assertEqual(response.get(attribute), value)
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptEnabledFlag.feature_enabled',
+        'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled',
         Mock(return_value=False),
     )
     @patch(

--- a/lms/djangoapps/mobile_api/video_outlines/views.py
+++ b/lms/djangoapps/mobile_api/video_outlines/views.py
@@ -19,8 +19,10 @@ from xmodule.exceptions import NotFoundError
 from xmodule.modulestore.django import modulestore
 from xmodule.video_module.transcripts_utils import (
     get_video_transcript_content,
-    is_val_transcript_feature_enabled_for_course,
     Transcript,
+)
+from xmodule.video_module.transcripts_model_utils import (
+    is_val_transcript_feature_enabled_for_course
 )
 
 from ..decorators import mobile_course_access, mobile_view


### PR DESCRIPTION
Fixes a model import error pre-Django-initialization that's preventing several XBlocks from loading in the Django 1.9+ tests. No ticket for this currently.