### PR TITLE
Show related programs when unenrolled

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -163,7 +163,7 @@ from student.models import CourseEnrollment
                 is_course_blocked = (session_id in block_courses)
                 course_verification_status = verification_status_by_course.get(session_id, {})
                 course_requirements = courses_requirements_not_met.get(session_id)
-                related_programs = inverted_programs.get(unicode(session_id))
+                related_programs = inverted_programs.get(unicode(entitlement.course_uuid if entitlement else session_id))
                 show_consent_link = (session_id in consent_required_courses)
                 course_overview = enrollment.course_overview
               %>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -299,7 +299,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
         </%static:require_module>
       %endif
 
-      % if related_programs and not entitlement:
+      % if related_programs:
       <div class="message message-related-programs is-shown">
         <span class="related-programs-preface" tabindex="0">${_('Related Programs')}:</span>
         <ul>


### PR DESCRIPTION
On the course dashboard, show related programs to your course
even if you are not enrolled in a current session.

https://openedx.atlassian.net/browse/LEARNER-3504

Note that there is a related-but-separate issue that you may hit when testing:
https://openedx.atlassian.net/browse/LEARNER-3523