### PR TITLE
ENT-768 Display friendly error message for SAML rejection

### DIFF
--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -279,7 +279,8 @@ def simulate_running_pipeline(pipeline_target, backend, email=None, fullname=Non
     pipeline_data = {
         "backend": backend,
         "kwargs": {
-            "details": kwargs
+            "details": kwargs,
+            "response": kwargs.get("response", {})
         }
     }
 

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -41,6 +41,7 @@ from openedx.core.lib.edx_api_utils import get_edx_api_data
 from openedx.core.lib.time_zone_utils import TIME_ZONE_CHOICES
 from openedx.features.enterprise_support.api import enterprise_customer_for_request, get_enterprise_learner_data
 from student.cookies import set_experiments_is_enterprise_cookie
+from openedx.features.enterprise_support.utils import update_third_party_auth_context_for_enterprise
 from student.helpers import destroy_oauth_tokens, get_next_url_for_login_page
 from student.models import UserProfile
 from student.views import register_user as old_register_view
@@ -387,6 +388,8 @@ def _third_party_auth_context(request, redirect_to, tpa_hint=None):
                 # msg may or may not be translated. Try translating [again] in case we are able to:
                 context['errorMessage'] = _(unicode(msg))  # pylint: disable=translation-of-non-string
                 break
+
+        context = update_third_party_auth_context_for_enterprise(context, enterprise_customer)
 
     return context
 

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -3,6 +3,10 @@ from __future__ import unicode_literals
 import hashlib
 
 import six
+from django.conf import settings
+from django.utils.translation import ugettext as _
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangolib.markup import HTML, Text
 
 
 def get_cache_key(**kwargs):
@@ -27,3 +31,40 @@ def get_cache_key(**kwargs):
     key = '__'.join(['{}:{}'.format(item, value) for item, value in six.iteritems(kwargs)])
 
     return hashlib.md5(key).hexdigest()
+
+
+def update_third_party_auth_context_for_enterprise(context, enterprise_customer=None):
+    """
+    Return updated context of third party auth with modified for enterprise.
+
+    Arguments:
+        context (dict): Context for third party auth providers and auth pipeline.
+        enterprise_customer (dict): data for enterprise customer
+
+    Returns:
+         context (dict): Updated context of third party auth with modified
+         `errorMessage`.
+    """
+    if enterprise_customer and context['errorMessage']:
+        context['errorMessage'] = Text(_(
+            u'We are sorry, you are not authorized to access {platform_name} via this channel. '
+            u'Please contact your {enterprise} administrator in order to access {platform_name} '
+            u'or contact {edx_support_link}.{line_break}'
+            u'{line_break}'
+            u'Error Details:{line_break}{error_message}')
+        ).format(
+            platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+            enterprise=enterprise_customer['name'],
+            error_message=context['errorMessage'],
+            edx_support_link=HTML(
+                '<a href="{edx_support_url}">{support_url_name}</a>'
+            ).format(
+                edx_support_url=configuration_helpers.get_value(
+                    'SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK
+                ),
+                support_url_name=_('edX Support'),
+            ),
+            line_break=HTML('<br/>')
+        )
+
+    return context


### PR DESCRIPTION
ENT-768
@asadiqbal08 @saleem-latif @georgebabey 
Display friendly error message for `SAML` rejection along with error message detail while logging in.

> We are sorry, you are not authorized to access edX via this channel. Please contact your Arbisoft administrator in order to access edX or contact edX Support.

> Error Details:
Authentication failed: SAML login failed ["invalid_response"] [SAML Response must contain 1 assertion]

**Example error screenshot:**
<img width="545" alt="screen shot 2017-12-18 at 12 40 44 pm" src="https://user-images.githubusercontent.com/5072991/34104281-9f61ce42-e411-11e7-99df-95e47587f2e0.png">
