### PR TITLE
ENT-779 Remove ProviderConfig.drop_existing_session field from DB.

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0014_auto_20171222_1233.py
+++ b/common/djangoapps/third_party_auth/migrations/0014_auto_20171222_1233.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0013_sync_learner_profile_data'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='ltiproviderconfig',
+            name='drop_existing_session',
+        ),
+        migrations.RemoveField(
+            model_name='oauth2providerconfig',
+            name='drop_existing_session',
+        ),
+        migrations.RemoveField(
+            model_name='samlproviderconfig',
+            name='drop_existing_session',
+        ),
+    ]

--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -237,10 +237,4 @@ class MigrationTests(TestCase):
         out = StringIO()
         call_command('makemigrations', dry_run=True, verbosity=3, stdout=out)
         output = out.getvalue()
-        # Temporarily disable this check so we can remove
-        # the ProviderConfig.drop_existing_session field.
-        # We will restore this check once the code referencing
-        # this field has been deleted/released and a migration
-        # for field removal has been added.
-        if 'Remove field' not in output:
-            self.assertIn('No changes detected', output)
+        self.assertIn('No changes detected', output)


### PR DESCRIPTION
DO NOT MERGE until https://github.com/edx/edx-platform/pull/16987 has been deployed to PROD.

References to this field were already removed with:

https://github.com/edx/edx-platform/pull/16987