### PR TITLE
Add some blocks to course_about.html

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -105,6 +105,8 @@ from openedx.core.lib.courses import course_image_url
 <%block name="pagetitle">${course.display_name_with_default_escaped}</%block>
 
 <section class="course-info">
+
+  <%block name="course_about_header">
   <header class="course-profile">
     <div class="intro-inner-wrapper">
       <div class="table">
@@ -199,6 +201,7 @@ from openedx.core.lib.courses import course_image_url
     </div>
       </div>
   </header>
+  </%block>
 
   <div class="container">
     <div class="details">
@@ -218,6 +221,7 @@ from openedx.core.lib.courses import course_image_url
 
         <%include file="course_about_sidebar_header.html" />
 
+        <%block name="course_about_important_dates">
         <ol class="important-dates">
           <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
           % if not course.start_date_is_still_default:
@@ -288,16 +292,20 @@ from openedx.core.lib.courses import course_image_url
             </p>
           </li>
           % endif
+
           % if get_course_about_section(request, course, "prerequisites"):
             <li class="important-dates-item"><span class="icon fa fa-book" aria-hidden="true"></span><p class="important-dates-item-title">${_("Requirements")}</p><span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span></li>
           % endif
         </ol>
+        </%block>
     </div>
 
+      <%block name="course_about_reviews_tool">
       ## Course reviews tool
       % if reviews_fragment_view:
        ${HTML(reviews_fragment_view.body_html())}
       % endif
+      </%block>
 
       ## For now, ocw links are the only thing that goes in additional resources
       % if get_course_about_section(request, course, "ocw_links"):


### PR DESCRIPTION
Now that https://github.com/edx/edx-platform/pull/16856/ was merged, themes can implement particular blocks in templates, without having to redefine the whole `.html`
For this we need the definition of the blocks to be redefined. This PR adds block names to some sections of `course_about.html` that we needed to rewrite.
 
**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: https://pr17091.sandbox.opencraft.hosting/ , https://studio-pr17091.sandbox.opencraft.hosting/
**Merge deadline**: None

**Testing instructions**:

Adding blocks should be harmless. But if you want to test it in practice and check the new block override system, these are the full testing instructions:

1. Without this change (i.e. with your normal devstack server), go to http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/about and save the HTML in a file
2. If not using master, cherry-pick this: https://github.com/edx/edx-platform/pull/16856
3. Apply the patch in this PR, go to the same URL and save to another file
4. Compare files, the HTML should be the same (ignoring whitespace and django-debug-toolbar)
5. Check that no blocks are defined inside other blocks
6. Check that these blocks are like the rest of the other blocks. Or if you're not sure and want to test it, create a theme with a file `lms/templates/course_about.html` which redefines one of the blocks, e.g. `<%block name="course_about_header">`
7. Check that block names don't conflict with other block names used in templates
8. Check that names make sense

**Reviewers**
- [ ] @mtyaka 
- [ ] edX, TBD

**Author concerns**: None
**Settings**: None

  