### PR TITLE
PLAT-1858 Better capture of deprecation warnings

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -21,7 +21,6 @@ sessions. Assumes structure:
 from .common import *
 import os
 from path import Path as path
-from warnings import filterwarnings, simplefilter
 from uuid import uuid4
 from util.db import NoOpMigrationModules
 from openedx.core.lib.derived import derive_settings
@@ -174,15 +173,6 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
     },
 }
-
-# hide ratelimit warnings while running tests
-filterwarnings('ignore', message='No request passed to the backend, unable to rate-limit')
-
-# Ignore deprecation warnings (so we don't clutter Jenkins builds/production)
-# https://docs.python.org/2/library/warnings.html#the-warnings-filter
-# Change to "default" to see the first instance of each hit
-# or "error" to convert all into errors
-simplefilter('ignore')
 
 ################################# CELERY ######################################
 

--- a/cms/pytest.ini
+++ b/cms/pytest.ini
@@ -1,6 +1,11 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = cms.envs.test
 addopts = --nomigrations --reuse-db --durations=20 -p no:randomly
+# Enable default handling for all warnings, including those that are ignored by default;
+# but hide rate-limit warnings, because we deliberately don't throttle test user logins
+filterwarnings =
+    default
+    ignore:No request passed to the backend, unable to rate-limit:UserWarning
 norecursedirs = envs
 python_classes =
 python_files = tests.py test_*.py *_tests.py

--- a/common/lib/pytest.ini
+++ b/common/lib/pytest.ini
@@ -1,6 +1,11 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = openedx.tests.settings
 addopts = --nomigrations --reuse-db --durations=20
+# Enable default handling for all warnings, including those that are ignored by default;
+# but hide rate-limit warnings, because we deliberately don't throttle test user logins
+filterwarnings =
+    default
+    ignore:No request passed to the backend, unable to rate-limit:UserWarning
 norecursedirs = .cache
 python_classes =
 python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py

--- a/common/test/pytest.ini
+++ b/common/test/pytest.ini
@@ -1,3 +1,8 @@
 [pytest]
 addopts = -p no:randomly --durations=20
+# Enable default handling for all warnings, including those that are ignored by default;
+# but hide rate-limit warnings, because we deliberately don't throttle test user logins
+filterwarnings =
+    default
+    ignore:No request passed to the backend, unable to rate-limit:UserWarning
 norecursedirs = .cache

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -22,7 +22,6 @@ from .common import *
 import os
 from path import Path as path
 from uuid import uuid4
-from warnings import filterwarnings, simplefilter
 
 from util.db import NoOpMigrationModules
 from openedx.core.lib.derived import derive_settings
@@ -231,15 +230,6 @@ CACHES = {
 
 # Dummy secret key for dev
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
-
-# hide ratelimit warnings while running tests
-filterwarnings('ignore', message='No request passed to the backend, unable to rate-limit')
-
-# Ignore deprecation warnings (so we don't clutter Jenkins builds/production)
-# https://docs.python.org/2/library/warnings.html#the-warnings-filter
-# Change to "default" to see the first instance of each hit
-# or "error" to convert all into errors
-simplefilter('ignore')
 
 ############################# SECURITY SETTINGS ################################
 # Default to advanced security in common.py, so tests can reset here to use

--- a/openedx/tests/settings.py
+++ b/openedx/tests/settings.py
@@ -58,10 +58,12 @@ INSTALLED_APPS = (
     'djcelery',
     'openedx.core.djangoapps.video_config',
     'openedx.core.djangoapps.video_pipeline',
+    'openedx.core.djangoapps.bookmarks.apps.BookmarksConfig',
     'edxval',
     'courseware',
     'student',
     'certificates.apps.CertificatesConfig',
+    'openedx.core.djangoapps.user_api',
     'course_modes.apps.CourseModesConfig',
     'lms.djangoapps.verify_student.apps.VerifyStudentConfig',
     'openedx.core.djangoapps.dark_lang',
@@ -71,6 +73,7 @@ INSTALLED_APPS = (
     'openedx.core.djangoapps.self_paced',
     'milestones',
     'celery_utils',
+    'lms.djangoapps.completion.apps.CompletionAppConfig',
 )
 
 LMS_ROOT_URL = 'http://localhost:8000'

--- a/openedx/tests/util/__init__.py
+++ b/openedx/tests/util/__init__.py
@@ -12,6 +12,7 @@ def expected_redirect_url(relative_url, hostname='testserver'):
     """
     Get the expected redirect URL for the current Django version and the
     given relative URL:
+
     * Django 1.8 and earlier redirect URLs beginning with a slash to absolute
       URLs, later versions redirect to relative ones.
     * Django 1.8 and earlier leave URLs without a leading slash alone, later

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -131,14 +131,8 @@ case "$TEST_SUITE" in
 
     "lms-unit")
         case "$SHARD" in
-            "all")
-                $TOX paver test_system -s lms --disable_capture $PAVER_ARGS $PARALLEL 2> lms-tests.log
-                ;;
-            [1-3])
-                $TOX paver test_system -s lms --disable_capture --eval-attr="shard==$SHARD" $PAVER_ARGS $PARALLEL 2> lms-tests.$SHARD.log
-                ;;
-            4|"noshard")
-                $TOX paver test_system -s lms --disable_capture --eval-attr='not shard' $PAVER_ARGS $PARALLEL 2> lms-tests.4.log
+            "all"|[1-4]|"noshard")
+                $TOX bash scripts/unit-tests.sh
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
@@ -151,12 +145,8 @@ case "$TEST_SUITE" in
         esac
         ;;
 
-    "cms-unit")
-        $TOX paver test_system -s cms --disable_capture $PAVER_ARGS 2> cms-tests.log
-        ;;
-
-    "commonlib-unit")
-        $TOX paver test_lib --disable_capture $PAVER_ARGS 2> common-tests.log
+    "cms-unit"|"commonlib-unit")
+        $TOX bash scripts/unit-tests.sh
         ;;
 
     "js-unit")

--- a/scripts/unit-tests.sh
+++ b/scripts/unit-tests.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+###############################################################################
+#
+#   unit-tests.sh
+#
+#   Execute Python unit tests for edx-platform.
+#
+#   This script is typically called from generic-ci-tests.sh, which defines
+#   these environment variables:
+#
+#   `TEST_SUITE` defines which kind of test to run.
+#   Possible values are:
+#
+#       - "lms-unit": Run the LMS Python unit tests
+#       - "cms-unit": Run the CMS Python unit tests
+#       - "commonlib-unit": Run Python unit tests from the common/lib directory
+#
+#   `SHARD` is a number indicating which subset of the tests to build.
+#
+#       For "lms-unit", the tests are put into shard groups
+#       using the 'attr' decorator (e.g. "@attr(shard=1)"). Anything with
+#       the 'shard=n' attribute will run in the nth shard. If there isn't a
+#       shard explicitly assigned, the test will run in the last shard.
+#
+#   This script is broken out so it can be run by tox and redirect stderr to
+#   the specified file before tox gets a chance to redirect it to stdout.
+#
+###############################################################################
+
+PAVER_ARGS="-v"
+PARALLEL="--processes=-1"
+
+case "${TEST_SUITE}" in
+
+    "lms-unit")
+        case "$SHARD" in
+            "all")
+                paver test_system -s lms --disable_capture ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.log
+                ;;
+            [1-3])
+                paver test_system -s lms --disable_capture --eval-attr="shard==$SHARD" ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.${SHARD}.log
+                ;;
+            4|"noshard")
+                paver test_system -s lms --disable_capture --eval-attr='not shard' ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.4.log
+                ;;
+        esac
+        ;;
+
+    "cms-unit")
+        paver test_system -s cms --disable_capture ${PAVER_ARGS} 2> cms-tests.log
+        ;;
+
+    "commonlib-unit")
+        paver test_lib --disable_capture ${PAVER_ARGS} 2> common-tests.log
+        ;;
+esac

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,11 @@ process-timeout=300
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = lms.envs.test
 addopts = --nomigrations --reuse-db --durations=20
+# Enable default handling for all warnings, including those that are ignored by default;
+# but hide rate-limit warnings, because we deliberately don't throttle test user logins
+filterwarnings =
+    default
+    ignore:No request passed to the backend, unable to rate-limit:UserWarning
 norecursedirs = .* *.egg build conf dist node_modules test_root cms/envs lms/envs
 python_classes =
 python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,8 @@ passenv =
     SELENIUM_BROWSER
     SELENIUM_HOST
     SELENIUM_PORT
+    SHARD
+    TEST_SUITE
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10


### PR DESCRIPTION
Background information is summarized in PLAT-1858. Main goals:

* Stop cluttering the Jenkins log with stderr data when running tests against Django 1.9+, without losing any deprecation warnings
* Get more deprecation warnings by default when running pytest directly

Also added more missing apps to openedx.tests.settings, spotted during the last Django 1.9 test run.

This is take 2 at this, now handling redirection to stderr in a new shell script instead of paver, because a deluge of spurious error logging at shutdown could swamp paver's output system and cause Jenkins to fail the job.