### PR TITLE
LEARNER-3377: Add tiny bar for 0 posts in My Stats.

### DIFF
--- a/lms/static/js/learner_analytics_dashboard/Discussions.jsx
+++ b/lms/static/js/learner_analytics_dashboard/Discussions.jsx
@@ -31,6 +31,12 @@ class Discussions extends React.Component {
   }
 
   getCountChart(count, percent, label, img = false) {
+    var percentWidth;
+    if (percent === 0) {
+        percentWidth = '2px';
+    } else {
+      percentWidth = 'calc((100% - 40px) * ' + percent + ')';
+    }
     return (
       <div className="count-chart">
         <div className={classNames(
@@ -43,7 +49,7 @@ class Discussions extends React.Component {
         <div className="chart-display">
           <div className="chart-bar"
                aria-hidden="true"
-               style={{width: `calc((100% - 40px) * ${percent})`}}></div>
+               style={{width: `${percentWidth}`}}></div>
           <span className="user-count">{count}</span>
         </div>
       </div>


### PR DESCRIPTION
I know this may not be a big deal, but it bugged me. :)

The bar for 0 count used to look as follows, which looked broken to me:
![screen shot 2018-01-29 at 10 47 17 am](https://user-images.githubusercontent.com/14576445/35519340-f630febe-04e1-11e8-96d1-601a65f681ce.png)


The bar for 0 count now looks as follows:
<img width="471" alt="screen shot 2018-01-27 at 12 20 56 am" src="https://user-images.githubusercontent.com/14576445/35468968-019ce7a4-02f8-11e8-84fc-f88a5dcab05f.png">

FYI: @edx/learner-growth 