### PR TITLE
EDUCATOR 1994: no-id-professional can auto-generate certs

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -17,7 +17,7 @@ from openedx.core.djangoapps.certificates.api import auto_certificate_generation
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.signals.signals import COURSE_GRADE_NOW_PASSED, LEARNER_NOW_VERIFIED
 from student.models import CourseEnrollment
-from common.djangoapps.course_modes.models import CourseMode
+from course_modes.models import CourseMode
 
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -89,7 +89,10 @@ def fire_ungenerated_certificate_task(user, course_key, expected_verification_st
     we regenerate the cert.
     """
     enrollment_mode, __ = CourseEnrollment.enrollment_mode_for_user(user, course_key)
-    mode_is_verified = enrollment_mode in GeneratedCertificate.VERIFIED_CERTS_MODES
+    modes_for_auto_cert_creation = GeneratedCertificate.VERIFIED_CERTS_MODES \
+        + [CourseMode.PROFESSIONAL, CourseMode.NO_ID_PROFESSIONAL_MODE]
+
+    mode_is_verified = enrollment_mode in modes_for_cert_auto_creation
     cert = GeneratedCertificate.certificate_for_student(user, course_key)
     if mode_is_verified and (cert is None or cert.status == 'unverified'):
         kwargs = {

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -17,6 +17,7 @@ from openedx.core.djangoapps.certificates.api import auto_certificate_generation
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.signals.signals import COURSE_GRADE_NOW_PASSED, LEARNER_NOW_VERIFIED
 from student.models import CourseEnrollment
+from common.djangoapps.course_modes.models import CourseMode
 
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -17,7 +17,6 @@ from openedx.core.djangoapps.certificates.api import auto_certificate_generation
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.signals.signals import COURSE_GRADE_NOW_PASSED, LEARNER_NOW_VERIFIED
 from student.models import CourseEnrollment
-from course_modes.models import CourseMode
 
 
 log = logging.getLogger(__name__)
@@ -89,8 +88,10 @@ def fire_ungenerated_certificate_task(user, course_key, expected_verification_st
     If the learner is verified and their cert has the 'unverified' status,
     we regenerate the cert.
     """
+    from course_modes.models import CourseMode
+    
     enrollment_mode, __ = CourseEnrollment.enrollment_mode_for_user(user, course_key)
-    modes_for_auto_cert_creation = GeneratedCertificate.VERIFIED_CERTS_MODES \
+    modes_for_cert_auto_creation = GeneratedCertificate.VERIFIED_CERTS_MODES \
         + [CourseMode.PROFESSIONAL, CourseMode.NO_ID_PROFESSIONAL_MODE]
 
     mode_is_verified = enrollment_mode in modes_for_cert_auto_creation


### PR DESCRIPTION
fix adds no-id-professional to course modes that can auto-generate certificates.