### PR TITLE
Remove a flaky html5 video test.

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/html5_video_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/html5_video_spec.js
@@ -48,14 +48,6 @@
                                 return state.videoPlayer.player.getPlayerState() === STATUS.PLAYING;
                             }).always(done);
                         });
-
-                        it('callback was called', function(done) {
-                            jasmine.waitUntil(function() {
-                                return state.videoPlayer.player.getPlayerState() !== STATUS.PAUSED;
-                            }).then(function() {
-                                expect(state.videoPlayer.player.callStateChangeCallback).toHaveBeenCalled();
-                            }).always(done);
-                        });
                     });
 
                     describe('[player is playing]', function() {


### PR DESCRIPTION
This test fails for 18408d2f10a1fe2b1865d305a92ff6b5cfab6de2(on master) and then succeeds for b16fd7047a6d72eef72d316f955fac279a8320b1(also master).  The only change between the two was an unrelated change to bokchoy DB caches.

I filed [EDUCATOR-2236](https://openedx.atlassian.net/browse/EDUCATOR-2236) for any follow-up that the educator team might want to do for this.