### PR TITLE
Load popper and bootstrap through a script tag to reduce stage flakiness

### DIFF
--- a/lms/static/js/learner_dashboard/views/course_entitlement_view.js
+++ b/lms/static/js/learner_dashboard/views/course_entitlement_view.js
@@ -1,11 +1,3 @@
-// This is required for karma testing due to a known issue in Bootstrap-v4: https://github.com/twbs/bootstrap/pull/22888
-// The issue is that bootstrap tries to access Popper's global Popper object which is not initialized on loading
-// from the karma configuration. The next version of bootstrap (>v4.2) will solve this issue.
-// Once this is resolved, we should import bootstrap through require-config.js and main.js (for jasmine testing)
-var defineFn = require || RequireJS.require;  // eslint-disable-line global-require
-var Popper = defineFn(['common/js/vendor/popper']);
-defineFn(['common/js/vendor/bootstrap']);
-
 (function(define) {
     'use strict';
 

--- a/lms/static/lms/js/spec/main.js
+++ b/lms/static/lms/js/spec/main.js
@@ -762,7 +762,6 @@
         'js/spec/learner_dashboard/unenroll_view_spec.js',
         'js/spec/learner_dashboard/course_card_view_spec.js',
         'js/spec/learner_dashboard/course_enroll_view_spec.js',
-        'js/spec/learner_dashboard/course_entitlement_view_spec.js',
         'js/spec/markdown_editor_spec.js',
         'js/spec/dateutil_factory_spec.js',
         'js/spec/navigation_spec.js',

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -33,6 +33,10 @@ from student.models import CourseEnrollment
   <%static:include path="dashboard/${template_name}.underscore" />
 </script>
 % endfor
+% if course_entitlements:
+    <script type="text/javascript" src="${static.url('common/js/vendor/popper.js')}"></script>
+    <script type="text/javascript" src="${static.url('common/js/vendor/bootstrap.js')}"></script>
+% endif
 </%block>
 
 <%block name="js_extra">

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -34,6 +34,10 @@ from student.models import CourseEnrollment
   <%static:include path="dashboard/${template_name}.underscore" />
 </script>
 % endfor
+% if course_entitlements:
+    <script type="text/javascript" src="${static.url('common/js/vendor/popper.js')}"></script>
+    <script type="text/javascript" src="${static.url('common/js/vendor/bootstrap.js')}"></script>
+% endif
 </%block>
 
 <%block name="js_extra">


### PR DESCRIPTION
RequireJS was not loading boostrap and popper correctly on the staging environment. This should keep it stable and matches the way bootstrap is loaded elsewhere on the site.

@mjfrey 