### PR TITLE
Fix crash using create_user

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -128,13 +128,21 @@ def validate_username(username):
     validator(username)
 
 
+def contains_html(value):
+    """
+    Validator method to check whether name contains html tags
+    """
+    regex = re.compile('(<|>)', re.UNICODE)
+    return bool(regex.search(value))
+
+
 def validate_name(name):
     """
     Verifies a Full_Name is valid, raises a ValidationError otherwise.
     Args:
         name (unicode): The name to validate.
     """
-    if accounts_settings.api.contains_html(name):
+    if contains_html(name):
         raise forms.ValidationError(_('Full Name cannot contain the following characters: < >'))
 
 

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -2,7 +2,6 @@
 """
 Programmatic integration point for User API Accounts sub-application
 """
-import re
 import datetime
 from pytz import UTC
 
@@ -537,14 +536,6 @@ def _get_user_and_profile(username):
     existing_user_profile, _ = UserProfile.objects.get_or_create(user=existing_user)
 
     return existing_user, existing_user_profile
-
-
-def contains_html(value):
-    """
-    Validator method to check whether name contains html tags
-    """
-    regex = re.compile('(<|>)', re.UNICODE)
-    return bool(regex.search(value))
 
 
 def _validate(validation_func, err, *args):


### PR DESCRIPTION
Fix an invalid import usage to avoid a crash with the management command create_user.

https://openedx.atlassian.net/browse/LEARNER-3932

Other possible fixes:
- Import submodule api in user_api.account's `__init__.py` so that the symbol is defined.
- Import submodule api explicitly in the calling module (but that didn't work because they are circularly importing each other)

But I figured since no one else uses this tiny utility function, I'd just move it and be done.