### PR TITLE
Always use a fresh tox env in Jenkins

### DIFF
--- a/scripts/accessibility-tests.sh
+++ b/scripts/accessibility-tests.sh
@@ -15,11 +15,11 @@ set -e
 ###############################################################################
 
 if [[ $DJANGO_VERSION == '1.11' ]]; then
-    TOX="tox -e py27-django111 --"
+    TOX="tox -r -e py27-django111 --"
 elif [[ $DJANGO_VERSION == '1.10' ]]; then
-    TOX="tox -e py27-django110 --"
+    TOX="tox -r -e py27-django110 --"
 elif [[ $DJANGO_VERSION == '1.9' ]]; then
-    TOX="tox -e py27-django19 --"
+    TOX="tox -r -e py27-django19 --"
 else
     TOX=""
 fi

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -70,11 +70,11 @@ END
 }
 
 if [[ $DJANGO_VERSION == '1.11' ]]; then
-    TOX="tox -e py27-django111 --"
+    TOX="tox -r -e py27-django111 --"
 elif [[ $DJANGO_VERSION == '1.10' ]]; then
-    TOX="tox -e py27-django110 --"
+    TOX="tox -r -e py27-django110 --"
 elif [[ $DJANGO_VERSION == '1.9' ]]; then
-    TOX="tox -e py27-django19 --"
+    TOX="tox -r -e py27-django19 --"
 else
     TOX=""
 fi


### PR DESCRIPTION
It looks like something occasionally goes wonky when we try to reuse a tox virtualenv on a Jenkins node; it doesn't have any of the lib/common/* apps installed, and the requirements files are configured in such a way that tox thinks that's ok (because something else is installed that boils down to the same underlying path).  This change will make Jenkins always rebuild the tox virtualenv, which will be somewhat slower on average but should make the problem go away until we can come up with a more elegant solution.