### PR TITLE
Update program detail fragment url for mobile apps.

### DIFF
--- a/lms/djangoapps/learner_dashboard/programs.py
+++ b/lms/djangoapps/learner_dashboard/programs.py
@@ -1,6 +1,8 @@
 """
 Fragments for rendering programs.
 """
+import json
+
 from django.http import Http404
 from django.template.loader import render_to_string
 from django.utils.translation import get_language_bidi
@@ -30,11 +32,12 @@ class ProgramsFragmentView(EdxFragmentView):
         Render the program listing fragment.
         """
         user = request.user
+        mobile_only = json.loads(request.GET.get('mobile_only', 'false'))
         programs_config = kwargs.get('programs_config') or ProgramsApiConfig.current()
         if not programs_config.enabled or not user.is_authenticated():
             raise Http404
 
-        meter = ProgramProgressMeter(request.site, user)
+        meter = ProgramProgressMeter(request.site, user, mobile_only=mobile_only)
 
         context = {
             'marketing_url': get_program_marketing_url(programs_config),

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -717,6 +717,33 @@ class TestProgramProgressMeter(TestCase):
 
             self.assertEqual(meter.progress(count_only=False), expected)
 
+    def test_detail_url_for_mobile_only(self, mock_get_programs):
+        """
+        Verify that correct program detail url is returned for mobile.
+        """
+        course_run_key = generate_course_run_key()
+        data = [
+            ProgramFactory(
+                courses=[
+                    CourseFactory(course_runs=[
+                        CourseRunFactory(key=course_run_key),
+                    ]),
+                ]
+            ),
+            ProgramFactory(),
+        ]
+        mock_get_programs.return_value = data
+
+        self._create_enrollments(course_run_key)
+        meter = ProgramProgressMeter(self.site, self.user, mobile_only=True)
+
+        program_data = meter.engaged_programs[0]
+        detail_fragment_url = reverse('program_details_fragment_view', kwargs={'program_uuid': program_data['uuid']})
+        path_id = detail_fragment_url.replace('/dashboard/', '')
+        expected_url = 'edxapp://enrolled_program_info?path_id={}'.format(path_id)
+
+        self.assertEqual(program_data['detail_url'], expected_url)
+
 
 def _create_course(self, course_price, course_run_count=1, make_entitlement=False):
     """


### PR DESCRIPTION
Use this format `edxapp://enrolled_program_info?path_id=programs/fa4e4674-7d35-41fe-ad10-9ddefefa5bc5/details_fragment/` on my program listing fragment for enrolled program detail fragment url for mobile apps.

LEARNER-3754