### PR TITLE
Remove username from force syncing in third party auth pipeline

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -751,6 +751,9 @@ def user_details_force_sync(auth_entry, strategy, details, user=None, *args, **k
             'country': (user.profile, 'country'),
         })
 
+        # Remove username from list of fields for update
+        field_mapping.pop('username', None)
+
         # Track any fields that would raise an integrity error if there was a conflict.
         integrity_conflict_fields = {'email': user.email, 'username': user.username}
 

--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -379,9 +379,11 @@ class UserDetailsForceSyncTestCase(testutil.TestCase, test.TestCase):
         # User now has updated information in the DB.
         user = User.objects.get()
         assert user.email == 'new+{}'.format(self.old_email)
-        assert user.username == 'new_{}'.format(self.old_username)
         assert user.profile.name == 'Grown Up {}'.format(self.old_fullname)
         assert user.profile.country == 'PK'
+
+        # Now verify that username field is not updated
+        assert user.username == self.old_username
 
         assert len(mail.outbox) == 1
 
@@ -403,9 +405,11 @@ class UserDetailsForceSyncTestCase(testutil.TestCase, test.TestCase):
         # The email is not changed, but everything else is.
         user = User.objects.get(pk=self.user.pk)
         assert user.email == self.old_email
-        assert user.username == 'new_{}'.format(self.old_username)
         assert user.profile.name == 'Grown Up {}'.format(self.old_fullname)
         assert user.profile.country == 'PK'
+
+        # Now verify that username field is not updated
+        assert user.username == self.old_username
 
         # No email should be sent for an email change.
         assert len(mail.outbox) == 0


### PR DESCRIPTION
[ENT-832](https://openedx.atlassian.net/browse/ENT-832)
@asadiqbal08 @saleem-latif 

Remove username from force syncing in third party auth pipeline in the `user_details_force_sync` method.