### PR TITLE
Install recent version of sqlite/pysqlite to fix crashes in tests.

### DIFF
--- a/scripts/upgrade_pysqlite.sh
+++ b/scripts/upgrade_pysqlite.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Upgrade the version of pysqlite/sqlite to avoid crashes during testing.
+# Ideally, this code would just install a pre-built wheel - change it to this
+# once edX has its own artifact server.
+pip uninstall -y pysqlite
+rm -rf tmp_pysqlite_upgrade && mkdir -p tmp_pysqlite_upgrade && cd tmp_pysqlite_upgrade
+curl -o 2.8.3.tar.gz https://codeload.github.com/ghaering/pysqlite/tar.gz/2.8.3
+curl -o sqlite-autoconf-3140100.tar.gz https://www.sqlite.org/2016/sqlite-autoconf-3140100.tar.gz
+tar -xzvf sqlite-autoconf-3140100.tar.gz
+tar -xzvf 2.8.3.tar.gz
+cp -av sqlite-autoconf-3140100/. pysqlite-2.8.3/
+cd ./pysqlite-2.8.3 && python setup.py build_static install
+cd ../.. && rm -rf tmp_pysqlite_upgrade

--- a/scripts/upgrade_pysqlite.sh
+++ b/scripts/upgrade_pysqlite.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# First, check to see if the pysqlite version has already been upgraded. If so, no installation is needed.
+# The pip-installed version of pysqlite has a sqlite_version of "3.11.0".
+sqlite_version=`python -c "from pysqlite2._sqlite import sqlite_version; print sqlite_version"`
+if [ $sqlite_version = "3.14.1" ]; then
+    exit 0
+fi
+
 # Upgrade the version of pysqlite/sqlite to avoid crashes during testing.
 # Ideally, this code would just install a pre-built wheel - change it to this
 # once edX has its own artifact server.

--- a/tox.ini
+++ b/tox.ini
@@ -52,13 +52,20 @@ deps =
     -rrequirements/edx/local.txt
     -rrequirements/edx/base.txt
     -rrequirements/edx/development.txt
-    # There's 1-2 tests which call a paver command...
     -rrequirements/edx/testing.txt
     -rrequirements/edx/post.txt
     -rrequirements/edx/edx-private.txt
     -rrequirements/edx-sandbox/base.txt
     -rrequirements/edx-sandbox/local.txt
     -rrequirements/edx-sandbox/post.txt
+whitelist_externals =
+    /bin/bash
+    /usr/bin/curl
+    /bin/tar
 commands =
+    # There's 1-2 tests which call a paver command...
     pip install -rrequirements/edx/paver.txt
+    # Upgrade sqlite to fix crashes during testing.
+    bash scripts/upgrade_pysqlite.sh
+    # Now perform testing.
     {posargs}


### PR DESCRIPTION
@bmedx reported sqlite crashes during our Django 1.9/10/11 testing. devstack currently uses a newer sqlite/pysqlite version using this Ansible play:
https://github.com/edx/configuration/blob/master/playbooks/roles/devstack_sqlite_fix/tasks/main.yml
However, since these tests run in the tox environment, this PR implements a tox-based upgrade of that package using a bash script and a command in the tox.ini file.