### PR TITLE
Add filename search to Files & Uploads

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1331,7 +1331,7 @@ FILES_AND_UPLOAD_TYPE_FILTERS = {
         'text/csv',
         'text/pdf',
         'text/x-sh',
-        '\application/pdf\""',
+        '\"application/pdf\"',
     ],
     "Audio": ['audio/mpeg', 'audio/mp3', 'audio/x-wav', 'audio/ogg', 'audio/wav', 'audio/aac', 'audio/x-m4a',
               'audio/mp4', 'audio/x-ms-wma', ],


### PR DESCRIPTION
This PR adds a `text_search` query parameter to the assets JSON API. It uses the ~~[mongo `$text` operator](https://docs.mongodb.com/manual/reference/operator/query/text/index.html)~~ mongo `$regex` operator.

I also refactored the existing content_type filter to use the `$or`, `$in`, and `$nin` instead of `$where`. I did this because [the mongo docs](https://docs.mongodb.com/manual/reference/operator/query/where/index.html#considerations) say that: "In general, you should use $where only when you can’t express your query using another operator". Also, I think it reduces some of the complexity.

If testing locally you will have to run this after pulling:

```
make studio-shell
$ ./manage.py cms ensure_indexes --settings devstack_docker
```

To test the new search filter I've been going to the Files & Uploads page and either using "Copy as cURL" in Chrome or "Edit and Resend" in Firefox. Then I send the same request but with a `&text_search=foo` tacked onto the end of the URL.
  