### PR TITLE
ENT-851 TPA Registry.get should return None if passed None.

### DIFF
--- a/common/djangoapps/third_party_auth/provider.py
+++ b/common/djangoapps/third_party_auth/provider.py
@@ -71,6 +71,8 @@ class Registry(object):
     @classmethod
     def get(cls, provider_id):
         """Gets provider by provider_id string if enabled, else None."""
+        if not provider_id:
+            return None
         if '-' not in provider_id:  # Check format - see models.py:ProviderConfig
             raise ValueError("Invalid provider_id. Expect something like oa2-google")
         try:

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -168,6 +168,9 @@ class RegistryTest(testutil.TestCase):
         self.configure_google_provider(enabled=True)
         self.assertNotIn(facebook_provider, provider.Registry.get_enabled_by_backend_name('google-oauth2'))
 
+    def test_get_returns_none_if_provider_id_is_none(self):
+        self.assertIsNone(provider.Registry.get(None))
+
     def test_get_returns_none_if_provider_not_enabled(self):
         linkedin_provider_id = "oa2-linkedin-oauth2"
         # At this point there should be no configuration entries at all so no providers should be enabled


### PR DESCRIPTION
## Testing Instructions

1. Visit https://business.sandbox.edx.org/enterprise/1b542b06-d353-45e6-9867-9579d9e12745/course/course-v1:edX+DemoX+Demo_Course/enroll/?catalog=067dfbf1-d3d8-48e0-8dfe-d37d73f1b3ab.
2. Click Create an Account.
3. Create a new account.
4. Visit https://business.sandbox.edx.org/account/settings.
5. Verify that the account settings page loads without error.