### PR TITLE
LEARNER-3945: Add try/catch in Learner Analytics View

### DIFF
--- a/lms/static/js/learner_analytics_dashboard/LearnerAnalyticsDashboard.jsx
+++ b/lms/static/js/learner_analytics_dashboard/LearnerAnalyticsDashboard.jsx
@@ -94,6 +94,7 @@ export function LearnerAnalyticsDashboard(props) {
           }
 
           <h3 className="section-heading">Graded Assignments</h3>
+          {/* TODO: LEARNER-3854: If implementing Learner Analytics, rename to graded-assignments-wrapper. */}
           <div className="graded-assessments-wrapper">
             <GradeTable assignmentTypes={assignmentTypes}
                         grades={grades}


### PR DESCRIPTION
[LEARNER-3945](https://openedx.atlassian.net/browse/LEARNER-3945)

Add `try/catch` when making calls to the Analytics API in order to provide a more robust experience to end users if there are any errors related to Analytics API calls.