### PR TITLE
Added field description for accessibility

### DIFF
--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -164,7 +164,7 @@
                                 required: true,
                                 refreshPageOnSave: true,
                                 helpMessage: StringUtils.interpolate(
-                                    gettext('The language used throughout this site. This site is currently available in a limited number of languages.'),  // eslint-disable-line max-len
+                                    gettext('The language used throughout this site. This site is currently available in a limited number of languages. Changing the value of this field will cause the page to refresh.'),  // eslint-disable-line max-len
                                     {platform_name: platformName}
                                 ),
                                 options: fieldsData.language.options,


### PR DESCRIPTION
In account settings page when language changes the page is refreshed
to apply changes. But user is not advised about this change before using
the field. So added description so user knows about reload beforehand.
LEARNER-3832

FYI: @edx/learner-spartans 