### PR TITLE
PLAT-1834 Support running a11y tests in tox

### DIFF
--- a/scripts/accessibility-tests.sh
+++ b/scripts/accessibility-tests.sh
@@ -1,15 +1,38 @@
 #!/usr/bin/env bash
 set -e
 
+###############################################################################
+#
+#   accessibility-tests.sh
+#
+#   Execute the accessibility tests for edx-platform.
+#
+#   If the optional `DJANGO_VERSION` environment variable is defined, it
+#   specifies which version of Django should be installed when running the
+#   tests inside a `tox` virtualenv.  If undefined, the tests are run using
+#   the currently active Python environment.
+#
+###############################################################################
+
+if [[ $DJANGO_VERSION == '1.11' ]]; then
+    TOX="tox -e py27-django111 --"
+elif [[ $DJANGO_VERSION == '1.10' ]]; then
+    TOX="tox -e py27-django110 --"
+elif [[ $DJANGO_VERSION == '1.9' ]]; then
+    TOX="tox -e py27-django19 --"
+else
+    TOX=""
+fi
+
 
 echo "Setting up for accessibility tests..."
 source scripts/jenkins-common.sh
 
 echo "Running explicit accessibility tests..."
-SELENIUM_BROWSER=phantomjs paver test_a11y
+SELENIUM_BROWSER=phantomjs $TOX paver test_a11y
 
 # The settings that we use are installed with the pa11ycrawler module
 export SCRAPY_SETTINGS_MODULE='pa11ycrawler.settings'
 
 echo "Running pa11ycrawler against test course..."
-paver pa11ycrawler --fasttest --skip-clean --fetch-course --with-html
+$TOX paver pa11ycrawler --fasttest --skip-clean --fetch-course --with-html

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ toxworkdir={homedir}/edxapp_toxenv
 # and look in site-packages.
 usedevelop=True
 setenv =
-    # Instruct paver not to install the packages tox just installed
     PYTHONHASHSEED=0
     TOXENV={envname}
 passenv =
@@ -38,6 +37,7 @@ passenv =
     NODE_PATH
     NODE_VIRTUAL_ENV
     NPM_CONFIG_PREFIX
+    SCRAPY_SETTINGS_MODULE
     SELENIUM_BROWSER
     SELENIUM_HOST
     SELENIUM_PORT


### PR DESCRIPTION
The a11y tests don't get run through `generic-ci-tests.sh`; updated their script to run paver in tox when instructed to by Jenkins.  Also let an envirionment variable required for them to pass into the tox environment, and removed an obsolete comment.