### PR TITLE
Extends <head> in Studio course outline 

### DIFF
--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -31,6 +31,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <%static:include path="js/${template_name}.underscore" />
 </script>
 % endfor
+<%static:optional_include_mako file="course_outline_header_extras_post.html" />
 </%block>
 
 <%block name="page_alert">


### PR DESCRIPTION
Open source edX installations can just add a file `cms/templates/course_outline_header_extras_post.html` with content:

```
% for template_name in ['YOUR_FILE_NAME',]:
<script type="text/template" id="${template_name}-tpl">
    <%static:include path="js/${template_name}.underscore" />
</script>
```

to add a lot of features to the studio course outline.

We (Stanford) use this to include extra underscore files into the course outline.