### PR TITLE
Define Studio sock links in separate themable file

### DIFF
--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 %>
 <%namespace file="sock_links.html" import="get_sock_links" />
+<%namespace file="sock_links_extra.html" import="get_sock_links_extra" />
 
 <div class="wrapper-sock wrapper">
   <ul class="list-actions list-cta">
@@ -17,10 +18,15 @@ from django.utils.translation import ugettext as _
 
   <div class="wrapper-inner wrapper">
     <section class="sock" id="sock" aria-labelledby="sock-heading">
-        <h2 id="sock-heading" class="title sr-only">${_("{studio_name} Documentation").format(studio_name=settings.STUDIO_NAME)}</h2>
+      <h2 id="sock-heading" class="title sr-only">${_("{studio_name} Documentation").format(studio_name=settings.STUDIO_NAME)}</h2>
+      <%
+        links = get_sock_links()
+        links_extra = get_sock_links_extra()
+        links.extend(links_extra)
+      %>
       <div class="support">
         <ul class="list-actions">
-          % for link in get_sock_links():
+          % for link in links:
             % if link['condition']:
               <li class="action-item">
                 <a href="${link['href']}" title="${link['sr_mouseover_text']}" rel="external" class="action action-primary">${link['text']}</a>

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -20,9 +20,7 @@ from django.utils.translation import ugettext as _
     <section class="sock" id="sock" aria-labelledby="sock-heading">
       <h2 id="sock-heading" class="title sr-only">${_("{studio_name} Documentation").format(studio_name=settings.STUDIO_NAME)}</h2>
       <%
-        links = get_sock_links()
-        links_extra = get_sock_links_extra()
-        links.extend(links_extra)
+        links = get_sock_links() + get_sock_links_extra()
       %>
       <div class="support">
         <ul class="list-actions">

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 %>
 <%namespace file="sock_links.html" import="get_sock_links" />
-<%namespace file="sock_links_extra.html" import="get_sock_links_extra" />
 
 <div class="wrapper-sock wrapper">
   <ul class="list-actions list-cta">
@@ -20,7 +19,7 @@ from django.utils.translation import ugettext as _
     <section class="sock" id="sock" aria-labelledby="sock-heading">
       <h2 id="sock-heading" class="title sr-only">${_("{studio_name} Documentation").format(studio_name=settings.STUDIO_NAME)}</h2>
       <%
-        links = get_sock_links() + get_sock_links_extra()
+        links = get_sock_links()
       %>
       <div class="support">
         <ul class="list-actions">

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -1,8 +1,10 @@
 <%page expression_filter="h" args="online_help_token" />
 <%!
+from django.conf import settings
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
 %>
+<%namespace file="sock_links.html" import="get_sock_links" />
+
 <div class="wrapper-sock wrapper">
   <ul class="list-actions list-cta">
     <li class="action-item">
@@ -17,41 +19,8 @@ from django.core.urlresolvers import reverse
     <section class="sock" id="sock" aria-labelledby="sock-heading">
         <h2 id="sock-heading" class="title sr-only">${_("{studio_name} Documentation").format(studio_name=settings.STUDIO_NAME)}</h2>
       <div class="support">
-        <%!
-        from django.conf import settings
-
-        partner_email = settings.PARTNER_SUPPORT_EMAIL
-
-        links = [{
-            'href': 'http://docs.edx.org',
-            'sr_mouseover_text': _('Access documentation on http://docs.edx.org'),
-            'text': _('edX Documentation'),
-            'condition': True
-        }, {
-            'href': 'https://open.edx.org',
-            'sr_mouseover_text': _('Access the Open edX Portal'),
-            'text': _('Open edX Portal'),
-            'condition': True
-        }, {
-            'href': 'https://www.edx.org/course/overview-creating-edx-course-edx-edx101#.VO4eaLPF-n1',
-            'sr_mouseover_text': _('Enroll in edX101: Overview of Creating an edX Course'),
-            'text': _('Enroll in edX101'),
-            'condition': True
-        }, {
-            'href': 'https://www.edx.org/course/creating-course-edx-studio-edx-studiox',
-            'sr_mouseover_text': _('Enroll in StudioX: Creating a Course with edX Studio'),
-            'text': _('Enroll in StudioX'),
-            'condition': True
-        }, {
-            'href': 'mailto:{email}'.format(email=partner_email),
-            'sr_mouseover_text': _('Send an email to {email}').format(email=partner_email),
-            'text': _('Contact Us'),
-            'condition': bool(partner_email)
-        }]
-        %>
-
         <ul class="list-actions">
-          % for link in links:
+          % for link in get_sock_links():
             % if link['condition']:
               <li class="action-item">
                 <a href="${link['href']}" title="${link['sr_mouseover_text']}" rel="external" class="action action-primary">${link['text']}</a>

--- a/cms/templates/widgets/sock_links.html
+++ b/cms/templates/widgets/sock_links.html
@@ -1,0 +1,40 @@
+<%page expression_filter="h" />
+<%!
+from django.conf import settings
+from django.utils.translation import ugettext as _
+%>
+
+<%def name="get_sock_links()">
+    <%
+        partner_email = settings.PARTNER_SUPPORT_EMAIL
+        links = [
+            {
+                'href': 'http://docs.edx.org',
+                'sr_mouseover_text': _('Access documentation on http://docs.edx.org'),
+                'text': _('edX Documentation'),
+                'condition': True
+            }, {
+                'href': 'https://open.edx.org',
+                'sr_mouseover_text': _('Access the Open edX Portal'),
+                'text': _('Open edX Portal'),
+                'condition': True
+            }, {
+                'href': 'https://www.edx.org/course/overview-creating-edx-course-edx-edx101#.VO4eaLPF-n1',
+                'sr_mouseover_text': _('Enroll in edX101: Overview of Creating an edX Course'),
+                'text': _('Enroll in edX101'),
+                'condition': True
+            }, {
+                'href': 'https://www.edx.org/course/creating-course-edx-studio-edx-studiox',
+                'sr_mouseover_text': _('Enroll in StudioX: Creating a Course with edX Studio'),
+                'text': _('Enroll in StudioX'),
+                'condition': True
+            }, {
+                'href': 'mailto:{email}'.format(email=partner_email),
+                'sr_mouseover_text': _('Send an email to {email}').format(email=partner_email),
+                'text': _('Contact Us'),
+                'condition': bool(partner_email)
+            }
+        ]
+        return links
+    %>
+</%def>

--- a/cms/templates/widgets/sock_links.html
+++ b/cms/templates/widgets/sock_links.html
@@ -3,6 +3,7 @@
 from django.conf import settings
 from django.utils.translation import ugettext as _
 %>
+<%namespace file="sock_links_extra.html" import="get_sock_links_extra" />
 
 <%def name="get_sock_links()">
     <%
@@ -35,6 +36,8 @@ from django.utils.translation import ugettext as _
                 'condition': bool(partner_email)
             }
         ]
+        links_extra = get_sock_links_extra()
+        links += links_extra
         return links
     %>
 </%def>

--- a/cms/templates/widgets/sock_links_extra.html
+++ b/cms/templates/widgets/sock_links_extra.html
@@ -1,0 +1,12 @@
+<%page expression_filter="h" />
+<%!
+from django.conf import settings
+from django.utils.translation import ugettext as _
+%>
+
+<%def name="get_sock_links_extra()">
+    <%
+        links_extra = []
+        return links_extra
+    %>
+</%def>


### PR DESCRIPTION
The Studio sock links are super useful, but hard to theme without forking templates. That makes it a burden for merging future Open edX releases.

This PR splits the list of links and related text out to a separate file that can be replaced with a theme version for Open edX installations.

I also added a second file for easily appending links to the end of the default list for even fewer merge conflicts.