### PR TITLE
Update functions in calc.py to work in complex plane

### DIFF
--- a/common/lib/calc/calc/calc.py
+++ b/common/lib/calc/calc/calc.py
@@ -30,6 +30,11 @@ from pyparsing import (
 
 import functions
 
+# Functions available by default
+# We use scimath variants which give complex results when needed. For example:
+#   np.sqrt(-4+0j) = 2j
+#   np.sqrt(-4) = nan, but
+#   np.lib.scimath.sqrt(-4) = 2j
 DEFAULT_FUNCTIONS = {
     'sin': numpy.sin,
     'cos': numpy.cos,
@@ -37,13 +42,13 @@ DEFAULT_FUNCTIONS = {
     'sec': functions.sec,
     'csc': functions.csc,
     'cot': functions.cot,
-    'sqrt': numpy.sqrt,
-    'log10': numpy.log10,
-    'log2': numpy.log2,
-    'ln': numpy.log,
+    'sqrt': numpy.lib.scimath.sqrt,
+    'log10': numpy.lib.scimath.log10,
+    'log2': numpy.lib.scimath.log2,
+    'ln': numpy.lib.scimath.log,
     'exp': numpy.exp,
-    'arccos': numpy.arccos,
-    'arcsin': numpy.arcsin,
+    'arccos': numpy.lib.scimath.arccos,
+    'arcsin': numpy.lib.scimath.arcsin,
     'arctan': numpy.arctan,
     'arcsec': functions.arcsec,
     'arccsc': functions.arccsc,
@@ -59,11 +64,12 @@ DEFAULT_FUNCTIONS = {
     'coth': functions.coth,
     'arcsinh': numpy.arcsinh,
     'arccosh': numpy.arccosh,
-    'arctanh': numpy.arctanh,
+    'arctanh': numpy.lib.scimath.arctanh,
     'arcsech': functions.arcsech,
     'arccsch': functions.arccsch,
     'arccoth': functions.arccoth
 }
+
 DEFAULT_VARIABLES = {
     'i': numpy.complex(0, 1),
     'j': numpy.complex(0, 1),

--- a/common/lib/calc/calc/tests/test_calc.py
+++ b/common/lib/calc/calc/tests/test_calc.py
@@ -190,13 +190,13 @@ class EvaluatorTest(unittest.TestCase):
         self.assert_function_values('tan', angles, tan_values)
 
         # Include those where the real part is between -pi/2 and pi/2
-        arcsin_inputs = ['-0.707', '0', '0.5', '0.588', '1.298 + 0.635*j']
-        arcsin_angles = [-0.785, 0, 0.524, 0.629, 1 + 1j]
+        arcsin_inputs = ['-0.707', '0', '0.5', '0.588', '1.298 + 0.635*j', '-1.1', '1.1']
+        arcsin_angles = [-0.785, 0, 0.524, 0.629, 1 + 1j, -1.570 + 0.443j, 1.570 - 0.443j]
         self.assert_function_values('arcsin', arcsin_inputs, arcsin_angles)
 
         # Include those where the real part is between 0 and pi
-        arccos_inputs = ['1', '0.866', '0.809', '0.834-0.989*j']
-        arccos_angles = [0, 0.524, 0.628, 1 + 1j]
+        arccos_inputs = ['1', '0.866', '0.809', '0.834-0.989*j', '-1.1', '1.1']
+        arccos_angles = [0, 0.524, 0.628, 1 + 1j, 3.141 - 0.443j, 0.443j]
         self.assert_function_values('arccos', arccos_inputs, arccos_angles)
 
         # Has the same range as arcsin

--- a/common/lib/calc/calc/tests/test_calc.py
+++ b/common/lib/calc/calc/tests/test_calc.py
@@ -193,16 +193,11 @@ class EvaluatorTest(unittest.TestCase):
         arcsin_inputs = ['-0.707', '0', '0.5', '0.588', '1.298 + 0.635*j']
         arcsin_angles = [-0.785, 0, 0.524, 0.629, 1 + 1j]
         self.assert_function_values('arcsin', arcsin_inputs, arcsin_angles)
-        # Rather than a complex number, numpy.arcsin gives nan
-        self.assertTrue(numpy.isnan(calc.evaluator({}, {}, 'arcsin(-1.1)')))
-        self.assertTrue(numpy.isnan(calc.evaluator({}, {}, 'arcsin(1.1)')))
 
         # Include those where the real part is between 0 and pi
         arccos_inputs = ['1', '0.866', '0.809', '0.834-0.989*j']
         arccos_angles = [0, 0.524, 0.628, 1 + 1j]
         self.assert_function_values('arccos', arccos_inputs, arccos_angles)
-        self.assertTrue(numpy.isnan(calc.evaluator({}, {}, 'arccos(-1.1)')))
-        self.assertTrue(numpy.isnan(calc.evaluator({}, {}, 'arccos(1.1)')))
 
         # Has the same range as arcsin
         arctan_inputs = ['-1', '0', '0.577', '0.727', '0.272 + 1.084*j']


### PR DESCRIPTION
This PR updates the functions used in calc.py to return complex numbers when provided with arguments outside the (real) domain of those functions. 

Currently:

* `sqrt(-1)` returns NAN
* `sqrt(-1+0*i)` returns i

(Note that NAN comparisons are always false, so students are always graded as incorrect when a NAN arises.) With this PR:

* `sqrt(-1)` and `sqrt(-1+0*i)` return i

This is not only sensible, but important in situations such as the following:

````xml
    <formularesponse inline="1" type="cs" samples="x@1:3#5" answer="sqrt(x-2)">
      <textline size="45" inline="1" math="1">
        <responseparam type="tolerance" default="0.1%"/>
      </textline>
    </formularesponse>
````

This would typically grade correct inputs as incorrect, as `sqrt(x-2)` currently returns NAN whenever x is sampled between 1 and 2. This meant that instructors had to be very careful about setting the sample ranges when using these functions, in case one of the functions went outside of its real domain. This could get very complicated, particularly when multiple variables are being sampled.