### PR TITLE
Fix typos in contentstore's mongo index keys

### DIFF
--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -485,7 +485,7 @@ class MongoContentStore(ContentStore):
             [
                 ('_id.org', pymongo.ASCENDING),
                 ('_id.course', pymongo.ASCENDING),
-                ('display_name', pymongo.ASCENDING)
+                ('displayname', pymongo.ASCENDING)
             ],
             sparse=True,
             background=True
@@ -505,7 +505,7 @@ class MongoContentStore(ContentStore):
             [
                 ('content_son.org', pymongo.ASCENDING),
                 ('content_son.course', pymongo.ASCENDING),
-                ('display_name', pymongo.ASCENDING)
+                ('displayname', pymongo.ASCENDING)
             ],
             sparse=True,
             background=True

--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -428,7 +428,7 @@ class MongoContentStore(ContentStore):
 
     def ensure_indexes(self):
         # Index needed thru 'category' by `_get_all_content_for_course` and others. That query also takes a sort
-        # which can be `uploadDate`, `display_name`,
+        # which can be `uploadDate`, `displayname`,
         create_collection_index(
             self.fs_files,
             [


### PR DESCRIPTION
While adding a new index to the contentstore I noticed this typo: "display_name" was specified as a key to two indexes, but items in the collection have the key "displayname" without an underscore.

```
> db.fs.files.find()
{ "_id" : "asset-v1:edX+DemoX+Demo_Course+type@thumbnail+block@student_to_teacher-png.jpg", "contentType" : "image/jpeg", "locked" : false, "chunkSize" : 261120, "content_son" : { "category" : "thumbnail", "name" : "student_to_teacher-png
.jpg", "course" : "DemoX", "tag" : "c4x", "org" : "edX", "revision" : null, "run" : "Demo_Course" }, "filename" : "asset-v1:edX+DemoX+Demo_Course+type@thumbnail+block@student_to_teacher-png.jpg", "displayname" : "student_to_teacher-png.jp
g", "length" : 2866, "import_path" : null, "uploadDate" : ISODate("2017-11-30T18:20:13.725Z"), "thumbnail_location" : null, "md5" : "8a4a7bd6f15d3bc5fd263c46e8245a83" }
...
```

After calling the `ensure_indexes` management command with this patch, new indexes are created which have a larger size than the old ones with the typo, which suggests to me that the index is actually using the `displayname` values now. I'm not aware of any other way to inspect mongo indexes.

```
> db.fs.files.stats()
{
...
    "indexSizes" : {
                ...
                "_id.org_1__id.course_1_display_name_1" : 4096,
                "content_son.org_1_content_son.course_1_display_name_1" : 16384,
                ...
                "_id.org_1__id.course_1_displayname_1" : 32768,
                "content_son.org_1_content_son.course_1_displayname_1" : 32768
        },
...
}
```

After this is merged to stage/prod, someone will have to manually run `./manage.py cms ensure_indexes` to create the fixed indexes.

We should also probably delete the old indexes in the prod/stage contentstores after this is merged and after the `ensure_indexes` management command is run. Deleting the indexes can be done in the mongo shell:

```
> db.fs.files.dropIndex("_id.org_1__id.course_1_display_name_1")
{ "nIndexesWas" : 12, "ok" : 1 }
> db.fs.files.dropIndex("content_son.org_1_content_son.course_1_display_name_1")
{ "nIndexesWas" : 11, "ok" : 1 }
```

But, I don't have access to do either of those manual actions. Maybe someone in @edx/devops could?