### PR TITLE
Add babel-polyfill to fix IE11 bug

### DIFF
--- a/common/static/js/src/ReactRenderer.jsx
+++ b/common/static/js/src/ReactRenderer.jsx
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-loader": "^6.4.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.2.1",
     "babel-preset-react": "^6.24.1",
     "backbone": "~1.3.2",


### PR DESCRIPTION
ReactRenderer used Object.assign which is an ES 2015 feature that is not
supported by IE11. babel-polyfill will now polyfills that function for browsers
that do not support it before ReactRenderer tries to use it.

I tested that this does fix the issue in IE11 on Windows 8.