### PR TITLE
[ENT-772]-UI Updates to Support Ent Data Synchronization

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -567,6 +567,14 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
                 (current_provider.skip_email_verification or current_provider.send_to_registration_first))
 
     if not user:
+        details = kwargs.get('details', {})
+        if 'email' in details or 'username' in details:
+            # pylint: disable=invalid-name
+            qs = {'email': details['email']} if details.get('email') else \
+                {'username': details.get('username')}
+            if User.objects.filter(**qs).exists():
+                return dispatch_to_login()
+
         if is_api(auth_entry):
             return HttpResponseBadRequest()
         elif auth_entry == AUTH_ENTRY_LOGIN:

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -640,6 +640,8 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
             "finishAuthUrl": finish_auth_url,
             "errorMessage": None,
             "registerFormSubmitButtonText": "Create Account",
+            "hideSignInLink": False,
+            "syncLearnerProfileData": False,
         }
         if expected_ec is not None:
             # If we set an EnterpriseCustomer, third-party auth providers ought to be hidden.

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -423,7 +423,7 @@ def _get_form_descriptions(request):
 
     return {
         'password_reset': get_password_reset_form().to_json(),
-        'login': get_login_session_form().to_json(),
+        'login': get_login_session_form(request).to_json(),
         'registration': RegistrationFormFactory().get_registration_form(request).to_json()
     }
 

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -71,10 +71,12 @@
                     };
 
                     this.platformName = options.platform_name;
+                    this.enterpriseName = options.enterprise_name;
                     this.supportURL = options.support_link;
                     this.passwordResetSupportUrl = options.password_reset_support_link;
                     this.createAccountOption = options.account_creation_allowed;
                     this.hideAuthWarnings = options.hide_auth_warnings || false;
+                    this.pipelineUserDetails = options.pipeline_user_details;
 
                 // The login view listens for 'sync' events from the reset model
                     this.resetModel = new PasswordResetModel({}, {
@@ -133,7 +135,8 @@
                             supportURL: this.supportURL,
                             passwordResetSupportUrl: this.passwordResetSupportUrl,
                             createAccountOption: this.createAccountOption,
-                            hideAuthWarnings: this.hideAuthWarnings
+                            hideAuthWarnings: this.hideAuthWarnings,
+                            pipelineUserDetails: this.pipelineUserDetails
                         });
 
                     // Listen for 'password-help' event to toggle sub-views
@@ -170,6 +173,7 @@
                             model: model,
                             thirdPartyAuth: this.thirdPartyAuth,
                             platformName: this.platformName,
+                            enterpriseName: this.enterpriseName,
                             hideAuthWarnings: this.hideAuthWarnings
                         });
 

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -136,7 +136,8 @@
                             passwordResetSupportUrl: this.passwordResetSupportUrl,
                             createAccountOption: this.createAccountOption,
                             hideAuthWarnings: this.hideAuthWarnings,
-                            pipelineUserDetails: this.pipelineUserDetails
+                            pipelineUserDetails: this.pipelineUserDetails,
+                            enterpriseName: this.enterpriseName
                         });
 
                     // Listen for 'password-help' event to toggle sub-views

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -50,6 +50,7 @@
                 this.accountActivationMessages = data.accountActivationMessages;
                 this.hideAuthWarnings = data.hideAuthWarnings;
                 this.pipelineUserDetails = data.pipelineUserDetails;
+                this.enterpriseName = data.enterpriseName;
 
                 this.listenTo(this.model, 'sync', this.saveSuccess);
                 this.listenTo(this.resetModel, 'sync', this.resetEmail);
@@ -68,7 +69,9 @@
                         hasSecondaryProviders: this.hasSecondaryProviders,
                         platformName: this.platformName,
                         createAccountOption: this.createAccountOption,
-                        pipelineUserDetails: this.pipelineUserDetails
+                        pipelineUserDetails: this.pipelineUserDetails,
+                        enterpriseName: this.enterpriseName
+
                     }
                 }));
 

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -49,6 +49,7 @@
                 this.createAccountOption = data.createAccountOption;
                 this.accountActivationMessages = data.accountActivationMessages;
                 this.hideAuthWarnings = data.hideAuthWarnings;
+                this.pipelineUserDetails = data.pipelineUserDetails;
 
                 this.listenTo(this.model, 'sync', this.saveSuccess);
                 this.listenTo(this.resetModel, 'sync', this.resetEmail);
@@ -66,7 +67,8 @@
                         providers: this.providers,
                         hasSecondaryProviders: this.hasSecondaryProviders,
                         platformName: this.platformName,
-                        createAccountOption: this.createAccountOption
+                        createAccountOption: this.createAccountOption,
+                        pipelineUserDetails: this.pipelineUserDetails
                     }
                 }));
 

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -55,6 +55,8 @@
                         data.thirdPartyAuth.secondaryProviders && data.thirdPartyAuth.secondaryProviders.length
                     );
                     this.currentProvider = data.thirdPartyAuth.currentProvider || '';
+                    this.hideSignInLink = data.thirdPartyAuth.hideSignInLink || false;
+                    this.enterpriseName = data.enterpriseName || '';
                     this.errorMessage = data.thirdPartyAuth.errorMessage || '';
                     this.platformName = data.platformName;
                     this.autoSubmit = data.thirdPartyAuth.autoSubmitRegForm;
@@ -141,6 +143,8 @@
                         context: {
                             fields: fields,
                             currentProvider: this.currentProvider,
+                            hideSignInLink: this.hideSignInLink,
+                            enterpriseName: this.enterpriseName,
                             providers: this.providers,
                             hasSecondaryProviders: this.hasSecondaryProviders,
                             platformName: this.platformName,

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -259,6 +259,20 @@
       display: none;
     }
 
+    input[readonly] {
+      font-family: OpenSans-Regular;
+      background-color: #e6e4e4;
+      color: #292b2c;
+      font-size: 22px;
+      border: none;
+      margin: 5px 0;
+
+      &:focus {
+        outline: none;
+      }
+    }
+
+
     .auto-register-message {
       font-size: 1.1em;
       line-height: 1.3em;
@@ -446,7 +460,8 @@
       outline: solid 1px $gray-l3;
       cursor: pointer;
 
-      &:active, &:focus {
+      &:active,
+      &:focus {
         outline: auto;
       }
     }
@@ -462,7 +477,8 @@
       }
     }
 
-    .tip, .label-optional {
+    .tip,
+    .label-optional {
       @extend %t-copy-sub1;
 
       color: $uxpl-gray-base;

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -91,7 +91,8 @@
             <% } %>
             <% if ( restrictions.min_length ) { %> minlength="<%- restrictions.min_length %>"<% } %>
             <% if ( restrictions.max_length ) { %> maxlength="<%- restrictions.max_length %>"<% } %>
-            <% if ( required ) { %> required<% } %>
+            <% if ( restrictions.readonly )   { %> readonly <% } %>
+            <% if ( required ) { %> required <% } %>
             <% if ( typeof errorMessages !== 'undefined' ) {
                 _.each(errorMessages, function( msg, type ) {%>
                     data-errormsg-<%- type %>="<%- msg %>"

--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -1,14 +1,24 @@
 <div class="js-form-feedback" aria-live="assertive" tabindex="-1">
 </div>
 
-<% if ( context.createAccountOption !== false ) { %>
+<% if ( context.createAccountOption !== false && context.enterpriseName == "") { %>
 <div class="toggle-form">
     <span class="text"><%- gettext("First time here?") %></span>
     <a href="#login" class="form-toggle" data-type="register"><%- gettext("Create an Account.") %></a>
 </div>
 <% } %>
 
-<h2><%- gettext("Sign In") %></h2>
+<% if (context.enterpriseName) { %>
+    <% if (context.pipelineUserDetails.email) { %>
+        <h2><%- gettext("Sign in to continue learning as {email}").replace("{email}", context.pipelineUserDetails.email) %></h2>
+    <% } else { %>
+        <h2><%- gettext("Sign in to continue learning") %></h2>
+    <% } %>
+    <p><%- gettext("You already have an edX account with your {enterprise_name} email address. Going forward, your account information will be updated and maintained by {enterprise_name}. You can view your information or unlink from {enterprise_name} anytime in your Account Settings.").replace(/{enterprise_name}/g, context.enterpriseName) %> </p>
+    <p><%- gettext("To continue learning with this account, sign in below.") %></p>
+<% } else { %>
+    <h2><%- gettext("Sign In") %></h2>
+<% } %>
 
 <form id="login" class="login-form" tabindex="-1" method="POST">
 

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -1,10 +1,14 @@
 <div class="js-form-feedback" aria-live="assertive" tabindex="-1">
 </div>
 
-<div class="toggle-form">
-    <span class="text"><%- edx.StringUtils.interpolate(gettext('Already have an {platformName} account?'), {platformName: context.platformName }) %></span>
-    <a href="#login" class="form-toggle" data-type="login"><%- gettext("Sign in.") %></a>
-</div>
+<% if (!context.hideSignInLink) { %>
+	<div class="toggle-form">
+		<span class="text"><%- edx.StringUtils.interpolate(gettext('Already have an {platformName} account?'), {platformName: context.platformName }) %></span>
+		<a href="#login" class="form-toggle" data-type="login"><%- gettext("Sign in.") %></a>
+	</div>
+<% } %>
+
+<h2><%- gettext('Create an Account')%></h2>
 
 <form id="register" class="register-form" autocomplete="off" tabindex="-1" method="POST">
 

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -835,35 +835,10 @@ class RegistrationFormFactory(object):
                 current_provider = third_party_auth.provider.Registry.get_from_pipeline(running_pipeline)
 
                 if current_provider:
-                    # Override username / email / full name
-                    field_overrides = current_provider.get_register_form_data(
-                        running_pipeline.get('kwargs')
+                    self._override_registration_fields_using_identity_provider_configuration(
+                        request, current_provider, running_pipeline, form_desc
                     )
 
-                    # When the TPA Provider is configured to skip the registration form and we are in an
-                    # enterprise context, we need to hide all fields except for terms of service and
-                    # ensure that the user explicitly checks that field.
-                    hide_registration_fields_except_tos = (current_provider.skip_registration_form and
-                                                           enterprise_customer_for_request(request))
-
-                    for field_name in self.DEFAULT_FIELDS + self.EXTRA_FIELDS:
-                        if field_name in field_overrides:
-                            form_desc.override_field_properties(
-                                field_name, default=field_overrides[field_name]
-                            )
-
-                            if (field_name not in ['terms_of_service', 'honor_code']
-                                    and field_overrides[field_name]
-                                    and hide_registration_fields_except_tos):
-
-                                form_desc.override_field_properties(
-                                    field_name,
-                                    field_type="hidden",
-                                    label="",
-                                    instructions="",
-                                )
-
-                    # Hide the password field
                     form_desc.override_field_properties(
                         "password",
                         default="",
@@ -880,4 +855,38 @@ class RegistrationFormFactory(object):
                         label="",
                         default=current_provider.name if current_provider.name else "Third Party",
                         required=False,
+                    )
+
+    # pylint: disable=invalid-name
+    def _override_registration_fields_using_identity_provider_configuration(
+            self, request, current_provider, running_pipeline, form_desc
+    ):
+        """
+        Apply form field overrides based on configuration of third party auth provider.
+        """
+        field_overrides = current_provider.get_register_form_data(
+            running_pipeline.get('kwargs')
+        )
+        # When the TPA Provider is configured to skip the registration form and we are in an
+        # enterprise context, we need to hide all fields except for terms of service and
+        # ensure that the user explicitly checks that field.
+        hide_registration_fields_except_tos = (
+            (
+                current_provider.skip_registration_form and enterprise_customer_for_request(request)
+            ) or current_provider.sync_learner_profile_data
+        )
+
+        for field_name in self.DEFAULT_FIELDS + self.EXTRA_FIELDS:
+            if field_name in field_overrides:
+                form_desc.override_field_properties(
+                    field_name, default=field_overrides[field_name]
+                )
+
+                if field_name not in ['terms_of_service', 'honor_code'] and field_overrides[field_name] and \
+                        hide_registration_fields_except_tos:
+                    form_desc.override_field_properties(
+                        field_name,
+                        field_type="hidden",
+                        label="",
+                        instructions="",
                     )

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -124,9 +124,9 @@ class FormDescription(object):
     ALLOWED_TYPES = ["text", "email", "select", "textarea", "checkbox", "password", "hidden"]
 
     ALLOWED_RESTRICTIONS = {
-        "text": ["min_length", "max_length"],
-        "password": ["min_length", "max_length"],
-        "email": ["min_length", "max_length"],
+        "text": ["min_length", "max_length", "readonly"],
+        "password": ["min_length", "max_length", "readonly"],
+        "email": ["min_length", "max_length", "readonly"],
     }
 
     FIELD_TYPE_MAP = {

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -43,7 +43,7 @@ class LoginSessionView(APIView):
 
     @method_decorator(ensure_csrf_cookie)
     def get(self, request):
-        return HttpResponse(get_login_session_form().to_json(), content_type="application/json")
+        return HttpResponse(get_login_session_form(request).to_json(), content_type="application/json")
 
     @method_decorator(require_post_params(["email", "password"]))
     @method_decorator(csrf_protect)


### PR DESCRIPTION
Task: [ENT-772](https://openedx.atlassian.net/browse/ENT-772)
### NOTE: The PR does not contain any style/CSS changes. 

**Changes:**
- Removed "first time here? Create an Account"
- Added Title / Header: "Sign in to continue learning as [email]."
- Added Paragraph at Top: "You already have an edX account with your [Enterprise] email address. Going forward, your account information will be updated and maintained by [Enterprise]. You can view your information or unlink from [Enterprise] anytime in your Account Settings.
To continue learning with this account, sign in below."
- Populated the email field  
- Disabled the email field. 

<img width="1278" alt="screen shot 2017-12-13 at 4 41 06 pm" src="https://user-images.githubusercontent.com/7334669/33937249-898559fe-e024-11e7-90f8-aa1a35d81d48.png">
