### PR TITLE
PLAT-1847 Fix cms tests under Django 1.9

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -659,7 +659,7 @@ class VideoImageTestCase(VideoUploadTestBase, CourseTestCase):
         error = validate_video_image({})
         self.assertEquals(error, 'The image must have name, content type, and size information.')
 
-    def test_currupt_image_file(self):
+    def test_corrupt_image_file(self):
         """
         Test that when corrupt file is provided to validate_video_image, it gives proper error message.
         """

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -213,6 +213,8 @@ def validate_video_image(image_file):
             image_file_width, image_file_height = get_image_dimensions(image_file)
         except TypeError:
             return _('There is a problem with this image file. Try to upload a different file.')
+        if image_file_width is None or image_file_height is None:
+            return _('There is a problem with this image file. Try to upload a different file.')
         image_file_aspect_ratio = abs(image_file_width / float(image_file_height) - settings.VIDEO_IMAGE_ASPECT_RATIO)
         if image_file_width < settings.VIDEO_IMAGE_MIN_WIDTH or image_file_height < settings.VIDEO_IMAGE_MIN_HEIGHT:
             error = _('Recommended image resolution is {image_file_max_width}x{image_file_max_height}. '

--- a/common/djangoapps/microsite_configuration/tests/factories.py
+++ b/common/djangoapps/microsite_configuration/tests/factories.py
@@ -14,6 +14,7 @@ class SiteFactory(DjangoModelFactory):
     """
     class Meta(object):
         model = Site
+        django_get_or_create = ('domain',)
 
     name = "test microsite"
     domain = "test-site.testserver"

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -130,7 +130,7 @@ class TestUserEvents(UserSettingsEventTestMixin, TestCase):
         """
         Verify that we don't emit events for related fields.
         """
-        self.user.passwordhistory_set.add(PasswordHistory(password='new_password'))
+        self.user.passwordhistory_set.create(password='new_password')
         self.user.save()
         self.assert_no_events_were_emitted()
 

--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -5,6 +5,7 @@ import time
 import unittest
 
 import ddt
+import pytest
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.db import IntegrityError, connection
@@ -215,6 +216,7 @@ class GenerateIntIdTestCase(TestCase):
             self.assertIn(int_id, list(set(range(minimum, maximum + 1)) - used_ids))
 
 
+@pytest.mark.django111_expected_failure
 class MigrationTests(TestCase):
     """
     Tests for migrations.

--- a/openedx/core/djangoapps/external_auth/tests/test_ssl.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_ssl.py
@@ -20,6 +20,7 @@ from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
 import openedx.core.djangoapps.external_auth.views as external_auth_views
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangolib.testing.utils import skip_unless_cms, skip_unless_lms
+from openedx.tests.util import expected_redirect_url
 from student.models import CourseEnrollment
 from student.roles import CourseStaffRole
 from student.tests.factories import UserFactory
@@ -182,7 +183,7 @@ class SSLClientTest(ModuleStoreTestCase):
         response = self.client.get(
             reverse('dashboard'), follow=True,
             SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL))
-        self.assertEquals(('http://testserver/dashboard', 302),
+        self.assertEquals((expected_redirect_url('/dashboard'), 302),
                           response.redirect_chain[-1])
         self.assertIn(SESSION_KEY, self.client.session)
 
@@ -196,7 +197,7 @@ class SSLClientTest(ModuleStoreTestCase):
         response = self.client.get(
             reverse('register_user'), follow=True,
             SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL))
-        self.assertEquals(('http://testserver/dashboard', 302),
+        self.assertEquals((expected_redirect_url('/dashboard'), 302),
                           response.redirect_chain[-1])
         self.assertIn(SESSION_KEY, self.client.session)
 
@@ -236,7 +237,7 @@ class SSLClientTest(ModuleStoreTestCase):
         response = self.client.get(
             reverse('signin_user'), follow=True,
             SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL))
-        self.assertEquals(('http://testserver/dashboard', 302),
+        self.assertEquals((expected_redirect_url('/dashboard'), 302),
                           response.redirect_chain[-1])
         self.assertIn(SESSION_KEY, self.client.session)
 
@@ -359,7 +360,7 @@ class SSLClientTest(ModuleStoreTestCase):
             SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL),
             HTTP_ACCEPT='text/html'
         )
-        self.assertEqual(('http://testserver{0}'.format(course_private_url), 302),
+        self.assertEqual((expected_redirect_url(course_private_url), 302),
                          response.redirect_chain[-1])
         self.assertIn(SESSION_KEY, self.client.session)
 
@@ -391,7 +392,7 @@ class SSLClientTest(ModuleStoreTestCase):
             SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL),
             HTTP_ACCEPT='text/html'
         )
-        self.assertEqual(('http://testserver{0}'.format(course_private_url), 302),
+        self.assertEqual((expected_redirect_url(course_private_url), 302),
                          response.redirect_chain[-1])
         self.assertIn(SESSION_KEY, self.client.session)
 
@@ -409,7 +410,7 @@ class SSLClientTest(ModuleStoreTestCase):
         response = self.client.get(
             reverse('dashboard'), follow=True,
             SSL_CLIENT_S_DN=self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL))
-        self.assertEquals(('http://testserver/dashboard', 302),
+        self.assertEquals((expected_redirect_url('/dashboard'), 302),
                           response.redirect_chain[-1])
         self.assertIn(SESSION_KEY, self.client.session)
         response = self.client.get(

--- a/openedx/core/djangoapps/schedules/tests/test_signals.py
+++ b/openedx/core/djangoapps/schedules/tests/test_signals.py
@@ -151,10 +151,8 @@ class UpdateScheduleTests(SharedModuleStoreTestCase):
 
     def assert_schedule_dates(self, schedule, expected_start):
         assert _strip_secs(schedule.start) == _strip_secs(expected_start)
-        assert (
-            _strip_secs(schedule.upgrade_deadline) ==
-            _strip_secs(expected_start) + datetime.timedelta(days=self.VERIFICATION_DEADLINE_DAYS),
-        )
+        deadline_delta = datetime.timedelta(days=self.VERIFICATION_DEADLINE_DAYS)
+        assert _strip_secs(schedule.upgrade_deadline) == _strip_secs(expected_start) + deadline_delta
 
     def test_updated_when_course_not_started(self, mock_get_current_site):
         mock_get_current_site.return_value = self.site

--- a/openedx/tests/util/__init__.py
+++ b/openedx/tests/util/__init__.py
@@ -1,0 +1,20 @@
+"""
+Utilities for Open edX unit tests.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import django
+
+
+# TODO: Remove Django 1.11 upgrade shim
+# SHIM: We should be able to get rid of this utility post-upgrade
+def expected_redirect_url(relative_url, hostname='testserver'):
+    """
+    Get the expected redirect URL for the current Django version and the
+    given relative URL.  Django 1.8 and earlier redirect to absolute URLs,
+    later versions redirect to relative ones.
+    """
+    if django.VERSION < (1, 9):
+        return 'http://{}{}'.format(hostname, relative_url)
+    else:
+        return relative_url


### PR DESCRIPTION
Fixes for the remaining cms unit test failures under Django 1.9:

* Django's `get_image_dimensions` utility started swallowing one kind of parsing error that we were counting on throwing an exception in a test; updated our wrapper to still return an appropriate error message.
* Updated a Site object factory to cope with there now being a unique constraint on the domain field.
* Explicitly save an object which had previously been auto-saved upon adding to a m2m collection.
* Mark the migration sync test as known to fail in the newer Django versions until we release new migrations with the Django 1.11 upgrade.
* Added a utility to handle the fact that redirect URLs switched from absolute to relative in 1.9; we'll probably need to use this in a bunch of lms tests also.
* Fixed an assertion which was always true because it was just checking that the following tuple existed.  The intention had apparently been to cleanly split a long condition across multiple lines by putting it in a tuple.