### PR TITLE
[ENT-829]: Move enterprise specific code in student_account views to enterprise_support

### DIFF
--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -866,10 +866,10 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, TestCase, ProgramsApiConf
         MessageMiddleware().process_request(self.request)
         messages.error(self.request, 'Facebook is already in use.', extra_tags='Auth facebook')
 
-    @mock.patch('student_account.views.get_enterprise_learner_data')
-    def test_context(self, mock_get_enterprise_learner_data):
+    @mock.patch('openedx.features.enterprise_support.api.get_enterprise_customer_for_learner')
+    def test_context(self, mock_get_enterprise_customer_for_learner):
         self.request.site = SiteFactory.create()
-        mock_get_enterprise_learner_data.return_value = []
+        mock_get_enterprise_customer_for_learner.return_value = {}
         context = account_settings_context(self.request)
 
         user_accounts_api_url = reverse("accounts_api", kwargs={'username': self.user.username})
@@ -899,19 +899,17 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, TestCase, ProgramsApiConf
             context['enterprise_readonly_account_fields'], {'fields': settings.ENTERPRISE_READONLY_ACCOUNT_FIELDS}
         )
 
-    @mock.patch('student_account.views.get_enterprise_learner_data')
-    @mock.patch('student_account.views.third_party_auth.provider.Registry.get')
+    @mock.patch('student_account.views.get_enterprise_customer_for_learner')
+    @mock.patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get')
     def test_context_for_enterprise_learner(
-            self, mock_get_auth_provider, mock_get_enterprise_learner_data
+            self, mock_get_auth_provider, mock_get_enterprise_customer_for_learner
     ):
         dummy_enterprise_customer = {
             'uuid': 'real-ent-uuid',
             'name': 'Dummy Enterprise',
             'identity_provider': 'saml-ubc'
         }
-        mock_get_enterprise_learner_data.return_value = [
-            {'enterprise_customer': dummy_enterprise_customer}
-        ]
+        mock_get_enterprise_customer_for_learner.return_value = dummy_enterprise_customer
         self.request.site = SiteFactory.create()
         mock_get_auth_provider.return_value.sync_learner_profile_data = True
         context = account_settings_context(self.request)

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -485,6 +485,20 @@ def get_enterprise_learner_data(site, user):
         return enterprise_learner_data['results']
 
 
+def get_enterprise_customer_for_learner(site, user):
+    """
+    Return enterprise customer to whom given learner belongs.
+    """
+    if not enterprise_enabled():
+        return {}
+
+    enterprise_learner_data = get_enterprise_learner_data(site, user)
+    if enterprise_learner_data:
+        return enterprise_learner_data[0]['enterprise_customer']
+
+    return {}
+
+
 def get_dashboard_consent_notification(request, user, course_enrollments):
     """
     If relevant to the request at hand, create a banner on the dashboard indicating consent failed.

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -5,6 +5,11 @@ import hashlib
 import six
 from django.conf import settings
 from django.utils.translation import ugettext as _
+
+import third_party_auth
+from third_party_auth import pipeline
+from student.cookies import set_experiments_is_enterprise_cookie
+
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.markup import HTML, Text
 
@@ -33,11 +38,96 @@ def get_cache_key(**kwargs):
     return hashlib.md5(key).hexdigest()
 
 
-def update_third_party_auth_context_for_enterprise(context, enterprise_customer=None):
+def update_logistration_context_for_enterprise(request, context, enterprise_customer):
+    """
+    Take the processed context produced by the view, determine if it's relevant
+    to a particular Enterprise Customer, and update it to include that customer's
+    enterprise metadata.
+
+     Arguments:
+         request (HttpRequest): The request for the logistration page.
+         context (dict): Context for logistration page.
+         enterprise_customer (dict): data for enterprise customer
+
+    """
+    sidebar_context = {}
+    if enterprise_customer:
+        sidebar_context = get_enterprise_sidebar_context(enterprise_customer)
+
+    if sidebar_context:
+        context['data']['registration_form_desc']['fields'] = enterprise_fields_only(
+            context['data']['registration_form_desc']
+        )
+        context.update(sidebar_context)
+        context['enable_enterprise_sidebar'] = True
+        context['data']['hide_auth_warnings'] = True
+    else:
+        context['enable_enterprise_sidebar'] = False
+
+    update_third_party_auth_context_for_enterprise(request, context, enterprise_customer)
+
+
+def get_enterprise_sidebar_context(enterprise_customer):
+    """
+    Get context information for enterprise sidebar for the given enterprise customer.
+
+    Enterprise Sidebar Context has the following key-value pairs.
+    {
+        'enterprise_name': 'Enterprise Name',
+        'enterprise_logo_url': 'URL of the enterprise logo image',
+        'enterprise_branded_welcome_string': 'Human readable welcome message customized for the enterprise',
+        'platform_welcome_string': 'Human readable welcome message for an enterprise learner',
+    }
+    """
+    platform_name = configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+
+    branding_configuration = enterprise_customer.get('branding_configuration', {})
+    logo_url = branding_configuration.get('logo', '') if isinstance(branding_configuration, dict) else ''
+
+    branded_welcome_template = configuration_helpers.get_value(
+        'ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE',
+        settings.ENTERPRISE_SPECIFIC_BRANDED_WELCOME_TEMPLATE
+    )
+
+    branded_welcome_string = branded_welcome_template.format(
+        start_bold=u'<b>',
+        end_bold=u'</b>',
+        enterprise_name=enterprise_customer['name'],
+        platform_name=platform_name
+    )
+
+    platform_welcome_template = configuration_helpers.get_value(
+        'ENTERPRISE_PLATFORM_WELCOME_TEMPLATE',
+        settings.ENTERPRISE_PLATFORM_WELCOME_TEMPLATE
+    )
+    platform_welcome_string = platform_welcome_template.format(platform_name=platform_name)
+
+    return {
+        'enterprise_name': enterprise_customer['name'],
+        'enterprise_logo_url': logo_url,
+        'enterprise_branded_welcome_string': branded_welcome_string,
+        'platform_welcome_string': platform_welcome_string,
+    }
+
+
+def enterprise_fields_only(fields):
+    """
+    Take the received field definition, and exclude those fields that we don't want
+    to require if the user is going to be a member of an Enterprise Customer.
+    """
+    enterprise_exclusions = configuration_helpers.get_value(
+        'ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS',
+        settings.ENTERPRISE_EXCLUDED_REGISTRATION_FIELDS
+    )
+    return [field for field in fields['fields'] if field['name'] not in enterprise_exclusions]
+
+
+def update_third_party_auth_context_for_enterprise(request, context, enterprise_customer=None):
     """
     Return updated context of third party auth with modified for enterprise.
 
     Arguments:
+        request (HttpRequest): The request for the logistration page.
         context (dict): Context for third party auth providers and auth pipeline.
         enterprise_customer (dict): data for enterprise customer
 
@@ -45,8 +135,8 @@ def update_third_party_auth_context_for_enterprise(context, enterprise_customer=
          context (dict): Updated context of third party auth with modified
          `errorMessage`.
     """
-    if enterprise_customer and context['errorMessage']:
-        context['errorMessage'] = Text(_(
+    if enterprise_customer and context['data']['third_party_auth']['errorMessage']:
+        context['data']['third_party_auth']['errorMessage'] = Text(_(
             u'We are sorry, you are not authorized to access {platform_name} via this channel. '
             u'Please contact your {enterprise} administrator in order to access {platform_name} '
             u'or contact {edx_support_link}.{line_break}'
@@ -55,7 +145,7 @@ def update_third_party_auth_context_for_enterprise(context, enterprise_customer=
         ).format(
             platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
             enterprise=enterprise_customer['name'],
-            error_message=context['errorMessage'],
+            error_message=context['data']['third_party_auth']['errorMessage'],
             edx_support_link=HTML(
                 '<a href="{edx_support_url}">{support_url_name}</a>'
             ).format(
@@ -67,4 +157,74 @@ def update_third_party_auth_context_for_enterprise(context, enterprise_customer=
             line_break=HTML('<br/>')
         )
 
+    if enterprise_customer:
+        context['data']['third_party_auth']['providers'] = []
+        context['data']['third_party_auth']['secondaryProviders'] = []
+
+    running_pipeline = pipeline.get(request)
+    if running_pipeline is not None:
+        current_provider = third_party_auth.provider.Registry.get_from_pipeline(running_pipeline)
+        if current_provider is not None and current_provider.skip_registration_form and enterprise_customer:
+            # For enterprise (and later for everyone), we need to get explicit consent to the
+            # Terms of service instead of auto submitting the registration form outright.
+            context['data']['third_party_auth']['autoSubmitRegForm'] = False
+            context['data']['third_party_auth']['autoRegisterWelcomeMessage'] = Text(_(
+                'Thank you for joining {platform_name}. '
+                'Just a couple steps before you start learning!')
+            ).format(
+                platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+            )
+            context['data']['third_party_auth']['registerFormSubmitButtonText'] = _('Continue')
+
     return context
+
+
+def handle_enterprise_cookies_for_logistration(request, response, context):
+    """
+    Helper method for setting or deleting enterprise cookies on logistration response.
+
+    Arguments:
+        request (HttpRequest): The request for the logistration page.
+        response (HttpResponse): The response for the logistration page.
+        context (dict): Context for logistration page.
+
+    """
+    # This cookie can be used for tests or minor features,
+    # but should not be used for payment related or other critical work
+    # since users can edit their cookies
+    set_experiments_is_enterprise_cookie(request, response, context['enable_enterprise_sidebar'])
+
+    # Remove enterprise cookie so that subsequent requests show default login page.
+    response.delete_cookie(
+        configuration_helpers.get_value('ENTERPRISE_CUSTOMER_COOKIE_NAME', settings.ENTERPRISE_CUSTOMER_COOKIE_NAME),
+        domain=configuration_helpers.get_value('BASE_COOKIE_DOMAIN', settings.BASE_COOKIE_DOMAIN),
+    )
+
+
+def update_account_settings_context_for_enterprise(context, enterprise_customer):
+    """
+    Take processed context for account settings page and update it taking enterprise customer into account.
+
+     Arguments:
+         context (dict): Context for account settings page.
+         enterprise_customer (dict): data for enterprise customer
+
+    """
+    enterprise_context = {
+        'enterprise_name': None,
+        'sync_learner_profile_data': False,
+        'edx_support_url': configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK),
+        'enterprise_readonly_account_fields': {
+            'fields': settings.ENTERPRISE_READONLY_ACCOUNT_FIELDS
+        }
+    }
+
+    if enterprise_customer:
+        enterprise_context['enterprise_name'] = enterprise_customer['name']
+        identity_provider = third_party_auth.provider.Registry.get(
+            provider_id=enterprise_customer['identity_provider'],
+        )
+        if identity_provider:
+            enterprise_context['sync_learner_profile_data'] = identity_provider.sync_learner_profile_data
+
+    context.update(enterprise_context)


### PR DESCRIPTION
__Description:__
We realized that existing logic for enterprise related context update is spread in student_account views and we need to isolate this enterprise related logic in `enterprise_support` module in `openedx`.
We need to refactor student_account views `lms/djangoapps/student_account/views.py` to move the enterprise related context update to enterprise_support module in `openedx` `openedx/features/enterprise_support/utils.py`.