### PR TITLE
Reenabling Entitlement Jasmine tests.

### DIFF
--- a/lms/static/js/spec/learner_dashboard/course_entitlement_view_spec.js
+++ b/lms/static/js/spec/learner_dashboard/course_entitlement_view_spec.js
@@ -22,16 +22,16 @@ define([
             initialSessionId = isAlreadyEnrolled ? testSessionIds[0] : '';
             entitlementAvailableSessions = [{
                 enrollment_end: null,
-                session_start: '2013-02-05T05:00:00+00:00',
+                start: '2019-02-05T05:00:00+00:00',
                 pacing_type: 'instructor_paced',
                 session_id: testSessionIds[0],
-                session_end: null
+                end: null
             }, {
-                enrollment_end: '2017-12-22T03:30:00Z',
-                session_start: '2018-01-03T13:00:00+00:00',
+                enrollment_end: '2019-12-22T03:30:00Z',
+                start: '2020-01-03T13:00:00+00:00',
                 pacing_type: 'self_paced',
                 session_id: testSessionIds[1],
-                session_end: '2018-03-09T21:30:00+00:00'
+                end: '2020-03-09T21:30:00+00:00'
             }];
 
             view = new CourseEntitlementView({

--- a/lms/static/lms/js/spec/main.js
+++ b/lms/static/lms/js/spec/main.js
@@ -766,6 +766,7 @@
         'js/spec/learner_dashboard/unenroll_view_spec.js',
         'js/spec/learner_dashboard/course_card_view_spec.js',
         'js/spec/learner_dashboard/course_enroll_view_spec.js',
+        'js/spec/learner_dashboard/course_entitlement_view_spec.js',
         'js/spec/markdown_editor_spec.js',
         'js/spec/dateutil_factory_spec.js',
         'js/spec/navigation_spec.js',


### PR DESCRIPTION
Adding back the entitlement jasmine tests now that requireJS is importing the new bootstrap build. This works due to https://github.com/edx/edx-platform/pull/16903 landing.

https://openedx.atlassian.net/browse/LEARNER-3483

@edx/helio 