### PR TITLE
EDUCATOR-1930 resolve Integrity Error exception in set score method for student module table's duplicate entry

### DIFF
--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -27,7 +27,7 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict, namedtuple
 
 from contracts import contract, new_contract
-from django.db import DatabaseError
+from django.db import DatabaseError, IntegrityError, transaction
 from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
 from opaque_keys.edx.block_types import BlockTypeKeyV1
 from opaque_keys.edx.keys import CourseKey
@@ -994,15 +994,27 @@ def set_score(user_id, usage_key, score, max_score):
     """
     Set the score and max_score for the specified user and xblock usage.
     """
-    student_module, created = StudentModule.objects.get_or_create(
-        student_id=user_id,
-        module_state_key=usage_key,
-        course_id=usage_key.course_key,
-        defaults={
-            'grade': score,
-            'max_grade': max_score,
-        }
-    )
+    created = False
+    kwargs = {"student_id": user_id, "module_state_key": usage_key, "course_id": usage_key.course_key}
+    try:
+        with transaction.atomic():
+            student_module, created = StudentModule.objects.get_or_create(
+                defaults={
+                    'grade': score,
+                    'max_grade': max_score,
+                },
+                **kwargs
+            )
+    except IntegrityError:
+        # log information for duplicate entry and get the record as above command failed.
+        student_module = StudentModule.objects.get(**kwargs)
+        log.warning(
+            'set_score: IntegrityError for student %d - course_id %s - usage_key %s having '
+            'score %d and max_score %d same as request score %d and max_score %d',
+            user_id, usage_key.course_key, usage_key, student_module.grade, student_module.max_grade,
+            score, max_score
+        )
+
     if not created:
         student_module.grade = score
         student_module.max_grade = max_score


### PR DESCRIPTION
# [set_score raises IntegrityError in a few xBlocks - EDUCATOR-1930](https://openedx.atlassian.net/browse/EDUCATOR-1930)

### Description
This PR resolves `IntegrityError` in `set_score` method when duplicate entry is trying to be inserted in `StudentModule` table.

### How to Test?

**Stage** 
N/A

**Sandbox**
N/A


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @awaisdar001 
- [x] Code review: @ssemenova 

### Post-review
- [ ] Rebase and squash commits