### PR TITLE
PLAT-1840 Fix common/lib tests under Django 1.9

### DIFF
--- a/openedx/tests/settings.py
+++ b/openedx/tests/settings.py
@@ -5,7 +5,38 @@ Required in Django 1.9+ due to imports of models in stock Django apps.
 
 from __future__ import absolute_import, unicode_literals
 
+import sys
 import tempfile
+
+from path import Path
+
+# TODO: Remove the rest of the sys.path modification here and in (cms|lms)/envs/common.py
+REPO_ROOT = Path(__file__).abspath().dirname().dirname().dirname()  # /edx-platform/
+sys.path.append(REPO_ROOT / 'common' / 'djangoapps')
+sys.path.append(REPO_ROOT / 'lms' / 'djangoapps')
+
+ALL_LANGUAGES = []
+
+BLOCK_STRUCTURES_SETTINGS = dict(
+    COURSE_PUBLISH_TASK_DELAY=30,
+    TASK_DEFAULT_RETRY_DELAY=30,
+    TASK_MAX_RETRIES=5,
+)
+
+COURSE_KEY_PATTERN = r'(?P<course_key_string>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
+COURSE_ID_PATTERN = COURSE_KEY_PATTERN.replace('course_key_string', 'course_id')
+
+COURSE_MODE_DEFAULTS = {
+    'bulk_sku': None,
+    'currency': 'usd',
+    'description': None,
+    'expiration_datetime': None,
+    'min_price': 0,
+    'name': 'Audit',
+    'sku': None,
+    'slug': 'audit',
+    'suggested_prices': '',
+}
 
 DATABASES = {
     'default': {
@@ -18,17 +49,39 @@ DATABASES = {
     }
 }
 
+FEATURES = {}
+
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
+    'djcelery',
     'openedx.core.djangoapps.video_config',
     'openedx.core.djangoapps.video_pipeline',
     'edxval',
+    'courseware',
+    'student',
+    'certificates.apps.CertificatesConfig',
+    'course_modes.apps.CourseModesConfig',
+    'lms.djangoapps.verify_student.apps.VerifyStudentConfig',
+    'openedx.core.djangoapps.dark_lang',
+    'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig',
+    'openedx.core.djangoapps.content.block_structure.apps.BlockStructureConfig',
+    'openedx.core.djangoapps.catalog',
+    'openedx.core.djangoapps.self_paced',
+    'milestones',
+    'celery_utils',
 )
+
+LMS_ROOT_URL = 'http://localhost:8000'
 
 MEDIA_ROOT = tempfile.mkdtemp()
 
+MICROSITE_BACKEND = 'microsite_configuration.backends.filebased.FilebasedMicrositeBackend'
+MICROSITE_TEMPLATE_BACKEND = 'microsite_configuration.backends.filebased.FilebasedMicrositeTemplateBackend'
+
 SECRET_KEY = 'insecure-secret-key'
+
+TRACK_MAX_EVENT = 50000
 
 USE_TZ = True

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -70,18 +70,15 @@ END
 }
 
 if [[ $DJANGO_VERSION == '1.11' ]]; then
-    PAVER_ARGS="-v --django_version=1.11"
     TOX="tox -e py27-django111 --"
 elif [[ $DJANGO_VERSION == '1.10' ]]; then
-    PAVER_ARGS="-v --django_version=1.10"
     TOX="tox -e py27-django110 --"
 elif [[ $DJANGO_VERSION == '1.9' ]]; then
-    PAVER_ARGS="-v --django_version=1.9"
     TOX="tox -e py27-django19 --"
 else
-    PAVER_ARGS="-v"
     TOX=""
 fi
+PAVER_ARGS="-v"
 PARALLEL="--processes=-1"
 export SUBSET_JOB=$JOB_NAME
 
@@ -135,13 +132,13 @@ case "$TEST_SUITE" in
     "lms-unit")
         case "$SHARD" in
             "all")
-                paver test_system -s lms --disable_capture $PAVER_ARGS $PARALLEL 2> lms-tests.log
+                $TOX paver test_system -s lms --disable_capture $PAVER_ARGS $PARALLEL 2> lms-tests.log
                 ;;
             [1-3])
-                paver test_system -s lms --disable_capture --eval-attr="shard==$SHARD" $PAVER_ARGS $PARALLEL 2> lms-tests.$SHARD.log
+                $TOX paver test_system -s lms --disable_capture --eval-attr="shard==$SHARD" $PAVER_ARGS $PARALLEL 2> lms-tests.$SHARD.log
                 ;;
             4|"noshard")
-                paver test_system -s lms --disable_capture --eval-attr='not shard' $PAVER_ARGS $PARALLEL 2> lms-tests.4.log
+                $TOX paver test_system -s lms --disable_capture --eval-attr='not shard' $PAVER_ARGS $PARALLEL 2> lms-tests.4.log
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
@@ -155,11 +152,11 @@ case "$TEST_SUITE" in
         ;;
 
     "cms-unit")
-        paver test_system -s cms --disable_capture $PAVER_ARGS 2> cms-tests.log
+        $TOX paver test_system -s cms --disable_capture $PAVER_ARGS 2> cms-tests.log
         ;;
 
     "commonlib-unit")
-        paver test_lib --disable_capture $PAVER_ARGS 2> common-tests.log
+        $TOX paver test_lib --disable_capture $PAVER_ARGS 2> common-tests.log
         ;;
 
     "js-unit")

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,9 @@ toxworkdir={homedir}/edxapp_toxenv
 # and look in site-packages.
 usedevelop=True
 setenv =
-    PYTHONHASHSEED = 0
+    # Instruct paver not to install the packages tox just installed
+    NO_PREREQ_INSTALL=True
+    PYTHONHASHSEED=0
     TOXENV={envname}
 passenv =
     BOK_CHOY_CMS_PORT


### PR DESCRIPTION
Some changes to fix and speed up the common/lib and pavelib tests under Django 1.9:

* Added settings and `INSTALLED_APPS` until I stopped getting xblock load failures and "model not included in installed apps" errors
* Switched from "paver calls tox calls pytest" to "tox calls paver calls pytest", both to use a shared virtualenv and to let paver correctly handle pytest return codes for subdirectories containing no tests (which tox treats as a failure)
* Stop paver from updating Python dependencies for runs inside tox, since tox is doing that anyway

Locally this got me to zero failures under Django 1.9 for this subset of the tests, we'll see how it fares in Jenkins.