### PR TITLE
Reduce escaping on sandbox errors returned to learners

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -554,7 +554,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
                     url=cgi.escape(text_type(self.location)))
             )
             msg += u'<p>Error:</p><p><pre>{msg}</pre></p>'.format(msg=cgi.escape(text_type(err)))
-            msg += u'<p><pre>{tb}</pre></p>'.format(tb=cgi.escape(traceback.format_exc()))
+            msg += u'<p><pre>{tb}</pre></p>'.format(tb=traceback.format_exc())
             html = msg
 
         else:
@@ -1238,17 +1238,17 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
             # the full exception, including traceback,
             # in the response
             if self.runtime.user_is_staff:
-                msg = u"Staff debug info: {tb}".format(tb=cgi.escape(traceback.format_exc()))
+                msg = u"Staff debug info: {tb}".format(tb=traceback.format_exc())
 
             # Otherwise, display just an error message,
             # without a stack trace
             else:
-                escaped_message = cgi.escape(inst.args[0])
+                full_error = inst.args[0]
                 try:
                     # only return the error value of the exception
-                    msg = escaped_message.split("\\n")[-2].split(": ", 1)[1]
+                    msg = full_error.split("\\n")[-2].split(": ", 1)[1]
                 except IndexError:
-                    msg = escaped_message
+                    msg = full_error
 
             return {'success': msg}
 

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -867,7 +867,7 @@ class CapaModuleTest(unittest.TestCase):
             # Ensure that the user is NOT staff
             module.system.user_is_staff = False
 
-            # Simulate a codejail exception 'Exception: test error'
+            # Simulate a codejail exception "Exception: Couldn't execute jailed code"
             with patch('capa.capa_problem.LoncapaProblem.grade_answers') as mock_grade:
                 try:
                     raise ResponseError(
@@ -876,14 +876,14 @@ class CapaModuleTest(unittest.TestCase):
                         '  File "jailed_code", line 15, in <module>\\n'
                         '    exec code in g_dict\\n  File "<string>", line 67, in <module>\\n'
                         '  File "<string>", line 65, in check_func\\n'
-                        'Exception: test error\\n\' with status code: 1',)
+                        'Exception: Couldn\'t execute jailed code\\n\' with status code: 1',)
                 except ResponseError as err:
                     mock_grade.side_effect = exception_class(six.text_type(err))
                 get_request_dict = {CapaFactory.input_key(): '3.14'}
                 result = module.submit_problem(get_request_dict)
 
             # Expect an AJAX alert message in 'success' without the text of the stack trace
-            expected_msg = 'test error'
+            expected_msg = 'Couldn\'t execute jailed code'
             self.assertEqual(expected_msg, result['success'])
 
             # Expect that the number of attempts is NOT incremented


### PR DESCRIPTION
fixes https://github.com/mitodl/edx-platform/issues/55

When a customeresponse problem raises an exception, the returned error is being escaped too many times. 

Sample OLX that demonstrates this issue:

```
<problem>
<script type="loncapa/python">
def grader(expect, answer):
   raise Exception("This shouldn't be escaped!")
</script>

 <p>Press submit! (Enter anything)</p>
 <customresponse cfn="grader">
   <textline />
 </customresponse>
</problem>
```