### PR TITLE
Reduce size of the commons.js bundle.

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -76,7 +76,7 @@ module.exports = {
             // common/djangoapps/pipeline_mako/templates/static_content.html
             name: 'commons',
             filename: 'commons.js',
-            minChunks: 2
+            minChunks: 3
         })
     ],
 


### PR DESCRIPTION
Increase the number of bundles that a chunk has to appear in to be put
into the commons.js bundle. This drastically reduces the size of the
commons.js bundle (used basically everywhere on LMS and Studio) from
953K to 188K, mostly at the cost of making AccessibilityPage and
AssetsPage (both Studio-only) larger -- 345K -> 1.1M, 91K -> 865K.

All figures are uncompressed.