### PR TITLE
Add FA loading spinner to each problem

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -1675,3 +1675,10 @@ div.problem .annotation-input {
     content: '';
   }
 }
+
+// Loading Spinner
+// ====================
+.problems-wrapper .loading-spinner {
+  text-align: center;
+  color: $gray-d1;
+}

--- a/lms/templates/problem_ajax.html
+++ b/lms/templates/problem_ajax.html
@@ -6,4 +6,8 @@
      data-attempts-used="${attempts_used}"
      data-content="${content | h}"
      data-graded="${graded}">
+    <p class="loading-spinner">
+        <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
+        <span class="sr">Loading&hellip;</span>
+    </p>
 </div>


### PR DESCRIPTION
Depending on the number of components on the page/the speed of the server it is sometimes the case that a unit in Open edX loads slowly.

- If a unit loads slowly, this small change lets users know which/how many problems they need to wait for. 
- The loading spinner gets replaced automatically by the problem content as soon as it loads.

Screenshot of mockup on edx.org:
![screen shot 2018-01-19 at 10 56 36 am](https://user-images.githubusercontent.com/3364609/35166656-7976784a-fd07-11e7-912a-a78dca990ccb.png)
