### PR TITLE
PLAT-1873 to_deprecated_string() cleanup part 1

### DIFF
--- a/cms/djangoapps/contentstore/config/forms.py
+++ b/cms/djangoapps/contentstore/config/forms.py
@@ -8,6 +8,7 @@ from django import forms
 from contentstore.config.models import CourseNewAssetsPageFlag
 
 from opaque_keys import InvalidKeyError
+from six import text_type
 from xmodule.modulestore.django import modulestore
 from opaque_keys.edx.locator import CourseLocator
 
@@ -31,7 +32,7 @@ class CourseNewAssetsPageAdminForm(forms.ModelForm):
             raise forms.ValidationError(msg)
 
         if not modulestore().has_course(course_key):
-            msg = u'Course not found. Entered course id was: "{0}". '.format(course_key.to_deprecated_string())
+            msg = u'Course not found. Entered course id was: "{0}". '.format(text_type(course_key))
             raise forms.ValidationError(msg)
 
         return course_key

--- a/cms/djangoapps/contentstore/config/models.py
+++ b/cms/djangoapps/contentstore/config/models.py
@@ -4,6 +4,7 @@ controlling the new assets page.
 """
 from config_models.models import ConfigurationModel
 from django.db.models import BooleanField
+from six import text_type
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 
@@ -74,4 +75,4 @@ class CourseNewAssetsPageFlag(ConfigurationModel):
         if self.enabled:
             not_en = ""
         # pylint: disable=no-member
-        return u"Course '{}': New assets page {}Enabled".format(self.course_id.to_deprecated_string(), not_en)
+        return u"Course '{}': New assets page {}Enabled".format(text_type(self.course_id), not_en)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -10,6 +10,7 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from pytz import UTC
+from six import text_type
 
 from django_comment_common.models import assign_default_role
 from django_comment_common.utils import seed_permissions_roles
@@ -126,8 +127,8 @@ def get_lms_link_for_item(location, preview=False):
 
     return u"//{lms_base}/courses/{course_key}/jump_to/{location}".format(
         lms_base=lms_base,
-        course_key=location.course_key.to_deprecated_string(),
-        location=location.to_deprecated_string(),
+        course_key=text_type(location.course_key),
+        location=text_type(location),
     )
 
 

--- a/cms/templates/widgets/metadata-edit.html
+++ b/cms/templates/widgets/metadata-edit.html
@@ -5,8 +5,9 @@
   import hashlib
   import copy
   import json
+  from six import text_type
   from xmodule.modulestore import EdxJSONEncoder
-  hlskey = hashlib.md5(module.location.to_deprecated_string().encode('utf-8')).hexdigest()
+  hlskey = hashlib.md5(text_type(module.location).encode('utf-8')).hexdigest()
 %>
 
 ## js templates

--- a/cms/templates/widgets/source-edit.html
+++ b/cms/templates/widgets/source-edit.html
@@ -1,6 +1,7 @@
 <%
   import hashlib
-  hlskey = hashlib.md5(module.location.to_deprecated_string()).hexdigest()
+  from six import text_type
+  hlskey = hashlib.md5(text_type(module.location)).hexdigest()
 %>
 
   <section id="hls-modal-${hlskey}" class="upload-modal modal" style="overflow:scroll; background:#ddd; padding: 10px 0;box-shadow: 0 0 5px 0 #555;" >

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -19,6 +19,7 @@ from django.utils.translation import get_language, to_locale
 from django.views.generic.base import View
 from ipware.ip import get_ip
 from opaque_keys.edx.keys import CourseKey
+from six import text_type
 
 from course_modes.models import CourseMode
 from courseware.access import has_access
@@ -138,7 +139,7 @@ class ChooseModeView(View):
             CourseMode.is_credit_mode(mode) for mode
             in CourseMode.modes_for_course(course_key, only_selectable=False)
         )
-        course_id = course_key.to_deprecated_string()
+        course_id = text_type(course_key)
         context = {
             "course_modes_choose_url": reverse(
                 "course_modes_choose",

--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -10,6 +10,7 @@ from django.dispatch import receiver
 from django.utils.translation import ugettext_noop
 
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, NoneToEmptyManager
+from six import text_type
 from student.models import CourseEnrollment
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -74,7 +75,7 @@ class Role(models.Model):
 
     def __unicode__(self):
         # pylint: disable=no-member
-        return self.name + " for " + (self.course_id.to_deprecated_string() if self.course_id else "all courses")
+        return self.name + " for " + (text_type(self.course_id) if self.course_id else "all courses")
 
     # TODO the name of this method is a little bit confusing,
     # since it's one-off and doesn't handle inheritance later

--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from xmodule.contentstore.content import StaticContent
 
 from opaque_keys.edx.locator import AssetLocator
+from six import text_type
 
 log = logging.getLogger(__name__)
 XBLOCK_STATIC_RESOURCE_PREFIX = '/static/xblock'
@@ -83,7 +84,7 @@ def replace_course_urls(text, course_key):
     returns: text with the links replaced
     """
 
-    course_id = course_key.to_deprecated_string()
+    course_id = text_type(course_key)
 
     def replace_course_url(match):
         quote = match.group('quote')

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -43,6 +43,7 @@ from eventtracking import tracker
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
+from six import text_type
 from slumber.exceptions import HttpClientError, HttpServerError
 
 import dogstats_wrapper as dog_stats_api
@@ -1219,7 +1220,7 @@ class CourseEnrollment(models.Model):
             assert isinstance(self.course_id, CourseKey)
             data = {
                 'user_id': self.user.id,
-                'course_id': self.course_id.to_deprecated_string(),
+                'course_id': text_type(self.course_id),
                 'mode': self.mode,
             }
 
@@ -1230,7 +1231,7 @@ class CourseEnrollment(models.Model):
                     tracking_context = tracker.get_tracker().resolve_context()
                     analytics.track(self.user_id, event_name, {
                         'category': 'conversion',
-                        'label': self.course_id.to_deprecated_string(),
+                        'label': text_type(self.course_id),
                         'org': self.course_id.org,
                         'course': self.course_id.course,
                         'run': self.course_id.run,
@@ -1303,14 +1304,14 @@ class CourseEnrollment(models.Model):
                 log.warning(
                     u"User %s failed to enroll in course %s because enrollment is closed",
                     user.username,
-                    course_key.to_deprecated_string()
+                    text_type(course_key)
                 )
                 raise EnrollmentClosedError
 
             if cls.objects.is_course_full(course):
                 log.warning(
                     u"Course %s has reached its maximum enrollment of %d learners. User %s failed to enroll.",
-                    course_key.to_deprecated_string(),
+                    text_type(course_key),
                     course.max_student_enrollments_allowed,
                     user.username,
                 )
@@ -1319,7 +1320,7 @@ class CourseEnrollment(models.Model):
             log.warning(
                 u"User %s attempted to enroll in %s, but they were already enrolled",
                 user.username,
-                course_key.to_deprecated_string()
+                text_type(course_key)
             )
             if check_access:
                 raise AlreadyEnrolledError

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -14,6 +14,7 @@ from django.test import TestCase
 from django.test.client import Client
 from django.test.utils import override_settings
 from mock import patch
+from six import text_type
 from social_django.models import UserSocialAuth
 
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
@@ -498,7 +499,7 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
         Tests the redirects when visiting course-specific URL with @login_required.
         Should vary by course depending on its enrollment_domain
         """
-        TARGET_URL = reverse('courseware', args=[self.course.id.to_deprecated_string()])            # pylint: disable=invalid-name
+        TARGET_URL = reverse('courseware', args=[text_type(self.course.id)])            # pylint: disable=invalid-name
         noshib_response = self.client.get(TARGET_URL, follow=True, HTTP_ACCEPT="text/html")
         self.assertEqual(noshib_response.redirect_chain[-1],
                          (expected_redirect_url('/login?next={url}'.format(url=TARGET_URL)), 302))
@@ -506,7 +507,7 @@ class ExternalAuthShibTest(ModuleStoreTestCase):
                                               .format(platform_name=settings.PLATFORM_NAME)))
         self.assertEqual(noshib_response.status_code, 200)
 
-        TARGET_URL_SHIB = reverse('courseware', args=[self.shib_course.id.to_deprecated_string()])  # pylint: disable=invalid-name
+        TARGET_URL_SHIB = reverse('courseware', args=[text_type(self.shib_course.id)])  # pylint: disable=invalid-name
         shib_response = self.client.get(**{'path': TARGET_URL_SHIB,
                                            'follow': True,
                                            'REMOTE_USER': self.extauth.external_id,

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -21,6 +21,7 @@ from nose.plugins.attrib import attr
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import CourseLocator
 from pyquery import PyQuery as pq
+from six import text_type
 
 import shoppingcart  # pylint: disable=import-error
 from bulk_email.models import Optout  # pylint: disable=import-error
@@ -442,11 +443,11 @@ class DashboardTest(ModuleStoreTestCase):
         self.assertEqual(len(optout_object), 1)
 
         # Direct link to course redirect to user dashboard
-        self.client.get(reverse('courseware', kwargs={"course_id": self.course.id.to_deprecated_string()}))
+        self.client.get(reverse('courseware', kwargs={"course_id": text_type(self.course.id)}))
         log_warning.assert_called_with(
             u'User %s cannot access the course %s because payment has not yet been received',
             self.user,
-            unicode(self.course.id),
+            text_type(self.course.id),
         )
 
         # Now re-validating the invoice
@@ -711,7 +712,7 @@ class EnrollmentEventTestMixin(EventTestMixin):
         self.mock_tracker.emit.assert_called_once_with(  # pylint: disable=maybe-no-member
             'edx.course.enrollment.mode_changed',
             {
-                'course_id': course_key.to_deprecated_string(),
+                'course_id': text_type(course_key),
                 'user_id': user.pk,
                 'mode': mode
             }
@@ -723,7 +724,7 @@ class EnrollmentEventTestMixin(EventTestMixin):
         self.mock_tracker.emit.assert_called_once_with(  # pylint: disable=maybe-no-member
             'edx.course.enrollment.activated',
             {
-                'course_id': course_key.to_deprecated_string(),
+                'course_id': text_type(course_key),
                 'user_id': user.pk,
                 'mode': CourseMode.DEFAULT_MODE_SLUG
             }
@@ -735,7 +736,7 @@ class EnrollmentEventTestMixin(EventTestMixin):
         self.mock_tracker.emit.assert_called_once_with(  # pylint: disable=maybe-no-member
             'edx.course.enrollment.deactivated',
             {
-                'course_id': course_key.to_deprecated_string(),
+                'course_id': text_type(course_key),
                 'user_id': user.pk,
                 'mode': CourseMode.DEFAULT_MODE_SLUG
             }
@@ -942,7 +943,7 @@ class ChangeEnrollmentViewTest(ModuleStoreTestCase):
         """ Enroll a student in a course. """
         response = self.client.post(
             reverse('change_enrollment'), {
-                'course_id': course.id.to_deprecated_string(),
+                'course_id': text_type(course.id),
                 'enrollment_action': 'enroll'
             }
         )

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -45,6 +45,7 @@ from provider.oauth2.models import Client
 from pytz import UTC
 from ratelimitbackend.exceptions import RateLimitException
 from requests import HTTPError
+from six import text_type
 from social_core.backends import oauth as social_oauth
 from social_core.exceptions import AuthAlreadyAssociated, AuthException
 from social_django import utils as social_utils
@@ -609,7 +610,7 @@ def is_course_blocked(request, redeemed_registration_codes, course_key):
                 track.views.server_track(
                     request,
                     "change-email1-settings",
-                    {"receive_emails": "no", "course": course_key.to_deprecated_string()},
+                    {"receive_emails": "no", "course": text_type(course_key)},
                     page='dashboard',
                 )
                 break

--- a/common/djangoapps/track/contexts.py
+++ b/common/djangoapps/track/contexts.py
@@ -3,6 +3,7 @@ import logging
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from six import text_type
 
 from util.request import COURSE_REGEX
 
@@ -51,6 +52,6 @@ def course_context_from_course_id(course_id):
     # TODO: Make this accept any CourseKey, and serialize it using .to_string
     assert isinstance(course_id, CourseKey)
     return {
-        'course_id': course_id.to_deprecated_string(),
+        'course_id': text_type(course_id),
         'org_id': course_id.org,
     }

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -34,6 +34,7 @@ from lxml.html.soupparser import fromstring as fromstring_bs  # uses Beautiful S
 from pyparsing import ParseException
 from pytz import UTC
 from shapely.geometry import MultiPoint, Point
+from six import text_type
 
 import capa.safe_exec as safe_exec
 import capa.xqueue_interface as xqueue_interface
@@ -368,7 +369,7 @@ class LoncapaResponse(object):
         # self.runtime.track_function('get_demand_hint', event_info)
         # This this "feedback hint" event
         event_info = dict()
-        event_info['module_id'] = self.capa_module.location.to_deprecated_string()
+        event_info['module_id'] = text_type(self.capa_module.location)
         event_info['problem_part_id'] = self.id
         event_info['trigger_type'] = 'single'  # maybe be overwritten by log_extra
         event_info['hint_label'] = label

--- a/common/lib/capa/capa/tests/helpers.py
+++ b/common/lib/capa/capa/tests/helpers.py
@@ -6,6 +6,7 @@ import os
 import os.path
 
 import fs.osfs
+import six
 
 from capa.capa_problem import LoncapaProblem, LoncapaSystem
 from capa.inputtypes import Status
@@ -84,8 +85,17 @@ def mock_capa_module():
     """
     capa response types needs just two things from the capa_module: location and track_function.
     """
+    def mock_location_text(self):
+        """
+        Mock implementation of __unicode__ or __str__ for the module's location.
+        """
+        return u'i4x://Foo/bar/mock/abc'
+
     capa_module = Mock()
-    capa_module.location.to_deprecated_string.return_value = 'i4x://Foo/bar/mock/abc'
+    if six.PY2:
+        capa_module.location.__unicode__ = mock_location_text
+    else:
+        capa_module.location.__str__ = mock_location_text
     # The following comes into existence by virtue of being called
     # capa_module.runtime.track_function
     return capa_module

--- a/common/lib/capa/capa/tests/test_hint_functionality.py
+++ b/common/lib/capa/capa/tests/test_hint_functionality.py
@@ -52,7 +52,7 @@ class TextInputHintsTest(HintTest):
         self.get_hint(u'1_3_1', u'Blue')
         self.problem.capa_module.runtime.track_function.assert_called_with(
             'edx.problem.hint.feedback_displayed',
-            {'module_id': 'i4x://Foo/bar/mock/abc',
+            {'module_id': u'i4x://Foo/bar/mock/abc',
              'problem_part_id': '1_2',
              'trigger_type': 'single',
              'hint_label': u'Correct:',
@@ -225,7 +225,7 @@ class NumericInputHintsTest(HintTest):
         self.get_hint(u'1_2_1', u'1.141')
         self.problem.capa_module.runtime.track_function.assert_called_with(
             'edx.problem.hint.feedback_displayed',
-            {'module_id': 'i4x://Foo/bar/mock/abc', 'problem_part_id': '1_1', 'trigger_type': 'single',
+            {'module_id': u'i4x://Foo/bar/mock/abc', 'problem_part_id': '1_1', 'trigger_type': 'single',
              'hint_label': u'Nice',
              'correctness': True,
              'student_answer': [u'1.141'],
@@ -364,7 +364,7 @@ class CheckboxHintsTestTracking(HintTest):
         self.problem.capa_module.runtime.track_function.assert_called_with(
             'edx.problem.hint.feedback_displayed',
             {'hint_label': u'Incorrect:',
-             'module_id': 'i4x://Foo/bar/mock/abc',
+             'module_id': u'i4x://Foo/bar/mock/abc',
              'problem_part_id': '1_1',
              'choice_all': ['choice_0', 'choice_1', 'choice_2'],
              'correctness': False,
@@ -427,7 +427,7 @@ class MultpleChoiceHintsTest(HintTest):
         self.get_hint(u'1_3_1', u'choice_2')
         self.problem.capa_module.runtime.track_function.assert_called_with(
             'edx.problem.hint.feedback_displayed',
-            {'module_id': 'i4x://Foo/bar/mock/abc', 'problem_part_id': '1_2', 'trigger_type': 'single',
+            {'module_id': u'i4x://Foo/bar/mock/abc', 'problem_part_id': '1_2', 'trigger_type': 'single',
              'student_answer': [u'choice_2'], 'correctness': False, 'question_type': 'multiplechoiceresponse',
              'hint_label': 'OOPS', 'hints': [{'text': 'Apple is a fruit.'}]}
         )
@@ -467,7 +467,7 @@ class MultpleChoiceHintsWithHtmlTest(HintTest):
         self.get_hint(u'1_2_1', u'choice_0')
         self.problem.capa_module.runtime.track_function.assert_called_with(
             'edx.problem.hint.feedback_displayed',
-            {'module_id': 'i4x://Foo/bar/mock/abc', 'problem_part_id': '1_1', 'trigger_type': 'single',
+            {'module_id': u'i4x://Foo/bar/mock/abc', 'problem_part_id': '1_1', 'trigger_type': 'single',
              'student_answer': [u'choice_0'], 'correctness': False, 'question_type': 'multiplechoiceresponse',
              'hint_label': 'Incorrect:', 'hints': [{'text': 'Mushroom <img src="#" ale="#"/>is a fungus, not a fruit.'}]}
         )
@@ -500,7 +500,7 @@ class DropdownHintsTest(HintTest):
         self.get_hint(u'1_3_1', u'FACES')
         self.problem.capa_module.runtime.track_function.assert_called_with(
             'edx.problem.hint.feedback_displayed',
-            {'module_id': 'i4x://Foo/bar/mock/abc', 'problem_part_id': '1_2', 'trigger_type': 'single',
+            {'module_id': u'i4x://Foo/bar/mock/abc', 'problem_part_id': '1_2', 'trigger_type': 'single',
              'student_answer': [u'FACES'], 'correctness': True, 'question_type': 'optionresponse',
              'hint_label': 'Correct:', 'hints': [{'text': 'With lots of makeup, doncha know?'}]}
         )

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -19,6 +19,7 @@ except ImportError:
     dog_stats_api = None
 from pytz import utc
 from django.utils.encoding import smart_text
+from six import text_type
 
 from capa.capa_problem import LoncapaProblem, LoncapaSystem
 from capa.inputtypes import Status
@@ -246,7 +247,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         # Need the problem location in openendedresponse to send out.  Adding
         # it to the system here seems like the least clunky way to get it
         # there.
-        self.runtime.set('location', self.location.to_deprecated_string())
+        self.runtime.set('location', text_type(self.location))
 
         try:
             # TODO (vshnayder): move as much as possible of this work and error
@@ -264,7 +265,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
 
         except Exception as err:  # pylint: disable=broad-except
             msg = u'cannot create LoncapaProblem {loc}: {err}'.format(
-                loc=self.location.to_deprecated_string(), err=err)
+                loc=text_type(self.location), err=err)
             # TODO (vshnayder): do modules need error handlers too?
             # We shouldn't be switching on DEBUG.
             if self.runtime.DEBUG:
@@ -286,7 +287,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
                 problem_text = (
                     u'<problem><text><span class="inline-error">'
                     u'Problem {url} has an error:</span>{msg}</text></problem>'.format(
-                        url=self.location.to_deprecated_string(),
+                        url=text_type(self.location),
                         msg=msg,
                     )
                 )
@@ -429,7 +430,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
 
         return self.runtime.render_template('problem_ajax.html', {
             'element_id': self.location.html_id(),
-            'id': self.location.to_deprecated_string(),
+            'id': text_type(self.location),
             'ajax_url': self.runtime.ajax_url,
             'current_score': curr_score,
             'total_possible': total_possible,
@@ -550,7 +551,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
             msg = (
                 u'[courseware.capa.capa_module] <font size="+1" color="red">'
                 u'Failed to generate HTML for problem {url}</font>'.format(
-                    url=cgi.escape(self.location.to_deprecated_string()))
+                    url=cgi.escape(text_type(self.location)))
             )
             msg += u'<p>Error:</p><p><pre>{msg}</pre></p>'.format(msg=cgi.escape(err.message))
             msg += u'<p><pre>{tb}</pre></p>'.format(tb=cgi.escape(traceback.format_exc()))
@@ -661,7 +662,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         # Log this demand-hint request. Note that this only logs the last hint requested (although now
         # all previously shown hints are still displayed).
         event_info = dict()
-        event_info['module_id'] = self.location.to_deprecated_string()
+        event_info['module_id'] = text_type(self.location)
         event_info['hint_index'] = hint_index
         event_info['hint_len'] = len(demand_hints)
         event_info['hint_text'] = get_inner_html_from_xpath(demand_hints[hint_index])
@@ -723,7 +724,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
 
         context = {
             'problem': content,
-            'id': self.location.to_deprecated_string(),
+            'id': text_type(self.location),
             'short_id': self.location.html_id(),
             'submit_button': submit_button,
             'submit_button_submitting': submit_button_submitting,
@@ -1005,7 +1006,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
             (and also screen reader text).
         """
         event_info = dict()
-        event_info['problem_id'] = self.location.to_deprecated_string()
+        event_info['problem_id'] = text_type(self.location)
         self.track_function_unmask('showanswer', event_info)
         if not self.answer_available():
             raise NotFoundError('Answer is not available')
@@ -1159,7 +1160,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         """
         event_info = dict()
         event_info['state'] = self.lcp.get_state()
-        event_info['problem_id'] = self.location.to_deprecated_string()
+        event_info['problem_id'] = text_type(self.location)
 
         self.lcp.has_saved_answers = False
         answers = self.make_dict_of_responses(data)
@@ -1475,7 +1476,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         """
         event_info = dict()
         event_info['state'] = self.lcp.get_state()
-        event_info['problem_id'] = self.location.to_deprecated_string()
+        event_info['problem_id'] = text_type(self.location)
 
         answers = self.make_dict_of_responses(data)
         event_info['answers'] = answers
@@ -1535,7 +1536,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         """
         event_info = dict()
         event_info['old_state'] = self.lcp.get_state()
-        event_info['problem_id'] = self.location.to_deprecated_string()
+        event_info['problem_id'] = text_type(self.location)
         _ = self.runtime.service(self, "i18n").ugettext
 
         if self.closed():
@@ -1600,7 +1601,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         Returns the error messages for exceptions occurring while performing
         the rescoring, rather than throwing them.
         """
-        event_info = {'state': self.lcp.get_state(), 'problem_id': self.location.to_deprecated_string()}
+        event_info = {'state': self.lcp.get_state(), 'problem_id': text_type(self.location)}
 
         _ = self.runtime.service(self, "i18n").ugettext
 

--- a/common/lib/xmodule/xmodule/conditional_module.py
+++ b/common/lib/xmodule/xmodule/conditional_module.py
@@ -8,6 +8,7 @@ import logging
 from lazy import lazy
 from lxml import etree
 from pkg_resources import resource_string
+from six import text_type
 
 from opaque_keys.edx.locator import BlockUsageLocator
 from xblock.fields import ReferenceList, Scope, String
@@ -338,12 +339,12 @@ class ConditionalDescriptor(ConditionalFields, SequenceDescriptor, StudioEditabl
 
         if self.show_tag_list:
             show_str = u'<{tag_name} sources="{sources}" />'.format(
-                tag_name='show', sources=';'.join(location.to_deprecated_string() for location in self.show_tag_list))
+                tag_name='show', sources=';'.join(text_type(location) for location in self.show_tag_list))
             xml_object.append(etree.fromstring(show_str))
 
         # Overwrite the original sources attribute with the value from sources_list, as
         # Locations may have been changed to Locators.
-        stringified_sources_list = map(lambda loc: loc.to_deprecated_string(), self.sources_list)
+        stringified_sources_list = map(lambda loc: text_type(loc), self.sources_list)
         self.xml_attributes['sources'] = ';'.join(stringified_sources_list)
         self.xml_attributes[self.conditional_attr] = self.conditional_value
         self.xml_attributes['message'] = self.conditional_message

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -13,6 +13,7 @@ from lazy import lazy
 from lxml import etree
 from opaque_keys.edx.locator import LibraryLocator
 from pkg_resources import resource_string
+from six import text_type
 from webob import Response
 from xblock.core import XBlock
 from xblock.fields import Integer, List, Scope, String
@@ -326,7 +327,7 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
                 rendered_child = displayable.render(STUDENT_VIEW, child_context)
                 fragment.add_frag_resources(rendered_child)
                 contents.append({
-                    'id': displayable.location.to_deprecated_string(),
+                    'id': text_type(displayable.location),
                     'content': rendered_child.content,
                 })
 

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -66,6 +66,7 @@ from pytz import UTC
 from lxml import etree
 from oauthlib.oauth1.rfc5849 import signature
 from pkg_resources import resource_string
+from six import text_type
 from webob import Response
 from xblock.core import List, Scope, String, XBlock
 from xblock.fields import Boolean, Float
@@ -532,7 +533,7 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
         context_id is an opaque identifier that uniquely identifies the context (e.g., a course)
         that contains the link being launched.
         """
-        return self.course_id.to_deprecated_string()
+        return text_type(self.course_id)
 
     @property
     def role(self):
@@ -557,8 +558,8 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
         """
 
         client = oauthlib.oauth1.Client(
-            client_key=unicode(client_key),
-            client_secret=unicode(client_secret)
+            client_key=text_type(client_key),
+            client_secret=text_type(client_secret)
         )
 
         # Must have parameters for correct signing from LTI:

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from lxml import etree
 from pkg_resources import resource_string
 from pytz import UTC
+from six import text_type
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Boolean, Integer, List, Scope, String
@@ -311,7 +312,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
         params = {
             'items': self._render_student_view_for_items(context, display_items, fragment),
             'element_id': self.location.html_id(),
-            'item_id': self.location.to_deprecated_string(),
+            'item_id': text_type(self.location),
             'position': self.position,
             'tag': self.location.category,
             'ajax_url': self.system.ajax_url,
@@ -391,7 +392,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
                 'content': rendered_item.content,
                 'page_title': getattr(item, 'tooltip_title', ''),
                 'type': item_type,
-                'id': usage_id.to_deprecated_string(),
+                'id': text_type(usage_id),
                 'bookmarked': is_bookmarked,
                 'path': " > ".join(display_names + [item.display_name_with_default]),
             }

--- a/common/lib/xmodule/xmodule/split_test_module.py
+++ b/common/lib/xmodule/xmodule/split_test_module.py
@@ -16,6 +16,7 @@ from xmodule.validation import StudioValidation, StudioValidationMessage
 from xmodule.modulestore.inheritance import UserPartitionList
 
 from lxml import etree
+from six import text_type
 
 from xblock.core import XBlock
 from xblock.fields import Scope, Integer, String, ReferenceValueDict
@@ -225,7 +226,7 @@ class SplitTestModule(SplitTestFields, XModule, StudioEditableModule):
                 updated_group_id = [g_id for g_id, loc in self.group_id_to_child.items() if loc == child_location][0]
                 inactive_contents.append({
                     'group_name': _(u'{group_name} (inactive)').format(group_name=group_name),
-                    'id': child.location.to_deprecated_string(),
+                    'id': text_type(child.location),
                     'content': rendered_child.content,
                     'group_id': updated_group_id,
                 })
@@ -233,7 +234,7 @@ class SplitTestModule(SplitTestFields, XModule, StudioEditableModule):
 
             active_contents.append({
                 'group_name': group_name,
-                'id': child.location.to_deprecated_string(),
+                'id': text_type(child.location),
                 'content': rendered_child.content,
                 'group_id': updated_group_id,
             })
@@ -332,7 +333,7 @@ class SplitTestModule(SplitTestFields, XModule, StudioEditableModule):
         Record in the tracking logs which child was rendered
         """
         # TODO: use publish instead, when publish is wired to the tracking logs
-        self.system.track_function('xblock.split_test.child_render', {'child_id': self.child.scope_ids.usage_id.to_deprecated_string()})
+        self.system.track_function('xblock.split_test.child_render', {'child_id': text_type(self.child.scope_ids.usage_id)})
         return Response()
 
     def get_icon_class(self):
@@ -394,7 +395,7 @@ class SplitTestDescriptor(SplitTestFields, SequenceDescriptor, StudioEditableDes
         renderable_groups = {}
         # json.dumps doesn't know how to handle Location objects
         for group in self.group_id_to_child:
-            renderable_groups[group] = self.group_id_to_child[group].to_deprecated_string()
+            renderable_groups[group] = text_type(self.group_id_to_child[group])
         xml_object.set('group_id_to_child', json.dumps(renderable_groups))
         xml_object.set('user_partition_id', str(self.user_partition_id))
         for child in self.get_children():

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -5,6 +5,7 @@ import logging
 from abc import ABCMeta
 
 from django.core.files.storage import get_storage_class
+from six import text_type
 from xblock.fields import List
 
 from openedx.core.lib.api.plugins import PluginError
@@ -266,7 +267,7 @@ class TabFragmentViewMixin(object):
         # If not, then use the generic course tab URL
         def link_func(course, reverse_func):
             """ Returns a function that returns the course tab's URL. """
-            return reverse_func("course_tab_view", args=[course.id.to_deprecated_string(), self.type])
+            return reverse_func("course_tab_view", args=[text_type(course.id), self.type])
 
         return link_func
 
@@ -304,7 +305,7 @@ class StaticTab(CourseTab):
     def __init__(self, tab_dict=None, name=None, url_slug=None):
         def link_func(course, reverse_func):
             """ Returns a function that returns the static tab's URL. """
-            return reverse_func(self.type, args=[course.id.to_deprecated_string(), self.url_slug])
+            return reverse_func(self.type, args=[text_type(course.id), self.url_slug])
 
         self.url_slug = tab_dict.get('url_slug') if tab_dict else url_slug
 
@@ -612,7 +613,7 @@ def course_reverse_func_from_name_func(reverse_name_func):
     """
     return lambda course, reverse_url_func: reverse_url_func(
         reverse_name_func(course),
-        args=[course.id.to_deprecated_string()]
+        args=[text_type(course.id)]
     )
 
 

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -17,6 +17,7 @@ import ddt
 from django.utils.encoding import smart_text
 from lxml import etree
 from mock import Mock, patch, DEFAULT
+import six
 import webob
 from webob.multidict import MultiDict
 
@@ -1533,10 +1534,19 @@ class CapaModuleTest(unittest.TestCase):
         self.assertFalse(result['should_enable_next_hint'])
 
     def test_demand_hint_logging(self):
+        def mock_location_text(self):
+            """
+            Mock implementation of __unicode__ or __str__ for the module's location.
+            """
+            return u'i4x://edX/capa_test/problem/meh'
+
         module = CapaFactory.create(xml=self.demand_xml)
         # Re-mock the module_id to a fixed string, so we can check the logging
         module.location = Mock(module.location)
-        module.location.to_deprecated_string.return_value = 'i4x://edX/capa_test/problem/meh'
+        if six.PY2:
+            module.location.__unicode__ = mock_location_text
+        else:
+            module.location.__str__ = mock_location_text
 
         with patch.object(module.runtime, 'publish') as mock_track_function:
             module.get_problem_html()

--- a/lms/djangoapps/bulk_email/forms.py
+++ b/lms/djangoapps/bulk_email/forms.py
@@ -7,6 +7,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from six import text_type
 
 from bulk_email.models import COURSE_EMAIL_MESSAGE_BODY_TAG, CourseAuthorization, CourseEmailTemplate
 from xmodule.modulestore.django import modulestore
@@ -90,7 +91,7 @@ class CourseAuthorizationAdminForm(forms.ModelForm):
 
         if not modulestore().has_course(course_key):
             msg = u'COURSE NOT FOUND'
-            msg += u' --- Entered course id was: "{0}". '.format(course_key.to_deprecated_string())
+            msg += u' --- Entered course id was: "{0}". '.format(text_type(course_key))
             msg += 'Please recheck that you have supplied a valid course id.'
             raise forms.ValidationError(msg)
 

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -7,6 +7,7 @@ import markupsafe
 from config_models.models import ConfigurationModel
 from django.contrib.auth.models import User
 from django.db import models
+from six import text_type
 
 from course_modes.models import CourseMode
 from enrollment.api import validate_course_mode
@@ -434,7 +435,7 @@ class CourseAuthorization(models.Model):
         if self.email_enabled:
             not_en = ""
         # pylint: disable=no-member
-        return u"Course '{}': Instructor Email {}Enabled".format(self.course_id.to_deprecated_string(), not_en)
+        return u"Course '{}': Instructor Email {}Enabled".format(text_type(self.course_id), not_en)
 
 
 class BulkEmailFlag(ConfigurationModel):

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -34,6 +34,7 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import override as override_language
 from django.utils.translation import ugettext as _
 from markupsafe import escape
+from six import text_type
 
 import dogstats_wrapper as dog_stats_api
 from bulk_email.models import CourseEmail, Optout
@@ -97,7 +98,7 @@ def _get_course_email_context(course):
     """
     Returns context arguments to apply to all emails, independent of recipient.
     """
-    course_id = course.id.to_deprecated_string()
+    course_id = text_type(course.id)
     course_title = course.display_name
     course_end_date = get_default_time_display(course.end)
     course_root = reverse('course_root', kwargs={'course_id': course_id})

--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -9,6 +9,7 @@ from django.core.management import call_command
 from django.core.urlresolvers import reverse
 from mock import Mock, patch
 from nose.plugins.attrib import attr
+from six import text_type
 
 from bulk_email.models import BulkEmailFlag
 from bulk_email.policies import CourseEmailOptout
@@ -42,9 +43,9 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
 
         self.client.login(username=self.student.username, password="test")
 
-        self.send_mail_url = reverse('send_email', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        self.send_mail_url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
         self.success_content = {
-            'course_id': self.course.id.to_deprecated_string(),
+            'course_id': text_type(self.course.id),
             'success': True,
         }
         BulkEmailFlag.objects.create(enabled=True, require_course_email_auth=False)
@@ -52,7 +53,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
     def navigate_to_email_view(self):
         """Navigate to the instructor dash's email view"""
         # Pull up email view on instructor dashboard
-        url = reverse('instructor_dashboard', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('instructor_dashboard', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.get(url)
         email_section = '<div class="vert-left send-email" id="section-send-email">'
         # If this fails, it is likely because BulkEmailFlag.is_enabled() is set to False
@@ -65,7 +66,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
         url = reverse('change_email_settings')
         # This is a checkbox, so on the post of opting out (that is, an Un-check of the box),
         # the Post that is sent will not contain 'receive_emails'
-        response = self.client.post(url, {'course_id': self.course.id.to_deprecated_string()})
+        response = self.client.post(url, {'course_id': text_type(self.course.id)})
         self.assertEquals(json.loads(response.content), {'success': True})
 
         self.client.logout()
@@ -91,7 +92,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
         Make sure student receives course email after opting in.
         """
         url = reverse('change_email_settings')
-        response = self.client.post(url, {'course_id': self.course.id.to_deprecated_string(), 'receive_emails': 'on'})
+        response = self.client.post(url, {'course_id': text_type(self.course.id), 'receive_emails': 'on'})
         self.assertEquals(json.loads(response.content), {'success': True})
 
         self.client.logout()
@@ -140,7 +141,7 @@ class TestACEOptoutCourseEmails(ModuleStoreTestCase):
         url = reverse('change_email_settings')
         # This is a checkbox, so on the post of opting out (that is, an Un-check of the box),
         # the Post that is sent will not contain 'receive_emails'
-        post_data = {'course_id': self.course.id.to_deprecated_string()}
+        post_data = {'course_id': text_type(self.course.id)}
 
         if not opted_out:
             post_data['receive_emails'] = 'on'

--- a/lms/djangoapps/class_dashboard/dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/dashboard_data.py
@@ -7,6 +7,7 @@ from django.db.models import Count
 from django.utils.translation import ugettext as _
 
 from opaque_keys.edx.locations import Location
+from six import text_type
 
 from courseware import models
 from instructor_analytics.csvs import create_csv_response
@@ -214,7 +215,7 @@ def get_d3_problem_grade_distrib(course_id):
                                     'color': percent,
                                     'value': count_grade,
                                     'tooltip': tooltip,
-                                    'module_url': child.location.to_deprecated_string(),
+                                    'module_url': text_type(child.location),
                                 })
 
                         problem = {
@@ -276,7 +277,7 @@ def get_d3_sequential_open_distrib(course_id):
                 'color': 0,
                 'value': num_students,
                 'tooltip': tooltip,
-                'module_url': subsection.location.to_deprecated_string(),
+                'module_url': text_type(subsection.location),
             })
             subsection = {
                 'xValue': "SS {0}".format(c_subsection),
@@ -330,7 +331,7 @@ def get_d3_section_grade_distrib(course_id, section):
                     c_problem += 1
                     problem_set.append(child.location)
                     problem_info[child.location] = {
-                        'id': child.location.to_deprecated_string(),
+                        'id': text_type(child.location),
                         'x_value': "P{0}.{1}.{2}".format(c_subsection, c_unit, c_problem),
                         'display_name': own_metadata(child).get('display_name', ''),
                     }

--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import redirect
+from six import text_type
 from wiki.models import reverse
 
 from courseware.access import has_access
@@ -32,7 +33,7 @@ class WikiAccessMiddleware(object):
             # See if we are able to view the course. If we are, redirect to it
             try:
                 get_course_overview_with_access(request.user, 'load', course_id)
-                return redirect("/courses/{course_id}/wiki/{path}".format(course_id=course_id.to_deprecated_string(), path=wiki_path))
+                return redirect("/courses/{course_id}/wiki/{path}".format(course_id=text_type(course_id), path=wiki_path))
             except Http404:
                 # Even though we came from the course, we can't see it. So don't worry about it.
                 pass
@@ -55,7 +56,7 @@ class WikiAccessMiddleware(object):
 
         if course_id:
             # This is a /courses/org/name/run/wiki request
-            course_path = "/courses/{}".format(course_id.to_deprecated_string())
+            course_path = "/courses/{}".format(text_type(course_id))
             # HACK: django-wiki monkeypatches the reverse function to enable
             # urls to be rewritten
             reverse._transform_url = lambda url: course_path + url  # pylint: disable=protected-access
@@ -76,10 +77,10 @@ class WikiAccessMiddleware(object):
                 if not (is_enrolled or is_staff):
                     # if a user is logged in, but not authorized to see a page,
                     # we'll redirect them to the course about page
-                    return redirect('about_course', course_id.to_deprecated_string())
+                    return redirect('about_course', text_type(course_id))
 
                 # If we need enterprise data sharing consent for this course, then redirect to the form.
-                consent_url = get_enterprise_consent_url(request, unicode(course_id))
+                consent_url = get_enterprise_consent_url(request, text_type(course_id))
                 if consent_url:
                     return redirect(consent_url)
 

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -17,6 +17,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from pytz import UTC
 from opaque_keys.edx.keys import CourseKey, UsageKey
+from six import text_type
 from xblock.core import XBlock
 
 from courseware.access_response import (
@@ -607,7 +608,7 @@ def _dispatch(table, action, user, obj):
         debug("%s user %s, object %s, action %s",
               'ALLOWED' if result else 'DENIED',
               user,
-              obj.location.to_deprecated_string() if isinstance(obj, XBlock) else str(obj),
+              text_type(obj.location) if isinstance(obj, XBlock) else str(obj),
               action)
         return result
 

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -32,6 +32,7 @@ from opaque_keys.edx.keys import UsageKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from path import Path as path
+from six import text_type
 from static_replace import replace_static_urls
 from student.models import CourseEnrollment
 from survey.utils import is_survey_required_and_unanswered
@@ -294,7 +295,7 @@ def get_course_about_section(request, course, section_key):
         except ItemNotFoundError:
             log.warning(
                 u"Missing about section %s in course %s",
-                section_key, course.location.to_deprecated_string()
+                section_key, text_type(course.location)
             )
             return None
 
@@ -422,7 +423,7 @@ def get_course_syllabus_section(course, section_key):
         except ResourceNotFound:
             log.exception(
                 u"Missing syllabus section %s in course %s",
-                section_key, course.location.to_deprecated_string()
+                section_key, text_type(course.location)
             )
             return "! Syllabus missing !"
 

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -22,6 +22,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
+from six import text_type
 
 import coursewarehistoryextended
 from openedx.core.djangoapps.xmodule_django.models import BlockTypeKeyField, CourseKeyField, LocationKeyField
@@ -339,7 +340,7 @@ class OfflineComputedGradeLog(models.Model):
     nstudents = models.IntegerField(default=0)
 
     def __unicode__(self):
-        return "[OCGLog] %s: %s" % (self.course_id.to_deprecated_string(), self.created)  # pylint: disable=no-member
+        return "[OCGLog] %s: %s" % (text_type(self.course_id), self.created)  # pylint: disable=no-member
 
 
 class StudentFieldOverride(TimeStampedModel):

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -20,6 +20,7 @@ from edx_proctoring.services import ProctoringService
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from requests.auth import HTTPBasicAuth
+from six import text_type
 from xblock.core import XBlock
 from xblock.django.request import django_to_webob_request, webob_to_django_response
 from xblock.exceptions import NoSuchHandlerError, NoSuchViewError
@@ -430,9 +431,9 @@ def get_module_system_for_user(
         relative_xqueue_callback_url = reverse(
             'xqueue_callback',
             kwargs=dict(
-                course_id=course_id.to_deprecated_string(),
+                course_id=text_type(course_id),
                 userid=str(user.id),
-                mod_id=descriptor.location.to_deprecated_string(),
+                mod_id=text_type(descriptor.location),
                 dispatch=dispatch
             ),
         )
@@ -637,8 +638,8 @@ def get_module_system_for_user(
         block_wrappers.append(partial(
             wrap_xblock,
             'LmsRuntime',
-            extra_data={'course-id': course_id.to_deprecated_string()},
-            usage_id_serializer=lambda usage_id: quote_slashes(usage_id.to_deprecated_string()),
+            extra_data={'course-id': text_type(course_id)},
+            usage_id_serializer=lambda usage_id: quote_slashes(text_type(usage_id)),
             request_token=request_token,
         ))
 
@@ -666,7 +667,7 @@ def get_module_system_for_user(
     block_wrappers.append(partial(
         replace_jump_to_id_urls,
         course_id,
-        reverse('jump_to_id', kwargs={'course_id': course_id.to_deprecated_string(), 'module_id': ''}),
+        reverse('jump_to_id', kwargs={'course_id': text_type(course_id), 'module_id': ''}),
     ))
 
     if settings.FEATURES.get('DISPLAY_DEBUG_INFO_TO_STAFF'):
@@ -733,7 +734,7 @@ def get_module_system_for_user(
         replace_jump_to_id_urls=partial(
             static_replace.replace_jump_to_id_urls,
             course_id=course_id,
-            jump_to_id_base_url=reverse('jump_to_id', kwargs={'course_id': course_id.to_deprecated_string(), 'module_id': ''})
+            jump_to_id_base_url=reverse('jump_to_id', kwargs={'course_id': text_type(course_id), 'module_id': ''})
         ),
         node_path=settings.NODE_PATH,
         publish=publish,

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -28,6 +28,7 @@ from django.views.decorators.http import condition
 from django.views.generic.base import TemplateView
 from opaque_keys.edx.keys import CourseKey
 from path import Path as path
+from six import text_type
 
 import dashboard.git_import as git_import
 import track.views
@@ -265,7 +266,7 @@ class Users(SysadminDashboardView):
         self.msg += u'<ol>'
         for course in self.get_courses():
             self.msg += u'<li>{0} ({1})</li>'.format(
-                escape(course.id.to_deprecated_string()), course.location.to_deprecated_string())
+                escape(text_type(course.id)), text_type(course.location))
         self.msg += u'</ol>'
 
     def get(self, request):
@@ -427,7 +428,7 @@ class Courses(SysadminDashboardView):
 
         for course in self.get_courses():
             gdir = course.id.course
-            data.append([course.display_name, course.id.to_deprecated_string()]
+            data.append([course.display_name, text_type(course.id)]
                         + self.git_info_for_course(gdir))
 
         return dict(header=[_('Course Name'),
@@ -495,7 +496,7 @@ class Courses(SysadminDashboardView):
                 # don't delete user permission groups, though
                 self.msg += \
                     u"<font color='red'>{0} {1} = {2} ({3})</font>".format(
-                        _('Deleted'), course.location.to_deprecated_string(), course.id.to_deprecated_string(), course.display_name)
+                        _('Deleted'), text_type(course.location), text_type(course.id), course.display_name)
 
         context = {
             'datatable': self.make_datatable(),
@@ -653,7 +654,7 @@ class GitLogs(TemplateView):
         mdb.disconnect()
         context = {
             'logs': logs,
-            'course_id': course_id.to_deprecated_string() if course_id else None,
+            'course_id': text_type(course_id) if course_id else None,
             'error_msg': error_msg,
             'page_size': page_size
         }

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -11,6 +11,7 @@ from django.http import HttpResponse
 from pytz import UTC
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import i4xEncoder
+from six import text_type
 
 from courseware import courses
 from courseware.access import has_access
@@ -653,7 +654,7 @@ def get_metadata_for_threads(course_id, threads, user, user_info):
 
 def permalink(content):
     if isinstance(content['course_id'], CourseKey):
-        course_id = content['course_id'].to_deprecated_string()
+        course_id = text_type(content['course_id'])
     else:
         course_id = content['course_id']
     if content['type'] == 'thread':
@@ -701,10 +702,10 @@ def add_courseware_context(content_list, course, user, id_map=None):
     for content in content_list:
         commentable_id = content['commentable_id']
         if commentable_id in id_map:
-            location = id_map[commentable_id]["location"].to_deprecated_string()
+            location = text_type(id_map[commentable_id]["location"])
             title = id_map[commentable_id]["title"]
 
-            url = reverse('jump_to', kwargs={"course_id": course.id.to_deprecated_string(),
+            url = reverse('jump_to', kwargs={"course_id": text_type(course.id),
                           "location": location})
 
             content.update({"courseware_url": url, "courseware_title": title})

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -14,6 +14,7 @@ from django.contrib.auth.models import User
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.utils.translation import override as override_language
+from six import text_type
 
 from course_modes.models import CourseMode
 from courseware.models import StudentModule
@@ -262,8 +263,8 @@ def reset_student_attempts(course_id, student, module_state_key, requesting_user
     if delete_module and not submission_cleared:
         sub_api.reset_score(
             user_id,
-            course_id.to_deprecated_string(),
-            module_state_key.to_deprecated_string(),
+            text_type(course_id),
+            text_type(module_state_key),
         )
 
     module_to_reset = StudentModule.objects.get(
@@ -352,7 +353,7 @@ def get_email_params(course, auto_enroll, secure=True, course_key=None, display_
     """
 
     protocol = 'https' if secure else 'http'
-    course_key = course_key or course.id.to_deprecated_string()
+    course_key = course_key or text_type(course.id)
     display_name = display_name or course.display_name_with_default_escaped
 
     stripped_site_name = configuration_helpers.get_value(

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -27,6 +27,7 @@ from nose.plugins.attrib import attr
 from nose.tools import raises
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import UsageKey
+from six import text_type
 
 import lms.djangoapps.instructor.views.api
 import lms.djangoapps.instructor_task.api
@@ -389,7 +390,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
             cls.course.id,
             'robot-some-problem-urlname'
         )
-        cls.problem_urlname = cls.problem_location.to_deprecated_string()
+        cls.problem_urlname = text_type(cls.problem_location)
         BulkEmailFlag.objects.create(enabled=True, require_course_email_auth=False)
 
     @classmethod
@@ -454,7 +455,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
         status_code: expected HTTP status code response
         msg: message to display if assertion fails.
         """
-        url = reverse(endpoint, kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse(endpoint, kwargs={'course_id': text_type(self.course.id)})
         if endpoint in INSTRUCTOR_GET_ENDPOINTS:
             response = self.client.get(url, args)
         else:
@@ -1046,19 +1047,19 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
 
     def test_missing_params(self):
         """ Test missing all query parameters. """
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
 
     def test_bad_action(self):
         """ Test with an invalid action. """
         action = 'robot-not-an-action'
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.enrolled_student.email, 'action': action})
         self.assertEqual(response.status_code, 400)
 
     def test_invalid_email(self):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': 'percivaloctavius@', 'action': 'enroll', 'email_students': False})
         self.assertEqual(response.status_code, 200)
 
@@ -1078,7 +1079,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         self.assertEqual(res_json, expected)
 
     def test_invalid_username(self):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url,
                                     {'identifiers': 'percivaloctavius', 'action': 'enroll', 'email_students': False})
         self.assertEqual(response.status_code, 200)
@@ -1099,7 +1100,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         self.assertEqual(res_json, expected)
 
     def test_enroll_with_username(self):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.notenrolled_student.username, 'action': 'enroll',
                                           'email_students': False})
         self.assertEqual(response.status_code, 200)
@@ -1133,7 +1134,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         self.assertEqual(res_json, expected)
 
     def test_enroll_without_email(self):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.notenrolled_student.email, 'action': 'enroll',
                                           'email_students': False})
         print "type(self.notenrolled_student.email): {}".format(type(self.notenrolled_student.email))
@@ -1177,7 +1178,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
 
     @ddt.data('http', 'https')
     def test_enroll_with_email(self, protocol):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         params = {'identifiers': self.notenrolled_student.email, 'action': 'enroll', 'email_students': True}
         environ = {'wsgi.url_scheme': protocol}
         response = self.client.post(url, params, **environ)
@@ -1236,7 +1237,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
 
     @ddt.data('http', 'https')
     def test_enroll_with_email_not_registered(self, protocol):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         params = {'identifiers': self.notregistered_email, 'action': 'enroll', 'email_students': True}
         environ = {'wsgi.url_scheme': protocol}
         response = self.client.post(url, params, **environ)
@@ -1266,7 +1267,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
     @ddt.data('http', 'https')
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_enroll_email_not_registered_mktgsite(self, protocol):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         params = {'identifiers': self.notregistered_email, 'action': 'enroll', 'email_students': True}
         environ = {'wsgi.url_scheme': protocol}
         response = self.client.post(url, params, **environ)
@@ -1289,7 +1290,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
 
     @ddt.data('http', 'https')
     def test_enroll_with_email_not_registered_autoenroll(self, protocol):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         params = {'identifiers': self.notregistered_email, 'action': 'enroll', 'email_students': True,
                   'auto_enroll': True}
         environ = {'wsgi.url_scheme': protocol}
@@ -1320,7 +1321,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         )
 
     def test_unenroll_without_email(self):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.enrolled_student.email, 'action': 'unenroll',
                                           'email_students': False})
         print "type(self.enrolled_student.email): {}".format(type(self.enrolled_student.email))
@@ -1363,7 +1364,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         self.assertEqual(len(mail.outbox), 0)
 
     def test_unenroll_with_email(self):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.enrolled_student.email, 'action': 'unenroll',
                                           'email_students': True})
         print "type(self.enrolled_student.email): {}".format(type(self.enrolled_student.email))
@@ -1420,7 +1421,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         )
 
     def test_unenroll_with_email_allowed_student(self):
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url,
                                     {'identifiers': self.allowed_email, 'action': 'unenroll', 'email_students': True})
         print "type(self.allowed_email): {}".format(type(self.allowed_email))
@@ -1475,7 +1476,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
     def test_enroll_with_email_not_registered_with_shib(self, protocol, mock_uses_shib):
         mock_uses_shib.return_value = True
 
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         params = {'identifiers': self.notregistered_email, 'action': 'enroll', 'email_students': True}
         environ = {'wsgi.url_scheme': protocol}
         response = self.client.post(url, params, **environ)
@@ -1504,7 +1505,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         # Try with marketing site enabled and shib on
         mock_uses_shib.return_value = True
 
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         # Try with marketing site enabled
         with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True}):
             response = self.client.post(url, {'identifiers': self.notregistered_email, 'action': 'enroll',
@@ -1524,7 +1525,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
     def test_enroll_with_email_not_registered_with_shib_autoenroll(self, protocol, mock_uses_shib):
         mock_uses_shib.return_value = True
 
-        url = reverse('students_update_enrollment', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(self.course.id)})
         params = {'identifiers': self.notregistered_email, 'action': 'enroll', 'email_students': True,
                   'auto_enroll': True}
         environ = {'wsgi.url_scheme': protocol}
@@ -1590,7 +1591,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         manually enrolling the students for the paid courses.
         """
         paid_course = self.create_paid_course()
-        url = reverse('students_update_enrollment', kwargs={'course_id': paid_course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(paid_course.id)})
         params = {'identifiers': self.notregistered_email, 'action': 'enroll', 'email_students': False,
                   'auto_enroll': False}
         response = self.client.post(url, params)
@@ -1615,7 +1616,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         test to unenroll allow to enroll user.
         """
         paid_course = self.create_paid_course()
-        url = reverse('students_update_enrollment', kwargs={'course_id': paid_course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(paid_course.id)})
         params = {'identifiers': self.notregistered_email, 'action': 'enroll', 'email_students': False,
                   'auto_enroll': False, 'reason': 'testing..'}
         response = self.client.post(url, params)
@@ -1626,7 +1627,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
 
         # now registered the user
         UserFactory(email=self.notregistered_email)
-        url = reverse('students_update_enrollment', kwargs={'course_id': paid_course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(paid_course.id)})
         params = {'identifiers': self.notregistered_email, 'action': 'enroll', 'email_students': False,
                   'auto_enroll': False, 'reason': 'testing'}
         response = self.client.post(url, params)
@@ -1670,7 +1671,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         )
         self.assertEqual(course_enrollment.count(), 0)
 
-        url = reverse('students_update_enrollment', kwargs={'course_id': paid_course.id.to_deprecated_string()})
+        url = reverse('students_update_enrollment', kwargs={'course_id': text_type(paid_course.id)})
         params = {'identifiers': self.notregistered_email, 'action': 'unenroll', 'email_students': False,
                   'auto_enroll': False, 'reason': 'testing'}
 
@@ -1736,7 +1737,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         """
         url = reverse(
             'students_update_enrollment',
-            kwargs={'course_id': course.id.to_deprecated_string()},
+            kwargs={'course_id': text_type(course.id)},
         )
         params = {
             'identifiers': user.email,
@@ -1794,14 +1795,14 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
 
     def test_missing_params(self):
         """ Test missing all query parameters. """
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
 
     def test_bad_action(self):
         """ Test with an invalid action. """
         action = 'robot-not-an-action'
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.beta_tester.email, 'action': action})
         self.assertEqual(response.status_code, 400)
 
@@ -1838,32 +1839,32 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
         self.assertEqual(len(mail.outbox), 0)
 
     def test_add_notenrolled_email(self):
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.notenrolled_student.email, 'action': 'add', 'email_students': False})
         self.add_notenrolled(response, self.notenrolled_student.email)
         self.assertFalse(CourseEnrollment.is_enrolled(self.notenrolled_student, self.course.id))
 
     def test_add_notenrolled_email_autoenroll(self):
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.notenrolled_student.email, 'action': 'add', 'email_students': False, 'auto_enroll': True})
         self.add_notenrolled(response, self.notenrolled_student.email)
         self.assertTrue(CourseEnrollment.is_enrolled(self.notenrolled_student, self.course.id))
 
     def test_add_notenrolled_username(self):
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.notenrolled_student.username, 'action': 'add', 'email_students': False})
         self.add_notenrolled(response, self.notenrolled_student.username)
         self.assertFalse(CourseEnrollment.is_enrolled(self.notenrolled_student, self.course.id))
 
     def test_add_notenrolled_username_autoenroll(self):
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.notenrolled_student.username, 'action': 'add', 'email_students': False, 'auto_enroll': True})
         self.add_notenrolled(response, self.notenrolled_student.username)
         self.assertTrue(CourseEnrollment.is_enrolled(self.notenrolled_student, self.course.id))
 
     @ddt.data('http', 'https')
     def test_add_notenrolled_with_email(self, protocol):
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         params = {'identifiers': self.notenrolled_student.email, 'action': 'add', 'email_students': True}
         environ = {'wsgi.url_scheme': protocol}
         response = self.client.post(url, params, **environ)
@@ -1910,7 +1911,7 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
 
     @ddt.data('http', 'https')
     def test_add_notenrolled_with_email_autoenroll(self, protocol):
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         params = {'identifiers': self.notenrolled_student.email, 'action': 'add', 'email_students': True,
                   'auto_enroll': True}
         environ = {'wsgi.url_scheme': protocol}
@@ -1959,7 +1960,7 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
     def test_add_notenrolled_email_mktgsite(self):
         # Try with marketing site enabled
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'identifiers': self.notenrolled_student.email, 'action': 'add', 'email_students': True})
 
         self.assertEqual(response.status_code, 200)
@@ -1977,7 +1978,7 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
 
     def test_enroll_with_email_not_registered(self):
         # User doesn't exist
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url,
                                     {'identifiers': self.notregistered_email, 'action': 'add', 'email_students': True,
                                      'reason': 'testing'})
@@ -2001,7 +2002,7 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
         self.assertEqual(len(mail.outbox), 0)
 
     def test_remove_without_email(self):
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url,
                                     {'identifiers': self.beta_tester.email, 'action': 'remove', 'email_students': False,
                                      'reason': 'testing'})
@@ -2032,7 +2033,7 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
         self.assertEqual(len(mail.outbox), 0)
 
     def test_remove_with_email(self):
-        url = reverse('bulk_beta_modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('bulk_beta_modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url,
                                     {'identifiers': self.beta_tester.email, 'action': 'remove', 'email_students': True,
                                      'reason': 'testing'})
@@ -2108,13 +2109,13 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
 
     def test_modify_access_noparams(self):
         """ Test missing all query parameters. """
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
 
     def test_modify_access_bad_action(self):
         """ Test with an invalid action parameter. """
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.other_staff.email,
             'rolename': 'staff',
@@ -2124,7 +2125,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
 
     def test_modify_access_bad_role(self):
         """ Test with an invalid action parameter. """
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.other_staff.email,
             'rolename': 'robot-not-a-roll',
@@ -2133,7 +2134,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
         self.assertEqual(response.status_code, 400)
 
     def test_modify_access_allow(self):
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.other_user.email,
             'rolename': 'staff',
@@ -2142,7 +2143,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
         self.assertEqual(response.status_code, 200)
 
     def test_modify_access_allow_with_uname(self):
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.other_instructor.username,
             'rolename': 'staff',
@@ -2151,7 +2152,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
         self.assertEqual(response.status_code, 200)
 
     def test_modify_access_revoke(self):
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.other_staff.email,
             'rolename': 'staff',
@@ -2160,7 +2161,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
         self.assertEqual(response.status_code, 200)
 
     def test_modify_access_revoke_with_username(self):
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.other_staff.username,
             'rolename': 'staff',
@@ -2169,7 +2170,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
         self.assertEqual(response.status_code, 200)
 
     def test_modify_access_with_fake_user(self):
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': 'GandalfTheGrey',
             'rolename': 'staff',
@@ -2186,7 +2187,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
     def test_modify_access_with_inactive_user(self):
         self.other_user.is_active = False
         self.other_user.save()  # pylint: disable=no-member
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.other_user.username,
             'rolename': 'beta',
@@ -2202,7 +2203,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
 
     def test_modify_access_revoke_not_allowed(self):
         """ Test revoking access that a user does not have. """
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.other_staff.email,
             'rolename': 'instructor',
@@ -2214,7 +2215,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
         """
         Test that an instructor cannot remove instructor privelages from themself.
         """
-        url = reverse('modify_access', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('modify_access', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.instructor.email,
             'rolename': 'instructor',
@@ -2233,20 +2234,20 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
 
     def test_list_course_role_members_noparams(self):
         """ Test missing all query parameters. """
-        url = reverse('list_course_role_members', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_course_role_members', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
 
     def test_list_course_role_members_bad_rolename(self):
         """ Test with an invalid rolename parameter. """
-        url = reverse('list_course_role_members', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_course_role_members', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'rolename': 'robot-not-a-rolename',
         })
         self.assertEqual(response.status_code, 400)
 
     def test_list_course_role_members_staff(self):
-        url = reverse('list_course_role_members', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_course_role_members', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'rolename': 'staff',
         })
@@ -2254,7 +2255,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
 
         # check response content
         expected = {
-            'course_id': self.course.id.to_deprecated_string(),
+            'course_id': text_type(self.course.id),
             'staff': [
                 {
                     'username': self.other_staff.username,
@@ -2268,7 +2269,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
         self.assertEqual(res_json, expected)
 
     def test_list_course_role_members_beta(self):
-        url = reverse('list_course_role_members', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_course_role_members', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'rolename': 'beta',
         })
@@ -2276,7 +2277,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
 
         # check response content
         expected = {
-            'course_id': self.course.id.to_deprecated_string(),
+            'course_id': text_type(self.course.id),
             'beta': []
         }
         res_json = json.loads(response.content)
@@ -2301,7 +2302,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
         Test update forum role membership.
         Get unique_student_identifier, rolename and action and update forum role.
         """
-        url = reverse('update_forum_role_membership', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('update_forum_role_membership', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(
             url,
             {
@@ -2392,7 +2393,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         for i in range(2):
             course_registration_code = CourseRegistrationCode(
                 code='sale_invoice{}'.format(i),
-                course_id=self.course.id.to_deprecated_string(),
+                course_id=text_type(self.course.id),
                 created_by=self.instructor,
                 invoice=self.sale_invoice_1,
                 invoice_item=self.invoice_item,
@@ -2401,7 +2402,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             course_registration_code.save()
 
         data = {'invoice_number': self.sale_invoice_1.id, 'event_type': "invalidate"}
-        url = reverse('sale_validation', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('sale_validation', kwargs={'course_id': text_type(self.course.id)})
         self.assert_request_status_code(200, url, method="POST", data=data)
 
         #Now try to fetch data against not existing invoice number
@@ -2472,7 +2473,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         # get the redeemed coupon information
         coupon_redemption = CouponRedemption.objects.select_related('coupon').filter(order=self.cart)
 
-        sale_order_url = reverse('get_sale_order_records', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        sale_order_url = reverse('get_sale_order_records', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(sale_order_url)
         self.assertEqual(response['Content-Type'], 'text/csv')
         self.assertIn('36', response.content.split('\r\n')[1])
@@ -2506,7 +2507,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         # URL for instructor dashboard
         instructor_dashboard = reverse(
             'instructor_dashboard',
-            kwargs={'course_id': self.course.id.to_deprecated_string()},
+            kwargs={'course_id': text_type(self.course.id)},
             is_dashboard_endpoint=False
         )
         # visit the instructor dashboard page and
@@ -2533,7 +2534,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         for i in range(2):
             course_registration_code = CourseRegistrationCode(
                 code='sale_invoice{}'.format(i),
-                course_id=self.course.id.to_deprecated_string(),
+                course_id=text_type(self.course.id),
                 created_by=self.instructor,
                 invoice=self.sale_invoice_1,
                 invoice_item=self.invoice_item,
@@ -2543,7 +2544,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
         url = reverse(
             'get_sale_records',
-            kwargs={'course_id': self.course.id.to_deprecated_string()}
+            kwargs={'course_id': text_type(self.course.id)}
         )
         response = self.client.post(url + '/csv', {})
         self.assertEqual(response['Content-Type'], 'text/csv')
@@ -2555,7 +2556,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         for i in range(5):
             course_registration_code = CourseRegistrationCode(
                 code='sale_invoice{}'.format(i),
-                course_id=self.course.id.to_deprecated_string(),
+                course_id=text_type(self.course.id),
                 created_by=self.instructor,
                 invoice=self.sale_invoice_1,
                 invoice_item=self.invoice_item,
@@ -2563,7 +2564,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             )
             course_registration_code.save()
 
-        url = reverse('get_sale_records', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_sale_records', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
         res_json = json.loads(response.content)
         self.assertIn('sale', res_json)
@@ -2584,7 +2585,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         for i in range(5):
             course_registration_code = CourseRegistrationCode(
                 code='qwerty{}'.format(i),
-                course_id=self.course.id.to_deprecated_string(),
+                course_id=text_type(self.course.id),
                 created_by=self.instructor,
                 invoice=self.sale_invoice_1,
                 invoice_item=self.invoice_item,
@@ -2608,12 +2609,12 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
         for i in range(5):
             course_registration_code = CourseRegistrationCode(
-                code='xyzmn{}'.format(i), course_id=self.course.id.to_deprecated_string(),
+                code='xyzmn{}'.format(i), course_id=text_type(self.course.id),
                 created_by=self.instructor, invoice=sale_invoice_2, invoice_item=invoice_item_2, mode_slug='honor'
             )
             course_registration_code.save()
 
-        url = reverse('get_sale_records', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_sale_records', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
         res_json = json.loads(response.content)
         self.assertIn('sale', res_json)
@@ -2647,7 +2648,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         self.assertEqual(res['customer_reference_number'], invoice.customer_reference_number)
         self.assertEqual(res['invoice_number'], invoice.id)
         self.assertEqual(res['created_by'], course_registration_code.created_by.username)
-        self.assertEqual(res['course_id'], invoice_item.course_id.to_deprecated_string())
+        self.assertEqual(res['course_id'], text_type(invoice_item.course_id))
         self.assertEqual(res['total_used_codes'], used_codes)
         self.assertEqual(res['total_codes'], 5)
 
@@ -2732,7 +2733,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         for student in self.students:
             student.profile.city = "Mos Eisley {}".format(student.id)
             student.profile.save()
-        url = reverse('get_students_features', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_students_features', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
         res_json = json.loads(response.content)
         self.assertIn('students', res_json)
@@ -2752,7 +2753,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         Test that get_students_features includes cohort info when the course is
         cohorted, and does not when the course is not cohorted.
         """
-        url = reverse('get_students_features', kwargs={'course_id': unicode(self.course.id)})
+        url = reverse('get_students_features', kwargs={'course_id': text_type(self.course.id)})
         set_course_cohorted(self.course.id, is_cohorted)
 
         response = self.client.post(url, {})
@@ -2773,7 +2774,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             course_instructor = InstructorFactory(course_key=self.course.id)
             self.client.login(username=course_instructor.username, password='test')
 
-        url = reverse('get_students_features', kwargs={'course_id': unicode(self.course.id)})
+        url = reverse('get_students_features', kwargs={'course_id': text_type(self.course.id)})
 
         response = self.client.post(url, {})
         res_json = json.loads(response.content)
@@ -2867,7 +2868,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         decorated_func = require_finance_admin(func)
         request = self.mock_request()
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
-        decorated_func(request, self.course.id.to_deprecated_string())
+        decorated_func(request, text_type(self.course.id))
         self.assertTrue(func.called)
 
     def test_enrollment_report_features_csv(self):
@@ -2884,7 +2885,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         )
         course_registration_code = CourseRegistrationCode.objects.create(
             code='abcde',
-            course_id=self.course.id.to_deprecated_string(),
+            course_id=text_type(self.course.id),
             created_by=self.instructor,
             invoice=self.sale_invoice_1,
             invoice_item=self.invoice_item,
@@ -2906,7 +2907,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         UserProfileFactory.create(user=self.students[0], meta='{"company": "asdasda"}')
 
         self.client.login(username=self.instructor.username, password='test')
-        url = reverse('get_enrollment_report', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_enrollment_report', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
         self.assertIn('The detailed enrollment report is being created.', response.content)
 
@@ -2948,7 +2949,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         )
         course_registration_code = CourseRegistrationCode.objects.create(
             code='abcde',
-            course_id=self.course.id.to_deprecated_string(),
+            course_id=text_type(self.course.id),
             created_by=self.instructor,
             invoice=self.sale_invoice_1,
             invoice_item=self.invoice_item,
@@ -2961,7 +2962,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
         self.client.login(username=self.instructor.username, password='test')
 
-        url = reverse('get_enrollment_report', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_enrollment_report', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
         self.assertIn('The detailed enrollment report is being created.', response.content)
 
@@ -2973,7 +2974,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         """
         course_registration_code = CourseRegistrationCode.objects.create(
             code='abcde',
-            course_id=self.course.id.to_deprecated_string(),
+            course_id=text_type(self.course.id),
             created_by=self.instructor,
             mode_slug='honor'
         )
@@ -2983,7 +2984,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
         self.client.login(username=self.instructor.username, password='test')
 
-        url = reverse('get_enrollment_report', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_enrollment_report', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
         self.assertIn('The detailed enrollment report is being created.', response.content)
 
@@ -2995,7 +2996,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         """
         course_registration_code = CourseRegistrationCode.objects.create(
             code='abcde',
-            course_id=self.course.id.to_deprecated_string(),
+            course_id=text_type(self.course.id),
             created_by=self.instructor,
             invoice=self.sale_invoice_1,
             invoice_item=self.invoice_item,
@@ -3008,7 +3009,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
         self.client.login(username=self.instructor.username, password='test')
 
-        url = reverse('get_enrollment_report', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_enrollment_report', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
         self.assertIn('The detailed enrollment report is being created.', response.content)
 
@@ -3018,7 +3019,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         """
         Test the CSV output for the anonymized user ids.
         """
-        url = reverse('get_anon_ids', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_anon_ids', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
         self.assertEqual(response['Content-Type'], 'text/csv')
         body = response.content.replace('\r', '')
@@ -3038,7 +3039,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         """
         ex_status = 503
         ex_reason = 'Slow Down'
-        url = reverse('list_report_downloads', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_report_downloads', kwargs={'course_id': text_type(self.course.id)})
         with patch('openedx.core.storage.S3ReportStorage.listdir', side_effect=BotoServerError(ex_status, ex_reason)):
             response = self.client.post(url, {})
         mock_error.assert_called_with(
@@ -3052,7 +3053,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         self.assertEqual(res_json, {"downloads": []})
 
     def test_list_report_downloads(self):
-        url = reverse('list_report_downloads', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_report_downloads', kwargs={'course_id': text_type(self.course.id)})
         with patch('lms.djangoapps.instructor_task.models.DjangoStorageReportStore.links_for') as mock_links_for:
             mock_links_for.return_value = [
                 ('mock_file_name_1', 'https://1.mock.url'),
@@ -3141,7 +3142,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         self.assertIn(already_running_status, response.content)
 
     def test_get_ora2_responses_success(self):
-        url = reverse('export_ora2_data', kwargs={'course_id': unicode(self.course.id)})
+        url = reverse('export_ora2_data', kwargs={'course_id': text_type(self.course.id)})
 
         with patch('lms.djangoapps.instructor_task.api.submit_export_ora2_data') as mock_submit_ora2_task:
             mock_submit_ora2_task.return_value = True
@@ -3150,7 +3151,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         self.assertIn(success_status, response.content)
 
     def test_get_ora2_responses_already_running(self):
-        url = reverse('export_ora2_data', kwargs={'course_id': unicode(self.course.id)})
+        url = reverse('export_ora2_data', kwargs={'course_id': text_type(self.course.id)})
         task_type = 'export_ora2_data'
         already_running_status = generate_already_running_error_message(task_type)
 
@@ -3163,7 +3164,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
     def test_get_student_progress_url(self):
         """ Test that progress_url is in the successful response. """
-        url = reverse('get_student_progress_url', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_student_progress_url', kwargs={'course_id': text_type(self.course.id)})
         data = {'unique_student_identifier': self.students[0].email.encode("utf-8")}
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 200)
@@ -3172,7 +3173,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
     def test_get_student_progress_url_from_uname(self):
         """ Test that progress_url is in the successful response. """
-        url = reverse('get_student_progress_url', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_student_progress_url', kwargs={'course_id': text_type(self.course.id)})
         data = {'unique_student_identifier': self.students[0].username.encode("utf-8")}
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 200)
@@ -3181,13 +3182,13 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
     def test_get_student_progress_url_noparams(self):
         """ Test that the endpoint 404's without the required query params. """
-        url = reverse('get_student_progress_url', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_student_progress_url', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
 
     def test_get_student_progress_url_nostudent(self):
         """ Test that the endpoint 400's when requesting an unknown email. """
-        url = reverse('get_student_progress_url', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('get_student_progress_url', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
 
@@ -3209,7 +3210,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
             cls.course.id,
             'robot-some-problem-urlname'
         )
-        cls.problem_urlname = cls.problem_location.to_deprecated_string()
+        cls.problem_urlname = text_type(cls.problem_location)
 
     def setUp(self):
         super(TestInstructorAPIRegradeTask, self).setUp()
@@ -3228,7 +3229,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
 
     def test_reset_student_attempts_deletall(self):
         """ Make sure no one can delete all students state on a problem. """
-        url = reverse('reset_student_attempts', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('reset_student_attempts', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'problem_to_reset': self.problem_urlname,
             'all_students': True,
@@ -3238,7 +3239,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
 
     def test_reset_student_attempts_single(self):
         """ Test reset single student attempts. """
-        url = reverse('reset_student_attempts', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('reset_student_attempts', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'problem_to_reset': self.problem_urlname,
             'unique_student_identifier': self.student.email,
@@ -3255,7 +3256,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
     @patch.object(lms.djangoapps.instructor_task.api, 'submit_reset_problem_attempts_for_all_students')
     def test_reset_student_attempts_all(self, act):
         """ Test reset all student attempts. """
-        url = reverse('reset_student_attempts', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('reset_student_attempts', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'problem_to_reset': self.problem_urlname,
             'all_students': True,
@@ -3265,7 +3266,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
 
     def test_reset_student_attempts_missingmodule(self):
         """ Test reset for non-existant problem. """
-        url = reverse('reset_student_attempts', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('reset_student_attempts', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'problem_to_reset': 'robot-not-a-real-module',
             'unique_student_identifier': self.student.email,
@@ -3275,7 +3276,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
     @patch('lms.djangoapps.grades.signals.handlers.PROBLEM_WEIGHTED_SCORE_CHANGED.send')
     def test_reset_student_attempts_delete(self, _mock_signal):
         """ Test delete single student state. """
-        url = reverse('reset_student_attempts', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('reset_student_attempts', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'problem_to_reset': self.problem_urlname,
             'unique_student_identifier': self.student.email,
@@ -3294,7 +3295,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
 
     def test_reset_student_attempts_nonsense(self):
         """ Test failure with both unique_student_identifier and all_students. """
-        url = reverse('reset_student_attempts', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('reset_student_attempts', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'problem_to_reset': self.problem_urlname,
             'unique_student_identifier': self.student.email,
@@ -3305,7 +3306,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
     @patch.object(lms.djangoapps.instructor_task.api, 'submit_rescore_problem_for_student')
     def test_rescore_problem_single(self, act):
         """ Test rescoring of a single student. """
-        url = reverse('rescore_problem', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('rescore_problem', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'problem_to_reset': self.problem_urlname,
             'unique_student_identifier': self.student.email,
@@ -3316,7 +3317,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
     @patch.object(lms.djangoapps.instructor_task.api, 'submit_rescore_problem_for_student')
     def test_rescore_problem_single_from_uname(self, act):
         """ Test rescoring of a single student. """
-        url = reverse('rescore_problem', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('rescore_problem', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'problem_to_reset': self.problem_urlname,
             'unique_student_identifier': self.student.username,
@@ -3327,7 +3328,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
     @patch.object(lms.djangoapps.instructor_task.api, 'submit_rescore_problem_for_all_students')
     def test_rescore_problem_all(self, act):
         """ Test rescoring for all students. """
-        url = reverse('rescore_problem', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('rescore_problem', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'problem_to_reset': self.problem_urlname,
             'all_students': True,
@@ -3339,7 +3340,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
     def test_course_has_entrance_exam_in_student_attempts_reset(self):
         """ Test course has entrance exam id set while resetting attempts"""
         url = reverse('reset_student_attempts_for_entrance_exam',
-                      kwargs={'course_id': unicode(self.course.id)})
+                      kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'all_students': True,
             'delete_module': False,
@@ -3349,7 +3350,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
     @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})
     def test_rescore_entrance_exam_with_invalid_exam(self):
         """ Test course has entrance exam id set while re-scoring. """
-        url = reverse('rescore_entrance_exam', kwargs={'course_id': unicode(self.course.id)})
+        url = reverse('rescore_entrance_exam', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'unique_student_identifier': self.student.email,
         })
@@ -3671,13 +3672,13 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
         self.client.login(username=self.instructor.username, password='test')
 
     def test_send_email_as_logged_in_instructor(self):
-        url = reverse('send_email', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, self.full_test_message)
         self.assertEqual(response.status_code, 200)
 
     def test_send_email_but_not_logged_in(self):
         self.client.logout()
-        url = reverse('send_email', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, self.full_test_message)
         self.assertEqual(response.status_code, 403)
 
@@ -3685,7 +3686,7 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
         self.client.logout()
         student = UserFactory()
         self.client.login(username=student.username, password='test')
-        url = reverse('send_email', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, self.full_test_message)
         self.assertEqual(response.status_code, 403)
 
@@ -3695,7 +3696,7 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
         self.assertNotEqual(response.status_code, 200)
 
     def test_send_email_no_sendto(self):
-        url = reverse('send_email', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'subject': 'test subject',
             'message': 'test message',
@@ -3703,7 +3704,7 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
         self.assertEqual(response.status_code, 400)
 
     def test_send_email_invalid_sendto(self):
-        url = reverse('send_email', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'send_to': '["invalid_target", "staff"]',
             'subject': 'test subject',
@@ -3712,7 +3713,7 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
         self.assertEqual(response.status_code, 400)
 
     def test_send_email_no_subject(self):
-        url = reverse('send_email', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'send_to': '["staff"]',
             'message': 'test message',
@@ -3720,7 +3721,7 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
         self.assertEqual(response.status_code, 400)
 
     def test_send_email_no_message(self):
-        url = reverse('send_email', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'send_to': '["staff"]',
             'subject': 'test subject',
@@ -3731,7 +3732,7 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
         site_email = self.site_configuration.values.get('course_email_from_addr')
         site_template = self.site_configuration.values.get('course_email_template_name')
         CourseEmailTemplate.objects.create(name=site_template)
-        url = reverse('send_email', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, self.full_test_message)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(1, CourseEmail.objects.filter(
@@ -3752,7 +3753,7 @@ class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollm
             'course_email_template_name': {self.course.id.org: org_template}
         })
         self.site_configuration.save()
-        url = reverse('send_email', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, self.full_test_message)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(1, CourseEmail.objects.filter(
@@ -3836,7 +3837,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
             cls.course.id,
             'robot-some-problem-urlname'
         )
-        cls.problem_urlname = cls.problem_location.to_deprecated_string()
+        cls.problem_urlname = text_type(cls.problem_location)
 
     def setUp(self):
         super(TestInstructorAPITaskLists, self).setUp()
@@ -3860,7 +3861,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
     def test_list_instructor_tasks_running(self, act):
         """ Test list of all running tasks. """
         act.return_value = self.tasks
-        url = reverse('list_instructor_tasks', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_instructor_tasks', kwargs={'course_id': text_type(self.course.id)})
         mock_factory = MockCompletionInfo()
         with patch(
             'lms.djangoapps.instructor.views.instructor_task_helpers.get_task_completion_info'
@@ -3881,7 +3882,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
     def test_list_background_email_tasks(self, act):
         """Test list of background email tasks."""
         act.return_value = self.tasks
-        url = reverse('list_background_email_tasks', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_background_email_tasks', kwargs={'course_id': text_type(self.course.id)})
         mock_factory = MockCompletionInfo()
         with patch(
             'lms.djangoapps.instructor.views.instructor_task_helpers.get_task_completion_info'
@@ -3902,7 +3903,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
     def test_list_instructor_tasks_problem(self, act):
         """ Test list task history for problem. """
         act.return_value = self.tasks
-        url = reverse('list_instructor_tasks', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_instructor_tasks', kwargs={'course_id': text_type(self.course.id)})
         mock_factory = MockCompletionInfo()
         with patch(
             'lms.djangoapps.instructor.views.instructor_task_helpers.get_task_completion_info'
@@ -3925,7 +3926,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
     def test_list_instructor_tasks_problem_student(self, act):
         """ Test list task history for problem AND student. """
         act.return_value = self.tasks
-        url = reverse('list_instructor_tasks', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_instructor_tasks', kwargs={'course_id': text_type(self.course.id)})
         mock_factory = MockCompletionInfo()
         with patch(
             'lms.djangoapps.instructor.views.instructor_task_helpers.get_task_completion_info'
@@ -3989,7 +3990,7 @@ class TestInstructorEmailContentList(SharedModuleStoreTestCase, LoginEnrollmentT
         """ Calls the list_email_content endpoint and returns the repsonse """
         self.setup_fake_email_info(num_emails, with_failures)
         task_history_request.return_value = self.tasks.values()
-        url = reverse('list_email_content', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_email_content', kwargs={'course_id': text_type(self.course.id)})
         with patch('lms.djangoapps.instructor.views.api.CourseEmail.objects.get') as mock_email_info:
             mock_email_info.side_effect = self.get_matching_mock_email
             response = self.client.post(url, {})
@@ -4042,7 +4043,7 @@ class TestInstructorEmailContentList(SharedModuleStoreTestCase, LoginEnrollmentT
         invalid_task = FakeContentTask(0, 0, 0, 'test')
         invalid_task.make_invalid_input()
         task_history_request.return_value = [invalid_task]
-        url = reverse('list_email_content', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_email_content', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, 200)
 
@@ -4066,7 +4067,7 @@ class TestInstructorEmailContentList(SharedModuleStoreTestCase, LoginEnrollmentT
         email = FakeEmail(0)
         email_info = FakeEmailInfo(email, 0, 10)
         task_history_request.return_value = [task_info]
-        url = reverse('list_email_content', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('list_email_content', kwargs={'course_id': text_type(self.course.id)})
         with patch('lms.djangoapps.instructor.views.api.CourseEmail.objects.get') as mock_email_info:
             mock_email_info.return_value = email
             response = self.client.post(url, {})
@@ -4151,15 +4152,15 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             cls.week2 = ItemFactory.create(due=cls.due)
             cls.week3 = ItemFactory.create()  # No due date
             cls.course.children = [
-                cls.week1.location.to_deprecated_string(),
-                cls.week2.location.to_deprecated_string(),
-                cls.week3.location.to_deprecated_string()
+                text_type(cls.week1.location),
+                text_type(cls.week2.location),
+                text_type(cls.week3.location)
             ]
             cls.homework = ItemFactory.create(
                 parent_location=cls.week1.location,
                 due=cls.due
             )
-            cls.week1.children = [cls.homework.location.to_deprecated_string()]
+            cls.week1.children = [text_type(cls.homework.location)]
 
     def setUp(self):
         """
@@ -4219,10 +4220,10 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.client.login(username=self.instructor.username, password='test')
 
     def test_change_due_date(self):
-        url = reverse('change_due_date', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('change_due_date', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'student': self.user1.username,
-            'url': self.week1.location.to_deprecated_string(),
+            'url': text_type(self.week1.location),
             'due_datetime': '12/30/2013 00:00'
         })
         self.assertEqual(response.status_code, 200, response.content)
@@ -4230,10 +4231,10 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
                          get_extended_due(self.course, self.week1, self.user1))
 
     def test_change_to_invalid_due_date(self):
-        url = reverse('change_due_date', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('change_due_date', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'student': self.user1.username,
-            'url': self.week1.location.to_deprecated_string(),
+            'url': text_type(self.week1.location),
             'due_datetime': '01/01/2009 00:00'
         })
         self.assertEqual(response.status_code, 400, response.content)
@@ -4243,10 +4244,10 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         )
 
     def test_change_nonexistent_due_date(self):
-        url = reverse('change_due_date', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('change_due_date', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'student': self.user1.username,
-            'url': self.week3.location.to_deprecated_string(),
+            'url': text_type(self.week3.location),
             'due_datetime': '12/30/2013 00:00'
         })
         self.assertEqual(response.status_code, 400, response.content)
@@ -4257,10 +4258,10 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
     def test_reset_date(self):
         self.test_change_due_date()
-        url = reverse('reset_due_date', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('reset_due_date', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'student': self.user1.username,
-            'url': self.week1.location.to_deprecated_string(),
+            'url': text_type(self.week1.location),
         })
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(
@@ -4269,18 +4270,18 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         )
 
     def test_reset_nonexistent_extension(self):
-        url = reverse('reset_due_date', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('reset_due_date', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'student': self.user1.username,
-            'url': self.week1.location.to_deprecated_string(),
+            'url': text_type(self.week1.location),
         })
         self.assertEqual(response.status_code, 400, response.content)
 
     def test_show_unit_extensions(self):
         self.test_change_due_date()
         url = reverse('show_unit_extensions',
-                      kwargs={'course_id': self.course.id.to_deprecated_string()})
-        response = self.client.post(url, {'url': self.week1.location.to_deprecated_string()})
+                      kwargs={'course_id': text_type(self.course.id)})
+        response = self.client.post(url, {'url': text_type(self.week1.location)})
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(json.loads(response.content), {
             u'data': [{u'Extended Due Date': u'2013-12-30 00:00',
@@ -4293,7 +4294,7 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     def test_show_student_extensions(self):
         self.test_change_due_date()
         url = reverse('show_student_extensions',
-                      kwargs={'course_id': self.course.id.to_deprecated_string()})
+                      kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {'student': self.user1.username})
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(json.loads(response.content), {
@@ -4320,15 +4321,15 @@ class TestDueDateExtensionsDeletedDate(ModuleStoreTestCase, LoginEnrollmentTestC
             self.week2 = ItemFactory.create(due=self.due)
             self.week3 = ItemFactory.create()  # No due date
             self.course.children = [
-                self.week1.location.to_deprecated_string(),
-                self.week2.location.to_deprecated_string(),
-                self.week3.location.to_deprecated_string()
+                text_type(self.week1.location),
+                text_type(self.week2.location),
+                text_type(self.week3.location)
             ]
             self.homework = ItemFactory.create(
                 parent_location=self.week1.location,
                 due=self.due
             )
-            self.week1.children = [self.homework.location.to_deprecated_string()]
+            self.week1.children = [text_type(self.homework.location)]
 
         user1 = UserFactory.create()
         StudentModule(
@@ -4387,10 +4388,10 @@ class TestDueDateExtensionsDeletedDate(ModuleStoreTestCase, LoginEnrollmentTestC
         due date, without causing an error.
         """
 
-        url = reverse('change_due_date', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('change_due_date', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'student': self.user1.username,
-            'url': self.week1.location.to_deprecated_string(),
+            'url': text_type(self.week1.location),
             'due_datetime': '12/30/2013 00:00'
         })
         self.assertEqual(response.status_code, 200, response.content)
@@ -4400,10 +4401,10 @@ class TestDueDateExtensionsDeletedDate(ModuleStoreTestCase, LoginEnrollmentTestC
         self.week1.due = None
         self.week1 = self.store.update_item(self.week1, self.user1.id)
         # Now, week1's normal due date is deleted but the extension still exists.
-        url = reverse('reset_due_date', kwargs={'course_id': self.course.id.to_deprecated_string()})
+        url = reverse('reset_due_date', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {
             'student': self.user1.username,
-            'url': self.week1.location.to_deprecated_string(),
+            'url': text_type(self.week1.location),
         })
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(
@@ -4535,7 +4536,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         cls.course = CourseFactory.create()
         cls.url = reverse(
             'generate_registration_codes',
-            kwargs={'course_id': cls.course.id.to_deprecated_string()}
+            kwargs={'course_id': text_type(cls.course.id)}
         )
 
     def setUp(self):
@@ -4579,7 +4580,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         generating registration codes
         """
         url_reg_code = reverse('generate_registration_codes',
-                               kwargs={'course_id': self.course.id.to_deprecated_string()})
+                               kwargs={'course_id': text_type(self.course.id)})
 
         data = {
             'total_registration_codes': 5, 'company_name': 'Group Alpha', 'company_contact_name': 'Test@company.com',
@@ -4601,7 +4602,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         Test to remember user invoice copy preference
         """
         url_reg_code = reverse('generate_registration_codes',
-                               kwargs={'course_id': self.course.id.to_deprecated_string()})
+                               kwargs={'course_id': text_type(self.course.id)})
 
         data = {
             'total_registration_codes': 5, 'company_name': 'Group Alpha', 'company_contact_name': 'Test@company.com',
@@ -4618,7 +4619,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
 
         # get user invoice copy preference.
         url_user_invoice_preference = reverse('get_user_invoice_preference',
-                                              kwargs={'course_id': self.course.id.to_deprecated_string()})
+                                              kwargs={'course_id': text_type(self.course.id)})
 
         response = self.client.post(url_user_invoice_preference, data)
         result = json.loads(response.content)
@@ -4632,7 +4633,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
 
         # get user invoice copy preference.
         url_user_invoice_preference = reverse('get_user_invoice_preference',
-                                              kwargs={'course_id': self.course.id.to_deprecated_string()})
+                                              kwargs={'course_id': text_type(self.course.id)})
 
         response = self.client.post(url_user_invoice_preference, data)
         result = json.loads(response.content)
@@ -4643,7 +4644,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         Test to generate a response of all the generated course registration codes
         """
         url = reverse('generate_registration_codes',
-                      kwargs={'course_id': self.course.id.to_deprecated_string()})
+                      kwargs={'course_id': text_type(self.course.id)})
 
         data = {
             'total_registration_codes': 15, 'company_name': 'Group Alpha', 'company_contact_name': 'Test@company.com',
@@ -4665,7 +4666,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         Test to generate a response of all the generated course registration codes
         """
         url = reverse('generate_registration_codes',
-                      kwargs={'course_id': self.course.id.to_deprecated_string()})
+                      kwargs={'course_id': text_type(self.course.id)})
 
         data = {
             'total_registration_codes': 15, 'company_name': 'Group Alpha', 'company_contact_name': 'Test@company.com',
@@ -4699,9 +4700,9 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         Test the generated course registration code is already in the Coupon Table
         """
         url = reverse('generate_registration_codes',
-                      kwargs={'course_id': self.course.id.to_deprecated_string()})
+                      kwargs={'course_id': text_type(self.course.id)})
 
-        coupon = Coupon(code='first', course_id=self.course.id.to_deprecated_string(), created_by=self.instructor)
+        coupon = Coupon(code='first', course_id=text_type(self.course.id), created_by=self.instructor)
         coupon.save()
         data = {
             'total_registration_codes': 3, 'company_name': 'Group Alpha', 'company_contact_name': 'Test@company.com',
@@ -4725,7 +4726,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
        Test for the Integrity error against the generated code
         """
         url = reverse('generate_registration_codes',
-                      kwargs={'course_id': self.course.id.to_deprecated_string()})
+                      kwargs={'course_id': text_type(self.course.id)})
 
         data = {
             'total_registration_codes': 2, 'company_name': 'Test Group', 'company_contact_name': 'Test@company.com',
@@ -4747,7 +4748,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         Test to generate a response of all the spent course registration codes
         """
         url = reverse('spent_registration_codes',
-                      kwargs={'course_id': self.course.id.to_deprecated_string()})
+                      kwargs={'course_id': text_type(self.course.id)})
 
         data = {'spent_company_name': ''}
         response = self.client.post(url, data)
@@ -4760,7 +4761,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         self.assertEqual(len(body.split('\n')), 7)
 
         generate_code_url = reverse(
-            'generate_registration_codes', kwargs={'course_id': self.course.id.to_deprecated_string()}
+            'generate_registration_codes', kwargs={'course_id': text_type(self.course.id)}
         )
 
         data = {
@@ -4800,7 +4801,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         Test to generate a response of all the active course registration codes
         """
         url = reverse('active_registration_codes',
-                      kwargs={'course_id': self.course.id.to_deprecated_string()})
+                      kwargs={'course_id': text_type(self.course.id)})
 
         data = {'active_company_name': ''}
         response = self.client.post(url, data)
@@ -4811,7 +4812,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         self.assertEqual(len(body.split('\n')), 9)
 
         generate_code_url = reverse(
-            'generate_registration_codes', kwargs={'course_id': self.course.id.to_deprecated_string()}
+            'generate_registration_codes', kwargs={'course_id': text_type(self.course.id)}
         )
 
         data = {
@@ -4838,7 +4839,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         Test to generate a response of all the course registration codes
         """
         url = reverse(
-            'get_registration_codes', kwargs={'course_id': self.course.id.to_deprecated_string()}
+            'get_registration_codes', kwargs={'course_id': text_type(self.course.id)}
         )
 
         data = {'download_company_name': ''}
@@ -4850,7 +4851,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         self.assertEqual(len(body.split('\n')), 14)
 
         generate_code_url = reverse(
-            'generate_registration_codes', kwargs={'course_id': self.course.id.to_deprecated_string()}
+            'generate_registration_codes', kwargs={'course_id': text_type(self.course.id)}
         )
 
         data = {
@@ -4878,7 +4879,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         when generating registration codes.
         """
         generate_code_url = reverse(
-            'generate_registration_codes', kwargs={'course_id': self.course.id.to_deprecated_string()}
+            'generate_registration_codes', kwargs={'course_id': text_type(self.course.id)}
         )
         data = {
             'total_registration_codes': 9, 'company_name': 'Group Alpha', 'company_contact_name': 'Test@company.com',
@@ -4896,7 +4897,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         Test to generate a response of all the course registration codes
         """
         generate_code_url = reverse(
-            'generate_registration_codes', kwargs={'course_id': self.course.id.to_deprecated_string()}
+            'generate_registration_codes', kwargs={'course_id': text_type(self.course.id)}
         )
 
         data = {
@@ -4911,7 +4912,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, 200, response.content)
 
         url = reverse('get_registration_codes',
-                      kwargs={'course_id': self.course.id.to_deprecated_string()})
+                      kwargs={'course_id': text_type(self.course.id)})
         data = {'download_company_name': 'Group Invoice'}
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 200, response.content)
@@ -4924,7 +4925,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         Test to generate a response of all the course registration codes
         """
         generate_code_url = reverse(
-            'generate_registration_codes', kwargs={'course_id': self.course.id.to_deprecated_string()}
+            'generate_registration_codes', kwargs={'course_id': text_type(self.course.id)}
         )
 
         data = {
@@ -4944,7 +4945,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         Test to download a response of all the active coupon codes
         """
         get_coupon_code_url = reverse(
-            'get_coupon_codes', kwargs={'course_id': self.course.id.to_deprecated_string()}
+            'get_coupon_codes', kwargs={'course_id': text_type(self.course.id)}
         )
         for i in range(10):
             coupon = Coupon(

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -14,6 +14,7 @@ from django.core.urlresolvers import reverse
 from django.db.models import Count, Q
 from edx_proctoring.api import get_exam_violation_report
 from opaque_keys.edx.keys import UsageKey
+from six import text_type
 
 import xmodule.graders as xmgraders
 from certificates.models import CertificateStatuses, GeneratedCertificate
@@ -168,7 +169,7 @@ def sale_record_features(course_id, features):
             course_reg_dict = dict((feature, None)
                                    for feature in course_reg_features)
 
-        course_reg_dict['course_id'] = course_id.to_deprecated_string()
+        course_reg_dict['course_id'] = text_type(course_id)
         course_reg_dict.update({'codes': ", ".join(codes)})
         sale_dict.update(dict(course_reg_dict.items()))
 
@@ -401,7 +402,7 @@ def coupon_codes_features(features, coupons_list, course_id):
         # They have not been redeemed yet
 
         coupon_dict['expiration_date'] = coupon.display_expiry_date
-        coupon_dict['course_id'] = coupon_dict['course_id'].to_deprecated_string()
+        coupon_dict['course_id'] = text_type(coupon_dict['course_id'])
         return coupon_dict
     return [extract_coupon(coupon, features) for coupon in coupons_list]
 
@@ -489,7 +490,7 @@ def course_registration_features(features, registration_codes, csv_type):
             except ObjectDoesNotExist:
                 pass
 
-        course_registration_dict['course_id'] = course_registration_dict['course_id'].to_deprecated_string()
+        course_registration_dict['course_id'] = text_type(course_registration_dict['course_id'])
         return course_registration_dict
     return [extract_course_registration(code, features, csv_type) for code in registration_codes]
 
@@ -517,7 +518,7 @@ def dump_grading_context(course):
             subgrader.index = 1
             graders[subgrader.type] = subgrader
     msg += hbar
-    msg += "Listing grading context for course %s\n" % course.id.to_deprecated_string()
+    msg += "Listing grading context for course %s\n" % text_type(course.id)
 
     gcontext = grading_context_for_course(course)
     msg += "graded sections:\n"

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -12,6 +12,7 @@ from celery.result import AsyncResult
 from celery.states import FAILURE, READY_STATES, REVOKED, SUCCESS
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import UsageKey
+from six import text_type
 
 from courseware.courses import get_problems_in_section
 from courseware.module_render import get_xqueue_callback_url_prefix
@@ -380,11 +381,11 @@ def encode_problem_and_student_input(usage_key, student=None):  # pylint: disabl
 
     assert isinstance(usage_key, UsageKey)
     if student is not None:
-        task_input = {'problem_url': usage_key.to_deprecated_string(), 'student': student.username}
-        task_key_stub = "{student}_{problem}".format(student=student.id, problem=usage_key.to_deprecated_string())
+        task_input = {'problem_url': text_type(usage_key), 'student': student.username}
+        task_key_stub = "{student}_{problem}".format(student=student.id, problem=text_type(usage_key))
     else:
-        task_input = {'problem_url': usage_key.to_deprecated_string()}
-        task_key_stub = "_{problem}".format(problem=usage_key.to_deprecated_string())
+        task_input = {'problem_url': text_type(usage_key)}
+        task_key_stub = "_{problem}".format(problem=text_type(usage_key))
 
     # create the key value by using MD5 hash:
     task_key = hashlib.md5(task_key_stub).hexdigest()
@@ -402,11 +403,11 @@ def encode_entrance_exam_and_student_input(usage_key, student=None):  # pylint: 
     """
     assert isinstance(usage_key, UsageKey)
     if student is not None:
-        task_input = {'entrance_exam_url': unicode(usage_key), 'student': student.username}
-        task_key_stub = "{student}_{entranceexam}".format(student=student.id, entranceexam=unicode(usage_key))
+        task_input = {'entrance_exam_url': text_type(usage_key), 'student': student.username}
+        task_key_stub = "{student}_{entranceexam}".format(student=student.id, entranceexam=text_type(usage_key))
     else:
-        task_input = {'entrance_exam_url': unicode(usage_key)}
-        task_key_stub = "_{entranceexam}".format(entranceexam=unicode(usage_key))
+        task_input = {'entrance_exam_url': text_type(usage_key)}
+        task_key_stub = "_{entranceexam}".format(entranceexam=text_type(usage_key))
 
     # create the key value by using MD5 hash:
     task_key = hashlib.md5(task_key_stub).hexdigest()

--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -24,6 +24,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.db import models, transaction
+from six import text_type
 
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.storage import get_storage
@@ -306,5 +307,5 @@ class DjangoStorageReportStore(ReportStore):
         """
         Return the full path to a given file for a given course.
         """
-        hashed_course_id = hashlib.sha1(course_id.to_deprecated_string()).hexdigest()
+        hashed_course_id = hashlib.sha1(text_type(course_id)).hexdigest()
         return os.path.join(hashed_course_id, filename)

--- a/lms/djangoapps/lms_migration/migrate.py
+++ b/lms/djangoapps/lms_migration/migrate.py
@@ -8,6 +8,7 @@ import os
 
 from django.conf import settings
 from django.http import HttpResponse
+from six import text_type
 
 import track.views
 import xmodule.modulestore.django as xmodule_django
@@ -122,7 +123,7 @@ def manage_modulestores(request, reload_dir=None, commit_id=None):
             settings.EDX_ROOT_URL,
             escape(cdir),
             escape(cdir),
-            course.location.to_deprecated_string()
+            text_type(course.location)
         )
     html += '</ol>'
 

--- a/lms/djangoapps/notes/models.py
+++ b/lms/djangoapps/notes/models.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.html import strip_tags
+from six import text_type
 
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
@@ -63,7 +64,7 @@ class Note(models.Model):
         Returns the absolute url for the note object.
         """
         # pylint: disable=no-member
-        kwargs = {'course_id': self.course_id.to_deprecated_string(), 'note_id': str(self.pk)}
+        kwargs = {'course_id': text_type(self.course_id), 'note_id': str(self.pk)}
         return reverse('notes_api_note', kwargs=kwargs)
 
     def as_dict(self):

--- a/lms/djangoapps/notes/tests.py
+++ b/lms/djangoapps/notes/tests.py
@@ -11,6 +11,7 @@ from django.test import RequestFactory, TestCase
 from django.test.client import Client
 from mock import Mock, patch
 from opaque_keys.edx.locator import CourseLocator
+from six import text_type
 
 from courseware.tabs import CourseTab, get_course_tab_list
 from notes import api, models, utils
@@ -136,7 +137,7 @@ class ApiTest(TestCase):
         self.client.login(username=username, password=password)
 
     def url(self, name, args={}):
-        args.update({'course_id': self.course_key.to_deprecated_string()})
+        args.update({'course_id': text_type(self.course_key)})
         return reverse(name, kwargs=args)
 
     def create_notes(self, num_notes, create=True):

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -29,6 +29,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from model_utils.managers import InheritanceManager
 from model_utils.models import TimeStampedModel
+from six import text_type
 
 from course_modes.models import CourseMode
 from courseware.courses import get_course_by_id
@@ -1836,7 +1837,7 @@ class CourseRegCodeItemAnnotation(models.Model):
 
     def __unicode__(self):
         # pylint: disable=no-member
-        return u"{} : {}".format(self.course_id.to_deprecated_string(), self.annotation)
+        return u"{} : {}".format(text_type(self.course_id), self.annotation)
 
 
 class PaidCourseRegistrationAnnotation(models.Model):
@@ -1854,7 +1855,7 @@ class PaidCourseRegistrationAnnotation(models.Model):
 
     def __unicode__(self):
         # pylint: disable=no-member
-        return u"{} : {}".format(self.course_id.to_deprecated_string(), self.annotation)
+        return u"{} : {}".format(text_type(self.course_id), self.annotation)
 
 
 class CertificateItem(OrderItem):

--- a/lms/djangoapps/shoppingcart/reports.py
+++ b/lms/djangoapps/shoppingcart/reports.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 import unicodecsv
 from django.utils.translation import ugettext as _
+from six import text_type
 
 from course_modes.models import CourseMode
 from courseware.courses import get_course_by_id
@@ -275,7 +276,7 @@ def course_ids_between(start_word, end_word):
 
     valid_courses = []
     for course in modulestore().get_courses():
-        course_id = course.id.to_deprecated_string()
+        course_id = text_type(course.id)
         if start_word.lower() <= course_id.lower() <= end_word.lower():
             valid_courses.append(course.id)
     return valid_courses

--- a/lms/djangoapps/staticbook/tests.py
+++ b/lms/djangoapps/staticbook/tests.py
@@ -7,6 +7,7 @@ import textwrap
 import mock
 import requests
 from django.core.urlresolvers import NoReverseMatch, reverse
+from six import text_type
 
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -67,7 +68,7 @@ class StaticBookTest(ModuleStoreTestCase):
         Automatically provides the course id.
 
         """
-        kwargs['course_id'] = self.course.id.to_deprecated_string()
+        kwargs['course_id'] = text_type(self.course.id)
         url = reverse(url_name, kwargs=kwargs)
         return url
 

--- a/lms/lib/comment_client/user.py
+++ b/lms/lib/comment_client/user.py
@@ -1,4 +1,6 @@
 """ User model wrapper for comment service"""
+from six import text_type
+
 import settings
 
 import models
@@ -102,7 +104,7 @@ class User(models.Model):
         if not self.course_id:
             raise utils.CommentClientRequestError("Must provide course_id when retrieving active threads for the user")
         url = _url_for_user_active_threads(self.id)
-        params = {'course_id': self.course_id.to_deprecated_string()}
+        params = {'course_id': text_type(self.course_id)}
         params = utils.merge_dict(params, query_params)
         response = utils.perform_request(
             'get',
@@ -118,7 +120,7 @@ class User(models.Model):
         if not self.course_id:
             raise utils.CommentClientRequestError("Must provide course_id when retrieving subscribed threads for the user")
         url = _url_for_user_subscribed_threads(self.id)
-        params = {'course_id': self.course_id.to_deprecated_string()}
+        params = {'course_id': text_type(self.course_id)}
         params = utils.merge_dict(params, query_params)
         response = utils.perform_request(
             'get',
@@ -140,7 +142,7 @@ class User(models.Model):
         retrieve_params = self.default_retrieve_params.copy()
         retrieve_params.update(kwargs)
         if self.attributes.get('course_id'):
-            retrieve_params['course_id'] = self.course_id.to_deprecated_string()
+            retrieve_params['course_id'] = text_type(self.course_id)
         if self.attributes.get('group_id'):
             retrieve_params['group_id'] = self.group_id
         try:

--- a/lms/templates/class_dashboard/all_section_metrics.js
+++ b/lms/templates/class_dashboard/all_section_metrics.js
@@ -2,11 +2,12 @@
 <%!
   import json
   from django.core.urlresolvers import reverse
+  from six import text_type
 %>
 
 $(function () {
 
-  d3.json("${reverse('all_sequential_open_distrib', kwargs=dict(course_id=course_id.to_deprecated_string()))}", function(error, json) {
+  d3.json("${reverse('all_sequential_open_distrib', kwargs=dict(course_id=text_type(course_id)))}", function(error, json) {
     var section, paramOpened, barGraphOpened, error;
     var i, curr_id;
     var errorMessage = gettext('Unable to retrieve data, please try again later.');
@@ -53,7 +54,7 @@ $(function () {
     }
   });
 
-  d3.json("${reverse('all_problem_grade_distribution', kwargs=dict(course_id=course_id.to_deprecated_string()))}", function(error, json) {
+  d3.json("${reverse('all_problem_grade_distribution', kwargs=dict(course_id=text_type(course_id)))}", function(error, json) {
     var section, paramGrade, barGraphGrade, error;
     var i, curr_id;
     var errorMessage = gettext('Unable to retrieve data, please try again later.');

--- a/lms/templates/conditional_module.html
+++ b/lms/templates/conditional_module.html
@@ -1,13 +1,14 @@
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
+from six import text_type
 %>
 
 <%
 def _message(reqm, message):
     return message.format(link="<a href={url}>{url_name}</a>".format(
-        url = reverse('jump_to', kwargs=dict(course_id=reqm.course_id.to_deprecated_string(),
-                        location=reqm.location.to_deprecated_string())),
+        url = reverse('jump_to', kwargs=dict(course_id=text_type(reqm.course_id),
+                        location=text_type(reqm.location))),
         url_name = reqm.display_name_with_default_escaped))
 %>
 % if message:

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -3,10 +3,11 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from six import text_type
 %>
 <%page args="course" expression_filter="h"/>
 <article class="course" id="${course.id}" role="region" aria-label="${course.display_name_with_default}">
-  <a href="${reverse('about_course', args=[course.id.to_deprecated_string()])}">
+  <a href="${reverse('about_course', args=[text_type(course.id)])}">
     <header class="course-image">
       <div class="cover-image">
         <img src="${course.course_image_url}" alt="${course.display_name_with_default} ${course.display_number_with_default}" />

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from courseware.courses import get_course_about_section
 from django.conf import settings
+from six import text_type
 from edxmako.shortcuts import marketing_link
 from openedx.core.djangolib.markup import HTML
 from openedx.core.lib.courses import course_image_url
@@ -42,7 +43,7 @@ from openedx.core.lib.courses import course_image_url
 
       $("#add_to_cart_post").click(function(event){
         $.ajax({
-          url: "${reverse('add_course_to_cart', args=[course.id.to_deprecated_string()])}",
+          url: "${reverse('add_course_to_cart', args=[text_type(course.id)])}",
           type: "POST",
           /* Rant: HAD TO USE COMPLETE B/C PROMISE.DONE FOR SOME REASON DOES NOT WORK ON THIS PAGE. */
           complete: add_course_complete_handler
@@ -65,7 +66,7 @@ from openedx.core.lib.courses import course_image_url
       if(xhr.status == 200) {
         location.href = "${reverse('dashboard')}";
       } else if (xhr.status == 403) {
-        location.href = "${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}?course_id=${course.id | u}&enrollment_action=enroll";
+        location.href = "${reverse('course-specific-register', args=[text_type(course.id)])}?course_id=${course.id | u}&enrollment_action=enroll";
       } else if (xhr.status == 400) { //This means the user did not have permission
         $('#register_error').html("${perms_error}").css("display", "block");
       } else {

--- a/lms/templates/courseware/course_about_sidebar_header.html
+++ b/lms/templates/courseware/course_about_sidebar_header.html
@@ -5,6 +5,7 @@ import urllib
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from six import text_type
 %>
 
 <header>
@@ -29,7 +30,7 @@ from django.conf import settings
                 protocol=site_protocol,
                 domain=site_domain,
                 path=urllib.quote_plus(
-                    reverse('about_course', args=[course.id.to_deprecated_string()])
+                    reverse('about_course', args=[text_type(course.id)])
                 )
             )
         ).replace(u" ", u"+")
@@ -47,7 +48,7 @@ from django.conf import settings
                     protocol=site_protocol,
                     domain=site_domain,
                     path=urllib.quote_plus(
-                        reverse('about_course', args=[course.id.to_deprecated_string()]),
+                        reverse('about_course', args=[text_type(course.id)]),
                     )
                 )
             )

--- a/lms/templates/courseware/gradebook.html
+++ b/lms/templates/courseware/gradebook.html
@@ -3,6 +3,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from six import text_type
 %>
 
 <%block name="js_extra">
@@ -56,7 +57,7 @@ from django.core.urlresolvers import reverse
         %for student in students:
         <tr>
           <td>
-            <a href="${reverse('student_progress', kwargs=dict(course_id=course_id.to_deprecated_string(), student_id=student['id']))}">${student['username']}</a>
+            <a href="${reverse('student_progress', kwargs=dict(course_id=text_type(course_id), student_id=student['id']))}">${student['username']}</a>
           </td>
         </tr>
         %endfor

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -10,6 +10,7 @@ from openedx.core.djangolib.markup import HTML, Text
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.utils.http import urlquote_plus
+from six import text_type
 %>
 <%block name="bodyclass">view-in-course view-progress</%block>
 
@@ -162,7 +163,7 @@ from django.utils.http import urlquote_plus
                                         percentageString = "{0:.0%}".format(section.percent_graded) if earned > 0 and total > 0 else ""
                                         %>
                                         <h4 class="hd hd-4">
-                                            <a href="${reverse('courseware_section', kwargs=dict(course_id=course.id.to_deprecated_string(), chapter=chapter['url_name'], section=section.url_name))}">
+                                            <a href="${reverse('courseware_section', kwargs=dict(course_id=text_type(course.id), chapter=chapter['url_name'], section=section.url_name))}">
                                                 ${ section.display_name}
                                                 %if total > 0 or earned > 0:
                                                 <span class="sr">

--- a/lms/templates/header/navbar-not-authenticated.html
+++ b/lms/templates/header/navbar-not-authenticated.html
@@ -8,6 +8,7 @@
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
+from six import text_type
 %>
 
 <%
@@ -46,10 +47,10 @@ from django.utils.translation import ugettext as _
       % if allows_login:
         % if restrict_enroll_for_course:
           <div class="mobile-nav-item hidden-mobile nav-item">
-            <a class="register-btn btn" href="${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}">${_("Register")}</a>
+            <a class="register-btn btn" href="${reverse('course-specific-register', args=[text_type(course.id)])}">${_("Register")}</a>
           </div>
           <div class="mobile-nav-item hidden-mobile nav-item">
-            <a class="sign-in-btn btn" href="${reverse('course-specific-login', args=[course.id.to_deprecated_string()])}${login_query()}">${_("Sign in")}</a>
+            <a class="sign-in-btn btn" href="${reverse('course-specific-login', args=[text_type(course.id)])}${login_query()}">${_("Sign in")}</a>
           </div>
         % else:
           % if allow_public_account_creation:

--- a/lms/templates/navigation/navbar-not-authenticated.html
+++ b/lms/templates/navigation/navbar-not-authenticated.html
@@ -7,6 +7,7 @@
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
+from six import text_type
 %>
 
 <ol class="left list-inline nav-global">
@@ -35,7 +36,7 @@ from django.utils.translation import ugettext as _
       %endif
       % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
         <li class="item nav-global-04">
-          <a class="btn btn-neutral btn-register" href="${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}">${_("Register")}</a>
+          <a class="btn btn-neutral btn-register" href="${reverse('course-specific-register', args=[text_type(course.id)])}">${_("Register")}</a>
         </li>
       % elif static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')):
         <li class="item nav-global-04">
@@ -51,7 +52,7 @@ from django.utils.translation import ugettext as _
     <li class="item nav-courseware-01">
       % if not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register:
         % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
-          <a class="btn btn-brand btn-login" href="${reverse('course-specific-login', args=[course.id.to_deprecated_string()])}${login_query()}">${_("Sign in")}</a>
+          <a class="btn btn-brand btn-login" href="${reverse('course-specific-login', args=[text_type(course.id)])}${login_query()}">${_("Sign in")}</a>
         % else:
           <a class="btn brn-brand btn-login" href="/login${login_query()}">${_("Sign in")}</a>
         % endif

--- a/lms/templates/shoppingcart/registration_code_receipt.html
+++ b/lms/templates/shoppingcart/registration_code_receipt.html
@@ -1,6 +1,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from six import text_type
 from openedx.core.lib.courses import course_image_url
 from openedx.features.course_experience import course_home_url_name
 %>
@@ -75,7 +76,7 @@ from openedx.features.course_experience import course_home_url_name
       </div>
       % if not reg_code_already_redeemed:
         %if redemption_success:
-          <% course_url = reverse(course_home_url_name(course.id), args=[course.id.to_deprecated_string()]) %>
+          <% course_url = reverse(course_home_url_name(course.id), args=[text_type(course.id)]) %>
           <a href="${course_url}" class="link-button course-link-bg-color">${_("View Course")} <span class="icon fa fa-caret-right" aria-hidden="true"></span></a>
         %elif not registered_for_course:
           <form method="post">

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -2,6 +2,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.template.defaultfilters import escapejs
+from six import text_type
 %>
 
 ## The JS for this is defined in xqa_interface.html
@@ -99,7 +100,7 @@ ${block_content}
 
     <div class="staff_info" style="display:block">
       is_released = ${is_released}
-      location = ${location.to_deprecated_string() | h}
+      location = ${text_type(location) | h}
 
       <table summary="${_('Module Fields')}">
         <tr><th>${_('Module Fields')}</th></tr>

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -6,6 +6,7 @@ import mimetypes
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from mock import patch
+from six import text_type
 
 from edxmako import LOOKUP, add_lookup
 from microsite_configuration import microsite
@@ -58,6 +59,6 @@ class HelpModalTests(ModuleStoreTestCase):
         Simple test to make sure that you don't get a 500 error when the modal
         is enabled.
         """
-        url = reverse(course_home_url_name(self.course.id), args=[self.course.id.to_deprecated_string()])
+        url = reverse(course_home_url_name(self.course.id), args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)

--- a/openedx/core/lib/courses.py
+++ b/openedx/core/lib/courses.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import CourseKey
+from six import text_type
 from xmodule.assetstore.assetmgr import AssetManager
 from xmodule.contentstore.content import StaticContent
 from xmodule.contentstore.django import contentstore
@@ -77,7 +78,7 @@ def clean_course_id(model_form, is_required=True):
         raise forms.ValidationError(msg)
 
     if not modulestore().has_course(course_key):
-        msg = u'Course not found. Entered course id was: "{0}". '.format(course_key.to_deprecated_string())
+        msg = u'Course not found. Entered course id was: "{0}". '.format(text_type(course_key))
         raise forms.ValidationError(msg)
 
     return course_key

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -7,6 +7,7 @@ import unittest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from nose.plugins.attrib import attr
+from six import text_type
 
 from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
@@ -56,7 +57,7 @@ class TestCrowdsourceHinter(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         cls.course_url = reverse(
             'courseware_section',
             kwargs={
-                'course_id': cls.course.id.to_deprecated_string(),
+                'course_id': text_type(cls.course.id),
                 'chapter': 'Overview',
                 'section': 'Welcome',
             }
@@ -78,9 +79,8 @@ class TestCrowdsourceHinter(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         if xblock_name is None:
             xblock_name = TestCrowdsourceHinter.XBLOCK_NAMES[0]
         return reverse('xblock_handler', kwargs={
-            'course_id': self.course.id.to_deprecated_string(),
-            'usage_id': quote_slashes(self.course.id.make_usage_key('crowdsourcehinter', xblock_name).
-                                      to_deprecated_string()),
+            'course_id': text_type(self.course.id),
+            'usage_id': quote_slashes(text_type(self.course.id.make_usage_key('crowdsourcehinter', xblock_name))),
             'handler': handler,
             'suffix': ''
         })

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -16,6 +16,7 @@ from ddt import data, ddt
 from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from nose.plugins.attrib import attr
+from six import text_type
 from openedx.core.lib.url_utils import quote_slashes
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -67,7 +68,7 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         cls.course_url = reverse(
             'courseware_section',
             kwargs={
-                'course_id': cls.course.id.to_deprecated_string(),
+                'course_id': text_type(cls.course.id),
                 'chapter': 'Overview',
                 'section': 'Welcome',
             }
@@ -129,8 +130,8 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         if xblock_name is None:
             xblock_name = TestRecommender.XBLOCK_NAMES[0]
         return reverse('xblock_handler', kwargs={
-            'course_id': self.course.id.to_deprecated_string(),
-            'usage_id': quote_slashes(self.course.id.make_usage_key('recommender', xblock_name).to_deprecated_string()),
+            'course_id': text_type(self.course.id),
+            'usage_id': quote_slashes(text_type(self.course.id.make_usage_key('recommender', xblock_name))),
             'handler': handler,
             'suffix': ''
         })


### PR DESCRIPTION
First large batch of replacing the deprecated `to_deprecated_string()` method of `CourseLocator`, `BlockUsageLocator`, and `AssetLocator` with direct calls to the `six.text_type()` function which they already wrap.  Splitting this into a few PRs to make them slightly less tedious to review.