### PR TITLE
Fixed multiple CourseAccessRole error on publish

### DIFF
--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -58,11 +58,11 @@ class CourseRunTeamSerializerMixin(serializers.Serializer):
         # when using `bulk_create` with existing data. Given the relatively small number of team members
         # in a course, this is not worth optimizing at this time.
         for member in team:
-            CourseAccessRole.objects.update_or_create(
+            CourseAccessRole.objects.get_or_create(
                 course_id=instance.id,
                 org=instance.id.org,
                 user=User.objects.get(username=member['user']),
-                defaults={'role': member['role']}
+                role=member['role']
             )
 
 


### PR DESCRIPTION
## [EDUCATOR-1958](https://openedx.atlassian.net/browse/EDUCATOR-1958)

### Description
Fixed the update_team method to allow a user to have more than one CourseAccessRole in the same course.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @noraiz-anwar    
- [ ] @awaisdar001

### Post-review
- [ ] Rebase and squash commits
