### PR TITLE
Fix login box alignment in IE

### DIFF
--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -104,7 +104,6 @@
   $third-party-button-height: ($baseline*1.75);
 
   display: block;
-  margin:auto;
   max-width: 500px;
 
   .instructions {


### PR DESCRIPTION
In IE 11, the login page form was being shown right-aligned on the page. This is because of some IE interaction with margin: auto. Removing that and simply relying on flexbox justification fixes it and makes the form centered again.

I've tested this fix in IE, Edge, Firefox, and Chrome.  They all still work fine (because the parent div already sets justify-content: center).

https://openedx.atlassian.net/browse/LEARNER-3001