### PR TITLE
Ensuring div and not button inside link tag for a11y.

### DIFF
--- a/lms/static/sass/features/_course-sock.scss
+++ b/lms/static/sass/features/_course-sock.scss
@@ -102,6 +102,12 @@
         color: theme-color("inverse");
         background-image: none;
         box-shadow: none;
+        cursor: pointer;
+
+        &:hover {
+          background-color: theme-color("inverse");
+          color: theme-color("success");
+        }
 
         @media (max-width: 960px) {
           & {

--- a/openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
@@ -59,9 +59,9 @@ from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
                 % endif
                 <img class="mini-cert" src="${static.url('course_experience/images/verified-cert.png')}"/>
                 <a href="${upgrade_url}">
-                    <button type="button" class="btn btn-upgrade stuck-top focusable action-upgrade-certificate" data-creative="original_sock" data-position="sock">
+                    <div class="btn btn-upgrade stuck-top focusable action-upgrade-certificate" data-creative="original_sock" data-position="sock">
                         ${Text(_('Upgrade ({course_price})')).format(course_price=HTML(course_price))}
-                    </button>
+                    </div>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
The upgrade button needs to be a div inside of a link, not a button inside of a link. Also, we need an affordance to show that the button is clickable.

@cptvitamin 