### PR TITLE
Fix double headers or WL registration page

### DIFF
--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -8,8 +8,6 @@
 	</div>
 <% } %>
 
-<h2><%- gettext('Create an Account')%></h2>
-
 <form id="register" class="register-form" autocomplete="off" tabindex="-1" method="POST">
 
     <% if (!context.currentProvider) { %>


### PR DESCRIPTION
Second "Create an Account" header was accidentally added in #16691. This reverts the additional header.