### PR TITLE
ENT-807: Utilize configured user for SuccessFactors BizX OData API callbacks

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -230,6 +230,10 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
     def odata_client_id(self):
         return self.conf['odata_client_id']
 
+    @property
+    def oauth_user_id(self):
+        return self.conf.get('oauth_user_id')
+
     def invalid_configuration(self):
         """
         Check that we have all the details we need to properly retrieve rich data from the
@@ -282,12 +286,15 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
         """
         Obtain a SAML assertion from the SAP SuccessFactors BizX OAuth2 identity provider service using
         information specified in the third party authentication configuration "Advanced Settings" section.
+        Utilizes the OAuth user_id if defined in Advanced Settings in order to generate the SAML assertion,
+        otherwise utilizes the user_id for the current user in context.
         """
         session = requests.Session()
+        oauth_user_id = self.oauth_user_id if self.oauth_user_id else user_id
         transaction_data = {
             'token_url': self.sapsf_token_url,
             'client_id': self.odata_client_id,
-            'user_id': user_id,
+            'user_id': oauth_user_id,
             'private_key': self.sapsf_private_key,
         }
         try:


### PR DESCRIPTION
Currently the SuccessFactors BizX OData API callback implementation conducts queries in the context of each individual SuccessFactors user.  It would be better if OData API callbacks were conducted in the context of a singular user that we ask each customer to configure for the integration. This makes it clear on the SuccessFactors side which user is requesting the information. In addition the data set for this user can be constrained to include only those fields pertinent to registration.