### PR TITLE
PLAT-1864: Remove test_course_listing_performance flaky test.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -240,7 +240,6 @@ class TestCourseListing(ModuleStoreTestCase):
 
     @ddt.data(
         (ModuleStoreEnum.Type.split, 3, 3),
-        (ModuleStoreEnum.Type.mongo, 2, 2)
     )
     @ddt.unpack
     def test_course_listing_performance(self, store, courses_list_from_group_calls, courses_list_calls):


### PR DESCRIPTION
[PLAT-1864](https://openedx.atlassian.net/browse/PLAT-1864)

The following test fails intermittently and has been removed from the codebase:
cms.djangoapps.contentstore.tests.test_course_listing.TestCourseListing.test_course_listing_performance_2___mongo___2__2_

3 failures from master, which has many other builds that are passing:

Error Message
AssertionError: 0.0041980743408203125 not greater than or equal to 0.0805349349975586

Error Message
AssertionError: 0.004446983337402344 not greater than or equal to 0.010442972183227539

Error Message
AssertionError: 0.0045778751373291016 not greater than or equal to 0.006994962692260742

Stacktrace
self = <cms.djangoapps.contentstore.tests.test_course_listing.TestCourseListing testMethod=test_course_listing_performance_2___mongo___2__2_>

    @wraps(func)
    def wrapper(self):
>       return func(self, *args, **kwargs)

../../edx-venv/local/lib/python2.7/site-packages/ddt.py:114: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
cms/djangoapps/contentstore/tests/test_course_listing.py:290: in test_course_listing_performance
    self.assertGreaterEqual(iteration_over_courses_time_1.elapsed, iteration_over_groups_time_1.elapsed)
E   AssertionError: 0.0045778751373291016 not greater than or equal to 0.006994962692260742
