### PR TITLE
Use percentage widths to fix flex-box bug

### DIFF
--- a/lms/static/sass/discussion/_layouts.scss
+++ b/lms/static/sass/discussion/_layouts.scss
@@ -27,9 +27,8 @@
 
 .forum-nav {
   @include media-breakpoint-up(md) {
-    // Note: a single width setting is not obeyed by a flex layout
-    min-width: 300px;
     max-width: 300px;
+    width: 25%;
   }
 }
 
@@ -42,6 +41,7 @@
 
     min-height: 500px;
     margin-bottom: 0;
+    width: 75%;
   }
 
   .new-post-article {


### PR DESCRIPTION
This is a fix for a bug in some discussion threads that caused the posts to fall off the edge of the page (EDUCATOR-2104). This CSS essentially subverts the flex-box CSS and instead uses percentage widths for the thread list and discussion post columns until the screen is mobile or smaller (at which point they become stacked).

This will cause some small visual differences for all discussion threads (e.g. the thread list column can shrink to smaller than 300px if the screen is small but bigger than mobile size), but other than that it should behave largely the same as before.

While I was unable to reproduce the flex-box bug locally, I was able to apply these styles to the production CSS using the Chrome DevTools Inspector and confirmed it fixed the bug.