### PR TITLE
Don't wrap enroll button text

### DIFF
--- a/lms/static/sass/views/_course-entitlements.scss
+++ b/lms/static/sass/views/_course-entitlements.scss
@@ -27,12 +27,13 @@
       height: $baseline*1.5;
       flex-grow: 1;
       letter-spacing: 0;
+      white-space: nowrap;
       background: theme-color("inverse");
       border-color: theme-color("primary");
       color: theme-color("primary");
       text-shadow: none;
       font-size: $font-size-base;
-      padding: 0;
+      padding: 0 $baseline/4;
       box-shadow: none;
       border-radius: $border-radius-sm;
       transition: all 0.4s ease-out;


### PR DESCRIPTION
The "Leave Current/Switch/Select" Session button was sometimes
wrapping its text if it wasn't given enough horizontal space.
Now it should never wrap, instead stealing space from the
dropdown next to it (or being bumped to a line below the dropdown).

https://openedx.atlassian.net/browse/LEARNER-3668