### PR TITLE
strip_all_tags_but_br_filter would return HTML safe string.

### DIFF
--- a/openedx/core/djangolib/markup.py
+++ b/openedx/core/djangolib/markup.py
@@ -37,7 +37,7 @@ def HTML(html):                                 # pylint: disable=invalid-name
 
 def strip_all_tags_but_br(string_to_strip):
     """
-    Strips all tags from a string except <br/>
+    Strips all tags from a string except <br/> and marks as HTML.
 
     Usage:
         <%page expression_filter="h"/>
@@ -53,4 +53,4 @@ def strip_all_tags_but_br(string_to_strip):
     string_to_strip = decode.utf8(string_to_strip)
     string_to_strip = bleach.clean(string_to_strip, tags=['br'], strip=True)
 
-    return string_to_strip
+    return HTML(string_to_strip)

--- a/openedx/core/djangolib/tests/test_markup.py
+++ b/openedx/core/djangolib/tests/test_markup.py
@@ -90,3 +90,12 @@ class FormatHtmlTest(unittest.TestCase):
 
         self.assertIn('<br>', rendered_template)
         self.assertNotIn('<script>', rendered_template)
+
+    def test_strip_all_tags_but_br_returns_html(self):
+        """
+        Verify filter returns HTML Markup safe string object
+        """
+
+        html = strip_all_tags_but_br('{name}<br><script>')
+        html = html.format(name='Rock & Roll')
+        self.assertEqual(html.decode(), u'Rock &amp; Roll<br>')

--- a/scripts/tests/test_xss_linter.py
+++ b/scripts/tests/test_xss_linter.py
@@ -592,6 +592,21 @@ class TestMakoTemplateLinter(TestLinter):
 
         self.assertEqual(len(results.violations), 0)
 
+    def test_check_mako_expressions_in_html_with_escape_filter(self):
+        """
+        Test _check_mako_file_is_safe results in no violations,
+        when strip_all_tags_but_br filter is applied in html context
+        """
+        linter = MakoTemplateLinter()
+        results = FileResults('')
+
+        mako_template = textwrap.dedent("""
+            ${x | n, strip_all_tags_but_br}
+        """)
+
+        linter._check_mako_file_is_safe(mako_template, results)
+        self.assertEqual(len(results.violations), 0)
+
     def test_check_mako_expressions_in_html_without_default(self):
         """
         Test _check_mako_file_is_safe in html context without the page level

--- a/scripts/xss_linter.py
+++ b/scripts/xss_linter.py
@@ -2272,6 +2272,9 @@ class MakoTemplateLinter(BaseLinter):
                     results.violations.append(ExpressionRuleViolation(
                         Rules.mako_unwanted_html_filter, expression
                     ))
+            elif filters == ['n', 'strip_all_tags_but_br']:
+                # {x | n,  strip_all_tags_but_br} is valid in html context
+                pass
             else:
                 results.violations.append(ExpressionRuleViolation(
                     Rules.mako_invalid_html_filter, expression


### PR DESCRIPTION
Now returning HTML safe string to template instead
of just bleaching string for br tags.

LEARNER-3930