### PR TITLE
Updates course about date conditionals

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -245,7 +245,7 @@ from six import string_types
           % endif
             ## We plan to ditch end_date (which is not stored in course metadata),
             ## but for backwards compatibility, show about/end_date blob if it exists.
-            % if get_course_about_section(request, course, "end_date") or course.end:
+            % if course.end:
                 <%
                     course_end_date = course.end
                 %>
@@ -253,7 +253,7 @@ from six import string_types
             <li class="important-dates-item">
                 <span class="icon fa fa-calendar" aria-hidden="true"></span>
                 <p class="important-dates-item-title">${_("Classes End")}</p>
-                  % if isinstance(course_end_date, str):
+                  % if isinstance(course_end_date, string_types):
                       <span class="important-dates-item-text final-date">${course_end_date}</span>
                   % else:
                     <%


### PR DESCRIPTION
- Formatted date start strings can contain unicode, so basestring is a better `is_instance` check
from edge.edx.org:
<img width="929" alt="screen shot 2018-01-19 at 4 35 43 pm" src="https://user-images.githubusercontent.com/3364609/35177746-d1becb90-fd36-11e7-8800-4dd4fb163998.png">


- "end_date" is no longer a key in the `get_course_about_section` dictionary, so that check is not necessary