### PR TITLE
Convert weekly highlights exception to warning.

### DIFF
--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -356,7 +356,7 @@ class CourseUpdateResolver(BinnedSchedulesBaseResolver):
             try:
                 week_highlights = get_week_highlights(user, enrollment.course_id, week_num)
             except CourseUpdateDoesNotExist:
-                LOG.exception(
+                LOG.warning(
                     'Weekly highlights for user {} in week {} of course {} does not exist or is disabled'.format(
                         user, week_num, enrollment.course_id
                     )


### PR DESCRIPTION
We get a lot of schedules alerts about these things: http://splunk.edx.org/en-US/app/search/search?display.page.search.mode=fast&dispatch.sample_ratio=1&q=search%20index%3Dprod-edx%20schedules%20(CASE(ERROR)%20OR%20CASE(CRITICAL))%20%7C%20rex%20%22(%3F%3Clast_line%3E.*%3F)(%5C(.*%5C))*%24%22%20%7C%20rex%20%22(%3F%3Cthird_last_line%3E.*)%5B%5Cn%5Cr%5D%2B(.*)%5B%5Cn%5Cr%5D%2B(.*)%24%22%20%20%7C%20dedup%20last_line%20third_last_line%20%7C%20search%20last_line%3D%22CourseUpdateDoesNotExist%3A%20Requested%20week%206%20but%20course-v1%3AUBCx%2BSoftConst2x%2B3T2017%20has%20only%205%20sections.%22&earliest=-1d&latest=now&display.general.type=events&sid=1514992596.386362

...which according to Nimisha are expected - course teams won't have entered highlights for certain weeks.