### PR TITLE
LEARNER-2653 Remove compilejsi18n commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ pull_translations:
 	i18n_tool extract
 	i18n_tool dummy
 	i18n_tool generate
-	python manage.py lms --settings='devstack' compilejsi18n
-	python manage.py cms --settings='devstack' compilejsi18n
 	i18n_tool generate --strict
 	git clean -fdX conf/locale/rtl
 	git clean -fdX conf/locale/eo


### PR DESCRIPTION
Removing the compilejsi18n managment commands. 
Wont be possible to compile them bcz of the version difference. 