### PR TITLE
jaebradley/learner 3376 analytics api integration

### DIFF
--- a/openedx/features/learner_analytics/templates/learner_analytics/dashboard.html
+++ b/openedx/features/learner_analytics/templates/learner_analytics/dashboard.html
@@ -62,8 +62,8 @@ from openedx.features.course_experience import course_home_page_title
                 'grading_policy': grading_policy,
                 'grades': assignment_grades,
                 'discussion_info': discussion_info,
-                'weekly_active_users': context['weekly_active_users'],
-                'week_streak': context['week_streak'],
+                'weekly_active_users': weekly_active_users,
+                'week_streak': week_streak,
               }
             )}
         </div>

--- a/openedx/features/learner_analytics/templates/learner_analytics/dashboard.html
+++ b/openedx/features/learner_analytics/templates/learner_analytics/dashboard.html
@@ -61,7 +61,9 @@ from openedx.features.course_experience import course_home_page_title
                 'schedule': assignment_schedule,
                 'grading_policy': grading_policy,
                 'grades': assignment_grades,
-                'discussion_info': discussion_info
+                'discussion_info': discussion_info,
+                'weekly_active_users': context['weekly_active_users'],
+                'week_streak': context['week_streak'],
               }
             )}
         </div>

--- a/openedx/features/learner_analytics/views.py
+++ b/openedx/features/learner_analytics/views.py
@@ -71,7 +71,12 @@ class LearnerAnalyticsView(View):
             'assignment_grades': self.get_grade_data(request.user, course_key, grading_policy['GRADE_CUTOFFS']),
             'assignment_schedule': self.get_schedule(request, course_key),
             'discussion_info': self.get_discussion_data(request, course_key),
+            'weekly_active_users': self.get_weekly_course_activities(course_key),
+            'week_streak': self.consecutive_weeks_of_course_activity_for_user(
+                request.user.username, course_key
+            )
         }
+
         return render_to_response('learner_analytics/dashboard.html', context)
 
     def get_grade_data(self, user, course_key, grade_cutoffs):
@@ -111,7 +116,7 @@ class LearnerAnalyticsView(View):
         context = create_user_profile_context(request, course_key, request.user.id)
         threads = context['threads']
         profiled_user = context['profiled_user']
-        content_authored = profiled_user['threads_count'] +profiled_user['comments_count']
+        content_authored = profiled_user['threads_count'] + profiled_user['comments_count']
         thread_votes = 0
         for thread in threads:
             if thread['user_id'] == profiled_user['external_id']:

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -103,6 +103,7 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.1.6#egg=lti_consumer-xbloc
 git+https://github.com/edx/edx-proctoring.git@1.3.1#egg=edx-proctoring==1.3.1
 # This is here because all of the other XBlocks are located here. However, it is published to PyPI and will be installed that way
 xblock-review==1.1.1
+git+https://github.com/edx/edx-analytics-data-api-client.git@0.13.0#egg=edx-analytics-data-api-client==0.13.0
 
 
 # Third Party XBlocks


### PR DESCRIPTION
### Description
Import data from the Analytics API to power our
* Weekly Activity Metric (i.e. any activity on the course in the previous 7 days)
* Week Streak Metric (i.e. the number of weeks in a row that a learner was active on a course)

Additionally, I added caching. There are two caching opportunities
1. Cache the activity for a course for a 24 hour period
2. Cache the daily activities for a user / course for a 24 hour period
    * The reason I'm caching once per 24 hour period and not doing a diff for a user / course / day is that
        1. it's simpler this way
        2. and more importantly, the Analytics API endpoint (`engagement_timeline`) returns the entire timeline

Currently, the cache key is set to expire at the next UTC midnight. We can change this in the future. After talking to data engineering it did not seem like there is a set time when this data is updated as jobs run throughout the day with varying lengths.

### What the frontend will be passed
```
// This is the context object
{
   ...,
   'weekly_active_users': 100,
   'week_streak': 4,
}
```

### Props
![image](https://user-images.githubusercontent.com/8136030/34219620-d127a7b6-e57f-11e7-866c-053536c43dbb.png)


### Data from the Analytics API

#### Weekly Activity Metric
```json
[
    {
        "interval_start": "2017-12-11T000000",
        "interval_end": "2017-12-18T000000",
        "course_id": "course-v1:edX+edX101+3T2016",
        "any": 91,
        "attempted_problem": 24,
        "played_video": 36,
        "posted_forum": 8,
        "created": "2017-12-19T151347"
    }
]
```

#### Engagement Timeline (Day Streak)
```json
{
    "days": [
        {
            "date": "2017-06-29",
            "problems_attempted": 0,
            "problems_completed": 0,
            "discussion_contributions": 0,
            "videos_viewed": 3
        },
        {
            "date": "2017-06-30",
            "problems_attempted": 0,
            "problems_completed": 0,
            "discussion_contributions": 0,
            "videos_viewed": 2
        },
        {
            "date": "2017-07-01",
            "problems_attempted": 0,
            "problems_completed": 0,
            "discussion_contributions": 0,
            "videos_viewed": 0
        },
        {
            "date": "2017-07-02",
            "problems_attempted": 0,
            "problems_completed": 0,
            "discussion_contributions": 0,
            "videos_viewed": 0
        },
        {
            "date": "2017-07-03",
            "problems_attempted": 0,
            "problems_completed": 0,
            "discussion_contributions": 0,
            "videos_viewed": 0
        },
        {
            "date": "2017-07-04",
            "problems_attempted": 1,
            "problems_completed": 1,
            "discussion_contributions": 2,
            "videos_viewed": 2
        }
    ]
}
```

cc: @stroilova 

### TODO
- [x] Rebase