### PR TITLE
Remove deprecated enabled field

### DIFF
--- a/common/test/db_fixtures/certificates_web_view.json
+++ b/common/test/db_fixtures/certificates_web_view.json
@@ -14,7 +14,6 @@
     "fields": {
       "modified": "2015-06-18 11:02:13.007790+00:00",
       "course_key": "course-v1:test_org+3355358979513794782079645765720179311111+test_run",
-      "enabled": true,
       "self_generation_enabled": true
     }
   },

--- a/lms/djangoapps/certificates/migrations/0013_remove_certificategenerationcoursesetting_enabled.py
+++ b/lms/djangoapps/certificates/migrations/0013_remove_certificategenerationcoursesetting_enabled.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('certificates', '0012_certificategenerationcoursesetting_include_hours_of_effort'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='certificategenerationcoursesetting',
+            name='enabled',
+        ),
+    ]

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -848,11 +848,6 @@ class CertificateGenerationCourseSetting(TimeStampedModel):
     not in the data layer.
     """
     course_key = CourseKeyField(max_length=255, db_index=True)
-    enabled = models.BooleanField(
-        default=False,
-        help_text=u"DEPRECATED, please use self_generation_enabled instead."
-    )
-    # TODO: Learner-2549 remove deprecated enabled field
 
     self_generation_enabled = models.BooleanField(
         default=False,


### PR DESCRIPTION
The CertificateGenerationCourseSetting.enabled column is deprecated. It is no longer referenced anywhere in the code, and it's time to remove it.

Original code by Michael LoTurco.

https://openedx.atlassian.net/browse/LEARNER-2549

There were three open courses that had the old flag set in our database but not the new one.  I've reached out to all three PCs and had them update the fields.