### PR TITLE
Show white listed certificates on progress page

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -34,7 +34,7 @@ import courseware.views.views as views
 import shoppingcart
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from certificates import api as certs_api
-from certificates.models import CertificateGenerationConfiguration, CertificateStatuses
+from certificates.models import CertificateGenerationConfiguration, CertificateStatuses, CertificateWhitelist
 from certificates.tests.factories import CertificateInvalidationFactory, GeneratedCertificateFactory
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
@@ -1465,13 +1465,13 @@ class ProgressPageTests(ProgressPageBaseTests):
         """Test that query counts remain the same for self-paced and instructor-paced courses."""
         SelfPacedConfiguration(enabled=self_paced_enabled).save()
         self.setup_course(self_paced=self_paced)
-        with self.assertNumQueries(35 if self_paced else 34, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST), check_mongo_calls(1):
+        with self.assertNumQueries(36 if self_paced else 35, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST), check_mongo_calls(1):
             self._get_progress_page()
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(
-        (False, 41, 27),
-        (True, 34, 23)
+        (False, 42, 28),
+        (True, 35, 24)
     )
     @ddt.unpack
     def test_progress_queries(self, enable_waffle, initial, subsequent):
@@ -1561,6 +1561,49 @@ class ProgressPageTests(ProgressPageBaseTests):
             course_grade.passed = True
             course_grade.summary = {
                 'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}
+            }
+
+            resp = self._get_progress_page()
+            self.assertContains(resp, u"View Certificate")
+            self.assert_invalidate_certificate(generated_certificate)
+
+    @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
+    def test_page_with_whitelisted_certificate_with_html_view(self):
+        """
+        Verify that for white listed user the view certificate is
+        appearing on dashboard
+        """
+        generated_certificate = self.generate_certificate(
+            "http://www.example.com/certificate.pdf", "honor"
+        )
+
+        # Course certificate configurations
+        certificates = [
+            {
+                'id': 1,
+                'name': 'dummy',
+                'description': 'dummy description',
+                'course_title': 'dummy title',
+                'signatories': [],
+                'version': 1,
+                'is_active': True
+            }
+        ]
+        self.course.certificates = {'certificates': certificates}
+        self.course.cert_html_view_enabled = True
+        self.course.save()
+        self.store.update_item(self.course, self.user.id)
+        CertificateWhitelist.objects.create(
+            user=self.user,
+            course_id=self.course.id,
+            whitelist=True
+        )
+
+        with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
+            course_grade = mock_create.return_value
+            course_grade.passed = False
+            course_grade.summary = {
+                'grade': 'Fail', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}
             }
 
             resp = self._get_progress_page()

--- a/openedx/core/djangoapps/certificates/api.py
+++ b/openedx/core/djangoapps/certificates/api.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from pytz import UTC
 
+from certificates.models import CertificateWhitelist
 from openedx.core.djangoapps.certificates.config import waffle
 from student.models import CourseEnrollment
 
@@ -54,11 +55,12 @@ def is_certificate_valid(certificate):
 
 
 def can_show_certificate_message(course, student, course_grade, certificates_enabled_for_course):
+    is_whitelisted = CertificateWhitelist.objects.filter(user=student, course_id=course.id, whitelist=True).exists()
     if not (
         (auto_certificate_generation_enabled() or certificates_enabled_for_course) and
         CourseEnrollment.is_enrolled(student, course.id) and
         certificates_viewable_for_course(course) and
-        course_grade.passed
+        (course_grade.passed or is_whitelisted)
     ):
         return False
     return True


### PR DESCRIPTION
White listed certificates should appear on the progress page
even if the user has not passed the course
LEARNER-3546