### PR TITLE
course title link to course home when enrolled

### DIFF
--- a/lms/static/js/learner_dashboard/models/course_card_model.js
+++ b/lms/static/js/learner_dashboard/models/course_card_model.js
@@ -185,12 +185,18 @@
 
                 setActiveCourseRun: function(courseRun, userPreferences) {
                     var startDateString,
+                        courseTitleLink = '',
                         isEnrolled = this.isEnrolledInSession() && courseRun.key;
                     if (courseRun) {
                         if (this.valueIsDefined(courseRun.advertised_start)) {
                             startDateString = courseRun.advertised_start;
                         } else {
                             startDateString = this.formatDate(courseRun.start, userPreferences);
+                        }
+                        if (isEnrolled && courseRun.course_url) {
+                            courseTitleLink = courseRun.course_url;
+                        } else if (!isEnrolled && courseRun.marketing_url) {
+                            courseTitleLink = courseRun.marketing_url;
                         }
                         this.set({
                             certificate_url: courseRun.certificate_url,
@@ -210,7 +216,8 @@
                             start_date: startDateString,
                             upcoming_course_runs: this.getUpcomingCourseRuns(),
                             upgrade_url: courseRun.upgrade_url,
-                            price: this.getCertificatePriceString(courseRun)
+                            price: this.getCertificatePriceString(courseRun),
+                            course_title_link: courseTitleLink
                         });
 
                         // This is used to render the date for completed and in progress courses

--- a/lms/static/js/spec/learner_dashboard/course_card_view_spec.js
+++ b/lms/static/js/spec/learner_dashboard/course_card_view_spec.js
@@ -80,7 +80,7 @@ define([
                 ]
             };
 
-            setupView(course, false);
+            setupView(course, true);
         });
 
         afterEach(function() {
@@ -89,12 +89,6 @@ define([
 
         it('should exist', function() {
             expect(view).toBeDefined();
-        });
-
-        it('should render the course card based on the data enrolled', function() {
-            view.remove();
-            setupView(course, true);
-            validateCourseInfoDisplay();
         });
 
         it('should render final grade if course is completed', function() {
@@ -110,10 +104,13 @@ define([
         });
 
         it('should render the course card based on the data not enrolled', function() {
+            view.remove();
+            setupView(course, false);
             validateCourseInfoDisplay();
         });
 
         it('should update render if the course card is_enrolled updated', function() {
+            setupView(course, false);
             courseCardModel.set({
                 is_enrolled: true
             });
@@ -216,21 +213,26 @@ define([
             expect(view.$('.enrollment-opens').length).toEqual(0);
         });
 
-        it('should link to the marketing site when a URL is available', function() {
+        it('should link to the marketing site when the user is not enrolled', function() {
+            setupView(course, false);
             expect(view.$('.course-title-link').attr('href')).toEqual(course.course_runs[0].marketing_url);
         });
 
-        it('should link to the course home when no marketing URL is available', function() {
-            course.course_runs[0].marketing_url = null;
-            setupView(course, false);
-
+        it('should link to the course home when the user is enrolled', function() {
+            setupView(course, true);
             expect(view.$('.course-title-link').attr('href')).toEqual(course.course_runs[0].course_url);
         });
 
-        it('should not link to the marketing site or the course home if neither URL is available', function() {
+        it('should not link to the marketing site if the URL is not available', function() {
             course.course_runs[0].marketing_url = null;
-            course.course_runs[0].course_url = null;
             setupView(course, false);
+
+            expect(view.$('.course-title-link').length).toEqual(0);
+        });
+
+        it('should not link to the course home if the URL is not available', function() {
+            course.course_runs[0].course_url = null;
+            setupView(course, true);
 
             expect(view.$('.course-title-link').length).toEqual(0);
         });

--- a/lms/templates/learner_dashboard/course_card.underscore
+++ b/lms/templates/learner_dashboard/course_card.underscore
@@ -3,8 +3,8 @@
         <div class="course-content">
             <div class="course-details">
                 <h5 class="course-title">
-                    <% if ( (marketing_url || course_url) &&  !is_unfulfilled_entitlement) { %>
-                        <a href="<%- marketing_url || course_url %>" class="course-title-link">
+                    <% if (course_title_link) { %>
+                        <a href="<%- course_title_link %>" class="course-title-link">
                             <%- title %>
                         </a>
                     <% } else { %>


### PR DESCRIPTION
Have course titles on the program details page on the learner dashboard link to the course home when the user is enrolled in a course run and to the course about page on the marketing site when the user is not enrolled in a course run. All of this is regardless of whether or not the user holds an entitlement for the course.

[LEARNER-3727](https://openedx.atlassian.net/browse/LEARNER-3727)