### PR TITLE
LEARNER-3469 - More registration form cleanup.

### DIFF
--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -213,7 +213,8 @@
                                     isCheckbox = $input.attr('class').indexOf('checkbox') !== -1;
 
                                 if (!isCheckbox) {
-                                    if ($input.val().length === 0 && !$input.is(':-webkit-autofill')) {
+                                    if ($input.find(inputSelectors).val().length === 0
+                                        && !$input.is(':-webkit-autofill')) {
                                         $input.find('label').addClass('focus-out')
                                             .removeClass('focus-in');
                                     } else {
@@ -235,12 +236,14 @@
                     // is a required checkbox field and the optional fields toggle is a cosmetic
                     // improvement so that we don't have to show all the optional fields.
                     // xss-lint: disable=javascript-jquery-insert-into-target
-                    $('.checkbox-optional_fields_toggle').insertBefore('.optional-fields');
+                    $('.checkbox-optional_fields_toggle').insertAfter('.required-fields');
                     if (!this.hasOptionalFields) {
                         $('.checkbox-optional_fields_toggle').addClass('hidden');
                     }
                     // xss-lint: disable=javascript-jquery-insert-into-target
                     $('.checkbox-honor_code').insertAfter('.optional-fields');
+                    // xss-lint: disable=javascript-jquery-insert-into-target
+                    $('.checkbox-terms_of_service').insertAfter('.optional-fields');
 
                     // Clicking on links inside a label should open that link.
                     $('label a').click(function(ev) {

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -42,6 +42,8 @@
                     <span class="text"><%- gettext("or create a new one here") %></span>
                 </h3>
             </div>
+        <% } else { %>
+            <h2><%- gettext('Create an Account')%></h2>
         <% } %>
     <% } else if (context.autoRegisterWelcomeMessage) { %>
         <span class="auto-register-message"><%- context.autoRegisterWelcomeMessage %></span>

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -786,13 +786,14 @@ class RegistrationFormFactory(object):
         # in order to register a new account.
         terms_label = _(u"Terms of Service")
         terms_link = marketing_link("TOS")
-        terms_text = _(u"Review the Terms of Service")
 
         # Translators: "Terms of service" is a legal document users must agree to
         # in order to register a new account.
-        label = _(u"I agree to the {platform_name} {terms_of_service}").format(
+        label = Text(_(u"I agree to the {platform_name} {tos_link_start}{terms_of_service}{tos_link_end}")).format(
             platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
-            terms_of_service=terms_label
+            terms_of_service=terms_label,
+            tos_link_start=HTML("<a href='{terms_link}' target='_blank'>").format(terms_link=terms_link),
+            tos_link_end=HTML("</a>"),
         )
 
         # Translators: "Terms of service" is a legal document users must agree to
@@ -811,8 +812,6 @@ class RegistrationFormFactory(object):
             error_messages={
                 "required": error_msg
             },
-            supplementalLink=terms_link,
-            supplementalText=terms_text
         )
 
     def _apply_third_party_auth_overrides(self, request, form_desc):

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1593,12 +1593,13 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
 
         # Terms of service field should also be present
         link_label = "Terms of Service"
+        link_template = "<a href='https://www.test.com/tos' target='_blank'>{link_label}</a>"
         self._assert_reg_field(
             {"honor_code": "required", "terms_of_service": "required"},
             {
                 "label": u"I agree to the {platform_name} {link_label}".format(
                     platform_name=settings.PLATFORM_NAME,
-                    link_label=link_label
+                    link_label=link_template.format(link_label=link_label)
                 ),
                 "name": "terms_of_service",
                 "defaultValue": False,
@@ -1640,12 +1641,13 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
 
         link_label = 'Terms of Service'
         # Terms of service field should also be present
+        link_template = "<a href='/tos' target='_blank'>{link_label}</a>"
         self._assert_reg_field(
             {"honor_code": "required", "terms_of_service": "required"},
             {
                 "label": u"I agree to the {platform_name} {link_label}".format(
                     platform_name=settings.PLATFORM_NAME,
-                    link_label=link_label
+                    link_label=link_template.format(link_label=link_label)
                 ),
                 "name": "terms_of_service",
                 "defaultValue": False,


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-3469

Sandbox: https://dianakhuang.sandbox.edx.org/register

1. Added the 'Create an Account' title when the 3rd party auth header isn't shown
2. Modified the terms of service link to behave like the honor code link
3. Ensured that both the TOS checkbox and the Honor Code checkbox are below the optional fields toggle.