### PR TITLE
Fixed crash on about page when course end date is null

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -245,15 +245,14 @@ from six import string_types
           % endif
             ## We plan to ditch end_date (which is not stored in course metadata),
             ## but for backwards compatibility, show about/end_date blob if it exists.
-            % if get_course_about_section(request, course, "end_date") or course.end:
-                <%
-                    course_end_date = course.end
-                %>
-
+            <%
+               course_end_date = course.end
+            %>
+            % if course_end_date:
             <li class="important-dates-item">
                 <span class="icon fa fa-calendar" aria-hidden="true"></span>
                 <p class="important-dates-item-title">${_("Classes End")}</p>
-                  % if isinstance(course_end_date, str):
+                  % if isinstance(course_end_date, string_types):
                       <span class="important-dates-item-text final-date">${course_end_date}</span>
                   % else:
                     <%


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/490 
fixes https://github.com/mitodl/salt-ops/issues/503

#### What's this PR do?
fixes about course template to check null in course end date

#### How should this be manually tested?
- add "end": null in policy.json and tar.zip it and import it
- go to about page it should not crash

@pdpinch @annagav 