### PR TITLE
Add ENABLE_COSMETIC_DISPLAY_MULTIPLE_PRICES to configure and display …

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -774,6 +774,19 @@ def get_course_prices(course, verified_only=False):
     return registration_price, format_course_price(price)
 
 
+def get_course_all_prices(course_key):
+    """
+    Return all cosmetic_display_prices defined for the course_key in CourseModes.
+    * price is the course mode price as a string preceded by correct currency, or 'Free'.
+    """
+    course_all_prices = {}
+    all_modes = CourseMode.modes_for_course_dict(course_key, include_expired=True)
+    for key, mode in all_modes.iteritems():
+        course_all_prices[key] = {'name': mode.name, 'price': format_course_price(mode.min_price)}
+
+    return course_all_prices
+
+
 def format_course_price(price):
     """
     Return a formatted price for a course (a string preceded by correct currency, or 'Free').

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -42,7 +42,7 @@ import shoppingcart
 import survey.views
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import CertificateStatuses
-from course_modes.models import CourseMode, get_course_prices
+from course_modes.models import CourseMode, get_course_prices, get_course_all_prices
 from courseware.access import has_access, has_ccx_coach_role
 from courseware.access_utils import check_course_open_for_learner
 from courseware.courses import (
@@ -817,6 +817,7 @@ def course_about(request, course_id):
                 ecommerce_bulk_checkout_link = ecomm_service.get_checkout_page_url(professional_mode.bulk_sku)
 
         registration_price, course_price = get_course_prices(course)
+        course_all_prices = get_course_all_prices(course_key)
 
         # Determine which checkout workflow to use -- LMS shoppingcart or Otto basket
         can_add_course_to_cart = _is_shopping_cart_enabled and registration_price and not ecommerce_checkout_link
@@ -858,7 +859,9 @@ def course_about(request, course_id):
             'registered': registered,
             'course_target': course_target,
             'is_cosmetic_price_enabled': settings.FEATURES.get('ENABLE_COSMETIC_DISPLAY_PRICE'),
+            'is_cosmetic_multiple_prices_enabled': settings.FEATURES.get('ENABLE_COSMETIC_DISPLAY_MULTIPLE_PRICES'),
             'course_price': course_price,
+            'course_all_prices': course_all_prices,
             'in_cart': in_cart,
             'ecommerce_checkout': ecommerce_checkout,
             'ecommerce_checkout_link': ecommerce_checkout_link,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -196,6 +196,10 @@ FEATURES = {
     # Enable the display of cosmetic course price display (set in course advanced settings)
     'ENABLE_COSMETIC_DISPLAY_PRICE': False,
 
+    # Enable the display of cosmetic course multiple prices display (set in Course Modes of Django Admin)
+    # The parameter ENABLE_COSMETIC_DISPLAY_PRICE must be set to True in order for this to work
+    'ENABLE_COSMETIC_DISPLAY_MULTIPLE_PRICES': False,
+
     # Automatically approve student identity verification attempts
     'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': False,
 

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -275,11 +275,21 @@ from six import string_types
           ##<li class="important-dates-item"><span class="icon fa fa-clock-o" aria-hidden="true"></span><p class="important-dates-item-title">${_('Course Length')}</p><span class="important-dates-item-text course-length">${_('{number} weeks').format(number=15)}</span></li>
 
           %if course_price and (can_add_course_to_cart or is_cosmetic_price_enabled):
-            <li class="important-dates-item">
-              <span class="icon fa fa-money" aria-hidden="true"></span>
-              <p class="important-dates-item-title">${_("Price")}</p>
-              <span class="important-dates-item-text">${course_price}</span>
-            </li>
+            %if not is_cosmetic_multiple_prices_enabled:
+              <li class="important-dates-item">
+                <span class="icon fa fa-money" aria-hidden="true"></span>
+                <p class="important-dates-item-title">${_("Price")}</p>
+                <span class="important-dates-item-text">${course_price}</span>
+              </li>
+            %elif course_all_prices:
+              %for key,mode in course_all_prices.iteritems():
+                <li class="important-dates-item">
+                  <span class="icon fa fa-money" aria-hidden="true"></span>
+                  <p class="important-dates-item-title">${_("Price")} - ${mode['name']}</p>
+                  <span class="important-dates-item-text">${mode['price']}</span>
+                </li>
+              %endfor
+            %endif
           %endif
 
           % if pre_requisite_courses:


### PR DESCRIPTION
…all course modes with cosmetic prices in about course

This follows PR #16821 

This feature enables to show all modes defined and its price in the course about page of a course. It is enabled by defining `ENABLE_COSMETIC_DISPLAY_MULTIPLE_PRICES` to `True` in `FEATURES` (`lms.env.json` file).

* If `ENABLE_COSMETIC_DISPLAY_MULTIPLE_PRICES: false` in json files, the platform behaves as this PR was never done. Default behavior.

![05-disable-multiple-cosmetic](https://user-images.githubusercontent.com/11334168/34940638-9279bed4-f9f0-11e7-9d58-23758f249ee4.png)

* If `ENABLE_COSMETIC_DISPLAY_PRICE: true` in json files, and no course mode defined, shows the default course enrollment mode, Audit for Free:

![04-enable-multiple-no-course-mode](https://user-images.githubusercontent.com/11334168/34940660-acef2218-f9f0-11e7-9159-4ce70ec6c91e.png)

* If `ENABLE_COSMETIC_DISPLAY_PRICE: true` in json files, and course modes defined, shows all the course modes names and prices. If some of the prices is 0, it will show Free:

![03-enable-multiple-audit-0](https://user-images.githubusercontent.com/11334168/34940694-d7b8698c-f9f0-11e7-9802-a06fbad6f9be.png)

![02-enable-multiple-honor](https://user-images.githubusercontent.com/11334168/34940700-dc4a5082-f9f0-11e7-93a4-c136382ee591.png)

![01-enable-multiple-audit-honor](https://user-images.githubusercontent.com/11334168/34940704-e0ad8338-f9f0-11e7-9360-55395b7cd583.png)

 @marcotuts @caesar2164 