### PR TITLE
LEARNER-3858 revert rate limit on end point '/oauth2/access_token'

### DIFF
--- a/lms/djangoapps/oauth2_handler/tests.py
+++ b/lms/djangoapps/oauth2_handler/tests.py
@@ -1,5 +1,4 @@
 # pylint: disable=missing-docstring
-import mock
 from django.core.cache import cache
 from django.test.utils import override_settings
 # Will also run default tests for IDTokens and UserInfo
@@ -134,13 +133,6 @@ class IDTokenTest(BaseTestMixin, IDTokenTestCase):
         self.user.save()
         _scopes, claims = self.get_id_token_values('openid profile permissions')
         self.assertTrue(claims['administrator'])
-
-    def test_rate_limit_token(self):
-        with mock.patch('openedx.core.djangoapps.oauth_dispatch.views.AccessTokenView.ratelimit_rate', '1/m'):
-            response = self.get_access_token_response('openid profile permissions')
-            self.assertEqual(response.status_code, 200)
-            response = self.get_access_token_response('openid profile permissions')
-            self.assertEqual(response.status_code, 403)
 
 
 class UserInfoTest(BaseTestMixin, UserInfoTestCase):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3438,10 +3438,6 @@ EDX_PLATFORM_REVISION = 'unknown'
 # (0.0 = 0%, 1.0 = 100%)
 COMPLETION_VIDEO_COMPLETE_PERCENTAGE = 0.95
 
-############### Settings for Django Rate limit #####################
-RATELIMIT_ENABLE = True
-RATELIMIT_RATE = '30/m'
-
 ############## Plugin Django Apps #########################
 
 from openedx.core.djangolib.django_plugins import DjangoAppRegistry, ProjectType, SettingsType

--- a/openedx/core/djangoapps/oauth_dispatch/views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/views.py
@@ -17,8 +17,6 @@ from edx_oauth2_provider import views as dop_views  # django-oauth2-provider vie
 from jwkest.jwk import RSAKey
 from oauth2_provider import models as dot_models  # django-oauth-toolkit
 from oauth2_provider import views as dot_views
-from ratelimit import ALL
-from ratelimit.mixins import RatelimitMixin
 
 from openedx.core.djangoapps.auth_exchange import views as auth_exchange_views
 from openedx.core.lib.token_utils import JwtBuilder
@@ -85,16 +83,12 @@ class _DispatchingView(View):
             return request.POST.get('client_id')
 
 
-class AccessTokenView(RatelimitMixin, _DispatchingView):
+class AccessTokenView(_DispatchingView):
     """
     Handle access token requests.
     """
     dot_view = dot_views.TokenView
     dop_view = dop_views.AccessTokenView
-    ratelimit_key = 'openedx.core.djangoapps.util.ratelimit.real_ip'
-    ratelimit_rate = settings.RATELIMIT_RATE
-    ratelimit_block = True
-    ratelimit_method = ALL
 
     def dispatch(self, request, *args, **kwargs):
         response = super(AccessTokenView, self).dispatch(request, *args, **kwargs)

--- a/openedx/core/djangoapps/util/ratelimit.py
+++ b/openedx/core/djangoapps/util/ratelimit.py
@@ -1,5 +1,0 @@
-from ipware.ip import get_ip
-
-
-def real_ip(group, request):
-    return get_ip(request)


### PR DESCRIPTION
Errors in 'prod-edx-edxapp-lms' due to rate limit at end point '/oauth2/access_token'
Reverting this change. 