### PR TITLE
Upgrade edx-proctoring to 1.3.4

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -100,7 +100,7 @@ git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.2#egg=edx-user-state-client==1.0.2
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.6#egg=lti_consumer-xblock==1.1.6
-git+https://github.com/edx/edx-proctoring.git@1.3.3#egg=edx-proctoring==1.3.3
+git+https://github.com/edx/edx-proctoring.git@1.3.4#egg=edx-proctoring==1.3.4
 # This is here because all of the other XBlocks are located here. However, it is published to PyPI and will be installed that way
 xblock-review==1.1.2
 


### PR DESCRIPTION
[1.3.4](https://github.com/edx/edx-proctoring/releases/tag/1.3.4): Specify required dependencies in setup.py to prevent bugs with missing dependencies in the future.