### PR TITLE
Video completion recording does not happen at the end of the video

### DIFF
--- a/common/lib/xmodule/xmodule/assets/vertical/public/js/vertical_student_view.js
+++ b/common/lib/xmodule/xmodule/assets/vertical/public/js/vertical_student_view.js
@@ -28,7 +28,7 @@ window.VerticalStudentView = function(runtime, element) {
         function(idx, block) {
             var blockKey = block.dataset.id;
 
-            if (block.dataset.completableByViewing === undefined) {
+            if (!block.dataset.completableByViewing) {
                 return;
             }
             // TODO: EDUCATOR-1778

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -438,6 +438,7 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
     module_class = VideoModule
     transcript = module_attr('transcript')
     publish_completion = module_attr('publish_completion')
+    has_custom_completion = module_attr('has_custom_completion')
 
     show_in_read_only_mode = True
 

--- a/lms/templates/vert_module.html
+++ b/lms/templates/vert_module.html
@@ -12,7 +12,7 @@
 % for idx, item in enumerate(items):
   <div class="vert vert-${idx}" data-id="${item['id']}" \
     % if item['id'] in watched_completable_blocks:
-      data-completable-by-viewing \
+      data-completable-by-viewing=True \
     % endif
       >
     ${HTML(item['content'])}


### PR DESCRIPTION
## [Educator-2140](https://openedx.atlassian.net/browse/EDUCATOR-2140)

Videos were marked as completed upon page viewing. Now they are marked as completed upon whatever ```COMPLETION_VIDEO_COMPLETE_PERCENTAGE``` is set to (currently, 95%). There were two problems:

1) As stated in the ticket, [this code](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/js/src/video/09_completion.js#L124-L125) compares the amount of the video watched to ```completionPercentage```. However, an ajax call was already sent to ```publish_completion``` on pageload, because [the encompassing view](https://github.com/edx/edx-platform/blob/201712869cdf77dac7d2f0cb44117c40a22fd1e0/common/lib/xmodule/xmodule/assets/vertical/public/js/vertical_student_view.js#L31) checks for ```block.dataset.completableByViewing```, which was set [in this template](https://github.com/edx/edx-platform/blob/201712869cdf77dac7d2f0cb44117c40a22fd1e0/lms/templates/vert_module.html#L15) to always be an empty string. Because the javascript was just checking for the variable to be undefined, all xblocks bypassed that if statement and were completable on viewing. I think the variable was set to an empty string (and not undefined) because of some way Backbone handles/sanitizes getting data from the HTML, but that's just a hunch.

2) The [VideoModule](https://github.com/edx/edx-platform/blob/201712869cdf77dac7d2f0cb44117c40a22fd1e0/common/lib/xmodule/xmodule/video_module/video_module.py#L114) has ```has_custom_completion``` set to True, but later, when [this code](https://github.com/edx/edx-platform/blob/201712869cdf77dac7d2f0cb44117c40a22fd1e0/common/lib/xmodule/xmodule/vertical_block.py#L34) checks for whether an xblock is completable on viewing, ```has_custom_completion``` was not there. That's because ```is_completable_by_viewing``` is called with a *VideoDescriptor*, not a VideoModule.