### PR TITLE
Move default overlay content to themable file

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -17,10 +17,7 @@ from openedx.core.djangolib.markup import HTML, Text
               % if homepage_overlay_html:
                 ${homepage_overlay_html | n, decode.utf8}
               % else:
-                  ## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See http://open.edx.org for more information.
-                  <h1>${Text(_(u"Welcome to the Open edX{registered_trademark} platform!")).format(registered_trademark=HTML("<sup style='font-size: 65%'>&reg;</sup>"))}</h1>
-                  ## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See http://open.edx.org for more information.
-                  <p>${_("It works! This is the default homepage for this Open edX instance.")}</p>
+                <%include file="index_overlay.html" />
               % endif
             </div>
             % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):

--- a/lms/templates/index_overlay.html
+++ b/lms/templates/index_overlay.html
@@ -1,0 +1,11 @@
+<%page expression_filter="h"/>
+
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+
+## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See http://open.edx.org for more information.
+<h1>${Text(_(u"Welcome to the Open edX{registered_trademark} platform!")).format(registered_trademark=HTML("<sup style='font-size: 65%'>&reg;</sup>"))}</h1>
+## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See http://open.edx.org for more information.
+<p>${_("It works! This is the default homepage for this Open edX instance.")}</p>


### PR DESCRIPTION
Moving default index overlay text content to a separate file to make it comprehensive theme compatible. 

With this code change, open source installations only need to override this new template to override the index overlay HTML without forking.