### PR TITLE
add update link on name field for django admin SAMLProviderConfigAdmin

### DIFF
--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -5,6 +5,7 @@ Admin site configuration for third party authentication
 from config_models.admin import KeyedConfigurationModelAdmin
 from django import forms
 from django.contrib import admin
+from django.core.urlresolvers import reverse
 
 from third_party_auth.provider import Registry
 
@@ -19,6 +20,7 @@ from .models import (
     SAMLProviderData
 )
 from .tasks import fetch_saml_metadata
+from openedx.core.djangolib.markup import HTML
 
 
 class OAuth2ProviderConfigForm(forms.ModelForm):
@@ -52,9 +54,25 @@ class SAMLProviderConfigAdmin(KeyedConfigurationModelAdmin):
     def get_list_display(self, request):
         """ Don't show every single field in the admin change list """
         return (
-            'name', 'enabled', 'site', 'backend_name', 'entity_id', 'metadata_source',
-            'has_data', 'mode', 'change_date', 'changed_by', 'edit_link',
+            'name_with_update_link', 'enabled', 'site', 'backend_name', 'entity_id', 'metadata_source',
+            'has_data', 'mode', 'change_date', 'changed_by',
         )
+
+    list_display_links = None
+
+    def name_with_update_link(self, instance):
+        """
+        Record name with link for the change view.
+        """
+        if not instance.is_active:
+            return instance.name
+
+        update_url = reverse('admin:{}_{}_add'.format(self.model._meta.app_label, self.model._meta.model_name))
+        update_url += '?source={}'.format(instance.pk)
+        return HTML(u'<a href="{}">{}</a>').format(update_url, instance.name)
+
+    name_with_update_link.allow_tags = True
+    name_with_update_link.short_description = u'Name'
 
     def has_data(self, inst):
         """ Do we have cached metadata for this SAML provider? """


### PR DESCRIPTION
ENT-403
@asadiqbal08 @saleem-latif 

* Update the `name` field link in django admin for `SAMLProviderConfigAdmin` to point to edit page.
* Remove existing `update` column (`edit_link` provided by base class [`KeyedConfigurationModelAdmin` of config_models](https://github.com/edx/django-config-models/blob/master/config_models/admin.py)) at the end of django admin for `SAMLProviderConfigAdmin`

**Sandbox:**  https://business.sandbox.edx.org/admin/third_party_auth/samlproviderconfig/

<img width="1396" alt="screen shot 2018-01-03 at 6 33 11 pm" src="https://user-images.githubusercontent.com/5072991/34522486-a6d20b88-f0b4-11e7-8ebc-b2db6ccb80fe.png">
