### PR TITLE
Show browser support alert

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -387,6 +387,9 @@ FEATURES = {
     # that they don't have an account associated with email addresses they believe they've registered with.
     'ENABLE_PASSWORD_RESET_FAILURE_EMAIL': False,
 
+    # Sets the default browser support. For more information go to http://browser-update.org/customize.html
+    'UNSUPPORTED_BROWSER_ALERT_VERSIONS': "{i:10,f:-3,o:-3,s:-3,c:-3}",
+
     # Set this to true to make API docs available at /api-docs/.
     'ENABLE_API_DOCS': False,
 

--- a/lms/static/sass/_build-lms-v1.scss
+++ b/lms/static/sass/_build-lms-v1.scss
@@ -70,6 +70,7 @@
 @import 'features/bookmarks-v1';
 @import 'features/learner-profile';
 @import 'features/journals';
+@import 'features/_unsupported-browser-alert';
 
 // search
 @import 'search/search';

--- a/lms/static/sass/features/_unsupported-browser-alert.scss
+++ b/lms/static/sass/features/_unsupported-browser-alert.scss
@@ -1,0 +1,52 @@
+
+@import 'lms/theme/variables-v1';
+
+// Unsupported browser alert
+$browser-update-background: #fff;
+$browser-update-ok-button: $button-color;
+$browser-update-ignore-button: $action-primary-disabled-bg;
+
+// Name of the style class used to customize browser-update alert
+.buorg {
+  background-color: $browser-update-background;
+  background-position: 8px 17px;
+  border-bottom: 1px solid #c5c6c7;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 17px;
+  left: 0;
+  position: absolute;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 2;
+
+  a {
+    color: #fff;
+
+    &:hover {
+      color: #fff !important;
+    }
+  }
+
+  #buorgul {
+    background-color: $browser-update-ok-button;
+  }
+
+  #buorgig {
+    background-color: $browser-update-ignore-button;
+  }
+}
+
+@media only screen and (max-width: 700px) {
+  .buorg div {
+    padding: 5px 12px 5px 9px;
+    text-indent: 22px;
+    line-height: 1.3em;
+  }
+
+  .buorg {
+    background-position: 9px 8px;
+  }
+}

--- a/lms/static/sass/features/_unsupported-browser-alert.scss
+++ b/lms/static/sass/features/_unsupported-browser-alert.scss
@@ -22,20 +22,22 @@ $browser-update-ignore-button: $action-primary-disabled-bg;
   width: 100%;
   z-index: 2;
 
-  a {
-    color: #fff;
+  .buorg-buttons {
+    a {
+      color: #fff;
 
-    &:hover {
-      color: #fff !important;
+      &:hover {
+        color: #fff !important;
+      }
     }
-  }
 
-  #buorgul {
-    background-color: $browser-update-ok-button;
-  }
+    #buorgul {
+      background-color: $browser-update-ok-button;
+    }
 
-  #buorgig {
-    background-color: $browser-update-ignore-button;
+    #buorgig {
+      background-color: $browser-update-ignore-button;
+    }
   }
 }
 

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -7,6 +7,7 @@
 <%!
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+import waffle
 
 from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangolib.markup import HTML, Text
@@ -14,6 +15,7 @@ from openedx.core.djangolib.markup import HTML, Text
 # App that handles subdomain specific branding
 from branding import api as branding_api
 from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 %>
 
@@ -27,6 +29,26 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
     HeaderFactory();
     </%static:require_module>
     </%block>
+% endif
+
+<%
+  unsupported_browser_alert_versions = configuration_helpers.get_value('UNSUPPORTED_BROWSER_ALERT_VERSIONS', settings.FEATURES.get('UNSUPPORTED_BROWSER_ALERT_VERSIONS'))
+%>
+% if waffle.switch_is_active('enable_unsupported_browser_alert'):
+  <script>
+    var $buoop = {
+        notify:${unsupported_browser_alert_versions | n, decode.utf8},
+        api:5,
+        reminder:0
+    };
+    function $buo_f() {
+        var e = document.createElement("script");
+        e.src = "//browser-update.org/update.min.js";
+        document.body.appendChild(e);
+    };
+    try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
+    catch(e){window.attachEvent("onload", $buo_f)}
+  </script>
 % endif
 
 <header class="global-header ${'slim' if course else ''}">


### PR DESCRIPTION
[OSPR-2147 ](https://openedx.atlassian.net/browse/OSPR-2147)

Adding one ```waffle switch``` ```enable_unsupported_browser_alert``` and one variable in ```site_configuration``` ```UNSUPPORTED_BROWSER_ALERT_VERSIONS```  makes the site show an unsupported browser alert if the user is using an outdated browser. 

This PR uses [Browser Update](https://browser-update.org/)

### Test

Go to https://pr17216.sandbox.opencraft.hosting/
Login to the ```admin``` with:
- Username: ```staff```
- Password: ```edx```

Go to waffle switches on Admin:
```
enable_unsupported_browser_alert: enabled
```

Go to site configuration and add the following:
```
{
  "UNSUPPORTED_BROWSER_ALERT_VERSIONS":"{i:10,f:-3,o:-3,s:-3,c:-3}"
}
```

Wait 3-5 minutes for it to be active

Go to https://www.browserling.com/ and paste the url of the dev box.

See the alert message on different browsers and versions.

### Screenshots
![image](https://user-images.githubusercontent.com/3858265/41441993-d4514432-6ffa-11e8-8c03-43788936af10.png)

Reviewers:
- [ ] Code review: ¯_(ツ)_/¯

![](https://media.giphy.com/media/IL4iTvQH0MjS/giphy.gif)

cc @pomegranited @mduboseedx