### PR TITLE
Send student course goal event to GA

### DIFF
--- a/lms/djangoapps/course_goals/tests/test_api.py
+++ b/lms/djangoapps/course_goals/tests/test_api.py
@@ -1,9 +1,11 @@
 """
 Unit tests for course_goals.api methods.
 """
+import mock
 
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
 from lms.djangoapps.course_goals.models import CourseGoal
 from rest_framework.test import APIClient
 from student.models import CourseEnrollment
@@ -34,10 +36,13 @@ class TestCourseGoalsAPI(EventTrackingTestCase, SharedModuleStoreTestCase):
 
         self.apiUrl = reverse('course_goals_api:v0:course_goal-list')
 
-    def test_add_valid_goal(self):
-        """ Ensures a correctly formatted post succeeds. """
+    @mock.patch('lms.djangoapps.course_goals.views.update_google_analytics')
+    @override_settings(LMS_SEGMENT_KEY="foobar")
+    def test_add_valid_goal(self, ga_call):
+        """ Ensures a correctly formatted post succeeds."""
         response = self.post_course_goal(valid=True, goal_key='certify')
         self.assertEqual(self.get_event(-1)['name'], EVENT_NAME_ADDED)
+        ga_call.assert_called_with(EVENT_NAME_ADDED, self.user.id)
         self.assertEqual(response.status_code, 201)
 
         current_goals = CourseGoal.objects.filter(user=self.user, course_key=self.course.id)
@@ -50,13 +55,16 @@ class TestCourseGoalsAPI(EventTrackingTestCase, SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(len(CourseGoal.objects.filter(user=self.user, course_key=self.course.id)), 0)
 
-    def test_update_goal(self):
+    @mock.patch('lms.djangoapps.course_goals.views.update_google_analytics')
+    @override_settings(LMS_SEGMENT_KEY="foobar")
+    def test_update_goal(self, ga_call):
         """ Ensures that repeated course goal post events do not create new instances of the goal. """
         self.post_course_goal(valid=True, goal_key='explore')
         self.post_course_goal(valid=True, goal_key='certify')
         self.post_course_goal(valid=True, goal_key='unsure')
         self.assertEqual(self.get_event(-1)['name'], EVENT_NAME_UPDATED)
 
+        ga_call.assert_called_with(EVENT_NAME_UPDATED, self.user.id)
         current_goals = CourseGoal.objects.filter(user=self.user, course_key=self.course.id)
         self.assertEqual(len(current_goals), 1)
         self.assertEqual(current_goals[0].goal_key, 'unsure')

--- a/lms/djangoapps/course_goals/views.py
+++ b/lms/djangoapps/course_goals/views.py
@@ -1,7 +1,10 @@
 """
 Course Goals Views - includes REST API
 """
+import analytics
+
 from django.contrib.auth import get_user_model
+from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.http import JsonResponse
@@ -105,4 +108,22 @@ def emit_course_goal_event(sender, instance, **kwargs):
         {
             'goal_key': instance.goal_key,
         }
+    )
+    if settings.LMS_SEGMENT_KEY:
+        update_google_analytics(name, instance.user.id)
+
+
+def update_google_analytics(name, user_id):
+    """ Update student course goal for Google Analytics using Segment. """
+    tracking_context = tracker.get_tracker().resolve_context()
+    context = {
+        'ip': tracking_context.get('ip'),
+        'Google Analytics': {
+            'clientId': tracking_context.get('client_id')
+        }
+    }
+    analytics.track(
+        user_id,
+        name,
+        context=context
     )

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -19,7 +19,7 @@ from django.core.urlresolvers import reverse
 from django.db import DatabaseError
 from django.test import TestCase
 from django.test.utils import override_settings
-from mock import MagicMock, patch
+from mock import Mock, MagicMock, patch
 from nose.plugins.attrib import attr
 from opaque_keys.edx.locator import CourseLocator
 
@@ -912,6 +912,7 @@ class CertificateItemTest(ModuleStoreTestCase):
 
     @override_settings(LMS_SEGMENT_KEY="foobar")
     @patch.dict(settings.FEATURES, {'STORE_BILLING_INFO': True})
+    @patch('lms.djangoapps.course_goals.views.update_google_analytics', Mock(return_value=True))
     @patch('student.models.CourseEnrollment.refund_cutoff_date')
     def test_refund_cert_callback_no_expiration(self, cutoff_date):
         # When there is no expiration date on a verified mode, the user can always get a refund
@@ -950,6 +951,7 @@ class CertificateItemTest(ModuleStoreTestCase):
 
     @override_settings(LMS_SEGMENT_KEY="foobar")
     @patch.dict(settings.FEATURES, {'STORE_BILLING_INFO': True})
+    @patch('lms.djangoapps.course_goals.views.update_google_analytics', Mock(return_value=True))
     @patch('student.models.CourseEnrollment.refund_cutoff_date')
     def test_refund_cert_callback_before_expiration(self, cutoff_date):
         # If the expiration date has not yet passed on a verified mode, the user can be refunded


### PR DESCRIPTION
### Send Course Goal of User to GA
Ensure an event is fired whenever a student updates/creates
its course goal.'edx.course_goal.created' and 'edx.course_goal.updated'
should be sent after creation and updation respectively.

LEARNER-3352