### PR TITLE
install paver after other requirements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,6 @@ deps =
     -rrequirements/edx/base.txt
     -rrequirements/edx/development.txt
     # There's 1-2 tests which call a paver command...
-    -rrequirements/edx/paver.txt
     -rrequirements/edx/testing.txt
     -rrequirements/edx/post.txt
     -rrequirements/edx/edx-private.txt
@@ -61,4 +60,5 @@ deps =
     -rrequirements/edx-sandbox/local.txt
     -rrequirements/edx-sandbox/post.txt
 commands =
+    pip install -rrequirements/edx/paver.txt
     {posargs}


### PR DESCRIPTION
We need to use boto in a paver script we are working on, but it is causing a lot of import errors. A relatively recent commit to paver stops vendoring six, which fixes these issues. While we wait for a new release of paver, we have temporarily forked it and install it from https://github.com/jzoldak/paver. Unfortunately, tox is having trouble installing six (via requirements/base.txt) and paver in the same pip command. 

This is a temporary fix to get the django upgrade tests up and running. We eventually want to stop using the fork of paver