### PR TITLE
PLAT-1889 Fix URL config and reversal issues

### DIFF
--- a/common/djangoapps/student/management/tests/test_change_enterprise_user_username.py
+++ b/common/djangoapps/student/management/tests/test_change_enterprise_user_username.py
@@ -45,7 +45,7 @@ class ChangeEnterpriseUserUsernameCommandTests(TestCase):
         Test that the command updates the user's username when the user is linked to an Enterprise.
         """
         user = User.objects.create(is_active=True, username='old_username', email='test@example.com')
-        site = Site.objects.create(domain='example.com')
+        site, _ = Site.objects.get_or_create(domain='example.com')
         enterprise_customer = EnterpriseCustomer.objects.create(
             name='Test EnterpriseCustomer',
             site=site

--- a/common/djangoapps/student/tests/test_refunds.py
+++ b/common/djangoapps/student/tests/test_refunds.py
@@ -16,13 +16,13 @@ from django.test.client import Client
 from django.test.utils import override_settings
 from mock import patch
 
-from certificates.models import CertificateStatuses, GeneratedCertificate  # pylint: disable=import-error
-from certificates.tests.factories import GeneratedCertificateFactory  # pylint: disable=import-error
+from certificates.models import CertificateStatuses, GeneratedCertificate
+from certificates.tests.factories import GeneratedCertificateFactory
 # These imports refer to lms djangoapps.
 # Their testcases are only run under lms.
 from course_modes.tests.factories import CourseModeFactory
 from openedx.core.djangoapps.commerce.utils import ECOMMERCE_DATE_FORMAT
-from student.models import CourseEnrollment, CourseEnrollmentAttribute
+from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -191,5 +191,5 @@ class RefundableTest(SharedModuleStoreTestCase):
             )
 
         self.client.login(username=self.user.username, password=self.USER_PASSWORD)
-        resp = self.client.post(reverse('student.views.dashboard', args=[]))
+        resp = self.client.post(reverse('dashboard', args=[]))
         self.assertEqual(resp.status_code, 200)

--- a/lms/djangoapps/static_template_view/urls.py
+++ b/lms/djangoapps/static_template_view/urls.py
@@ -11,8 +11,8 @@ urlpatterns = [
     # Semi-static views (these need to be rendered and have the login bar, but don't change)
     url(r'^404$', views.render, {'template': '404.html'}, name="404"),
     # display error page templates, for testing purposes
-    url(r'^404$', views.render_404),  # Can this be deleted? Test test_404_microsites fails with this.
-    url(r'^500$', views.render_500),
+    url(r'^404$', views.render_404, name='static_template_view.views.render_404'),
+    url(r'^500$', views.render_500, name='static_template_view.views.render_500'),
 
     url(r'^blog$', views.render, {'template': 'blog.html'}, name="blog"),
     url(r'^contact$', views.render, {'template': 'contact.html'}, name="contact"),

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -35,6 +35,7 @@ from openedx.core.djangoapps.course_groups import views as course_groups_views
 from openedx.core.djangoapps.debug import views as openedx_debug_views
 from openedx.core.djangoapps.external_auth import views as external_auth_views
 from openedx.core.djangoapps.lang_pref import views as lang_pref_views
+from openedx.core.djangoapps.plugins import constants as plugin_constants, plugin_urls
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -173,12 +174,6 @@ if settings.FEATURES['ENABLE_OPENBADGES']:
         url(r'^api/badges/v1/', include('badges.api.urls', app_name='badges', namespace='badges_api')),
     ]
 
-js_info_dict = {
-    'domain': 'djangojs',
-    # We need to explicitly include external Django apps that are not in LOCALE_PATHS.
-    'packages': ('openassessment',),
-}
-
 urlpatterns += [
     url(r'^openassessment/fileupload/', include('openassessment.fileupload.urls')),
 ]
@@ -218,7 +213,8 @@ if settings.WIKI_ENABLED:
         # never be returned by a reverse() so they come after the other url patterns
         url(r'^courses/{}/course_wiki/?$'.format(settings.COURSE_ID_PATTERN),
             course_wiki_views.course_wiki_redirect, name='course_wiki'),
-        url(r'^courses/{}/wiki/'.format(settings.COURSE_KEY_REGEX), include(wiki_pattern(app_name='course_wiki_do_not_reverse', namespace='course_wiki_do_not_reverse'))),
+        url(r'^courses/{}/wiki/'.format(settings.COURSE_KEY_REGEX),
+            include(wiki_pattern(app_name='course_wiki_do_not_reverse', namespace='course_wiki_do_not_reverse'))),
     ]
 
 COURSE_URLS = [
@@ -1080,9 +1076,7 @@ if settings.FEATURES.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
 # Branch.io Text Me The App
 if settings.BRANCH_IO_KEY:
     urlpatterns += [
-        url(r'^text-me-the-app', 'student.views.text_me_the_app', name='text_me_the_app'),
+        url(r'^text-me-the-app', student_views.text_me_the_app, name='text_me_the_app'),
     ]
 
-
-from openedx.core.djangoapps.plugins import constants as plugin_constants, plugin_urls
 urlpatterns.extend(plugin_urls.get_patterns(plugin_constants.ProjectType.LMS))


### PR DESCRIPTION
Fixed a handful of URL resolution issues we missed in the earlier round of cleanup in preparation for Django 1.10 (the one in `lms/urls.py` snuck in just after that round of changes).

Also fixed a recently added test which broke under Django 1.9 due to Site's "domain" field getting a unique constraint.