### PR TITLE
PLAT-1884 Replace deprecated xblock.fragment usage

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -18,9 +18,9 @@ from django.views.decorators.http import require_http_methods
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryUsageLocator
 from pytz import UTC
+from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Scope
-from xblock.fragment import Fragment
 
 import dogstats_wrapper as dog_stats_api
 from cms.lib.xblock.authoring_mixin import VISIBILITY_VIEW
@@ -87,7 +87,7 @@ highlights_setting = WaffleSwitch(u'dynamic_pacing', u'studio_course_update')
 
 def hash_resource(resource):
     """
-    Hash a :class:`xblock.fragment.FragmentResource`.
+    Hash a :class:`web_fragments.fragment.FragmentResource`.
     """
     md5 = hashlib.md5()
     md5.update(repr(resource))

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -9,9 +9,9 @@ from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import UsageKey
+from web_fragments.fragment import Fragment
 from xblock.django.request import django_to_webob_request, webob_to_django_response
 from xblock.exceptions import NoSuchHandlerError
-from xblock.fragment import Fragment
 from xblock.runtime import KvsFieldData
 
 import static_replace
@@ -130,14 +130,14 @@ class PreviewModuleSystem(ModuleSystem):  # pylint: disable=abstract-method
     def layout_asides(self, block, context, frag, view_name, aside_frag_fns):
         position_for_asides = '<!-- footer for xblock_aside -->'
         result = Fragment()
-        result.add_frag_resources(frag)
+        result.add_fragment_resources(frag)
 
         for aside, aside_fn in aside_frag_fns:
             aside_frag = aside_fn(block, context)
             if aside_frag.content != u'':
                 aside_frag_wrapped = self.wrap_aside(block, aside, view_name, aside_frag, context)
                 aside.save()
-                result.add_frag_resources(aside_frag_wrapped)
+                result.add_fragment_resources(aside_frag_wrapped)
                 replacement = position_for_asides + aside_frag_wrapped.content
                 frag.content = frag.content.replace(position_for_asides, replacement)
 

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -14,11 +14,11 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locations import Location
 from pyquery import PyQuery
 from pytz import UTC
+from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.core import XBlockAside
 from xblock.exceptions import NoSuchHandlerError
 from xblock.fields import Scope, ScopeIds, String
-from xblock.fragment import Fragment
 from xblock.runtime import DictKeyValueStore, KvsFieldData
 from xblock.test.tools import TestRuntime
 from xblock.validation import ValidationMessage

--- a/cms/lib/xblock/authoring_mixin.py
+++ b/cms/lib/xblock/authoring_mixin.py
@@ -5,9 +5,9 @@ Mixin class that provides authoring capabilities for XBlocks.
 import logging
 
 from django.conf import settings
+from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import XBlockMixin
-from xblock.fragment import Fragment
 
 log = logging.getLogger(__name__)
 

--- a/cms/lib/xblock/tagging/tagging.py
+++ b/cms/lib/xblock/tagging/tagging.py
@@ -4,10 +4,10 @@ Structured Tagging based on XBlockAsides
 """
 
 from django.conf import settings
+from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.core import XBlock, XBlockAside
 from xblock.fields import Dict, Scope
-from xblock.fragment import Fragment
 
 from edxmako.shortcuts import render_to_string
 from xmodule.capa_module import CapaModule

--- a/common/lib/xmodule/xmodule/conditional_module.py
+++ b/common/lib/xmodule/xmodule/conditional_module.py
@@ -11,8 +11,8 @@ from pkg_resources import resource_string
 from six import text_type
 
 from opaque_keys.edx.locator import BlockUsageLocator
+from web_fragments.fragment import Fragment
 from xblock.fields import ReferenceList, Scope, String
-from xblock.fragment import Fragment
 
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.seq_module import SequenceDescriptor

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -11,9 +11,9 @@ from fs.errors import ResourceNotFound
 from lxml import etree
 from path import Path as path
 from pkg_resources import resource_string
+from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Boolean, List, Scope, String
-from xblock.fragment import Fragment
 
 import dogstats_wrapper as dog_stats_api
 from xmodule.contentstore.content import StaticContent

--- a/common/lib/xmodule/xmodule/imageannotation_module.py
+++ b/common/lib/xmodule/xmodule/imageannotation_module.py
@@ -5,8 +5,8 @@ import textwrap
 
 from lxml import etree
 from pkg_resources import resource_string
+from web_fragments.fragment import Fragment
 from xblock.core import Scope, String
-from xblock.fragment import Fragment
 
 from xmodule.annotator_mixin import get_instructions, html_to_text
 from xmodule.annotator_token import retrieve_token

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -14,10 +14,10 @@ from lxml import etree
 from opaque_keys.edx.locator import LibraryLocator
 from pkg_resources import resource_string
 from six import text_type
+from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.core import XBlock
 from xblock.fields import Integer, List, Scope, String
-from xblock.fragment import Fragment
 
 from capa.responsetypes import registry
 from xmodule.studio_editable import StudioEditableDescriptor, StudioEditableModule
@@ -325,7 +325,7 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
         for child in self._get_selected_child_blocks():
             for displayable in child.displayable_items():
                 rendered_child = displayable.render(STUDENT_VIEW, child_context)
-                fragment.add_frag_resources(rendered_child)
+                fragment.add_fragment_resources(rendered_child)
                 contents.append({
                     'id': text_type(displayable.location),
                     'content': rendered_child.content,

--- a/common/lib/xmodule/xmodule/library_root_xblock.py
+++ b/common/lib/xmodule/xmodule/library_root_xblock.py
@@ -3,9 +3,9 @@
 """
 import logging
 
+from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Boolean, List, Scope, String
-from xblock.fragment import Fragment
 
 from xmodule.studio_editable import StudioEditableModule
 
@@ -97,7 +97,7 @@ class LibraryRoot(XBlock):
                 rendered_child = self.runtime.render_child(child, child_view_name, child_context)
             else:
                 rendered_child = self.runtime.render_child_placeholder(child, child_view_name, child_context)
-            fragment.add_frag_resources(rendered_child)
+            fragment.add_fragment_resources(rendered_child)
 
             contents.append({
                 'id': unicode(child.location),

--- a/common/lib/xmodule/xmodule/mako_module.py
+++ b/common/lib/xmodule/xmodule/mako_module.py
@@ -1,7 +1,7 @@
 """
 Code to handle mako templating for XModules and XBlocks.
 """
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 
 from .x_module import DescriptorSystem, XModuleDescriptor, shim_xmodule_js
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_asides.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_asides.py
@@ -1,9 +1,9 @@
 """
 Tests for Asides
 """
+from web_fragments.fragment import Fragment
 from xblock.core import XBlockAside
 from xblock.fields import Scope, String
-from xblock.fragment import Fragment
 from unittest import TestCase
 from xmodule.modulestore.tests.utils import XmlModulestoreBuilder
 from mock import patch

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -22,6 +22,7 @@ import pymongo
 from pytz import UTC
 from shutil import rmtree
 from tempfile import mkdtemp
+from web_fragments.fragment import Fragment
 
 from xmodule.x_module import XModuleMixin
 from xmodule.modulestore.edit_info import EditInfoMixin
@@ -33,7 +34,6 @@ from xmodule.modulestore.xml_exporter import export_course_to_xml
 from xmodule.modulestore.tests.test_asides import AsideTestType
 from xblock.core import XBlockAside
 from xblock.fields import Scope, String, ScopeIds
-from xblock.fragment import Fragment
 from xblock.runtime import DictKeyValueStore, KvsFieldData
 from xblock.test.tools import TestRuntime
 

--- a/common/lib/xmodule/xmodule/randomize_module.py
+++ b/common/lib/xmodule/xmodule/randomize_module.py
@@ -2,8 +2,8 @@ import logging
 import random
 
 from lxml import etree
+from web_fragments.fragment import Fragment
 from xblock.fields import Integer, Scope
-from xblock.fragment import Fragment
 
 from xmodule.seq_module import SequenceDescriptor
 from xmodule.x_module import STUDENT_VIEW, XModule

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -12,10 +12,10 @@ from lxml import etree
 from pkg_resources import resource_string
 from pytz import UTC
 from six import text_type
+from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Boolean, Integer, List, Scope, String
-from xblock.fragment import Fragment
 
 from .exceptions import NotFoundError
 from .fields import Date
@@ -386,7 +386,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             context['bookmarked'] = is_bookmarked
 
             rendered_item = item.render(STUDENT_VIEW, context)
-            fragment.add_frag_resources(rendered_item)
+            fragment.add_fragment_resources(rendered_item)
 
             iteminfo = {
                 'content': rendered_item.content,

--- a/common/lib/xmodule/xmodule/split_test_module.py
+++ b/common/lib/xmodule/xmodule/split_test_module.py
@@ -18,9 +18,9 @@ from xmodule.modulestore.inheritance import UserPartitionList
 from lxml import etree
 from six import text_type
 
+from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Scope, Integer, String, ReferenceValueDict
-from xblock.fragment import Fragment
 
 log = logging.getLogger('edx.' + __name__)
 
@@ -218,7 +218,7 @@ class SplitTestModule(SplitTestFields, XModule, StudioEditableModule):
             child_descriptor = self.get_child_descriptor_by_location(child_location)
             child = self.system.get_module(child_descriptor)
             rendered_child = child.render(STUDENT_VIEW, context)
-            fragment.add_frag_resources(rendered_child)
+            fragment.add_fragment_resources(rendered_child)
             group_name, updated_group_id = self.get_data_for_vertical(child)
 
             if updated_group_id is None:  # inactive group
@@ -300,7 +300,7 @@ class SplitTestModule(SplitTestFields, XModule, StudioEditableModule):
                         DEFAULT_GROUP_NAME.format(group_id=group_id),
                         group_name
                     )
-            fragment.add_frag_resources(rendered_child)
+            fragment.add_fragment_resources(rendered_child)
             html = html + rendered_child.content
 
         return html
@@ -322,7 +322,7 @@ class SplitTestModule(SplitTestFields, XModule, StudioEditableModule):
                 'child_content': child_fragment.content,
                 'child_id': self.child.scope_ids.usage_id,
             }))
-            fragment.add_frag_resources(child_fragment)
+            fragment.add_fragment_resources(child_fragment)
             fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/split_test_student.js'))
             fragment.initialize_js('SplitTestStudentView')
             return fragment

--- a/common/lib/xmodule/xmodule/studio_editable.py
+++ b/common/lib/xmodule/xmodule/studio_editable.py
@@ -24,7 +24,7 @@ class StudioEditableBlock(object):
                 context['reorderable_items'].add(child.location)
             context['can_add'] = can_add
             rendered_child = child.render(StudioEditableModule.get_preview_view_name(child), context)
-            fragment.add_frag_resources(rendered_child)
+            fragment.add_fragment_resources(rendered_child)
 
             contents.append({
                 'id': unicode(child.location),

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -7,7 +7,7 @@ Higher-level tests are in `cms/djangoapps/contentstore/tests/test_libraries.py`.
 from bson.objectid import ObjectId
 from mock import Mock, patch
 
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblock.runtime import Runtime as VanillaRuntime
 
 from xmodule.library_content_module import ANY_CAPA_TYPE_VALUE, LibraryContentDescriptor

--- a/common/lib/xmodule/xmodule/tests/test_library_root.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_root.py
@@ -4,7 +4,7 @@ Basic unit tests for LibraryRoot
 """
 from mock import patch
 
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblock.runtime import Runtime as VanillaRuntime
 from xmodule.x_module import AUTHOR_VIEW
 

--- a/common/lib/xmodule/xmodule/textannotation_module.py
+++ b/common/lib/xmodule/xmodule/textannotation_module.py
@@ -3,8 +3,8 @@ import textwrap
 
 from lxml import etree
 from pkg_resources import resource_string
+from web_fragments.fragment import Fragment
 from xblock.core import Scope, String
-from xblock.fragment import Fragment
 
 from xmodule.annotator_mixin import get_instructions
 from xmodule.annotator_token import retrieve_token

--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -10,10 +10,10 @@ import logging
 from lxml import etree
 from opaque_keys.edx.keys import UsageKey
 import six
+from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
-from xblock.fragment import Fragment
 
 
 from xmodule.mako_module import MakoTemplateBlockBase
@@ -106,7 +106,7 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
         # pylint: disable=no-member
         for child in self.get_display_items():
             rendered_child = child.render(STUDENT_VIEW, child_context)
-            fragment.add_frag_resources(rendered_child)
+            fragment.add_fragment_resources(rendered_child)
 
             contents.append({
                 'id': six.text_type(child.location),

--- a/common/lib/xmodule/xmodule/videoannotation_module.py
+++ b/common/lib/xmodule/xmodule/videoannotation_module.py
@@ -5,8 +5,8 @@ import textwrap
 
 from lxml import etree
 from pkg_resources import resource_string
+from web_fragments.fragment import Fragment
 from xblock.core import Scope, String
-from xblock.fragment import Fragment
 
 from xmodule.annotator_mixin import get_extension, get_instructions
 from xmodule.annotator_token import retrieve_token

--- a/common/lib/xmodule/xmodule/word_cloud_module.py
+++ b/common/lib/xmodule/xmodule/word_cloud_module.py
@@ -10,8 +10,8 @@ import json
 import logging
 
 from pkg_resources import resource_string
+from web_fragments.fragment import Fragment
 from xblock.fields import Boolean, Dict, Integer, List, Scope, String
-from xblock.fragment import Fragment
 
 from xmodule.editing_module import MetadataOnlyEditingDescriptor
 from xmodule.raw_module import EmptyDataRawDescriptor

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -14,6 +14,7 @@ from pkg_resources import (
     resource_string,
     resource_isdir,
 )
+from web_fragments.fragment import Fragment
 from webob import Response
 from webob.multidict import MultiDict
 from lazy import lazy
@@ -25,7 +26,6 @@ from xblock.fields import (
     ReferenceValueDict, UserScope
 )
 
-from xblock.fragment import Fragment
 from xblock.runtime import Runtime, IdReader, IdGenerator
 from xmodule import block_metadata_utils
 from xmodule.fields import RelativeTime
@@ -249,7 +249,7 @@ class HTMLSnippet(object):
 
 def shim_xmodule_js(block, fragment):
     """
-    Set up the XBlock -> XModule shim on the supplied :class:`xblock.fragment.Fragment`
+    Set up the XBlock -> XModule shim on the supplied :class:`web_fragments.fragment.Fragment`
     """
     if not fragment.js_init_fn:
         fragment.initialize_js('XBlockToXModuleShim')

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 from opaque_keys.edx.keys import CourseKey
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblock.runtime import KeyValueStore
 
 from student.models import CourseEnrollment

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -1097,7 +1097,7 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course
 
 def hash_resource(resource):
     """
-    Hash a :class:`xblock.fragment.FragmentResource
+    Hash a :class:`web_fragments.fragment.FragmentResource
     """
     md5 = hashlib.md5()
     for data in resource:

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -12,8 +12,8 @@ import uuid
 import ddt
 import mock
 from django.core.urlresolvers import reverse
+from web_fragments.fragment import Fragment
 from xblock.field_data import DictFieldData
-from xblock.fragment import Fragment
 
 from course_api.blocks.tests.helpers import deserialize_usage_key
 from courseware.module_render import get_module_for_descriptor_internal

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -27,11 +27,11 @@ from nose.plugins.attrib import attr
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from pyquery import PyQuery
 from six import text_type
+from web_fragments.fragment import Fragment
 from xblock.completable import CompletableXBlockMixin
 from xblock.core import XBlock, XBlockAside
 from xblock.field_data import FieldData
 from xblock.fields import ScopeIds
-from xblock.fragment import Fragment
 from xblock.runtime import Runtime
 
 from capa.tests.response_xml_factory import OptionResponseXMLFactory

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -26,9 +26,9 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import Location
 from pytz import UTC
 from six import text_type
+from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Scope, String
-from xblock.fragment import Fragment
 
 import courseware.views.views as views
 import shoppingcart

--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -8,7 +8,7 @@ import uuid
 import ddt
 from django.test.client import RequestFactory
 from nose.plugins.attrib import attr
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 
 from openedx.core.lib.url_utils import quote_slashes
 from openedx.core.lib.xblock_builtin import get_css_dependencies, get_js_dependencies

--- a/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
@@ -10,7 +10,7 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import get_language_bidi
 from xblock.core import XBlock
 from xblock.fields import Scope, String, UNIQUE_ID
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -20,9 +20,9 @@ from django.utils.html import escape
 from django.contrib.auth.models import User
 from edxmako.shortcuts import render_to_string
 from six import text_type
+from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.exceptions import InvalidScopeError
-from xblock.fragment import Fragment
 from xblock.scorable import ScorableXBlockMixin
 
 from xmodule.seq_module import SequenceModule
@@ -38,7 +38,7 @@ def wrap_fragment(fragment, new_content):
     as its content, and all of the resources from fragment
     """
     wrapper_frag = Fragment(content=new_content)
-    wrapper_frag.add_frag_resources(fragment)
+    wrapper_frag.add_fragment_resources(fragment)
     return wrapper_frag
 
 
@@ -224,7 +224,7 @@ def replace_jump_to_id_urls(course_id, jump_to_id_base_url, block, view, frag, c
         redirect. e.g. /courses/<org>/<course>/<run>/jump_to_id. NOTE the <id> will be appended to
         the end of this URL at re-write time
 
-    output: a new :class:`~xblock.fragment.Fragment` that modifies `frag` with
+    output: a new :class:`~web_fragments.fragment.Fragment` that modifies `frag` with
         content that has been update with /jump_to_id links replaced
     """
     return wrap_fragment(frag, static_replace.replace_jump_to_id_urls(frag.content, course_id, jump_to_id_base_url))


### PR DESCRIPTION
This has become just a deprecated wrapper around `web_fragments.fragment`; update all imports to use that directly to eliminate all the relevant warnings about it.