### PR TITLE
Fix webcam not loading in safari.

### DIFF
--- a/lms/static/js/verify_student/views/webcam_photo_view.js
+++ b/lms/static/js/verify_student/views/webcam_photo_view.js
@@ -84,7 +84,7 @@
                  getUserMediaCallback: function(stream) {
                      var video = this.getVideo();
                      this.stream = stream;
-                     video.src = this.URL.createObjectURL(stream);
+                     video.srcObject = stream;
                      video.play();
                      this.trigger('webcam-loaded');
                  },


### PR DESCRIPTION
`video.src = this.URL.createObjectURL(stream);` This is no longer supported in Safari. 

LEARNER-3758