### PR TITLE
Upgrade xblock-drag-and-drop-v2 to v2.1.5

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -109,4 +109,4 @@ xblock-review==1.1.2
 
 git+https://github.com/mitodl/edx-sga.git@d019b8a050c056db535e3ff13c93096145a932de#egg=edx-sga==0.7.1
 git+https://github.com/open-craft/xblock-poll@7ba819b968fe8faddb78bb22e1fe7637005eb414#egg=xblock-poll==1.2.7
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.0.18#egg=xblock-drag-and-drop-v2==2.0.18
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.5#egg=xblock-drag-and-drop-v2==2.1.5

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -109,4 +109,4 @@ xblock-review==1.1.2
 
 git+https://github.com/mitodl/edx-sga.git@d019b8a050c056db535e3ff13c93096145a932de#egg=edx-sga==0.7.1
 git+https://github.com/open-craft/xblock-poll@7ba819b968fe8faddb78bb22e1fe7637005eb414#egg=xblock-poll==1.2.7
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.5#egg=xblock-drag-and-drop-v2==2.1.5
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@2.1.5#egg=xblock-drag-and-drop-v2==2.1.5


### PR DESCRIPTION
Do not merge until v2.1.5 is merged in xblock-drag-and-drop-v2: https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/149

The version of this third-party xblock in the edx-platform has lagged behind. Version 2.1.5 specifically has a fix for a bug we were seeing on edx.org that was causing 500 server errors.