### PR TITLE
removed extract and dummy translation commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,6 @@ pull_translations:
 	## Pull translations from Transifex
 	git clean -fdX conf/locale
 	i18n_tool transifex pull
-	i18n_tool extract
-	i18n_tool dummy
 	i18n_tool generate
 	i18n_tool generate --strict
 	git clean -fdX conf/locale/rtl


### PR DESCRIPTION
Updated to remove extract and dummy translation commands as they make a huge change in python3. 