### PR TITLE
PLAT-1890 Fixed assorted ModifyingEnforceTypeWarning warnings

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -638,7 +638,7 @@ class MiscCourseTests(ContentStoreTestCase):
                 "youtube_id_1_25": "AKqURZnYqpk",
                 "youtube_id_1_5": "DYpADpL7jAY",
                 "name": "truncated_video",
-                "end_time": 10.0,
+                "end_time": timedelta(hours=10),
             }
         )
         self.store.create_child(

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1137,7 +1137,6 @@ def settings_handler(request, course_key_string):
                             entrance_exam_minimum_score_pct = float(ee_min_score_pct)
                         if entrance_exam_minimum_score_pct.is_integer():
                             entrance_exam_minimum_score_pct = entrance_exam_minimum_score_pct / 100
-                        entrance_exam_minimum_score_pct = unicode(entrance_exam_minimum_score_pct)
                         # If there's already an entrance exam defined, we'll update the existing one
                         if course_entrance_exam_present:
                             exam_data = {

--- a/cms/djangoapps/contentstore/views/entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/entrance_exam.py
@@ -145,7 +145,7 @@ def _create_entrance_exam(request, course_key, entrance_exam_minimum_score_pct=N
     course = modulestore().get_course(course_key)
     metadata = {
         'entrance_exam_enabled': True,
-        'entrance_exam_minimum_score_pct': unicode(entrance_exam_minimum_score_pct),
+        'entrance_exam_minimum_score_pct': entrance_exam_minimum_score_pct,
         'entrance_exam_id': unicode(created_block.location),
     }
     CourseMetadata.update_from_dict(metadata, course, request.user)

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -190,8 +190,8 @@ class CapaFields(object):
     # enforce_type is set to False here because this field is saved as a dict in the database.
     score = ScoreField(help=_("Dictionary with the current student score"), scope=Scope.user_state, enforce_type=False)
     has_saved_answers = Boolean(help=_("Whether or not the answers have been saved since last submit"),
-                                scope=Scope.user_state)
-    done = Boolean(help=_("Whether the student has answered the problem"), scope=Scope.user_state)
+                                scope=Scope.user_state, default=False)
+    done = Boolean(help=_("Whether the student has answered the problem"), scope=Scope.user_state, default=False)
     seed = Integer(help=_("Random seed for this student"), scope=Scope.user_state)
     last_submission_time = Date(help=_("Last submission time"), scope=Scope.user_state)
     submission_wait_seconds = Integer(

--- a/common/lib/xmodule/xmodule/modulestore/tests/sample_courses.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/sample_courses.py
@@ -58,7 +58,7 @@ TOY_BLOCK_INFO_TREE = [
                     ),
                     BlockInfo(
                         "toyjumpto", "html", {
-                            "data": "<a href=\"/jump_to_id/vertical_test\">This is a link to another page and some Chinese 四節比分和七年前</a> <p>Some more Chinese 四節比分和七年前</p>\n",
+                            "data": u"<a href=\"/jump_to_id/vertical_test\">This is a link to another page and some Chinese 四節比分和七年前</a> <p>Some more Chinese 四節比分和七年前</p>\n",
                             "xml_attributes": {"filename": ["html/toyjumpto.xml", "html/toyjumpto.xml"]}
                         }, []),
                     BlockInfo(
@@ -120,7 +120,7 @@ TOY_BLOCK_INFO_TREE = [
         "poll_test", "chapter", {}, [
             BlockInfo(
                 "T1_changemind_poll_foo", "poll_question", {
-                    "question": "<p>Have you changed your mind? ’</p>",
+                    "question": u"<p>Have you changed your mind? ’</p>",
                     "answers": [{"text": "Yes", "id": "yes"}, {"text": "No", "id": "no"}],
                     "xml_attributes": {"reset": "false", "filename": ["", None]},
                     "display_name": "Change your answer"
@@ -168,7 +168,7 @@ TOY_BLOCK_INFO_TREE = [
                         }, []),
                 ]),
                 BlockInfo("unicode", "html", {
-                    "data": "…", "xml_attributes": {"filename": ["", None]}
+                    "data": u"…", "xml_attributes": {"filename": ["", None]}
                 }, [])
             ]),
         ]

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -793,7 +793,7 @@ class VideoExportTestCase(VideoDescriptorTestBase):
         """
         Test XML export handles the unicode characters.
         """
-        self.descriptor.display_name = '这是文'
+        self.descriptor.display_name = u'这是文'
         xml = self.descriptor.definition_to_xml(None)
         self.assertEqual(xml.get('display_name'), u'\u8fd9\u662f\u6587')
 

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -9,7 +9,8 @@ import json
 import logging
 import os
 
-from datetime import datetime
+import six
+from django.utils.timezone import now
 from webob import Response
 
 from xblock.core import XBlock
@@ -40,6 +41,17 @@ log = logging.getLogger(__name__)
 # Disable no-member warning:
 # pylint: disable=no-member
 
+def to_boolean(value):
+    """
+    Convert a value from a GET or POST request parameter to a bool
+    """
+    if isinstance(value, six.binary_type):
+        value = value.decode('ascii', errors='replace')
+    if isinstance(value, six.text_type):
+        return value.lower() == 'true'
+    else:
+        return bool(value)
+
 
 class VideoStudentViewHandlers(object):
     """
@@ -61,6 +73,8 @@ class VideoStudentViewHandlers(object):
             'auto_advance': json.loads,
             'saved_video_position': RelativeTime.isotime_to_timedelta,
             'youtube_is_available': json.loads,
+            'bumper_last_view_date': to_boolean,
+            'bumper_do_not_show_again': to_boolean,
         }
 
         if dispatch == 'save_user_state':
@@ -72,7 +86,7 @@ class VideoStudentViewHandlers(object):
                         value = data[key]
 
                     if key == 'bumper_last_view_date':
-                        value = datetime.utcnow()
+                        value = now()
 
                     setattr(self, key, value)
 

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -178,7 +178,7 @@ class TestSplitTestVert(SplitTestBase):
             parent_location=self.sequential.location,
             category="split_test",
             display_name="Split test",
-            user_partition_id='0',
+            user_partition_id=0,
             group_id_to_child={"0": c0_url, "1": c1_url},
         )
 
@@ -252,7 +252,7 @@ class TestVertSplitTestVert(SplitTestBase):
             parent_location=vert1.location,
             category="split_test",
             display_name="Split test",
-            user_partition_id='0',
+            user_partition_id=0,
             group_id_to_child={"0": c0_url, "1": c1_url},
         )
 

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -1123,7 +1123,7 @@ class TestConditionalContent(TestSubmittingProblems):
             parent_location=self.homework_conditional.location,
             category="split_test",
             display_name="Split test",
-            user_partition_id='0',
+            user_partition_id=0,
             group_id_to_child=group_id_to_child,
         )
 

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -5,10 +5,11 @@ import json
 import os
 import tempfile
 import textwrap
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import ddt
 import freezegun
+from django.utils.timezone import now
 from mock import MagicMock, Mock, patch
 from nose.plugins.attrib import attr
 from webob import Request, Response
@@ -175,10 +176,10 @@ class TestVideo(BaseTestXmodule):
         self.item_descriptor.handle_ajax('save_user_state', {'bumper_do_not_show_again': True})
         self.assertEqual(self.item_descriptor.bumper_do_not_show_again, True)
 
-        with freezegun.freeze_time(datetime.now()):
+        with freezegun.freeze_time(now()):
             self.assertEqual(self.item_descriptor.bumper_last_view_date, None)
             self.item_descriptor.handle_ajax('save_user_state', {'bumper_last_view_date': True})
-            self.assertEqual(self.item_descriptor.bumper_last_view_date, datetime.utcnow())
+            self.assertEqual(self.item_descriptor.bumper_last_view_date, now())
 
         response = self.item_descriptor.handle_ajax('save_user_state', {u'demoo�': "sample"})
         self.assertEqual(json.loads(response)['success'], True)

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -698,7 +698,7 @@ class CategoryMapTestCase(CategoryMapTestMixin, ModuleStoreTestCase):
     def test_start_date_filter(self):
         now = datetime.datetime.now()
         self.create_discussion("Chapter 1", "Discussion 1", start=now)
-        self.create_discussion("Chapter 1", "Discussion 2 обсуждение", start=self.later)
+        self.create_discussion("Chapter 1", u"Discussion 2 обсуждение", start=self.later)
         self.create_discussion("Chapter 2", "Discussion", start=now)
         self.create_discussion("Chapter 2 / Section 1 / Subsection 1", "Discussion", start=self.later)
         self.create_discussion("Chapter 2 / Section 1 / Subsection 2", "Discussion", start=self.later)

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -311,10 +311,8 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
     @ddt.data(
         (True, True, True),
         (True, False, False),
-        (True, None, False),
         (False, True, False),
         (False, False, False),
-        (False, None, False),
     )
     @ddt.unpack
     def test_ccx_coaches_option_on_admin_list_management_instructor(

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -88,7 +88,7 @@ git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f3
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail==0.0
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@2.1.8#egg=ora2==2.1.8
+git+https://github.com/edx/edx-ora2.git@2.1.9#egg=ora2==2.1.9
 git+https://github.com/edx/RecommenderXBlock.git@1.3#egg=recommender-xblock==1.3
 git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock


### PR DESCRIPTION
Fixed various instances of `ModifyingEnforceTypeWarning`, where the value provided to an xblock field had to be modified in order to be correctly stored (the warning is so that code can be changed to provide the correct value in the first place).  The main causes of these:

* Unicode text in byte strings (I'm amazed this even worked)
* Boolean fields which defaulted to `None` instead of `False`, even though the former ultimately got coerced to the latter after raising a warning about it
* Other field values which were being provided in the incorrect format (integer number of hours instead of a `timedelta`, datetime without a timezone, etc.)
* One test which effectively had two `ddt` variations just confirming that a particular boolean xblock field does in fact convert `None` to `False` like all other boolean xblock fields.  I removed these cases, the XBlock repo's tests should cover this.

I left one warning intact, because there's a test verifying that unsupported characters in XML imported into a field correctly get stripped out during coercion, which seems like a reasonable place to test that.  I'll also be creating PRs against `edx-ora2` and `problem-builder` to fix a couple more, but I'd like to get the bulk of the fixes merged in while getting those reviewed.