### PR TITLE
Allows insertion of content above Files & Uploads

### DIFF
--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -56,6 +56,7 @@
 
 <div class="wrapper-content wrapper">
     <div class="content">
+        <%static:optional_include_mako file="asset_index_content_header.html" />
         % if waffle_flag_enabled:
             <%static:studiofrontend page="AssetsPage" lang="en">
                 {


### PR DESCRIPTION
We (Stanford) use this area to warn our instructors in our on-campus instance that files uploaded to `Files & Uploads` are viewable by anyone on the internet and not just the students in their class. (This matters because in most cases more secure course content has freer exemptions with regard to copyright...)

Example screenshot:
![screen shot 2018-01-25 at 1 01 13 pm](https://user-images.githubusercontent.com/3364609/35412827-5ce18952-01d2-11e8-863d-3a7f63cafc36.png)
