### PR TITLE
Fixed edX blocks api to load override data

### DIFF
--- a/lms/djangoapps/course_api/blocks/transformers/load_override_data.py
+++ b/lms/djangoapps/course_api/blocks/transformers/load_override_data.py
@@ -1,0 +1,96 @@
+"""
+Load Override Data Transformer
+"""
+from datetime import datetime
+import json
+from dateutil.parser import parse
+
+from openedx.core.djangoapps.content.block_structure.transformer import BlockStructureTransformer
+
+from courseware.models import StudentFieldOverride
+
+# The list of fields are in support of Individual due dates and could be expanded for other use cases.
+REQUESTED_FIELDS = [
+    'start',
+    'display_name',
+    'due'
+]
+
+
+def _get_override_query(course_key, location_list, user_id):
+    """
+    returns queryset containing override data.
+
+    Args:
+        course_key (CourseLocator): Course locator object
+        location_list (List<UsageKey>): List of usage key of all blocks
+        user_id (int): User id
+    """
+    return StudentFieldOverride.objects.filter(
+        course_id=course_key,
+        location__in=location_list,
+        student_id=user_id,
+        field__in=REQUESTED_FIELDS
+    )
+
+
+def override_xblock_fields(course_key, location_list, block_structure, user_id):
+    """
+    loads override data of block
+
+    Args:
+        course_key (CourseLocator): course locator object
+        location_list (List<UsageKey>): list of usage key of all blocks
+        block_structure (BlockStructure): block structure class
+        user_id (int): User id
+    """
+    query = _get_override_query(course_key, location_list, user_id)
+    for student_field_override in query:
+        if student_field_override.field == "due" or student_field_override.field == "start":
+            value = parse(json.loads(student_field_override.value))
+        else:
+            value = json.loads(student_field_override.value)
+        field = student_field_override.field
+        block_structure.override_xblock_field(
+            student_field_override.location,
+            field,
+            value
+        )
+
+
+class OverrideDataTransformer(BlockStructureTransformer):
+    """
+    A transformer that load override data in xblock.
+    """
+    WRITE_VERSION = 1
+    READ_VERSION = 1
+
+    def __init__(self, user):
+        self.user = user
+
+    @classmethod
+    def name(cls):
+        """
+        Unique identifier for the transformer's class;
+        same identifier used in setup.py.
+        """
+        return "load_override_data"
+
+    @classmethod
+    def collect(cls, block_structure):
+        """
+        Collects any information that's necessary to execute this transformer's transform method.
+        """
+        # collect basic xblock fields
+        block_structure.request_xblock_fields(*REQUESTED_FIELDS)
+
+    def transform(self, usage_info, block_structure):
+        """
+        loads override data into blocks
+        """
+        override_xblock_fields(
+            usage_info.course_key,
+            block_structure.topological_traversal(),
+            block_structure,
+            self.user.id
+        )

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_load_override_data.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_load_override_data.py
@@ -1,0 +1,72 @@
+"""
+Tests for OverrideDataTransformer.
+"""
+import datetime
+import pytz
+import ddt
+
+from courseware.student_field_overrides import get_override_for_user, override_field_for_user
+from openedx.core.djangoapps.content.block_structure.factory import BlockStructureFactory
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
+
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import ToyCourseFactory, ItemFactory
+
+from ..load_override_data import REQUESTED_FIELDS, OverrideDataTransformer
+
+
+expected_overrides = {
+    'start': datetime.datetime(
+        2017, 1, 20, 2, 42, tzinfo=pytz.UTC
+    ),
+    'display_name': "Section",
+    'due': datetime.datetime(
+        2017, 2, 20, 2, 42, tzinfo=pytz.UTC
+    )
+}
+
+
+@ddt.ddt
+class TestOverrideDataTransformer(ModuleStoreTestCase):
+    """
+    Test proper behavior for OverrideDataTransformer
+    """
+    @classmethod
+    def setUpClass(cls):
+        super(TestOverrideDataTransformer, cls).setUpClass()
+        cls.learner = UserFactory.create(password="test")
+
+    def setUp(self):
+        super(TestOverrideDataTransformer, self).setUp()
+        self.course_key = ToyCourseFactory.create().id
+        self.course_usage_key = self.store.make_course_usage_key(self.course_key)
+        self.block_structure = BlockStructureFactory.create_from_modulestore(self.course_usage_key, self.store)
+        self.course = course = modulestore().get_course(self.course_key)
+        section = course.get_children()[0]
+        subsection = section.get_children()[0]
+        self.block = self.store.create_child(
+            self.learner.id, subsection.location, 'html', 'new_component'
+        )
+        CourseEnrollmentFactory.create(user=self.learner, course_id=self.course_key, is_active=True)
+
+    @ddt.data(*REQUESTED_FIELDS)
+    def test_transform(self, field):
+        override_field_for_user(
+            self.learner,
+            self.block,
+            field,
+            expected_overrides.get(field)
+        )
+
+        # collect phase
+        OverrideDataTransformer.collect(self.block_structure)
+
+        # transform phase
+        OverrideDataTransformer(self.learner).transform(
+            usage_info=self.course_usage_key,
+            block_structure=self.block_structure,
+        )
+
+        # verify overridden data
+        assert get_override_for_user(self.learner, self.block, field) == expected_overrides.get(field)

--- a/lms/djangoapps/grades/course_grade.py
+++ b/lms/djangoapps/grades/course_grade.py
@@ -14,6 +14,8 @@ from .config import assume_zero_if_absent
 from .subsection_grade import ZeroSubsectionGrade
 from .subsection_grade_factory import SubsectionGradeFactory
 from .scores import compute_percent
+from lms.djangoapps.course_api.blocks.api import has_individual_student_override_provider
+from lms.djangoapps.course_api.blocks.transformers.load_override_data import override_xblock_fields
 
 
 class CourseGradeBase(object):
@@ -81,6 +83,14 @@ class CourseGradeBase(object):
         subsection grades, display name, and url name.
         """
         course_structure = self.course_data.structure
+        if has_individual_student_override_provider():
+            override_xblock_fields(
+                self.course_data.course_key,
+                course_structure.topological_traversal(),
+                course_structure,
+                self.user.id
+            )
+
         grades = OrderedDict()
         for chapter_key in course_structure.get_children(self.course_data.location):
             grades[chapter_key] = self._get_chapter_grade_info(course_structure[chapter_key], course_structure)

--- a/openedx/core/djangoapps/content/block_structure/block_structure.py
+++ b/openedx/core/djangoapps/content/block_structure/block_structure.py
@@ -466,6 +466,26 @@ class BlockStructureBlockData(BlockStructure):
         block_data = self._block_data_map.get(usage_key)
         return getattr(block_data, field_name, default) if block_data else default
 
+    def override_xblock_field(self, usage_key, field_name, override_data):
+        """
+        Set value of the xBlock field for the requested block for the requested field_name;
+
+        Arguments:
+            usage_key (UsageKey) - Usage key of the block whose xBlock
+                field is requested.
+
+            field_name (string) - The name of the field that is
+                requested.
+
+            override_data (object) - The data you want to set
+        """
+        block_data = self._block_data_map.get(usage_key)
+        setattr(
+            block_data,
+            field_name,
+            override_data
+        )
+
     def get_transformer_data(self, transformer, key, default=None):
         """
         Returns the value associated with the given key from the given

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
             "milestones = lms.djangoapps.course_api.blocks.transformers.milestones:MilestonesAndSpecialExamsTransformer",
             "grades = lms.djangoapps.grades.transformer:GradesTransformer",
             "completion = lms.djangoapps.course_api.blocks.transformers.block_completion:BlockCompletionTransformer",
+            "load_override_data = lms.djangoapps.course_api.blocks.transformers.load_override_data:OverrideDataTransformer"
         ],
         "openedx.ace.policy": [
             "bulk_email_optout = lms.djangoapps.bulk_email.policies:CourseEmailOptout"


### PR DESCRIPTION
### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/488

#### What's this PR do?
It checks if there is override fields for xblocks, if yes it will load these fields
i copied `StudentFieldOverride` from https://github.com/mitodl/edx-platform/blob/master/lms/djangoapps/courseware/student_field_overrides.py#L66

#### How should this be manually tested?
- follow the instructions in https://github.com/mitodl/salt-ops/issues/488

**To install transformer:**
- `make lms-shell`
- `pip install -e .`
- `docker-compose restart lms`

@pdpinch @annagav 
  