### PR TITLE
EDUCATOR-2055: resolving error causing upgrades to verified to fail

### DIFF
--- a/lms/djangoapps/grades/course_grade.py
+++ b/lms/djangoapps/grades/course_grade.py
@@ -278,7 +278,7 @@ class CourseGrade(CourseGradeBase):
 
     def _get_subsection_grade(self, subsection, force_update_subsections=False):
         if self.force_update_subsections:
-            return self._subsection_grade_factory.update(subsection, force_update_subsections)
+            return self._subsection_grade_factory.update(subsection, force_update_subsections=force_update_subsections)
         else:
             # Pass read_only here so the subsection grades can be persisted in bulk at the end.
             return self._subsection_grade_factory.create(subsection, read_only=True)

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -94,7 +94,7 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(2), mock_get_score(1, 2):
             _assert_read(expected_pass=False, expected_percent=0)  # start off with grade of 0
 
-        with self.assertNumQueries(32), mock_get_score(1, 2):
+        with self.assertNumQueries(29), mock_get_score(1, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
         with self.assertNumQueries(2):
@@ -106,11 +106,17 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(2):
             _assert_read(expected_pass=True, expected_percent=0.5)  # NOT updated to grade of .25
 
-        with self.assertNumQueries(15), mock_get_score(2, 2):
+        with self.assertNumQueries(12), mock_get_score(2, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
         with self.assertNumQueries(2):
             _assert_read(expected_pass=True, expected_percent=1.0)  # updated to grade of 1.0
+
+        with self.assertNumQueries(12), mock_get_score(0, 0):  # the subsection now is worth zero
+            grade_factory.update(self.request.user, self.course, force_update_subsections=True)
+
+        with self.assertNumQueries(2):
+            _assert_read(expected_pass=False, expected_percent=0.0)  # updated to grade of 0.0
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(*itertools.product((True, False), (True, False)))


### PR DESCRIPTION
The code was passing the value of `force_update_subsections` to `only_if_higher` instead!

FYI @noraiz-anwar @ssemenova 