### PR TITLE
Remove dealer.git (startup optimization).

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -95,6 +95,9 @@ CELERY_ROUTES = "{}celery.Router".format(QUEUE_VARIANT)
 with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
 
+# Do NOT calculate this dynamically at startup with git because it's *slow*.
+EDX_PLATFORM_REVISION = ENV_TOKENS.get('EDX_PLATFORM_REVISION', EDX_PLATFORM_REVISION)
+
 # STATIC_URL_BASE specifies the base url to use for static files
 STATIC_URL_BASE = ENV_TOKENS.get('STATIC_URL_BASE', None)
 if STATIC_URL_BASE:

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -130,7 +130,6 @@ from warnings import simplefilter
 
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 from cms.lib.xblock.authoring_mixin import AuthoringMixin
-import dealer.git
 from xmodule.modulestore.edit_info import EditInfoMixin
 from openedx.core.djangoapps.theming.helpers_dirs import (
     get_themes_unchecked,
@@ -333,7 +332,6 @@ CONTEXT_PROCESSORS = (
     'django.template.context_processors.i18n',
     'django.contrib.auth.context_processors.auth',  # this is required for admin
     'django.template.context_processors.csrf',
-    'dealer.contrib.django.staff.context_processor',  # access git revision
     'help_tokens.context_processor',
 )
 
@@ -611,15 +609,8 @@ SERVER_EMAIL = 'devops@example.com'
 ADMINS = []
 MANAGERS = ADMINS
 
-EDX_PLATFORM_REVISION = os.environ.get('EDX_PLATFORM_REVISION')
-
-if not EDX_PLATFORM_REVISION:
-    try:
-        # Get git revision of the current file
-        EDX_PLATFORM_REVISION = dealer.git.Backend(path=REPO_ROOT).revision
-    except TypeError:
-        # Not a git repository
-        EDX_PLATFORM_REVISION = 'unknown'
+# Initialize to 'unknown', but read from JSON in aws.py
+EDX_PLATFORM_REVISION = 'unknown'
 
 # Static content
 STATIC_URL = '/static/studio/'

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1080,6 +1080,9 @@ ACE_CHANNEL_SAILTHRU_API_KEY = AUTH_TOKENS.get('ACE_CHANNEL_SAILTHRU_API_KEY', A
 ACE_CHANNEL_SAILTHRU_API_SECRET = AUTH_TOKENS.get('ACE_CHANNEL_SAILTHRU_API_SECRET', ACE_CHANNEL_SAILTHRU_API_SECRET)
 ACE_ROUTING_KEY = ENV_TOKENS.get('ACE_ROUTING_KEY', ACE_ROUTING_KEY)
 
+# Do NOT calculate this dynamically at startup with git because it's *slow*.
+EDX_PLATFORM_REVISION = ENV_TOKENS.get('EDX_PLATFORM_REVISION', EDX_PLATFORM_REVISION)
+
 ########################## Extra middleware classes  #######################
 
 # Allow extra middleware classes to be added to the app through configuration.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -33,7 +33,6 @@ import imp
 import sys
 import os
 
-import dealer.git
 import django
 from path import Path as path
 from warnings import simplefilter
@@ -3452,11 +3451,5 @@ ACE_CHANNEL_SAILTHRU_API_SECRET = None
 
 ACE_ROUTING_KEY = LOW_PRIORITY_QUEUE
 
-EDX_PLATFORM_REVISION = os.environ.get('EDX_PLATFORM_REVISION')
-if not EDX_PLATFORM_REVISION:
-    try:
-        # Get git revision of the current file
-        EDX_PLATFORM_REVISION = dealer.git.Backend(path=REPO_ROOT).revision
-    except TypeError:
-        # Not a git repository
-        EDX_PLATFORM_REVISION = 'unknown'
+# Initialize to 'unknown', but read from JSON in aws.py
+EDX_PLATFORM_REVISION = 'unknown'

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -13,7 +13,6 @@ boto==2.39.0
 celery==3.1.18
 cryptography==1.9
 cssselect==0.9.1
-dealer==2.0.4
 defusedxml==0.4.1
 django-babel-underscore==0.5.2
 markey==0.8  # From django-babel-underscore


### PR DESCRIPTION
In the absence of an EDX_PLATFORM_VERSION OS env variable, we used to calculate the current version by looking at the current git revision of the edx-platform repo. This was an expensive calculation (~7% of startup costs). It also turns out that at some point we stopped setting that env variable anywhere, so it always fell back to recalculating it.

With this commit, we'll start reading the code version from the env JSON files, and fall back to "unknown" rather than doing the dealer.git call.

We're not actually setting this config value yet, so until we do, the value for this in edx-platform will always be "unknown". Only ACE uses this for the moment, for debugging, but it's generally useful so I'll see if it's easy to add to the config repo.