### PR TITLE
Pass ReadTheDocs path to studio-frontend

### DIFF
--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -66,6 +66,9 @@
                             "num": "${context_course.location.course | n, js_escaped_string}",
                             "display_course_number": "${context_course.display_coursenumber | n, js_escaped_string}",
                             "revision": "${context_course.location.revision | n, js_escaped_string}"
+                        },
+                        "help_tokens": {
+                            "files": "${get_online_help_info(online_help_token())['doc_url']}"
                         }
                     }
                 </%static:studiofrontend>

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -68,7 +68,7 @@
                             "revision": "${context_course.location.revision | n, js_escaped_string}"
                         },
                         "help_tokens": {
-                            "files": "${get_online_help_info(online_help_token())['doc_url']}"
+                            "files": "${get_online_help_info(online_help_token())['doc_url'] | n, js_escaped_string}"
                         }
                     }
                 </%static:studiofrontend>


### PR DESCRIPTION
The StudioFrontend assets page will want to link to the readthedocs page for course files documentation. This will pass the path used by page Help links along to be leveraged by SFE.

Ticket: [EDUCATOR-1995](https://openedx.atlassian.net/browse/EDUCATOR-1995)

FYI @edx/educator-dahlia 