### PR TITLE
PLAT-1830 Allow running any test suite in tox

### DIFF
--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -11,6 +11,7 @@ import os
 import sys
 from collections import defaultdict
 
+import django
 from docopt import docopt
 from path import Path as path
 
@@ -187,7 +188,23 @@ def main():
     Usage: static_content.py <output_root>
     """
     from django.conf import settings
-    settings.configure()
+    # Install only the apps whose models are imported when this runs
+    installed_apps = (
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'config_models',
+        'openedx.core.djangoapps.video_config',
+        'openedx.core.djangoapps.video_pipeline',
+    )
+    try:
+        import edxval
+        installed_apps += ('edxval',)
+    except ImportError:
+        pass
+    settings.configure(
+        INSTALLED_APPS=installed_apps,
+    )
+    django.setup()
 
     args = docopt(main.__doc__)
     root = path(args['<output_root>'])

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -33,6 +33,9 @@ PYTHON_REQ_FILES = [
     'requirements/edx/testing.txt',
     'requirements/edx/post.txt',
 ]
+if 'TOXENV' in os.environ:
+    # Let tox manage the Django version
+    PYTHON_REQ_FILES.remove('requirements/edx/django.txt')
 
 # Developers can have private requirements, for local copies of github repos,
 # or favorite debugging tools, etc.

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -32,7 +32,7 @@ __test__ = False  # do not collect
     ("fasttest", "a", "Run without collectstatic"),
     make_option(
         "--django_version", dest="django_version",
-        help="Run against which Django version (1.8 -or- 1.11)."
+        help="Run against which Django version (1.8, 1.9, 1.10, -or- 1.11)."
     ),
     make_option(
         "--eval-attr", dest="eval_attr",
@@ -77,7 +77,7 @@ def test_system(options, passthrough_options):
     django_version = getattr(options, 'django_version', None)
 
     assert(system in (None, 'lms', 'cms'))
-    assert(django_version in (None, '1.8', '1.11'))
+    assert(django_version in (None, '1.8', '1.9', '1.10', '1.11'))
 
     if test_id:
         # Testing a single test ID.
@@ -126,7 +126,7 @@ def test_system(options, passthrough_options):
     ("fail-fast", "x", "Run only failed tests"),
     make_option(
         "--django_version", dest="django_version",
-        help="Run against which Django version (1.8 -or- 1.11)."
+        help="Run against which Django version (1.8, 1.9, 1.10, -or- 1.11)."
     ),
     make_option(
         '-c', '--cov-args', default='',
@@ -151,7 +151,7 @@ def test_lib(options, passthrough_options):
     test_id = getattr(options, 'test_id', lib)
     django_version = getattr(options, 'django_version', None)
 
-    assert(django_version in (None, '1.8', '1.11'))
+    assert(django_version in (None, '1.8', '1.9', '1.10', '1.11'))
 
     if test_id:
         # Testing a single test id.

--- a/pavelib/utils/test/suites/pytest_suite.py
+++ b/pavelib/utils/test/suites/pytest_suite.py
@@ -28,10 +28,8 @@ class PytestSuite(TestSuite):
         django_version = kwargs.get('django_version', None)
         if django_version is None:
             self.django_toxenv = None
-        elif django_version == '1.11':
-            self.django_toxenv = 'py27-django111'
         else:
-            self.django_toxenv = 'py27-django18'
+            self.django_toxenv = 'py27-django{}'.format(django_version.replace('.', ''))
         self.disable_capture = kwargs.get('disable_capture', None)
         self.report_dir = Env.REPORT_DIR / self.root
 
@@ -134,8 +132,12 @@ class SystemTestSuite(PytestSuite):
         if self.django_toxenv:
             cmd = ['tox', '-e', self.django_toxenv, '--']
         else:
-            cmd = ['python', '-Wd', '-m', 'pytest']
+            cmd = []
         cmd.extend([
+            'python',
+            '-Wd',
+            '-m',
+            'pytest',
             '--ds={}'.format('{}.envs.{}'.format(self.root, self.settings)),
             "--junitxml={}".format(self.xunit_report),
         ])
@@ -223,11 +225,15 @@ class LibTestSuite(PytestSuite):
         if self.django_toxenv:
             cmd = ['tox', '-e', self.django_toxenv, '--']
         else:
-            cmd = ['python', '-Wd', '-m', 'pytest']
+            cmd = []
         cmd.extend([
-            "-p",
-            "no:randomly",
-            "--junitxml={}".format(self.xunit_report),
+            'python',
+            '-Wd',
+            '-m',
+            'pytest',
+            '-p',
+            'no:randomly',
+            '--junitxml={}'.format(self.xunit_report),
         ])
         cmd.extend(self.passthrough_options + self.test_options_flags)
         if self.verbosity < 1:

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -155,7 +155,7 @@ ddt==0.8.0
 django-crum==0.7.2
 django_nose==1.4.1
 factory_boy==2.8.1
-flaky==3.3.0
+flaky==3.4.0
 freezegun==0.3.8
 moto==0.3.1
 needle==0.5.0

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -84,7 +84,7 @@ git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4b
 
 # Why a django-celery fork? To add Django 1.11 compatibility to the abandoned repo.
 # This dependency will be removed by the Celery 4 upgrade: https://openedx.atlassian.net/browse/PLAT-1684
-git+https://github.com/edx/django-celery.git@f87c6f914a1410463f54aebf68458c0653b20602#egg=django-celery==3.2.1+edx.1
+git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail==0.0

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -71,8 +71,16 @@ END
 
 if [[ $DJANGO_VERSION == '1.11' ]]; then
     PAVER_ARGS="-v --django_version=1.11"
+    TOX="tox -e py27-django111 --"
+elif [[ $DJANGO_VERSION == '1.10' ]]; then
+    PAVER_ARGS="-v --django_version=1.10"
+    TOX="tox -e py27-django110 --"
+elif [[ $DJANGO_VERSION == '1.9' ]]; then
+    PAVER_ARGS="-v --django_version=1.9"
+    TOX="tox -e py27-django19 --"
 else
     PAVER_ARGS="-v"
+    TOX=""
 fi
 PARALLEL="--processes=-1"
 export SUBSET_JOB=$JOB_NAME
@@ -82,7 +90,7 @@ function run_paver_quality {
     shift
     mkdir -p test_root/log/
     LOG_PREFIX=test_root/log/$QUALITY_TASK
-    paver $QUALITY_TASK $* 2> $LOG_PREFIX.err.log > $LOG_PREFIX.out.log || {
+    $TOX paver $QUALITY_TASK $* 2> $LOG_PREFIX.err.log > $LOG_PREFIX.out.log || {
         echo "STDOUT (last 100 lines of $LOG_PREFIX.out.log):";
         tail -n 100 $LOG_PREFIX.out.log;
         echo "STDERR (last 100 lines of $LOG_PREFIX.err.log):";
@@ -155,12 +163,12 @@ case "$TEST_SUITE" in
         ;;
 
     "js-unit")
-        paver test_js --coverage
-        paver diff_coverage
+        $TOX paver test_js --coverage
+        $TOX paver diff_coverage
         ;;
 
     "commonlib-js-unit")
-        paver test_js --coverage --skip-clean || { EXIT=1; }
+        $TOX paver test_js --coverage --skip-clean || { EXIT=1; }
         paver test_lib --skip-clean $PAVER_ARGS || { EXIT=1; }
 
         # This is to ensure that the build status of the shard is properly set.
@@ -178,11 +186,11 @@ case "$TEST_SUITE" in
         ;;
 
     "lms-acceptance")
-        paver test_acceptance -s lms -vvv --with-xunit
+        $TOX paver test_acceptance -s lms -vvv --with-xunit
         ;;
 
     "cms-acceptance")
-        paver test_acceptance -s cms -vvv --with-xunit
+        $TOX paver test_acceptance -s cms -vvv --with-xunit
         ;;
 
     "bok-choy")
@@ -192,15 +200,15 @@ case "$TEST_SUITE" in
         case "$SHARD" in
 
             "all")
-                paver test_bokchoy $PAVER_ARGS
+                $TOX paver test_bokchoy $PAVER_ARGS
                 ;;
 
             [1-9]|10)
-                paver test_bokchoy --eval-attr="shard==$SHARD" $PAVER_ARGS
+                $TOX paver test_bokchoy --eval-attr="shard==$SHARD" $PAVER_ARGS
                 ;;
 
             11|"noshard")
-                paver test_bokchoy --eval-attr='not shard and not a11y' $PAVER_ARGS
+                $TOX paver test_bokchoy --eval-attr='not shard and not a11y' $PAVER_ARGS
                 ;;
 
             # Default case because if we later define another bok-choy shard on Jenkins

--- a/tox.ini
+++ b/tox.ini
@@ -22,12 +22,24 @@ toxworkdir={homedir}/edxapp_toxenv
 # directory without hacking sys.path, but they will inherit the tox virtualenv
 # and look in site-packages.
 usedevelop=True
-
 setenv =
     PYTHONHASHSEED = 0
+    TOXENV={envname}
 passenv =
+    BOK_CHOY_CMS_PORT
+    BOK_CHOY_HOSTNAME
+    BOK_CHOY_LMS_PORT
+    DISPLAY
     EDX_PLATFORM_SETTINGS
     EDXAPP_TEST_MONGO_HOST
+    NO_PREREQ_INSTALL
+    NO_PYTHON_UNINSTALL
+    NODE_PATH
+    NODE_VIRTUAL_ENV
+    NPM_CONFIG_PREFIX
+    SELENIUM_BROWSER
+    SELENIUM_HOST
+    SELENIUM_PORT
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
@@ -46,6 +58,5 @@ deps =
     -rrequirements/edx-sandbox/base.txt
     -rrequirements/edx-sandbox/local.txt
     -rrequirements/edx-sandbox/post.txt
-
 commands =
-    python -Wd -m pytest {posargs}
+    {posargs}


### PR DESCRIPTION
Instead of treating tox as a combination virtualenv manager and task runner, this PR lets it focus on the former task and leave the latter to paver.  So tox only manages one virtualenv for each Python/Django version combination, and you just pass in the command (usually pytest or a paver instruction) to run inside it.  Unit tests are the only exception, because we already had those working with tox-in-paver (although honestly, we may want to change those also to avoid setting up two virtualenvs with all edx-platform dependencies for each Jenkins worker).

Other fixes:

* Make xmodule static asset collection work on Django 1.9+
* Support Django 1.9 and 1.10 in paver commands and the Jenkins test script
* Upgraded `flaky` to fix some warnings on pytest startup
* Upgraded django-celery to get the fix from [PLAT-1423](https://openedx.atlassian.net/browse/PLAT-1423)
* Allow all relevant environment variables from the Jenkins and devstack environments to be passed through to the tox command environment