### PR TITLE
LEARNER-3881: Disable Learner Analytics for non-verified users.

### DIFF
--- a/openedx/features/learner_analytics/README.rst
+++ b/openedx/features/learner_analytics/README.rst
@@ -1,0 +1,10 @@
+Learner Analytics
+-----------------
+
+This is the current home of the Learner Analytics feature.  This is not a fully
+supported feature.
+
+See LEARNER-3854 for details.
+
+TODO: LEARNER-3854: If this feature gets implemented, this directory should
+move to lms/djangoapps and out of openedx/features.

--- a/openedx/features/learner_analytics/templates/learner_analytics/dashboard.html
+++ b/openedx/features/learner_analytics/templates/learner_analytics/dashboard.html
@@ -48,19 +48,26 @@ from openedx.features.course_experience import course_home_page_title
     </header>
     <div class="page-content learner-analytics-dashboard-wrapper">
         <div class="learner-analytics-dashboard">
-            ${static.renderReact(
-              component="LearnerAnalyticsDashboard",
-              id="react-learner-analytics-dashboard",
-              props={
-                'schedule': assignment_schedule,
-                'grading_policy': grading_policy,
-                'grades': assignment_grades,
-                'discussion_info': discussion_info,
-                'weekly_active_users': weekly_active_users,
-                'week_streak': week_streak,
-                'profile_images': profile_image_urls,
-              }
-            )}
+            % if is_verified:
+                ${static.renderReact(
+                  component="LearnerAnalyticsDashboard",
+                  id="react-learner-analytics-dashboard",
+                  props={
+                    'schedule': assignment_schedule,
+                    'grading_policy': grading_policy,
+                    'grades': assignment_grades,
+                    'discussion_info': discussion_info,
+                    'weekly_active_users': weekly_active_users,
+                    'week_streak': week_streak,
+                    'profile_images': profile_image_urls,
+                  }
+                )}
+            % else:
+                ## TODO: LEARNER-3854: Clean-up after Learner Analytics test.
+                ##   If we move forward with this, the upsell information should
+                ##   be added here.
+                Page is not available.
+            % endif
         </div>
     </div>
 </div>


### PR DESCRIPTION
## [LEARNER-3881](https://openedx.atlassian.net/browse/LEARNER-3881)

### Description

1. Stops Learner Analytics calculations from being processed for non-verified users.
2. Adds a README.
3. Fixes error that appeared for verified users that hadn't yet visited Discussions.

Once this merges, you will need to be a verified user to see the dashboard.  Locally, you can use http://localhost:18000/support/ to update a user's enrollment mode (like verified@example.com).

FYI: @edx/learner-growth 
 
### Post-review
- [ ] Rebase and squash commits