### PR TITLE
fix entitlement email settings list item class

### DIFF
--- a/lms/templates/dashboard/_dashboard_entitlement_actions.html
+++ b/lms/templates/dashboard/_dashboard_entitlement_actions.html
@@ -44,7 +44,7 @@ dropdown_btn_id = "entitlement-actions-dropdown-btn-{}".format(dashboard_index)
         </li>
       % endif
       % if show_email_settings:
-        <li class="entitlement-actions-item" id="actions-item-email-settings-${dashboard_index}" role="menuitem">
+        <li class="actions-item" id="actions-item-email-settings-${dashboard_index}" role="menuitem">
           ## href and rel must be defined for compatibility with lms/static/js/leanModal.js
           ## data-dropdown-selector and data-dropdown-button-selector must be defined for compatibility with lms/static/js/dashboard/dropdown.js
           <a href="#email-settings-modal" class="entitlement-action action-email-settings" rel="leanModal"


### PR DESCRIPTION
fix the off-by-one-load issue with email settings action for course entitlement cards on the learner dashboard

[LEARNER-3704](https://openedx.atlassian.net/browse/LEARNER-3704)