### PR TITLE
Add Job Title field to Registration Page

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -427,12 +427,13 @@ def _get_extended_profile_fields():
         "state": _(u"State/Province/Region"),
         "company": _(u"Company"),
         "title": _(u"Title"),
+        "job_title": _(u"Job Title"),
         "mailing_address": _(u"Mailing address"),
         "goals": _(u"Tell us why you're interested in {platform_name}").format(
             platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME)
         ),
-        "profession": _("Profession"),
-        "specialty": _("Specialty")
+        "profession": _(u"Profession"),
+        "specialty": _(u"Specialty")
     }
 
     extended_profile_field_names = configuration_helpers.get_value('extended_profile_fields', [])

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -144,6 +144,7 @@ class RegistrationFormFactory(object):
         "year_of_birth",
         "level_of_education",
         "company",
+        "job_title",
         "title",
         "mailing_address",
         "goals",
@@ -649,6 +650,23 @@ class RegistrationFormFactory(object):
         form_desc.add_field(
             "title",
             label=title_label,
+            required=required
+        )
+
+    def _add_job_title_field(self, form_desc, required=False):
+        """Add a Job Title field to a form description.
+        Arguments:
+            form_desc: A form description
+        Keyword Arguments:
+            required (bool): Whether this field is required; defaults to False
+        """
+        # Translators: This label appears above a field on the registration form
+        # which allows the user to input the Job Title
+        job_title_label = _(u"Job Title")
+
+        form_desc.add_field(
+            "job_title",
+            label=job_title_label,
             required=required
         )
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1731,6 +1731,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
             "level_of_education",
             "company",
             "title",
+            "job_title",
             "mailing_address",
             "goals",
             "honor_code",


### PR DESCRIPTION
Add 'Job Title' as configurable field on the registration page.
Job Title will be saved to the 'meta' field of the 'userprofile' table.