### PR TITLE
ENT-768 Display friendly error message for third party auth error

### DIFF
--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -136,25 +136,15 @@ def update_third_party_auth_context_for_enterprise(request, context, enterprise_
          context (dict): Updated context of third party auth with modified
          `errorMessage`.
     """
-    if enterprise_customer and context['data']['third_party_auth']['errorMessage']:
+    if context['data']['third_party_auth']['errorMessage']:
         context['data']['third_party_auth']['errorMessage'] = Text(_(
             u'We are sorry, you are not authorized to access {platform_name} via this channel. '
-            u'Please contact your {enterprise} administrator in order to access {platform_name} '
-            u'or contact {edx_support_link}.{line_break}'
-            u'{line_break}'
+            u'Please contact your learning administrator or manager in order to access {platform_name}.'
+            u'{line_break}{line_break}'
             u'Error Details:{line_break}{error_message}')
         ).format(
             platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
-            enterprise=enterprise_customer['name'],
             error_message=context['data']['third_party_auth']['errorMessage'],
-            edx_support_link=HTML(
-                '<a href="{edx_support_url}">{support_url_name}</a>'
-            ).format(
-                edx_support_url=configuration_helpers.get_value(
-                    'SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK
-                ),
-                support_url_name=_('edX Support'),
-            ),
             line_break=HTML('<br/>')
         )
 


### PR DESCRIPTION
@saleem-latif @asadiqbal08 
Update friendly error message for third party auth error along with error message detail while logging in. This message is changed from enterprise specific to a generic error message.

**Previous PR:** https://github.com/edx/edx-platform/pull/16919
> An error occurred when signing you in to edX.
> We are sorry, you are not authorized to access edX via this channel. Please contact your learning administrator or manager in order to access edX.
> 
> Error Details:
> Authentication failed: SAML login failed ["invalid_response"] [SAML Response must contain 1 assertion]

<img width="563" alt="screen shot 2018-01-09 at 4 53 21 pm" src="https://user-images.githubusercontent.com/5072991/34719727-af102462-f55d-11e7-9443-5264ae8aa9e6.png">
