### PR TITLE
PLAT-1859 Fix LMS shard 1 tests under Django 1.9

### DIFF
--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -2,13 +2,11 @@
 import json
 
 import ddt
-import pytest
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.test.utils import override_settings
-from mock import Mock
 from nose.plugins.attrib import attr
 from opaque_keys.edx.locator import CourseLocator
 from path import Path as path
@@ -264,14 +262,13 @@ class TestCertificateGenerationHistory(TestCase):
         ({"statuses_to_regenerate": ['downloadable', 'not_readable']}, 'already received', False),
     )
     @ddt.unpack
-    @pytest.mark.django111_expected_failure
     def test_get_certificate_generation_candidates(self, task_input, expected, is_regeneration):
         staff = AdminFactory.create()
         instructor_task = InstructorTaskFactory.create(
             task_input=json.dumps(task_input),
             requester=staff,
-            task_key=Mock(),
-            task_id=Mock(),
+            task_key='',
+            task_id='',
         )
         certificate_generation_history = CertificateGenerationHistory(
             course_id=instructor_task.course_id,
@@ -286,14 +283,13 @@ class TestCertificateGenerationHistory(TestCase):
 
     @ddt.data((True, "regenerated"), (False, "generated"))
     @ddt.unpack
-    @pytest.mark.django111_expected_failure
     def test_get_task_name(self, is_regeneration, expected):
         staff = AdminFactory.create()
         instructor_task = InstructorTaskFactory.create(
             task_input=json.dumps({}),
             requester=staff,
-            task_key=Mock(),
-            task_id=Mock(),
+            task_key='',
+            task_id='',
         )
         certificate_generation_history = CertificateGenerationHistory(
             course_id=instructor_task.course_id,

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -2,19 +2,18 @@
 Tests for course wiki
 """
 
-import pytest
 from django.core.urlresolvers import reverse
 from mock import patch
 from nose.plugins.attrib import attr
 
 from courseware.tests.tests import LoginEnrollmentTestCase
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
+from openedx.tests.util import expected_redirect_url
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for wiki course redirection.
@@ -58,7 +57,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         resp = self.client.get(destination, HTTP_REFERER=referer)
         self.assertEqual(resp.status_code, 302)
 
-        self.assertEqual(resp['Location'], 'http://testserver' + redirected_to)
+        self.assertEqual(resp['Location'], expected_redirect_url(redirected_to))
 
         # Now we test that the student will be redirected away from that page if the course doesn't exist
         # We do this in the same test because we want to make sure the redirected_to is constructed correctly
@@ -67,7 +66,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
 
         resp = self.client.get(bad_course_wiki_page, HTTP_REFERER=referer)
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['Location'], 'http://testserver' + destination)
+        self.assertEqual(resp['Location'], expected_redirect_url(destination))
 
     @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': False})
     def test_wiki_no_root_access(self):
@@ -100,7 +99,7 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
 
         ending_location = resp.redirect_chain[-1][0]
 
-        self.assertEquals(ending_location, 'http://testserver' + course_wiki_page)
+        self.assertEquals(ending_location, expected_redirect_url(course_wiki_page))
         self.assertEquals(resp.status_code, 200)
 
         self.has_course_navigator(resp)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -11,7 +11,6 @@ from urllib import quote, urlencode
 from uuid import uuid4
 
 import ddt
-import pytest
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse, reverse_lazy
@@ -62,6 +61,7 @@ from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.gating import api as gating_api
 from openedx.features.course_experience import COURSE_OUTLINE_PAGE_FLAG
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
+from openedx.tests.util import expected_redirect_url
 from student.models import CourseEnrollment
 from student.tests.factories import TEST_PASSWORD, AdminFactory, CourseEnrollmentFactory, UserFactory
 from util.tests.test_date_utils import fake_pgettext, fake_ugettext
@@ -115,7 +115,6 @@ class TestJumpTo(ModuleStoreTestCase):
         response = self.client.get(jumpto_url)
         self.assertRedirects(response, expected, status_code=302, target_status_code=302)
 
-    @pytest.mark.django111_expected_failure
     def test_jumpto_from_section(self):
         course = CourseFactory.create()
         chapter = ItemFactory.create(category='chapter', parent_location=course.location)
@@ -132,9 +131,8 @@ class TestJumpTo(ModuleStoreTestCase):
             unicode(section.location),
         )
         response = self.client.get(jumpto_url)
-        self.assertRedirects(response, expected, status_code=302, target_status_code=302)
+        self.assertRedirects(response, expected_redirect_url(expected), status_code=302, target_status_code=302)
 
-    @pytest.mark.django111_expected_failure
     def test_jumpto_from_module(self):
         course = CourseFactory.create()
         chapter = ItemFactory.create(category='chapter', parent_location=course.location)
@@ -156,7 +154,7 @@ class TestJumpTo(ModuleStoreTestCase):
             unicode(module1.location),
         )
         response = self.client.get(jumpto_url)
-        self.assertRedirects(response, expected, status_code=302, target_status_code=302)
+        self.assertRedirects(response, expected_redirect_url(expected), status_code=302, target_status_code=302)
 
         expected = 'courses/{course_id}/courseware/{chapter_id}/{section_id}/2?{activate_block_id}'.format(
             course_id=unicode(course.id),
@@ -170,9 +168,8 @@ class TestJumpTo(ModuleStoreTestCase):
             unicode(module2.location),
         )
         response = self.client.get(jumpto_url)
-        self.assertRedirects(response, expected, status_code=302, target_status_code=302)
+        self.assertRedirects(response, expected_redirect_url(expected), status_code=302, target_status_code=302)
 
-    @pytest.mark.django111_expected_failure
     def test_jumpto_from_nested_module(self):
         course = CourseFactory.create()
         chapter = ItemFactory.create(category='chapter', parent_location=course.location)
@@ -199,7 +196,7 @@ class TestJumpTo(ModuleStoreTestCase):
             unicode(module2.location),
         )
         response = self.client.get(jumpto_url)
-        self.assertRedirects(response, expected, status_code=302, target_status_code=302)
+        self.assertRedirects(response, expected_redirect_url(expected), status_code=302, target_status_code=302)
 
     def test_jumpto_id_invalid_location(self):
         location = Location('edX', 'toy', 'NoSuchPlace', None, None, None)

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2678,7 +2678,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             problem key that the get_problem_responses endpoint can
             work with.
             """
-            mock_problem_key = Mock(return_value=u'')
+            mock_problem_key = NonCallableMock(return_value=u'')
             mock_problem_key.course_key = self.course.id
             with patch.object(UsageKey, 'from_string') as patched_method:
                 patched_method.return_value = mock_problem_key


### PR DESCRIPTION
Tweaked a few usages of `mock` and wrapped a few more expected URLs in the utility designed to format them appropriately for the current version of Django.  This should get all the LMS shard 1 tests passing under Django 1.9.