### PR TITLE
LEARNER-3055: Clean up a11y issues on the verification sock

### DIFF
--- a/lms/static/sass/features/_course-sock.scss
+++ b/lms/static/sass/features/_course-sock.scss
@@ -48,6 +48,15 @@
       color: $black-t3;
       position: relative;
 
+      h2 {
+        font-size: 1.5rem;
+        font-weight: $font-weight-bold;
+      }
+
+      h3 {
+        font-size: 1.25rem;
+      }
+
       @media (max-width: 960px) {
         .mini-cert {
           display: none;
@@ -61,16 +70,6 @@
         position: absolute;
         top: $baseline;
         width: ($baseline * 13);
-      }
-
-      h2 {
-        font-size: 1.5rem;
-        font-weight: 700;
-      }
-
-      h4 {
-        font-size: 1.25rem;
-        font-weight: 600;
       }
 
       .learner-story-container {

--- a/openedx/features/course_experience/static/course_experience/js/CourseSock.js
+++ b/openedx/features/course_experience/static/course_experience/js/CourseSock.js
@@ -52,8 +52,12 @@ export class CourseSock {  // eslint-disable-line import/prefer-default-export
     // Open the sock when user clicks to Learn More
     $toggleActionButton.on('click', () => {
       const toggleSpeed = 400;
-      $toggleActionButton.toggleClass('active').toggleClass('aria-expanded');
+      $toggleActionButton.toggleClass('active');
       $verificationSock.slideToggle(toggleSpeed, fixUpgradeButton);
+
+      // Toggle aria-expanded attribute
+      const newAriaExpandedState = $toggleActionButton.attr('aria-expanded') === 'false';
+      $toggleActionButton.attr('aria-expanded', newAriaExpandedState);
 
       // Log open and close events
       const isOpening = $toggleActionButton.hasClass('active');

--- a/openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
@@ -16,20 +16,20 @@ from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
         style="display: none"
         %endif
     >
-        <button type="button" class="btn btn-primary focusable action-toggle-verification-sock">
+        <button type="button" aria-expanded="false" class="btn btn-primary focusable action-toggle-verification-sock">
             ${_('Learn About Verified Certificates')}
         </button>
         <div class="verification-main-panel">
             <div class="verification-desc-panel content-main">
                 <h2>${_('{platform_name} Verified Certificate').format(platform_name=settings.PLATFORM_NAME)}</h2>
-                <h4>${_('Why upgrade?')}</h4>
+                <h3>${_('Why upgrade?')}</h3>
                 <ul>
                     <li>${_('Official proof of completion')}</li>
                     <li>${_('Easily shareable certificate')}</li>
                     <li>${_('Proven motivator to complete the course')}</li>
                     <li>${_('Certificate purchases help {platform_name} continue to offer free courses').format(platform_name=settings.PLATFORM_NAME)}</li>
                 </ul>
-                <h4>${_('How it works')}</h4>
+                <h3>${_('How it works')}</h3>
                 <ul>
                     <li>${_('Pay the Verified Certificate upgrade fee')}</li>
                     <li>${_('Verify your identity with a webcam and government-issued ID')}</li>
@@ -37,7 +37,7 @@ from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
                     <li>${_('Share your certificate with friends, employers, and others')}</li>
                 </ul>
                 % if settings.PLATFORM_NAME == 'edX':
-                    <h4>${_('edX Learner Stories')}</h4>
+                    <h3>${_('edX Learner Stories')}</h3>
                     <div class="learner-story-container">
                         <img class="student-image" alt="Student Image" src="${static.url('course_experience/images/learner-quote.png')}" />
                         <div class="story-quote">
@@ -57,7 +57,7 @@ from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
                         </div>
                     </div>
                 % endif
-                <img class="mini-cert" src="${static.url('course_experience/images/verified-cert.png')}"/>
+                <img class="mini-cert" alt="Example Certificate Image" src="${static.url('course_experience/images/verified-cert.png')}"/>
                 <a href="${upgrade_url}">
                     <button type="button" class="btn btn-upgrade stuck-top focusable action-upgrade-certificate" data-creative="original_sock" data-position="sock">
                         ${Text(_('Upgrade ({course_price})')).format(course_price=HTML(course_price))}


### PR DESCRIPTION
LEARNER-3055

There were three major issues with the currently upgrade footer on the course home page: the image lacked an alt attribute, the header order was not logical and the dropdown button for the entire footer did not utilize the aria-expanded attribute to show state for screen readers.

This fix resolves those three issues.

@edx/helio @Mjloturco @cptvitamin 