### PR TITLE
Bump edxval@0.1.8

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -935,6 +935,7 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
             xml (lxml object): xml representation of video to be imported
             course_id (str): course id
         """
+        edx_video_id = ''
         if self.edx_video_id is not None:
             edx_video_id = self.edx_video_id.strip()
 

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1584,35 +1584,6 @@ class VideoDescriptorTest(TestCase, VideoDescriptorTestBase):
         expected = etree.XML(expected_str, parser=parser)
         self.assertXmlEqual(expected, actual)
 
-    def test_export_val_data_with_external(self):
-        """
-        Tests exported val data for external video.
-        """
-        external_video_id = '3_yD_cEKoCk'
-        create_or_update_video_transcript(
-            video_id=external_video_id,
-            language_code='ar',
-            metadata={
-                'provider': 'Cielo24',
-                'file_name': 'ext101.srt',
-                'file_format': 'srt'
-            }
-        )
-
-        actual = self.descriptor.definition_to_xml(resource_fs=None)
-        expected_str = """
-            <video url_name="SampleProblem" download_video="false">
-                <video_asset>
-                    <transcripts>
-                        <transcript file_format="srt" file_name="ext101.srt" language_code="ar" provider="Cielo24" video_id="{video_id}"/>
-                    </transcripts>
-                </video_asset>
-            </video>
-        """.format(video_id=external_video_id)
-        parser = etree.XMLParser(remove_blank_text=True)
-        expected = etree.XML(expected_str, parser=parser)
-        self.assertXmlEqual(expected, actual)
-
     def test_export_val_data_not_found(self):
         self.descriptor.edx_video_id = 'nonexistent'
         actual = self.descriptor.definition_to_xml(resource_fs=None)
@@ -1666,33 +1637,6 @@ class VideoDescriptorTest(TestCase, VideoDescriptorTestBase):
         self.assertDictEqual(
             get_video_transcript(video.edx_video_id, 'ar'),
             self.get_video_transcript_data('test_edx_video_id')
-        )
-
-    def test_import_val_data_external(self):
-        """
-        Tests video import with external video.
-        """
-        external_video_id = 'external_video_id'
-        module_system = DummySystem(load_error_modules=True)
-
-        xml_data = """
-            <video>
-                <video_asset>
-                    <transcripts>
-                        <transcript file_format="srt" file_name="ext101.srt" language_code="ar" provider="Cielo24" video_id="{video_id}"/>
-                    </transcripts>
-                </video_asset>
-            </video>
-        """.format(video_id=external_video_id)
-
-        id_generator = Mock()
-        id_generator.target_course_id = "test_course_id"
-        self.descriptor.from_xml(xml_data, module_system, id_generator)
-
-        # verify transcript data
-        self.assertDictEqual(
-            get_video_transcript(external_video_id, 'ar'),
-            self.get_video_transcript_data(external_video_id)
         )
 
     def test_import_val_data_invalid(self):

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -60,7 +60,7 @@ edx-organizations==0.4.9
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
 edx-submissions==2.0.12
-edxval==0.1.7
+edxval==0.1.8
 event-tracking==0.2.4
 feedparser==5.1.3
 firebase-token-generator==1.3.2


### PR DESCRIPTION
This PR bumps VAL to [0.1.8 release.](https://github.com/edx/edx-val/releases/tag/0.1.8)
and clean unnecessary tests related to export.