### PR TITLE
Do not show expired, unfulfilled entitlements on dashboards.

### DIFF
--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -376,11 +376,15 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin):
     @patch.object(CourseOverview, 'get_from_id')
     def test_unfulfilled_expired_entitlement(self, mock_course_overview, mock_course_runs):
         """
-        When a learner has an unfulfilled, expired entitlement, their course dashboard should have:
-            - a hidden 'View Course' button
-            - a message saying that they can no longer select a session
+        When a learner has an unfulfilled, expired entitlement, a card should NOT appear on the dashboard.
+        This use case represents either an entitlement that the user waited too long to fulfill, or an entitlement
+        for which they received a refund.
         """
-        CourseEntitlementFactory(user=self.user, created=self.THREE_YEARS_AGO)
+        CourseEntitlementFactory(
+            user=self.user,
+            created=self.THREE_YEARS_AGO,
+            expired_at=datetime.datetime.now()
+        )
         mock_course_overview.return_value = CourseOverviewFactory(start=self.TOMORROW)
         mock_course_runs.return_value = [
             {
@@ -391,9 +395,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin):
             }
         ]
         response = self.client.get(self.path)
-        self.assertIn('class="enter-course hidden"', response.content)
-        self.assertIn('You can no longer select a session', response.content)
-        self.assertNotIn('<div class="course-entitlement-selection-container ">', response.content)
+        self.assertEqual(response.content.count('<li class="course-item">'), 0)
 
     @patch('student.views.get_course_runs_for_course')
     @patch.object(CourseOverview, 'get_from_id')

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -698,7 +698,7 @@ def dashboard(request):
     course_enrollments = list(get_course_enrollments(user, site_org_whitelist, site_org_blacklist))
 
     # Get the entitlements for the user and a mapping to all available sessions for that entitlement
-    course_entitlements = list(CourseEntitlement.objects.filter(user=user).select_related('enrollment_course_run'))
+    course_entitlements = list(CourseEntitlement.get_active_entitlements_for_user(user))
     course_entitlement_available_sessions = {}
     for course_entitlement in course_entitlements:
         course_entitlement.update_expired_at()

--- a/lms/static/js/spec/learner_dashboard/course_card_view_spec.js
+++ b/lms/static/js/spec/learner_dashboard/course_card_view_spec.js
@@ -234,16 +234,6 @@ define([
 
             expect(view.$('.course-title-link').length).toEqual(0);
         });
-        it('should show an unfulfilled expired user entitlement not allowing the changing of sessions', function() {
-            course.user_entitlement = {
-                uuid: '99fc7414c36d4f56b37e8e30acf4c7ba',
-                course_uuid: '99fc7414c36d4f56b37e8e30acf4c7ba',
-                expired_at: '2017-12-06 01:06:12',
-                expiration_date: '2017-12-05 01:06:12'
-            };
-            setupView(course, false);
-            expect(view.$('.info-expires-at').text().trim()).toContain('You can no longer select a session. Your');
-        });
 
         it('should show an unfulfilled user entitlement allows you to select a session', function() {
             course.user_entitlement = {

--- a/lms/static/sass/views/_program-details.scss
+++ b/lms/static/sass/views/_program-details.scss
@@ -356,11 +356,15 @@
         background-color: palette(primary, dark);
         height: 37px;
         width: 128px;
-        border-radius: 0;
         padding: 0;
         margin-bottom: 5px;
         margin-top: 7px;
         font-size: 0.9375em;
+
+        &:hover {
+          color: palette(primary, dark);
+          background-color: theme-color("inverse");
+        }
 
         /* IE11 CSS styles */
         @media (min-width: $bp-screen-md) and (-ms-high-contrast: none), (-ms-high-contrast: active) {
@@ -393,14 +397,7 @@
     }
 
     .run-select {
-      @include margin-right(10px);
-
-      width: 95%;
-
-      @media (min-width: $bp-screen-sm) {
-        width: 300px;
-      }
-
+      width: 100%;
       height: 34px;
       padding: 0;
     }
@@ -511,7 +508,7 @@
 
     .course-actions {
       @media (min-width: $bp-screen-md) {
-        width: 200px;
+        width: 100%;
         text-align: right;
         float: right;
       }

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -131,9 +131,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                 % if is_unfulfilled_entitlement:
                     <span class="info-date-block" aria-live="polite">
                         <span class="icon fa fa-warning" aria-hidden="true"></span>
-                        % if entitlement_expired_at:
-                            ${_('You can no longer select a session, your final day to select a session was {entitlement_expired_at}.').format(entitlement_expired_at=entitlement_expired_at)}
-                        % else:
+                        % if not entitlement_expired_at:
                             % if entitlement_expiration_date:
                                 ${_('You must select a session by {expiration_date} to access the course.').format(expiration_date=entitlement_expiration_date)}
                             % else:
@@ -156,7 +154,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
             </span>
             % if entitlement and not is_unfulfilled_entitlement and entitlement_expiration_date:
                 <div class="info-expires-at">
-                        <span class="msg-icon fa fa-info" aria-hidden="true"></span>
+                        <span class="msg-icon fa fa-warning" aria-hidden="true"></span>
                         % if entitlement_expired_at:
                             ${_('You can no longer change sessions.')}
                         % else:

--- a/lms/templates/learner_dashboard/course_card.underscore
+++ b/lms/templates/learner_dashboard/course_card.underscore
@@ -25,9 +25,7 @@
                 <% if (user_entitlement && user_entitlement.expiration_date) { %>
                     <div class="info-expires-at">
                         <% if (is_unfulfilled_entitlement) { %>
-                            <% if (user_entitlement.expired_at) { %>
-                                <%- StringUtils.interpolate(gettext('You can no longer select a session. Your final day to select a session was {expiration_date}.'), {expiration_date: user_entitlement.expiration_date}) %>
-                            <% } else { %>
+                            <% if (!user_entitlement.expired_at) { %>
                                 <%- StringUtils.interpolate(gettext('You must select a session by {expiration_date} to access the course.'), {expiration_date: user_entitlement.expiration_date}) %>
                             <% } %>
                         <% } else { %>

--- a/lms/templates/learner_dashboard/course_enroll.underscore
+++ b/lms/templates/learner_dashboard/course_enroll.underscore
@@ -16,7 +16,7 @@
         <% if (enrollable_course_runs.length > 1) { %>
             <div class="run-select-container">
                 <label class="select-choice" for="select-<%- course_key %>-run">
-                    <%- gettext('Choose a course run:') %>
+                    <%- gettext('Select a session:') %>
                 </label>
                 <select id="select-<%- course_key %>-run" class="run-select field-input input-select" autocomplete="off">
                     <% _.each (enrollable_course_runs, function(courseRun) { %>

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -222,16 +222,20 @@ class ProgramProgressMeter(object):
             completed, in_progress, not_started = [], [], []
 
             for course in program_copy['courses']:
-                entitlement = CourseEntitlement.objects.filter(user=self.user,
-                                                               course_uuid=course['uuid']).first()
-
+                active_entitlement = CourseEntitlement.get_entitlement_if_active(
+                    user=self.user,
+                    course_uuid=course['uuid']
+                )
                 if self._is_course_complete(course):
                     completed.append(course)
-                elif self._is_course_enrolled(course) or entitlement:
-                    # Show all currently enrolled courses and entitlements as in progress
-                    if entitlement:
-                        course['user_entitlement'] = entitlement.to_dict()
-                        course['enroll_url'] = reverse('entitlements_api:v1:enrollments', args=[str(entitlement.uuid)])
+                elif self._is_course_enrolled(course) or active_entitlement:
+                    # Show all currently enrolled courses and active entitlements as in progress
+                    if active_entitlement:
+                        course['user_entitlement'] = active_entitlement.to_dict()
+                        course['enroll_url'] = reverse(
+                            'entitlements_api:v1:enrollments',
+                            args=[str(active_entitlement.uuid)]
+                        )
                         in_progress.append(course)
                     else:
                         course_in_progress = self._is_course_in_progress(now, course)


### PR DESCRIPTION
LEARNER-3636

This PR ensures that entitlements are only shown if they are unexpired or have an associated, enrolled session.

This avoids showing entitlements that are unexpired and not redeemable, whether the user waited too long to enroll in a session or they received a refund.

To test this, you can pull down the branch, and set the values directly in the database to check behavior in multiple states. Or I can show you at my computer.

The commands I used for DB manipulation are:
* To see IDs of the entitlement objects
`SELECT * FROM entitlements_courseentitlement;`
* Fulfill entitlement
`UPDATE entitlements_courseentitlement SET enrollment_course_run_id = 4  WHERE id=[the id you see];`
* Remove session from entitlement
`UPDATE entitlements_courseentitlement SET enrollment_course_run_id = NULL  WHERE id=[the id you see];`
* Un-expire the course
`UPDATE entitlements_courseentitlement SET expired_at = NULL  WHERE id=[the id you see];`
* Expire the course
`UPDATE entitlements_courseentitlement SET expired_at = 'NOW'  WHERE id=[the id you see];`

@edx/helio 