### PR TITLE
Remove added reqs that are already in base.txt.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,6 @@ edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
 edx-enterprise==0.55.4
 edx-oauth2-provider==1.2.2
-edx-opaque-keys==0.4.0
 edx-organizations==0.4.9
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
@@ -95,7 +94,6 @@ social-auth-core==1.4.0
 pytz==2016.7
 pysrt==0.4.7
 PyYAML==3.12
-requests==2.9.1
 requests-oauthlib==0.4.1
 rules==1.1.1
 scipy==0.14.0
@@ -113,7 +111,6 @@ unicodecsv==0.14.1
 django-require==1.0.11
 django-webpack-loader==0.4.1
 pyuca==1.1
-wrapt==1.10.5
 zendesk==1.1.1
 
 # lxml is also in requirements/edx-sandbox/post.txt
@@ -160,7 +157,6 @@ django_nose==1.4.1
 factory_boy==2.8.1
 flaky==3.3.0
 freezegun==0.3.8
-mock==1.0.1
 moto==0.3.1
 needle==0.5.0
 nose==1.3.7
@@ -210,3 +206,5 @@ XBlock==1.1.1
 
 # Redis version
 redis==2.10.6
+
+-r base_common.txt

--- a/requirements/edx/base_common.txt
+++ b/requirements/edx/base_common.txt
@@ -1,0 +1,12 @@
+# These requirements are needed by both paver.txt and base.txt currently.
+# When tox builds an environment with multiple requirements files and finds
+# the same package listed multiple times, it'll fail to build the tox environment.
+# Using a common base requirements file and '-r' including it in other files
+# works around the tox issue.
+#
+# We plan to move edx-platform to use pip-tools soon and each target will have its
+# own requirements files built, which will remove the need for this file.
+wrapt==1.10.5
+edx-opaque-keys==0.4.0
+requests==2.9.1
+mock==1.0.1

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -1,8 +1,5 @@
 # Requirements to run and test Paver
 Paver==1.2.4
 libsass==0.10.0
-wrapt==1.10.5
 markupsafe
-edx-opaque-keys
-requests
-mock
+-r base_common.txt


### PR DESCRIPTION
@cpennington These reqs were added here: https://github.com/edx/edx-platform/pull/14674

But they are causing tox virtual environment-building to fail due to double requirements, which tox doesn't allow:
```
15:07:46 py27-django111 installdeps: Django>=1.11,<2, -rrequirements/edx/pre.txt, -rrequirements/edx/github.txt, -rrequirements/edx/local.txt, -rrequirements/edx/base.txt, -rrequirements/edx/development.txt, -rrequirements/edx/paver.txt, -rrequirements/edx/testing.txt, -rrequirements/edx/post.txt, -rrequirements/edx/edx-private.txt, -rrequirements/edx-sandbox/base.txt, -rrequirements/edx-sandbox/local.txt, -rrequirements/edx-sandbox/post.txt
15:07:46 ERROR: invocation failed (exit code 1), logfile: /home/jenkins/edxapp_toxenv/py27-django111/log/py27-django111-1.log
15:07:46 ERROR: actionid: py27-django111
15:07:46 msg: getenv
15:07:46 cmdargs: ['/home/jenkins/edxapp_toxenv/py27-django111/bin/pip', 'install', 'Django>=1.11,<2', '-rrequirements/edx/pre.txt', '-rrequirements/edx/github.txt', '-rrequirements/edx/local.txt', '-rrequirements/edx/base.txt', '-rrequirements/edx/development.txt', '-rrequirements/edx/paver.txt', '-rrequirements/edx/testing.txt', '-rrequirements/edx/post.txt', '-rrequirements/edx/edx-private.txt', '-rrequirements/edx-sandbox/base.txt', '-rrequirements/edx-sandbox/local.txt', '-rrequirements/edx-sandbox/post.txt']
15:07:46 
15:07:46 Double requirement given: edx-opaque-keys (from -r requirements/edx/paver.txt (line 6)) (already in edx-opaque-keys==0.4.0 (from -r requirements/edx/base.txt (line 55)), name='edx-opaque-keys')
15:07:46 
15:07:46 ERROR: could not install deps [Django>=1.11,<2, -rrequirements/edx/pre.txt, -rrequirements/edx/github.txt, -rrequirements/edx/local.txt, -rrequirements/edx/base.txt, -rrequirements/edx/development.txt, -rrequirements/edx/paver.txt, -rrequirements/edx/testing.txt, -rrequirements/edx/post.txt, -rrequirements/edx/edx-private.txt, -rrequirements/edx-sandbox/base.txt, -rrequirements/edx-sandbox/local.txt, -rrequirements/edx-sandbox/post.txt]; v = InvocationError('/home/jenkins/edxapp_toxenv/py27-django111/bin/pip install Django>=1.11,<2 -rrequirements/edx/pre.txt -rrequirements/edx/github.txt -rrequirements/edx/local.txt -rrequirements/edx/base.txt -rrequirements/edx/development.txt -rrequirements/edx/paver.txt -rrequirements/edx/testing.txt -rrequirements/edx/post.txt -rrequirements/edx/edx-private.txt -rrequirements/edx-sandbox/base.txt -rrequirements/edx-sandbox/local.txt -rrequirements/edx-sandbox/post.txt (see /home/jenkins/edxapp_toxenv/py27-django111/log/py27-django111-1.log)', 1)
```
This PR removes all requirements from paver.txt that are already defined in base.txt.