### PR TITLE
deprecate html setting for web certs and set to true by default

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_header_menu.py
+++ b/cms/djangoapps/contentstore/views/tests/test_header_menu.py
@@ -31,6 +31,8 @@ class TestHeaderMenu(CourseTestCase, UrlResetMixin):
         Tests course header menu should not have `Certificates` menu item
         if course has not web/HTML certificates enabled.
         """
+        self.course.cert_html_view_enabled = False
+        self.save_course()
         outline_url = reverse_course_url('course_handler', self.course.id)
         resp = self.client.get(outline_url, HTTP_ACCEPT='text/html')
         self.assertEqual(resp.status_code, 200)
@@ -41,8 +43,6 @@ class TestHeaderMenu(CourseTestCase, UrlResetMixin):
         Tests course header menu should have `Certificates` menu item
         if course has web/HTML certificates enabled.
         """
-        self.course.cert_html_view_enabled = True
-        self.save_course()
         outline_url = reverse_course_url('course_handler', self.course.id)
         resp = self.client.get(outline_url, HTTP_ACCEPT='text/html')
         self.assertEqual(resp.status_code, 200)

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -282,6 +282,9 @@ FEATURES['ENABLE_DISCUSSION_SERVICE'] = False
 # Enable a parental consent age limit for testing
 PARENTAL_CONSENT_AGE_LIMIT = 13
 
+# Enable certificates for the tests
+FEATURES['CERTIFICATES_HTML_VIEW'] = True
+
 # Enable content libraries code for the tests
 FEATURES['ENABLE_CONTENT_LIBRARIES'] = True
 

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -547,7 +547,8 @@ class CourseFields(object):
         display_name=_("Certificate Web/HTML View Enabled"),
         help=_("If true, certificate Web/HTML views are enabled for the course."),
         scope=Scope.settings,
-        default=False,
+        default=True,
+        deprecated=True
     )
     cert_html_view_overrides = Dict(
         # Translators: This field is the container for course-specific certificate configuration values

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -217,7 +217,6 @@ class AdvancedSettingsPage(CoursePage):
             'annotation_storage_url',
             'social_sharing_url',
             'video_bumper',
-            'cert_html_view_enabled',
             'enable_proctored_exams',
             'allow_proctoring_opt_out',
             'enable_timed_exams',


### PR DESCRIPTION
Deprecates the setting that turns on web-view certificates, making it true by default. This will prevent course teams from inadvertently configuring courses to use PDF certs by accident.

cc @srpearce for doc impact.

FYI @edx/educator-neem 