### PR TITLE
LEARNER-3377: Drop due date section of Learner Analytics and fix grading section.

### DIFF
--- a/lms/static/js/learner_analytics_dashboard/LearnerAnalyticsDashboard.jsx
+++ b/lms/static/js/learner_analytics_dashboard/LearnerAnalyticsDashboard.jsx
@@ -61,7 +61,7 @@ function getStreakString(count) {
 }
 
 export function LearnerAnalyticsDashboard(props) {
-  const {grading_policy, grades, schedule, week_streak, weekly_active_users, discussion_info, profile_images, passing_grade, percent_grade} = props;
+  const {grading_policy, grades, schedule, schedule_raw, week_streak, weekly_active_users, discussion_info, profile_images, passing_grade, percent_grade} = props;
   const gradeBreakdown = grading_policy.GRADER.map(({type, weight}, index) => {
     return {
       value: weight,
@@ -74,6 +74,9 @@ export function LearnerAnalyticsDashboard(props) {
   const assignments = gradeBreakdown.map(value => value['label']);
   const assignmentTypes = [...new Set(assignments)];
   const assignmentCounts = getAssignmentCounts(assignmentTypes, schedule);
+
+  console.log(schedule_raw);
+  console.log(grades);
 
   return (
     <div className="learner-analytics-wrapper">
@@ -115,8 +118,6 @@ export function LearnerAnalyticsDashboard(props) {
       </div>
       <div className="analytics-group sidebar week-streak">
         <h2 className="group-heading">Timing</h2>
-        <h3 className="section-heading">Course due dates</h3>
-        <DueDates dates={schedule} assignmentCounts={assignmentCounts} />
         <div className="week-streak-wrapper">
           <h3 className="section-heading">Week streak</h3>
           {week_streak > 0 && 

--- a/openedx/features/learner_analytics/templates/learner_analytics/dashboard.html
+++ b/openedx/features/learner_analytics/templates/learner_analytics/dashboard.html
@@ -39,8 +39,7 @@ from openedx.features.course_experience import course_home_page_title
                             <a href="${course_url}">${course_home_page_title(course)}</a>
                         </span>
                         <span class="icon fa fa-angle-right" aria-hidden="true"></span>
-                        <span class="nav-item">${_('Learner Analytics')}</span>
-
+                        <span class="nav-item">${_('(Beta) My Stats')}</span>
                     </div>
                 </div>
             </nav>
@@ -54,6 +53,7 @@ from openedx.features.course_experience import course_home_page_title
                   id="react-learner-analytics-dashboard",
                   props={
                     'schedule': assignment_schedule,
+                    'schedule_raw': assignment_schedule_raw,
                     'grading_policy': grading_policy,
                     'grades': assignment_grades,
                     'discussion_info': discussion_info,


### PR DESCRIPTION
Contains the following changes:
- Course due dates section on right-hand side was dropped.
- Graded assignment list is added raw, rather than filtered with assignments with due dates.  Hopefully this fixes defect of graded assignments not appearing.
- Raw data for grades and schedules is logged to console to aid in debugging in Prod.

**NOTE:** We have other changes we are looking to get out, but since this seems like the biggest blocker to the test, I wanted to get this out asap.

FYI: @edx/learner-growth 