### PR TITLE
Fix optional registration fields toggle.

### DIFF
--- a/lms/static/js/spec/student_account/register_spec.js
+++ b/lms/static/js/spec/student_account/register_spec.js
@@ -213,7 +213,12 @@
                             }
                         ]
                     };
-                var createRegisterView = function(that) {
+                var createRegisterView = function(that, formFields) {
+                    var fields = formFields;
+                    if (typeof fields === 'undefined') {
+                        fields = FORM_DESCRIPTION.fields;
+                    }
+
                 // Initialize the register model
                     model = new RegisterModel({}, {
                         url: FORM_DESCRIPTION.submit_url,
@@ -222,7 +227,7 @@
 
                 // Initialize the register view
                     view = new RegisterView({
-                        fields: FORM_DESCRIPTION.fields,
+                        fields: fields,
                         model: model,
                         thirdPartyAuth: THIRD_PARTY_AUTH,
                         platformName: PLATFORM_NAME
@@ -536,6 +541,27 @@
 
                 // The iframe has been deleted
                     expect($content.find('iframe').length).toEqual(0);
+                });
+
+                it('displays optional fields toggle', function() {
+                    createRegisterView(this);
+                    expect(view.$('.checkbox-optional_fields_toggle')).toBeVisible();
+                });
+
+                it('hides optional fields toggle when there are no visible optional fields', function() {
+                    createRegisterView(this, [
+                        {
+                            placeholder: '',
+                            name: 'hidden_optional',
+                            label: 'Hidden Optional',
+                            defaultValue: '',
+                            type: 'hidden',
+                            required: false,
+                            instructions: 'Used for testing hidden input fields that are optional.',
+                            restrictions: {}
+                        }
+                    ]);
+                    expect(view.$('.checkbox-optional_fields_toggle')).toHaveClass('hidden');
                 });
             });
         });

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -94,26 +94,34 @@
                 buildForm: function(data) {
                     var html = [],
                         i,
+                        field,
                         len = data.length,
                         requiredFields = [],
                         optionalFields = [];
 
                     this.fields = data;
 
+                    this.hasOptionalFields = false;
                     for (i = 0; i < len; i++) {
-                        if (data[i].errorMessages) {
+                        field = data[i];
+                        if (field.errorMessages) {
                             // eslint-disable-next-line no-param-reassign
-                            data[i].errorMessages = this.escapeStrings(data[i].errorMessages);
+                            field.errorMessages = this.escapeStrings(field.errorMessages);
                         }
 
-                        if (data[i].required) {
-                            requiredFields.push(data[i]);
+                        if (field.required) {
+                            requiredFields.push(field);
                         } else {
-                            optionalFields.push(data[i]);
+                            if (field.type !== 'hidden') {
+                                // For the purporse of displaying the optional field toggle,
+                                // the form should be considered to have optional fields
+                                // only if all of the optional fields are being rendering as
+                                // input elements that are visible on the page.
+                                this.hasOptionalFields = true;
+                            }
+                            optionalFields.push(field);
                         }
                     }
-
-                    this.hasOptionalFields = optionalFields.length > 0;
 
                     html = this.renderFields(requiredFields, 'required-fields');
 


### PR DESCRIPTION
We need to account for optional fields that may get rendered
as hidden input elements due to the configuration of the
registration form when deciding whether or not to display
the optional registration fields toggle checkbox.

Under certain SSO configuration conditions, optional fields may get rendered as hidden input elements (because we want to streamline the registration process as much as possible for certain onboarding workflows). These fields need to be rendered as hidden inputs because they may have been populated with values provided by the SSO IdP.

**Testing Instructions**
1. Visit https://business.sandbox.edx.org/enterprise/2b5a2956-7746-4fc9-9587-bc887ba45973/course/course-v1:edX+DemoX+Demo_Course/enroll/?catalog=cff09318-1358-4703-a277-bc2596480ed5&utm_medium=enterprise&utm_source=pied-piper.
2. Login with testshib.
3. Verify that the "Support education research by providing additional information" checkbox is not displayed on the registration form.