### PR TITLE
Show programs for expired entitlements

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -176,7 +176,7 @@ from student.models import CourseEnrollment
                 is_course_blocked = (session_id in block_courses)
                 course_verification_status = verification_status_by_course.get(session_id, {})
                 course_requirements = courses_requirements_not_met.get(session_id)
-                related_programs = inverted_programs.get(unicode(entitlement.course_uuid if entitlement else session_id))
+                related_programs = inverted_programs.get(unicode(entitlement.course_uuid if is_unfulfilled_entitlement else session_id))
                 show_consent_link = (session_id in consent_required_courses)
                 course_overview = enrollment.course_overview
               %>

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -120,7 +120,6 @@ class ProgramProgressMeter(object):
                     program_list = inverted_programs[course_uuid]
                     if program not in program_list:
                         program_list.append(program)
-                    continue
                 for course_run in course['course_runs']:
                     course_run_id = course_run['key']
                     if course_run_id in self.course_run_ids:

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -172,7 +172,7 @@ from student.models import CourseEnrollment
             is_course_blocked = (session_id in block_courses)
             course_verification_status = verification_status_by_course.get(session_id, {})
             course_requirements = courses_requirements_not_met.get(session_id)
-            related_programs = inverted_programs.get(unicode(entitlement.course_uuid if entitlement else session_id))
+            related_programs = inverted_programs.get(unicode(entitlement.course_uuid if is_unfulfilled_entitlement else session_id))
             show_consent_link = (session_id in consent_required_courses)
             course_overview = enrollment.course_overview
           %>


### PR DESCRIPTION
The dashboard was not showing related programs for expired but fulfilled entitlements.

Simply use a different filter to look for course runs first, then only look up entitlements if we don't have a course run. 

https://openedx.atlassian.net/browse/LEARNER-3608