### PR TITLE
Add ENTERPRISE_REPORTING_SECRET to cms settings.

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -570,6 +570,14 @@ COMPLETION_VIDEO_COMPLETE_PERCENTAGE = ENV_TOKENS.get(
     COMPLETION_VIDEO_COMPLETE_PERCENTAGE,
 )
 
+####################### Enterprise Settings ######################
+# A shared secret to be used for encrypting passwords passed from the enterprise api
+# to the enteprise reporting script.
+ENTERPRISE_REPORTING_SECRET = AUTH_TOKENS.get(
+    'ENTERPRISE_REPORTING_SECRET',
+    ENTERPRISE_REPORTING_SECRET
+)
+
 ####################### Plugin Settings ##########################
 
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1456,6 +1456,8 @@ USER_TASKS_MAX_AGE = timedelta(days=7)
 ENTERPRISE_ENROLLMENT_API_URL = LMS_ROOT_URL + LMS_ENROLLMENT_API_PATH
 ENTERPRISE_SERVICE_WORKER_USERNAME = 'enterprise_worker'
 ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
+# The default value of this needs to be a 16 character string
+ENTERPRISE_REPORTING_SECRET = '0000000000000000'
 
 ############## Settings for the Discovery App ######################
 


### PR DESCRIPTION
This is required due to the way we run migrations, starting with cms.