### PR TITLE
temporarily disable all violations but using exec

### DIFF
--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -91,18 +91,18 @@ def _get_pylint_violations(systems=ALL_SYSTEMS.split(','), errors_only=False, cl
         # This makes the folder if it doesn't already exist.
         report_dir = (Env.REPORT_DIR / system).makedirs_p()
 
-        flags = []
-        if errors_only:
-            flags.append("--errors-only")
+        #flags = []
+        #if errors_only:
+        #    flags.append("--errors-only")
 
         apps_list = ' '.join(top_python_dirs(system))
 
         system_report = report_dir / 'pylint.report'
         if clean or not system_report.exists():
             sh(
-                "pylint {flags} --output-format=parseable {apps} "
+                "pylint --disable=all --enable=W0122 "
+                "--output-format=parseable {apps} "
                 "> {report_dir}/pylint.report".format(
-                    flags=" ".join(flags),
                     apps=apps_list,
                     report_dir=report_dir
                 ),

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -11,7 +11,7 @@ set -e
 ###############################################################################
 
 # Violations thresholds for failing the build
-export LOWER_PYLINT_THRESHOLD=1000
+export LOWER_PYLINT_THRESHOLD=1
 export UPPER_PYLINT_THRESHOLD=5900
 export ESLINT_THRESHOLD=5700
 export STYLELINT_THRESHOLD=973


### PR DESCRIPTION
Pylint was recently reenabled in our Jenkins tests and is now the longest test context. This PR disables all of the violations we check for (exception, it does check for `exec` calls, as i am not sure if you need to have at least one thing to check for in order to lint the codebase). This is an experiment to determine if the huge increase in time to lint is due to the number of violations we have added while pylint was not enabled or a combination of the codebase size and our ruleset.