### PR TITLE
Render discussion profile page as a fragment to fix styling issues

### DIFF
--- a/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
@@ -1,11 +1,9 @@
 ## mako
 
-<%! main_css = "style-discussion-main" %>
+<%namespace name='static' file='../static_content.html'/>
 
 <%page expression_filter="h"/>
-<%inherit file="../main.html" />
-<%namespace name='static' file='../static_content.html'/>
-<%def name="online_help_token()"><% return "discussions" %></%def>
+
 <%!
 import json
 from django.utils.translation import ugettext as _, ungettext
@@ -15,13 +13,6 @@ from django.core.urlresolvers import reverse
 from django_comment_client.permissions import has_permission
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>
-
-<%block name="bodyclass">discussion discussion-user-profile</%block>
-<%block name="pagetitle">${_("Discussion - {course_number}").format(course_number=course.display_number_with_default)}</%block>
-
-<%block name="headextra">
-<%include file="_js_head_dependencies.html" />
-</%block>
 
 <%block name="js_extra">
 <%include file="_js_body_dependencies.html" />
@@ -48,9 +39,6 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 </%static:require_module>
 </%block>
 
-<%include file="../courseware/course_navigation.html" args="active_page='discussion'" />
-
-<%block name="content">
 <section class="discussion inline-discussion discussion-user-profile-board page-content-container">
     <header class="page-header">
         <div class="page-header-main">
@@ -89,7 +77,6 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         </main>
     </div>
 </section>
-</%block>
 
 <%include file="_underscore_templates.html" />
 <%include file="_thread_list_template.html" />

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -1463,7 +1463,11 @@ class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTe
         Test that XSS attack is prevented
         """
         mock_threads.return_value = [], 1, 1
-        mock_from_django_user.return_value.to_dict.return_value = {}
+        mock_from_django_user.return_value.to_dict.return_value = {
+            'upvoted_ids': [],
+            'downvoted_ids': [],
+            'subscribed_thread_ids': []
+        }
         mock_request.side_effect = make_mock_request_impl(course=self.course, text='dummy')
 
         url = reverse('user_profile',


### PR DESCRIPTION
# [EDUCATOR-2119](https://openedx.atlassian.net/browse/EDUCATOR-2119)

I've attempted to fix this via @HarryRein's guidance. It's not perfect, but it's way better than before.

<img width="1433" alt="screen shot 2018-01-23 at 1 28 29 pm" src="https://user-images.githubusercontent.com/7373924/35293408-97caff4a-0041-11e8-8b60-b6eadf6bd0ba.png">
