### PR TITLE
Yro/EDUCATOR 2088

### DIFF
--- a/lms/djangoapps/completion/migrations/0002_auto_20180125_1510.py
+++ b/lms/djangoapps/completion/migrations/0002_auto_20180125_1510.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('completion', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='blockcompletion',
+            options={'get_latest_by': 'modified'},
+        ),
+    ]

--- a/lms/djangoapps/completion/tests/test_services.py
+++ b/lms/djangoapps/completion/tests/test_services.py
@@ -64,7 +64,7 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, TestCase):
                 self.block_keys[1]: 0.8,
                 self.block_keys[2]: 0.6,
                 self.block_keys[3]: 0.0,
-                self.block_keys[4]: 0.0,
+                self.block_keys[4]: 0.0
             },
         )
 

--- a/lms/djangoapps/completion/waffle.py
+++ b/lms/djangoapps/completion/waffle.py
@@ -4,13 +4,15 @@ waffle switches for the completion app.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+from openedx.core.djangoapps.theming.helpers import get_current_site
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace, WaffleSwitchNamespace
 
 # Namespace
 WAFFLE_NAMESPACE = 'completion'
+WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='completion')
 
 # Switches
-
 # Full name: completion.enable_completion_tracking
 # Indicates whether or not to track completion of individual blocks.  Keeping
 # this disabled will prevent creation of BlockCompletion objects in the
@@ -18,9 +20,74 @@ WAFFLE_NAMESPACE = 'completion'
 # xblocks.
 ENABLE_COMPLETION_TRACKING = 'enable_completion_tracking'
 
+# Full name completion.enable_visual_progress
+# Overrides completion.enable_course_visual_progress
+# Acts as a global override -- enable visual progress indicators
+# sitewide.
+ENABLE_VISUAL_PROGRESS = 'enable_visual_progress'
+
+# Full name completion.enable_course_visual_progress
+# Acts as a course-by-course enabling of visual progress
+# indicators, e.g. updated 'resume button' functionality
+ENABLE_COURSE_VISUAL_PROGRESS = 'enable_course_visual_progress'
+
+# SiteConfiguration visual progress enablement
+ENABLE_SITE_VISUAL_PROGRESS = 'enable_site_visual_progress'
+
 
 def waffle():
     """
     Returns the namespaced, cached, audited Waffle class for completion.
     """
     return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix='completion: ')
+
+
+def waffle_flag():
+    """
+    Returns the namespaced, cached, audited Waffle flags dictionary for Completion.
+    """
+    namespace = WaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'completion: ')
+    return {
+        # By default, disable visual progress. Can be enabled on a course-by-course basis.
+        # And overridden site-globally by ENABLE_VISUAL_PROGRESS
+        ENABLE_COURSE_VISUAL_PROGRESS: CourseWaffleFlag(
+            namespace,
+            ENABLE_COURSE_VISUAL_PROGRESS,
+            flag_undefined_default=False
+        )
+    }
+
+
+def visual_progress_enabled(course_key):
+    """
+    Exposes varia of visual progress feature.
+        ENABLE_COMPLETION_TRACKING, current_site.configuration, AND
+        enable_course_visual_progress OR enable_visual_progress
+
+    :return:
+
+        bool -> True if site/course/global enabled for visual progress tracking
+    """
+    if not waffle().is_enabled(ENABLE_COMPLETION_TRACKING):
+        return
+
+    try:
+        current_site = get_current_site()
+        if not current_site.configuration.get_value(ENABLE_SITE_VISUAL_PROGRESS, False):
+            return
+    except SiteConfiguration.DoesNotExist:
+        return
+
+    # Site-aware global override
+    if not waffle().is_enabled(ENABLE_VISUAL_PROGRESS):
+        # Course enabled
+        return waffle_flag()[ENABLE_COURSE_VISUAL_PROGRESS].is_enabled(course_key)
+
+    return True
+
+
+def site_configuration_enabled():
+    """
+    Helper function to return site-aware feature switch
+    :return: bool -> True if site enabled for visual progress tracking
+    """

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -26,7 +26,7 @@ from openedx.core.djangolib.markup import HTML, Text
                     <ol class="outline-item focusable">
                         % for subsection in section.get('children', []):
                             <li
-                                class="subsection ${ 'current' if subsection['last_accessed'] else '' }"
+                                class="subsection ${ 'current' if subsection['resume_block'] else '' }"
                             >
                                 <a
                                     class="outline-item focusable"
@@ -125,7 +125,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                     </div> <!-- /subsection-text -->
                                     <div class="subsection-actions">
                                         ## Resume button (if last visited section)
-                                        % if subsection['last_accessed']:
+                                        % if subsection['resume_block']:
                                             <span class="resume-right">
                                                 <b>${ _("Resume Course") }</b>
                                                 <span class="icon fa fa-arrow-circle-right" aria-hidden="true"></span>

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -4,21 +4,28 @@ Tests for the Course Outline view and supporting views.
 import datetime
 import json
 
+from django.contrib.sites.models import Site
 from django.core.urlresolvers import reverse
-from pyquery import PyQuery as pq
+from mock import Mock, patch
 from six import text_type
-from gating import api as lms_gating_api
-from mock import patch, Mock
 
 from courseware.tests.factories import StaffFactory
+from gating import api as lms_gating_api
+from lms.djangoapps.completion import waffle
+from lms.djangoapps.completion.models import BlockCompletion
+from lms.djangoapps.completion.test_utils import CompletionWaffleTestMixin
+from lms.djangoapps.course_api.blocks.transformers.milestones import MilestonesAndSpecialExamsTransformer
+from milestones.tests.utils import MilestonesTestCaseMixin
+from opaque_keys.edx.keys import CourseKey, UsageKey
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.lib.gating import api as gating_api
+from pyquery import PyQuery as pq
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
+from waffle.testutils import override_switch
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from milestones.tests.utils import MilestonesTestCaseMixin
-from lms.djangoapps.course_api.blocks.transformers.milestones import MilestonesAndSpecialExamsTransformer
 
 from .test_course_home import course_home_url
 
@@ -145,11 +152,28 @@ class TestCourseOutlinePageWithPrerequisites(SharedModuleStoreTestCase, Mileston
         course.enable_subsection_gating = True
         course_blocks = {}
         with cls.store.bulk_operations(course.id):
-            course_blocks['chapter'] = ItemFactory.create(category='chapter', parent_location=course.location)
-            course_blocks['prerequisite'] = ItemFactory.create(category='sequential', parent_location=course_blocks['chapter'].location, display_name='Prerequisite Exam')
-            course_blocks['gated_content'] = ItemFactory.create(category='sequential', parent_location=course_blocks['chapter'].location, display_name='Gated Content')
-            course_blocks['prerequisite_vertical'] = ItemFactory.create(category='vertical', parent_location=course_blocks['prerequisite'].location)
-            course_blocks['gated_content_vertical'] = ItemFactory.create(category='vertical', parent_location=course_blocks['gated_content'].location)
+            course_blocks['chapter'] = ItemFactory.create(
+                category='chapter',
+                parent_location=course.location
+            )
+            course_blocks['prerequisite'] = ItemFactory.create(
+                category='sequential',
+                parent_location=course_blocks['chapter'].location,
+                display_name='Prerequisite Exam'
+            )
+            course_blocks['gated_content'] = ItemFactory.create(
+                category='sequential',
+                parent_location=course_blocks['chapter'].location,
+                display_name='Gated Content'
+            )
+            course_blocks['prerequisite_vertical'] = ItemFactory.create(
+                category='vertical',
+                parent_location=course_blocks['prerequisite'].location
+            )
+            course_blocks['gated_content_vertical'] = ItemFactory.create(
+                category='vertical',
+                parent_location=course_blocks['gated_content'].location
+            )
         course.children = [course_blocks['chapter']]
         course_blocks['chapter'].children = [course_blocks['prerequisite'], course_blocks['gated_content']]
         course_blocks['prerequisite'].children = [course_blocks['prerequisite_vertical']]
@@ -245,7 +269,7 @@ class TestCourseOutlinePageWithPrerequisites(SharedModuleStoreTestCase, Mileston
         self.assertIn(self.UNLOCKED, subsection.children('.sr').html())
 
 
-class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase):
+class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase, CompletionWaffleTestMixin):
     """
     Test start course and resume course for the course outline view.
 
@@ -268,6 +292,12 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase):
         """Set up and enroll our fake user in the course."""
         cls.user = UserFactory(password=TEST_PASSWORD)
         CourseEnrollment.enroll(cls.user, cls.course.id)
+        cls.site = Site.objects.get_current()
+        SiteConfiguration.objects.get_or_create(
+            site=cls.site,
+            enabled=True,
+            values={waffle.ENABLE_SITE_VISUAL_PROGRESS: True}
+        )
 
     @classmethod
     def create_test_course(cls):
@@ -295,6 +325,7 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase):
         """
         super(TestCourseOutlineResumeCourse, self).setUp()
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
+        self.override_waffle_switch(False)
 
     def visit_sequential(self, course, chapter, sequential):
         """
@@ -310,6 +341,21 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase):
         )
         self.assertEqual(200, self.client.get(last_accessed_url).status_code)
 
+    def visit_course_home(self, course, start_count=0, resume_count=0):
+        """
+        Helper function to navigates to course home page, test for resume buttons
+
+        :param course: course factory object
+        :param start_count: number of times 'Start Course' should appear
+        :param resume_count: number of times 'Resume Course' should appear
+        :return: response object
+        """
+        response = self.client.get(course_home_url(course))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Start Course', count=start_count)
+        self.assertContains(response, 'Resume Course', count=resume_count)
+        return response
+
     def test_start_course(self):
         """
         Tests that the start course button appears when the course has never been accessed.
@@ -320,13 +366,9 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase):
         """
         course = self.course
 
-        response = self.client.get(course_home_url(course))
-        self.assertEqual(response.status_code, 200)
-
-        self.assertContains(response, 'Start Course', count=1)
-        self.assertContains(response, 'Resume Course', count=0)
-
+        response = self.visit_course_home(course, start_count=1, resume_count=0)
         content = pq(response.content)
+
         self.assertTrue(content('.action-resume-course').attr('href').endswith('/course/' + course.url_name))
 
     def test_resume_course(self):
@@ -338,17 +380,75 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase):
         # first navigate to a sequential to make it the last accessed
         chapter = course.children[0]
         sequential = chapter.children[0]
+        vertical = sequential.children[0]
         self.visit_sequential(course, chapter, sequential)
 
         # check resume course buttons
-        response = self.client.get(course_home_url(course))
-        self.assertEqual(response.status_code, 200)
-
-        self.assertContains(response, 'Start Course', count=0)
-        self.assertContains(response, 'Resume Course', count=2)
-
+        response = self.visit_course_home(course, resume_count=2)
         content = pq(response.content)
-        self.assertTrue(content('.action-resume-course').attr('href').endswith('/sequential/' + sequential.url_name))
+        self.assertTrue(content('.action-resume-course').attr('href').endswith('/vertical/' + vertical.url_name))
+
+    @override_switch(
+        '{}.{}'.format(
+            waffle.WAFFLE_NAMESPACE, waffle.ENABLE_VISUAL_PROGRESS
+        ),
+        active=True
+    )
+    # @patch('lms.djangoapps.completion.waffle.site_configuration_enabled')
+    @patch('lms.djangoapps.completion.waffle.get_current_site')
+    def test_resume_course_with_completion_api(self, get_patched_current_site):
+        """
+        Tests completion API resume button functionality
+        """
+        self.override_waffle_switch(True)
+        get_patched_current_site.return_value = self.site
+
+        # Course tree
+        course = self.course
+        course_key = CourseKey.from_string(str(course.id))
+        vertical1 = course.children[0].children[0].children[0]
+        vertical2 = course.children[0].children[1].children[0]
+
+        # Fake a visit to sequence1/vertical1
+        block_key = UsageKey.from_string(unicode(vertical1.location))
+        completion = 1.0
+        BlockCompletion.objects.submit_completion(
+            user=self.user,
+            course_key=course_key,
+            block_key=block_key,
+            completion=completion
+        )
+
+        # Test for 'resume' link
+        response = self.visit_course_home(course, resume_count=2)
+
+        # Test for 'resume' link URL - should be vertical 1
+        content = pq(response.content)
+        self.assertTrue(content('.action-resume-course').attr('href').endswith('/vertical/' + vertical1.url_name))
+
+        # Fake a visit to sequence2/vertical2
+        block_key = UsageKey.from_string(unicode(vertical2.location))
+        completion = 1.0
+        BlockCompletion.objects.submit_completion(
+            user=self.user,
+            course_key=course_key,
+            block_key=block_key,
+            completion=completion
+        )
+        response = self.visit_course_home(course, resume_count=2)
+
+        # Test for 'resume' link URL - should be vertical 2
+        content = pq(response.content)
+        self.assertTrue(content('.action-resume-course').attr('href').endswith('/vertical/' + vertical2.url_name))
+
+        # visit sequential 1, make sure 'Resume Course' URL is robust against 'Last Visited'
+        # (even though I visited seq1/vert1, 'Resume Course' still points to seq2/vert2)
+        self.visit_sequential(course, course.children[0], course.children[0].children[0])
+
+        # Test for 'resume' link URL - should be vertical 2 (last completed block, NOT last visited)
+        response = self.visit_course_home(course, resume_count=2)
+        content = pq(response.content)
+        self.assertTrue(content('.action-resume-course').attr('href').endswith('/vertical/' + vertical2.url_name))
 
     def test_resume_course_deleted_sequential(self):
         """
@@ -370,11 +470,7 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase):
             self.store.delete_item(sequential.location, self.user.id)
 
         # check resume course buttons
-        response = self.client.get(course_home_url(course))
-        self.assertEqual(response.status_code, 200)
-
-        self.assertContains(response, 'Start Course', count=0)
-        self.assertContains(response, 'Resume Course', count=2)
+        response = self.visit_course_home(course, resume_count=2)
 
         content = pq(response.content)
         self.assertTrue(content('.action-resume-course').attr('href').endswith('/sequential/' + sequential2.url_name))
@@ -399,11 +495,7 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase):
                 self.store.delete_item(sequential.location, self.user.id)
 
         # check resume course buttons
-        response = self.client.get(course_home_url(course))
-        self.assertEqual(response.status_code, 200)
-
-        self.assertContains(response, 'Start Course', count=0)
-        self.assertContains(response, 'Resume Course', count=1)
+        self.visit_course_home(course, resume_count=1)
 
 
 class TestCourseOutlinePreview(SharedModuleStoreTestCase):

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -8,7 +8,7 @@ from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from web_fragments.fragment import Fragment
 
 from course_modes.models import get_cosmetic_verified_display_price
@@ -36,6 +36,7 @@ from .course_outline import CourseOutlineFragmentView
 from .course_sock import CourseSockFragmentView
 from .latest_update import LatestUpdateFragmentView
 from .welcome_message import WelcomeMessageFragmentView
+
 
 EMPTY_HANDOUTS_HTML = u'<ol></ol>'
 
@@ -76,30 +77,32 @@ class CourseHomeFragmentView(EdxFragmentView):
 
         Returns a tuple: (has_visited_course, resume_course_url)
             has_visited_course: True if the user has ever visted the course, False otherwise.
-            resume_course_url: The URL of the last accessed block if the user has visited the course,
+            resume_course_url: The URL of the 'resume course' block if the user has visited the course,
                 otherwise the URL of the course root.
 
         """
 
-        def get_last_accessed_block(block):
+        def get_resume_block(block):
             """
-            Gets the deepest block marked as 'last_accessed'.
+            Gets the deepest block marked as 'resume_block'.
+
             """
-            if not block['last_accessed']:
+            if not block['resume_block']:
                 return None
             if not block.get('children'):
                 return block
+
             for child in block['children']:
-                last_accessed_block = get_last_accessed_block(child)
-                if last_accessed_block:
-                    return last_accessed_block
+                resume_block = get_resume_block(child)
+                if resume_block:
+                    return resume_block
             return block
 
         course_outline_root_block = get_course_outline_block_tree(request, course_id)
-        last_accessed_block = get_last_accessed_block(course_outline_root_block) if course_outline_root_block else None
-        has_visited_course = bool(last_accessed_block)
-        if last_accessed_block:
-            resume_course_url = last_accessed_block['lms_web_url']
+        resume_block = get_resume_block(course_outline_root_block) if course_outline_root_block else None
+        has_visited_course = bool(resume_block)
+        if resume_block:
+            resume_course_url = resume_block['lms_web_url']
         else:
             resume_course_url = course_outline_root_block['lms_web_url'] if course_outline_root_block else None
 


### PR DESCRIPTION
## [EDUCATOR-2088](https://openedx.atlassian.net/browse/EDUCATOR-2088)

### Description
Updates our resume button functionality to be 'last completed block', not 'last accessed'. 

NOTE: full tree traversal is necessary for EDUCATOR-2189 & EDUCATOR-2203. Included 'block_complete' flags for parent blocks with all completed child blocks.

Added waffle flag/switch for course-based UI changes, plus global override.

### Testing
- [ ] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @schenedx  / @iloveagent57 

FYI: @edx/educator-neem

### Post-review
- [x] Rebase and squash commits
