### PR TITLE
Fixes to teams tests in Django 1.9+

### DIFF
--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -112,7 +112,7 @@ class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):
         # that gets the current user's info
         mock_from_django_user.return_value = Mock()
 
-        url = reverse('discussion.views.user_profile',
+        url = reverse('user_profile',
                       kwargs={'course_id': self.course.id.to_deprecated_string(), 'user_id': '12345'})  # There is no user 12345
         self.response = self.client.get(url)
         self.assertEqual(self.response.status_code, 404)
@@ -129,7 +129,7 @@ class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):
         # that gets the current user's info
         mock_from_django_user.return_value = Mock()
 
-        url = reverse('discussion.views.followed_threads',
+        url = reverse('followed_threads',
                       kwargs={'course_id': self.course.id.to_deprecated_string(), 'user_id': '12345'})  # There is no user 12345
         self.response = self.client.get(url)
         self.assertEqual(self.response.status_code, 404)
@@ -882,7 +882,7 @@ class ForumFormDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdT
 
         self.client.login(username=user.username, password='test')
         return self.client.get(
-            reverse("discussion.views.forum_form_discussion", args=[unicode(self.course.id)]),
+            reverse("forum_form_discussion", args=[unicode(self.course.id)]),
             data=request_data,
             **headers
         )
@@ -1335,7 +1335,7 @@ class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, Mo
 
         self.client.get(
             reverse(
-                "discussion.views.single_thread",
+                "single_thread",
                 kwargs={
                     "course_id": self.course.id.to_deprecated_string(),
                     "discussion_id": "dummy_discussion_id",
@@ -1352,7 +1352,7 @@ class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, Mo
 
         self.client.get(
             reverse(
-                "discussion.views.forum_form_discussion",
+                "forum_form_discussion",
                 kwargs={"course_id": self.course.id.to_deprecated_string()}
             ),
         )
@@ -1446,7 +1446,7 @@ class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTe
         """
         mock_user.return_value.to_dict.return_value = {}
         reverse_url = "%s%s" % (reverse(
-            "discussion.views.forum_form_discussion",
+            "forum_form_discussion",
             kwargs={"course_id": unicode(self.course.id)}), '/forum_form_discussion')
         # Test that malicious code does not appear in html
         url = "%s?%s=%s" % (reverse_url, 'sort_key', malicious_code)
@@ -1465,7 +1465,7 @@ class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTe
         mock_from_django_user.return_value.to_dict.return_value = {}
         mock_request.side_effect = make_mock_request_impl(course=self.course, text='dummy')
 
-        url = reverse('discussion.views.user_profile',
+        url = reverse('user_profile',
                       kwargs={'course_id': unicode(self.course.id), 'user_id': str(self.student.id)})
         # Test that malicious code does not appear in html
         url_string = "%s?%s=%s" % (url, 'page', malicious_code)
@@ -1663,9 +1663,9 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ForumsEnableMixin
         mock_request.side_effect = make_mock_request_impl(course=self.course, text='dummy', thread_id=thread_id)
 
         for url in (
-                reverse('discussion.views.forum_form_discussion',
+                reverse('forum_form_discussion',
                         kwargs=dict(course_id=course_id)),
-                reverse('discussion.views.single_thread',
+                reverse('single_thread',
                         kwargs=dict(course_id=course_id, discussion_id=self.discussion_id, thread_id=thread_id)),
         ):
             self.verify_consent_required(self.client, url)

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -667,6 +667,16 @@ class OrderItem(TimeStampedModel):
         """ Return the total cost of this OrderItem """
         return self.qty * self.unit_cost
 
+    @line_cost.setter
+    def line_cost(self, value):
+        """
+        Django requires there be a setter for this, but it is not
+        necessary for the way we currently use it. Raising errors
+        here will cause a lot of issues and these should not be
+        mutable after construction, so for now we just eat this.
+        """
+        pass
+
     @classmethod
     def add_to_order(cls, order, *args, **kwargs):
         """

--- a/lms/djangoapps/teams/models.py
+++ b/lms/djangoapps/teams/models.py
@@ -182,7 +182,8 @@ class CourseTeamMembership(models.Model):
         """Memberships are immutable, with the exception of last activity
         date.
         """
-        if name in self.immutable_fields:
+        creating_model = name == '_state' or self._state.adding
+        if not creating_model and name in self.immutable_fields:
             # Check the current value -- if it is None, then this
             # model is being created from the database and it's fine
             # to set the value. Otherwise, we're trying to overwrite

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -41,6 +41,7 @@ ALLOWED_HOSTS = [
     '.testserver.fake',
     'test-site.testserver',
     'testserver.fakeother',
+    'edx.org'
 ]
 
 # Silence noisy logs to make troubleshooting easier when tests fail.

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -492,6 +492,17 @@ class CourseOverview(TimeStampedModel):
         """
         return json.loads(self._pre_requisite_courses_json)
 
+    @pre_requisite_courses.setter
+    def pre_requisite_courses(self, value):
+        """
+        Django requires there be a setter for this, but it is not
+        necessary for the way we currently use it. Due to the way
+        CourseOverviews are constructed raising errors here will
+        cause a lot of issues. These should not be mutable after
+        construction, so for now we just eat this.
+        """
+        pass
+
     @classmethod
     def update_select_courses(cls, course_keys, force_update=False):
         """


### PR DESCRIPTION
- add edx.org to lms tests KNOWN_HOSTS
- Don't check CourseTeamMembership field mutability on creation