### PR TITLE
PLAT-1885 Stop using deprecated BlockUsageLocator properties

### DIFF
--- a/cms/djangoapps/contentstore/course_group_config.py
+++ b/cms/djangoapps/contentstore/course_group_config.py
@@ -135,7 +135,7 @@ class GroupConfiguration(object):
 
         unit_url = reverse_usage_url(
             'container_handler',
-            course.location.course_key.make_usage_key(unit_for_url.location.block_type, unit_for_url.location.name)
+            course.location.course_key.make_usage_key(unit_for_url.location.block_type, unit_for_url.location.block_id)
         )
 
         usage_dict = {'label': u"{} / {}".format(unit.display_name, item.display_name), 'url': unit_url}

--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -597,7 +597,7 @@ class CourseAboutSearchIndexer(object):
 
         # load data for all of the 'about' modules for this course into a dictionary
         about_dictionary = {
-            item.location.name: item.data
+            item.location.block_id: item.data
             for item in modulestore.get_items(course.id, qualifiers={"category": "about"})
         }
 

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -299,7 +299,7 @@ class ImportRequiredTestCases(ContentStoreTestCase):
 
         for item in items:
             filesystem = OSFS(root_dir / ('test_export/' + dirname))
-            self.assertTrue(filesystem.exists(item.location.name + filename_suffix))
+            self.assertTrue(filesystem.exists(item.location.block_id + filename_suffix))
 
     @mock.patch('xmodule.course_module.requests.get')
     def test_export_course_roundtrip(self, mock_get):

--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -137,7 +137,7 @@ class CourseTestCase(ProceduralCourseTestMixin, ModuleStoreTestCase):
         vertical.location = vertical.location.replace(name='no_references')
         self.store.update_item(vertical, self.user.id, allow_not_found=True)
         orphan_vertical = self.store.get_item(vertical.location)
-        self.assertEqual(orphan_vertical.location.name, 'no_references')
+        self.assertEqual(orphan_vertical.location.block_id, 'no_references')
         self.assertEqual(len(orphan_vertical.children), len(vertical.children))
 
         # create an orphan vertical and html; we already don't try to import

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -541,7 +541,7 @@ def _delete_thumbnail(thumbnail_location, course_key, asset_key):
 
         # We are ignoring the value of the thumbnail_location-- we only care whether
         # or not a thumbnail has been stored, and we can now easily create the correct path.
-        thumbnail_location = course_key.make_asset_key('thumbnail', asset_key.name)
+        thumbnail_location = course_key.make_asset_key('thumbnail', asset_key.block_id)
 
         try:
             thumbnail_content = contentstore().find(thumbnail_location)

--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -282,7 +282,7 @@ def create_xblock(parent_locator, user, category, display_name, boilerplate=None
             course.tabs.append(
                 StaticTab(
                     name=display_name,
-                    url_slug=dest_usage_key.name,
+                    url_slug=dest_usage_key.block_id,
                 )
             )
             store.update_item(course, user.id)
@@ -298,7 +298,7 @@ def is_item_in_course_tree(item):
     if its parent has been deleted and is now an orphan.
     """
     ancestor = item.get_parent()
-    while ancestor is not None and ancestor.location.category != "course":
+    while ancestor is not None and ancestor.location.block_type != "course":
         ancestor = ancestor.get_parent()
 
     return ancestor is not None

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -585,7 +585,7 @@ def _save_xblock(user, xblock, data=None, children_strings=None, metadata=None, 
 
         # for static tabs, their containing course also records their display name
         course = store.get_course(xblock.location.course_key)
-        if xblock.location.category == 'static_tab':
+        if xblock.location.block_type == 'static_tab':
             # find the course's reference to this tab and update the name.
             static_tab = CourseTabList.get_tab_by_slug(course.tabs, xblock.location.name)
             # only update if changed
@@ -916,7 +916,7 @@ def _delete_item(usage_key, user):
         # VS[compat] cdodge: This is a hack because static_tabs also have references from the course module, so
         # if we add one then we need to also add it to the policy information (i.e. metadata)
         # we should remove this once we can break this reference from the course to static tabs
-        if usage_key.category == 'static_tab':
+        if usage_key.block_type == 'static_tab':
 
             dog_stats_api.increment(
                 DEPRECATION_VSCOMPAT_EVENT,
@@ -928,7 +928,7 @@ def _delete_item(usage_key, user):
 
             course = store.get_course(usage_key.course_key)
             existing_tabs = course.tabs or []
-            course.tabs = [tab for tab in existing_tabs if tab.get('url_slug') != usage_key.name]
+            course.tabs = [tab for tab in existing_tabs if tab.get('url_slug') != usage_key.block_id]
             store.update_item(course, user.id)
 
         store.delete_item(usage_key, user.id)
@@ -988,7 +988,7 @@ def _get_xblock(usage_key, user):
         try:
             return store.get_item(usage_key, depth=None)
         except ItemNotFoundError:
-            if usage_key.category in CREATE_IF_NOT_FOUND:
+            if usage_key.block_type in CREATE_IF_NOT_FOUND:
                 # Create a new one for certain categories only. Used for course info handouts.
                 return store.create_item(user.id, usage_key.course_key, usage_key.block_type, block_id=usage_key.block_id)
             else:

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -208,7 +208,7 @@ def library_blocks_view(library, user, response_format):
         return JsonResponse({
             "display_name": library.display_name,
             "library_id": unicode(library.location.library_key),
-            "version": unicode(library.runtime.course_entry.course_key.version),
+            "version": unicode(library.runtime.course_entry.course_key.version_guid),
             "previous_version": unicode(prev_version) if prev_version else None,
             "blocks": [unicode(x) for x in children],
         })

--- a/cms/djangoapps/contentstore/views/tests/test_course_updates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_updates.py
@@ -270,7 +270,7 @@ class CourseUpdateTest(CourseTestCase):
 
         updates_location = self.course.id.make_usage_key('course_info', 'updates')
         self.assertTrue(isinstance(updates_location, UsageKey))
-        self.assertEqual(updates_location.name, u'updates')
+        self.assertEqual(updates_location.block_id, u'updates')
 
         # check posting on handouts
         handouts_location = self.course.id.make_usage_key('course_info', 'handouts')

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -128,11 +128,11 @@ from openedx.core.djangolib.markup import HTML
                   window.course = new Course({
                       id: "${context_course.id | n, js_escaped_string}",
                       name: "${context_course.display_name_with_default | n, js_escaped_string}",
-                      url_name: "${context_course.location.name | n, js_escaped_string}",
+                      url_name: "${context_course.location.block_id | n, js_escaped_string}",
                       org: "${context_course.location.org | n, js_escaped_string}",
                       num: "${context_course.location.course | n, js_escaped_string}",
                       display_course_number: "${context_course.display_coursenumber | n, js_escaped_string}",
-                      revision: "${context_course.location.revision | n, js_escaped_string}",
+                      revision: "${context_course.location.branch | n, js_escaped_string}",
                       self_paced: ${context_course.self_paced | n, dump_js_escaped_json}
                   });
               % endif

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -146,7 +146,7 @@ from openedx.core.djangolib.markup import HTML, Text
                         <div class="wrapper-unit-id bar-mod-content">
                             <h5 class="title">${_("Location ID")}</h5>
                             <p class="unit-id">
-                                <span class="unit-id-value" id="unit-location-id-input">${unit.location.name}</span>
+                                <span class="unit-id-value" id="unit-location-id-input">${unit.location.block_id}</span>
                                 <span class="tip"><span class="sr">Tip: </span>${_('To create a link to this unit from an HTML component in this course, enter "/jump_to_id/<location ID>" as the URL value.')}</span>
                             </p>
                         </div>

--- a/common/lib/xmodule/xmodule/block_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/block_metadata_utils.py
@@ -15,7 +15,7 @@ def url_name_for_block(block):
         block (XModuleMixin|CourseOverview|BlockStructureBlockData):
             Block that is being accessed
     """
-    return block.location.name
+    return block.location.block_id
 
 
 def display_name_with_default(block):

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -117,7 +117,7 @@ class StaticContent(object):
         the actual /c4x/... path which the client needs to reference static content
         """
         if location is not None:
-            return u"/static/{name}".format(name=location.name)
+            return u"/static/{name}".format(name=location.block_id)
         else:
             return None
 
@@ -404,7 +404,7 @@ class ContentStore(object):
         is_svg = content.content_type == 'image/svg+xml'
         # use a naming convention to associate originals with the thumbnail
         thumbnail_name = StaticContent.generate_thumbnail_name(
-            content.location.name, dimensions=dimensions, extension='.svg' if is_svg else None
+            content.location.block_id, dimensions=dimensions, extension='.svg' if is_svg else None
         )
         thumbnail_file_location = StaticContent.compute_location(
             content.location.course_key, thumbnail_name, is_thumbnail=True

--- a/common/lib/xmodule/xmodule/error_module.py
+++ b/common/lib/xmodule/xmodule/error_module.py
@@ -99,7 +99,7 @@ class ErrorDescriptor(ErrorFields, XModuleDescriptor):
             # access to the user context, and this will only be seen by staff
             error_msg = 'Error not available'
 
-        if location.category == 'error':
+        if location.block_type == 'error':
             location = location.replace(
                 # Pick a unique url_name -- the sha1 hash of the contents.
                 # NOTE: We could try to pull out the url_name of the errored descriptor,

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -232,7 +232,7 @@ class HtmlDescriptor(HtmlBlock, XmlDescriptor, EditingDescriptor):  # pylint: di
             # (not same as 'html/blah.html' when the pointer is in a directory itself)
             pointer_path = "{category}/{url_path}".format(
                 category='html',
-                url_path=name_to_pathname(location.name)
+                url_path=name_to_pathname(location.block_id)
             )
             base = path(pointer_path).dirname()
             # log.debug("base = {0}, base.dirname={1}, filename={2}".format(base, base.dirname(), filename))

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -326,7 +326,7 @@ class InheritingFieldData(KvsFieldData):
             # from parent as '_copy_from_templates' puts fields into
             # defaults.
             if ancestor and \
-               ancestor.location.category == 'library_content' and \
+               ancestor.location.block_type == 'library_content' and \
                self.has_default_value(name):
                 return super(InheritingFieldData, self).default(block, name)
 

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -34,7 +34,7 @@ def wrap_draft(item):
     Sets `item.is_draft` to `True` if the item is DRAFT, and `False` otherwise.
     Sets the item's location to the non-draft location in either case.
     """
-    item.is_draft = (item.location.revision == MongoRevisionKey.draft)
+    item.is_draft = (item.location.branch == MongoRevisionKey.draft)
     item.location = item.location.replace(revision=MongoRevisionKey.published)
     return item
 
@@ -99,7 +99,7 @@ class DraftModuleStore(MongoModuleStore):
             return get_published()
 
         # if the item is direct-only, there can only be a published version
-        elif usage_key.category in DIRECT_ONLY_CATEGORIES:
+        elif usage_key.block_type in DIRECT_ONLY_CATEGORIES:
             return get_published()
 
         # return the draft version (without any fallback to PUBLISHED) if DRAFT-ONLY is requested
@@ -226,7 +226,7 @@ class DraftModuleStore(MongoModuleStore):
         for module in modules:
             original_loc = module.location
             module.location = module.location.map_into_course(dest_course_id)
-            if module.location.category == 'course':
+            if module.location.block_type == 'course':
                 module.location = module.location.replace(name=module.location.run)
 
             log.info("Cloning module %s to %s....", original_loc, module.location)
@@ -416,7 +416,7 @@ class DraftModuleStore(MongoModuleStore):
         _verify_revision_is_published(location)
 
         # ensure we are not creating a DRAFT of an item that is direct-only
-        if location.category in DIRECT_ONLY_CATEGORIES:
+        if location.block_type in DIRECT_ONLY_CATEGORIES:
             raise InvalidVersionError(location)
 
         def convert_item(item, to_be_deleted):
@@ -469,7 +469,7 @@ class DraftModuleStore(MongoModuleStore):
         draft_loc = self.for_branch_setting(xblock.location)
 
         # if the revision is published, defer to base
-        if draft_loc.revision == MongoRevisionKey.published:
+        if draft_loc.branch == MongoRevisionKey.published:
             item = super(DraftModuleStore, self).update_item(xblock, user_id, allow_not_found)
             course_key = xblock.location.course_key
             if isPublish or (item.category in DIRECT_ONLY_CATEGORIES and not child_update):
@@ -517,7 +517,7 @@ class DraftModuleStore(MongoModuleStore):
         self._verify_branch_setting(ModuleStoreEnum.Branch.draft_preferred)
         _verify_revision_is_published(location)
 
-        is_item_direct_only = location.category in DIRECT_ONLY_CATEGORIES
+        is_item_direct_only = location.block_type in DIRECT_ONLY_CATEGORIES
         if is_item_direct_only or revision == ModuleStoreEnum.RevisionOption.published_only:
             parent_revision = MongoRevisionKey.published
         elif revision == ModuleStoreEnum.RevisionOption.all:
@@ -542,7 +542,7 @@ class DraftModuleStore(MongoModuleStore):
         for parent_location in parent_locations:
             # don't remove from direct_only parent if other versions of this still exists (this code
             # assumes that there's only one parent_location in this case)
-            if not is_item_direct_only and parent_location.category in DIRECT_ONLY_CATEGORIES:
+            if not is_item_direct_only and parent_location.block_type in DIRECT_ONLY_CATEGORIES:
                 # see if other version of to-be-deleted root exists
                 query = location.to_deprecated_son(prefix='_id.')
                 del query['_id.revision']
@@ -699,7 +699,7 @@ class DraftModuleStore(MongoModuleStore):
                 for child_loc in item.children:
                     _internal_depth_first(child_loc, False)
 
-            if item_location.category in DIRECT_ONLY_CATEGORIES or not getattr(item, 'is_draft', False):
+            if item_location.block_type in DIRECT_ONLY_CATEGORIES or not getattr(item, 'is_draft', False):
                 # ignore noop attempt to publish something that can't be or isn't currently draft
                 return
 
@@ -757,7 +757,7 @@ class DraftModuleStore(MongoModuleStore):
         to remove things from the published version
         """
         # ensure we are not creating a DRAFT of an item that is direct-only
-        if location.category in DIRECT_ONLY_CATEGORIES:
+        if location.block_type in DIRECT_ONLY_CATEGORIES:
             raise InvalidVersionError(location)
 
         self._verify_branch_setting(ModuleStoreEnum.Branch.draft_preferred)
@@ -779,7 +779,7 @@ class DraftModuleStore(MongoModuleStore):
         self._verify_branch_setting(ModuleStoreEnum.Branch.draft_preferred)
         _verify_revision_is_published(location)
 
-        if location.category in DIRECT_ONLY_CATEGORIES:
+        if location.block_type in DIRECT_ONLY_CATEGORIES:
             return
 
         if not self.has_item(location, revision=ModuleStoreEnum.RevisionOption.published_only):
@@ -855,7 +855,7 @@ class DraftModuleStore(MongoModuleStore):
             query = []
             for item in items:
                 item_usage_key = UsageKey.from_string(item).map_into_course(course_key)
-                if item_usage_key.category not in DIRECT_ONLY_CATEGORIES:
+                if item_usage_key.block_type not in DIRECT_ONLY_CATEGORIES:
                     query.append(as_draft(item_usage_key).to_deprecated_son())
             if query:
                 query = {'_id': {'$in': query}}
@@ -907,4 +907,4 @@ def _verify_revision_is_published(location):
     """
     Asserts that the revision set on the given location is MongoRevisionKey.published
     """
-    assert location.revision == MongoRevisionKey.published
+    assert location.branch == MongoRevisionKey.published

--- a/common/lib/xmodule/xmodule/modulestore/search.py
+++ b/common/lib/xmodule/xmodule/modulestore/search.py
@@ -88,9 +88,9 @@ def path_to_location(modulestore, usage_key, full_path=False):
         n = len(path)
         course_id = path[0].course_key
         # pull out the location names
-        chapter = path[1].name if n > 1 else None
-        section = path[2].name if n > 2 else None
-        vertical = path[3].name if n > 3 else None
+        chapter = path[1].block_id if n > 1 else None
+        section = path[2].block_id if n > 2 else None
+        vertical = path[3].block_id if n > 3 else None
         # Figure out the position
         position = None
 

--- a/common/lib/xmodule/xmodule/modulestore/split_migrator.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_migrator.py
@@ -169,8 +169,8 @@ class SplitMigrator(object):
                 continue
             old_parent = self.source_modulestore.get_item(parent_loc, **kwargs)
             split_parent_loc = new_draft_course_loc.make_usage_key(
-                parent_loc.category,
-                parent_loc.block_id if parent_loc.category != 'course' else published_course_usage_key.block_id
+                parent_loc.block_type,
+                parent_loc.block_id if parent_loc.block_type != 'course' else published_course_usage_key.block_id
             )
             new_parent = self.split_modulestore.get_item(split_parent_loc, **kwargs)
             # this only occurs if the parent was also awaiting adoption: skip this one, go to next
@@ -202,8 +202,8 @@ class SplitMigrator(object):
             Convert the location
             """
             return new_course_key.make_usage_key(
-                location.category,
-                location.block_id if location.category != 'course' else course_block_id
+                location.block_type,
+                location.block_id if location.block_type != 'course' else course_block_id
             )
 
         result = {}

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -39,7 +39,7 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
             )
             if master_branch == ModuleStoreEnum.BranchName.draft and not skip_auto_publish:
                 # any other value is hopefully only cloning or doing something which doesn't want this value add
-                self._auto_publish_no_children(item.location, item.location.category, user_id, **kwargs)
+                self._auto_publish_no_children(item.location, item.location.block_type, user_id, **kwargs)
 
                 # create any other necessary things as a side effect: ensure they populate the draft branch
                 # and rely on auto publish to populate the published branch: split's create course doesn't
@@ -130,7 +130,7 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 keys_to_check = list(new_keys)
                 while keys_to_check:
                     usage_key = keys_to_check.pop()
-                    if usage_key.category in DIRECT_ONLY_CATEGORIES:
+                    if usage_key.block_type in DIRECT_ONLY_CATEGORIES:
                         self.publish(usage_key.version_agnostic(), user_id, blacklist=EXCLUDE_ALL, **kwargs)
                         children = getattr(self.get_item(usage_key, **kwargs), "children", [])
                         # e.g. if usage_key is a chapter, it may have an auto-publish sequential child
@@ -152,7 +152,7 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 asides=asides,
                 **kwargs
             )
-            self._auto_publish_no_children(item.location, item.location.category, user_id, **kwargs)
+            self._auto_publish_no_children(item.location, item.location.block_type, user_id, **kwargs)
             descriptor.location = old_descriptor_locn
             return item
 
@@ -171,7 +171,7 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 force=force, **kwargs
             )
             if not skip_auto_publish:
-                self._auto_publish_no_children(item.location, item.location.category, user_id, **kwargs)
+                self._auto_publish_no_children(item.location, item.location.block_type, user_id, **kwargs)
             return item
 
     def create_child(
@@ -185,8 +185,8 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
                 fields=fields, asides=asides, **kwargs
             )
             # Publish both the child and the parent, if the child is a direct-only category
-            self._auto_publish_no_children(item.location, item.location.category, user_id, **kwargs)
-            self._auto_publish_no_children(parent_usage_key, item.location.category, user_id, **kwargs)
+            self._auto_publish_no_children(item.location, item.location.block_type, user_id, **kwargs)
+            self._auto_publish_no_children(parent_usage_key, item.location.block_type, user_id, **kwargs)
             return item
 
     def delete_item(self, location, user_id, revision=None, skip_auto_publish=False, **kwargs):
@@ -215,7 +215,7 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
         with self.bulk_operations(location.course_key):
             if isinstance(location, LibraryUsageLocator):
                 branches_to_delete = [ModuleStoreEnum.BranchName.library]  # Libraries don't yet have draft/publish support
-            elif location.category in DIRECT_ONLY_CATEGORIES:
+            elif location.block_type in DIRECT_ONLY_CATEGORIES:
                 branches_to_delete = [ModuleStoreEnum.BranchName.published, ModuleStoreEnum.BranchName.draft]
             elif revision == ModuleStoreEnum.RevisionOption.all:
                 branches_to_delete = [ModuleStoreEnum.BranchName.published, ModuleStoreEnum.BranchName.draft]
@@ -408,7 +408,7 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
 
         :raises InvalidVersionError: if no published version exists for the location specified
         """
-        if location.category in DIRECT_ONLY_CATEGORIES:
+        if location.block_type in DIRECT_ONLY_CATEGORIES:
             return
 
         draft_course_key = location.course_key.for_branch(ModuleStoreEnum.BranchName.draft)

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -402,7 +402,7 @@ class ItemFactory(XModuleFactory):
 
                 course = store.get_course(location.course_key)
                 course.tabs.append(
-                    CourseTab.load('static_tab', name='Static Tab', url_slug=location.name)
+                    CourseTab.load('static_tab', name='Static Tab', url_slug=location.block_id)
                 )
                 store.update_item(course, user_id)
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_contentstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_contentstore.py
@@ -155,7 +155,7 @@ class TestContentstore(unittest.TestCase):
         self.assertEqual(count, len(self.course1_files), course1_assets)
         for asset in course1_assets:
             parsed = AssetKey.from_string(asset['filename'])
-            self.assertIn(parsed.name, self.course1_files)
+            self.assertIn(parsed.block_id, self.course1_files)
 
         course1_assets, __ = self.contentstore.get_all_content_for_course(self.course1_key, 1, 1)
         self.assertEqual(len(course1_assets), 1, course1_assets)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -715,7 +715,7 @@ class TestMongoModuleStore(TestMongoModuleStoreBase):
         course_key = CourseLocator(org="edX", course="101", run="2015")
         root_block_key = self.draft_store.make_course_usage_key(course_key)
         self.assertEqual(root_block_key.block_type, "course")
-        self.assertEqual(root_block_key.name, "2015")
+        self.assertEqual(root_block_key.block_id, "2015")
 
 
 class TestMongoModuleStoreWithNoAssetCollection(TestMongoModuleStore):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_migrator.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_migrator.py
@@ -38,7 +38,7 @@ class TestMigration(SplitWMongoCourseBootstrapper):
         self._create_item('chapter', chapter1_name, {}, {'display_name': 'Chapter 1'}, 'course', 'runid', split=False)
         chap2_loc = self.old_course_key.make_usage_key('chapter', uuid.uuid4().hex)
         self._create_item(
-            chap2_loc.category, chap2_loc.name, {}, {'display_name': 'Chapter 2'}, 'course', 'runid', split=False
+            chap2_loc.block_type, chap2_loc.block_id, {}, {'display_name': 'Chapter 2'}, 'course', 'runid', split=False
         )
         # vertical in live only
         live_vert_name = uuid.uuid4().hex
@@ -50,7 +50,7 @@ class TestMigration(SplitWMongoCourseBootstrapper):
         # vertical in both live and draft
         both_vert_loc = self.old_course_key.make_usage_key('vertical', uuid.uuid4().hex)
         self._create_item(
-            both_vert_loc.category, both_vert_loc.name, {}, {'display_name': 'Both vertical'}, 'chapter', chapter1_name,
+            both_vert_loc.block_type, both_vert_loc.block_id, {}, {'display_name': 'Both vertical'}, 'chapter', chapter1_name,
             draft=False, split=False
         )
         self.create_random_units(False, both_vert_loc)
@@ -61,13 +61,13 @@ class TestMigration(SplitWMongoCourseBootstrapper):
         # vertical in draft only (x2)
         draft_vert_loc = self.old_course_key.make_usage_key('vertical', uuid.uuid4().hex)
         self._create_item(
-            draft_vert_loc.category, draft_vert_loc.name, {}, {'display_name': 'Draft vertical'}, 'chapter', chapter1_name,
+            draft_vert_loc.block_type, draft_vert_loc.block_id, {}, {'display_name': 'Draft vertical'}, 'chapter', chapter1_name,
             draft=True, split=False
         )
         self.create_random_units(True, draft_vert_loc)
         draft_vert_loc = self.old_course_key.make_usage_key('vertical', uuid.uuid4().hex)
         self._create_item(
-            draft_vert_loc.category, draft_vert_loc.name, {}, {'display_name': 'Draft vertical2'}, 'chapter', chapter1_name,
+            draft_vert_loc.block_type, draft_vert_loc.block_id, {}, {'display_name': 'Draft vertical2'}, 'chapter', chapter1_name,
             draft=True, split=False
         )
         self.create_random_units(True, draft_vert_loc)
@@ -75,7 +75,7 @@ class TestMigration(SplitWMongoCourseBootstrapper):
         # and finally one in live only (so published has to skip 2 preceding sibs)
         live_vert_loc = self.old_course_key.make_usage_key('vertical', uuid.uuid4().hex)
         self._create_item(
-            live_vert_loc.category, live_vert_loc.name, {}, {'display_name': 'Live vertical end'}, 'chapter', chapter1_name,
+            live_vert_loc.block_type, live_vert_loc.block_id, {}, {'display_name': 'Live vertical end'}, 'chapter', chapter1_name,
             draft=False, split=False
         )
         self.create_random_units(False, live_vert_loc)
@@ -86,7 +86,7 @@ class TestMigration(SplitWMongoCourseBootstrapper):
         indirect2_loc = self.old_course_key.make_usage_key('html', uuid.uuid4().hex)
         conditional_loc = self.old_course_key.make_usage_key('conditional', uuid.uuid4().hex)
         self._create_item(
-            conditional_loc.category, conditional_loc.name,
+            conditional_loc.block_type, conditional_loc.block_id,
             {
                 'show_tag_list': [indirect1_loc, indirect2_loc],
                 'sources_list': [live_vert_loc, ],
@@ -96,18 +96,18 @@ class TestMigration(SplitWMongoCourseBootstrapper):
                     'completed': True,
                 },
             },
-            chap2_loc.category, chap2_loc.name,
+            chap2_loc.block_type, chap2_loc.block_id,
             draft=False, split=False
         )
         # create the children
         self._create_item(
-            indirect1_loc.category, indirect1_loc.name, {'data': ""}, {'display_name': 'conditional show 1'},
-            conditional_loc.category, conditional_loc.name,
+            indirect1_loc.block_type, indirect1_loc.block_id, {'data': ""}, {'display_name': 'conditional show 1'},
+            conditional_loc.block_type, conditional_loc.block_id,
             draft=False, split=False
         )
         self._create_item(
-            indirect2_loc.category, indirect2_loc.name, {'data': ""}, {'display_name': 'conditional show 2'},
-            conditional_loc.category, conditional_loc.name,
+            indirect2_loc.block_type, indirect2_loc.block_id, {'data': ""}, {'display_name': 'conditional show 2'},
+            conditional_loc.block_type, conditional_loc.block_id,
             draft=False, split=False
         )
 
@@ -143,7 +143,7 @@ class TestMigration(SplitWMongoCourseBootstrapper):
             metadata = {'display_name': str(uuid.uuid4()), 'graded': True}
             data = {}
             self._create_item(
-                location.category, location.name, data, metadata, parent_loc.category, parent_loc.name,
+                location.block_type, location.block_id, data, metadata, parent_loc.block_type, parent_loc.block_id,
                 draft=draft, split=False
             )
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -932,7 +932,7 @@ class SplitModuleCourseTests(SplitModuleTest):
         root_block_key = modulestore().make_course_usage_key(course_key)
         self.assertIsInstance(root_block_key, root_block_cls)
         self.assertEqual(root_block_key.block_type, "course")
-        self.assertEqual(root_block_key.name, "course")
+        self.assertEqual(root_block_key.block_id, "course")
 
 
 class TestCourseStructureCache(SplitModuleTest):

--- a/common/lib/xmodule/xmodule/modulestore/xml_exporter.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_exporter.py
@@ -280,7 +280,7 @@ class CourseExportManager(ExportManager):
 
         # export all of the course metadata in policy.json
         with course_run_policy_dir.open(u'policy.json', 'wb') as course_policy:
-            policy = {'course/' + courselike.location.name: own_metadata(courselike)}
+            policy = {'course/' + courselike.location.block_id: own_metadata(courselike)}
             course_policy.write(dumps(policy, cls=EdxJSONEncoder, sort_keys=True, indent=4).encode('utf-8'))
 
         _export_drafts(self.modulestore, self.courselike_key, export_fs, xml_centric_courselike_key)
@@ -389,7 +389,7 @@ def _export_field_content(xblock_item, item_dir):
         for field_name in module_data:
             if field_name not in DEFAULT_CONTENT_FIELDS:
                 # filename format: {dirname}.{field_name}.json
-                with item_dir.open(u'{0}.{1}.{2}'.format(xblock_item.location.name, field_name, 'json'),
+                with item_dir.open(u'{0}.{1}.{2}'.format(xblock_item.location.block_id, field_name, 'json'),
                                    'wb') as field_content_file:
                     field_content_file.write(dumps(module_data.get(field_name, {}), cls=EdxJSONEncoder,
                                                    sort_keys=True, indent=4).encode('utf-8'))
@@ -402,7 +402,7 @@ def export_extra_content(export_fs, modulestore, source_course_key, dest_course_
         item_dir = export_fs.makedir(dirname, recreate=True)
         for item in items:
             adapt_references(item, dest_course_key, export_fs)
-            with item_dir.open(item.location.name + file_suffix, 'wb') as item_file:
+            with item_dir.open(item.location.block_id + file_suffix, 'wb') as item_file:
                 item_file.write(item.data.encode('utf8'))
 
                 # export content fields other then metadata and data in json format in current directory

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -741,7 +741,7 @@ def _update_and_import_module(
     asides = module.get_asides() if isinstance(module, XModuleMixin) else None
 
     block = store.import_xblock(
-        user_id, dest_course_id, module.location.category,
+        user_id, dest_course_id, module.location.block_type,
         module.location.block_id, fields, runtime, asides=asides
     )
 
@@ -749,7 +749,7 @@ def _update_and_import_module(
     # Get to the point where XML import is happening inside the
     # modulestore that is eventually going to store the data.
     # Ticket: https://openedx.atlassian.net/browse/PLAT-1046
-    if block.location.category == 'library_content':
+    if block.location.block_type == 'library_content':
         # if library exists, update source_library_version and children
         # according to this existing library and library content block.
         if store.get_library(block.source_library_key):
@@ -919,7 +919,7 @@ def check_module_metadata_editability(module):
     we can't support editing. However we always allow 'display_name'
     and 'xml_attributes'
     """
-    allowed = allowed_metadata_by_category(module.location.category)
+    allowed = allowed_metadata_by_category(module.location.block_type)
     if '*' in allowed:
         # everything is allowed
         return 0
@@ -994,7 +994,7 @@ def validate_no_non_editable_metadata(module_store, course_id, category):
     err_cnt = 0
     for module_loc in module_store.modules[course_id]:
         module = module_store.modules[course_id][module_loc]
-        if module.location.category == category:
+        if module.location.block_type == category:
             err_cnt = err_cnt + check_module_metadata_editability(module)
 
     return err_cnt
@@ -1007,19 +1007,19 @@ def validate_category_hierarchy(
     parents = []
     # get all modules of parent_category
     for module in module_store.modules[course_id].itervalues():
-        if module.location.category == parent_category:
+        if module.location.block_type == parent_category:
             parents.append(module)
 
     for parent in parents:
         for child_loc in parent.children:
-            if child_loc.category != expected_child_category:
+            if child_loc.block_type != expected_child_category:
                 err_cnt += 1
                 print(
                     "ERROR: child {child} of parent {parent} was expected to be "
                     "category of {expected} but was {actual}".format(
                         child=child_loc, parent=parent.location,
                         expected=expected_child_category,
-                        actual=child_loc.category
+                        actual=child_loc.block_type
                     )
                 )
 
@@ -1063,7 +1063,7 @@ def validate_course_policy(module_store, course_id):
     # is there a reliable way to get the module location just given the course_id?
     warn_cnt = 0
     for module in module_store.modules[course_id].itervalues():
-        if module.location.category == 'course':
+        if module.location.block_type == 'course':
             if not module._field_data.has(module, 'rerandomize'):
                 warn_cnt += 1
                 print(

--- a/common/lib/xmodule/xmodule/poll_module.py
+++ b/common/lib/xmodule/xmodule/poll_module.py
@@ -121,7 +121,7 @@ class PollModule(PollFields, XModule):
         """Renders parameters to template."""
         params = {
             'element_id': self.location.html_id(),
-            'element_class': self.location.category,
+            'element_class': self.location.block_type,
             'ajax_url': self.system.ajax_url,
             'configuration_json': self.dump_poll(),
         }

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -314,7 +314,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             'element_id': self.location.html_id(),
             'item_id': text_type(self.location),
             'position': self.position,
-            'tag': self.location.category,
+            'tag': self.location.block_type,
             'ajax_url': self.system.ajax_url,
             'next_url': context.get('next_url'),
             'prev_url': context.get('prev_url'),

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -549,11 +549,11 @@ class CourseComparisonTest(BulkAssertionTest):
                 actual_item_location = actual_course_key.make_usage_key(expected_item.category, expected_item.location.block_id)
                 # split and old mongo use different names for the course root but we don't know which
                 # modulestore actual's come from here; so, assume old mongo and if that fails, assume split
-                if expected_item.location.category == 'course':
+                if expected_item.location.block_type == 'course':
                     actual_item_location = actual_item_location.replace(name=actual_item_location.run)
                 actual_item = actual_item_map.get(map_key(actual_item_location))
                 # must be split
-                if actual_item is None and expected_item.location.category == 'course':
+                if actual_item is None and expected_item.location.block_type == 'course':
                     actual_item_location = actual_item_location.replace(name='course')
                     actual_item = actual_item_map.get(map_key(actual_item_location))
 

--- a/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
@@ -127,8 +127,8 @@ class CourseMetadataUtilsTestCase(TestCase):
                 ),
             ]),
             FunctionTest(url_name_for_block, [
-                TestScenario((self.demo_course,), self.demo_course.location.name),
-                TestScenario((self.html_course,), self.html_course.location.name),
+                TestScenario((self.demo_course,), self.demo_course.location.block_id),
+                TestScenario((self.html_course,), self.html_course.location.block_id),
             ]),
             FunctionTest(display_name_with_default_escaped, [
                 # Test course with no display name.

--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -132,7 +132,7 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
     def test_tooltip(self):
         html = self._get_rendered_student_view(self.sequence_3_1, requested_child=None)
         for child in self.sequence_3_1.children:
-            self.assertIn("'page_title': '{}'".format(child.name), html)
+            self.assertIn("'page_title': '{}'".format(child.block_id), html)
 
     def test_hidden_content_before_due(self):
         html = self._get_rendered_student_view(self.sequence_4_1)

--- a/common/lib/xmodule/xmodule/word_cloud_module.py
+++ b/common/lib/xmodule/xmodule/word_cloud_module.py
@@ -244,7 +244,7 @@ class WordCloudModule(WordCloudFields, XModule):
             'ajax_url': self.system.ajax_url,
             'display_name': self.display_name,
             'instructions': self.instructions,
-            'element_class': self.location.category,
+            'element_class': self.location.block_type,
             'element_id': self.location.html_id(),
             'num_inputs': self.num_inputs,
             'submitted': self.submitted,

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -936,7 +936,7 @@ def policy_key(location):
     Get the key for a location in a policy file.  (Since the policy file is
     specific to a course, it doesn't need the full location url).
     """
-    return u'{cat}/{name}'.format(cat=location.category, name=location.name)
+    return u'{cat}/{name}'.format(cat=location.block_type, name=location.block_id)
 
 
 Template = namedtuple("Template", "metadata data children")

--- a/lms/djangoapps/class_dashboard/dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/dashboard_data.py
@@ -170,7 +170,7 @@ def get_d3_problem_grade_distrib(course_id):
                 for child in unit.get_children():
 
                     # Student data is at the problem level
-                    if child.location.category == 'problem':
+                    if child.location.block_type == 'problem':
                         c_problem += 1
                         stack_data = []
 
@@ -327,7 +327,7 @@ def get_d3_section_grade_distrib(course_id, section):
             c_unit += 1
             c_problem = 0
             for child in unit.get_children():
-                if child.location.category == 'problem':
+                if child.location.block_type == 'problem':
                     c_problem += 1
                     problem_set.append(child.location)
                     problem_info[child.location] = {
@@ -414,7 +414,7 @@ def get_array_section_has_problem(course_id):
         for subsection in section.get_children():
             for unit in subsection.get_children():
                 for child in unit.get_children():
-                    if child.location.category == 'problem':
+                    if child.location.block_type == 'problem':
                         b_section_has_problem[i] = True
                         break  # out of child loop
                 if b_section_has_problem[i]:

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -536,7 +536,7 @@ def get_problems_in_section(section):
     for subsection in section_descriptor.get_children():
         for vertical in subsection.get_children():
             for component in vertical.get_children():
-                if component.location.category == 'problem' and getattr(component, 'has_score', False):
+                if component.location.block_type == 'problem' and getattr(component, 'has_score', False):
                     problem_descriptors[unicode(component.location)] = component
 
     return problem_descriptors

--- a/lms/djangoapps/courseware/management/commands/dump_course_structure.py
+++ b/lms/djangoapps/courseware/management/commands/dump_course_structure.py
@@ -93,7 +93,7 @@ def dump_module(module, destination=None, inherited=False, defaults=False):
     filtered_metadata = {k: v for k, v in items.iteritems() if k not in FILTER_LIST}
 
     destination[unicode(module.location)] = {
-        'category': module.location.category,
+        'category': module.location.block_type,
         'children': [unicode(child) for child in getattr(module, 'children', [])],
         'metadata': filtered_metadata,
     }

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -233,8 +233,8 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         expected_url = reverse('courseware_section',
                                kwargs={
                                    'course_id': unicode(self.course.id),
-                                   'chapter': self.entrance_exam.location.name,
-                                   'section': self.exam_1.location.name
+                                   'chapter': self.entrance_exam.location.block_id,
+                                   'section': self.exam_1.location.block_id
                                })
         resp = self.client.get(url)
         self.assertRedirects(resp, expected_url, status_code=302, target_status_code=200)
@@ -248,8 +248,8 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         expected_url = reverse('courseware_section',
                                kwargs={
                                    'course_id': unicode(self.course.id),
-                                   'chapter': self.chapter.location.name,
-                                   'section': self.welcome.location.name
+                                   'chapter': self.chapter.location.block_id,
+                                   'section': self.welcome.location.block_id
                                })
         resp = self.client.get(url)
         self.assertRedirects(resp, expected_url, status_code=302, target_status_code=200)
@@ -265,8 +265,8 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         expected_url = reverse('courseware_section',
                                kwargs={
                                    'course_id': unicode(self.course.id),
-                                   'chapter': self.entrance_exam.location.name,
-                                   'section': self.exam_1.location.name
+                                   'chapter': self.entrance_exam.location.block_id,
+                                   'section': self.exam_1.location.block_id
                                })
         resp = self.client.get(url)
         self.assertRedirects(resp, expected_url, status_code=302, target_status_code=200)
@@ -296,8 +296,8 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
             'courseware_section',
             kwargs={
                 'course_id': unicode(self.course.id),
-                'chapter': self.entrance_exam.location.name,
-                'section': self.exam_1.location.name,
+                'chapter': self.entrance_exam.location.block_id,
+                'section': self.exam_1.location.block_id,
             }
         )
         resp = self.client.get(url)
@@ -320,8 +320,8 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
             'courseware_section',
             kwargs={
                 'course_id': unicode(self.course.id),
-                'chapter': self.entrance_exam.location.name,
-                'section': self.exam_1.location.name
+                'chapter': self.entrance_exam.location.block_id,
+                'section': self.exam_1.location.block_id
             }
         )
         resp = self.client.get(url)
@@ -346,8 +346,8 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
             'courseware_section',
             kwargs={
                 'course_id': unicode(self.course.id),
-                'chapter': self.chapter.location.name,
-                'section': self.chapter_subsection.location.name
+                'chapter': self.chapter.location.block_id,
+                'section': self.chapter_subsection.location.block_id
             }
         )
         resp = self.client.get(url)
@@ -366,8 +366,8 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
             'courseware_section',
             kwargs={
                 'course_id': unicode(self.course.id),
-                'chapter': self.entrance_exam.location.name,
-                'section': self.exam_1.location.name
+                'chapter': self.entrance_exam.location.block_id,
+                'section': self.exam_1.location.block_id
             }
         )
 
@@ -450,8 +450,8 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         expected_url = reverse('courseware_section',
                                kwargs={
                                    'course_id': unicode(self.course.id),
-                                   'chapter': self.entrance_exam.location.name,
-                                   'section': self.exam_1.location.name
+                                   'chapter': self.entrance_exam.location.block_id,
+                                   'section': self.exam_1.location.block_id
                                })
         self.assertRedirects(response, expected_url, status_code=302, target_status_code=200)
 

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -86,8 +86,8 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             'courseware_section',
             kwargs={
                 'course_id': unicode(self.course.id),
-                'chapter': self.chapter.location.name,
-                'section': self.sequential.location.name,
+                'chapter': self.chapter.location.block_id,
+                'section': self.sequential.location.block_id,
             }
         )
         return self.client.get(url)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -225,8 +225,8 @@ class IndexQueryTestCase(ModuleStoreTestCase):
                     'courseware_section',
                     kwargs={
                         'course_id': unicode(course.id),
-                        'chapter': unicode(chapter.location.name),
-                        'section': unicode(section.location.name),
+                        'chapter': unicode(chapter.location.block_id),
+                        'section': unicode(section.location.block_id),
                     }
                 )
                 response = self.client.get(url)
@@ -345,8 +345,8 @@ class ViewsTestCase(ModuleStoreTestCase):
             'courseware_section',
             kwargs={
                 'course_id': unicode(self.course_key),
-                'chapter': unicode(self.chapter.location.name) if chapter_name is None else chapter_name,
-                'section': unicode(self.section2.location.name) if section_name is None else section_name,
+                'chapter': unicode(self.chapter.location.block_id) if chapter_name is None else chapter_name,
+                'section': unicode(self.section2.location.block_id) if section_name is None else section_name,
             }
         )
         response = self.client.get(url)
@@ -365,7 +365,7 @@ class ViewsTestCase(ModuleStoreTestCase):
 
         url = reverse(
             'courseware_chapter',
-            kwargs={'course_id': unicode(self.course.id), 'chapter': unicode(self.chapter.location.name)},
+            kwargs={'course_id': unicode(self.course.id), 'chapter': unicode(self.chapter.location.block_id)},
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -388,8 +388,8 @@ class ViewsTestCase(ModuleStoreTestCase):
             'courseware_section',
             kwargs={
                 'course_id': unicode(self.course_key),
-                'chapter': unicode(self.chapter.location.name),
-                'section': unicode(self.section.location.name),
+                'chapter': unicode(self.chapter.location.block_id),
+                'section': unicode(self.section.location.block_id),
             }
         )
         # create the url for enroll_staff view
@@ -546,8 +546,8 @@ class ViewsTestCase(ModuleStoreTestCase):
             '/courses',
             unicode(self.course.id),
             'courseware',
-            self.chapter.location.name,
-            self.section.location.name,
+            self.chapter.location.block_id,
+            self.section.location.block_id,
             'f'
         ])
         self.assertTrue(self.client.login(username=self.user.username, password=TEST_PASSWORD))
@@ -559,8 +559,8 @@ class ViewsTestCase(ModuleStoreTestCase):
             '/courses',
             unicode(self.course.id),
             'courseware',
-            self.chapter.location.name,
-            self.section.location.name,
+            self.chapter.location.block_id,
+            self.section.location.block_id,
             '1'
         ]
         self.assertTrue(self.client.login(username=self.user.username, password=TEST_PASSWORD))
@@ -2516,8 +2516,8 @@ class TestIndexViewCrawlerStudentStateWrites(SharedModuleStoreTestCase):
             'courseware_section',
             kwargs={
                 'course_id': unicode(self.course.id),
-                'chapter': unicode(self.chapter.location.name),
-                'section': unicode(self.section.location.name),
+                'chapter': unicode(self.chapter.location.block_id),
+                'section': unicode(self.section.location.block_id),
             }
         )
         response = self.client.get(url, HTTP_USER_AGENT=user_agent)

--- a/lms/djangoapps/courseware/tests/test_word_cloud.py
+++ b/lms/djangoapps/courseware/tests/test_word_cloud.py
@@ -260,7 +260,7 @@ class TestWordCloud(BaseTestXmodule):
             'ajax_url': self.item_descriptor.xmodule_runtime.ajax_url,
             'display_name': self.item_descriptor.display_name,
             'instructions': self.item_descriptor.instructions,
-            'element_class': self.item_descriptor.location.category,
+            'element_class': self.item_descriptor.location.block_type,
             'element_id': self.item_descriptor.location.html_id(),
             'num_inputs': 5,  # default value
             'submitted': False,  # default value,

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -279,7 +279,7 @@ class CoursewareIndex(View):
         """
         child = None
         if url_name:
-            child = parent.get_child_by(lambda m: m.location.name == url_name)
+            child = parent.get_child_by(lambda m: m.location.block_id == url_name)
             if not child:
                 # User may be trying to access a child that isn't live yet
                 if not self._is_masquerading_as_student():
@@ -523,7 +523,7 @@ def save_child_position(seq_module, child_name):
     child_name: url_name of the child
     """
     for position, child in enumerate(seq_module.get_display_items(), start=1):
-        if child.location.name == child_name:
+        if child.location.block_id == child_name:
             # Only save if position changed
             if position != seq_module.position:
                 seq_module.position = position
@@ -553,6 +553,6 @@ def save_positions_recursively_up(user, request, field_data_cache, xmodule, cour
             )
 
         if parent and hasattr(parent, 'position'):
-            save_child_position(parent, current_module.location.name)
+            save_child_position(parent, current_module.location.block_id)
 
         current_module = parent

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -256,7 +256,7 @@ class InstructorTaskModuleTestCase(InstructorTaskCourseTestCase):
         """Get StudentModule object for test course, given the `username` and the problem's `descriptor`."""
         return StudentModule.objects.get(course_id=self.course.id,
                                          student=User.objects.get(username=username),
-                                         module_type=descriptor.location.category,
+                                         module_type=descriptor.location.block_type,
                                          module_state_key=descriptor.location,
                                          )
 

--- a/lms/djangoapps/mobile_api/video_outlines/serializers.py
+++ b/lms/djangoapps/mobile_api/video_outlines/serializers.py
@@ -137,7 +137,7 @@ def find_urls(course_id, block, child_to_parent, request):
     if block_count > 3:
         position = 1
         for block in section.children:
-            if block.name == block_list[3].url_name:
+            if block.block_id == block_list[3].url_name:
                 break
             position += 1
 

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -26,7 +26,7 @@ ${block_content}
   <a class="instructor-info-action" href="#${element_id}_debug" id="${element_id}_trig">${_("Staff Debug Info")}</a>
 
   %  if settings.FEATURES.get('ENABLE_STUDENT_HISTORY_VIEW') and \
-    location.category == 'problem':
+    location.block_type == 'problem':
     <a class="instructor-info-action" href="#${element_id}_history" id="${element_id}_history_trig">${_("Submission history")}</a>
   %  endif
 </div>
@@ -64,17 +64,17 @@ ${block_content}
     <div class="staff_actions">
       <h3>${_('Actions')}</h3>
       <div>
-        <label for="sd_fu_${location.name | h}">${_('Username')}:</label>
-        <input type="text" tabindex="0" id="sd_fu_${location.name | h}" placeholder="${user.username}"/>
+        <label for="sd_fu_${location.block_id | h}">${_('Username')}:</label>
+        <input type="text" tabindex="0" id="sd_fu_${location.block_id | h}" placeholder="${user.username}"/>
       </div>
       % if can_override_problem_score:
       <div>
-        <label for="sd_fs_${location.name | h}">${_('Score (for override only)')}:</label>
-        <input type="text" tabindex="0" id="sd_fs_${location.name | h}" placeholder="0"/>
-        <label for="sd_fs_${location.name | h}"> / ${max_problem_score}</label>
+        <label for="sd_fs_${location.block_id | h}">${_('Score (for override only)')}:</label>
+        <input type="text" tabindex="0" id="sd_fs_${location.block_id | h}" placeholder="0"/>
+        <label for="sd_fs_${location.block_id | h}"> / ${max_problem_score}</label>
       </div>
       % endif
-      <div data-location="${location | h}" data-location-name="${location.name | h}">
+      <div data-location="${location | h}" data-location-name="${location.block_id | h}">
         [
         % if can_reset_attempts:
         <button type="button" class="btn-link staff-debug-reset">${_('Reset Learner\'s Attempts to Zero')}</button>
@@ -95,7 +95,7 @@ ${block_content}
         % endif
         ]
       </div>
-      <div id="result_${location.name | h}"></div>
+      <div id="result_${location.block_id | h}"></div>
     </div>
 
     <div class="staff_info" style="display:block">

--- a/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
+++ b/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
@@ -275,12 +275,12 @@ class TestModuleStoreSerializer(TestDumpToNeo4jCommandBase):
         ).for_version('test_version')
 
         self.assertIsNotNone(location.branch)
-        self.assertIsNotNone(location.version)
+        self.assertIsNotNone(location.version_guid)
 
         stripped_location = strip_branch_and_version(location)
 
         self.assertIsNone(stripped_location.branch)
-        self.assertIsNone(stripped_location.version)
+        self.assertIsNone(stripped_location.version_guid)
 
     @staticmethod
     def _extract_relationship_pairs(relationships, relationship_type):

--- a/openedx/core/djangoapps/models/tests/test_course_details.py
+++ b/openedx/core/djangoapps/models/tests/test_course_details.py
@@ -29,7 +29,7 @@ class CourseDetailsTestCase(ModuleStoreTestCase):
         details = CourseDetails.fetch(self.course.id)
         self.assertEqual(details.org, self.course.location.org, "Org not copied into")
         self.assertEqual(details.course_id, self.course.location.course, "Course_id not copied into")
-        self.assertEqual(details.run, self.course.location.name, "Course name not copied into")
+        self.assertEqual(details.run, self.course.location.block_id, "Course name not copied into")
         self.assertEqual(details.course_image_name, self.course.course_image)
         self.assertIsNotNone(details.start_date.tzinfo)
         self.assertIsNone(details.end_date, "end date somehow initialized " + str(details.end_date))

--- a/openedx/tests/xblock_integration/test_review_xblock.py
+++ b/openedx/tests/xblock_integration/test_review_xblock.py
@@ -227,8 +227,8 @@ class TestReviewFunctions(TestReviewXBlock):
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': review_section_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': review_section_actual.location.block_id,
             }
         ))
 
@@ -253,8 +253,8 @@ class TestReviewFunctions(TestReviewXBlock):
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': self.section1_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': self.section1_actual.location.block_id,
             }
         ))
         if num_desired > 6:
@@ -262,16 +262,16 @@ class TestReviewFunctions(TestReviewXBlock):
                 'courseware_section',
                 kwargs={
                     'course_id': self.course_actual.id,
-                    'chapter': self.chapter_actual.location.name,
-                    'section': self.section2_actual.location.name,
+                    'chapter': self.chapter_actual.location.block_id,
+                    'section': self.section2_actual.location.block_id,
                 }
             ))
             self.client.get(reverse(
                 'courseware_section',
                 kwargs={
                     'course_id': self.course_actual.id,
-                    'chapter': self.chapter_actual.location.name,
-                    'section': self.section3_actual.location.name,
+                    'chapter': self.chapter_actual.location.block_id,
+                    'section': self.section3_actual.location.block_id,
                 }
             ))
 
@@ -295,8 +295,8 @@ class TestReviewFunctions(TestReviewXBlock):
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': review_section_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': review_section_actual.location.block_id,
             }
         ))
 
@@ -318,24 +318,24 @@ class TestReviewFunctions(TestReviewXBlock):
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': self.section1_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': self.section1_actual.location.block_id,
             }
         ))
         self.client.get(reverse(
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': self.section2_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': self.section2_actual.location.block_id,
             }
         ))
         self.client.get(reverse(
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': self.section3_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': self.section3_actual.location.block_id,
             }
         ))
 
@@ -359,8 +359,8 @@ class TestReviewFunctions(TestReviewXBlock):
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': review_section_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': review_section_actual.location.block_id,
             }
         ))
 
@@ -397,24 +397,24 @@ class TestReviewFunctions(TestReviewXBlock):
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': self.section1_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': self.section1_actual.location.block_id,
             }
         ))
         self.client.get(reverse(
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': self.section2_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': self.section2_actual.location.block_id,
             }
         ))
         self.client.get(reverse(
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': self.section3_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': self.section3_actual.location.block_id,
             }
         ))
 
@@ -456,16 +456,16 @@ class TestReviewFunctions(TestReviewXBlock):
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': self.section1_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': self.section1_actual.location.block_id,
             }
         ))
         self.client.get(reverse(
             'courseware_section',
             kwargs={
                 'course_id': self.course_actual.id,
-                'chapter': self.chapter_actual.location.name,
-                'section': self.section3_actual.location.name,
+                'chapter': self.chapter_actual.location.block_id,
+                'section': self.section3_actual.location.block_id,
             }
         ))
 

--- a/requirements/edx/base_common.txt
+++ b/requirements/edx/base_common.txt
@@ -7,6 +7,6 @@
 # We plan to move edx-platform to use pip-tools soon and each target will have its
 # own requirements files built, which will remove the need for this file.
 wrapt==1.10.5
-edx-opaque-keys==0.4.0
+edx-opaque-keys==0.4.1
 requests==2.9.1
 mock==1.0.1


### PR DESCRIPTION
Lots and lots of substitutions for the same 4 deprecated properties of `BlockUsageLocator`.  Also upgrades the `edx-opaque-keys` package to a version which stops using the deprecated properties internally in other non-deprecated code (that change is being tested and reviewed [here](https://github.com/edx/opaque-keys/pull/91)).