### PR TITLE
Fix modules[moduleId] error when running JS tests

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -83,6 +83,13 @@ module.exports = {
     ],
 
     module: {
+        noParse: [
+            // See sinon/webpack interaction weirdness:
+            // https://github.com/webpack/webpack/issues/304#issuecomment-272150177
+            // (I've tried every other suggestion solution on that page, this
+            // was the only one that worked.)
+            /\/sinon\.js/
+        ],
         rules: [
             {
                 test: namespacedRequireFiles,
@@ -151,7 +158,13 @@ module.exports = {
         alias: {
             'edx-ui-toolkit': 'edx-ui-toolkit/src/',  // @TODO: some paths in toolkit are not valid relative paths
             'jquery.ui': 'jQuery-File-Upload/js/vendor/jquery.ui.widget.js',
-            jquery: 'jquery/src/jquery'  // Use the non-dist form of jQuery for better debugging + optimization
+            jquery: 'jquery/src/jquery',  // Use the non-dist form of jQuery for better debugging + optimization
+
+            // See sinon/webpack interaction weirdness:
+            // https://github.com/webpack/webpack/issues/304#issuecomment-272150177
+            // (I've tried every other suggestion solution on that page, this
+            // was the only one that worked.)
+            sinon: __dirname + '/node_modules/sinon/pkg/sinon.js'
         },
         modules: [
             'node_modules',


### PR DESCRIPTION
Running LMS Karma tests was causing the following error:

  TypeError: modules[moduleId] is undefined
  at /edx/app/edxapp/edx-platform/lms/static/course_experience/js/spec/Enrollment_spec.js:20

The root issue was sinon, as documented here:
  https://github.com/webpack/webpack/issues/304

I tried multiple fixes suggested from that issue until I found one that
worked: https://github.com/webpack/webpack/issues/304#issuecomment-272150177