### PR TITLE
Avoid a dropdown for course runs

### DIFF
--- a/common/djangoapps/entitlements/admin.py
+++ b/common/djangoapps/entitlements/admin.py
@@ -14,6 +14,7 @@ class CourseEntitlementAdmin(admin.ModelAdmin):
                     'mode',
                     'enrollment_course_run',
                     'order_number')
+    raw_id_fields = ('enrollment_course_run', 'user',)
 
 
 @admin.register(CourseEntitlementPolicy)


### PR DESCRIPTION
Entitlement detail pages in django admin normally show a dropdown
button for the enrollment_course_run field. But on stage, that can
cause a timeout because the enrollment database is so large.
So instead, just show it as a raw id field.