### PR TITLE
PLAT-1350 Log Python warnings in production

### DIFF
--- a/cms/wsgi.py
+++ b/cms/wsgi.py
@@ -1,3 +1,17 @@
+"""
+WSGI config for CMS.
+
+This module contains the WSGI application used by Django's development server
+and any production WSGI deployments.
+It exposes a module-level variable named ``application``. Django's
+``runserver`` and ``runfcgi`` commands discover this application via the
+``WSGI_APPLICATION`` setting.
+"""
+from __future__ import absolute_import
+
+from openedx.core.lib.logsettings import log_python_warnings
+log_python_warnings()
+
 # Patch the xml libs before anything else.
 from safe_lxml import defuse_xml_libs
 defuse_xml_libs()

--- a/lms/wsgi.py
+++ b/lms/wsgi.py
@@ -7,6 +7,10 @@ It exposes a module-level variable named ``application``. Django's
 ``runserver`` and ``runfcgi`` commands discover this application via the
 ``WSGI_APPLICATION`` setting.
 """
+from __future__ import absolute_import
+
+from openedx.core.lib.logsettings import log_python_warnings
+log_python_warnings()
 
 # Patch the xml libs
 from safe_lxml import defuse_xml_libs

--- a/lms/wsgi_apache_lms.py
+++ b/lms/wsgi_apache_lms.py
@@ -4,6 +4,10 @@ Apache WSGI file for LMS
 This module contains the WSGI application used for Apache deployment.
 It exposes a module-level variable named ``application``.
 """
+from __future__ import absolute_import
+
+from openedx.core.lib.logsettings import log_python_warnings
+log_python_warnings()
 
 # Patch the xml libs before anything else.
 from safe_lxml import defuse_xml_libs

--- a/manage.py
+++ b/manage.py
@@ -10,15 +10,21 @@ by passing the --settings flag, you can specify what environment specific settin
 
 Any arguments not understood by this manage.py will be passed to django-admin.py
 """
+# pylint: disable=wrong-import-order, wrong-import-position
+from __future__ import absolute_import, print_function
+
+from openedx.core.lib.logsettings import log_python_warnings
+log_python_warnings()
 
 # Patch the xml libs before anything else.
 from safe_lxml import defuse_xml_libs
 defuse_xml_libs()
 
+import importlib
 import os
 import sys
-import importlib
 from argparse import ArgumentParser
+
 import contracts
 
 
@@ -82,8 +88,8 @@ def parse_args():
     edx_args, django_args = parser.parse_known_args()
 
     if edx_args.help:
-        print "edX:"
-        print edx_args.help_string
+        print("edX:")
+        print(edx_args.help_string)
 
     return edx_args, django_args
 
@@ -104,7 +110,7 @@ if __name__ == "__main__":
         contracts.disable_all()
 
     if edx_args.help:
-        print "Django:"
+        print("Django:")
         # This will trigger django-admin.py to print out its help
         django_args.append('--help')
 

--- a/openedx/core/lib/logsettings.py
+++ b/openedx/core/lib/logsettings.py
@@ -1,8 +1,10 @@
 """Get log settings."""
 
+import logging
 import os
 import platform
 import sys
+import warnings
 from logging.handlers import SysLogHandler
 
 LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
@@ -161,3 +163,15 @@ def get_logger_config(log_dir,
         })
 
     return logger_config
+
+
+def log_python_warnings():
+    """
+    Stop ignoring DeprecationWarning, ImportWarning, and PendingDeprecationWarning;
+    log all Python warnings to the main log file.
+
+    Not used in test runs, so pytest can collect the warnings triggered for
+    each test case.
+    """
+    warnings.simplefilter('default')
+    logging.captureWarnings(True)


### PR DESCRIPTION
Update all our server entry points to log all Python warnings (once per line they occur on) to the default logger.  They should appear in Splunk as having been logged by the `py.warnings` logger.  We don't want this active for test runs, because pytest works nicely with the default warnings mechanism to output all triggered warnings grouped by the test that triggered them (whereas log output is only shown for failing tests).