### PR TITLE
Bump READ_VERSION of BlockCompletionTransformer to 1.

### DIFF
--- a/lms/djangoapps/course_api/blocks/transformers/block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/block_completion.py
@@ -12,7 +12,7 @@ class BlockCompletionTransformer(BlockStructureTransformer):
     """
     Keep track of the completion of each block within the block structure.
     """
-    READ_VERSION = 0
+    READ_VERSION = 1
     WRITE_VERSION = 1
     COMPLETION = 'completion'
 


### PR DESCRIPTION
This PR bumps READ_VERSION of BlockCompletionTransformer introduced in #16674 to 1.

It should be merged only after #16674 is merged and the following info appears on the #16674:
`EdX Release Notice: This PR has been deployed to the production environment.`

Rebased from d4f7032b5d74fb284bd60f8b693c101884cdadc9 onto master.