### PR TITLE
Changes the Program Details page to show the most recently purchased

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -800,12 +800,11 @@ def dashboard(request):
     urls, program_data = {}, {}
     bundles_on_dashboard_flag = WaffleFlag(WaffleFlagNamespace(name=u'student.experiments'), u'bundles_on_dashboard')
 
-    if (bundles_on_dashboard_flag.is_enabled()):
+    if bundles_on_dashboard_flag.is_enabled():
         programs_data = meter.programs
         if programs_data:
             program_data = meter.programs[0]
             program_data = ProgramDataExtender(program_data, request.user).extend()
-            course_data = meter.progress(programs=[program_data], count_only=False)[0]
 
             program_data.pop('courses')
             skus = program_data.get('skus')

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -237,7 +237,10 @@ class ProgramProgressMeter(object):
                 elif self._is_course_enrolled(course) or active_entitlement:
                     # Show all currently enrolled courses and active entitlements as in progress
                     if active_entitlement:
-                        course['course_runs'] = get_fulfillable_course_runs_for_entitlement(active_entitlement, course['course_runs'])
+                        course['course_runs'] = get_fulfillable_course_runs_for_entitlement(
+                            active_entitlement,
+                            course['course_runs']
+                        )
                         course['user_entitlement'] = active_entitlement.to_dict()
                         course['enroll_url'] = reverse(
                             'entitlements_api:v1:enrollments',


### PR DESCRIPTION
entitlement data

[LEARNER-3708]

https://openedx.atlassian.net/browse/LEARNER-3708

These changes make it so that the most recently purchased, active course entitlement, is used to get the Course data on the Program Details page.

Also as a result of these changes the Course Entitlements in CourseDashboard will be sorted with the most recent at the top.

Please see the ticket for details.