### PR TITLE
Add DISABLE_LIBRARY_CREATION setting to library creator logic

### DIFF
--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -58,7 +58,13 @@ def get_library_creator_status(user):
     elif settings.FEATURES.get('ENABLE_CREATOR_GROUP', False):
         return get_course_creator_status(user) == 'granted'
     else:
-        return not settings.FEATURES.get('DISABLE_COURSE_CREATION', False)
+        # EDUCATOR-1924: DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION, if present.
+        disable_library_creation = settings.FEATURES.get('DISABLE_LIBRARY_CREATION', None)
+        disable_course_creation = settings.FEATURES.get('DISABLE_COURSE_CREATION', False)
+        if disable_library_creation is not None:
+            return not disable_library_creation
+        else:
+            return not disable_course_creation
 
 
 @login_required

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -64,6 +64,30 @@ class UnitTestLibraries(CourseTestCase):
         _, nostaff_user = self.create_non_staff_authed_user_client()
         self.assertEqual(get_library_creator_status(nostaff_user), True)
 
+    @ddt.data(
+        (False, False, True),
+        (False, True, False),
+        (True, False, True),
+        (True, True, False),
+        (True, None, False),
+        (False, None, True)
+    )
+    @ddt.unpack
+    def test_library_creator_status_settings(self, disable_course, disable_library, expected_status):
+        """
+        Ensure that the setting DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION as expected.
+        """
+        _, nostaff_user = self.create_non_staff_authed_user_client()
+        with mock.patch("contentstore.views.library.LIBRARIES_ENABLED", True):
+            with mock.patch.dict(
+                "django.conf.settings.FEATURES",
+                {
+                    "DISABLE_COURSE_CREATION": disable_course,
+                    "DISABLE_LIBRARY_CREATION": disable_library
+                }
+            ):
+                self.assertEqual(get_library_creator_status(nostaff_user), expected_status)
+
     @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': True})
     @mock.patch("contentstore.views.library.LIBRARIES_ENABLED", True)
     def test_library_creator_status_with_no_course_creator_role_and_disabled_nonstaff_course_creation(self):


### PR DESCRIPTION
# [EDUCATOR-1924](https://openedx.atlassian.net/browse/EDUCATOR-1924)

Adds a new setting, `DISABLE_LIBRARY_CREATION`. Previous work had assumed `DISABLE_COURSE_CREATION` was enough to gate library creation, but now we want to have more granularity. After this lands it will be possible to disable course creation but allow library creation.

