### PR TITLE
Append dashboard url with slash to improve user experience

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -60,7 +60,7 @@ urlpatterns = [
 
     url(r'', include('student.urls')),
     # TODO: Move lms specific student views out of common code
-    url(r'^dashboard$', student_views.dashboard, name='dashboard'),
+    url(r'^dashboard/?$', student_views.dashboard, name='dashboard'),
     url(r'^change_enrollment$', student_views.change_enrollment, name='change_enrollment'),
 
     # Event tracking endpoints


### PR DESCRIPTION
The Dashboard url in LMS is only accessible in the absence of
slash at its end.To improve the user experience its URL is
updated.

LEARNER-3812