### PR TITLE
EDUCATOR-2067 If SFE enabled, hide sidebar and upload button

### DIFF
--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -42,71 +42,78 @@
             <span class="sr">- </span>${_("Files & Uploads")}
         </h3>
 
-        <div class="nav-actions">
-            <ul>
-                <li class="nav-item">
-                    <a href="#" class="button upload-button new-button"><span class="icon fa fa-plus" aria-hidden="true"></span> ${_("Upload New File")}</a>
-                </li>
-            </ul>
-        </div>
+        % if not waffle_flag_enabled:
+            <div class="nav-actions">
+                <ul>
+                    <li class="nav-item">
+                        <a href="#" class="button upload-button new-button"><span class="icon fa fa-plus" aria-hidden="true"></span> ${_("Upload New File")}</a>
+                    </li>
+                </ul>
+            </div>
+        % endif
     </header>
 </div>
 
 <div class="wrapper-content wrapper">
     <div class="content">
-        <div class="content-primary">
-            % if waffle_flag_enabled:
-                <%static:studiofrontend page="AssetsPage" lang="en">
-                    {
-                        "course": {
-                            "id": "${context_course.id | n, js_escaped_string}",
-                            "name": "${context_course.display_name_with_default | n, js_escaped_string}",
-                            "url_name": "${context_course.location.name | n, js_escaped_string}",
-                            "org": "${context_course.location.org | n, js_escaped_string}",
-                            "num": "${context_course.location.course | n, js_escaped_string}",
-                            "display_course_number": "${context_course.display_coursenumber | n, js_escaped_string}",
-                            "revision": "${context_course.location.revision | n, js_escaped_string}"
-                        },
-                        "help_tokens": {
-                            "files": "${get_online_help_info(online_help_token())['doc_url'] | n, js_escaped_string}"
-                        },
-                        "upload_settings": {
-                            "max_file_size_in_mbs": ${max_file_size_in_mbs|n, dump_js_escaped_json}
-                        }
+        % if waffle_flag_enabled:
+            <%static:studiofrontend page="AssetsPage" lang="en">
+                {
+                    "course": {
+                        "id": "${context_course.id | n, js_escaped_string}",
+                        "name": "${context_course.display_name_with_default | n, js_escaped_string}",
+                        "url_name": "${context_course.location.name | n, js_escaped_string}",
+                        "org": "${context_course.location.org | n, js_escaped_string}",
+                        "num": "${context_course.location.course | n, js_escaped_string}",
+                        "display_course_number": "${context_course.display_coursenumber | n, js_escaped_string}",
+                        "revision": "${context_course.location.revision | n, js_escaped_string}"
+                    },
+                    "help_tokens": {
+                        "files": "${get_online_help_info(online_help_token())['doc_url'] | n, js_escaped_string}"
+                    },
+                    "upload_settings": {
+                        "max_file_size_in_mbs": ${max_file_size_in_mbs|n, dump_js_escaped_json}
                     }
-                </%static:studiofrontend>
-            % else:
-                <div class="wrapper-assets"></div>
-            % endif
+                }
+            </%static:studiofrontend>
             <div class="ui-loading">
                 <p><span class="spin"><span class="icon fa fa-refresh" aria-hidden="true"></span></span> <span class="copy">${_("Loading")}</span></p>
             </div>
-        </div>
-
-        <aside class="content-supplementary" role="complementary" aria-label="${_("Help adding Files and Uploads")}">
-            <div class="bit">
-                <h3 class="title-3">${_("Adding Files for Your Course")}</h3>
-
-                <p>${Text(_("To add files to use in your course, click {em_start}Upload New File{em_end}. Then follow the prompts to upload a file from your computer.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
-
-                <p>${Text(_("{em_start}Caution{em_end}: {platform_name} recommends that you limit the file size to {em_start}10 MB{em_end}. In addition, do not upload video or audio files. You should use a third party service to host multimedia files.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"), platform_name=settings.PLATFORM_NAME)}</p>
-
-            	<p>${_("The course image, textbook chapters, and files that appear on your Course Handouts sidebar also appear in this list.")}</p>
+        % else:
+            <div class="content-primary">
+                <div class="wrapper-assets"></div>
+                <div class="ui-loading">
+                    <p><span class="spin"><span class="icon fa fa-refresh" aria-hidden="true"></span></span> <span class="copy">${_("Loading")}</span></p>
+                </div>
             </div>
-            <div class="bit">
-                <h3 class="title-3">${_("Using File URLs")}</h3>
+        % endif
 
-                <p>${Text(_("Use the {em_start}{studio_name} URL{em_end} value to link to the file or image from a component, a course update, or a course handout.")).format(studio_name=settings.STUDIO_SHORT_NAME, em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
+        % if not waffle_flag_enabled:
+            <aside class="content-supplementary" role="complementary" aria-label="${_("Help adding Files and Uploads")}">
+                <div class="bit">
+                    <h3 class="title-3">${_("Adding Files for Your Course")}</h3>
 
-                <p>${Text(_("Use the {em_start}Web URL{em_end} value to reference the file or image only from outside of your course. {em_start}Note:{em_end} If you lock a file, the Web URL no longer works for external access to a file.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
+                    <p>${Text(_("To add files to use in your course, click {em_start}Upload New File{em_end}. Then follow the prompts to upload a file from your computer.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
 
-                <p>${_("To copy a URL, double click the value in the URL column, then copy the selected text.")}</p>
-            </div>
-            <div class="bit external-help">
-                <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about managing files")}</a>
-            </div>
+                    <p>${Text(_("{em_start}Caution{em_end}: {platform_name} recommends that you limit the file size to {em_start}10 MB{em_end}. In addition, do not upload video or audio files. You should use a third party service to host multimedia files.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"), platform_name=settings.PLATFORM_NAME)}</p>
 
-        </aside>
+                  <p>${_("The course image, textbook chapters, and files that appear on your Course Handouts sidebar also appear in this list.")}</p>
+                </div>
+                <div class="bit">
+                    <h3 class="title-3">${_("Using File URLs")}</h3>
+
+                    <p>${Text(_("Use the {em_start}{studio_name} URL{em_end} value to link to the file or image from a component, a course update, or a course handout.")).format(studio_name=settings.STUDIO_SHORT_NAME, em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
+
+                    <p>${Text(_("Use the {em_start}Web URL{em_end} value to reference the file or image only from outside of your course. {em_start}Note:{em_end} If you lock a file, the Web URL no longer works for external access to a file.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
+
+                    <p>${_("To copy a URL, double click the value in the URL column, then copy the selected text.")}</p>
+                </div>
+                <div class="bit external-help">
+                    <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about managing files")}</a>
+                </div>
+
+            </aside>
+        % endif
     </div>
 </div>
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "1.7.1",
-    "@edx/studio-frontend": "0.7.0",
+    "@edx/studio-frontend": "0.8.2",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-plugin-transform-class-properties": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "1.7.1",
-    "@edx/studio-frontend": "0.8.2",
+    "@edx/studio-frontend": "0.8.3",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-plugin-transform-class-properties": "6.24.1",


### PR DESCRIPTION
Makes the new React Files & Uploads table full-page by removing the `content-primary` and `content-supplementary` divs.

@edx/educator-dahlia 