### PR TITLE
zendesk proxy and front end of support form updated

### DIFF
--- a/lms/djangoapps/support/static/support/jsx/logged_in_user.jsx
+++ b/lms/djangoapps/support/static/support/jsx/logged_in_user.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import FileUpload from './file_upload';
 
-function LoggedInUser({ userInformation, setErrorState, zendeskApiHost, accessToken, submitForm }) {
+function LoggedInUser({ userInformation, setErrorState, zendeskApiHost, submitForm }) {
   let courseElement;
   if (userInformation.enrollments) {
     courseElement = (<div>
@@ -70,11 +70,12 @@ function LoggedInUser({ userInformation, setErrorState, zendeskApiHost, accessTo
       </div>
     </div>
 
-    <FileUpload
-      setErrorState={setErrorState}
-      zendeskApiHost={zendeskApiHost}
-      accessToken={accessToken}
-    />
+    {/*TODO file uploading will be done after initial release*/}
+    {/*<FileUpload*/}
+      {/*setErrorState={setErrorState}*/}
+      {/*zendeskApiHost={zendeskApiHost}*/}
+      {/*accessToken={accessToken}*/}
+    {/*/>*/}
 
     <div className="row">
       <div className="col-sm-12">
@@ -91,8 +92,7 @@ LoggedInUser.propTypes = {
   setErrorState: PropTypes.func.isRequired,
   submitForm: PropTypes.func.isRequired,
   userInformation: PropTypes.arrayOf(PropTypes.object).isRequired,
-  zendeskApiHost: PropTypes.string.isRequired,
-  accessToken: PropTypes.string.isRequired,
+  zendeskProxyUrl: PropTypes.string.isRequired,
 };
 
 export default LoggedInUser;

--- a/lms/djangoapps/support/views/contact_us.py
+++ b/lms/djangoapps/support/views/contact_us.py
@@ -18,8 +18,6 @@ class ContactUsView(View):
     def get(self, request):
         context = {
             'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
-            'zendesk_api_host': settings.ZENDESK_URL,
-            'access_token': 'DUMMY_ACCESS_TOKEN',  # LEARNER-3450
             'custom_fields': settings.ZENDESK_CUSTOM_FIELDS
         }
 

--- a/lms/templates/support/contact_us.html
+++ b/lms/templates/support/contact_us.html
@@ -33,8 +33,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_j
             'loginQuery': "${login_query() | n, js_escaped_string}",
             'dashboardUrl': "${reverse('dashboard') | n, js_escaped_string}",
             'homepageUrl': "${marketing_link('ROOT') | n, js_escaped_string}",
-            'zendeskApiHost': "${zendesk_api_host | n, js_escaped_string}",
-            'accessToken': "${access_token | n, js_escaped_string}",
+            'zendeskProxyUrl': "${reverse('zendesk_proxy_v1') | n, js_escaped_string}",
             'customFields': ${custom_fields | n, dump_js_escaped_json},
             'zendeskTags': ${zendesk_tags | n, dump_js_escaped_json},
         }

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v0_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v0_views.py
@@ -1,0 +1,86 @@
+"""Tests for zendesk_proxy views."""
+import json
+from copy import deepcopy
+
+import ddt
+from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
+from mock import MagicMock, patch
+
+from openedx.core.djangoapps.zendesk_proxy.v0.views import ZENDESK_REQUESTS_PER_HOUR
+from openedx.core.lib.api.test_utils import ApiTestCase
+
+
+@ddt.ddt
+@override_settings(
+    ZENDESK_URL="https://www.superrealurlsthataredefinitelynotfake.com",
+    ZENDESK_OAUTH_ACCESS_TOKEN="abcdefghijklmnopqrstuvwxyz1234567890"
+)
+class ZendeskProxyTestCase(ApiTestCase):
+    """Tests for zendesk_proxy views."""
+
+    def setUp(self):
+        self.url = reverse('zendesk_proxy_v0')
+        self.request_data = {
+            'name': 'John Q. Student',
+            'tags': ['python_unit_test'],
+            'email': {
+                'from': 'JohnQStudent@example.com',
+                'subject': 'Python Unit Test Help Request',
+                'message': "Help! I'm trapped in a unit test factory and I can't get out!",
+            }
+        }
+        return super(ZendeskProxyTestCase, self).setUp()
+
+    def test_post(self):
+        with patch('requests.post', return_value=MagicMock(status_code=201)) as mock_post:
+            response = self.request_without_auth(
+                'post',
+                self.url,
+                data=json.dumps(self.request_data),
+                content_type='application/json'
+            )
+            self.assertHttpCreated(response)
+            (mock_args, mock_kwargs) = mock_post.call_args
+            self.assertEqual(mock_args, ('https://www.superrealurlsthataredefinitelynotfake.com/api/v2/tickets.json',))
+            self.assertEqual(
+                mock_kwargs,
+                {
+                    'headers': {
+                        'content-type': 'application/json',
+                        'Authorization': 'Bearer abcdefghijklmnopqrstuvwxyz1234567890'
+                    },
+                    'data': '{"ticket": {"comment": {"body": "Help! I\'m trapped in a unit test factory and I can\'t get out!", "uploads": null}, "tags": ["python_unit_test"], "subject": "Python Unit Test Help Request", "custom_fields": null, "requester": {"name": "John Q. Student", "email": "JohnQStudent@example.com"}}}'  # pylint: disable=line-too-long
+                }
+            )
+
+    @ddt.data('name', 'tags', 'email')
+    def test_bad_request(self, key_to_delete):
+        test_data = deepcopy(self.request_data)
+        _ = test_data.pop(key_to_delete)
+
+        response = self.request_without_auth(
+            'post',
+            self.url,
+            data=json.dumps(test_data),
+            content_type='application/json'
+        )
+        self.assertHttpBadRequest(response)
+
+    @override_settings(
+        CACHES={
+            'default': {
+                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+                'LOCATION': 'zendesk_proxy',
+            }
+        }
+    )
+    def test_rate_limiting(self):
+        """
+        Confirm rate limits work as expected. Note that drf's rate limiting makes use of the default cache to enforce
+        limits; that's why this test needs a "real" default cache (as opposed to the usual-for-tests DummyCache)
+        """
+        for _ in range(ZENDESK_REQUESTS_PER_HOUR):
+            self.request_without_auth('post', self.url)
+        response = self.request_without_auth('post', self.url)
+        self.assertEqual(response.status_code, 429)

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
@@ -1,14 +1,14 @@
 """Tests for zendesk_proxy views."""
-from copy import deepcopy
-import ddt
 import json
-from mock import MagicMock, patch
+from copy import deepcopy
 
+import ddt
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
+from mock import MagicMock, patch
 
+from openedx.core.djangoapps.zendesk_proxy.v1.views import ZendeskProxyThrottle
 from openedx.core.lib.api.test_utils import ApiTestCase
-from openedx.core.djangoapps.zendesk_proxy.v0.views import ZENDESK_REQUESTS_PER_HOUR
 
 
 @ddt.ddt
@@ -20,15 +20,23 @@ class ZendeskProxyTestCase(ApiTestCase):
     """Tests for zendesk_proxy views."""
 
     def setUp(self):
-        self.url = reverse('zendesk_proxy_v0')
+        self.url = reverse('zendesk_proxy_v1')
         self.request_data = {
-            'name': 'John Q. Student',
+            'requester': {
+                'email': 'JohnQStudent@example.com',
+                'name': 'John Q. Student'
+            },
+            'subject': 'Python Unit Test Help Request',
+            'comment': {
+                'body': "Help! I'm trapped in a unit test factory and I can't get out!",
+            },
             'tags': ['python_unit_test'],
-            'email': {
-                'from': 'JohnQStudent@example.com',
-                'subject': 'Python Unit Test Help Request',
-                'message': "Help! I'm trapped in a unit test factory and I can't get out!",
-            }
+            'custom_fields': [
+                {
+                    'id': '001',
+                    'value': 'demo-course'
+                }
+            ],
         }
         return super(ZendeskProxyTestCase, self).setUp()
 
@@ -50,11 +58,11 @@ class ZendeskProxyTestCase(ApiTestCase):
                         'content-type': 'application/json',
                         'Authorization': 'Bearer abcdefghijklmnopqrstuvwxyz1234567890'
                     },
-                    'data': '{"ticket": {"comment": {"body": "Help! I\'m trapped in a unit test factory and I can\'t get out!"}, "subject": "Python Unit Test Help Request", "tags": ["python_unit_test"], "requester": {"name": "John Q. Student", "email": "JohnQStudent@example.com"}}}'  # pylint: disable=line-too-long
+                    'data': '{"ticket": {"comment": {"body": "Help! I\'m trapped in a unit test factory and I can\'t get out!", "uploads": null}, "tags": ["python_unit_test"], "subject": "Python Unit Test Help Request", "custom_fields": [{"id": "001", "value": "demo-course"}], "requester": {"name": "John Q. Student", "email": "JohnQStudent@example.com"}}}'  # pylint: disable=line-too-long
                 }
             )
 
-    @ddt.data('name', 'tags', 'email')
+    @ddt.data('requester', 'tags')
     def test_bad_request(self, key_to_delete):
         test_data = deepcopy(self.request_data)
         _ = test_data.pop(key_to_delete)
@@ -66,40 +74,6 @@ class ZendeskProxyTestCase(ApiTestCase):
             content_type='application/json'
         )
         self.assertHttpBadRequest(response)
-
-    @override_settings(
-        ZENDESK_URL=None,
-        ZENDESK_OAUTH_ACCESS_TOKEN=None
-    )
-    def test_missing_settings(self):
-        response = self.request_without_auth(
-            'post',
-            self.url,
-            data=json.dumps(self.request_data),
-            content_type='application/json'
-        )
-        self.assertEqual(response.status_code, 503)
-
-    @ddt.data(201, 400, 401, 403, 404, 500)
-    def test_zendesk_status_codes(self, mock_code):
-        with patch('requests.post', return_value=MagicMock(status_code=mock_code)):
-            response = self.request_without_auth(
-                'post',
-                self.url,
-                data=json.dumps(self.request_data),
-                content_type='application/json'
-            )
-            self.assertEqual(response.status_code, mock_code)
-
-    def test_unexpected_error_pinging_zendesk(self):
-        with patch('requests.post', side_effect=Exception("WHAMMY")):
-            response = self.request_without_auth(
-                'post',
-                self.url,
-                data=json.dumps(self.request_data),
-                content_type='application/json'
-            )
-            self.assertEqual(response.status_code, 500)
 
     @override_settings(
         CACHES={
@@ -114,7 +88,8 @@ class ZendeskProxyTestCase(ApiTestCase):
         Confirm rate limits work as expected. Note that drf's rate limiting makes use of the default cache to enforce
         limits; that's why this test needs a "real" default cache (as opposed to the usual-for-tests DummyCache)
         """
-        for _ in range(ZENDESK_REQUESTS_PER_HOUR):
+
+        for _ in range(ZendeskProxyThrottle().num_requests):
             self.request_without_auth('post', self.url)
         response = self.request_without_auth('post', self.url)
         self.assertEqual(response.status_code, 429)

--- a/openedx/core/djangoapps/zendesk_proxy/urls.py
+++ b/openedx/core/djangoapps/zendesk_proxy/urls.py
@@ -5,7 +5,9 @@ Map urls to the relevant view handlers
 from django.conf.urls import url
 
 from openedx.core.djangoapps.zendesk_proxy.v0.views import ZendeskPassthroughView as v0_view
+from openedx.core.djangoapps.zendesk_proxy.v1.views import ZendeskPassthroughView as v1_view
 
 urlpatterns = [
     url(r'^v0$', v0_view.as_view(), name='zendesk_proxy_v0'),
+    url(r'^v1$', v1_view.as_view(), name='zendesk_proxy_v1'),
 ]

--- a/openedx/core/djangoapps/zendesk_proxy/utils.py
+++ b/openedx/core/djangoapps/zendesk_proxy/utils.py
@@ -12,7 +12,7 @@ from rest_framework import status
 log = logging.getLogger(__name__)
 
 
-def create_zendesk_ticket(requester_name, requester_email, subject, body, tags=None):
+def create_zendesk_ticket(requester_name, requester_email, subject, body, custom_fields=None, uploads=None, tags=None):
     """
     Create a Zendesk ticket via API.
 
@@ -24,8 +24,9 @@ def create_zendesk_ticket(requester_name, requester_email, subject, body, tags=N
         """Internal helper to standardize error message. This allows for simpler splunk alerts."""
         return 'zendesk_proxy action required\n{}\nNo ticket created for payload {}'.format(details, payload)
 
-    # Remove duplicates from tags list
-    tags = list(set(tags))
+    if tags:
+        # Remove duplicates from tags list
+        tags = list(set(tags))
 
     data = {
         'ticket': {
@@ -34,7 +35,11 @@ def create_zendesk_ticket(requester_name, requester_email, subject, body, tags=N
                 'email': requester_email
             },
             'subject': subject,
-            'comment': {'body': body},
+            'comment': {
+                'body': body,
+                'uploads': uploads
+            },
+            'custom_fields': custom_fields,
             'tags': tags
         }
     }

--- a/openedx/core/djangoapps/zendesk_proxy/v1/views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/v1/views.py
@@ -1,0 +1,69 @@
+"""
+Define request handlers used by the zendesk_proxy djangoapp
+"""
+from rest_framework import status
+from rest_framework.parsers import JSONParser
+from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
+from rest_framework.views import APIView
+
+from openedx.core.djangoapps.zendesk_proxy.utils import create_zendesk_ticket
+
+REQUESTS_PER_HOUR = 50
+
+
+class ZendeskProxyThrottle(UserRateThrottle):
+    """
+    Custom throttle rates for this particular endpoint's use case.
+    """
+
+    def __init__(self):
+        self.rate = '{}/hour'.format(REQUESTS_PER_HOUR)
+        super(ZendeskProxyThrottle, self).__init__()
+
+
+class ZendeskPassthroughView(APIView):
+    """
+    An APIView that will take in inputs from an unauthenticated endpoint, and use them to securely create a zendesk
+    ticket.
+    """
+    throttle_classes = ZendeskProxyThrottle,
+    parser_classes = JSONParser,
+
+    def post(self, request):
+        """
+        request body is expected to look like this:
+        {
+            "requester": {
+                "email": "john@example.com",
+                "name": "name"
+            },
+            "subject": "test subject",
+            "comment": {
+                "body": "message details",
+                "uploads": ['file_token'],
+            },
+            "custom_fields": [
+                {
+                    "id": '001',
+                    "value": 'demo-course'
+                }
+            ],
+            "tags": ["LMS"]
+        }
+        """
+        try:
+            proxy_status = create_zendesk_ticket(
+                requester_name=request.data['requester']['name'],
+                requester_email=request.data['requester']['email'],
+                subject=request.data['subject'],
+                body=request.data['comment']['body'],
+                custom_fields=request.data['custom_fields'],
+                tags=request.data['tags']
+            )
+        except KeyError:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(
+            status=proxy_status
+        )


### PR DESCRIPTION
[LEARNER-3594](https://openedx.atlassian.net/browse/LEARNER-3594) and [LEARNER-3450](https://openedx.atlassian.net/browse/LEARNER-3450)

- V1 of proxy is added
- update request format in proxy
- add `custom_fields` to request
- fix request and validation code from JSX
- remove component of file uploading from form
- Tests are refactored

**Sandbox link:** tasawernawaz.sandbox.edx.org/support/contact_us

FYI: @edx/learner-spartans 