### PR TITLE
Disable optimizely for xblocks for the mobile app

### DIFF
--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -137,7 +137,7 @@ class ActivationEmailTests(TestCase):
         Registration().register(inactive_user)
         request = RequestFactory().get(settings.SOCIAL_AUTH_INACTIVE_USER_URL)
         request.user = inactive_user
-        with patch('edxmako.request_context.get_current_request'):
+        with patch('edxmako.request_context.get_current_request', return_value=request):
             inactive_user_view(request)
             mock_log.info.assert_called_with(
                 "Activation Email has been sent to User {user_email}".format(

--- a/lms/djangoapps/mobile_api/context_processor.py
+++ b/lms/djangoapps/mobile_api/context_processor.py
@@ -1,0 +1,14 @@
+"""
+Django template context processors.
+"""
+
+from openedx.core.lib.mobile_utils import is_request_from_mobile_app
+
+
+def is_from_mobile_app(request):  # pylint: disable=unused-argument
+    """
+    Configuration context for django templates.
+    """
+    return {
+        'is_from_mobile_app': is_request_from_mobile_app(request)
+    }

--- a/lms/djangoapps/mobile_api/tests/test_context_processor.py
+++ b/lms/djangoapps/mobile_api/tests/test_context_processor.py
@@ -1,0 +1,32 @@
+"""
+Tests for Django template context processors.
+"""
+from django.conf import settings
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from lms.djangoapps.mobile_api.context_processor import is_from_mobile_app
+
+
+class MobileContextProcessorTests(TestCase):
+    """
+    Tests for the configuration context processor.
+    """
+
+    def test_is_from_mobile_app(self):
+        """
+        Verify the context is from mobile app.
+        """
+        request = RequestFactory().get('/')
+        request.META['HTTP_USER_AGENT'] = settings.MOBILE_APP_USER_AGENT_REGEXES[0]
+        context = is_from_mobile_app(request)
+        self.assertEqual(context['is_from_mobile_app'], True)
+
+    def test_not_is_from_mobile_app(self):
+        """
+        Verify the context is not from the mobile app.
+        """
+        request = RequestFactory().get('/')
+        request.META['HTTP_USER_AGENT'] = "Not from the mobile app"
+        context = is_from_mobile_app(request)
+        self.assertEqual(context['is_from_mobile_app'], False)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -595,7 +595,10 @@ CONTEXT_PROCESSORS = [
 
     # Online contextual help
     'help_tokens.context_processor',
-    'openedx.core.djangoapps.site_configuration.context_processors.configuration_context'
+    'openedx.core.djangoapps.site_configuration.context_processors.configuration_context',
+
+    # Mobile App processor (Detects if request is from the mobile app)
+    'mobile_api.context_processor.is_from_mobile_app'
 ]
 
 # Django templating

--- a/lms/templates/widgets/optimizely.html
+++ b/lms/templates/widgets/optimizely.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
 
-% if settings.OPTIMIZELY_PROJECT_ID and not disable_optimizely:
+% if settings.OPTIMIZELY_PROJECT_ID and not disable_optimizely and not is_from_mobile_app:
 <script src=${ '//cdn.optimizely.com/js/{}.js'.format(settings.OPTIMIZELY_PROJECT_ID) }></script>
 % endif


### PR DESCRIPTION
Disable optimizely for xblocks for the mobile app

https://openedx.atlassian.net/wiki/spaces/PERF/pages/493748591/Removing+Optimizely+for+edX+Mobile+Apps+Improves+Render+Speed+for+Assessments
