### PR TITLE
Move default Promo Video html to themable file

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -38,13 +38,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
           </div>
 
-          % if show_homepage_promo_video:
-            <a href="#video-modal" class="media" rel="leanModal">
-              <div class="hero">
-                <div class="play-intro"></div>
-              </div>
-            </a>
-          % endif
+          <%include file="index_promo_video.html" />
         </div>
 
       </header>

--- a/lms/templates/index_promo_video.html
+++ b/lms/templates/index_promo_video.html
@@ -1,0 +1,9 @@
+<%page expression_filter="h"/>
+
+% if show_homepage_promo_video:
+  <a href="#video-modal" class="media" rel="leanModal">
+    <div class="hero">
+      <div class="play-intro"></div>
+    </div>
+  </a>
+% endif


### PR DESCRIPTION
Moving default index promo video content to a separate file to make it comprehensive theme compatible. 

With this code change, open source installations only need to override this new template to override the promo video HTML without forking.