### PR TITLE
Remove physical constants and suffixes from calc.py

### DIFF
--- a/common/lib/calc/calc/calc.py
+++ b/common/lib/calc/calc/calc.py
@@ -75,21 +75,10 @@ DEFAULT_VARIABLES = {
     'j': numpy.complex(0, 1),
     'e': numpy.e,
     'pi': numpy.pi,
-    'k': scipy.constants.k,  # Boltzmann: 1.3806488e-23 (Joules/Kelvin)
-    'c': scipy.constants.c,  # Light Speed: 2.998e8 (m/s)
-    'T': 298.15,  # Typical room temperature: 298.15 (Kelvin), same as 25C/77F
-    'q': scipy.constants.e  # Fund. Charge: 1.602176565e-19 (Coulombs)
 }
 
-# We eliminated the following extreme suffixes:
-#   P (1e15), E (1e18), Z (1e21), Y (1e24),
-#   f (1e-15), a (1e-18), z (1e-21), y (1e-24)
-# since they're rarely used, and potentially confusing.
-# They may also conflict with variables if we ever allow e.g.
-#   5R instead of 5*R
 SUFFIXES = {
-    '%': 0.01, 'k': 1e3, 'M': 1e6, 'G': 1e9, 'T': 1e12,
-    'c': 1e-2, 'm': 1e-3, 'u': 1e-6, 'n': 1e-9, 'p': 1e-12
+    '%': 0.01,
 }
 
 

--- a/common/lib/calc/calc/tests/test_calc.py
+++ b/common/lib/calc/calc/tests/test_calc.py
@@ -88,13 +88,10 @@ class EvaluatorTest(unittest.TestCase):
         """
         Test calc.py's unique functionality of interpreting si 'suffixes'.
 
-        For instance 'k' stand for 'kilo-' so '1k' should be 1,000
+        For instance '%' stand for 1/100th so '1%' should be 0.01
         """
         test_mapping = [
-            ('4.2%', 0.042), ('2.25k', 2250), ('8.3M', 8300000),
-            ('9.9G', 9.9e9), ('1.2T', 1.2e12), ('7.4c', 0.074),
-            ('5.4m', 0.0054), ('8.7u', 0.0000087),
-            ('5.6n', 5.6e-9), ('4.2p', 4.2e-12)
+            ('4.2%', 0.042)
         ]
 
         for (expr, answer) in test_mapping:
@@ -355,7 +352,7 @@ class EvaluatorTest(unittest.TestCase):
         """
         Test the default constants provided in calc.py
 
-        which are: j (complex number), e, pi, k, c, T, q
+        which are: j (complex number), e, pi
         """
 
         # Of the form ('expr', python value, tolerance (or None for exact))
@@ -364,10 +361,6 @@ class EvaluatorTest(unittest.TestCase):
             ('j', 1j, None),
             ('e', 2.7183, 1e-4),
             ('pi', 3.1416, 1e-4),
-            ('k', 1.3806488e-23, 1e-26),  # Boltzmann constant (Joules/Kelvin)
-            ('c', 2.998e8, 1e5),  # Light Speed in (m/s)
-            ('T', 298.15, 0.01),  # Typical room temperature (Kelvin)
-            ('q', 1.602176565e-19, 1e-22)  # Fund. Charge (Coulombs)
         ]
         for (variable, value, tolerance) in default_variables:
             fail_msg = "Failed on constant '{0}', not within bounds".format(
@@ -404,10 +397,6 @@ class EvaluatorTest(unittest.TestCase):
         self.assertAlmostEqual(
             calc.evaluator({}, {}, "sin(e)"),
             0.41, delta=0.01
-        )
-        self.assertAlmostEqual(
-            calc.evaluator({}, {}, "k*T/q"),
-            0.025, delta=1e-3
         )
         self.assertAlmostEqual(
             calc.evaluator({}, {}, "e^(j*pi)"),
@@ -484,17 +473,15 @@ class EvaluatorTest(unittest.TestCase):
             8.0
         )
 
-        variables = {'t': 1.0}
-        self.assertEqual(calc.evaluator(variables, {}, "t"), 1.0)
-        self.assertEqual(calc.evaluator(variables, {}, "T"), 1.0)
+        variables = {'E': 1.0}
         self.assertEqual(
-            calc.evaluator(variables, {}, "t", case_sensitive=True),
+            calc.evaluator(variables, {}, "E", case_sensitive=True),
             1.0
         )
-        # Recall 'T' is a default constant, with value 298.15
+        # Recall 'e' is a default constant, with value 2.718
         self.assertAlmostEqual(
-            calc.evaluator(variables, {}, "T", case_sensitive=True),
-            298, delta=0.2
+            calc.evaluator(variables, {}, "e", case_sensitive=True),
+            2.718, delta=0.02
         )
 
     def test_simple_funcs(self):

--- a/common/lib/calc/calc/tests/test_preview.py
+++ b/common/lib/calc/calc/tests/test_preview.py
@@ -84,7 +84,7 @@ class LatexPreviewTest(unittest.TestCase):
 
     def test_number_suffix(self):
         """ Suffixes should be escaped. """
-        self.assertEquals(preview.latex_preview('1.618k'), r'1.618\text{k}')
+        self.assertEquals(preview.latex_preview('1.618%'), r'1.618\text{%}')
 
     def test_number_sci_notation(self):
         """ Numbers with scientific notation should display nicely """
@@ -95,17 +95,6 @@ class LatexPreviewTest(unittest.TestCase):
         self.assertEquals(
             preview.latex_preview('-6.0221413E+23'),
             r'-6.0221413\!\times\!10^{+23}'
-        )
-
-    def test_number_sci_notation_suffix(self):
-        """ Test numbers with both of these. """
-        self.assertEquals(
-            preview.latex_preview('6.0221413E+23k'),
-            r'6.0221413\!\times\!10^{+23}\text{k}'
-        )
-        self.assertEquals(
-            preview.latex_preview('-6.0221413E+23k'),
-            r'-6.0221413\!\times\!10^{+23}\text{k}'
         )
 
     def test_variable_simple(self):


### PR DESCRIPTION
In formula problems, a number of physical constants have been predefined, as well as some suffixes. In my experience, these only lead to student confusion. Students expect an error to be raised when invalid input is given. So, when the answer to a given problem is `2*m` and students forget the multiplication sign and instead enter `2m` and are graded incorrect, this leads to student frustration, excess discussion forum posts, extra work for the instructor, etc. The problem is exacerbated in an exam situation where correctness is not shown until the end of the exam.

The physical constants have been defined to be particular numbers, and often lead to unintended consequences. Students expect that undefined variables will raise an error message, but the variables `c`, `Q`, `T` and `k` are accepted without warning. These variables are also particularly useless as defined, as they're specified in particular units, and cannot be used when working with different units. Best practice is definitely to sample variables appropriately when allowing for formula input.

This PR removes all extraneous physical constants and suffixes.