### PR TITLE
Bump SFE to 0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "^0.4.1",
     "@edx/paragon": "^0.2.0",
-    "@edx/studio-frontend": "^0.6.1",
+    "@edx/studio-frontend": "^0.6.3",
     "babel-core": "^6.23.0",
     "babel-loader": "^6.4.0",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
Bumps studio-frontend to version 0.6.3 to get copy updates to the accessibility form.