### PR TITLE
Handle Exception in getting cookies from Sailthru

### DIFF
--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -97,6 +97,9 @@ def add_email_marketing_cookies(sender, response=None, user=None,
     except SailthruClientError as exc:
         log.error("Exception attempting to obtain cookie from Sailthru: %s", unicode(exc))
         return response
+    except Exception:
+        log.error("Exception Connecting to celery task for %s", user.email)
+        return response
 
     if not cookie:
         log.error("No cookie returned attempting to obtain cookie from Sailthru for %s", user.email)


### PR DESCRIPTION
## [LEARNER-3465](https://openedx.atlassian.net/browse/LEARNER-3465)

### Description
In order to send email, cookies are required from Sailthru.Ocassionally, celery task fails possibly because of request timeout that ultimately fails login.To avoid it, generic exception handler is added so that login will not fail in future.

- [x] Unit Tests