### PR TITLE
Use user's language preference on bookmark page

### DIFF
--- a/openedx/features/course_bookmarks/views/course_bookmarks.py
+++ b/openedx/features/course_bookmarks/views/course_bookmarks.py
@@ -17,6 +17,7 @@ from web_fragments.fragment import Fragment
 
 from courseware.courses import get_course_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.user_api.models import UserPreference
 from openedx.features.course_experience import default_course_url_name
 from util.views import ensure_valid_course_key
 
@@ -69,11 +70,13 @@ class CourseBookmarksFragmentView(EdxFragmentView):
         course_key = CourseKey.from_string(course_id)
         course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=True)
 
+        language = UserPreference.get_value(request.user, 'pref-lang', default='en')
+
         context = {
             'csrf': csrf(request)['csrf_token'],
             'course': course,
             'bookmarks_api_url': reverse('bookmarks'),
-            'language_preference': 'en',  # TODO:
+            'language_preference': language,
         }
         html = render_to_string('course_bookmarks/course-bookmarks-fragment.html', context)
         inline_js = render_to_string('course_bookmarks/course_bookmarks_js.template', context)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-2353

Use user's language preference on bookmark page. Language was hardcoded to 'en' with a #TODO tag when rendering the bookmarks page.

@edx/learner Please review