### PR TITLE
Upgrade httpretty to fix test issues in Django 1.9+

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -484,6 +484,5 @@ class TrackSelectionEmbargoTest(UrlResetMixin, ModuleStoreTestCase):
 
     @httpretty.activate
     def test_embargo_allow(self):
-
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)

--- a/common/djangoapps/student/tests/test_refunds.py
+++ b/common/djangoapps/student/tests/test_refunds.py
@@ -14,9 +14,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.client import Client
 from django.test.utils import override_settings
-from edx_rest_api_client.exceptions import SlumberBaseException
 from mock import patch
-from slumber.exceptions import HttpClientError, HttpServerError
 
 from certificates.models import CertificateStatuses, GeneratedCertificate  # pylint: disable=import-error
 from certificates.tests.factories import GeneratedCertificateFactory  # pylint: disable=import-error
@@ -195,17 +193,3 @@ class RefundableTest(SharedModuleStoreTestCase):
         self.client.login(username=self.user.username, password=self.USER_PASSWORD)
         resp = self.client.post(reverse('student.views.dashboard', args=[]))
         self.assertEqual(resp.status_code, 200)
-
-    @ddt.data(HttpServerError, HttpClientError, SlumberBaseException)
-    @override_settings(ECOMMERCE_API_URL=TEST_API_URL)
-    def test_refund_cutoff_date_with_api_error(self, exception):
-        """ Verify that dashboard will not throw internal server error if HttpClientError
-        raised while getting order detail for ecommerce.
-        """
-        # importing this after overriding value of ECOMMERCE_API_URL
-        from lms.djangoapps.commerce.tests.mocks import mock_order_endpoint
-
-        self.client.login(username=self.user.username, password=self.USER_PASSWORD)
-        with mock_order_endpoint(order_number=self.ORDER_NUMBER, exception=exception, reset_on_exit=False):
-            response = self.client.post(reverse('student.views.dashboard', args=[]))
-            self.assertEqual(response.status_code, 200)

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -49,6 +49,9 @@ class SamlIntegrationTestUtilities(object):
         )
         # Mock out HTTP requests that may be made to TestShib:
         httpretty.enable()
+        httpretty.reset()
+        self.addCleanup(httpretty.reset)
+        self.addCleanup(httpretty.disable)
 
         def metadata_callback(_request, _uri, headers):
             """ Return a cached copy of TestShib's metadata by reading it from disk """
@@ -66,8 +69,6 @@ class SamlIntegrationTestUtilities(object):
             content_type='text/xml',
             body=cache_duration_metadata_callback
         )
-        self.addCleanup(httpretty.disable)
-        self.addCleanup(httpretty.reset)
 
         # Configure the SAML library to use the same request ID for every request.
         # Doing this and freezing the time allows us to play back recorded request/response pairs

--- a/lms/djangoapps/commerce/api/v0/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v0/tests/test_views.py
@@ -303,7 +303,7 @@ class BasketOrderViewTests(UserMixin, TestCase):
 
     def test_order_not_found(self):
         """ If the order is not found, the view should return a 404. """
-        with mock_basket_order(basket_id=1, exception=exceptions.HttpNotFoundError):
+        with mock_basket_order(basket_id=1, status=404):
             response = self.client.get(self.path)
         self.assertEqual(response.status_code, 404)
 

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -417,7 +417,7 @@ class OrderViewTests(UserMixin, TestCase):
 
     def test_order_not_found(self):
         """ If the order is not found, the view should return a 404. """
-        with mock_order_endpoint(order_number=self.ORDER_NUMBER, exception=exceptions.HttpNotFoundError):
+        with mock_order_endpoint(order_number=self.ORDER_NUMBER, status=404):
             response = self.client.get(self.path)
         self.assertEqual(response.status_code, 404)
 

--- a/lms/djangoapps/commerce/tests/mocks.py
+++ b/lms/djangoapps/commerce/tests/mocks.py
@@ -74,10 +74,13 @@ class mock_ecommerce_api_endpoint(object):
         )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        assert self.expect_called == (httpretty.last_request().headers != {})
+        called_if_expected = self.expect_called == (httpretty.last_request().headers != {})
         httpretty.disable()
+
         if self.reset_on_exit:
             httpretty.reset()
+
+        assert called_if_expected
 
 
 class mock_basket_order(mock_ecommerce_api_endpoint):

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -581,6 +581,7 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
         super(GetThreadListTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.maxDiff = None  # pylint: disable=invalid-name
         self.user = UserFactory.create()
@@ -998,6 +999,7 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
         super(GetCommentListTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.maxDiff = None  # pylint: disable=invalid-name
         self.user = UserFactory.create()
@@ -1477,6 +1479,7 @@ class CreateThreadTest(
         super(CreateThreadTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.user = UserFactory.create()
         self.register_get_user_response(self.user)
@@ -1741,6 +1744,7 @@ class CreateCommentTest(
         super(CreateCommentTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.user = UserFactory.create()
         self.register_get_user_response(self.user)
@@ -2006,6 +2010,7 @@ class UpdateThreadTest(
         super(UpdateThreadTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
 
         self.user = UserFactory.create()
@@ -2388,6 +2393,7 @@ class UpdateCommentTest(
 
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
 
         self.user = UserFactory.create()
@@ -2787,6 +2793,7 @@ class DeleteThreadTest(
         super(DeleteThreadTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.user = UserFactory.create()
         self.register_get_user_response(self.user)
@@ -2924,6 +2931,7 @@ class DeleteCommentTest(
         super(DeleteCommentTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.user = UserFactory.create()
         self.register_get_user_response(self.user)
@@ -3078,6 +3086,7 @@ class RetrieveThreadTest(
         super(RetrieveThreadTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.user = UserFactory.create()
         self.register_get_user_response(self.user)

--- a/lms/djangoapps/discussion_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion_api/tests/test_serializers.py
@@ -44,6 +44,7 @@ class SerializerTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetM
         super(SerializerTestMixin, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.maxDiff = None  # pylint: disable=invalid-name
         self.user = UserFactory.create()
@@ -411,6 +412,7 @@ class ThreadSerializerDeserializationTest(
         super(ThreadSerializerDeserializationTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.user = UserFactory.create()
         self.register_get_user_response(self.user)
@@ -612,6 +614,7 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMoc
         super(CommentSerializerDeserializationTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.user = UserFactory.create()
         self.register_get_user_response(self.user)

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -1421,6 +1421,7 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
         super(CommentViewSetPartialUpdateTest, self).setUp()
         httpretty.reset()
         httpretty.enable()
+        self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         self.register_get_user_response(self.user)
         self.url = reverse("comment-detail", kwargs={"comment_id": "test_comment"})

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -71,6 +71,8 @@ class CommentsServiceMockMixin(object):
     """Mixin with utility methods for mocking the comments service"""
     def register_get_threads_response(self, threads, page, num_pages):
         """Register a mock response for GET on the CS thread list endpoint"""
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
+
         httpretty.register_uri(
             httpretty.GET,
             "http://localhost:4567/api/v1/threads",
@@ -85,6 +87,7 @@ class CommentsServiceMockMixin(object):
 
     def register_get_threads_search_response(self, threads, rewrite, num_pages=1):
         """Register a mock response for GET on the CS thread search endpoint"""
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.GET,
             "http://localhost:4567/api/v1/search/threads",
@@ -100,6 +103,7 @@ class CommentsServiceMockMixin(object):
 
     def register_post_thread_response(self, thread_data):
         """Register a mock response for POST on the CS commentable endpoint"""
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.POST,
             re.compile(r"http://localhost:4567/api/v1/(\w+)/threads"),
@@ -111,6 +115,7 @@ class CommentsServiceMockMixin(object):
         Register a mock response for PUT on the CS endpoint for the given
         thread_id.
         """
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.PUT,
             "http://localhost:4567/api/v1/threads/{}".format(thread_data["id"]),
@@ -119,6 +124,7 @@ class CommentsServiceMockMixin(object):
 
     def register_get_thread_error_response(self, thread_id, status_code):
         """Register a mock error response for GET on the CS thread endpoint."""
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.GET,
             "http://localhost:4567/api/v1/threads/{id}".format(id=thread_id),
@@ -130,6 +136,7 @@ class CommentsServiceMockMixin(object):
         """
         Register a mock response for GET on the CS thread instance endpoint.
         """
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.GET,
             "http://localhost:4567/api/v1/threads/{id}".format(id=thread["id"]),
@@ -148,6 +155,7 @@ class CommentsServiceMockMixin(object):
         else:
             url = "http://localhost:4567/api/v1/threads/{}/comments".format(thread_id)
 
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.POST,
             url,
@@ -161,6 +169,7 @@ class CommentsServiceMockMixin(object):
         """
         thread_id = comment_data["thread_id"]
         parent_id = comment_data.get("parent_id")
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.PUT,
             "http://localhost:4567/api/v1/comments/{}".format(comment_data["id"]),
@@ -172,6 +181,7 @@ class CommentsServiceMockMixin(object):
         Register a mock error response for GET on the CS comment instance
         endpoint.
         """
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.GET,
             "http://localhost:4567/api/v1/comments/{id}".format(id=comment_id),
@@ -184,6 +194,7 @@ class CommentsServiceMockMixin(object):
         Register a mock response for GET on the CS comment instance endpoint.
         """
         comment = make_minimal_cs_comment(response_overrides)
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.GET,
             "http://localhost:4567/api/v1/comments/{id}".format(id=comment["id"]),
@@ -193,6 +204,7 @@ class CommentsServiceMockMixin(object):
 
     def register_get_user_response(self, user, subscribed_thread_ids=None, upvoted_ids=None):
         """Register a mock response for GET on the CS user instance endpoint"""
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.GET,
             "http://localhost:4567/api/v1/users/{id}".format(id=user.id),
@@ -206,6 +218,7 @@ class CommentsServiceMockMixin(object):
 
     def register_subscribed_threads_response(self, user, threads, page, num_pages):
         """Register a mock response for GET on the CS user instance endpoint"""
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.GET,
             "http://localhost:4567/api/v1/users/{}/subscribed_threads".format(user.id),
@@ -223,6 +236,7 @@ class CommentsServiceMockMixin(object):
         Register a mock response for POST and DELETE on the CS user subscription
         endpoint
         """
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         for method in [httpretty.POST, httpretty.DELETE]:
             httpretty.register_uri(
                 method,
@@ -236,6 +250,7 @@ class CommentsServiceMockMixin(object):
         Register a mock response for PUT and DELETE on the CS thread votes
         endpoint
         """
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         for method in [httpretty.PUT, httpretty.DELETE]:
             httpretty.register_uri(
                 method,
@@ -249,6 +264,7 @@ class CommentsServiceMockMixin(object):
         Register a mock response for PUT and DELETE on the CS comment votes
         endpoint
         """
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         for method in [httpretty.PUT, httpretty.DELETE]:
             httpretty.register_uri(
                 method,
@@ -259,6 +275,7 @@ class CommentsServiceMockMixin(object):
 
     def register_flag_response(self, content_type, content_id):
         """Register a mock response for PUT on the CS flag endpoints"""
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         for path in ["abuse_flag", "abuse_unflag"]:
             httpretty.register_uri(
                 "PUT",
@@ -275,6 +292,7 @@ class CommentsServiceMockMixin(object):
         """
         Register a mock response for POST on the CS 'read' endpoint
         """
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.POST,
             "http://localhost:4567/api/v1/users/{id}/read".format(id=user.id),
@@ -295,6 +313,7 @@ class CommentsServiceMockMixin(object):
         """
         Register a mock response for DELETE on the CS thread instance endpoint
         """
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.DELETE,
             "http://localhost:4567/api/v1/threads/{id}".format(id=thread_id),
@@ -306,6 +325,7 @@ class CommentsServiceMockMixin(object):
         """
         Register a mock response for DELETE on the CS comment instance endpoint
         """
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
         httpretty.register_uri(
             httpretty.DELETE,
             "http://localhost:4567/api/v1/comments/{id}".format(id=comment_id),

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -63,7 +63,7 @@ GitPython==0.3.2.RC1
 glob2==0.3
 gunicorn==0.17.4
 help-tokens==1.0.3
-httpretty==0.8.3
+httpretty==0.8.14
 lazy==1.1
 mako==1.0.2
 Markdown>=2.6,<2.7


### PR DESCRIPTION
I ran into some httpretty issues testing Django 1.9+ in devstack. They looked a lot like some things we were seeing in Jenkins testing that cause tests to hang in one shard. This PR fixes the issues I saw in devstack and has completed the failing shard twice out of many attempts. While it doesn't fix everything it does address a couple of things that definitely needed fixing.