### PR TITLE
Importing bootstrap and popper through webpack.

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -33,11 +33,6 @@ from student.models import CourseEnrollment
   <%static:include path="dashboard/${template_name}.underscore" />
 </script>
 % endfor
-% if course_entitlements:
-    <!-- This is a temporary solution before we land a fix to load these through Webpack, tracked by LEARNER-3483 -->
-    <script type="text/javascript" src="${static.url('common/js/vendor/popper.js')}"></script>
-    <script type="text/javascript" src="${static.url('common/js/vendor/bootstrap.js')}"></script>
-% endif
 </%block>
 
 <%block name="js_extra">
@@ -52,6 +47,7 @@ from student.models import CourseEnrollment
       });
     });
   </script>
+  <%static:webpack entry="Bootstrap"></%static:webpack>
   <%static:require_module module_name="js/learner_dashboard/unenrollment_factory" class_name="UnenrollmentFactory">
     UnenrollmentFactory({
       urls: {

--- a/lms/templates/learner_dashboard/program_details_fragment.html
+++ b/lms/templates/learner_dashboard/program_details_fragment.html
@@ -9,10 +9,7 @@ from openedx.core.djangolib.js_utils import (
 %>
 
 <%block name="js_extra">
-<!-- This is a temporary solution before we land a fix to load these through Webpack, tracked by LEARNER-3483 -->
-<script type="text/javascript" src="${static.url('common/js/vendor/popper.js')}"></script>
-<script type="text/javascript" src="${static.url('common/js/vendor/bootstrap.js')}"></script>
-
+<%static:webpack entry="Bootstrap"></%static:webpack>
 <%static:require_module module_name="js/learner_dashboard/program_details_factory" class_name="ProgramDetailsFactory">
 ProgramDetailsFactory({
     programData: ${program_data | n, dump_js_escaped_json},

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -34,11 +34,6 @@ from student.models import CourseEnrollment
   <%static:include path="dashboard/${template_name}.underscore" />
 </script>
 % endfor
-% if course_entitlements:
-    <!-- This is a temporary solution before we land a fix to load these through Webpack, tracked by LEARNER-3483 -->
-    <script type="text/javascript" src="${static.url('common/js/vendor/popper.js')}"></script>
-    <script type="text/javascript" src="${static.url('common/js/vendor/bootstrap.js')}"></script>
-% endif
 </%block>
 
 <%block name="js_extra">
@@ -53,6 +48,7 @@ from student.models import CourseEnrollment
       });
     });
   </script>
+  <%static:webpack entry="Bootstrap"></%static:webpack>
   <%static:require_module module_name="js/learner_dashboard/unenrollment_factory" class_name="UnenrollmentFactory">
     UnenrollmentFactory({
       urls: {

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -26,7 +26,6 @@ module.exports = {
         SingleSupportForm: './lms/static/support/jsx/single_support_form.jsx',
         AlertStatusBar: './lms/static/js/accessible_components/StatusBarAlert.jsx',
         Bootstrap: './lms/static/common/js/vendor/bootstrap.js',
-        EntitlementView: './lms/static/js/learner_dashboard/views/course_entitlement_view.js',
 
         // Features
         CourseGoals: './openedx/features/course_experience/static/course_experience/js/CourseGoals.js',
@@ -63,7 +62,8 @@ module.exports = {
             _: 'underscore',
             $: 'jquery',
             jQuery: 'jquery',
-            'window.jQuery': 'jquery'
+            'window.jQuery': 'jquery',
+            Popper: ['popper.js', 'default']
         }),
 
         // Note: Until karma-webpack releases v3, it doesn't play well with


### PR DESCRIPTION
Load bootstrap javascript files through webpack and not through the script tags.

It seems like this is a fix for the issue that causes this from the requireJS logs (http://requirejs.org/docs/errors.html).
"If you manually code a script tag in HTML to load a script with an anonymous define() call, this error can occur."

This makes it seem like you are not allowed to call bootstrap.js or popper.js through a script tag. However, I can't seem to figure out why this doesn't occur on the new course home page that does do this. Somehow it must be that the v1 pages use a different compilation for requireJS.

@AlasdairSwan @mjfrey 