### PR TITLE
Fix breadcrumb display so it does not include parent node texts

### DIFF
--- a/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
+++ b/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
@@ -279,12 +279,17 @@
                     crumbs = [],
                     subTopic = $('.forum-nav-browse-title', $item)
                         .first()
+                        .contents()
+                        .last()
                         .text()
                         .trim();
 
                 $parentSubMenus.each(function(i, el) {
-                    crumbs.push($(el).siblings('.forum-nav-browse-title')
+                    crumbs.push(
+                        $(el).siblings('.forum-nav-browse-title')
                         .first()
+                        .contents()
+                        .last()
                         .text()
                         .trim()
                     );


### PR DESCRIPTION
Before this fix, the problem is that, the discussion breadcrumb on the top of the page, will contain the text intended only for screenreaders. With the fix below, we will make sure the breadcrumb contain text displayed
EDUCATOR-1549

@cptvitamin FYI
@ssemenova Please review