### PR TITLE
Entitlement API Changes to support User Revoke and Refund

### DIFF
--- a/common/djangoapps/entitlements/models.py
+++ b/common/djangoapps/entitlements/models.py
@@ -221,12 +221,12 @@ class CourseEntitlement(TimeStampedModel):
             'expired_at': self.expired_at
         }
 
-    @classmethod
-    def set_enrollment(cls, entitlement, enrollment):
+    def set_enrollment(self, enrollment):
         """
         Fulfills an entitlement by specifying a session.
         """
-        cls.objects.filter(id=entitlement.id).update(enrollment_course_run=enrollment)
+        self.enrollment_course_run = enrollment
+        self.save()
 
     @classmethod
     def unexpired_entitlements_for_user(cls, user):

--- a/common/djangoapps/entitlements/signals.py
+++ b/common/djangoapps/entitlements/signals.py
@@ -1,0 +1,6 @@
+"""
+Enrollment track related signals.
+"""
+from django.dispatch import Signal
+
+REFUND_ENTITLEMENT = Signal(providing_args=['course_entitlement'])

--- a/lms/djangoapps/commerce/signals.py
+++ b/lms/djangoapps/commerce/signals.py
@@ -14,12 +14,12 @@ from django.contrib.auth.models import AnonymousUser
 from django.dispatch import receiver
 from django.utils.translation import ugettext as _
 
+from entitlements.signals import REFUND_ENTITLEMENT
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client, is_commerce_service_configured
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming import helpers as theming_helpers
 from request_cache.middleware import RequestCache
 from student.signals import REFUND_ORDER
-
 from .models import CommerceConfiguration
 
 log = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ def handle_refund_order(sender, course_enrollment=None, **kwargs):
                 # there's certainly no need to inform Otto about this request.
                 return
             refund_seat(course_enrollment)
-        except:  # pylint: disable=bare-except
+        except Exception:  # pylint: disable=broad-except
             # don't assume the signal was fired with `send_robust`.
             # avoid blowing up other signal handlers by gracefully
             # trapping the Exception and logging an error.
@@ -54,6 +54,30 @@ def handle_refund_order(sender, course_enrollment=None, **kwargs):
                 "Unexpected exception while attempting to initiate refund for user [%s], course [%s]",
                 course_enrollment.user.id,
                 course_enrollment.course_id,
+            )
+
+
+# pylint: disable=unused-argument
+@receiver(REFUND_ENTITLEMENT)
+def handle_refund_entitlement(sender, course_entitlement=None, **kwargs):
+    if not is_commerce_service_configured():
+        return
+
+    if course_entitlement and course_entitlement.is_entitlement_refundable():
+        try:
+            request_user = get_request_user()
+            if request_user and course_entitlement.user == request_user:
+                refund_entitlement(course_entitlement)
+        except Exception as exc:  # pylint: disable=broad-except
+            # don't assume the signal was fired with `send_robust`.
+            # avoid blowing up other signal handlers by gracefully
+            # trapping the Exception and logging an error.
+            log.exception(
+                "Unexpected exception while attempting to initiate refund for user [%s], "
+                "course entitlement [%s] message: [%s]",
+                course_entitlement.user.id,
+                course_entitlement.uuid,
+                str(exc)
             )
 
 
@@ -67,6 +91,57 @@ def get_request_user():
     """
     request = RequestCache.get_current_request()
     return getattr(request, 'user', None)
+
+
+def _process_refund(refund_ids, api_client, course_product, is_entitlement=False):
+    """
+    Helper method to process a refund for a given course_product
+    """
+    config = CommerceConfiguration.current()
+
+    if config.enable_automatic_refund_approval:
+        refunds_requiring_approval = []
+
+        for refund_id in refund_ids:
+            try:
+                # NOTE: Approve payment only because the user has already been unenrolled. Additionally, this
+                # ensures we don't tie up an additional web worker when the E-Commerce Service tries to unenroll
+                # the learner
+                api_client.refunds(refund_id).process.put({'action': 'approve_payment_only'})
+                log.info('Refund [%d] successfully approved.', refund_id)
+            except:  # pylint: disable=bare-except
+                log.exception('Failed to automatically approve refund [%d]!', refund_id)
+                refunds_requiring_approval.append(refund_id)
+    else:
+        refunds_requiring_approval = refund_ids
+
+    if refunds_requiring_approval:
+        # XCOM-371: this is a temporary measure to suppress refund-related email
+        # notifications to students and support for free enrollments.  This
+        # condition should be removed when the CourseEnrollment.refundable() logic
+        # is updated to be more correct, or when we implement better handling (and
+        # notifications) in Otto for handling reversal of $0 transactions.
+        if course_product.mode != 'verified':
+            # 'verified' is the only enrollment mode that should presently
+            # result in opening a refund request.
+            msg = 'Skipping refund email notification for non-verified mode for user [%s], course [%s], mode: [%s]'
+            course_identifier = course_product.course_id
+            if is_entitlement:
+                course_identifier = str(course_product.uuid)
+                msg = ('Skipping refund email notification for non-verified mode for user [%s], '
+                       'course entitlement [%s], mode: [%s]')
+            log.info(
+                msg,
+                course_product.user.id,
+                course_identifier,
+                course_product.mode,
+            )
+        else:
+            try:
+                send_refund_notification(course_product, refunds_requiring_approval)
+            except:  # pylint: disable=bare-except
+                # don't break, just log a warning
+                log.warning('Could not send email notification for refund.', exc_info=True)
 
 
 def refund_seat(course_enrollment):
@@ -98,47 +173,60 @@ def refund_seat(course_enrollment):
     if refund_ids:
         log.info('Refund successfully opened for user [%s], course [%s]: %r', enrollee.id, course_key_str, refund_ids)
 
-        config = CommerceConfiguration.current()
-
-        if config.enable_automatic_refund_approval:
-            refunds_requiring_approval = []
-
-            for refund_id in refund_ids:
-                try:
-                    # NOTE: Approve payment only because the user has already been unenrolled. Additionally, this
-                    # ensures we don't tie up an additional web worker when the E-Commerce Service tries to unenroll
-                    # the learner
-                    api_client.refunds(refund_id).process.put({'action': 'approve_payment_only'})
-                    log.info('Refund [%d] successfully approved.', refund_id)
-                except:  # pylint: disable=bare-except
-                    log.exception('Failed to automatically approve refund [%d]!', refund_id)
-                    refunds_requiring_approval.append(refund_id)
-        else:
-            refunds_requiring_approval = refund_ids
-
-        if refunds_requiring_approval:
-            # XCOM-371: this is a temporary measure to suppress refund-related email
-            # notifications to students and support for free enrollments.  This
-            # condition should be removed when the CourseEnrollment.refundable() logic
-            # is updated to be more correct, or when we implement better handling (and
-            # notifications) in Otto for handling reversal of $0 transactions.
-            if course_enrollment.mode != 'verified':
-                # 'verified' is the only enrollment mode that should presently
-                # result in opening a refund request.
-                log.info(
-                    'Skipping refund email notification for non-verified mode for user [%s], course [%s], mode: [%s]',
-                    course_enrollment.user.id,
-                    course_enrollment.course_id,
-                    course_enrollment.mode,
-                )
-            else:
-                try:
-                    send_refund_notification(course_enrollment, refunds_requiring_approval)
-                except:  # pylint: disable=bare-except
-                    # don't break, just log a warning
-                    log.warning('Could not send email notification for refund.', exc_info=True)
+        _process_refund(
+            refund_ids=refund_ids,
+            api_client=api_client,
+            course_product=course_enrollment,
+        )
     else:
         log.info('No refund opened for user [%s], course [%s]', enrollee.id, course_key_str)
+
+    return refund_ids
+
+
+def refund_entitlement(course_entitlement):
+    """
+    Attempt a refund of a course entitlement
+    :param course_entitlement:
+    :return:
+    """
+    user_model = get_user_model()
+    enrollee = course_entitlement.user
+    entitlement_uuid = str(course_entitlement.uuid)
+
+    service_user = user_model.objects.get(username=settings.ECOMMERCE_SERVICE_WORKER_USERNAME)
+    api_client = ecommerce_api_client(service_user)
+
+    log.info(
+        'Attempting to create a refund for user [%s], course entitlement [%s]...',
+        enrollee.username,
+        entitlement_uuid
+    )
+
+    refund_ids = api_client.refunds.post(
+        {
+            'order_number': course_entitlement.order_number,
+            'username': enrollee.username,
+            'entitlement_uuid': entitlement_uuid,
+        }
+    )
+
+    if refund_ids:
+        log.info(
+            'Refund successfully opened for user [%s], course entitlement [%s]: %r',
+            enrollee.username,
+            entitlement_uuid,
+            refund_ids,
+        )
+
+        _process_refund(
+            refund_ids=refund_ids,
+            api_client=api_client,
+            course_product=course_entitlement,
+            is_entitlement=True
+        )
+    else:
+        log.info('No refund opened for user [%s], course entitlement [%s]', enrollee.id, entitlement_uuid)
 
     return refund_ids
 
@@ -206,7 +294,7 @@ def generate_refund_notification_body(student, refund_ids):  # pylint: disable=i
     return '{msg}\n\n{urls}'.format(msg=msg, urls='\n'.join(refund_urls))
 
 
-def send_refund_notification(course_enrollment, refund_ids):
+def send_refund_notification(course_product, refund_ids):
     """ Notify the support team of the refund request. """
 
     tags = ['auto_refund']
@@ -215,7 +303,7 @@ def send_refund_notification(course_enrollment, refund_ids):
         # this is not presently supported with the external service.
         raise NotImplementedError("Unable to send refund processing emails to support teams.")
 
-    student = course_enrollment.user
+    student = course_product.user
     subject = _("[Refund] User-Requested Refund")
     body = generate_refund_notification_body(student, refund_ids)
     requester_name = student.profile.name or student.username


### PR DESCRIPTION
[LEARNER-2668]

These changes will support a user intiated Revoke and Refund of
an Entitlement. This includes unenrolling the User from
any related Course Runs they are currently enrolled in.

https://openedx.atlassian.net/browse/LEARNER-2668