### PR TITLE
Fix layout in learner profile

### DIFF
--- a/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_view.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_view.js
@@ -87,8 +87,7 @@
                             viewLabel: gettext('Profile')
                         });
 
-                        this.tabbedView.render();
-                        this.$el.find('.account-settings-container').append(this.tabbedView.el);
+                        this.$el.find('.wrapper-profile-bio').html(this.tabbedView.render().el);
 
                         if (this.firstRender) {
                             this.router.on('route:loadTab', _.bind(this.setActiveTab, this));


### PR DESCRIPTION
[OSPR-2179 ](https://openedx.atlassian.net/browse/OSPR-2179)

The current layout of the learner profile looks weird when badges are enabled.

<img width="1425" alt="screen shot 2018-01-30 at 4 18 25 pm" src="https://user-images.githubusercontent.com/3858265/35572434-48cdc534-05dd-11e8-9c53-08a3e7df5bea.png">

This PR fixes this issue

<img width="1431" alt="screen shot 2018-01-30 at 4 41 18 pm" src="https://user-images.githubusercontent.com/3858265/35572490-62d87c08-05dd-11e8-8568-2cea4fc9544c.png">

Reviewers:
- [ ] Code review: ¯_(ツ)_/¯

![](https://media.giphy.com/media/s13IgnI5iMhGg/giphy.gif)

cc @nedbat 
