### PR TITLE
check tracking ID first

### DIFF
--- a/openedx/core/djangoapps/ace_common/tracking.py
+++ b/openedx/core/djangoapps/ace_common/tracking.py
@@ -108,7 +108,7 @@ class GoogleAnalyticsTrackingPixel(object):
         return u"https://www.google-analytics.com/collect?{params}".format(params=urlencode(parameters))
 
     def _get_tracking_id(self):
-        tracking_id = get_config_value_from_site_or_settings("GOOGLE_ANALYTICS_ACCOUNT", site=self.site)
+        tracking_id = get_config_value_from_site_or_settings("GOOGLE_ANALYTICS_TRACKING_ID", site=self.site)
         if tracking_id is None:
-            tracking_id = get_config_value_from_site_or_settings("GOOGLE_ANALYTICS_TRACKING_ID", site=self.site)
+            tracking_id = get_config_value_from_site_or_settings("GOOGLE_ANALYTICS_ACCOUNT", site=self.site)
         return tracking_id


### PR DESCRIPTION
GA pixels are not being included in emails, I strongly suspect this is due to a configuration issue. We want the legacy GOOGLE_ANALYTICS_ACCOUNT setting to be checked after the newer GOOGLE_ANALYTICS_TRACKING_ID setting.