### PR TITLE
show programs in which user holds a course entitlement on program listing page

### DIFF
--- a/common/djangoapps/entitlements/models.py
+++ b/common/djangoapps/entitlements/models.py
@@ -219,3 +219,7 @@ class CourseEntitlement(TimeStampedModel):
         Fulfills an entitlement by specifying a session.
         """
         cls.objects.filter(id=entitlement.id).update(enrollment_course_run=enrollment)
+
+    @classmethod
+    def unexpired_entitlements_for_user(cls, user):
+        return cls.objects.filter(user=user, expired_at=None).select_related('user')

--- a/common/djangoapps/entitlements/tests/factories.py
+++ b/common/djangoapps/entitlements/tests/factories.py
@@ -27,6 +27,7 @@ class CourseEntitlementFactory(factory.django.DjangoModelFactory):
 
     uuid = factory.LazyFunction(uuid4)
     course_uuid = factory.LazyFunction(uuid4)
+    expired_at = None
     mode = FuzzyChoice([CourseMode.VERIFIED, CourseMode.PROFESSIONAL])
     user = factory.SubFactory(UserFactory)
     order_number = FuzzyText(prefix='TEXTX', chars=string.digits)


### PR DESCRIPTION
Include programs in which a user holds an entitlement for one or more course in the 'engaged programs' for that user, thus including them in those displayed on the learner dashboard programs listing page.

[LEARNER-3493](https://openedx.atlassian.net/browse/LEARNER-3493)