### PR TITLE
Add entitlements app to CMS installed apps.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1135,6 +1135,9 @@ INSTALLED_APPS = [
     # DRF filters
     'django_filters',
     'cms.djangoapps.api',
+
+    # Entitlement API
+    'entitlements',
 ]
 
 


### PR DESCRIPTION
The CMS test shard is crashing before Django 1.11 tests run due to `entitlements` not being in INSTALLED_APPS. This issue might also be fixed via an `app_label` - but seems like we've decided this solution is our best practice?