### PR TITLE
Remove an extra call to pip freeze

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -308,8 +308,6 @@ def install_python_prereqs():
 
     prereq_cache("Python prereqs", files_to_fingerprint, python_prereqs_installation)
 
-    sh("pip freeze")
-
 
 @task
 @timed


### PR DESCRIPTION
[we log it to a file anyhow,](../../blob/badb1f848208e1c5df0d673d5d0dfb8dabd03e5e/pavelib/prereqs.py#L326) which on Jenkins gets saved as an artifact.