### PR TITLE
fix course staff ability to perform operations on instructor dashboard

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -1137,6 +1137,7 @@ class StudentAdminPage(PageObject):
     Student admin section of the Instructor dashboard.
     """
     url = None
+    PAGE_SELECTOR = 'section#student_admin'
     CONTAINER = None
 
     PROBLEM_INPUT_NAME = None
@@ -1226,6 +1227,19 @@ class StudentAdminPage(PageObject):
         Return Background Tasks History button.
         """
         return self._input_with_name(self.BACKGROUND_TASKS_BUTTON_NAME)
+
+    @property
+    def running_tasks_section(self):
+        """
+        Returns the "Pending Instructor Tasks" section.
+        """
+        return self.get_selector('div.running-tasks-container')
+
+    def get_selector(self, css_selector):
+        """
+        Makes query selector by pre-pending student admin section
+        """
+        return self.q(css=' '.join([self.PAGE_SELECTOR, css_selector]))
 
     def wait_for_task_history_table(self):
         """

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -203,6 +203,7 @@
     <hr>
 </div>
 %endif
+%endif
 
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
 <div class="running-tasks-container action-type-container">
@@ -214,6 +215,4 @@
     </div>
     <div class="no-pending-tasks-message"></div>
 </div>
-%endif
-
 %endif


### PR DESCRIPTION
## [EDUCATOR-2028](https://openedx.atlassian.net/browse/EDUCATOR-2028)

### Description

Some buttons on instructor tab are not triggering required action for course staff. Due to this, staff users are not able to perform certain operations. This PR is made in effort to fix this situation. Acceptance tests are added.

### How to Test?

**Stage** 
- Login to stage as a course staff user (not global staff and course admin)
- Go to Instructor tab -> Student Admin
- Observe: 
      - 1 Buttons on this page are not working
      - 2 Pending Tasks section is not visible.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @asadazam93 
- [ ] Code review: @Rabia23 

FYI: @awaisdar001 

### Post-review
- [x] Rebase and squash commits