### PR TITLE
PLAT-1900 Remove dependency on abandoned django-pipeline-forgiving

### DIFF
--- a/openedx/core/lib/django_require/staticstorage.py
+++ b/openedx/core/lib/django_require/staticstorage.py
@@ -2,7 +2,7 @@
 :class:`~django_require.staticstorage.OptimizedCachedRequireJsStorage`
 """
 
-from django_pipeline_forgiving.storages import PipelineForgivingStorage
+from openedx.core.storage import PipelineForgivingStorage
 from require.storage import OptimizedFilesMixin
 
 

--- a/openedx/core/storage.py
+++ b/openedx/core/storage.py
@@ -4,12 +4,26 @@ Django storage backends for Open edX.
 from django.contrib.staticfiles.storage import StaticFilesStorage
 from django.core.files.storage import get_storage_class
 from django.utils.lru_cache import lru_cache
-from django_pipeline_forgiving.storages import PipelineForgivingStorage
-from pipeline.storage import NonPackagingMixin
+from pipeline.storage import NonPackagingMixin, PipelineCachedStorage
 from require.storage import OptimizedFilesMixin
 from storages.backends.s3boto import S3BotoStorage
 
 from openedx.core.djangoapps.theming.storage import ThemeCachedFilesMixin, ThemePipelineMixin, ThemeStorage
+
+
+class PipelineForgivingStorage(PipelineCachedStorage):
+    """
+    An extension of the django-pipeline storage backend which forgives missing files.
+    """
+    def hashed_name(self, name, content=None, **kwargs):
+        try:
+            out = super(PipelineForgivingStorage, self).hashed_name(name, content, **kwargs)
+        except ValueError:
+            # This means that a file could not be found, and normally this would
+            # cause a fatal error, which seems rather excessive given that
+            # some packages have missing files in their css all the time.
+            out = name
+        return out
 
 
 class ProductionStorage(

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -27,7 +27,6 @@ django-ipware==1.1.0
 django-model-utils==3.0.0
 django-mptt>=0.8.6,<0.9
 django-oauth-toolkit==0.12.0
-django-pipeline-forgiving==1.0.0
 django-pyfs==2.0
 django-ratelimit==1.1.0
 django-sekizai>=0.10


### PR DESCRIPTION
Copied in the handful of lines of code from this package and tweaked the method signature to work with Django 1.11.