### PR TITLE
bump enterprise version from 0.61.4 to 0.61.5

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -54,7 +54,7 @@ git+https://github.com/cpennington/pylint-django@fix-field-inference-during-monk
 enum34==1.1.6
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.61.4
+edx-enterprise==0.61.5
 edx-oauth2-provider==1.2.2
 edx-organizations==0.4.9
 edx-rest-api-client==1.7.1


### PR DESCRIPTION
ENT-842
@saleem-latif @asadiqbal08 @georgebabey 

**Related PR:** https://github.com/edx/edx-enterprise/pull/276

Here is the commits list from version 0.61.4 to 0.61.5: https://github.com/edx/edx-enterprise/compare/0.61.4...0.61.5