### PR TITLE
ENT-800 Fix IE11 Broken Submit button on Registration Page

### DIFF
--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -179,7 +179,7 @@
 
                             // Show each input tip
                             $(this).children().each(function() {
-                                if (inputTipSelectorsHidden.includes($(this).attr('class'))) {
+                                if (inputTipSelectorsHidden.indexOf($(this).attr('class')) >= 0) {
                                     $(this).removeClass('hidden');
                                 }
                             });
@@ -193,7 +193,7 @@
 
                             // Hide each input tip
                             $(this).children().each(function() {
-                                if (inputTipSelectors.includes($(this).attr('class'))) {
+                                if (inputTipSelectors.indexOf($(this).attr('class')) >= 0) {
                                     $(this).addClass('hidden');
                                 }
                             });
@@ -207,7 +207,7 @@
 
                             // Initially hide each input tip
                             input.children().each(function() {
-                                if (inputTipSelectors.includes($(this).attr('class'))) {
+                                if (inputTipSelectors.indexOf($(this).attr('class')) >= 0) {
                                     $(this).addClass('hidden');
                                 }
                             });


### PR DESCRIPTION
There was a bug in IE11 where the submit button for registration forms would grey out when clicked and not continue to the next page, but the account would get created. It turned out to be the use of the function includes which is not supported in IE11, so I switched the calls to indexOf which is supported and should behave the same.

This can be tested by using a virtualbox windows VM with IE11, navigating to business.sandbox.edx.org with the browser in that VM, and registering a new account.