### PR TITLE
Allow to pay for a finished course according to a parameter

### DIFF
--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -265,10 +265,11 @@ class PayAndVerifyView(View):
         #   let someone upgrade into a verified track if they can't complete verification?
         #
         verification_deadline = VerificationDeadline.deadline_for_course(course.id)
-        response = self._response_if_deadline_passed(course, self.VERIFICATION_DEADLINE, verification_deadline)
-        if response is not None:
-            log.info(u"Verification deadline for '%s' has passed.", course.id)
-            return response
+        if not settings.FEATURES.get('IGNORE_VERIFICATION_DEADLINE_FOR_PAY', False):
+            response = self._response_if_deadline_passed(course, self.VERIFICATION_DEADLINE, verification_deadline)
+            if response is not None:
+                log.info(u"Verification deadline for '%s' has passed.", course.id)
+                return response
 
         # Retrieve the relevant course mode for the payment/verification flow.
         #

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -392,6 +392,9 @@ FEATURES = {
 
     # Whether to display the account deletion section the account settings page
     'ENABLE_ACCOUNT_DELETION': True,
+
+    # Ignore verification deadline for paying for course
+    'IGNORE_VERIFICATION_DEADLINE_FOR_PAY': False,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews


### PR DESCRIPTION
This feature allows to pay for a finished course according to parameter `IGNORE_VERIFICATION_DEADLINE_FOR_PAY`. Default value of this parameter is `False`, so students are not allow to pay for a finished course. That means, we keep the default behaviour of the platform. If we change this value to `True`, the student will be able to pay for a finished course.