### PR TITLE
Upgrade setuptools to avoid bug that prevents OpenStack requirements install

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -5,7 +5,7 @@
 #   * @edx/devops - to check system requirements
 
 # Pin packaging tools the same as edxapp.  Keep them in sync for our sanity.
-setuptools==34.0.2
+setuptools==37.0.0
 pip==9.0.1
 
 

--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -6,7 +6,7 @@
 
 # Packaging pre-requisites.
 pyparsing==2.0.7
-setuptools==34.0.2
+setuptools==37.0.0
 pip==9.0.1
 
 # Numpy and scipy can't be installed in the same pip run.


### PR DESCRIPTION
There is a [bug in setuptools  34](https://github.com/pypa/setuptools/issues/951) that has started to trigger recently while installing OpenStack requirements. In this pull request, we're upgrading to setuptools 37.0.0. 

This bug surfaces while installing OpenStack requirements, and as such it affects Ginkgo as well. 

NOTE: Originally this pull request was downgrading setuptools to 24.0.3 while installing OpenStack requirements.

**Dependencies**: https://github.com/edx/configuration/pull/4279

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: before Hawthorn.

**Testing instructions**:
1. Use ``configuration`` to set up an Open edX instance using ``edx-platform``  master or Ginkgo branch
2. The requirements for OpenStack will install successfully.

**Reviewers**
- [x] @pomegranited 
- [ ] edX reviewer[s] TBD