### PR TITLE
Ignore certain patterns during collectstatic.

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -700,10 +700,31 @@ def collect_assets(systems, settings, **kwargs):
     `settings` is the Django settings module to use.
     `**kwargs` include arguments for using a log directory for collectstatic output. Defaults to /dev/null.
     """
+    ignore_patterns = [
+        # Karma test related files...
+        "fixtures",
+        "karma_*.js",
+        "spec",
+        "spec_helpers",
+        "spec-helpers",
+        "xmodule_js",  # symlink for tests
+
+        # Geo-IP data, only accessed in Python
+        "geoip",
+
+        # We compile these out, don't need the source files in staticfiles
+        "sass",
+        "*.coffee",
+    ]
+
+    ignore_args = " ".join(
+        '--ignore "{}"'.format(pattern) for pattern in ignore_patterns
+    )
 
     for sys in systems:
         collectstatic_stdout_str = _collect_assets_cmd(sys, **kwargs)
-        sh(django_cmd(sys, settings, "collectstatic --noinput {logfile_str}".format(
+        sh(django_cmd(sys, settings, "collectstatic {ignore_args} --noinput {logfile_str}".format(
+            ignore_args=ignore_args,
             logfile_str=collectstatic_stdout_str
         )))
         print("\t\tFinished collecting {} assets.".format(sys))

--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -30,7 +30,11 @@ EXPECTED_CMS_SASS_COMMAND = [
     u"python manage.py cms --settings={asset_settings} compile_sass cms ",
 ]
 EXPECTED_COLLECT_STATIC_COMMAND = (
-    u"python manage.py {system} --settings={asset_settings} collectstatic --noinput {log_string}"
+    u'python manage.py {system} --settings={asset_settings} collectstatic '
+    u'--ignore "fixtures" --ignore "karma_*.js" --ignore "spec" '
+    u'--ignore "spec_helpers" --ignore "spec-helpers" --ignore "xmodule_js" '
+    u'--ignore "geoip" --ignore "sass" --ignore "*.coffee" '
+    u'--noinput {log_string}'
 )
 EXPECTED_CELERY_COMMAND = (
     u"python manage.py lms --settings={settings} celery worker --beat --loglevel=INFO --pythonpath=."


### PR DESCRIPTION
There are symlinks and file types that are not necessary to copy over
to the actual static files output, either because they are source files
that get compiled out, or because they exist only for tests. FEDX-448.

With themes enabled, this reduces the unoptimized static asset build
size from 343M to 212M. The optimized version goes from 838M to 500M.