### PR TITLE
ENT-869: Login page does not render correctly when using enterprise-related coupon URL

### DIFF
--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -764,7 +764,7 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
             "errorMessage": None,
             "registerFormSubmitButtonText": "Create Account",
             "syncLearnerProfileData": False,
-            "pipeline_user_details": {"email": "test@test.com"} if add_user_details else None
+            "pipeline_user_details": {"email": "test@test.com"} if add_user_details else {}
         }
         if expected_ec is not None:
             # If we set an EnterpriseCustomer, third-party auth providers ought to be hidden.

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -269,7 +269,7 @@ def _third_party_auth_context(request, redirect_to, tpa_hint=None):
         "errorMessage": None,
         "registerFormSubmitButtonText": _("Create Account"),
         "syncLearnerProfileData": False,
-        "pipeline_user_details": None
+        "pipeline_user_details": {}
     }
 
     if third_party_auth.is_enabled():

--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -9,7 +9,7 @@
 <% } %>
 
 <% if (context.enterpriseName) { %>
-    <% if (context.pipelineUserDetails.email) { %>
+    <% if (context.pipelineUserDetails && context.pipelineUserDetails.email) { %>
         <h2><%- gettext("Sign in to continue learning as {email}").replace("{email}", context.pipelineUserDetails.email) %></h2>
     <% } else { %>
         <h2><%- gettext("Sign in to continue learning") %></h2>


### PR DESCRIPTION
__Description:__
This PR fixes the issue where login page was erroring out for non SSO flow where enterprise customer can be found from the request.

__Testing Instructions:__
1. Open https://business.sandbox.edx.org/login?enterprise_customer=1b542b06-d353-45e6-9867-9579d9e12745 and make sure login page is rendered without errors.